### PR TITLE
fix(app): keep long sessions responsive with incremental loading

### DIFF
--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -105,7 +105,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       return globalSync.child(directory)
     }
     const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
-    const messagePageSize = 400
+    const messagePageSize = 120
     const inflight = new Map<string, Promise<void>>()
     const inflightDiff = new Map<string, Promise<void>>()
     const inflightTodo = new Map<string, Promise<void>>()

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1358,82 +1358,21 @@ export default function Page() {
 
   const turnInit = 20
   const turnBatch = 20
-  let turnHandle: number | undefined
-  let turnIdle = false
-
-  function cancelTurnBackfill() {
-    const handle = turnHandle
-    if (handle === undefined) return
-    turnHandle = undefined
-
-    if (turnIdle && window.cancelIdleCallback) {
-      window.cancelIdleCallback(handle)
-      return
-    }
-
-    clearTimeout(handle)
-  }
-
-  function scheduleTurnBackfill() {
-    if (turnHandle !== undefined) return
-    if (store.turnStart <= 0) return
-
-    if (window.requestIdleCallback) {
-      turnIdle = true
-      turnHandle = window.requestIdleCallback(() => {
-        turnHandle = undefined
-        backfillTurns()
-      })
-      return
-    }
-
-    turnIdle = false
-    turnHandle = window.setTimeout(() => {
-      turnHandle = undefined
-      backfillTurns()
-    }, 0)
-  }
-
-  function backfillTurns() {
-    const start = store.turnStart
-    if (start <= 0) return
-
-    const next = start - turnBatch
-    const nextStart = next > 0 ? next : 0
-
-    const el = scroller
-    if (!el) {
-      setStore("turnStart", nextStart)
-      scheduleTurnBackfill()
-      return
-    }
-
-    const beforeTop = el.scrollTop
-    const beforeHeight = el.scrollHeight
-
-    setStore("turnStart", nextStart)
-
-    requestAnimationFrame(() => {
-      const delta = el.scrollHeight - beforeHeight
-      if (!delta) return
-      el.scrollTop = beforeTop + delta
-    })
-
-    scheduleTurnBackfill()
+  const revealEarlierTurns = (count = turnBatch) => {
+    if (count <= 0) return
+    setStore("turnStart", (value) => Math.max(0, value - count))
   }
 
   createEffect(
     on(
       () => [params.id, messagesReady()] as const,
       ([id, ready]) => {
-        cancelTurnBackfill()
         setStore("turnStart", 0)
         if (!id || !ready) return
 
         const len = visibleUserMessages().length
         const start = len > turnInit ? len - turnInit : 0
         setStore("turnStart", start)
-        scheduleTurnBackfill()
       },
       { defer: true },
     ),
@@ -1473,7 +1412,6 @@ export default function Page() {
     setPendingMessage: (value) => setUi("pendingMessage", value),
     setActiveMessage,
     setTurnStart: (value) => setStore("turnStart", value),
-    scheduleTurnBackfill,
     autoScroll,
     scroller: () => scroller,
     anchor,
@@ -1538,7 +1476,6 @@ export default function Page() {
   })
 
   onCleanup(() => {
-    cancelTurnBackfill()
     document.removeEventListener("keydown", handleKeyDown)
     scrollSpy.destroy()
     if (scrollStateFrame !== undefined) cancelAnimationFrame(scrollStateFrame)
@@ -1624,14 +1561,17 @@ export default function Page() {
                       if (root) scheduleScrollState(root)
                     }}
                     turnStart={store.turnStart}
-                    onRenderEarlier={() => setStore("turnStart", 0)}
+                    onRenderEarlier={() => revealEarlierTurns()}
                     historyMore={historyMore()}
                     historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
+                    onLoadEarlier={async () => {
                       const id = params.id
                       if (!id) return
-                      setStore("turnStart", 0)
-                      sync.session.history.loadMore(id)
+                      const before = visibleUserMessages().length
+                      await sync.session.history.loadMore(id)
+                      const added = Math.max(0, visibleUserMessages().length - before)
+                      if (added <= 0) return
+                      setStore("turnStart", (value) => value + added)
                     }}
                     renderedUserMessages={renderedUserMessages()}
                     anchor={anchor}

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -19,7 +19,6 @@ export const useSessionHashScroll = (input: {
   setPendingMessage: (value: string | undefined) => void
   setActiveMessage: (message: UserMessage | undefined) => void
   setTurnStart: (value: number) => void
-  scheduleTurnBackfill: () => void
   autoScroll: { pause: () => void; forceScrollToBottom: () => void }
   scroller: () => HTMLDivElement | undefined
   anchor: (id: string) => string
@@ -56,7 +55,6 @@ export const useSessionHashScroll = (input: {
     const index = messageIndex().get(message.id) ?? -1
     if (index !== -1 && index < input.turnStart()) {
       input.setTurnStart(index)
-      input.scheduleTurnBackfill()
 
       requestAnimationFrame(() => {
         const el = document.getElementById(input.anchor(message.id))


### PR DESCRIPTION
## Summary
- Reduce the initial session history fetch size from 400 to 120 messages so long sessions do not eagerly hydrate multi-megabyte payloads.
- Remove automatic idle backfilling of older turns and keep history expansion user-driven, in batches.
- Preserve viewport responsiveness when `Load earlier` fetches more history by keeping newly fetched older turns collapsed behind `Render earlier`.

## Validation
- `bun test --preload ./happydom.ts ./src/pages/session/use-session-hash-scroll.test.ts`
- `bun run typecheck` (in `packages/app`)
- `git push -u fork fix/long-session-windowing` (pre-push hook runs `bun turbo typecheck`)
- Remote reproduction data from `YC Interview Prep: AI Agent Product Strategy Discussion`: `session.messages(limit=400)` payload ~5.5MB; `limit=120` payload ~0.85MB.

## Notes
- The mounted `/w/.../opencode` route requires bearer auth headers on navigation, so browser automation could not directly open that endpoint without a header-injection bridge.