### PR TITLE
refactor: migrate cli/cmd/github.ts from Bun.write() to Filesystem module

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { exec } from "child_process"
+import { Filesystem } from "../../util/filesystem"
 import * as prompts from "@clack/prompts"
 import { map, pipe, sortBy, values } from "remeda"
 import { Octokit } from "@octokit/rest"
@@ -360,7 +361,7 @@ export const GithubInstallCommand = cmd({
                 ? ""
                 : `\n        env:${providers[provider].env.map((e) => `\n          ${e}: \${{ secrets.${e} }}`).join("")}`
 
-            await Bun.write(
+            await Filesystem.write(
               path.join(app.root, WORKFLOW_FILE),
               `name: opencode
 


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/github.ts` from Bun-specific file APIs to the Filesystem utility module.

## Changes

- Added `Filesystem` import
- Replaced `Bun.write()` with `Filesystem.write()`

## Related

Part of the Bun.file() migration effort.