### PR TITLE
fix: root-level permission config not being respected

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -45,7 +45,15 @@ export namespace PermissionNext {
 
   export function fromConfig(permission: Config.Permission) {
     const ruleset: Ruleset = []
-    for (const [key, value] of Object.entries(permission)) {
+    // Process wildcard permission keys first so that specific tool rules
+    // (like "bash") always appear later and win via findLast.
+    // This prevents key ordering issues from mergeDeep where "*" can end up
+    // after specific tools in the object.
+    // See: https://github.com/anomalyco/opencode/issues/8832
+    const entries = Object.entries(permission)
+    const wildcards = entries.filter(([key]) => key.includes("*"))
+    const rest = entries.filter(([key]) => !key.includes("*"))
+    for (const [key, value] of [...wildcards, ...rest]) {
       if (typeof value === "string") {
         ruleset.push({
           permission: key,

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -652,6 +652,19 @@ test("defaultAgent throws when default_agent points to non-existent agent", asyn
   })
 })
 
+test("root-level permission config is respected", () => {
+  // https://github.com/anomalyco/opencode/issues/8832
+  // User has { "permission": { "*": "ask", "bash": { "*": "ask", "ls *": "allow" } } }
+  // After config merging, key order may put "*" after "bash", so { *, *, ask }
+  // ends up after { bash, ls *, allow } in the ruleset. The specific bash rule
+  // should still win over the catch-all "*" rule.
+  const ruleset = PermissionNext.fromConfig({
+    bash: { "*": "ask", "ls *": "allow" },
+    "*": "ask",
+  })
+  expect(PermissionNext.evaluate("bash", "ls -la", ruleset).action).toBe("allow")
+})
+
 test("defaultAgent returns plan when build is disabled and default_agent not set", async () => {
   await using tmp = await tmpdir({
     config: {


### PR DESCRIPTION
## Summary

Fixes #8832

Root-level `permission` config in `opencode.json` was being ignored. The same config worked when placed under `agent.build.permission` but not at the root.

## Examples that didn't work

Setting permissions at the root level had no effect — bash commands would still be auto-allowed instead of prompting:

```json
{
  "permission": {
    "*": "ask",
    "bash": {
      "*": "ask",
      "ls *": "allow"
    }
  }
}
```

Similarly, this config intended to require approval for all bash except `ls`, but all commands ran without asking:

```json
{
  "permission": {
    "*": "allow",
    "bash": {
      "*": "ask",
      "git log *": "allow",
      "ls *": "allow"
    },
    "edit": "ask"
  }
}
```

Moving the exact same config under `agent.build.permission` worked fine.

## Cause

When multiple config sources are merged via `mergeDeep` (e.g. global config + project config), JavaScript object key ordering is not guaranteed. The catch-all `"*": "ask"` key could end up *after* specific tool keys like `"bash"` in the merged object.

`fromConfig` iterates with `Object.entries()`, so the `{ permission: "*", pattern: "*", action: "ask" }` rule would appear *after* `{ permission: "bash", pattern: "ls *", action: "allow" }` in the ruleset. Since `evaluate` uses `findLast`, the wildcard `*` rule won over the specific `bash` rule.

## Fix

In `fromConfig`, wildcard permission keys (like `"*"`) are now always processed before specific tool keys. This ensures specific tool rules appear later in the ruleset and take precedence via `findLast`, regardless of the key ordering in the config object.