### PR TITLE
refactor: migrate src/util/log.ts from Bun.file() to Node.js fs module

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs/promises"
+import { createWriteStream } from "fs"
 import { Global } from "../global"
 import z from "zod"
 
@@ -63,13 +64,15 @@ export namespace Log {
       Global.Path.log,
       options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
     )
-    const logfile = Bun.file(logpath)
     await fs.truncate(logpath).catch(() => {})
-    const writer = logfile.writer()
+    const stream = createWriteStream(logpath, { flags: "a" })
     write = async (msg: any) => {
-      const num = writer.write(msg)
-      writer.flush()
-      return num
+      return new Promise((resolve, reject) => {
+        stream.write(msg, (err) => {
+          if (err) reject(err)
+          else resolve(msg.length)
+        })
+      })
     }
   }
 


### PR DESCRIPTION
## Summary

Migrate `src/util/log.ts` from Bun-specific file writer API to Node.js fs module for better compatibility.

## Changes

- Added `createWriteStream` import from `fs` module
- Replaced `Bun.file().writer()` with `createWriteStream()` for log file writing
- Updated write function to use stream-based writing

## Testing

All 53 util tests pass.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.