### PR TITLE
feat(cmd): Allow line ranges in `opencode run` file attachments

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -28,6 +28,26 @@ import { ShellID } from "../../tool/shell/id"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "@/util/locale"
 
+function extractFileLineRange(input: string) {
+  const colonIndex = input.lastIndexOf(":")
+  if (colonIndex === -1) return { filePath: input }
+
+  const potentialPath = input.substring(0, colonIndex)
+  const linePart = input.substring(colonIndex + 1)
+  const lineMatch = linePart.match(/^(\d+)(?:-(\d*))?$/)
+
+  if (!lineMatch) return { filePath: input }
+
+  const startLine = Number(lineMatch[1])
+  const endLine = lineMatch[2] && startLine < Number(lineMatch[2]) ? Number(lineMatch[2]) : undefined
+
+  return {
+    filePath: potentialPath,
+    startLine,
+    endLine,
+  }
+}
+
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
   metadata: Tool.InferMetadata<T>
@@ -327,7 +347,11 @@ export const RunCommand = effectCmd({
         const list = Array.isArray(args.file) ? args.file : [args.file]
 
         for (const filePath of list) {
-          const resolvedPath = path.resolve(process.cwd(), filePath)
+          const givenPath = path.resolve(process.cwd(), filePath)
+          const givenExists = await Filesystem.exists(givenPath)
+          const extracted = givenExists ? undefined : extractFileLineRange(filePath)
+          const resolvedPath = extracted ? path.resolve(process.cwd(), extracted.filePath) : givenPath
+
           if (!(await Filesystem.exists(resolvedPath))) {
             UI.error(`File not found: ${filePath}`)
             process.exit(1)
@@ -335,14 +359,22 @@ export const RunCommand = effectCmd({
 
           const mime = (await Filesystem.isDir(resolvedPath)) ? "application/x-directory" : "text/plain"
 
+          const urlObj = pathToFileURL(resolvedPath)
+          if (extracted?.startLine !== undefined) {
+            urlObj.searchParams.set("start", String(extracted.startLine))
+            if (extracted.endLine !== undefined) urlObj.searchParams.set("end", String(extracted.endLine))
+          }
+
           files.push({
             type: "file",
-            url: pathToFileURL(resolvedPath).href,
+            url: urlObj.href,
             filename: path.basename(resolvedPath),
             mime,
           })
         }
       }
+
+
 
       if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
 


### PR DESCRIPTION
### What does this PR do?

Allows specifying line range for the `opencode run` CLI file attachment option `-f`. e.g. `opencode run "Tell me the exact contents of this line range" -f path/to/file.js:59-66`. It will verify whether there is a file with that exact name (for whatever strange reason someone might have that syntax in their filenames) before extracting the line number/range.

### How did you verify your code works?

`cd packages/opencode && bun dev run "Repeat the exact contents of the attached files" -f README.md:12 -f bunfig.toml -f package.json:11-15`

It successfully repeated the given snippets and whole files.

Closes #14193