### PR TITLE
docs: add Meganova provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1198,6 +1198,33 @@ To use Kimi K2 from Moonshot AI:
 
 ---
 
+### Meganova
+
+1. Head over to the [Meganova console](https://console.meganova.ai/) and create an account. A default API key will be provided — copy it from the **API Keys** page.
+
+2. Run the `/connect` command and search for **Meganova**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Meganova API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _DeepSeek V3.2_ or _GLM-5_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Nebius Token Factory
 
 1. Head over to the [Nebius Token Factory console](https://tokenfactory.nebius.com/), create an account, and click **Add Key**.


### PR DESCRIPTION
### Issue for this PR

N/A — Adding provider documentation for Meganova (already available via [models.dev#968](https://github.com/anomalyco/models.dev/pull/968)).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Meganova provider documentation to the providers page. Meganova is a model aggregator providing access to open-weight models (DeepSeek, GLM, Kimi, MiniMax, Qwen, etc.) through a single API.

### How did you verify your code works?

Simple mdx change. Verified the section renders correctly in the local dev server.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR