### PR TITLE
refactor: migrate editor.ts from Bun.file()/Bun.write() to Filesystem module

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -3,6 +3,7 @@ import { rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { CliRenderer } from "@opentui/core"
+import { Filesystem } from "@/util/filesystem"
 
 export namespace Editor {
   export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
@@ -12,7 +13,7 @@ export namespace Editor {
     const filepath = join(tmpdir(), `${Date.now()}.md`)
     await using _ = defer(async () => rm(filepath, { force: true }))
 
-    await Bun.write(filepath, opts.value)
+    await Filesystem.write(filepath, opts.value)
     opts.renderer.suspend()
     opts.renderer.currentRenderBuffer.clear()
     const parts = editor.split(" ")
@@ -23,7 +24,7 @@ export namespace Editor {
       stderr: "inherit",
     })
     await proc.exited
-    const content = await Bun.file(filepath).text()
+    const content = await Filesystem.readText(filepath)
     opts.renderer.currentRenderBuffer.clear()
     opts.renderer.resume()
     opts.renderer.requestRender()


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/tui/util/editor.ts` from Bun-specific file APIs to the Filesystem utility module.

## Changes

- Added `Filesystem` import
- Replaced `Bun.write()` with `Filesystem.write()`
- Replaced `Bun.file().text()` with `Filesystem.readText()`

## Related

Part of the Bun.file() migration effort.