### PR TITLE
fix(opencode): run tui worker shutdown on signal/terminal-exit paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -81,6 +81,7 @@ export const TuiThreadCommand = cmd({
     // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
     // (Important when running under `bun run` wrappers on Windows.)
     const unguard = win32InstallCtrlCGuard()
+    let unsignal = () => {}
     try {
       // Must be the very first thing — disables CTRL_C_EVENT before any Worker
       // spawn or async work so the OS cannot kill the process group.
@@ -128,6 +129,30 @@ export const TuiThreadCommand = cmd({
         await client.call("reload", undefined)
       })
 
+      let pending: Promise<void> | undefined
+      const shutdown = () => {
+        if (pending) return pending
+        pending = Promise.race([
+          client.call("shutdown", undefined),
+          new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+        ]).catch(() => {})
+        return pending
+      }
+
+      const onSignal = async () => {
+        await shutdown()
+        process.exit(0)
+      }
+
+      process.on("SIGINT", onSignal)
+      process.on("SIGTERM", onSignal)
+      process.on("SIGHUP", onSignal)
+      unsignal = () => {
+        process.off("SIGINT", onSignal)
+        process.off("SIGTERM", onSignal)
+        process.off("SIGHUP", onSignal)
+      }
+
       const prompt = await iife(async () => {
         const piped = !process.stdin.isTTY ? await Bun.stdin.text() : undefined
         if (!args.prompt) return piped
@@ -172,7 +197,7 @@ export const TuiThreadCommand = cmd({
           fork: args.fork,
         },
         onExit: async () => {
-          await client.call("shutdown", undefined)
+          await shutdown()
         },
       })
 
@@ -182,6 +207,7 @@ export const TuiThreadCommand = cmd({
 
       await tuiPromise
     } finally {
+      unsignal()
       unguard?.()
     }
     process.exit(0)


### PR DESCRIPTION
Fixes #14237

### What does this PR do?

Ensures the TUI command routes process-exit signals through the existing worker
shutdown path, instead of only cleaning up during normal UI exit.

### Why this change

`thread.ts` calls `client.call("shutdown")` only inside `onExit`. There are no
handlers for `SIGINT`, `SIGTERM`, or `SIGHUP`, so signal-based exits skip worker
cleanup and child resources can survive.

`worker.ts` already has the canonical cleanup (`Instance.disposeAll()` with timeout
+ `server.stop(true)`). This patch reliably invokes that existing logic from all
exit paths.

### Changes

`packages/opencode/src/cli/cmd/tui/thread.ts` — one idempotent `shutdown` wrapper
with a 5s timeout, signal handlers for `SIGINT`/`SIGTERM`/`SIGHUP`, and `onExit`
routed through the same path. Mirrors signal-driven shutdown already used in other
command entrypoints. No new cleanup semantics introduced.

### How did you verify your code works?

Reproduced leak before fix using a deterministic harness (local fake MCP server
under `script -q -c`), then verified clean exit after fix:

```bash
# start TUI under pseudo-terminal host
script -q -c "opencode /tmp/repro-project" /tmp/tui.log &
# send SIGHUP to TUI process
kill -HUP "$(pgrep -f 'opencode /tmp/repro-project')"
# confirm clean exit (exit code 0, no surviving children)
```

Full test suite: `bun test --timeout 30000` in `packages/opencode` — 1095 pass,
5 skip, 0 fail.