### PR TITLE
sdk: build to dist/ instead of dist/src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target
 opencode-dev
 logs/
 *.bun-build
+tsconfig.tsbuildinfo

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -13,15 +13,15 @@
     "./client": "./src/client.ts",
     "./server": "./src/server.ts",
     "./v2": {
-      "types": "./dist/src/v2/index.d.ts",
+      "types": "./dist/v2/index.d.ts",
       "default": "./src/v2/index.ts"
     },
     "./v2/client": {
-      "types": "./dist/src/v2/client.d.ts",
+      "types": "./dist/v2/client.d.ts",
       "default": "./src/v2/client.ts"
     },
     "./v2/gen/client": {
-      "types": "./dist/src/v2/gen/client/index.d.ts",
+      "types": "./dist/v2/gen/client/index.d.ts",
       "default": "./src/v2/gen/client/index.ts"
     },
     "./v2/server": "./src/v2/server.ts"

--- a/packages/sdk/js/tsconfig.json
+++ b/packages/sdk/js/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "moduleResolution": "nodenext",
     "lib": ["es2022", "dom", "dom.iterable"],
-    "composite": true
+    "composite": true,
+    "rootDir": "src"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Fixes #14364

Problem was caused by setting `composite: true` in the tsconfig, which helps with making typescript work better in our monorepo.
Setting `rootDir: true` lifts up the build outputs to be in `dist`, but results in the `tsconfig.tsbuildinfo` cache file to be written to `packages/sdk/js/tsconfig.tsbuildinfo`, so that's been added to the gitignore.