### PR TITLE
fix: preserve per-session input drafts when switching sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -40,6 +40,7 @@ import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { TuiConfigProvider } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
+import { drafts } from "./component/prompt"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -385,11 +386,12 @@ function App() {
       },
       onSelect: () => {
         const current = promptRef.current
-        // Don't require focus - if there's any text, preserve it
-        const currentPrompt = current?.current?.input ? current.current : undefined
+        // Save draft for the current session instead of carrying it to home
+        if (current?.current?.input && route.data.type === "session") {
+          drafts.set(route.data.sessionID, { input: current.current.input, parts: [...current.current.parts] })
+        }
         route.navigate({
           type: "home",
-          initialPrompt: currentPrompt,
         })
         dialog.clear()
       },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -389,6 +389,8 @@ function App() {
         // Save draft for the current session instead of carrying it to home
         if (current?.current?.input && route.data.type === "session") {
           drafts.set(route.data.sessionID, { input: current.current.input, parts: [...current.current.parts] })
+        } else if (route.data.type === "session") {
+          drafts.delete(route.data.sessionID)
         }
         route.navigate({
           type: "home",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -11,6 +11,8 @@ import { DialogSessionRename } from "./dialog-session-rename"
 import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
 import { Spinner } from "./spinner"
+import { usePromptRef } from "../context/prompt"
+import { drafts } from "./prompt"
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -20,6 +22,7 @@ export function DialogSessionList() {
   const { theme } = useTheme()
   const sdk = useSDK()
   const kv = useKV()
+  const promptRef = usePromptRef()
 
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
@@ -74,6 +77,15 @@ export function DialogSessionList() {
         setToDelete(undefined)
       }}
       onSelect={(option) => {
+        // Save current prompt as draft for the current session
+        if (route.data.type === "session") {
+          const current = promptRef.current
+          if (current?.current?.input) {
+            drafts.set(route.data.sessionID, { input: current.current.input, parts: [...current.current.parts] })
+          } else {
+            drafts.delete(route.data.sessionID)
+          }
+        }
         route.navigate({
           type: "session",
           sessionID: option.value,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -98,6 +98,7 @@ export function DialogSessionList() {
           title: "delete",
           onTrigger: async (option) => {
             if (toDelete() === option.value) {
+              drafts.delete(option.value)
               sdk.client.session.delete({
                 sessionID: option.value,
               })

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -140,16 +140,15 @@ export function Prompt(props: PromptProps) {
     interrupt: 0,
   })
 
-  let previousSessionID: string | undefined = props.sessionID
   createEffect(
     on(
       () => props.sessionID,
-      (nextSessionID) => {
+      (nextSessionID, prev) => {
         // Save current draft for the previous session
-        if (previousSessionID && store.prompt.input) {
-          drafts.set(previousSessionID, { input: store.prompt.input, parts: [...store.prompt.parts] })
-        } else if (previousSessionID) {
-          drafts.delete(previousSessionID)
+        if (prev && store.prompt.input) {
+          drafts.set(prev, { input: store.prompt.input, parts: [...store.prompt.parts] })
+        } else if (prev) {
+          drafts.delete(prev)
         }
 
         // Restore draft for the new session or clear
@@ -159,17 +158,16 @@ export function Prompt(props: PromptProps) {
           setStore("prompt", { input: draft.input, parts: draft.parts })
           restoreExtmarksFromParts(draft.parts)
           input.gotoBufferEnd()
-        } else {
+        } else if (prev) {
           input.clear()
           input.extmarks.clear()
           setStore("prompt", { input: "", parts: [] })
           setStore("extmarkToPartIndex", new Map())
         }
 
-        previousSessionID = nextSessionID
+        setStore("mode", "normal")
         setStore("placeholder", Math.floor(Math.random() * PLACEHOLDERS.length))
       },
-      { defer: true },
     ),
   )
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -58,6 +58,9 @@ export type PromptRef = {
 const PLACEHOLDERS = ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"]
 const SHELL_PLACEHOLDERS = ["ls -la", "git status", "pwd"]
 
+// Per-session draft input storage
+export const drafts = new Map<string, PromptInfo>()
+
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
@@ -137,10 +140,33 @@ export function Prompt(props: PromptProps) {
     interrupt: 0,
   })
 
+  let previousSessionID: string | undefined = props.sessionID
   createEffect(
     on(
       () => props.sessionID,
-      () => {
+      (nextSessionID) => {
+        // Save current draft for the previous session
+        if (previousSessionID && store.prompt.input) {
+          drafts.set(previousSessionID, { input: store.prompt.input, parts: [...store.prompt.parts] })
+        } else if (previousSessionID) {
+          drafts.delete(previousSessionID)
+        }
+
+        // Restore draft for the new session or clear
+        const draft = nextSessionID ? drafts.get(nextSessionID) : undefined
+        if (draft) {
+          input.setText(draft.input)
+          setStore("prompt", { input: draft.input, parts: draft.parts })
+          restoreExtmarksFromParts(draft.parts)
+          input.gotoBufferEnd()
+        } else {
+          input.clear()
+          input.extmarks.clear()
+          setStore("prompt", { input: "", parts: [] })
+          setStore("extmarkToPartIndex", new Map())
+        }
+
+        previousSessionID = nextSessionID
         setStore("placeholder", Math.floor(Math.random() * PLACEHOLDERS.length))
       },
       { defer: true },
@@ -645,6 +671,7 @@ export function Prompt(props: PromptProps) {
       parts: [],
     })
     setStore("extmarkToPartIndex", new Map())
+    if (props.sessionID) drafts.delete(props.sessionID)
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent


### PR DESCRIPTION
### Issue for this PR

Closes #14263

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Switching sessions lost or leaked draft input text. This stores drafts in a per-session Map so each session keeps its own input state independently.

Three touch points save/restore drafts: the reactive effect in Prompt when `sessionID` changes, the "new session" command in app.tsx, and the session list dialog. Drafts are cleared on submit and on session deletion.

### How did you verify your code works?

Typecheck passes. Manually tested: type text in session A, switch to session B (text gone, fresh input), switch back to A (text restored), submit (draft cleared). Also verified new session, child session cycling, and session deletion all behave correctly.

### Screenshots / recordings

_N/A — behavior change only, no visual changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR