### PR TITLE
fix: compaction bugs #13946 and #13980

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -43,7 +43,7 @@ export namespace SessionCompaction {
       config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))
     const usable = input.model.limit.input
       ? input.model.limit.input - reserved
-      : context - ProviderTransform.maxOutputTokens(input.model)
+      : context - reserved // Fix #13980: apply reserved even when limit.input is not set
     return count >= usable
   }
 
@@ -199,7 +199,7 @@ When constructing the summary, try to stick to this template:
       model,
     })
 
-    if (result === "continue" && input.auto) {
+    if ((result === "continue" || result === "compact") && input.auto) {
       const continueMsg = await Session.updateMessage({
         id: Identifier.ascending("message"),
         role: "user",


### PR DESCRIPTION
### Issue for this PR

Closes #13946
Closes #13980

### Type of change

- [x] Bug fix

### What does this PR do?

This PR fixes two separate bugs in the compaction logic, both of which I hit while running `opencode` in headless/daemon mode.

**Fix #13946 — Compaction crash in headless mode**

When the compaction processor runs and the summary itself exceeds the context window (result becomes `"compact"`), the code path that creates the synthetic `"Continue..."` user message was being skipped. That message is what lets the next turn resume — without it, `opencode run` exits silently mid-session instead of continuing. The fix adds a check for `result === "compact"` alongside the existing `result === "continue"` check so the resume message is always created when running in auto mode.

**Fix #13980 — `compaction.reserved` ignored for Claude / models without `limit.input`**

The `shouldCompact` function computes how many tokens are "usable" before triggering a summary. For models that do have `limit.input` set, it correctly subtracts the `reserved` buffer. But for models that only have `limit.context` (e.g. Claude via GitHub Copilot), the fallback branch was computing `context - maxOutputTokens`, ignoring the configured `reserved` value entirely. This made it impossible to tune the compaction threshold on those models. The fix applies `context - reserved` in the fallback branch, consistent with the behavior for models with explicit input limits.

### How did you verify your code works?

- Ran the patched binary as the backing process for a persistent AI assistant that triggers compaction regularly. Confirmed `opencode run` no longer exits after compaction turns, and that the reserved threshold is respected correctly across sessions.
- Ran `turbo typecheck` — no type errors.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR