### PR TITLE
feat: add language aliases for TUI syntax highlighting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -81,6 +81,36 @@ import { UI } from "@/cli/ui.ts"
 
 addDefaultParsers(parsers.parsers)
 
+// Register language aliases so common code fence names resolve to existing parsers.
+// For example, ```jsonc should highlight using the json parser.
+const LANGUAGE_ALIASES: Record<string, string> = {
+  jsonc: "json",
+  json5: "json",
+  jsonl: "json",
+  sh: "bash",
+  zsh: "bash",
+  shell: "bash",
+  "c++": "cpp",
+  "c#": "csharp",
+  yml: "yaml",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  hs: "haskell",
+  js: "javascript",
+  jsx: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  md: "markdown",
+}
+
+for (const [alias, target] of Object.entries(LANGUAGE_ALIASES)) {
+  const targetParser = parsers.parsers.find((p: { filetype: string }) => p.filetype === target)
+  if (targetParser) {
+    addDefaultParsers([{ ...targetParser, filetype: alias }])
+  }
+}
+
 class CustomSpeedScroll implements ScrollAcceleration {
   constructor(private speed: number) {}
 


### PR DESCRIPTION
### Issue for this PR

Closes #12211

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `LANGUAGE_ALIASES` map to the TUI code block highlighter so that common code fence language names that don't have their own tree-sitter parser resolve to an existing one.

For example, ```jsonc now highlights as JSON, ```tsx as TypeScript, ```sh as Bash, etc.

**18 aliases added:** jsonc, json5, jsonl, sh, zsh, shell, c++, c#, yml, py, rb, rs, hs, js, jsx, ts, tsx, md.

### How did you verify your code works?

Tested locally in TUI — code blocks with `jsonc`, `jsx`, `tsx`, `sh` and other aliased languages now render with proper syntax highlighting.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR