### PR TITLE
refactor: migrate uninstall.ts from Bun.file()/Bun.write() to Filesystem module

### DIFF
--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -7,6 +7,7 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import os from "os"
+import { Filesystem } from "../../util/filesystem"
 
 interface UninstallArgs {
   keepConfig: boolean
@@ -267,9 +268,7 @@ async function getShellConfigFile(): Promise<string | null> {
       .catch(() => false)
     if (!exists) continue
 
-    const content = await Bun.file(file)
-      .text()
-      .catch(() => "")
+    const content = await Filesystem.readText(file).catch(() => "")
     if (content.includes("# opencode") || content.includes(".opencode/bin")) {
       return file
     }
@@ -279,7 +278,7 @@ async function getShellConfigFile(): Promise<string | null> {
 }
 
 async function cleanShellConfig(file: string) {
-  const content = await Bun.file(file).text()
+  const content = await Filesystem.readText(file)
   const lines = content.split("\n")
 
   const filtered: string[] = []
@@ -315,7 +314,7 @@ async function cleanShellConfig(file: string) {
   }
 
   const output = filtered.join("\n") + "\n"
-  await Bun.write(file, output)
+  await Filesystem.write(file, output)
 }
 
 async function getDirectorySize(dir: string): Promise<number> {


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/uninstall.ts` from Bun-specific file APIs to the Filesystem utility module.

## Changes

- Added `Filesystem` import
- Replaced `Bun.file().text()` with `Filesystem.readText()`
- Replaced `Bun.write()` with `Filesystem.write()`

## Related

Part of the Bun.file() migration effort.