### PR TITLE
docs: clarify tool name collision precedence

### DIFF
--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -100,7 +100,7 @@ export default tool({
 ```
 
 :::note
-Prefer unique names unless you intentionally want to replace a built-in tool. If you want a safer wrapper, create `safe_bash` and deny `bash` using [permissions](/docs/permissions).
+Prefer unique names unless you intentionally want to replace a built-in tool. If you want to disable a built in tool but not override it, use [permissions](/docs/permissions).
 :::
 
 ---

--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -81,7 +81,7 @@ This creates two tools: `math_add` and `math_multiply`.
 
 #### Name collisions with built-in tools
 
-Custom tools are keyed by tool name. If a custom tool uses the same name as a built-in tool, the custom tool takes precedence for that session.
+Custom tools are keyed by tool name. If a custom tool uses the same name as a built-in tool, the custom tool takes precedence.
 
 For example, this file replaces the built-in `bash` tool:
 
@@ -100,7 +100,7 @@ export default tool({
 ```
 
 :::note
-Prefer unique names unless you intentionally want to replace a built-in tool. A common pattern is to create `safe_bash` and disable `bash` using [permissions](/docs/permissions).
+Prefer unique names unless you intentionally want to replace a built-in tool. If you want a safer wrapper, create `safe_bash` and deny `bash` using [permissions](/docs/permissions).
 :::
 
 ---

--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -79,6 +79,32 @@ This creates two tools: `math_add` and `math_multiply`.
 
 ---
 
+#### Name collisions with built-in tools
+
+Custom tools are keyed by tool name. If a custom tool uses the same name as a built-in tool, the custom tool takes precedence for that session.
+
+For example, this file replaces the built-in `bash` tool:
+
+```ts title=".opencode/tools/bash.ts"
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Restricted bash wrapper",
+  args: {
+    command: tool.schema.string(),
+  },
+  async execute(args) {
+    return `blocked: ${args.command}`
+  },
+})
+```
+
+:::note
+Prefer unique names unless you intentionally want to replace a built-in tool. A common pattern is to create `safe_bash` and disable `bash` using [permissions](/docs/permissions).
+:::
+
+---
+
 ### Arguments
 
 You can use `tool.schema`, which is just [Zod](https://zod.dev), to define argument types.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -308,6 +308,10 @@ The `tool` helper creates a custom tool that opencode can call. It takes a Zod s
 
 Your custom tools will be available to opencode alongside built-in tools.
 
+:::note
+If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence for that session.
+:::
+
 ---
 
 ### Logging

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -309,7 +309,7 @@ The `tool` helper creates a custom tool that opencode can call. It takes a Zod s
 Your custom tools will be available to opencode alongside built-in tools.
 
 :::note
-If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence for that session.
+If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence.
 :::
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #14248

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR documents tool-name collision behavior when custom or plugin-defined tools use the same name as built-in tools.

Changes:
- add a Name collisions with built-in tools section to /docs/custom-tools
- add a matching note to /docs/plugins
- recommend using unique names unless intentionally overriding built-ins

Why this works:
runtime tools are keyed by tool ID; same-ID custom entries take precedence in the session tool map.

### How did you verify your code works?

- confirmed docs formatting matches nearby style (separators, notes, concise example)
- verified code path behavior:
  - ToolRegistry assembles built-in and custom tools
  - SessionPrompt.resolveTools inserts tools by ID into the runtime map
  - same-ID inserts overwrite prior entries
- verified added link paths are valid

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR