### PR TITLE
refactor: migrate src/auth/index.ts from Bun.file()/Bun.write() to Filesystem module

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { Global } from "../global"
 import z from "zod"
+import { Filesystem } from "../util/filesystem"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -42,8 +43,7 @@ export namespace Auth {
   }
 
   export async function all(): Promise<Record<string, Info>> {
-    const file = Bun.file(filepath)
-    const data = await file.json().catch(() => ({}) as Record<string, unknown>)
+    const data = await Filesystem.readJson<Record<string, unknown>>(filepath).catch(() => ({}))
     return Object.entries(data).reduce(
       (acc, [key, value]) => {
         const parsed = Info.safeParse(value)
@@ -56,15 +56,13 @@ export namespace Auth {
   }
 
   export async function set(key: string, info: Info) {
-    const file = Bun.file(filepath)
     const data = await all()
-    await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2), { mode: 0o600 })
+    await Filesystem.writeJson(filepath, { ...data, [key]: info }, 0o600)
   }
 
   export async function remove(key: string) {
-    const file = Bun.file(filepath)
     const data = await all()
     delete data[key]
-    await Bun.write(file, JSON.stringify(data, null, 2), { mode: 0o600 })
+    await Filesystem.writeJson(filepath, data, 0o600)
   }
 }


### PR DESCRIPTION
## Summary

Migrate `src/auth/index.ts` from Bun-specific file APIs to the Filesystem utility module for better compatibility.

## Changes

- Added `Filesystem` import from `../util/filesystem`
- Replaced `Bun.file().json()` with `Filesystem.readJson<T>()`
- Replaced `Bun.write()` with `Filesystem.writeJson()` with mode 0o600

## Testing

Typecheck passes.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.