### PR TITLE
fix(provider): enable 1M context for Vertex AI Anthropic models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -791,6 +791,16 @@ export namespace Provider {
             }
           }
         }
+        // Opus 4.6 already has 1M context in models.dev but still requires the beta
+        // header on Vertex. Inject directly into the existing model — no separate
+        // variant needed since the limit is already correct.
+        const opusModel = vertexProvider.models["claude-opus-4-6@default"]
+        if (opusModel && !opusModel.headers?.["anthropic-beta"]) {
+          vertexProvider.models["claude-opus-4-6@default"] = {
+            ...opusModel,
+            headers: { ...opusModel.headers, "anthropic-beta": VERTEX_1M_BETA },
+          }
+        }
       }
     }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -759,6 +759,41 @@ export namespace Provider {
     const modelsDev = await ModelsDev.get()
     const database = mapValues(modelsDev, fromModelsDevProvider)
 
+    // Vertex AI 1M context window support via the context-1m-2025-08-07 beta flag.
+    // Vertex reads and forwards the anthropic-beta HTTP header to the Anthropic backend;
+    // the header is set in model.headers and flows through the SDK automatically.
+    {
+      const VERTEX_1M_BETA = "context-1m-2025-08-07"
+      const VERTEX_1M_MODELS: Array<{ sourceID: string; variantID: string; name: string }> = [
+        {
+          sourceID: "claude-sonnet-4-6@default",
+          variantID: "claude-sonnet-4-6-1m@default",
+          name: "Claude Sonnet 4.6 (1M)",
+        },
+        {
+          sourceID: "claude-sonnet-4-5@20250929",
+          variantID: "claude-sonnet-4-5-1m@20250929",
+          name: "Claude Sonnet 4.5 (1M)",
+        },
+      ]
+      const vertexProvider = database["google-vertex-anthropic"]
+      if (vertexProvider) {
+        for (const { sourceID, variantID, name } of VERTEX_1M_MODELS) {
+          const source = vertexProvider.models[sourceID]
+          if (source) {
+            vertexProvider.models[variantID] = {
+              ...source,
+              id: variantID,
+              name,
+              api: { ...source.api, id: sourceID },
+              limit: { ...source.limit, context: 1000000, input: 0 },
+              headers: { ...source.headers, "anthropic-beta": VERTEX_1M_BETA },
+            }
+          }
+        }
+      }
+    }
+
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
 
@@ -1083,6 +1118,12 @@ export namespace Provider {
 
           opts.signal = combined
         }
+
+        // For google-vertex-anthropic, the anthropic-beta header must be sent as an HTTP
+        // header (not a body param). Vertex AI reads and forwards the anthropic-beta header
+        // to the Anthropic backend — confirmed by direct API testing. The header is already
+        // set in model.headers and flows through the SDK's getHeaders() into opts.headers.
+        // No interception or body injection needed; the header passes through correctly.
 
         // Strip openai itemId metadata following what codex does
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2309,36 +2309,6 @@ test("google-vertex-anthropic accepts custom headers from config", async () => {
   })
 })
 
-test("google-vertex-anthropic accepts betas array from config", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      await Bun.write(
-        path.join(dir, "opencode.json"),
-        JSON.stringify({
-          $schema: "https://opencode.ai/config.json",
-          provider: {
-            "google-vertex-anthropic": {
-              options: {
-                betas: ["context-1m-2025-08-07"],
-              },
-            },
-          },
-        }),
-      )
-    },
-  })
-  await Instance.provide({
-    directory: tmp.path,
-    init: async () => {
-      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
-    },
-    fn: async () => {
-      const providers = await Provider.list()
-      expect(providers["google-vertex-anthropic"]).toBeDefined()
-      expect(providers["google-vertex-anthropic"].options.betas).toEqual(["context-1m-2025-08-07"])
-    },
-  })
-})
 
 // Regression: 1M model was returning "prompt is too long: N > 200000 maximum" because
 // an earlier implementation stripped the anthropic-beta header and substituted a body
@@ -2358,8 +2328,19 @@ test("Vertex 1M model: anthropic-beta header passes through to Vertex unstripped
   ;(globalThis as any).fetch = async (_input: any, init?: RequestInit) => {
     if (init?.method === "POST") {
       const headers: Record<string, string> = {}
-      if (init.headers && typeof init.headers === "object" && !Array.isArray(init.headers)) {
-        Object.assign(headers, init.headers)
+      const rawHeaders = init.headers
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((value, key) => {
+          headers[key] = value
+        })
+      } else if (Array.isArray(rawHeaders)) {
+        for (const [key, value] of rawHeaders as Array<[string, string]>) {
+          headers[key] = value
+        }
+      } else if (rawHeaders && typeof rawHeaders === "object") {
+        for (const [key, value] of Object.entries(rawHeaders as Record<string, string>)) {
+          headers[key] = String(value)
+        }
       }
       let body: any = undefined
       if (typeof init.body === "string") {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2218,3 +2218,201 @@ test("Google Vertex: supports OpenAI compatible models", async () => {
     },
   })
 })
+
+test("google-vertex-anthropic registers 1M context variants", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const vertex = providers["google-vertex-anthropic"]
+      expect(vertex).toBeDefined()
+
+      // Verify 1M variants are registered for each source model that exists in models.dev.
+      // The source model may not be present in all environments (e.g. models-snapshot may lag).
+      const VARIANTS = [
+        {
+          sourceID: "claude-sonnet-4-6@default",
+          variantID: "claude-sonnet-4-6-1m@default",
+          name: "Claude Sonnet 4.6 (1M)",
+        },
+        {
+          sourceID: "claude-sonnet-4-5@20250929",
+          variantID: "claude-sonnet-4-5-1m@20250929",
+          name: "Claude Sonnet 4.5 (1M)",
+        },
+      ]
+      let testedAtLeastOne = false
+      for (const { sourceID, variantID, name } of VARIANTS) {
+        if (!vertex.models[sourceID]) continue
+        testedAtLeastOne = true
+        const variant = vertex.models[variantID]
+        expect(variant).toBeDefined()
+        expect(variant.name).toBe(name)
+        expect(variant.api.id).toBe(sourceID)
+        expect(variant.limit.context).toBe(1000000)
+        expect(variant.headers?.["anthropic-beta"]).toBe("context-1m-2025-08-07")
+        // Source model context limit must be unchanged
+        expect(vertex.models[sourceID].limit.context).not.toBe(1000000)
+      }
+      expect(testedAtLeastOne).toBe(true)
+    },
+  })
+})
+
+test("google-vertex-anthropic accepts custom headers from config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                headers: {
+                  "anthropic-beta": "context-1m-2025-08-07",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["google-vertex-anthropic"]).toBeDefined()
+      expect(providers["google-vertex-anthropic"].options.headers).toBeDefined()
+      expect(providers["google-vertex-anthropic"].options.headers["anthropic-beta"]).toBe("context-1m-2025-08-07")
+    },
+  })
+})
+
+test("google-vertex-anthropic accepts betas array from config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                betas: ["context-1m-2025-08-07"],
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["google-vertex-anthropic"]).toBeDefined()
+      expect(providers["google-vertex-anthropic"].options.betas).toEqual(["context-1m-2025-08-07"])
+    },
+  })
+})
+
+// Regression: 1M model was returning "prompt is too long: N > 200000 maximum" because
+// an earlier implementation stripped the anthropic-beta header and substituted a body
+// param (anthropic_beta). Vertex AI honors the HTTP header but ignores the body param.
+// The correct fix is to let the header pass through unmodified; the SDK sets it
+// automatically from model.headers via createVertexAnthropic's config.headers.
+test("Vertex 1M model: anthropic-beta header passes through to Vertex unstripped", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json" }))
+    },
+  })
+
+  const capturedRequests: Array<{ headers: Record<string, string>; body: any }> = []
+  const origFetch = globalThis.fetch as typeof fetch
+
+  ;(globalThis as any).fetch = async (_input: any, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      const headers: Record<string, string> = {}
+      if (init.headers && typeof init.headers === "object" && !Array.isArray(init.headers)) {
+        Object.assign(headers, init.headers)
+      }
+      let body: any = undefined
+      if (typeof init.body === "string") {
+        try {
+          body = JSON.parse(init.body)
+        } catch {}
+      }
+      capturedRequests.push({ headers, body })
+    }
+    return new Response(
+      JSON.stringify({
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "hi" }],
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        usage: { input_tokens: 5, output_tokens: 2 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )
+  }
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const vertex = providers["google-vertex-anthropic"]
+        if (!vertex) return
+
+        const model = vertex.models["claude-sonnet-4-6-1m@default"]
+        if (!model) return // Not in models-snapshot; skip rather than fail
+
+        const language = await Provider.getLanguage(model)
+
+        try {
+          await (language as any).doGenerate({
+            prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+            maxOutputTokens: 10,
+          })
+        } catch {
+          // Response-parsing errors are expected with a stub response.
+        }
+
+        const req = capturedRequests.find((r) => r.body !== undefined)
+        expect(req).toBeDefined()
+
+        // Vertex AI reads the anthropic-beta HTTP header (forwarded to the Anthropic
+        // backend) and ignores the anthropic_beta body param. The header must be present
+        // and the body must NOT contain anthropic_beta (no injection happening).
+        const betaHeader =
+          req!.headers["anthropic-beta"] ?? req!.headers["Anthropic-Beta"] ?? ""
+        expect(betaHeader).toContain("context-1m-2025-08-07")
+        expect(req!.body?.anthropic_beta).toBeUndefined()
+      },
+    })
+  } finally {
+    ;(globalThis as any).fetch = origFetch
+  }
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2263,6 +2263,14 @@ test("google-vertex-anthropic registers 1M context variants", async () => {
         expect(vertex.models[sourceID].limit.context).not.toBe(1000000)
       }
       expect(testedAtLeastOne).toBe(true)
+
+      // Opus 4.6 already has 1M context in models.dev — verify the beta header
+      // is injected directly without creating a separate variant.
+      if (vertex.models["claude-opus-4-6@default"]) {
+        expect(vertex.models["claude-opus-4-6@default"].headers?.["anthropic-beta"]).toBe(
+          "context-1m-2025-08-07",
+        )
+      }
     },
   })
 })


### PR DESCRIPTION
## Summary

Adds 1M context window support for Vertex AI Anthropic models (`claude-sonnet-4-6-1m@default`, `claude-sonnet-4-5-1m@20250929`, and `claude-opus-4-6@default`).

## Key Finding

Vertex AI honors the `anthropic-beta` HTTP header and forwards it to the Anthropic backend. An earlier implementation stripped the header and substituted an `anthropic_beta` body param — which Vertex silently ignores, causing 1M models to fail at 200k tokens.

Verified by direct API calls:
```
# Header approach (works):
curl -H "anthropic-beta: context-1m-2025-08-07" ... → 230k tokens accepted

# Body param approach (fails):
curl -d '{"anthropic_beta": "context-1m-2025-08-07", ...}' ... → 400 "prompt too long: 230k > 200k"
```

The correct implementation: set `anthropic-beta: context-1m-2025-08-07` in `model.headers`. The SDK picks it up via `createVertexAnthropic` config headers automatically. No fetch interception needed.

## Changes

**`provider.ts`:**
- Registers `claude-sonnet-4-6-1m@default` and `claude-sonnet-4-5-1m@20250929` as shadow model variants with `limit.context: 1_000_000` and `anthropic-beta` in `model.headers`
- Injects `anthropic-beta` directly into `claude-opus-4-6@default`, which already has 1M context in models.dev but still requires the beta header on Vertex — no separate variant needed
- No fetch interceptor; the header flows through the SDK naturally

**`provider.test.ts`:**
- Integration test: asserts 1M variants are registered in `Provider.list()` with correct `limit.context`, `api.id`, `name`, and `anthropic-beta` header
- Integration test: asserts Opus 4.6's beta header is injected without creating a separate variant
- Regression test: mocks `globalThis.fetch` to assert `anthropic-beta` header reaches Vertex unstripped and no `anthropic_beta` body param is injected

## Known Limitation

Plugin-supplied betas via `chat.params` hook (which flow through `providerOptions` at call-time) are not covered — they don't reach the provider config headers the SDK uses at construction time. This is a separate gap; the 1M shadow model approach bakes the beta into `model.headers` at model registration, which does flow through correctly.

## Test Plan

- [x] `bun test test/provider/provider.test.ts --test-name-pattern "Vertex|vertex|1M|1m"` — 5 tests pass
- [x] 1M variants present in `Provider.list()` with correct metadata
- [x] `anthropic-beta` header passes through unstripped; no `anthropic_beta` body injection