### PR TITLE
refactor: migrate index.ts from Bun.file() to Filesystem module

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -13,6 +13,7 @@ import { Installation } from "./installation"
 import { NamedError } from "@opencode-ai/util/error"
 import { FormatError } from "./cli/error"
 import { ServeCommand } from "./cli/cmd/serve"
+import { Filesystem } from "./util/filesystem"
 import { DebugCommand } from "./cli/cmd/debug"
 import { StatsCommand } from "./cli/cmd/stats"
 import { McpCommand } from "./cli/cmd/mcp"
@@ -81,7 +82,7 @@ const cli = yargs(hideBin(process.argv))
     })
 
     const marker = path.join(Global.Path.data, "opencode.db")
-    if (!(await Bun.file(marker).exists())) {
+    if (!(await Filesystem.exists(marker))) {
       const tty = process.stderr.isTTY
       process.stderr.write("Performing one time database migration, may take a few minutes..." + EOL)
       const width = 36


### PR DESCRIPTION
## Summary

Migrate `src/index.ts` from Bun-specific file APIs to the Filesystem utility module.

## Changes

- Added `Filesystem` import from `./util/filesystem`
- Replaced `Bun.file().exists()` with `Filesystem.exists()`

## Related

Part of the Bun.file() migration effort.