### PR TITLE
refactor: migrate src/cli/cmd/tui/thread.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -3,10 +3,12 @@ import { tui } from "./app"
 import { Rpc } from "@/util/rpc"
 import { type rpc } from "./worker"
 import path from "path"
+import { fileURLToPath } from "url"
 import { UI } from "@/cli/ui"
 import { iife } from "@/util/iife"
 import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
+import { Filesystem } from "@/util/filesystem"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
@@ -99,7 +101,7 @@ export const TuiThreadCommand = cmd({
       const distWorker = new URL("./cli/cmd/tui/worker.js", import.meta.url)
       const workerPath = await iife(async () => {
         if (typeof OPENCODE_WORKER_PATH !== "undefined") return OPENCODE_WORKER_PATH
-        if (await Bun.file(distWorker).exists()) return distWorker
+        if (await Filesystem.exists(fileURLToPath(distWorker))) return distWorker
         return localWorker
       })
       try {


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/tui/thread.ts` from Bun-specific file APIs to the Filesystem utility module for better compatibility.

## Changes

- Added `Filesystem` import from `@/util/filesystem`
- Added `fileURLToPath` import from `url`
- Replaced `Bun.file(distWorker).exists()` with `Filesystem.exists(fileURLToPath(distWorker))`

## Testing

All 58 CLI tests pass.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.