### PR TITLE
refactor: migrate clipboard.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -4,6 +4,7 @@ import clipboardy from "clipboardy"
 import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"
 import path from "path"
+import { Filesystem } from "../../../../util/filesystem"
 
 /**
  * Writes text to clipboard via OSC 52 escape sequence.
@@ -34,9 +35,8 @@ export namespace Clipboard {
         await $`osascript -e 'set imageData to the clipboard as "PNGf"' -e 'set fileRef to open for access POSIX file "${tmpfile}" with write permission' -e 'set eof fileRef to 0' -e 'write imageData to fileRef' -e 'close access fileRef'`
           .nothrow()
           .quiet()
-        const file = Bun.file(tmpfile)
-        const buffer = await file.arrayBuffer()
-        return { data: Buffer.from(buffer).toString("base64"), mime: "image/png" }
+        const buffer = await Filesystem.readBytes(tmpfile)
+        return { data: buffer.toString("base64"), mime: "image/png" }
       } catch {
       } finally {
         await $`rm -f "${tmpfile}"`.nothrow().quiet()


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/tui/util/clipboard.ts` from Bun-specific file APIs to the Filesystem utility module.

## Changes

- Added `Filesystem` import
- Replaced `Bun.file().arrayBuffer()` with `Filesystem.readBytes()`

## Related

Part of the Bun.file() migration effort.