### PR TITLE
fix(tui): coerce path to string in normalizePath to prevent crash

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2121,12 +2121,13 @@ function Skill(props: ToolProps<typeof SkillTool>) {
   )
 }
 
-function normalizePath(input?: string) {
+function normalizePath(input?: string | number) {
   if (!input) return ""
-  if (path.isAbsolute(input)) {
-    return path.relative(process.cwd(), input) || "."
+  const p = typeof input === "string" ? input : String(input)
+  if (path.isAbsolute(p)) {
+    return path.relative(process.cwd(), p) || "."
   }
-  return input
+  return p
 }
 
 function input(input: Record<string, any>, omit?: string[]): string {


### PR DESCRIPTION
## Problem

`normalizePath()` in `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` crashes when it receives a `number` instead of a `string`, because `path.isAbsolute()` only accepts strings.

This has been reported **4+ times** by different users:
- #14020
- #13394  
- #12697
- #12414
- #14279 (this fix)

Stack trace:
```
TypeError: The "path" property must be of type string, got number
    at isAbsolute (unknown)
    at normalizePath3 (src/cli/cmd/tui/routes/session/index.tsx:3012:12)
```

## Fix

Widen the `input` parameter type to `string | number` and coerce to string before passing to `path.isAbsolute()`:

```ts
-function normalizePath(input?: string) {
+function normalizePath(input?: string | number) {
   if (!input) return ""
-  if (path.isAbsolute(input)) {
-    return path.relative(process.cwd(), input) || "."
+  const p = typeof input === "string" ? input : String(input)
+  if (path.isAbsolute(p)) {
+    return path.relative(process.cwd(), p) || "."
   }
-  return input
+  return p
 }
```

Minimal, type-safe, no behavioural changes for existing string callers.

Closes #14279