### PR TITLE
refactor: migrate src/lsp/client.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -147,8 +147,7 @@ export namespace LSPClient {
       notify: {
         async open(input: { path: string }) {
           input.path = path.isAbsolute(input.path) ? input.path : path.resolve(Instance.directory, input.path)
-          const file = Bun.file(input.path)
-          const text = await file.text()
+          const text = await Filesystem.readText(input.path)
           const extension = path.extname(input.path)
           const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
 


### PR DESCRIPTION
## Summary

Migrate `src/lsp/client.ts` from Bun-specific file APIs to the Filesystem utility module for better compatibility.

## Changes

- Replaced `Bun.file().text()` with existing `Filesystem.readText()`

## Testing

All 3 lsp tests pass.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.