### PR TITLE
fix(core): normalize file.status paths relative to instance dir

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -417,10 +417,13 @@ export namespace File {
       }
     }
 
-    return changedFiles.map((x) => ({
-      ...x,
-      path: path.relative(Instance.directory, x.path),
-    }))
+    return changedFiles.map((x) => {
+      const full = path.isAbsolute(x.path) ? x.path : path.join(Instance.directory, x.path)
+      return {
+        ...x,
+        path: path.relative(Instance.directory, full),
+      }
+    })
   }
 
   export async function read(file: string): Promise<Content> {


### PR DESCRIPTION
### Issue for this PR

None

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

file.status returns incorrect/unstable file paths when x-opencode-directory points inside a repo (including git worktrees) because it runs path.relative(Instance.directory, x.path) on git-provided paths that are already relative, causing bogus ../... paths and inconsistent results depending on server cwd and request directory.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Manual API verification and tested with https://github.com/NeuralNomadsAI/CodeNomad/issues/180

### Screenshots / recordings

Pre Change
```
[
    {
        "path": "../../../banner.py",
        "added": 0,
        "removed": 1,
        "status": "modified"
    },
    {
        "path": "../../../tasmotizer.py",
        "added": 150,
        "removed": 2,
        "status": "modified"
    }
]
```


Post Change
```
[
    {
        "path": "banner.py",
        "added": 0,
        "removed": 1,
        "status": "modified"
    },
    {
        "path": "tasmotizer.py",
        "added": 150,
        "removed": 2,
        "status": "modified"
    }
]
```
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
