### PR TITLE
fix(opencode): stabilize codex browser oauth server startup

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -11,7 +11,12 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
+const OAUTH_HOST = "127.0.0.1"
+const OAUTH_REDIRECT_URI = `http://localhost:${OAUTH_PORT}/auth/callback`
+const OAUTH_CANCEL_URI = `http://${OAUTH_HOST}:${OAUTH_PORT}/cancel`
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+const OAUTH_RETRY_DELAY_MS = 200
+const OAUTH_MAX_START_ATTEMPTS = 10
 
 interface PkceCodes {
   verifier: string
@@ -244,73 +249,105 @@ let pendingOAuth: PendingOAuth | undefined
 
 async function startOAuthServer(): Promise<{ port: number; redirectUri: string }> {
   if (oauthServer) {
-    return { port: OAUTH_PORT, redirectUri: `http://localhost:${OAUTH_PORT}/auth/callback` }
+    return { port: OAUTH_PORT, redirectUri: OAUTH_REDIRECT_URI }
   }
 
-  oauthServer = Bun.serve({
+  const serve = () => {
+    try {
+      oauthServer = Bun.serve({
+        hostname: OAUTH_HOST,
+        port: OAUTH_PORT,
+        fetch(req) {
+          const url = new URL(req.url)
+
+          if (url.pathname === "/auth/callback") {
+            const code = url.searchParams.get("code")
+            const state = url.searchParams.get("state")
+            const error = url.searchParams.get("error")
+            const errorDescription = url.searchParams.get("error_description")
+
+            if (error) {
+              const errorMsg = errorDescription || error
+              pendingOAuth?.reject(new Error(errorMsg))
+              pendingOAuth = undefined
+              return new Response(HTML_ERROR(errorMsg), {
+                headers: { "Content-Type": "text/html" },
+              })
+            }
+
+            if (!code) {
+              const errorMsg = "Missing authorization code"
+              pendingOAuth?.reject(new Error(errorMsg))
+              pendingOAuth = undefined
+              return new Response(HTML_ERROR(errorMsg), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              })
+            }
+
+            if (!pendingOAuth || state !== pendingOAuth.state) {
+              const errorMsg = "Invalid state - potential CSRF attack"
+              pendingOAuth?.reject(new Error(errorMsg))
+              pendingOAuth = undefined
+              return new Response(HTML_ERROR(errorMsg), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              })
+            }
+
+            const current = pendingOAuth
+            pendingOAuth = undefined
+
+            exchangeCodeForTokens(code, OAUTH_REDIRECT_URI, current.pkce)
+              .then((tokens) => current.resolve(tokens))
+              .catch((err) => current.reject(err))
+
+            return new Response(HTML_SUCCESS, {
+              headers: { "Content-Type": "text/html" },
+            })
+          }
+
+          if (url.pathname === "/cancel") {
+            pendingOAuth?.reject(new Error("Login cancelled"))
+            pendingOAuth = undefined
+            queueMicrotask(stopOAuthServer)
+            return new Response("Login cancelled", { status: 200 })
+          }
+
+          return new Response("Not found", { status: 404 })
+        },
+      })
+      log.info("codex oauth server started", { port: OAUTH_PORT, hostname: OAUTH_HOST })
+      return true
+    } catch {
+      oauthServer = undefined
+      return false
+    }
+  }
+
+  if (serve()) {
+    return { port: OAUTH_PORT, redirectUri: OAUTH_REDIRECT_URI }
+  }
+
+  log.warn("codex oauth server failed to start, retrying after cancel request", {
     port: OAUTH_PORT,
-    fetch(req) {
-      const url = new URL(req.url)
-
-      if (url.pathname === "/auth/callback") {
-        const code = url.searchParams.get("code")
-        const state = url.searchParams.get("state")
-        const error = url.searchParams.get("error")
-        const errorDescription = url.searchParams.get("error_description")
-
-        if (error) {
-          const errorMsg = errorDescription || error
-          pendingOAuth?.reject(new Error(errorMsg))
-          pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
-            headers: { "Content-Type": "text/html" },
-          })
-        }
-
-        if (!code) {
-          const errorMsg = "Missing authorization code"
-          pendingOAuth?.reject(new Error(errorMsg))
-          pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
-            status: 400,
-            headers: { "Content-Type": "text/html" },
-          })
-        }
-
-        if (!pendingOAuth || state !== pendingOAuth.state) {
-          const errorMsg = "Invalid state - potential CSRF attack"
-          pendingOAuth?.reject(new Error(errorMsg))
-          pendingOAuth = undefined
-          return new Response(HTML_ERROR(errorMsg), {
-            status: 400,
-            headers: { "Content-Type": "text/html" },
-          })
-        }
-
-        const current = pendingOAuth
-        pendingOAuth = undefined
-
-        exchangeCodeForTokens(code, `http://localhost:${OAUTH_PORT}/auth/callback`, current.pkce)
-          .then((tokens) => current.resolve(tokens))
-          .catch((err) => current.reject(err))
-
-        return new Response(HTML_SUCCESS, {
-          headers: { "Content-Type": "text/html" },
-        })
-      }
-
-      if (url.pathname === "/cancel") {
-        pendingOAuth?.reject(new Error("Login cancelled"))
-        pendingOAuth = undefined
-        return new Response("Login cancelled", { status: 200 })
-      }
-
-      return new Response("Not found", { status: 404 })
-    },
+    hostname: OAUTH_HOST,
   })
 
-  log.info("codex oauth server started", { port: OAUTH_PORT })
-  return { port: OAUTH_PORT, redirectUri: `http://localhost:${OAUTH_PORT}/auth/callback` }
+  for (const _ of Array.from({ length: OAUTH_MAX_START_ATTEMPTS })) {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 2000)
+    await fetch(OAUTH_CANCEL_URI, {
+      signal: controller.signal,
+    }).catch(() => undefined)
+    clearTimeout(timeout)
+    await Bun.sleep(OAUTH_RETRY_DELAY_MS)
+    if (serve()) {
+      return { port: OAUTH_PORT, redirectUri: OAUTH_REDIRECT_URI }
+    }
+  }
+
+  throw new Error(`Failed to start server. Is port ${OAUTH_PORT} in use?`)
 }
 
 function stopOAuthServer() {


### PR DESCRIPTION

  ### Issue for this PR

  Closes #14276

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Fixes OpenAI ChatGPT Pro/Plus (browser) auth failing with `Failed to start server. Is port 1455 in use?`.

  Changes:
  - Bind the Codex OAuth callback server explicitly to `127.0.0.1` (instead of default bind behavior).
  - Keep OAuth `redirect_uri` as `http://localhost:1455/auth/callback`.
  - Add startup retry logic: if first bind fails, call `GET /cancel` on `127.0.0.1:1455`, wait briefly, and retry (up to 10 attempts).
  - Make `/cancel` stop the local OAuth server after responding, so stale instances release the port.

  Why this works:
  - A stale local OAuth server can keep port `1455` occupied. The new cancel/retry flow clears that stale server and allows a clean restart.
  - Explicit loopback binding makes callback server startup more reliable on Windows setups.

  ### How did you verify your code works?

  - Ran `bun test test/plugin/codex.test.ts` in `packages/opencode` (`13 pass, 0 fail`).
  - Ran `bun test test/plugin` in `packages/opencode` (`14 pass, 0 fail`).
  - Pre-push hook ran `bun turbo typecheck` successfully (`12 successful, 0 failed`).

  ### Screenshots / recordings

  N/A (no UI change).

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR