### PR TITLE
docs: add Meganova provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1198,6 +1198,35 @@ To use Kimi K2 from Moonshot AI:
 
 ---
 
+### Meganova
+
+[Meganova](https://meganova.ai) is a model aggregator that provides access to open-weight models including DeepSeek, GLM, Kimi, MiniMax, Qwen, and more through a single API.
+
+1. Head over to [meganova.ai](https://meganova.ai), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **Meganova**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Meganova API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _DeepSeek V3.2_ or _GLM-5_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Nebius Token Factory
 
 1. Head over to the [Nebius Token Factory console](https://tokenfactory.nebius.com/), create an account, and click **Add Key**.


### PR DESCRIPTION
### Type of change

- [x] Documentation

### What does this PR do?

Adds Meganova provider documentation to the providers page. Meganova is a model aggregator providing access to open-weight models (DeepSeek, GLM, Kimi, MiniMax, Qwen, etc.) through a single API.

Provider data already available via [models.dev#968](https://github.com/anomalyco/models.dev/pull/968) (merged).

### How did you verify your code works?

Simple mdx change. Verified the section renders correctly in the local dev server.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR