### PR TITLE
fix(opencode): enable adaptive thinking for claude-sonnet-4-6 on Vertex and Bedrock

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -502,7 +502,12 @@ export namespace ProviderTransform {
       case "@ai-sdk/google-vertex/anthropic":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
 
-        if (model.api.id.includes("opus-4-6") || model.api.id.includes("opus-4.6")) {
+        if (
+          model.api.id.includes("opus-4-6") ||
+          model.api.id.includes("opus-4.6") ||
+          model.api.id.includes("sonnet-4-6") ||
+          model.api.id.includes("sonnet-4.6")
+        ) {
           const efforts = ["low", "medium", "high", "max"]
           return Object.fromEntries(
             efforts.map((effort) => [
@@ -534,7 +539,12 @@ export namespace ProviderTransform {
 
       case "@ai-sdk/amazon-bedrock":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
-        if (model.api.id.includes("opus-4-6") || model.api.id.includes("opus-4.6")) {
+        if (
+          model.api.id.includes("opus-4-6") ||
+          model.api.id.includes("opus-4.6") ||
+          model.api.id.includes("sonnet-4-6") ||
+          model.api.id.includes("sonnet-4.6")
+        ) {
           const efforts = ["low", "medium", "high", "max"]
           return Object.fromEntries(
             efforts.map((effort) => [


### PR DESCRIPTION
Closes #14066

The adaptive thinking guard in `transform.ts` only matched `opus-4-6` / `opus-4.6`. Sonnet 4.6 also supports adaptive reasoning on both `@ai-sdk/google-vertex/anthropic` and `@ai-sdk/amazon-bedrock`, so I added `sonnet-4-6` / `sonnet-4.6` to the same condition.

**Verified by:** checking the `thinking` config object returned for a `claude-sonnet-4-6-20251001` model ID — it now returns `{ type: "adaptive" }` with effort levels instead of falling through to the static `budgetTokens` path.