### PR TITLE
fix: .ignore rules ignored when --glob include patterns are present

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -207,6 +207,21 @@ export namespace Ripgrep {
     return filepath
   }
 
+  // Read .ignore entries and return them as negation globs.
+  // ripgrep's --glob flag overrides .ignore rules, so when user-provided
+  // include globs are present (e.g. **/*.json), ignored files that match
+  // the glob are whitelisted back. Re-applying them as negation globs
+  // after the include globs restores the intended filtering.
+  async function negationsFromIgnore(cwd: string) {
+    const content = await fs.readFile(path.join(cwd, ".ignore"), "utf-8").catch(() => "")
+    const globs: string[] = []
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim()
+      if (trimmed && !trimmed.startsWith("#")) globs.push(`--glob=!${trimmed}`)
+    }
+    return globs
+  }
+
   export async function* files(input: {
     cwd: string
     glob?: string[]
@@ -225,6 +240,7 @@ export namespace Ripgrep {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)
       }
+      args.push(...(await negationsFromIgnore(input.cwd)))
     }
 
     // Bun.spawn should throw this, but it incorrectly reports that the executable does not exist.
@@ -347,6 +363,7 @@ export namespace Ripgrep {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)
       }
+      args.push(...(await negationsFromIgnore(input.cwd)))
     }
 
     if (input.limit) {


### PR DESCRIPTION
## Problem

ripgrep's `--glob` flag overrides `.ignore` rules. When a user passes an
include glob like `**/*.json`, any file matching that glob is whitelisted
back into results — even if it's listed in `.ignore`.

This means projects that use `.ignore` to hide internal config files
(e.g. `opencode.json`, `config.json`) still expose them when the glob
tool or grep tool is invoked with a matching pattern.

Confirmed via `rg --debug`:
`whitelisting ./opencode.json: Whitelist(IgnoreMatch(Override(Glob(Matched(...)))))`

## Fix

After appending user-provided globs, read the `.ignore` file from `cwd`
and re-apply its entries as negation globs (`--glob=!<entry>`). Since
ripgrep evaluates globs in order and later ones take precedence, the
negations override the include whitelist.
- Adds `negationsFromIgnore()` helper to `Ripgrep` namespace
- Applied to both `files()` (glob tool) and `search()` (grep tool)
- Only activates when user globs are present AND `.ignore` exists
- No-op if `.ignore` is missing or empty

## Testing

```sh
# Before: opencode.json appear despite .ignore
rg --files --hidden --glob='!.git/*' --glob='**/*.json'
# → includes opencode.json
# After: negation globs restore .ignore filtering
rg --files --hidden --glob='!.git/*' --glob='**/*.json' --glob='!opencode.json'
# → no opencode.json