### PR TITLE
feat: add footer status bar toggle

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -251,6 +251,7 @@ function App() {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
+  const [footerVisible, setFooterVisible] = kv.signal("footer_visible", true)
 
   createEffect(() => {
     console.log(JSON.stringify(route.data))
@@ -550,6 +551,16 @@ function App() {
         dialog.replace(() => <DialogHelp />)
       },
       category: "System",
+    },
+    {
+      title: footerVisible() ? "Hide footer" : "Show footer",
+      value: "footer.toggle",
+      keybind: "footer_toggle",
+      category: "System",
+      onSelect: (dialog) => {
+        setFooterVisible((prev) => !prev)
+        dialog.clear()
+      },
     },
     {
       title: "Open docs",

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -36,6 +36,7 @@ export function Home() {
 
   const isFirstTimeUser = createMemo(() => sync.data.session.length === 0)
   const tipsHidden = createMemo(() => kv.get("tips_hidden", false))
+  const footerVisible = createMemo(() => kv.get("footer_visible", true))
   const showTips = createMemo(() => {
     // Don't show tips for first-time users
     if (isFirstTimeUser()) return false
@@ -117,29 +118,31 @@ export function Home() {
         <box flexGrow={1} minHeight={0} />
         <Toast />
       </box>
-      <box paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2} flexDirection="row" flexShrink={0} gap={2}>
-        <text fg={theme.textMuted}>{directory()}</text>
-        <box gap={1} flexDirection="row" flexShrink={0}>
-          <Show when={mcp()}>
-            <text fg={theme.text}>
-              <Switch>
-                <Match when={mcpError()}>
-                  <span style={{ fg: theme.error }}>⊙ </span>
-                </Match>
-                <Match when={true}>
-                  <span style={{ fg: connectedMcpCount() > 0 ? theme.success : theme.textMuted }}>⊙ </span>
-                </Match>
-              </Switch>
-              {connectedMcpCount()} MCP
-            </text>
-            <text fg={theme.textMuted}>/status</text>
-          </Show>
+      <Show when={footerVisible()}>
+        <box paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2} flexDirection="row" flexShrink={0} gap={2}>
+          <text fg={theme.textMuted}>{directory()}</text>
+          <box gap={1} flexDirection="row" flexShrink={0}>
+            <Show when={mcp()}>
+              <text fg={theme.text}>
+                <Switch>
+                  <Match when={mcpError()}>
+                    <span style={{ fg: theme.error }}>⊙ </span>
+                  </Match>
+                  <Match when={true}>
+                    <span style={{ fg: connectedMcpCount() > 0 ? theme.success : theme.textMuted }}>⊙ </span>
+                  </Match>
+                </Switch>
+                {connectedMcpCount()} MCP
+              </text>
+              <text fg={theme.textMuted}>/status</text>
+            </Show>
+          </box>
+          <box flexGrow={1} />
+          <box flexShrink={0}>
+            <text fg={theme.textMuted}>{Installation.VERSION}</text>
+          </box>
         </box>
-        <box flexGrow={1} />
-        <box flexShrink={0}>
-          <text fg={theme.textMuted}>{Installation.VERSION}</text>
-        </box>
-      </box>
+      </Show>
     </>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -152,6 +152,7 @@ export function Session() {
   const [showHeader, setShowHeader] = kv.signal("header_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
+  const footerVisible = createMemo(() => kv.get("footer_visible", true))
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -1122,6 +1123,9 @@ export function Session() {
                 sessionID={route.sessionID}
               />
             </box>
+          </Show>
+          <Show when={footerVisible()}>
+            <Footer />
           </Show>
           <Toast />
         </box>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -768,6 +768,7 @@ export namespace Config {
       theme_list: z.string().optional().default("<leader>t").describe("List available themes"),
       sidebar_toggle: z.string().optional().default("<leader>b").describe("Toggle sidebar"),
       scrollbar_toggle: z.string().optional().default("none").describe("Toggle session scrollbar"),
+      footer_toggle: z.string().optional().default("none").describe("Toggle footer status bar visibility"),
       username_toggle: z.string().optional().default("none").describe("Toggle username visibility"),
       status_view: z.string().optional().default("<leader>s").describe("View status"),
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -795,6 +795,10 @@ export type KeybindsConfig = {
    */
   scrollbar_toggle?: string
   /**
+   * Toggle footer status bar visibility
+   */
+  footer_toggle?: string
+  /**
    * Toggle username visibility
    */
   username_toggle?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1020,6 +1020,10 @@ export type KeybindsConfig = {
    */
   scrollbar_toggle?: string
   /**
+   * Toggle footer status bar visibility
+   */
+  footer_toggle?: string
+  /**
    * Toggle username visibility
    */
   username_toggle?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8599,6 +8599,11 @@
             "default": "none",
             "type": "string"
           },
+          "footer_toggle": {
+            "description": "Toggle footer status bar visibility",
+            "default": "none",
+            "type": "string"
+          },
           "username_toggle": {
             "description": "Toggle username visibility",
             "default": "none",


### PR DESCRIPTION
### What does this PR do?

Closes #14078

The footer status bar (working directory path, LSP/MCP indicators, version number) is always visible and takes up a line of terminal space. On smaller terminals this matters.

This PR adds a `footer_toggle` keybind so users can show/hide it, following the exact same pattern as the existing `sidebar_toggle`, `scrollbar_toggle`, and `username_toggle`.

**What changed:**

- `config.ts`: new `footer_toggle` keybind, defaults to `none` (no behavior change for existing users)
- `app.tsx`: "Hide footer" / "Show footer" command in the command palette, state persisted via `kv.signal("footer_visible", true)`
- `home.tsx`: wrapped the bottom bar in `<Show when={footerVisible()}>` 
- `session/index.tsx`: wired up the already-imported-but-unused `Footer` component with the same toggle signal
- SDK types + OpenAPI spec: added `footer_toggle` to `KeybindsConfig`

The `Footer` component in `session/footer.tsx` was already imported in `session/index.tsx` but never rendered. This PR puts it to use.

### How did you verify your code works?

1. `turbo typecheck` — all 12 packages pass, zero errors
2. Built standalone binary via `./packages/opencode/script/build.ts --single`, launched it, opened command palette (Ctrl+P), toggled "Hide footer" / "Show footer" — footer hides and shows correctly on both Home and Session views
3. Restarted the app — toggle state persists (stored in kv.json)