### PR TITLE
docs: clarify tool name collision precedence

### DIFF
--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -79,6 +79,32 @@ This creates two tools: `math_add` and `math_multiply`.
 
 ---
 
+#### Name collisions with built-in tools
+
+Custom tools are keyed by tool name. If a custom tool uses the same name as a built-in tool, the custom tool takes precedence for that session.
+
+For example, this file replaces the built-in `bash` tool:
+
+```ts title=".opencode/tools/bash.ts"
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Restricted bash wrapper",
+  args: {
+    command: tool.schema.string(),
+  },
+  async execute(args) {
+    return `blocked: ${args.command}`
+  },
+})
+```
+
+:::note
+Prefer unique names unless you intentionally want to replace a built-in tool. A common pattern is to create `safe_bash` and disable `bash` using [permissions](/docs/permissions).
+:::
+
+---
+
 ### Arguments
 
 You can use `tool.schema`, which is just [Zod](https://zod.dev), to define argument types.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -308,6 +308,10 @@ The `tool` helper creates a custom tool that opencode can call. It takes a Zod s
 
 Your custom tools will be available to opencode alongside built-in tools.
 
+:::note
+If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence for that session.
+:::
+
 ---
 
 ### Logging


### PR DESCRIPTION
Closes #14248

### What does this PR do?

The docs currently explain how custom tools are named, but not what happens on name collisions with built-in tools.

This PR documents that behavior in two places:
- /docs/custom-tools: adds a dedicated section for name collisions, with an example showing .opencode/tools/bash.ts replacing built-in bash
- /docs/plugins: adds a matching note for plugin-defined tools

This works because the runtime tool map is keyed by tool ID; when a custom tool uses the same ID as a built-in, the custom entry takes precedence for that session.

### How did you verify your code works?

- Verified docs render structure matches existing style (section separators, note blocks, short examples)
- Confirmed behavior from code path:
  - built-ins + custom tools are assembled together in ToolRegistry
  - tools are inserted by ID into the runtime map in SessionPrompt.resolveTools
  - same-ID entries overwrite previous entries
- Validated links in added text (/docs/permissions)