### PR TITLE
fix: fallback to config key when model id override misses in models.dev

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -820,7 +820,7 @@ export namespace Provider {
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-        const existingModel = parsed.models[model.id ?? modelID]
+        const existingModel = parsed.models[model.id ?? modelID] ?? (model.id ? parsed.models[modelID] : undefined)
         const name = iife(() => {
           if (model.name) return model.name
           if (model.id && model.id !== modelID) return modelID


### PR DESCRIPTION
### Issue for this PR

Closes #14361

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When `model.id` is set but doesn't match any model in models.dev fall back to looking up the config key (`modelID`). This lets custom inference profiles inherit cost/limit data from the base model.

### How did you verify your code works?
Tested locally with configuring a Bedrock model with `id: "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"` and key `anthropic.claude-sonnet-4-5-20250929-v1:0` . The cost now correctly inherits $3/$15 per million tokens instead of $0.00.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
