### PR TITLE
docs(ko): improve wording in ecosystem, enterprise, formatters, and github docs

### DIFF
--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -1,76 +1,76 @@
 ---
 title: 생태계
-description: OpenCode로 구축된 프로젝트 및 통합.
+description: OpenCode로 구축된 프로젝트와 통합.
 ---
 
-opencode에 내장 된 커뮤니티 프로젝트의 컬렉션.
+OpenCode를 기반으로 만들어진 커뮤니티 프로젝트 모음입니다.
 
 :::note
-이 목록에 opencode 관련 프로젝트를 추가하시겠습니까? PR 제출
+이 목록에 OpenCode 관련 프로젝트를 추가하고 싶다면 PR을 제출하세요.
 :::
 
-[awesome-opencode](https://github.com/awesome-opencode/awesome-opencode) 및 [opencode.cafe](https://opencode.cafe), 생태계와 커뮤니티를 통합하는 커뮤니티도 확인할 수 있습니다.
+[awesome-opencode](https://github.com/awesome-opencode/awesome-opencode)와 [opencode.cafe](https://opencode.cafe)도 함께 확인해 보세요. ecosystem과 community 정보를 한곳에 모아볼 수 있습니다.
 
 ---
 
 ## 플러그인
 
-| 이름                                                                                                      | 설명                                                                                   |
-| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [opencode-daytona](https://github.com/jamesmurdza/daytona/blob/main/guides/typescript/opencode/README.md) | git sync와 live preview를 가진 고립된 Daytona 샌드박스의 opencode 세션을 자동으로 실행 |
-| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                         | 자주 사용되는 Helicone session headers for request grouping                            |
-| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                                   | Auto-inject TypeScript/Svelte 타입의 파일 검색 도구                                    |
-| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)                    | API 크레딧 대신 ChatGPT Plus/Pro 구독 사용                                             |
-| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                                   | API 결제 대신 기존 Gemini 플랜 사용                                                    |
-| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                       | API 결제 대신 Antigravity의 무료 모델 사용                                             |
-| [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                                | 얕은 clones와 자동 할당된 포트가 있는 Multi-branch devcontainer 고립                   |
-| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)          | Google Antigravity OAuth Plugin, 구글 검색 지원, 더 강력한 API 처리                    |
-| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)         | 펀딩이 없는 툴 출력으로 토큰 사용 최적화                                               |
-| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                        | 한국어 지원 제공 업체에 대한 기본 웹 연구 지원 추가 Google 접지 스타일                 |
-| [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                              | PTY에서 배경 프로세스를 실행하기 위한 AI Agent를 사용해서 대화형 입력을 보냅니다. ·    |
-| [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | 비동기 포탄 명령에 대한 지침 - TTY 의존 작업에서 걸림 방지                             |
-| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Wakatime의 opencode 사용 추적                                                          |
-| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | LLMs에서 생산한 Markdown 테이블 정리                                                   |
-| [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x 빠른 코드 편집 및 Morph Fast Apply API 및 게으른 편집 마커                         |
-| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | 배경 에이전트, 사전 제작된 LSP/AST/MCP 도구, 큐레이터 에이전트, 클로드 코드 호환       |
-| [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | opencode 세션을 위한 데스크탑 알림 및 사운드 알림                                      |
-| [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | 허가, 완료 및 오류 이벤트용 데스크탑 알림 및 사운드 알림                               |
-| [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | opencode 컨텍스트를 기반으로 하는 AI-powered automatic Zellij session naming           |
-| [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | 기술검출 및 주사를 요구하는 opencode Agent를 게으른 로드 프롬프트 허용                 |
-| [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Supermemory를 사용하여 세션 전반에 걸쳐 지속되는 메모리                                |
-| [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)        | (영어) 상호 작용하는 계획은 시각적인 주석 및 개인/오프라인 공유를 검토합니다           |
-| [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                                     | granular flow control과 강력한 오케스트라 시스템 확장                                  |
-| [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                                  | cron 구문을 가진 발사된 (Mac) 또는 체계화된 (Linux)를 사용하여 작업 재발견             |
-| [micode](https://github.com/vtemian/micode)                                                               | Structured Brainstorm → Plan → 세션 연속성으로 워크플로우 구현                         |
-| [octto](https://github.com/vtemian/octto)                                                                 | 멀티 퀘스트 양식으로 AI Brainstorming을 위한 인터랙티브 브라우저 UI                    |
-| [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agent)                      | 동기화 위임 및 컨텍스트의 코드 스타일 배경 에이전트                                    |
-| [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | opencode의 Native OS 알림 – 작업이 완료되면 알 수 있습니다                             |
-| [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | 멀티 시약 오케스트라 묶음 하네스 – 16개 부품, 하나 설치                                |
-| [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | opencode를 위한 Zero-friction git worktree                                             |
+| 이름                                                                                                      | 설명                                                                                            |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [opencode-daytona](https://github.com/jamesmurdza/daytona/blob/main/guides/typescript/opencode/README.md) | git sync와 live preview를 지원하는 격리된 Daytona sandbox에서 OpenCode 세션을 자동 실행합니다.  |
+| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                         | 요청을 그룹화할 수 있도록 Helicone session header를 자동으로 주입합니다.                        |
+| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                                   | 조회 tool과 함께 TypeScript/Svelte 타입 정보를 파일 읽기에 자동 주입합니다.                     |
+| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)                    | API 크레딧 대신 ChatGPT Plus/Pro 구독을 사용할 수 있습니다.                                     |
+| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                                   | API 과금 대신 기존 Gemini 플랜을 사용할 수 있습니다.                                            |
+| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                       | API 과금 대신 Antigravity의 무료 model을 사용할 수 있습니다.                                    |
+| [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                                | shallow clone과 자동 포트 할당을 기반으로 multi-branch devcontainer 격리를 제공합니다.          |
+| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)          | Google Search 지원과 견고한 API 처리를 제공하는 Google Antigravity OAuth Plugin입니다.          |
+| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)         | 오래된 tool output을 정리해 token 사용량을 최적화합니다.                                        |
+| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                        | 지원 provider에서 Google grounded 스타일의 네이티브 websearch를 추가합니다.                     |
+| [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                              | AI agent가 PTY에서 백그라운드 프로세스를 실행하고 대화형 입력을 보낼 수 있게 합니다.            |
+| [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | 비대화형 shell 명령 실행 지침을 제공해 TTY 의존 작업으로 인한 멈춤을 방지합니다.                |
+| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Wakatime으로 OpenCode 사용량을 추적합니다.                                                      |
+| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | LLM이 생성한 markdown 표를 정리합니다.                                                          |
+| [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | Morph Fast Apply API와 lazy edit marker를 활용해 코드 편집 속도를 크게 높입니다.                |
+| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | background agent, 사전 구성된 LSP/AST/MCP tool, curated agent, Claude Code 호환성을 제공합니다. |
+| [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | OpenCode 세션에 데스크톱 알림과 사운드 알림을 제공합니다.                                       |
+| [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | permission, 완료, 오류 이벤트에 대한 데스크톱 알림과 사운드 알림을 제공합니다.                  |
+| [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | OpenCode 맥락을 기반으로 Zellij session 이름을 AI로 자동 지정합니다.                            |
+| [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | skill 탐색과 주입을 통해 OpenCode agent가 필요 시 prompt를 lazy load하도록 합니다.              |
+| [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Supermemory를 사용해 세션 간 persistent memory를 제공합니다.                                    |
+| [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)        | 시각 주석과 private/offline 공유를 포함한 인터랙티브 계획 리뷰를 제공합니다.                    |
+| [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                                     | 세밀한 flow control로 opencode /commands를 강력한 orchestration 시스템으로 확장합니다.          |
+| [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                                  | cron 문법을 사용해 launchd(Mac) 또는 systemd(Linux) 기반 반복 작업을 예약합니다.                |
+| [micode](https://github.com/vtemian/micode)                                                               | Structured Brainstorm → Plan → Implement 워크플로를 session continuity와 함께 제공합니다.       |
+| [octto](https://github.com/vtemian/octto)                                                                 | 다중 질문 폼 기반의 AI 브레인스토밍용 인터랙티브 브라우저 UI를 제공합니다.                      |
+| [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)                     | Claude Code 스타일의 background agent를 async delegation과 context persistence로 제공합니다.    |
+| [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | OpenCode 작업 완료 시점을 native OS 알림으로 알려줍니다.                                        |
+| [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | 16개 구성요소를 한 번에 설치하는 bundled multi-agent orchestration harness를 제공합니다.        |
+| [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | OpenCode용 git worktree를 손쉽게 사용할 수 있도록 돕습니다.                                     |
 
 ---
 
 ## 프로젝트
 
-| 이름                                                                                       | 설명                                                             |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [kimaki](https://github.com/remorses/kimaki)                                               | SDK 내장 opencode 세션을 제어하는 Discord bot                    |
-| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | API에 내장된 편집기웨어 프롬프롬프 플러그인                      |
-| [portal](https://github.com/hosenur/portal)                                                | Tailscale/VPN에 opencode를 위한 모바일 최초의 웹 UI              |
-| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | opencode 플러그인 구축 템플릿                                    |
-| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | opencode를 위한 Neovim frontend - terminal 기반 AI 코딩 에이전트 |
-| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | @opencode-ai/sdk를 통해 opencode를 사용하는 Vercel AI SDK 제공   |
-| [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | 웹 / 데스크탑 앱 및 VS Code Extension for opencode               |
-| [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian 플러그인 Obsidian의 UI에서 opencode를 포함              |
-| [OpenWork](https://github.com/different-ai/openwork)                                       | opencode에 의해 구동 Claude Cowork에 대한 오픈 소스 대안         |
-| [ocx](https://github.com/kdcokenny/ocx)                                                    | 휴대용, 절연 프로파일을 갖춘 opencode 확장 관리자.               |
-| [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | opencode를 위한 데스크탑, 웹, 모바일 및 원격 클라이언트 앱       |
+| 이름                                                                                       | 설명                                                                   |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| [kimaki](https://github.com/remorses/kimaki)                                               | SDK 기반으로 OpenCode 세션을 제어하는 Discord bot입니다.               |
+| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | API 기반 editor-aware prompt를 제공하는 Neovim plugin입니다.           |
+| [portal](https://github.com/hosenur/portal)                                                | Tailscale/VPN 환경에서 OpenCode를 쓰기 위한 mobile-first 웹 UI입니다.  |
+| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | OpenCode plugin 개발을 위한 템플릿입니다.                              |
+| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | terminal 기반 AI 코딩 agent인 opencode용 Neovim frontend입니다.        |
+| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | `@opencode-ai/sdk`로 OpenCode를 사용하는 Vercel AI SDK provider입니다. |
+| [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode용 Web/Desktop App 및 VS Code Extension입니다.                 |
+| [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian UI에 OpenCode를 내장하는 Obsidian plugin입니다.               |
+| [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode 기반의 Claude Cowork 대체 오픈소스 프로젝트입니다.            |
+| [ocx](https://github.com/kdcokenny/ocx)                                                    | 휴대형 격리 프로필을 지원하는 OpenCode extension manager입니다.        |
+| [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode용 Desktop/Web/Mobile/Remote client app입니다.                 |
 
 ---
 
 ## 에이전트
 
-| 이름                                                              | 설명                                                            |
-| ----------------------------------------------------------------- | --------------------------------------------------------------- |
-| [Agentic](https://github.com/Cluster444/agentic)                  | 구조 개발용 모듈형 AI 에이전트 및 명령                          |
-| [opencode-agents](https://github.com/darrenhinde/opencode-agents) | 향상된 워크플로우를 위한 컨피그, 프롬프트, 에이전트 및 플러그인 |
+| 이름                                                              | 설명                                                             |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Agentic](https://github.com/Cluster444/agentic)                  | 구조화된 개발을 위한 모듈형 AI agent와 command를 제공합니다.     |
+| [opencode-agents](https://github.com/darrenhinde/opencode-agents) | 향상된 워크플로를 위한 config, prompt, agent, plugin 모음입니다. |

--- a/packages/web/src/content/docs/ko/enterprise.mdx
+++ b/packages/web/src/content/docs/ko/enterprise.mdx
@@ -1,48 +1,47 @@
 ---
 title: 엔터프라이즈
-description: 조직에서 OpenCode를 안전하게 사용하세요.
+description: 조직에서 OpenCode를 안전하게 사용하는 방법입니다.
 ---
 
-import config from "../../../../config.mjs"
+import config from "../../../config.mjs"
 export const email = `mailto:${config.email}`
 
-opencode Enterprise는 코드와 데이터가 인프라를 결코 나타낸다는 것을 보증하는 단체입니다. SSO 및 내부 AI 게이트웨이와 통합하는 중앙화 된 구성을 사용하여 이것을 할 수 있습니다.
+OpenCode Enterprise는 코드와 데이터가 조직의 인프라 밖으로 나가지 않도록 보장하려는 조직을 위한 기능입니다. SSO 및 내부 AI gateway와 연동되는 중앙 config를 사용해 이를 구현할 수 있습니다.
 
 :::note
-opencode는 코드 또는 컨텍스트 데이터를 저장하지 않습니다.
+OpenCode는 코드나 context 데이터를 저장하지 않습니다.
 :::
 
-opencode Enterprise로 시작하려면:
+OpenCode Enterprise를 시작하려면 다음 단계를 진행하세요.
 
-1. 시험은 당신의 팀과 내부적으로 합니다.
-2. **<a href={email}> 연락처</a>** 가격 및 구현 옵션을 논의합니다.
-
----
-
-## 시험
-
-opencode는 오픈 소스이며 코드를 저장하지 않거나 컨텍스트 데이터, 그래서 개발자는 단순히 [get start](/docs/) 그리고 재판을 수행 할 수 있습니다.
+1. 팀 내부에서 trial을 먼저 진행하세요.
+2. 가격 및 도입 옵션을 논의하려면 **<a href={email}>문의해 주세요</a>**.
 
 ---
 
-## 데이터 처리
+## Trial
 
-**opencode는 코드 또는 컨텍스트 데이터를 저장하지 않습니다. ** 모든 처리는 로컬 또는 직접 API 호출을 통해 AI 공급자.
-
-이것은 당신이 신뢰하는 공급자, 또는 내부를 사용하고 있는 경우에
-AI 게이트웨이, opencode를 안전하게 사용할 수 있습니다.
-
-여기에서 유일한 caveat는 선택적인 `/share` 특징입니다.
+OpenCode는 오픈소스이며 코드나 context 데이터를 저장하지 않으므로, 개발자는 바로 [시작하기](/docs/)를 참고해 trial을 진행할 수 있습니다.
 
 ---
 
-### 공유 대화
+### Data handling
 
-사용자가 `/share` 기능을 활성화하면 대화와 관련된 데이터가 opencode.ai에서 이러한 공유 페이지를 호스팅하는 데 사용됩니다.
+**OpenCode는 코드나 context 데이터를 저장하지 않습니다.** 모든 처리는 로컬 환경 또는 AI provider로의 직접 API 호출로 이루어집니다.
 
-데이터는 현재 CDN의 가장자리 네트워크를 통해 제공되며 사용자가 가까운 가장자리에 캐시됩니다.
+따라서 신뢰할 수 있는 provider 또는 내부 AI gateway를 사용한다면 OpenCode를 안전하게 사용할 수 있습니다.
 
-우리는 당신이 당신의 재판을 위해 이것을 비활성화하는 것을 추천합니다.
+주의할 점은 선택 기능인 `/share`입니다.
+
+---
+
+#### Sharing conversations
+
+사용자가 `/share` 기능을 활성화하면, 대화와 관련 데이터가 opencode.ai의 share 페이지 호스팅 서비스로 전송됩니다.
+
+현재 이 데이터는 CDN edge network를 통해 제공되며, 사용자와 가까운 edge에 캐시됩니다.
+
+trial 단계에서는 이 기능을 비활성화할 것을 권장합니다.
 
 ```json title="opencode.json"
 {
@@ -51,111 +50,107 @@ AI 게이트웨이, opencode를 안전하게 사용할 수 있습니다.
 }
 ```
 
-[공유에 대해 더 알아보기](/docs/share).
+[sharing에 대해 더 알아보기](/docs/share).
 
 ---
 
-### 코드 소유권
+### Code ownership
 
-**opencode에 의해 생성 된 모든 코드를 소유합니다. ** 제한 또는 소유권 주장이 없습니다.
-
----
-
-## 가격
-
-opencode Enterprise의 per-seat 모델을 사용합니다. LLM 게이트웨이를 가지고 있다면 토큰을 사용할 수 없습니다. 가격 및 구현 옵션에 대한 자세한 내용은 **<a href={email}>contact us</a>**.
+**OpenCode가 생성한 코드는 모두 사용자에게 소유권이 있습니다.** 라이선스 제한이나 소유권 주장도 없습니다.
 
 ---
 
-## 배포
+## Pricing
 
-시험이 완료되면 opencode를 사용해야합니다.
-조직, 당신은 할 수 있습니다 **<a href={email}>contact us</a>** 토론하기
-가격 및 구현 옵션.
+OpenCode Enterprise는 seat당 과금 모델을 사용합니다. 자체 LLM gateway를 사용하는 경우에는 사용 token에 대해 별도 과금하지 않습니다. 가격 및 도입 옵션의 자세한 내용은 **<a href={email}>문의해 주세요</a>**.
 
 ---
 
-### 중앙 구성
+## Deployment
 
-opencode를 설정하여 전체 조직의 단일 중앙 구성을 사용할 수 있습니다.
-
-이 중앙 집중식 구성은 SSO 공급자와 통합할 수 있으며 내부 AI 게이트웨이 만 모든 사용자 액세스를 보장합니다.
+trial을 마치고 조직에서 OpenCode를 본격적으로 사용하려면, 가격 및 도입 옵션 논의를 위해 **<a href={email}>문의해 주세요</a>**.
 
 ---
 
-### SSO 통합
+### Central Config
 
-중앙 구성을 통해 opencode는 인증 기관의 SSO 공급자와 통합 할 수 있습니다.
+조직 전체에서 단일 중앙 config를 사용하도록 OpenCode를 설정할 수 있습니다.
 
-opencode는 기존 ID 관리 시스템을 통해 내부 AI 게이트웨이에 대한 자격 증명을 얻을 수 있습니다.
-
----
-
-## 내부 AI 게이트웨이
-
-중앙 설정으로, opencode는 내부 AI 게이트웨이만 사용할 수 있습니다.
-
-또한 다른 모든 AI 제공 업체를 비활성화 할 수 있습니다, 모든 요청은 조직의 승인 된 인프라를 통해 이동합니다.
+이 중앙 config는 SSO provider와 연동할 수 있으며, 모든 사용자가 내부 AI gateway만 사용하도록 보장합니다.
 
 ---
 
-## 셀프 호스팅
+### SSO integration
 
-공유 페이지를 비활성화하는 것이 좋습니다.
-당신의 조직, 우리는 또한 당신의 인프라에 자기 호스팅을 도울 수 있습니다.
+중앙 config를 통해 OpenCode는 조직의 SSO provider와 인증 연동을 구성할 수 있습니다.
 
-이것은 현재 우리의 로드맵에 있습니다. 관심이 있다면, **<a href={email}>는</a>**를 알려줍니다.
+이를 통해 기존 ID 관리 시스템으로 내부 AI gateway credential을 안전하게 획득할 수 있습니다.
 
 ---
 
-## 자주 묻는 질문
+### Internal AI gateway
+
+중앙 config를 사용하면 OpenCode를 내부 AI gateway만 사용하도록 설정할 수 있습니다.
+
+또한 다른 AI provider를 모두 비활성화해, 모든 요청이 조직에서 승인한 인프라만 통과하도록 구성할 수 있습니다.
+
+---
+
+### Self-hosting
+
+데이터가 조직 외부로 나가지 않도록 share 페이지 비활성화를 권장하지만, 원하시면 해당 페이지를 조직 인프라에 self-hosting하는 방식도 지원할 수 있습니다.
+
+이 기능은 현재 로드맵에 있으며, 관심이 있다면 **<a href={email}>문의해 주세요</a>**.
+
+---
+
+## FAQ
 
 <details>
-<summary>opencode Enterprise란 무엇입니까?</summary>
+<summary>OpenCode Enterprise란 무엇인가요?</summary>
 
-opencode Enterprise는 코드와 데이터가 인프라를 결코 나타낸다는 것을 보증하는 단체입니다. SSO 및 내부 AI 게이트웨이와 통합하는 중앙화 된 구성을 사용하여 이것을 할 수 있습니다.
+OpenCode Enterprise는 코드와 데이터가 조직 인프라 밖으로 나가지 않도록 보장하려는 조직을 위한 기능입니다. SSO 및 내부 AI gateway와 연동되는 중앙 config를 사용해 이를 구현할 수 있습니다.
 
 </details>
 
 <details>
-<summary>opencode Enterprise를 어떻게 시작하나요?</summary>
+<summary>OpenCode Enterprise는 어떻게 시작하나요?</summary>
 
-단순히 팀과 내부 평가판을 시작합니다. 기본값으로 opencode는 코드를 저장하지 않거나 context data, 시작하기 쉬운 만들기.
+먼저 팀 내부 trial부터 시작하세요. OpenCode는 기본적으로 코드나 context 데이터를 저장하지 않으므로 도입을 빠르게 시작할 수 있습니다.
 
-그런 다음 **<a href={email}>contact us</a>**는 가격과 구현 옵션을 논의합니다.
+그다음 가격 및 도입 옵션 논의를 위해 **<a href={email}>문의해 주세요</a>**.
 
 </details>
 
 <details>
 <summary>엔터프라이즈 가격 정책은 어떻게 되나요?</summary>
 
-우리는 per-seat 기업 가격을 제안합니다. LLM 게이트웨이를 가지고 있다면 토큰을 사용할 수 없습니다. 더 자세한 내용은 **<a href={email}>contact us</a>** 를 통해 조직의 요구에 따라 맞춤형 견적을 제공합니다.
+seat당 과금 방식의 엔터프라이즈 요금제를 제공합니다. 자체 LLM gateway를 사용하면 token 사용량에 대한 별도 과금은 없습니다. 자세한 내용은 **<a href={email}>문의해 주세요</a>**. 조직 상황에 맞는 맞춤 견적을 안내해 드립니다.
 
 </details>
 
 <details>
-<summary>opencode Enterprise에서 내 데이터는 안전한가요?</summary>
+<summary>OpenCode Enterprise에서 데이터는 안전한가요?</summary>
 
-예. opencode는 코드 또는 컨텍스트 데이터를 저장하지 않습니다. 모든 처리는 로컬 또는 직접 API 호출을 통해 AI 공급자. 중앙 설정 및 SSO 통합으로 데이터는 조직의 인프라 내에서 안전하게 유지됩니다.
+네. OpenCode는 코드나 context 데이터를 저장하지 않습니다. 모든 처리는 로컬 또는 AI provider로의 직접 API 호출로 이루어집니다. 중앙 config와 SSO integration을 함께 사용하면 데이터는 조직 인프라 내부에서 안전하게 유지됩니다.
 
 </details>
 
 <details>
-<summary>자체 비공개 npm 레지스트리를 사용할 수 있나요?</summary>
+<summary>사내 private NPM registry를 사용할 수 있나요?</summary>
 
-opencode는 Bun's native `.npmrc` 파일 지원을 통해 개인 npm 등록을 지원합니다. 조직이 JFrog Artifactory, Nexus 또는 이와 같은 개인 레지스트리를 사용한다면, 개발자가 opencode를 실행하기 전에 인증됩니다.
+OpenCode는 Bun의 기본 `.npmrc` 지원을 통해 private npm registry를 사용할 수 있습니다. 조직에서 JFrog Artifactory, Nexus 등 private registry를 사용한다면 OpenCode 실행 전에 개발자 인증을 완료하세요.
 
-개인 레지스트리로 인증을 설정하려면:
+private registry 인증 예시는 다음과 같습니다.
 
 ```bash
 npm login --registry=https://your-company.jfrog.io/api/npm/npm-virtual/
 ```
 
-`~/.npmrc`를 인증 세부 사항으로 만듭니다. opencode는 자동으로
-지금 구매하세요.
+이 명령은 인증 정보가 포함된 `~/.npmrc`를 생성하며, OpenCode는 이를 자동으로 인식합니다.
 
 :::caution
-opencode를 실행하기 전에 개인 레지스트리에 로그인해야합니다.
+OpenCode 실행 전에 private registry 로그인 상태여야 합니다.
 :::
 
 또는 `.npmrc` 파일을 수동으로 구성할 수 있습니다.
@@ -165,6 +160,6 @@ registry=https://your-company.jfrog.io/api/npm/npm-virtual/
 //your-company.jfrog.io/api/npm/npm-virtual/:_authToken=${NPM_AUTH_TOKEN}
 ```
 
-개발자는 opencode를 실행하기 전에 개인 레지스트리에 로그인해야하며 패키지를 설치할 수 있습니다.
+엔터프라이즈 registry에서 패키지를 정상 설치하려면, 개발자는 OpenCode 실행 전에 private registry 인증을 완료해야 합니다.
 
 </details>

--- a/packages/web/src/content/docs/ko/formatters.mdx
+++ b/packages/web/src/content/docs/ko/formatters.mdx
@@ -1,62 +1,64 @@
 ---
 title: 포매터
-description: opencode는 언어별 포매터를 사용합니다.
+description: OpenCode는 언어별 포매터를 사용합니다.
 ---
 
-opencode는 언어 별 형식을 사용하여 작성 또는 편집 한 후 자동으로 파일을 포맷합니다. 이 생성 된 코드는 프로젝트의 코드 스타일을 따릅니다.
+OpenCode는 파일을 write하거나 edit한 뒤, 언어별 포매터를 사용해 자동으로 포맷합니다. 이를 통해 생성된 코드가 프로젝트의 코드 스타일을 따르도록 보장합니다.
 
 ---
 
 ## 내장
 
-opencode는 인기있는 언어 및 프레임 워크에 대한 몇 가지 내장 형식자와 함께 제공됩니다. 아래는 formatters, 지원된 파일 확장 및 명령 또는 구성 옵션의 목록입니다.
+OpenCode는 주요 언어와 프레임워크를 위한 여러 내장 포매터를 제공합니다. 아래는 포매터 목록, 지원 확장자, 필요한 명령 또는 config 옵션입니다.
 
-| 포매터               | 확장자                                                                             | 요구 사항                                                                                     |
-| -------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| gofmt                | .go                                                                                | `gofmt` 명령 사용 가능                                                                        |
-| Mix                  | .ex, .ex, .eex, .heex, .leex, .neex, .sface                                        | `mix` 명령 사용 가능                                                                          |
-| Biome                | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, [기타](https://biomejs.dev/) | `biome.json(c)` 구성 파일                                                                     |
-| Zig                  | .zig, .zon                                                                         | `zig` 명령 사용 가능                                                                          |
-| clang-format         | .c, .cpp, .h, .hpp, .ino, [기타](https://clang.llvm.org/docs/ClangFormat.html)     | `.clang-format` 구성 파일                                                                     |
-| ktlint               | .kt, .kts                                                                          | `ktlint` 명령 사용 가능                                                                       |
-| ruff                 | .py, .pyi                                                                          | 구성 가능한 `ruff` 명령                                                                       |
-| rustfmt              | .rs                                                                                | `rustfmt` 명령 사용 가능                                                                      |
-| cargo fmt            | .rs                                                                                | `cargo fmt` 명령 사용 가능                                                                    |
-| uv                   | .py, .pyi                                                                          | `uv` 명령 사용 가능                                                                           |
-| rubocop              | .rb, .rake, .gemspec, .ru                                                          | `rubocop` 명령 사용 가능                                                                      |
-| StandardRB           | .rb, .rake, .gemspec, .ru                                                          | `standardrb` 명령 사용 가능                                                                   |
-| htmlbeautifier       | .erb, .html.erb                                                                    | `htmlbeautifier` 명령 사용 가능                                                               |
-| Air                  | .R                                                                                 | `air` 명령 사용 가능                                                                          |
-| Dart                 | 다트                                                                               | `dart` 명령                                                                                   |
-| dfmt                 | .d                                                                                 | `dfmt` 명령 사용 가능                                                                         |
-| ocamlformat          | .ml, .mli                                                                          | `ocamlformat` 명령 사용 가능·`.ocamlformat` 설정 파일                                         |
-| Terraform            | .tf, .tfvars                                                                       | `terraform` 명령 사용 가능                                                                    |
-| gleam                | .gleam                                                                             | `gleam` 명령 사용 가능                                                                        |
-| nixfmt               | .nix                                                                               | `nixfmt` 명령 사용 가능                                                                       |
-| shfmt                | .sh, .bash                                                                         | `shfmt` 명령 사용 가능                                                                        |
-| Pint                 | .php                                                                               | `laravel/pint` 의존도 `composer.json`                                                         |
-| oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                               | `oxfmt` Dependency in `package.json`, [experimental env 변수 플래그](/docs/cli/#experimental) |
-| ormolu               | .hs                                                                                | `ormolu` 명령 사용 가능                                                                       |
+| 포매터               | 확장자                                                                                               | 요구 사항                                                                                             |
+| -------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| air                  | .R                                                                                                   | `air` 명령 사용 가능                                                                                  |
+| biome                | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, [기타](https://biomejs.dev/)                   | `biome.json(c)` config 파일                                                                           |
+| cargofmt             | .rs                                                                                                  | `cargo fmt` 명령 사용 가능                                                                            |
+| clang-format         | .c, .cpp, .h, .hpp, .ino, [기타](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config 파일                                                                           |
+| cljfmt               | .clj, .cljs, .cljc, .edn                                                                             | `cljfmt` 명령 사용 가능                                                                               |
+| dart                 | .dart                                                                                                | `dart` 명령 사용 가능                                                                                 |
+| dfmt                 | .d                                                                                                   | `dfmt` 명령 사용 가능                                                                                 |
+| gleam                | .gleam                                                                                               | `gleam` 명령 사용 가능                                                                                |
+| gofmt                | .go                                                                                                  | `gofmt` 명령 사용 가능                                                                                |
+| htmlbeautifier       | .erb, .html.erb                                                                                      | `htmlbeautifier` 명령 사용 가능                                                                       |
+| ktlint               | .kt, .kts                                                                                            | `ktlint` 명령 사용 가능                                                                               |
+| mix                  | .ex, .exs, .eex, .heex, .leex, .neex, .sface                                                         | `mix` 명령 사용 가능                                                                                  |
+| nixfmt               | .nix                                                                                                 | `nixfmt` 명령 사용 가능                                                                               |
+| ocamlformat          | .ml, .mli                                                                                            | `ocamlformat` 명령 사용 가능 및 `.ocamlformat` config 파일 필요                                       |
+| ormolu               | .hs                                                                                                  | `ormolu` 명령 사용 가능                                                                               |
+| oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                                                 | `package.json`에 `oxfmt` dependency 필요 및 [experimental env variable flag](/docs/cli/#experimental) |
+| pint                 | .php                                                                                                 | `composer.json`에 `laravel/pint` dependency 필요                                                      |
+| prettier             | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, [기타](https://prettier.io/docs/en/index.html) | `package.json`에 `prettier` dependency 필요                                                           |
+| rubocop              | .rb, .rake, .gemspec, .ru                                                                            | `rubocop` 명령 사용 가능                                                                              |
+| ruff                 | .py, .pyi                                                                                            | `ruff` 명령 사용 가능 및 관련 config 필요                                                             |
+| rustfmt              | .rs                                                                                                  | `rustfmt` 명령 사용 가능                                                                              |
+| shfmt                | .sh, .bash                                                                                           | `shfmt` 명령 사용 가능                                                                                |
+| standardrb           | .rb, .rake, .gemspec, .ru                                                                            | `standardrb` 명령 사용 가능                                                                           |
+| terraform            | .tf, .tfvars                                                                                         | `terraform` 명령 사용 가능                                                                            |
+| uv                   | .py, .pyi                                                                                            | `uv` 명령 사용 가능                                                                                   |
+| zig                  | .zig, .zon                                                                                           | `zig` 명령 사용 가능                                                                                  |
 
-그래서 프로젝트가 `prettier`를 `package.json`에 가지고 있다면, opencode는 자동으로 그것을 사용합니다.
+예를 들어 프로젝트 `package.json`에 `prettier`가 있으면 OpenCode가 자동으로 해당 포매터를 사용합니다.
 
 ---
 
 ## 작동 방식
 
-opencode가 파일을 작성하거나 편집할 때:
+OpenCode가 파일을 write하거나 edit할 때 다음 순서로 동작합니다.
 
-1. 모든 활성화된 formatters에 대한 파일 확장을 확인합니다.
-2. 파일에 적절한 형식의 명령을 실행합니다.
-3. 형식 변경을 자동으로 적용합니다.
+1. 활성화된 모든 포매터와 파일 확장자를 대조합니다.
+2. 파일에 맞는 포매터 명령을 실행합니다.
+3. 포맷 변경 사항을 자동으로 적용합니다.
 
-이 과정은 배경에서 발생합니다. 코드 스타일은 수동 단계없이 유지됩니다.
+이 과정은 background에서 실행되며, 수동 작업 없이 코드 스타일이 유지됩니다.
 
 ---
 
 ## 구성
 
-opencode config의 `formatter` 섹션을 통해 형식기를 사용자 정의 할 수 있습니다.
+OpenCode config의 `formatter` 섹션에서 포매터를 커스터마이즈할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -65,22 +67,22 @@ opencode config의 `formatter` 섹션을 통해 형식기를 사용자 정의 �
 }
 ```
 
-각 formatter 구성은 다음을 지원합니다:
+각 formatter 설정에서 지원하는 항목은 다음과 같습니다.
 
-| 속성          | 타입     | 설명                              |
-| ------------- | -------- | --------------------------------- |
-| `disabled`    | boolean  | `true`로 설정하여 포매터 비활성화 |
-| `command`     | 문자열[] | 형식을 실행하는 명령              |
-| `environment` | 객체     | 형식의 실행시 설정하는 환경 변수  |
-| `extensions`  | string[] | 이 형식의 파일 확장자 취급        |
+| 속성          | 타입     | 설명                                           |
+| ------------- | -------- | ---------------------------------------------- |
+| `disabled`    | boolean  | `true`로 설정하면 해당 포매터를 비활성화합니다 |
+| `command`     | string[] | 포맷 실행 명령입니다                           |
+| `environment` | object   | 포매터 실행 시 설정할 환경 변수입니다          |
+| `extensions`  | string[] | 해당 포매터가 처리할 파일 확장자입니다         |
 
-몇 가지 예제를 살펴 보자.
+아래 예시를 참고하세요.
 
 ---
 
-## 포매터 비활성화
+### 포매터 비활성화
 
-모든 포매터를 비활성화하려면 `formatter`를 `false`로 설정하십시오:
+전체 포매터를 전역에서 비활성화하려면 `formatter`를 `false`로 설정하세요.
 
 ```json title="opencode.json" {3}
 {
@@ -89,7 +91,7 @@ opencode config의 `formatter` 섹션을 통해 형식기를 사용자 정의 �
 }
 ```
 
-**특정** 포매터의 경우, `disabled`를 `true`로 설정하십시오:
+특정 포매터만 비활성화하려면 `disabled`를 `true`로 설정하세요.
 
 ```json title="opencode.json" {5}
 {
@@ -106,7 +108,7 @@ opencode config의 `formatter` 섹션을 통해 형식기를 사용자 정의 �
 
 ### 사용자 정의 포매터
 
-내장 형식자를 무시하거나 명령, 환경 변수 및 파일 확장을 지정하여 새로운 것을 추가 할 수 있습니다.
+명령, 환경 변수, 파일 확장자를 지정해 내장 포매터를 override하거나 새 포매터를 추가할 수 있습니다.
 
 ```json title="opencode.json" {4-14}
 {
@@ -127,4 +129,4 @@ opencode config의 `formatter` 섹션을 통해 형식기를 사용자 정의 �
 }
 ```
 
-명령의 **`$FILE` placeholder**는 형식의 파일 경로로 대체됩니다.
+명령의 **`$FILE` placeholder**는 포맷 대상 파일 경로로 치환됩니다.

--- a/packages/web/src/content/docs/ko/github.mdx
+++ b/packages/web/src/content/docs/ko/github.mdx
@@ -1,45 +1,45 @@
 ---
 title: GitHub
-description: GitHub 이슈 및 풀 리퀘스트에서 opencode를 사용하세요.
+description: GitHub issue와 pull request에서 OpenCode를 사용하세요.
 ---
 
-opencode는 GitHub 워크플로우와 통합됩니다. Mention `/opencode` 또는 `/oc` 당신의 의견에, 그리고 opencode는 당신의 GitHub 활동 주자 안에 작업을 실행할 것입니다.
+OpenCode는 GitHub 워크플로와 통합됩니다. 댓글에 `/opencode` 또는 `/oc`를 mention하면 OpenCode가 GitHub Actions runner 안에서 작업을 실행합니다.
 
 ---
 
 ## 기능
 
-- **이슈**: opencode가 이슈를 보고 설명해 줍니다.
-- **수정 및 구현**: 이슈를 수정하거나 기능을 구현하도록 opencode에 요청하세요. 새로운 브랜치에서 작업하고 변경 사항으로 PR을 제출합니다.
-- **보안**: opencode는 GitHub 러너 내부에서 실행됩니다.
+- **Issue triage**: OpenCode에게 issue를 분석하고 내용을 설명하도록 요청할 수 있습니다.
+- **Fix and implement**: OpenCode에게 issue 수정이나 기능 구현을 요청할 수 있습니다. 새 branch에서 작업한 뒤 변경 사항을 담은 PR을 생성합니다.
+- **Secure**: OpenCode는 GitHub runner 내부에서 실행됩니다.
 
 ---
 
 ## 설치
 
-GitHub 저장소에서 다음과 같은 명령을 실행:
+GitHub repo에 연결된 프로젝트에서 아래 명령을 실행하세요.
 
 ```bash
 opencode github install
 ```
 
-GitHub 앱을 설치하고 워크플로를 만들고 비밀을 설정할 수 있습니다.
+이 명령은 GitHub app 설치, workflow 생성, secrets 설정 과정을 안내합니다.
 
 ---
 
-## 수동 설정
+### Manual Setup
 
-또는 수동으로 설정할 수 있습니다.
+원하면 수동으로도 설정할 수 있습니다.
 
-1. **GitHub 앱 설치**
+1. **Install the GitHub app**
 
-[**github.com/apps/opencode-agent**](https://github.com/apps/opencode-agent)로 이동합니다. 대상 저장소에 설치되어 있는지 확인하십시오.
+   [**github.com/apps/opencode-agent**](https://github.com/apps/opencode-agent)로 이동하세요. 대상 repo에 app이 설치되어 있는지 확인하세요.
 
-2. **워크플로우 추가**
+2. **Add the workflow**
 
-저장소에 `.github/workflows/opencode.yml`에 다음 작업 흐름 파일을 추가합니다. 적절한 `model`를 설정하고 `env`의 API 키가 필요합니다.
+   아래 workflow 파일을 repo의 `.github/workflows/opencode.yml`에 추가하세요. `env`에는 필요한 API key를 넣고, `model`은 환경에 맞게 설정하세요.
 
-```yml title=".github/workflows/opencode.yml" {24,26}
+   ```yml title=".github/workflows/opencode.yml" {24,26}
    name: opencode
 
    on:
@@ -71,52 +71,52 @@ GitHub 앱을 설치하고 워크플로를 만들고 비밀을 설정할 수 있
              model: anthropic/claude-sonnet-4-20250514
              # share: true
              # github_token: xxxx
-```
+   ```
 
-3. **API 키를 Secret으로 저장**
+3. **Store the API keys in secrets**
 
-조직 또는 프로젝트 **Settings**에서, 왼쪽의 **Secrets and variables**를 확장하고 **Actions**를 선택합니다. 그리고 필요한 API 키를 추가합니다.
+   조직 또는 프로젝트 **Settings**에서 왼쪽의 **Secrets and variables**를 펼친 뒤 **Actions**를 선택하세요. 필요한 API key를 추가하면 됩니다.
 
 ---
 
 ## 구성
 
-- `model`: opencode를 사용하는 모형. `provider/model`의 형식을 가져 가라. **필수**입니다.
-- `agent`: 사용을 위한 에이전트. 주요 에이전트이어야 합니다. `default_agent`로 돌아와서 config 또는 `"build"`에서 찾을 수 없습니다.
-- `share`: opencode 세션을 공유하는 것. Defaults to **true** for public 저장소.
-- `prompt` : 기본 동작을 무시하기 위해 옵션 사용자 정의 프롬프트. opencode 프로세스 요청을 사용자 정의하기 위해 이것을 사용합니다.
-- `token`: 코멘트를 생성, 커밋 변경 및 오프닝 풀 요청과 같은 작업을 수행하기위한 옵션 GitHub 액세스 토큰. 기본적으로 opencode는 opencode GitHub App에서 설치 액세스 토큰을 사용하므로 커밋, 코멘트 및 풀 요청은 앱에서 오는 것과 같이 나타납니다.
+- `model`: OpenCode에서 사용할 model입니다. `provider/model` 형식이며 **필수**입니다.
+- `agent`: 사용할 agent입니다. primary agent여야 합니다. 찾지 못하면 config의 `default_agent`를 사용하고, 그것도 없으면 `"build"`로 fallback합니다.
+- `share`: OpenCode 세션 공유 여부입니다. public repo에서는 기본값이 **true**입니다.
+- `prompt`: 기본 동작을 override하는 선택형 custom prompt입니다. OpenCode의 요청 처리 방식을 조정할 때 사용합니다.
+- `token`: 댓글 생성, 커밋, PR 생성 같은 작업을 수행할 때 사용하는 선택형 GitHub access token입니다. 기본적으로 OpenCode는 OpenCode GitHub App의 installation access token을 사용하므로, 커밋/댓글/PR 작성 주체가 app으로 표시됩니다.
 
-대안으로, GitHub Action runner의 [붙박이 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github token)을 사용하여 opencode GitHub 앱을 설치하지 않고 사용할 수 있습니다. 워크플로우에서 필요한 권한을 부여하는 것을 확인하십시오.
+  또는 OpenCode GitHub App을 설치하지 않고도 GitHub Action runner의 [기본 제공 `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token)을 사용할 수 있습니다. 이 경우 workflow에 필요한 permission을 반드시 부여하세요.
 
-```yaml
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  issues: write
-```
+  ```yaml
+  permissions:
+    id-token: write
+    contents: write
+    pull-requests: write
+    issues: write
+  ```
 
-또한 [개인 액세스 토큰](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)를 사용할 수 있습니다.
+  필요하면 [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT)도 사용할 수 있습니다.
 
 ---
 
-## 지원되는 이벤트
+## Supported Events
 
-opencode는 다음 GitHub 이벤트에 의해 트리거 될 수 있습니다:
+OpenCode는 아래 GitHub event로 트리거할 수 있습니다.
 
-| 이벤트 타입                   | Triggered by              | 상세                                                                                                                |
-| ----------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `issue_comment`               | 이슈 또는 PR 댓글         | 멘션 `/opencode` 또는 `/oc` 당신의 의견. opencode는 컨텍스트를 읽고, 지점을 만들 수 있습니다, 열린 PR, 또는 대답. · |
-| `pull_request_review_comment` | PR의 특정 코드 라인 댓글  | Mention `/opencode` 또는 `/oc` 코드 검토 중. opencode는 파일 경로, 줄 번호 및 diff 컨텍스트를 수신합니다. ·         |
-| `issues`                      | 이슈가 열리거나 편집됨    | 이슈가 생성되거나 수정될 때 자동으로 opencode를 트리거합니다. `prompt` 입력이 필요합니다.                           |
-| `pull_request`                | PR 오픈 또는 업데이트     | PR이 열릴 때 자동 트리거 opencode 자동 리뷰에 대한 유용한 정보                                                      |
-| `schedule`                    | 크론 기반 일정            | 일정에 opencode를 실행합니다. `prompt` 입력을 요구합니다. 출력 로그 및 PR에 간다 (댓글이 없습니다).                 |
-| `workflow_dispatch`           | GitHub UI에서 수동 트리거 | 액션 탭을 통해 까다로운 Trigger opencode. `prompt` 입력을 요구합니다. 출력 로그 및 PR에 간다.                       |
+| Event Type                    | Triggered By            | Details                                                                                                                |
+| ----------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `issue_comment`               | issue 또는 PR 댓글      | 댓글에 `/opencode` 또는 `/oc`를 mention하세요. OpenCode가 맥락을 읽고 branch 생성, PR 생성, 답변을 수행할 수 있습니다. |
+| `pull_request_review_comment` | PR의 특정 코드 줄 댓글  | 코드 리뷰 중 `/opencode` 또는 `/oc`를 mention하세요. OpenCode가 파일 경로, 라인 번호, diff 맥락을 받습니다.            |
+| `issues`                      | issue 생성 또는 수정    | issue가 생성/수정될 때 OpenCode를 자동 트리거합니다. `prompt` 입력이 필요합니다.                                       |
+| `pull_request`                | PR 생성 또는 업데이트   | PR open/synchronize/reopen 시 OpenCode를 자동 트리거합니다. 자동 리뷰에 유용합니다.                                    |
+| `schedule`                    | cron 기반 스케줄        | 스케줄에 따라 OpenCode를 실행합니다. `prompt` 입력이 필요합니다. 출력은 로그와 PR로 남습니다(issue 댓글 대상 없음).    |
+| `workflow_dispatch`           | GitHub UI에서 수동 실행 | Actions 탭에서 필요 시 OpenCode를 실행합니다. `prompt` 입력이 필요하며 출력은 로그와 PR로 남습니다.                    |
 
-### 일정 예제
+### Schedule Example
 
-자동화된 작업을 수행하는 일정에 opencode를 실행:
+자동화 작업을 위해 스케줄 기반으로 OpenCode를 실행할 수 있습니다.
 
 ```yaml title=".github/workflows/opencode-scheduled.yml"
 name: Scheduled OpenCode Task
@@ -150,13 +150,13 @@ jobs:
             If you find issues worth addressing, open an issue to track them.
 ```
 
-스케줄된 이벤트의 경우, `prompt` 입력은 **필요 ** 이후의 지시를 추출할 수 없습니다. 사용자 컨텍스트 없이 실행되는 워크플로우는 권한 확인을 위해, 워크플로우는 `contents: write`와 `pull-requests: write`를 부여해야 하며, opencode가 지점이나 PR을 만들게 됩니다.
+schedule event는 지시를 추출할 댓글이 없기 때문에 `prompt` 입력이 **필수**입니다. 또한 schedule workflow는 permission 체크용 사용자 맥락 없이 실행되므로, OpenCode가 branch나 PR을 만들게 하려면 `contents: write`와 `pull-requests: write`를 부여해야 합니다.
 
 ---
 
-## Pull Request 예제
+### Pull Request Example
 
-자동 검토 PR 때 그들은 열려있거나 업데이트 :
+PR이 열리거나 업데이트될 때 자동 리뷰를 수행할 수 있습니다.
 
 ```yaml title=".github/workflows/opencode-review.yml"
 name: opencode-review
@@ -191,13 +191,13 @@ jobs:
             - Suggest improvements
 ```
 
-`pull_request` 이벤트의 경우 `prompt`가 제공되지 않은 경우, 풀 요청을 검토하는 opencode 기본값.
+`pull_request` event에서 `prompt`를 지정하지 않으면 OpenCode는 pull request 리뷰를 기본 동작으로 수행합니다.
 
 ---
 
-### 이슈 분류 예제
+### Issues Triage Example
 
-자동으로 새로운 문제를 삼는다. 이 예제는 스팸을 줄이기 위해 30 일 이상 계정 필터 :
+새로운 issue를 자동으로 triage할 수 있습니다. 아래 예시는 스팸을 줄이기 위해 계정 생성 후 30일 이상인 사용자만 대상으로 필터링합니다.
 
 ```yaml title=".github/workflows/opencode-triage.yml"
 name: Issue Triage
@@ -246,13 +246,13 @@ jobs:
             Otherwise, do not comment.
 ```
 
-`issues` 사건을 위해, `prompt` 입력은 ** 필요 ** 거기에서 지시를 추출하는 코멘트가 없습니다.
+`issues` event 역시 지시를 추출할 댓글이 없기 때문에 `prompt` 입력이 **필수**입니다.
 
 ---
 
-## 사용자 정의 프롬프트
+## Custom prompts
 
-opencode의 작업 흐름을 사용자 정의하는 기본 프롬프트를 부여합니다.
+기본 prompt를 override해 워크플로에 맞게 OpenCode 동작을 커스터마이즈할 수 있습니다.
 
 ```yaml title=".github/workflows/opencode.yml"
 - uses: anomalyco/opencode/github@latest
@@ -265,58 +265,57 @@ opencode의 작업 흐름을 사용자 정의하는 기본 프롬프트를 부�
       - Suggest improvements
 ```
 
-이것은 특정한 검토 기준, 기호화 기준, 또는 당신의 프로젝트에 관련된 초점 지역을 enforcing를 위해 유용합니다.
+이 방식은 프로젝트별 리뷰 기준, 코딩 표준, 중점 점검 항목을 강제할 때 유용합니다.
 
 ---
 
-## 예제
+## 예시
 
-GitHub에서 opencode를 사용할 수있는 몇 가지 예입니다.
+아래는 GitHub에서 OpenCode를 활용하는 대표 예시입니다.
 
-- **이슈 설명**
+- **Issue 설명 요청**
 
-GitHub 문제에서 이 의견 추가.
+  GitHub issue에 아래 댓글을 남기세요.
 
-```
+  ```
   /opencode explain this issue
-```
+  ```
 
-opencode는 모든 코멘트를 포함하여 전체 스레드를 읽고, 명확한 설명과 대답.
+  OpenCode는 전체 스레드와 모든 댓글을 읽고 명확한 설명으로 답변합니다.
 
-- **이슈 해결**
+- **Issue 수정 요청**
 
-GitHub 문제에서:
+  GitHub issue에서 아래처럼 요청하세요.
 
-```
+  ```
   /opencode fix this
-```
+  ```
 
-opencode는 새로운 지점을 만들 것이며 변경 사항을 실행하고 PR을 변경합니다.
+  OpenCode가 새 branch를 만들고 변경을 구현한 뒤, 변경 사항이 담긴 PR을 생성합니다.
 
-- **PR 및 변경 사항 검토**
+- **PR 리뷰 중 변경 요청**
 
-GitHub PR에 다음 댓글을 남겨주세요.
+  GitHub PR에 아래 댓글을 남기세요.
 
-```
+  ```
   Delete the attachment from S3 when the note is removed /oc
-```
+  ```
 
-opencode는 요청한 변경을 구현하고 동일한 PR에 커밋합니다.
+  OpenCode가 요청한 변경을 구현하고 같은 PR에 커밋합니다.
 
-- **특정 코드 라인**
+- **특정 코드 줄 리뷰 요청**
 
-PR의 "Files" 탭의 코드 라인에 직접 댓글을 남겨주세요. opencode는 파일, 줄 번호 및 diff 컨텍스트를 자동으로 감지하여 정확한 응답을 제공합니다.
+  PR의 "Files" 탭에서 코드 줄에 직접 댓글을 남기세요. OpenCode는 파일, 줄 번호, diff 맥락을 자동으로 인식해 더 정확한 응답을 제공합니다.
 
-```
+  ```
   [Comment on specific lines in Files tab]
   /oc add error handling here
-```
+  ```
 
-특정 라인에 대한 의견이 있을 때, opencode는 다음과 같습니다.
+  특정 줄 댓글에서는 OpenCode가 다음 정보를 함께 받습니다.
+  - 검토 중인 정확한 파일
+  - 해당 코드 줄
+  - 주변 diff 맥락
+  - 라인 번호 정보
 
-- 검토되는 정확한 파일
-- 코드의 특정 라인
-- 주변 diff 컨텍스트
-- 라인 번호 정보
-
-파일 경로 또는 라인 번호를 수동으로 지정하지 않고 더 많은 대상 요청을 허용합니다.
+  따라서 파일 경로나 라인 번호를 직접 적지 않아도 더 정밀하게 요청할 수 있습니다.


### PR DESCRIPTION
### Issue for this PR

Closes #14219 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Korean docs wording improvements for the following pages:
- `packages/web/src/content/docs/ko/ecosystem.mdx`
- `packages/web/src/content/docs/ko/enterprise.mdx`
- `packages/web/src/content/docs/ko/formatters.mdx`
- `packages/web/src/content/docs/ko/github.mdx`

I rewrote awkward literal translations into more natural Korean while preserving technical meaning and document structure.

This PR only updates docs wording/terminology consistency and keeps code blocks, commands, links, and headings intact.

### How did you verify your code works?

- Reviewed each diff against the English source docs.
- Checked MDX structure integrity (frontmatter, headings, tables, code blocks, links).
- Confirmed this PR is docs-only and does not change runtime behavior.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
