### PR TITLE
refactor: migrate src/acp/agent.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -30,6 +30,7 @@ import {
 
 import { Log } from "../util/log"
 import { pathToFileURL } from "bun"
+import { Filesystem } from "../util/filesystem"
 import { ACPSessionManager } from "./session"
 import type { ACPConfig } from "./types"
 import { Provider } from "../provider/provider"
@@ -228,8 +229,7 @@ export namespace ACP {
                 const metadata = permission.metadata || {}
                 const filepath = typeof metadata["filepath"] === "string" ? metadata["filepath"] : ""
                 const diff = typeof metadata["diff"] === "string" ? metadata["diff"] : ""
-                const file = Bun.file(filepath)
-                const content = (await file.exists()) ? await file.text() : ""
+                const content = (await Filesystem.exists(filepath)) ? await Filesystem.readText(filepath) : ""
                 const newContent = getNewContent(content, diff)
 
                 if (newContent) {


### PR DESCRIPTION
## Summary

Migrate `src/acp/agent.ts` from Bun-specific file APIs to the Filesystem utility module for better compatibility.

## Changes

- Added `Filesystem` import from `../util/filesystem`
- Replaced `Bun.file().exists()` and `Bun.file().text()` with `Filesystem.exists()` and `Filesystem.readText()`

## Testing

All 6 acp tests pass.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.