### PR TITLE
fix(app): on cancel comment unhighlight lines

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -370,6 +370,12 @@ export function FileTabContent(props: { tab: string }) {
     })
   }
 
+  const cancelCommenting = () => {
+    const p = path()
+    if (p) file.setSelectedLines(p, null)
+    setNote("commenting", null)
+  }
+
   createEffect(
     on(
       () => state()?.loaded,
@@ -483,7 +489,7 @@ export function FileTabContent(props: { tab: string }) {
               value={note.draft}
               selection={formatCommentLabel(range())}
               onInput={(value) => setNote("draft", value)}
-              onCancel={() => setCommenting(null)}
+              onCancel={cancelCommenting}
               onSubmit={(value) => {
                 const p = path()
                 if (!p) return
@@ -497,7 +503,7 @@ export function FileTabContent(props: { tab: string }) {
 
                 setTimeout(() => {
                   if (!document.activeElement || !current.contains(document.activeElement)) {
-                    setCommenting(null)
+                    cancelCommenting()
                   }
                 }, 0)
               }}


### PR DESCRIPTION
### What does this PR do?

When cancelling a comment it will unhighlight the selected lines rather than staying highlighted

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Select some lines from a file and cancel commenting

https://github.com/user-attachments/assets/f59e2152-3d38-4999-92cf-f3f3bb70318d

