### PR TITLE
refactor: migrate src/global/index.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import { xdgData, xdgCache, xdgConfig, xdgState } from "xdg-basedir"
 import path from "path"
 import os from "os"
+import { Filesystem } from "../util/filesystem"
 
 const app = "opencode"
 
@@ -35,9 +36,7 @@ await Promise.all([
 
 const CACHE_VERSION = "21"
 
-const version = await Bun.file(path.join(Global.Path.cache, "version"))
-  .text()
-  .catch(() => "0")
+const version = await Filesystem.readText(path.join(Global.Path.cache, "version")).catch(() => "0")
 
 if (version !== CACHE_VERSION) {
   try {
@@ -51,5 +50,5 @@ if (version !== CACHE_VERSION) {
       ),
     )
   } catch (e) {}
-  await Bun.file(path.join(Global.Path.cache, "version")).write(CACHE_VERSION)
+  await Filesystem.write(path.join(Global.Path.cache, "version"), CACHE_VERSION)
 }


### PR DESCRIPTION
## Summary

Migrate `src/global/index.ts` from Bun-specific file APIs to the Filesystem utility module for better compatibility.

## Changes

- Added `Filesystem` import from `../util/filesystem`
- Replaced `Bun.file().text()` with `Filesystem.readText()`
- Replaced `Bun.file().write()` with `Filesystem.write()`

## Testing

Typecheck passes.

## Related

Part of the Bun.file() migration effort tracked in MIGRATION.md.