### PR TITLE
fix(github): emit PROMPT_TOO_LARGE error on context overflow

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -175,11 +175,12 @@ export function extractResponseText(parts: MessageV2.Part[]): string | null {
 
 /**
  * Formats a PROMPT_TOO_LARGE error message with details about files in the prompt.
+ * Content is base64 encoded, so we calculate original size by multiplying by 0.75.
  */
 export function formatPromptTooLargeError(files: { filename: string; content: string }[]): string {
   const fileDetails =
     files.length > 0
-      ? `\n\nFiles in prompt:\n${files.map((f) => `  - ${f.filename} (${(f.content.length / 1024).toFixed(0)} KB)`).join("\n")}`
+      ? `\n\nFiles in prompt:\n${files.map((f) => `  - ${f.filename} (${((f.content.length * 0.75) / 1024).toFixed(0)} KB)`).join("\n")}`
       : ""
   return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
 }

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -173,6 +173,17 @@ export function extractResponseText(parts: MessageV2.Part[]): string | null {
   throw new Error("Failed to parse response: no parts returned")
 }
 
+/**
+ * Formats a PROMPT_TOO_LARGE error message with details about files in the prompt.
+ */
+export function formatPromptTooLargeError(files: { filename: string; content: string }[]): string {
+  const fileDetails =
+    files.length > 0
+      ? `\n\nFiles in prompt:\n${files.map((f) => `  - ${f.filename} (${(f.content.length / 1024).toFixed(0)} KB)`).join("\n")}`
+      : ""
+  return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
+}
+
 export const GithubCommand = cmd({
   command: "github",
   describe: "manage GitHub agent",
@@ -802,6 +813,7 @@ export const GithubRunCommand = cmd({
             replacement,
           })
         }
+
         return { userPrompt: prompt, promptFiles: imgData }
       }
 
@@ -909,10 +921,15 @@ export const GithubRunCommand = cmd({
 
         // result should always be assistant just satisfying type checker
         if (result.info.role === "assistant" && result.info.error) {
-          console.error("Agent error:", result.info.error)
-          throw new Error(
-            `${result.info.error.name}: ${"message" in result.info.error ? result.info.error.message : ""}`,
-          )
+          const err = result.info.error
+          console.error("Agent error:", err)
+
+          if (err.name === "ContextOverflowError") {
+            throw new Error(formatPromptTooLargeError(files))
+          }
+
+          const errorMsg = err.data?.message || ""
+          throw new Error(`${err.name}: ${errorMsg}`)
         }
 
         const text = extractResponseText(result.parts)
@@ -938,10 +955,15 @@ export const GithubRunCommand = cmd({
         })
 
         if (summary.info.role === "assistant" && summary.info.error) {
-          console.error("Summary agent error:", summary.info.error)
-          throw new Error(
-            `${summary.info.error.name}: ${"message" in summary.info.error ? summary.info.error.message : ""}`,
-          )
+          const err = summary.info.error
+          console.error("Summary agent error:", err)
+
+          if (err.name === "ContextOverflowError") {
+            throw new Error(formatPromptTooLargeError(files))
+          }
+
+          const errorMsg = err.data?.message || ""
+          throw new Error(`${err.name}: ${errorMsg}`)
         }
 
         const summaryText = extractResponseText(summary.parts)

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -166,20 +166,23 @@ describe("formatPromptTooLargeError", () => {
     expect(result).toBe("PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.")
   })
 
-  test("formats error with files", () => {
+  test("formats error with files (base64 content)", () => {
+    // Base64 is ~33% larger than original, so we multiply by 0.75 to get original size
+    // 400 KB base64 = 300 KB original, 200 KB base64 = 150 KB original
     const files = [
-      { filename: "screenshot.png", content: "a".repeat(400 * 1024) }, // 400 KB
-      { filename: "diagram.png", content: "b".repeat(200 * 1024) }, // 200 KB
+      { filename: "screenshot.png", content: "a".repeat(400 * 1024) },
+      { filename: "diagram.png", content: "b".repeat(200 * 1024) },
     ]
     const result = formatPromptTooLargeError(files)
 
     expect(result).toStartWith("PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.")
     expect(result).toInclude("Files in prompt:")
-    expect(result).toInclude("screenshot.png (400 KB)")
-    expect(result).toInclude("diagram.png (200 KB)")
+    expect(result).toInclude("screenshot.png (300 KB)")
+    expect(result).toInclude("diagram.png (150 KB)")
   })
 
   test("lists all files when multiple present", () => {
+    // Base64 sizes: 4KB -> 3KB, 8KB -> 6KB, 12KB -> 9KB
     const files = [
       { filename: "img1.png", content: "x".repeat(4 * 1024) },
       { filename: "img2.jpg", content: "y".repeat(8 * 1024) },
@@ -187,8 +190,8 @@ describe("formatPromptTooLargeError", () => {
     ]
     const result = formatPromptTooLargeError(files)
 
-    expect(result).toInclude("img1.png (4 KB)")
-    expect(result).toInclude("img2.jpg (8 KB)")
-    expect(result).toInclude("img3.gif (12 KB)")
+    expect(result).toInclude("img1.png (3 KB)")
+    expect(result).toInclude("img2.jpg (6 KB)")
+    expect(result).toInclude("img3.gif (9 KB)")
   })
 })

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractResponseText } from "../../src/cli/cmd/github"
+import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 
 // Helper to create minimal valid parts
@@ -157,5 +157,38 @@ describe("extractResponseText", () => {
   test("prefers text over tools when both present", () => {
     const parts = [createToolPart("read", "src/file.ts"), createTextPart("Here's what I found")]
     expect(extractResponseText(parts)).toBe("Here's what I found")
+  })
+})
+
+describe("formatPromptTooLargeError", () => {
+  test("formats error without files", () => {
+    const result = formatPromptTooLargeError([])
+    expect(result).toBe("PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.")
+  })
+
+  test("formats error with files", () => {
+    const files = [
+      { filename: "screenshot.png", content: "a".repeat(400 * 1024) }, // 400 KB
+      { filename: "diagram.png", content: "b".repeat(200 * 1024) }, // 200 KB
+    ]
+    const result = formatPromptTooLargeError(files)
+
+    expect(result).toStartWith("PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.")
+    expect(result).toInclude("Files in prompt:")
+    expect(result).toInclude("screenshot.png (400 KB)")
+    expect(result).toInclude("diagram.png (200 KB)")
+  })
+
+  test("lists all files when multiple present", () => {
+    const files = [
+      { filename: "img1.png", content: "x".repeat(4 * 1024) },
+      { filename: "img2.jpg", content: "y".repeat(8 * 1024) },
+      { filename: "img3.gif", content: "z".repeat(12 * 1024) },
+    ]
+    const result = formatPromptTooLargeError(files)
+
+    expect(result).toInclude("img1.png (4 KB)")
+    expect(result).toInclude("img2.jpg (8 KB)")
+    expect(result).toInclude("img3.gif (12 KB)")
   })
 })


### PR DESCRIPTION
Adds clear error handling when prompts with large images exceed the model's context limit.

When the GitHub Action failed due to context overflow (e.g. comments with several large images), the error message was unclear - often just `UnknownError:` with no actionable information.

Failing workflow: https://github.com/cloudflare/kumo/actions/runs/22146051799/job/64023564804

- catch `ContextOverflowError` and transform to `PROMPT_TOO_LARGE` with file details
- fix dead fallback code in error message extraction (`err.data?.message` is the correct path for serialized NamedErrors)
- apply consistent error handling to both primary chat and summary chat paths

Error output now shows:
```
PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.

Files in prompt:
  - screenshot1.png (400 KB)
  - screenshot2.png (600 KB)
```

Tests added for `formatPromptTooLargeError`.