### PR TITLE
fix(cli): session list --max-count not honored, shows too few sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -85,26 +85,17 @@ export const SessionListCommand = cmd({
   },
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
-      const sessions = []
-      for await (const session of Session.list()) {
-        if (!session.parentID) {
-          sessions.push(session)
-        }
-      }
+      const sessions = [...Session.list({ roots: true, limit: args.maxCount })]
 
-      sessions.sort((a, b) => b.time.updated - a.time.updated)
-
-      const limitedSessions = args.maxCount ? sessions.slice(0, args.maxCount) : sessions
-
-      if (limitedSessions.length === 0) {
+      if (sessions.length === 0) {
         return
       }
 
       let output: string
       if (args.format === "json") {
-        output = formatSessionJSON(limitedSessions)
+        output = formatSessionJSON(sessions)
       } else {
-        output = formatSessionTable(limitedSessions)
+        output = formatSessionTable(sessions)
       }
 
       const shouldPaginate = process.stdout.isTTY && !args.maxCount && args.format === "table"


### PR DESCRIPTION
Fixes #14163

## Summary

`opencode session list` shows far fewer sessions than expected and `--max-count` has no effect for values above ~24.

**Root cause:** The CLI handler calls `Session.list()` with no arguments, so the DB query applies `LIMIT 100` (the default). It then filters out child/delegation sessions in JS, and only after that applies `--max-count` via `Array.slice()`. Since many of the 100 rows are child sessions, the user sees far fewer root sessions than exist — and passing `-n 1000` can never return more than the ~24 that survive the JS filter.

**Fix:** Pass `roots: true` and `limit: args.maxCount` to `Session.list()`, matching what the server HTTP API already does. This moves both the parent filter (`WHERE parent_id IS NULL`) and the limit into the SQL query where they belong. The redundant in-memory sort is also removed since `Session.list()` already returns results ordered by `time_updated DESC`.

Related: #13877 (same root cause affecting TUI `/sessions` picker)

(FYI I am a human being that experienced this bug and wanted a fix. Obviously I prompted an LLM on what to do, etc, but just making clear this fix was the idea of a human being. Love the project)