### PR TITLE
feat: add branch selector and VCS checkout APIs

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { Popover } from "@opencode-ai/ui/popover"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { Keybind } from "@opencode-ai/ui/keybind"
+import { List } from "@opencode-ai/ui/list"
 import { showToast } from "@opencode-ai/ui/toast"
 import { StatusPopover } from "../status-popover"
 
@@ -89,11 +90,30 @@ const detectOS = (platform: ReturnType<typeof usePlatform>): OS => {
   return "unknown"
 }
 
+const errorText = (value: unknown): string => {
+  if (value && typeof value === "object" && "data" in value) {
+    const data = (value as { data?: { message?: unknown } }).data
+    if (typeof data?.message === "string" && data.message) return data.message
+  }
+  if (value && typeof value === "object" && "error" in value) {
+    const nested = errorText((value as { error?: unknown }).error)
+    if (nested) return nested
+  }
+  if (value && typeof value === "object" && "message" in value) {
+    const message = (value as { message?: unknown }).message
+    if (typeof message === "string" && message) return message
+  }
+  if (value instanceof Error && value.message) return value.message
+  if (typeof value === "string" && value) return value
+  return ""
+}
+
 const showRequestError = (language: ReturnType<typeof useLanguage>, err: unknown) => {
+  const message = errorText(err)
   showToast({
     variant: "error",
     title: language.t("common.requestFailed"),
-    description: err instanceof Error ? err.message : String(err),
+    description: message || language.t("common.requestFailed"),
   })
 }
 
@@ -204,6 +224,112 @@ export function SessionHeader() {
     if (current) return current.name || getFilename(current.worktree)
     return getFilename(projectDirectory())
   })
+  const workspace = createMemo(() => {
+    const directory = projectDirectory()
+    if (!directory) return ""
+
+    const current = project()
+    if (!current) return getFilename(directory)
+
+    const root = getFilename(current.worktree)
+    if (directory === current.worktree) return root
+
+    const leaf = getFilename(directory)
+    if (!leaf) return root
+    if (!root) return leaf
+    if (leaf === root) return root
+    return `${root}/${leaf}`
+  })
+
+  const [branchMenu, setBranchMenu] = createStore({
+    open: false,
+    loading: false,
+    switching: false,
+    branch: "",
+    items: [] as { name: string; remote: boolean; worktree?: string }[],
+  })
+
+  const target = createMemo(() => {
+    const directory = projectDirectory()
+    if (!directory) return
+    return {
+      workspace: workspace(),
+      branch: sync.data.vcs?.branch || branchMenu.branch || "HEAD",
+    }
+  })
+
+  createEffect(() => {
+    const branch = sync.data.vcs?.branch
+    if (!branch) return
+    if (branchMenu.branch === branch) return
+    setBranchMenu("branch", branch)
+  })
+
+  const branches = createMemo(() => branchMenu.items)
+  const currentBranch = createMemo(() => {
+    const branch = sync.data.vcs?.branch || branchMenu.branch
+    if (!branch) return
+    return branches().find((item) => item.name === branch)
+  })
+  const localGroup = () => language.t("session.header.branch.group.local")
+  const remoteGroup = () => language.t("session.header.branch.group.remote")
+
+  createEffect(() => {
+    if (!branchMenu.open) return
+    const directory = projectDirectory()
+    if (!directory) return
+    setBranchMenu("loading", true)
+    void globalSDK.client.vcs
+      .branches({ directory })
+      .then((result) => {
+        setBranchMenu("items", result.data ?? [])
+      })
+      .catch((err: unknown) => {
+        setBranchMenu("items", [])
+        showRequestError(language, err)
+      })
+      .finally(() => {
+        setBranchMenu("loading", false)
+      })
+  })
+
+  const switchBranch = (name: string) => {
+    const directory = projectDirectory()
+    if (!directory) return
+    const current = sync.data.vcs?.branch || branchMenu.branch
+    if (current === name) {
+      setBranchMenu("open", false)
+      return
+    }
+
+    const item = branchMenu.items.find((b) => b.name === name)
+    if (item?.worktree) {
+      showToast({
+        variant: "error",
+        title: language.t("session.header.branch.inUse.title"),
+        description: language.t("session.header.branch.inUse.description", { branch: name }),
+      })
+      return
+    }
+
+    setBranchMenu("switching", true)
+    void globalSDK.client.vcs
+      .checkout({
+        directory,
+        vcsCheckoutInput: { branch: name },
+      })
+      .then((result) => {
+        setBranchMenu("branch", result.data?.branch ?? name)
+        setBranchMenu("open", false)
+      })
+      .catch((err: unknown) => {
+        showRequestError(language, err)
+      })
+      .finally(() => {
+        setBranchMenu("switching", false)
+      })
+  }
+
   const hotkey = createMemo(() => command.keybind("file.open"))
 
   const currentSession = createMemo(() => sync.data.session.find((s) => s.id === params.id))
@@ -296,12 +422,12 @@ export function SessionHeader() {
     platform,
   })
 
-  const centerMount = createMemo(() => document.getElementById("opencode-titlebar-center"))
+  const leftMount = createMemo(() => document.getElementById("opencode-titlebar-left"))
   const rightMount = createMemo(() => document.getElementById("opencode-titlebar-right"))
 
   return (
     <>
-      <Show when={centerMount()}>
+      <Show when={leftMount()}>
         {(mount) => (
           <Portal mount={mount()}>
             <Button
@@ -332,6 +458,85 @@ export function SessionHeader() {
         {(mount) => (
           <Portal mount={mount()}>
             <div class="flex items-center gap-2">
+              <Show when={target()}>
+                {(value) => (
+                  <div class="hidden lg:flex min-w-0 max-w-sm">
+                    <Popover
+                      open={branchMenu.open}
+                      onOpenChange={(open) => setBranchMenu("open", open)}
+                      placement="bottom-end"
+                      gutter={4}
+                      class="w-96 flex flex-col rounded-md border border-border-base bg-surface-raised-stronger-non-alpha p-2 shadow-md z-50 outline-none overflow-hidden"
+                      triggerAs={Button}
+                      triggerProps={{
+                        variant: "ghost",
+                        size: "small",
+                        disabled: branchMenu.switching,
+                        class:
+                          "h-[24px] min-w-0 max-w-sm items-center gap-1.5 rounded-md border border-border-weak-base bg-surface-panel px-2 shadow-none data-[expanded]:bg-surface-base-active",
+                        "aria-label": value().branch,
+                      }}
+                      trigger={
+                        <>
+                          <Icon name="folder" size="small" class="icon-base shrink-0 size-3.5" />
+                          <span class="min-w-0 truncate text-12-regular text-text-strong">{value().workspace}</span>
+                          <div class="h-3 w-px shrink-0 bg-border-weak-base" />
+                          <Icon name="branch" size="small" class="icon-base shrink-0 size-3.5" />
+                          <span class="min-w-0 truncate text-12-regular text-text-weak">{value().branch}</span>
+                          <Icon name="chevron-down" size="small" class="icon-base shrink-0 size-3.5 text-icon-weak" />
+                        </>
+                      }
+                    >
+                      <List
+                        items={branches}
+                        key={(item) => item.name}
+                        current={currentBranch()}
+                        filterKeys={["name"]}
+                        groupBy={(item) => (item.remote ? remoteGroup() : localGroup())}
+                        sortGroupsBy={(a, b) => {
+                          const local = localGroup()
+                          if (a.category === b.category) return 0
+                          if (a.category === local) return -1
+                          if (b.category === local) return 1
+                          return 0
+                        }}
+                        groupHeader={(group) => (
+                          <div class="flex w-full flex-col">
+                            <Show when={group.category === remoteGroup()}>
+                              <div class="my-1 h-px bg-border-weak-base" />
+                            </Show>
+                            <span class="px-2 py-1 text-11-regular text-text-subtle">{group.category}</span>
+                          </div>
+                        )}
+                        search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
+                        class="flex-1 min-h-0 !gap-2 !px-1.5 [&_[data-slot=list-search-wrapper]]:!mb-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0 [&_[data-slot=list-scroll]]:max-h-[300px] [&_[data-slot=list-scroll]]:!gap-0 [&_[data-slot=list-group]:last-child]:!pb-1 [&_[data-slot=list-header]]:!p-0 [&_[data-slot=list-header]]:!bg-transparent [&_[data-slot=list-header]]:!static [&_[data-slot=list-header]]:after:!hidden [&_[data-slot=list-item]]:overflow-hidden [&_[data-slot=list-item][data-active=true]_[data-slot=list-item-selected-icon]]:!hidden [&_[data-slot=list-item][data-active=true]_[data-slot=branch-badge]]:!hidden"
+                        onSelect={(item) => {
+                          if (!item) return
+                          switchBranch(item.name)
+                        }}
+                      >
+                        {(item) => (
+                          <div
+                            class="w-full min-w-0 flex items-center gap-2 text-13-regular overflow-hidden"
+                            classList={{ "opacity-50": !!item.worktree }}
+                          >
+                            <Icon name="branch" size="small" class="icon-base shrink-0 size-3.5" />
+                            <span class="min-w-0 truncate">{item.name}</span>
+                            <Show when={item.worktree}>
+                              <span data-slot="branch-badge" class="ml-auto shrink-0 text-11-regular text-text-subtle">
+                                {language.t("session.header.branch.inUse.badge")}
+                              </span>
+                            </Show>
+                          </div>
+                        )}
+                      </List>
+                      <Show when={branchMenu.loading}>
+                        <div class="px-2 pt-2 text-12-regular text-text-weak">{language.t("common.loading")}</div>
+                      </Show>
+                    </Popover>
+                  </div>
+                )}
+              </Show>
               <StatusPopover />
               <Show when={projectDirectory()}>
                 <div class="hidden xl:flex items-center">

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -524,6 +524,11 @@ export const dict = {
   "session.header.open.ariaLabel": "Open in {{app}}",
   "session.header.open.menu": "Open options",
   "session.header.open.copyPath": "Copy path",
+  "session.header.branch.group.local": "local",
+  "session.header.branch.group.remote": "remote",
+  "session.header.branch.inUse.badge": "in use",
+  "session.header.branch.inUse.title": "Branch in use",
+  "session.header.branch.inUse.description": "{{branch}} is checked out in another worktree",
 
   "status.popover.trigger": "Status",
   "status.popover.ariaLabel": "Server configurations",

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -80,9 +80,68 @@ export namespace Vcs {
       .filter(Boolean)
       .join("\n")
 
+  type Worktree = {
+    path?: string
+    branch?: string
+    head?: string
+    detached?: boolean
+  }
+
+  const parseWorktrees = (value: string) =>
+    value
+      .split("\n")
+      .map((line) => line.replace(/\r$/, ""))
+      .reduce<Worktree[]>((all, line) => {
+        if (!line.trim()) return all
+        if (line.startsWith("worktree ")) {
+          all.push({ path: line.slice("worktree ".length) })
+          return all
+        }
+        const item = all[all.length - 1]
+        if (!item) return all
+        if (line.startsWith("branch refs/heads/")) {
+          item.branch = line.slice("branch refs/heads/".length)
+          return all
+        }
+        if (line.startsWith("HEAD ")) {
+          item.head = line.slice("HEAD ".length)
+          return all
+        }
+        if (line === "detached") {
+          item.detached = true
+        }
+        return all
+      }, [])
+
+  const occupied = (value: string) =>
+    parseWorktrees(value).reduce<Map<string, string>>((all, item) => {
+      if (!item.path || !item.branch) return all
+      all.set(item.branch, item.path)
+      return all
+    }, new Map())
+
   const has = async (ref: string) => {
     const result = await $`git show-ref --verify --quiet ${ref}`.quiet().nothrow().cwd(Instance.worktree)
     return result.exitCode === 0
+  }
+
+  const upstream = async (name: string) => {
+    const result = await $`git for-each-ref --format=%(upstream:short) refs/heads/${name}`
+      .quiet()
+      .nothrow()
+      .cwd(Instance.worktree)
+    if (result.exitCode !== 0) return
+    const ref = output(result.stdout).trim()
+    if (!ref) return
+    return ref
+  }
+
+  const revision = async (ref: string) => {
+    const result = await $`git rev-parse --verify --quiet ${ref}`.quiet().nothrow().cwd(Instance.worktree)
+    if (result.exitCode !== 0) return
+    const hash = output(result.stdout).trim()
+    if (!hash) return
+    return hash
   }
 
   async function currentBranch() {
@@ -153,28 +212,11 @@ export namespace Vcs {
       throw new BranchListFailedError({ message: message(remote) || "Failed to list remote git branches" })
     }
 
-    const occupied = new Map<string, string>()
+    const inuse = new Map<string, string>()
     if (worktrees.exitCode === 0) {
-      output(worktrees.stdout)
-        .split("\n")
-        .map((line) => line.replace(/\r$/, ""))
-        .reduce<{ path?: string; branch?: string }[]>((acc, line) => {
-          if (!line.trim()) return acc
-          if (line.startsWith("worktree ")) {
-            acc.push({ path: line.slice("worktree ".length) })
-            return acc
-          }
-          const item = acc[acc.length - 1]
-          if (!item) return acc
-          if (line.startsWith("branch refs/heads/")) {
-            item.branch = line.slice("branch refs/heads/".length)
-          }
-          return acc
-        }, [])
-        .forEach((item) => {
-          if (!item.path || !item.branch) return
-          occupied.set(item.branch, item.path)
-        })
+      occupied(output(worktrees.stdout)).forEach((dir, name) => {
+        inuse.set(name, dir)
+      })
     }
 
     const current = Instance.worktree
@@ -193,7 +235,7 @@ export namespace Vcs {
 
     return [
       ...localBranches.map((name) => {
-        const dir = occupied.get(name)
+        const dir = inuse.get(name)
         const worktree = dir && dir !== current ? dir : undefined
         return Branch.parse({ name, remote: false, worktree })
       }),
@@ -214,6 +256,16 @@ export namespace Vcs {
       throw new BranchCheckoutFailedError({ message: "Branch name is required" })
     }
 
+    const worktrees = await $`git worktree list --porcelain`.quiet().nothrow().cwd(Instance.worktree)
+    const inuse = worktrees.exitCode === 0 ? occupied(output(worktrees.stdout)) : new Map<string, string>()
+    const ensureFree = (name: string) => {
+      const dir = inuse.get(name)
+      if (!dir || dir === Instance.worktree) return
+      throw new BranchCheckoutFailedError({
+        message: `Branch "${name}" is checked out in another worktree: ${dir}`,
+      })
+    }
+
     const current = await currentBranch()
     if (current === target) {
       return Info.parse({ branch: target })
@@ -221,6 +273,7 @@ export namespace Vcs {
 
     const local = await has(`refs/heads/${target}`)
     if (local) {
+      ensureFree(target)
       const switched = await $`git switch ${target}`.quiet().nothrow().cwd(Instance.worktree)
       if (switched.exitCode !== 0) {
         throw new BranchCheckoutFailedError({
@@ -236,7 +289,8 @@ export namespace Vcs {
       return Info.parse({ branch })
     }
 
-    const remote = target.includes("/") ? target : `origin/${target}`
+    const explicit = target.includes("/")
+    const remote = explicit ? target : `origin/${target}`
     const remoteRef = `refs/remotes/${remote}`
     const exists = await has(remoteRef)
     if (!exists) {
@@ -249,8 +303,28 @@ export namespace Vcs {
       throw new BranchCheckoutFailedError({ message: `Invalid branch: ${target}` })
     }
 
+    ensureFree(localName)
+
     const localRef = `refs/heads/${localName}`
     const localExists = await has(localRef)
+
+    if (explicit && localExists) {
+      const tracked = await upstream(localName)
+      if (tracked && tracked !== remote) {
+        throw new BranchCheckoutFailedError({
+          message: `Local branch "${localName}" tracks "${tracked}", not "${remote}"`,
+        })
+      }
+      if (!tracked) {
+        const [a, b] = await Promise.all([revision(localRef), revision(remoteRef)])
+        if (a && b && a !== b) {
+          throw new BranchCheckoutFailedError({
+            message: `Local branch "${localName}" differs from "${remote}"`,
+          })
+        }
+      }
+    }
+
     const switched = localExists
       ? await $`git switch ${localName}`.quiet().nothrow().cwd(Instance.worktree)
       : await $`git switch --track -c ${localName} ${remote}`.quiet().nothrow().cwd(Instance.worktree)

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,11 +1,12 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { $ } from "bun"
-import path from "path"
 import z from "zod"
 import { Log } from "@/util/log"
 import { Instance } from "./instance"
 import { FileWatcher } from "@/file/watcher"
+import { NamedError } from "@opencode-ai/util/error"
+import { fn } from "@/util/fn"
 
 const log = Log.create({ service: "vcs" })
 
@@ -19,6 +20,28 @@ export namespace Vcs {
     ),
   }
 
+  export const Branch = z
+    .object({
+      name: z.string(),
+      remote: z.boolean(),
+      worktree: z.string().optional(),
+    })
+    .meta({
+      ref: "VcsBranch",
+    })
+
+  export type Branch = z.infer<typeof Branch>
+
+  export const CheckoutInput = z
+    .object({
+      branch: z.string(),
+    })
+    .meta({
+      ref: "VcsCheckoutInput",
+    })
+
+  export type CheckoutInput = z.infer<typeof CheckoutInput>
+
   export const Info = z
     .object({
       branch: z.string(),
@@ -28,20 +51,56 @@ export namespace Vcs {
     })
   export type Info = z.infer<typeof Info>
 
+  export const BranchListFailedError = NamedError.create(
+    "VcsBranchListFailedError",
+    z.object({
+      message: z.string(),
+    }),
+  )
+
+  export const BranchNotFoundError = NamedError.create(
+    "VcsBranchNotFoundError",
+    z.object({
+      message: z.string(),
+    }),
+  )
+
+  export const BranchCheckoutFailedError = NamedError.create(
+    "VcsBranchCheckoutFailedError",
+    z.object({
+      message: z.string(),
+    }),
+  )
+
+  const output = (value: Uint8Array | undefined) => (value ? Buffer.from(value).toString("utf8") : "")
+
+  const message = (result: { stdout?: Uint8Array; stderr?: Uint8Array }) =>
+    [output(result.stderr), output(result.stdout)]
+      .map((x) => x.trim())
+      .filter(Boolean)
+      .join("\n")
+
+  const has = async (ref: string) => {
+    const result = await $`git show-ref --verify --quiet ${ref}`.quiet().nothrow().cwd(Instance.worktree)
+    return result.exitCode === 0
+  }
+
   async function currentBranch() {
-    return $`git rev-parse --abbrev-ref HEAD`
-      .quiet()
-      .nothrow()
-      .cwd(Instance.worktree)
-      .text()
-      .then((x) => x.trim())
-      .catch(() => undefined)
+    const result = await $`git rev-parse --abbrev-ref HEAD`.quiet().nothrow().cwd(Instance.worktree)
+    if (result.exitCode !== 0) return
+    const branch = output(result.stdout).trim()
+    if (!branch) return
+    return branch
   }
 
   const state = Instance.state(
     async () => {
       if (Instance.project.vcs !== "git") {
-        return { branch: async () => undefined, unsubscribe: undefined }
+        return {
+          branch: async () => undefined,
+          setBranch: (_value: string | undefined) => undefined,
+          unsubscribe: undefined,
+        }
       }
       let current = await currentBranch()
       log.info("initialized", { branch: current })
@@ -58,6 +117,9 @@ export namespace Vcs {
 
       return {
         branch: async () => current,
+        setBranch: (value: string | undefined) => {
+          current = value
+        },
         unsubscribe,
       }
     },
@@ -73,4 +135,137 @@ export namespace Vcs {
   export async function branch() {
     return await state().then((s) => s.branch())
   }
+
+  export async function branches() {
+    if (Instance.project.vcs !== "git") return [] as Branch[]
+
+    const [local, remote, worktrees] = await Promise.all([
+      $`git branch --list --no-color`.quiet().nothrow().cwd(Instance.worktree),
+      $`git branch --remotes --no-color`.quiet().nothrow().cwd(Instance.worktree),
+      $`git worktree list --porcelain`.quiet().nothrow().cwd(Instance.worktree),
+    ])
+
+    if (local.exitCode !== 0) {
+      throw new BranchListFailedError({ message: message(local) || "Failed to list local git branches" })
+    }
+
+    if (remote.exitCode !== 0) {
+      throw new BranchListFailedError({ message: message(remote) || "Failed to list remote git branches" })
+    }
+
+    const occupied = new Map<string, string>()
+    if (worktrees.exitCode === 0) {
+      output(worktrees.stdout)
+        .split("\n")
+        .map((line) => line.replace(/\r$/, ""))
+        .reduce<{ path?: string; branch?: string }[]>((acc, line) => {
+          if (!line.trim()) return acc
+          if (line.startsWith("worktree ")) {
+            acc.push({ path: line.slice("worktree ".length) })
+            return acc
+          }
+          const item = acc[acc.length - 1]
+          if (!item) return acc
+          if (line.startsWith("branch refs/heads/")) {
+            item.branch = line.slice("branch refs/heads/".length)
+          }
+          return acc
+        }, [])
+        .forEach((item) => {
+          if (!item.path || !item.branch) return
+          occupied.set(item.branch, item.path)
+        })
+    }
+
+    const current = Instance.worktree
+    const localBranches = output(local.stdout)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.replace(/^[*+]\s+/, "").trim())
+      .filter(Boolean)
+
+    const remoteBranches = output(remote.stdout)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => !line.includes(" -> "))
+
+    return [
+      ...localBranches.map((name) => {
+        const dir = occupied.get(name)
+        const worktree = dir && dir !== current ? dir : undefined
+        return Branch.parse({ name, remote: false, worktree })
+      }),
+      ...remoteBranches.map((name) => Branch.parse({ name, remote: true })),
+    ].sort((a, b) => {
+      if (a.remote !== b.remote) return a.remote ? 1 : -1
+      return a.name.localeCompare(b.name)
+    })
+  }
+
+  export const checkout = fn(CheckoutInput, async (input) => {
+    if (Instance.project.vcs !== "git") {
+      throw new BranchCheckoutFailedError({ message: "Branch switching is only supported for git projects" })
+    }
+
+    const target = input.branch.trim()
+    if (!target) {
+      throw new BranchCheckoutFailedError({ message: "Branch name is required" })
+    }
+
+    const current = await currentBranch()
+    if (current === target) {
+      return Info.parse({ branch: target })
+    }
+
+    const local = await has(`refs/heads/${target}`)
+    if (local) {
+      const switched = await $`git switch ${target}`.quiet().nothrow().cwd(Instance.worktree)
+      if (switched.exitCode !== 0) {
+        throw new BranchCheckoutFailedError({
+          message: message(switched) || `Failed to switch to ${target}`,
+        })
+      }
+
+      const next = await currentBranch()
+      const branch = next ?? target
+      const cache = await state()
+      cache.setBranch(branch)
+      Bus.publish(Event.BranchUpdated, { branch })
+      return Info.parse({ branch })
+    }
+
+    const remote = target.includes("/") ? target : `origin/${target}`
+    const remoteRef = `refs/remotes/${remote}`
+    const exists = await has(remoteRef)
+    if (!exists) {
+      throw new BranchNotFoundError({ message: `Branch not found: ${target}` })
+    }
+
+    const index = remote.indexOf("/")
+    const localName = index >= 0 ? remote.slice(index + 1) : remote
+    if (!localName) {
+      throw new BranchCheckoutFailedError({ message: `Invalid branch: ${target}` })
+    }
+
+    const localRef = `refs/heads/${localName}`
+    const localExists = await has(localRef)
+    const switched = localExists
+      ? await $`git switch ${localName}`.quiet().nothrow().cwd(Instance.worktree)
+      : await $`git switch --track -c ${localName} ${remote}`.quiet().nothrow().cwd(Instance.worktree)
+
+    if (switched.exitCode !== 0) {
+      throw new BranchCheckoutFailedError({
+        message: message(switched) || `Failed to switch to ${target}`,
+      })
+    }
+
+    const next = await currentBranch()
+    const branch = next ?? localName
+    const cache = await state()
+    cache.setBranch(branch)
+    Bus.publish(Event.BranchUpdated, { branch })
+    return Info.parse({ branch })
+  })
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -68,6 +68,7 @@ export namespace Server {
             if (err instanceof NotFoundError) status = 404
             else if (err instanceof Provider.ModelNotFoundError) status = 400
             else if (err.name.startsWith("Worktree")) status = 400
+            else if (err.name.startsWith("Vcs")) status = 400
             else status = 500
             return c.json(err.toObject(), { status })
           }
@@ -320,6 +321,54 @@ export namespace Server {
             return c.json({
               branch,
             })
+          },
+        )
+        .get(
+          "/vcs/branches",
+          describeRoute({
+            summary: "List branches",
+            description: "Retrieve all local and remote branches for the current git project.",
+            operationId: "vcs.branches",
+            responses: {
+              200: {
+                description: "List of branches",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.array(Vcs.Branch)),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          async (c) => {
+            const branches = await Vcs.branches()
+            return c.json(branches)
+          },
+        )
+        .post(
+          "/vcs/checkout",
+          describeRoute({
+            summary: "Checkout branch",
+            description: "Switch the current git workspace to the selected branch.",
+            operationId: "vcs.checkout",
+            responses: {
+              200: {
+                description: "Current branch after checkout",
+                content: {
+                  "application/json": {
+                    schema: resolver(Vcs.Info),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", Vcs.checkout.schema),
+          async (c) => {
+            const body = c.req.valid("json")
+            const info = await Vcs.checkout(body)
+            return c.json(info)
           },
         )
         .get(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -163,6 +163,11 @@ import type {
   TuiSelectSessionResponses,
   TuiShowToastResponses,
   TuiSubmitPromptResponses,
+  VcsBranchesErrors,
+  VcsBranchesResponses,
+  VcsCheckoutErrors,
+  VcsCheckoutInput,
+  VcsCheckoutResponses,
   VcsGetResponses,
   WorktreeCreateErrors,
   WorktreeCreateInput,
@@ -3012,6 +3017,60 @@ export class Vcs extends HeyApiClient {
       url: "/vcs",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * List branches
+   *
+   * Retrieve all local and remote branches for the current git project.
+   */
+  public branches<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<VcsBranchesResponses, VcsBranchesErrors, ThrowOnError>({
+      url: "/vcs/branches",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Checkout branch
+   *
+   * Switch the current git workspace to the selected branch.
+   */
+  public checkout<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      vcsCheckoutInput?: VcsCheckoutInput
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "vcsCheckoutInput", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<VcsCheckoutResponses, VcsCheckoutErrors, ThrowOnError>({
+      url: "/vcs/checkout",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2198,6 +2198,16 @@ export type VcsInfo = {
   branch: string
 }
 
+export type VcsBranch = {
+  name: string
+  remote: boolean
+  worktree?: string
+}
+
+export type VcsCheckoutInput = {
+  branch: string
+}
+
 export type Command = {
   name: string
   description?: string
@@ -4904,6 +4914,60 @@ export type VcsGetResponses = {
 }
 
 export type VcsGetResponse = VcsGetResponses[keyof VcsGetResponses]
+
+export type VcsBranchesData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/vcs/branches"
+}
+
+export type VcsBranchesErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type VcsBranchesError = VcsBranchesErrors[keyof VcsBranchesErrors]
+
+export type VcsBranchesResponses = {
+  /**
+   * List of branches
+   */
+  200: Array<VcsBranch>
+}
+
+export type VcsBranchesResponse = VcsBranchesResponses[keyof VcsBranchesResponses]
+
+export type VcsCheckoutData = {
+  body?: VcsCheckoutInput
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/vcs/checkout"
+}
+
+export type VcsCheckoutErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type VcsCheckoutError = VcsCheckoutErrors[keyof VcsCheckoutErrors]
+
+export type VcsCheckoutResponses = {
+  /**
+   * Current branch after checkout
+   */
+  200: VcsInfo
+}
+
+export type VcsCheckoutResponse = VcsCheckoutResponses[keyof VcsCheckoutResponses]
 
 export type CommandListData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #14265

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds VCS API endpoints for branch listing and checkout (`/vcs/branches`, `/vcs/checkout`) with typed errors and SDK generation.
- Adds a branch/workspace selector in the session header to browse local and remote branches and switch from the UI.
- Prevents switching to branches already checked out in another worktree.
- Makes `git worktree list --porcelain` parsing CRLF-safe to avoid platform parsing issues.

### How did you verify your code works?

- `bun run typecheck` in `packages/opencode`
- `bun run typecheck` in `packages/app`
- `OPENCODE_SERVER_PASSWORD= bun run test` in `packages/opencode`
- `bun run test:unit` in `packages/app`
- `bun run build` in `packages/opencode`
- `bun run build` in `packages/app`

### Screenshots / recordings
[
<img width="1512" height="982" alt="Screenshot 2026-02-19 at 3 20 01 PM" src="https://github.com/user-attachments/assets/99ea5112-08df-4726-a712-439205ee8596" />
](url)

<img width="344" height="426" alt="opencode" src="https://github.com/user-attachments/assets/5ad8c317-4b0f-4f4c-bb31-e5f03106707d" />

- UI change: session header now includes a branch/workspace popover with grouped local/remote branches and an "in use" badge.
- I could not capture a screenshot from this CLI-only environment.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR