### PR TITLE
fix: .ignore rules bypassed when --glob include patterns are present

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -207,6 +207,21 @@ export namespace Ripgrep {
     return filepath
   }
 
+  // Read .ignore entries and return them as negation globs.
+  // ripgrep's --glob flag overrides .ignore rules, so when user-provided
+  // include globs are present (e.g. **/*.json), ignored files that match
+  // the glob are whitelisted back. Re-applying them as negation globs
+  // after the include globs restores the intended filtering.
+  async function negationsFromIgnore(cwd: string) {
+    const content = await fs.readFile(path.join(cwd, ".ignore"), "utf-8").catch(() => "")
+    const globs: string[] = []
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim()
+      if (trimmed && !trimmed.startsWith("#")) globs.push(`--glob=!${trimmed}`)
+    }
+    return globs
+  }
+
   export async function* files(input: {
     cwd: string
     glob?: string[]
@@ -225,6 +240,7 @@ export namespace Ripgrep {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)
       }
+      args.push(...(await negationsFromIgnore(input.cwd)))
     }
 
     // Bun.spawn should throw this, but it incorrectly reports that the executable does not exist.
@@ -347,6 +363,7 @@ export namespace Ripgrep {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)
       }
+      args.push(...(await negationsFromIgnore(input.cwd)))
     }
 
     if (input.limit) {


### PR DESCRIPTION
### Issue for this PR

Closes #14298 

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ripgrep's `--glob` flag has higher precedence than `.ignore` rules. When a user-provided include glob matches an ignored file (e.g. `**/*.json` matches a file listed in `.ignore`), ripgrep whitelists it back into results, bypassing the `.ignore` file entirely.

This can be confirmed with `rg --debug`:
`whitelisting ./opencode.json: Whitelist(IgnoreMatch(Override(Glob(Matched(Glob { from: None, original: "*/.json" })))))`

The fix reads the `.ignore` file from the working directory and re-applies its entries as negation globs (`--glob=!<entry>`) after the user's include globs. Since ripgrep evaluates globs in order and later ones take precedence, the negations override the whitelist.

This only activates when user globs are present. Without user globs, `.ignore` works correctly on its own so there's nothing to fix.

Changed both `Ripgrep.files()` (used by the glob tool) and `Ripgrep.search()` (used by the grep tool).

### How did you verify your code works?

Tested directly inside the container with the bundled ripgrep binary:

```sh
# Before: opencode.json appears despite being in .ignore
rg --files --hidden --glob='!.git/*' --glob='**/*.json'
# → opencode.json included
# After: adding negation globs restores .ignore filtering
rg --files --hidden --glob='!.git/*' --glob='**/*.json' --glob='!opencode.json'
# → no opencode.json