### PR TITLE
fix: add missing id/sessionID/messageID to MCP tool attachments

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -909,7 +909,12 @@ export namespace SessionPrompt {
           title: "",
           metadata,
           output: truncated.content,
-          attachments,
+          attachments: attachments.map((attachment) => ({
+            ...attachment,
+            id: Identifier.ascending("part"),
+            sessionID: ctx.sessionID,
+            messageID: input.processor.message.id,
+          })),
           content: result.content, // directly return content to preserve ordering when outputting to model
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #14355

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP tool results (e.g. Playwright `take_screenshot`) return attachments without `id`, `sessionID`, and `messageID` fields. This causes Zod validation to fail on `MessageV2.FilePart`, and the tool result is silently lost.

Built-in tools already map attachments to include these fields (prompt.ts L808-814), but the MCP tool path (L874) explicitly omits them via `Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">`.

This patch applies the same `.map()` logic to MCP tool attachments, making both paths consistent.

**Before:** Playwright `take_screenshot` → image attachment missing id fields → Zod parse error → tool result lost
**After:** Playwright `take_screenshot` → image attachment has id fields → works like built-in tools

### How did you verify your code works?

- Used Playwright MCP `take_screenshot` tool — screenshot returns without Zod errors
- Verified built-in tool attachments still work (e.g. `read` on an image file)
- Confirmed `MessageV2.FilePart` Zod validation passes for MCP tool attachments

### Screenshots / recordings

_N/A — backend logic change, no UI affected._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR