### PR TITLE
feat(opencode): add IONOS Cloud AI Model Hub as native provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -589,6 +589,12 @@ export namespace Provider {
         },
       }
     },
+    ionos: async () => {
+      return {
+        autoload: false,
+        options: {},
+      }
+    },
   }
 
   export const Model = z
@@ -780,6 +786,162 @@ export namespace Provider {
     log.info("init")
 
     const configProviders = Object.entries(config.provider ?? {})
+
+    // Add IONOS AI Model Hub provider if not already in models.dev
+    if (!database["ionos"]) {
+      const ionosAPI = {
+        npm: "@ai-sdk/openai-compatible",
+        url: "https://openai.inference.de-txl.ionos.com/v1",
+      }
+      const ionosModels: Record<string, Model> = {
+        "meta-llama/Meta-Llama-3.1-8B-Instruct": {
+          id: "meta-llama/Meta-Llama-3.1-8B-Instruct",
+          providerID: "ionos",
+          name: "Meta Llama 3.1 8B",
+          family: "llama",
+          api: { id: "meta-llama/Meta-Llama-3.1-8B-Instruct", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2024-07-23",
+          variants: {},
+        },
+        "meta-llama/Llama-3.3-70B-Instruct": {
+          id: "meta-llama/Llama-3.3-70B-Instruct",
+          providerID: "ionos",
+          name: "Meta Llama 3.3 70B",
+          family: "llama",
+          api: { id: "meta-llama/Llama-3.3-70B-Instruct", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2024-12-09",
+          variants: {},
+        },
+        "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8": {
+          id: "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8",
+          providerID: "ionos",
+          name: "Meta Llama 3.1 405B",
+          family: "llama",
+          api: { id: "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2024-07-23",
+          variants: {},
+        },
+        "mistralai/Mistral-Nemo-Instruct-2407": {
+          id: "mistralai/Mistral-Nemo-Instruct-2407",
+          providerID: "ionos",
+          name: "Mistral Nemo 12B",
+          family: "mistral",
+          api: { id: "mistralai/Mistral-Nemo-Instruct-2407", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2024-07-18",
+          variants: {},
+        },
+        "mistralai/Mistral-Small-24B-Instruct": {
+          id: "mistralai/Mistral-Small-24B-Instruct",
+          providerID: "ionos",
+          name: "Mistral Small 24B",
+          family: "mistral",
+          api: { id: "mistralai/Mistral-Small-24B-Instruct", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: true, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2025-06-25",
+          variants: {},
+        },
+        "openGPT-X/Teuken-7B-instruct-commercial": {
+          id: "openGPT-X/Teuken-7B-instruct-commercial",
+          providerID: "ionos",
+          name: "openGPT-X Teuken 7B",
+          family: "teuken",
+          api: { id: "openGPT-X/Teuken-7B-instruct-commercial", ...ionosAPI },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 8000, output: 4096 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: false,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "2024-11-26",
+          variants: {},
+        },
+      }
+      database["ionos"] = {
+        id: "ionos",
+        name: "IONOS AI Model Hub",
+        source: "custom",
+        env: ["IONOS_API_TOKEN"],
+        options: {},
+        models: ionosModels,
+      }
+    }
 
     // Add GitHub Copilot Enterprise provider that inherits from GitHub Copilot
     if (database["github-copilot"]) {

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1511,6 +1511,39 @@ STACKIT AI Model Serving provides fully managed soverign hosting environment for
 
 ---
 
+### IONOS AI Model Hub
+
+IONOS AI Model Hub is a fully managed, serverless inference platform hosted in Germany, providing access to LLMs like Llama, Mistral, and openGPT-X Teuken with EU data sovereignty guarantees.
+
+1. Head over to the [IONOS Cloud Console](https://dcd.ionos.com), navigate to **Access Management**, and generate an API token.
+
+   :::tip
+   You need an IONOS Cloud account before generating API tokens.
+   :::
+
+2. Run the `/connect` command and search for **IONOS**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your IONOS API token.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select from available models like _Llama 3.3 70B_ or _Mistral Small 24B_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### OVHcloud AI Endpoints
 
 1. Head over to the [OVHcloud panel](https://ovh.com/manager). Navigate to the `Public Cloud` section, `AI & Machine Learning` > `AI Endpoints` and in `API Keys` tab, click **Create a new API key**.

--- a/packages/web/src/content/docs/zh-cn/providers.mdx
+++ b/packages/web/src/content/docs/zh-cn/providers.mdx
@@ -1497,6 +1497,39 @@ STACKIT AI Model Serving 提供完全托管的主权托管环境，专注于 Lla
 
 ---
 
+### IONOS AI Model Hub
+
+IONOS AI Model Hub 是一个完全托管的无服务器推理平台，托管于德国，提供 Llama、Mistral 和 openGPT-X Teuken 等大语言模型的访问，并保障欧盟数据主权。
+
+1. 前往 [IONOS Cloud 控制台](https://dcd.ionos.com)，导航到 **Access Management**，并生成 API 令牌。
+
+   :::tip
+   你需要先拥有 IONOS Cloud 账号才能生成 API 令牌。
+   :::
+
+2. 执行 `/connect` 命令并搜索 **IONOS**。
+
+   ```txt
+   /connect
+   ```
+
+3. 输入你的 IONOS API 令牌。
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. 执行 `/models` 命令，从可用模型中选择，例如 _Llama 3.3 70B_ 或 _Mistral Small 24B_。
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### OVHcloud AI Endpoints
 
 1. 前往 [OVHcloud 管理面板](https://ovh.com/manager)。导航到 `Public Cloud` 部分，`AI & Machine Learning` > `AI Endpoints`，在 `API Keys` 标签页中点击 **Create a new API key**。

--- a/packages/web/src/content/docs/zh-tw/providers.mdx
+++ b/packages/web/src/content/docs/zh-tw/providers.mdx
@@ -1497,6 +1497,39 @@ STACKIT AI Model Serving 提供完全託管的主權託管環境，專注於 Lla
 
 ---
 
+### IONOS AI Model Hub
+
+IONOS AI Model Hub 是一個完全託管的無伺服器推論平台，託管於德國，提供 Llama、Mistral 和 openGPT-X Teuken 等大語言模型的存取，並保障歐盟資料主權。
+
+1. 前往 [IONOS Cloud 控制台](https://dcd.ionos.com)，導覽到 **Access Management**，並產生 API 權杖。
+
+   :::tip
+   您需要先擁有 IONOS Cloud 帳號才能產生 API 權杖。
+   :::
+
+2. 執行 `/connect` 指令並搜尋 **IONOS**。
+
+   ```txt
+   /connect
+   ```
+
+3. 輸入您的 IONOS API 權杖。
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. 執行 `/models` 指令，從可用模型中選擇，例如 _Llama 3.3 70B_ 或 _Mistral Small 24B_。
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### OVHcloud AI Endpoints
 
 1. 前往 [OVHcloud 管理面板](https://ovh.com/manager)。導覽到 `Public Cloud` 部分，`AI & Machine Learning` > `AI Endpoints`，在 `API Keys` 分頁中點擊 **Create a new API key**。


### PR DESCRIPTION
## Summary

- Adds IONOS Cloud AI Model Hub as a native provider with 6 LLM models
- Uses existing `@ai-sdk/openai-compatible` package — zero new dependencies
- EU-hosted (Germany) serverless inference with OpenAI-compatible API
- Adds provider documentation in English, zh-tw, and zh-cn

Fixes #14102

## Changes

**`packages/opencode/src/provider/provider.ts`**
- Injects IONOS provider into the model database (6 models: Llama 3.1 8B/405B, Llama 3.3 70B, Mistral Nemo 12B, Mistral Small 24B, Teuken 7B)
- Adds `ionos` custom loader with `autoload: false` (only appears when `IONOS_API_TOKEN` is set)

**`packages/web/src/content/docs/providers.mdx`** + zh-tw + zh-cn
- Adds IONOS setup instructions to provider docs

## Test plan

- [x] `bun typecheck` passes (12/12 packages)
- [x] `./script/format.ts` clean
- [x] All 996 tests pass (`cd packages/opencode && bun test`)
- [x] IONOS API verified via curl with real token
