### PR TITLE
feat(desktop): clear terminal with meta k

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -362,6 +362,13 @@ export const Terminal = (props: TerminalProps) => {
           return true
         }
 
+        if (event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === "k") {
+          event.preventDefault()
+          event.stopPropagation()
+          t.clear()
+          return true
+        }
+
         // allow for toggle terminal keybinds in parent
         const config = settings.keybinds.get(TOGGLE_TERMINAL_ID) ?? DEFAULT_TOGGLE_TERMINAL_KEYBIND
         const keybinds = parseKeybind(config)

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -365,7 +365,7 @@ export const Terminal = (props: TerminalProps) => {
         if (event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && key === "k") {
           event.preventDefault()
           event.stopPropagation()
-          t.clear()
+          if (ws?.readyState === WebSocket.OPEN) ws.send("\f")
           return true
         }
 


### PR DESCRIPTION
### What does this PR do?

Implements #14161

Tried the desktop app and noticed that the `meta+k` key does not clear the terminal output as (imo) expected.

I implemented this by sending the `\f` command to the pty which clears the terminal and draws the shell prompt (`t.clear` does not redraw the shell prompt, that's why it's not used).

### How did you verify your code works?

I ran the desktop app locally and tested the changes. When the output is cleared in the video I press cmd+k.

I only have a mac so I could only test on that, but according to my research (gpt-5.2) this should be fairly cross platform compatible as most shell environments interpret `\f` as clear+draw shell prompt.


https://github.com/user-attachments/assets/e59cfbd4-56a3-4b99-b1ab-de26141757c7

