### PR TITLE
fix(win32): Sidecar spawning a window

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -3136,6 +3136,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "webkit2gtk",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -54,6 +54,9 @@ chrono = "0.4"
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 process-wrap = { version = "9.0.3", features = ["tokio1"] }
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = ["Win32_System_Threading"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"
 webkit2gtk = "=2.0.2"

--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -3,9 +3,7 @@ use process_wrap::tokio::CommandWrap;
 #[cfg(unix)]
 use process_wrap::tokio::ProcessGroup;
 #[cfg(windows)]
-use process_wrap::tokio::{CreationFlags, JobObject, KillOnDrop};
-#[cfg(windows)]
-use windows::Win32::System::Threading::CREATE_NO_WINDOW;
+use process_wrap::tokio::{CommandWrapper, JobObject, KillOnDrop};
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::sync::Arc;
@@ -20,9 +18,24 @@ use tokio::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
+#[cfg(windows)]
+use windows::Win32::System::Threading::{CREATE_NO_WINDOW, CREATE_SUSPENDED};
 
 use crate::server::get_wsl_config;
 
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug)]
+// Keep this as a custom wrapper instead of process_wrap::CreationFlags.
+// JobObject pre_spawn rewrites creation flags, so this must run after it.
+struct WinCreationFlags;
+
+#[cfg(windows)]
+impl CommandWrapper for WinCreationFlags {
+    fn pre_spawn(&mut self, command: &mut Command, _core: &CommandWrap) -> std::io::Result<()> {
+        command.creation_flags((CREATE_NO_WINDOW | CREATE_SUSPENDED).0);
+        Ok(())
+    }
+}
 
 const CLI_INSTALL_DIR: &str = ".opencode/bin";
 const CLI_BINARY_NAME: &str = "opencode";
@@ -205,7 +218,7 @@ fn get_user_shell() -> String {
 }
 
 fn is_wsl_enabled(_app: &tauri::AppHandle) -> bool {
-  get_wsl_config(_app.clone()).is_ok_and(|v| v.enabled)
+    get_wsl_config(_app.clone()).is_ok_and(|v| v.enabled)
 }
 
 fn shell_escape(input: &str) -> String {
@@ -329,9 +342,7 @@ pub fn spawn_command(
 
     #[cfg(windows)]
     {
-        wrap.wrap(CreationFlags(CREATE_NO_WINDOW))
-            .wrap(JobObject)
-            .wrap(KillOnDrop);
+        wrap.wrap(JobObject).wrap(WinCreationFlags).wrap(KillOnDrop);
     }
 
     let mut child = wrap.spawn()?;

--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -3,7 +3,9 @@ use process_wrap::tokio::CommandWrap;
 #[cfg(unix)]
 use process_wrap::tokio::ProcessGroup;
 #[cfg(windows)]
-use process_wrap::tokio::{JobObject, KillOnDrop};
+use process_wrap::tokio::{CreationFlags, JobObject, KillOnDrop};
+#[cfg(windows)]
+use windows::Win32::System::Threading::CREATE_NO_WINDOW;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
 use std::sync::Arc;
@@ -318,9 +320,6 @@ pub fn spawn_command(
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());
 
-    #[cfg(windows)]
-    cmd.creation_flags(0x0800_0000);
-
     let mut wrap = CommandWrap::from(cmd);
 
     #[cfg(unix)]
@@ -330,7 +329,9 @@ pub fn spawn_command(
 
     #[cfg(windows)]
     {
-        wrap.wrap(JobObject).wrap(KillOnDrop);
+        wrap.wrap(CreationFlags(CREATE_NO_WINDOW))
+            .wrap(JobObject)
+            .wrap(KillOnDrop);
     }
 
     let mut child = wrap.spawn()?;


### PR DESCRIPTION
### What does this PR do?

Fixes a Windows desktop regression where starting the local `opencode-cli` sidecar opens a visible console window.

### Regression timeline (data-driven)

- `v1.2.4..v1.2.5`: no changes to `packages/desktop/src-tauri/src/cli.rs` sidecar spawn path.
- First bad commit: `920255e8c` (`desktop: use process-wrap instead of manual job object`, #13431), included in `v1.2.6` / `github-v1.2.16`.
- `d338bd528` (`Hide server CLI on windows`, #13936) attempted to set `CREATE_NO_WINDOW`, but did not fully resolve the issue.

### Root cause

When using `process-wrap` + `JobObject` on Windows, creation flags set directly on `Command` can be overwritten during wrapper `pre_spawn` handling, so `CREATE_NO_WINDOW` may be lost.

### Fix approach

Apply Windows creation flags with process-wrap-aware ordering/handling so the spawned sidecar keeps `CREATE_NO_WINDOW` while preserving `JobObject` lifecycle behavior.

### Verification

- Traced commit history and diffs around `packages/desktop/src-tauri/src/cli.rs`.
- Confirmed behavior against upstream source:
  - `process-wrap/src/generic_wrap.rs`
  - `process-wrap/src/tokio/job_object.rs`
  - `process-wrap/src/tokio/creation_flags.rs`
- Local compile check passes for Windows target:
  - `cargo check --target x86_64-pc-windows-msvc` (from `packages/desktop/src-tauri`)