### PR TITLE
fix(opencode): prevent resource leaks in serve/web shutdown and SSE stream cleanup

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,6 +2,7 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Instance } from "../../project/instance"
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -14,7 +15,13 @@ export const ServeCommand = cmd({
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    const shutdown = async () => {
+      await Promise.race([Instance.disposeAll(), new Promise((resolve) => setTimeout(resolve, 5000))])
+      server.stop(true)
+      process.exit(0)
+    }
+    process.on("SIGTERM", shutdown)
+    process.on("SIGINT", shutdown)
     await new Promise(() => {})
-    await server.stop()
   },
 })

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -3,6 +3,7 @@ import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Instance } from "../../project/instance"
 import open from "open"
 import { networkInterfaces } from "os"
 
@@ -75,7 +76,13 @@ export const WebCommand = cmd({
       open(displayUrl).catch(() => {})
     }
 
+    const shutdown = async () => {
+      await Promise.race([Instance.disposeAll(), new Promise((resolve) => setTimeout(resolve, 5000))])
+      server.stop(true)
+      process.exit(0)
+    }
+    process.on("SIGTERM", shutdown)
+    process.on("SIGINT", shutdown)
     await new Promise(() => {})
-    await server.stop()
   },
 })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -515,6 +515,8 @@ export namespace Server {
                   data: JSON.stringify(event),
                 })
                 if (event.type === Bus.InstanceDisposed.type) {
+                  clearInterval(heartbeat)
+                  unsub()
                   stream.close()
                 }
               })


### PR DESCRIPTION
### What does this PR do?

Fixes #14091

Two resource cleanup bugs in the `serve`/`web` commands and the SSE event endpoint:

1. **serve.ts and web.ts** — `server.stop()` is dead code (unreachable after `await new Promise(() => {})`), and no signal handlers exist. On SIGTERM/SIGINT, `Instance.disposeAll()` never runs, so MCP subprocesses, LSP servers, and other child resources are orphaned.

2. **server.ts** — The SSE `/event` endpoint puts `clearInterval(heartbeat)` and `unsub()` inside `stream.onAbort()`, which Hono only calls on client disconnect. When the server closes the stream on `InstanceDisposed` via `stream.close()`, cleanup never runs and the interval + subscription leak.

### Changes

**serve.ts and web.ts** — Add signal handlers following the existing pattern from `worker.ts:137-147`:
```typescript
const shutdown = async () => {
  await Promise.race([Instance.disposeAll(), new Promise((resolve) => setTimeout(resolve, 5000))])
  server.stop(true)
  process.exit(0)
}
process.on("SIGTERM", shutdown)
process.on("SIGINT", shutdown)
```

**server.ts** — Add `clearInterval(heartbeat)` and `unsub()` to the `InstanceDisposed` handler before `stream.close()`. Both calls are idempotent, so the existing `onAbort` handler remains as a fallback for normal client disconnects.

### How did you verify your code works?

- Full test suite passes (996 tests, 0 failures)
- Manual: `bun dev serve`, then `kill -TERM <pid>` — process now exits cleanly (exit 0) instead of being killed by signal (exit 143)
- Code review: the shutdown pattern is identical to the existing `worker.ts` implementation that already handles this correctly