### PR TITLE
docs: add P4OC to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -65,6 +65,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [P4OC](https://github.com/theblazehen/P4OC)                                               | Native Android client for OpenCode                               |
 
 ---
 


### PR DESCRIPTION
Adds [P4OC (Pocket for OpenCode)](https://github.com/theblazehen/P4OC) to the ecosystem Projects table.

Native Android client for OpenCode — chat, manage sessions, browse files, view diffs, embedded terminal. Built with Kotlin + Jetpack Compose.

- [Google Play](https://play.google.com/store/apps/details?id=dev.blazelight.p4oc)
- [Source on GitHub](https://github.com/theblazehen/P4OC)