### PR TITLE
refactor: migrate cli/cmd/run.ts from Bun.file() to Filesystem/stat modules

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { exec } from "child_process"
+import { Filesystem } from "../../util/filesystem"
 import * as prompts from "@clack/prompts"
 import { map, pipe, sortBy, values } from "remeda"
 import { Octokit } from "@octokit/rest"
@@ -360,7 +361,7 @@ export const GithubInstallCommand = cmd({
                 ? ""
                 : `\n        env:${providers[provider].env.map((e) => `\n          ${e}: \${{ secrets.${e} }}`).join("")}`
 
-            await Bun.write(
+            await Filesystem.write(
               path.join(app.root, WORKFLOW_FILE),
               `name: opencode
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -6,6 +6,8 @@ import { cmd } from "./cmd"
 import { Flag } from "../../flag/flag"
 import { bootstrap } from "../bootstrap"
 import { EOL } from "os"
+import { Filesystem } from "../../util/filesystem"
+import { stat } from "fs/promises"
 import { createOpencodeClient, type Message, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Server } from "../../server/server"
 import { Provider } from "../../provider/provider"
@@ -315,19 +317,13 @@ export const RunCommand = cmd({
 
       for (const filePath of list) {
         const resolvedPath = path.resolve(process.cwd(), filePath)
-        const file = Bun.file(resolvedPath)
-        const stats = await file.stat().catch(() => {})
-        if (!stats) {
-          UI.error(`File not found: ${filePath}`)
-          process.exit(1)
-        }
-        if (!(await file.exists())) {
+        if (!(await Filesystem.exists(resolvedPath))) {
           UI.error(`File not found: ${filePath}`)
           process.exit(1)
         }
 
-        const stat = await file.stat()
-        const mime = stat.isDirectory() ? "application/x-directory" : "text/plain"
+        const s = await stat(resolvedPath)
+        const mime = s.isDirectory() ? "application/x-directory" : "text/plain"
 
         files.push({
           type: "file",

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -321,8 +321,7 @@ export const RunCommand = cmd({
           process.exit(1)
         }
 
-        const isDir = await Filesystem.isDir(resolvedPath)
-        const mime = isDir ? "application/x-directory" : "text/plain"
+        const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
 
         files.push({
           type: "file",

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -7,7 +7,6 @@ import { Flag } from "../../flag/flag"
 import { bootstrap } from "../bootstrap"
 import { EOL } from "os"
 import { Filesystem } from "../../util/filesystem"
-import { stat } from "fs/promises"
 import { createOpencodeClient, type Message, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { Server } from "../../server/server"
 import { Provider } from "../../provider/provider"
@@ -322,8 +321,8 @@ export const RunCommand = cmd({
           process.exit(1)
         }
 
-        const s = await stat(resolvedPath)
-        const mime = s.isDirectory() ? "application/x-directory" : "text/plain"
+        const isDir = await Filesystem.isDir(resolvedPath)
+        const mime = isDir ? "application/x-directory" : "text/plain"
 
         files.push({
           type: "file",


### PR DESCRIPTION
## Summary

Migrate `src/cli/cmd/run.ts` from Bun-specific file APIs to the Filesystem utility module and Node.js fs/promises.

## Changes

- Added `Filesystem` import from `../../util/filesystem`
- Added `stat` import from `fs/promises`
- Replaced `Bun.file().exists()` with `Filesystem.exists()`
- Replaced `Bun.file().stat()` with `stat()` from fs/promises

## Related

Part of the Bun.file() migration effort.