### PR TITLE
fix(desktop): ignore git sync-only updates in Session Changes

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -10,6 +10,52 @@ import { Storage } from "@/storage/storage"
 import { Bus } from "@/bus"
 
 export namespace SessionSummary {
+  const syncGit = new Set(["pull", "fetch", "switch", "checkout", "merge", "rebase", "reset", "restore"])
+  const readGit = new Set([
+    "status",
+    "branch",
+    "log",
+    "show",
+    "diff",
+    "rev-parse",
+    "remote",
+    "symbolic-ref",
+    "for-each-ref",
+    "ls-remote",
+  ])
+  const readTool = new Set([
+    "read",
+    "glob",
+    "grep",
+    "ls",
+    "question",
+    "webfetch",
+    "websearch",
+    "codesearch",
+    "skill",
+    "todowrite",
+    "todoread",
+    "plan_enter",
+    "plan_exit",
+    "lsp",
+  ])
+  const gitFlagsWithValue = new Set([
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+    "--config-env",
+    "--exec-path",
+  ])
+
+  type Step = {
+    from: string
+    to: string
+    sync: boolean
+  }
+
   function unquoteGitPath(input: string) {
     if (!input.startsWith('"')) return input
     if (!input.endsWith('"')) return input
@@ -64,6 +110,167 @@ export namespace SessionSummary {
     }
 
     return Buffer.from(bytes).toString()
+  }
+
+  function words(input: string) {
+    return input
+      .split(/\s+/)
+      .map((x) => x.trim())
+      .filter(Boolean)
+  }
+
+  function commandParts(input: string) {
+    return input
+      .split(/&&|\|\||;|\n/)
+      .map((x) => x.trim())
+      .filter(Boolean)
+  }
+
+  function isGitBinary(input: string) {
+    return /(^|[\\/])git(\.exe)?$/i.test(input)
+  }
+
+  function gitSubcommand(input: string) {
+    const list = words(input.replace(/^[()]+|[()]+$/g, ""))
+    if (!list.length) return
+
+    let i = 0
+    while (i < list.length && /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(list[i]!)) i++
+    while (i < list.length && (list[i] === "env" || list[i] === "command" || list[i] === "sudo")) i++
+    if (!list[i]) return
+    if (!isGitBinary(list[i]!)) return
+    i++
+
+    while (i < list.length) {
+      const token = list[i]!
+      if (token === "--") {
+        i++
+        break
+      }
+      if (!token.startsWith("-")) break
+      if (token.includes("=")) {
+        i++
+        continue
+      }
+      if (gitFlagsWithValue.has(token)) {
+        i += 2
+        continue
+      }
+      i++
+    }
+
+    const sub = list[i]
+    if (!sub) return
+    return sub.toLowerCase()
+  }
+
+  export function isGitSyncBashCommand(input: string) {
+    const list = commandParts(input)
+    if (!list.length) return false
+
+    let sync = false
+    for (const item of list) {
+      const sub = gitSubcommand(item)
+      if (!sub) return false
+      if (syncGit.has(sub)) {
+        sync = true
+        continue
+      }
+      if (readGit.has(sub)) continue
+      return false
+    }
+
+    return sync
+  }
+
+  function bashCommand(input: MessageV2.ToolPart) {
+    if (input.tool !== "bash") return
+    const command = input.state.input.command
+    if (typeof command !== "string") return
+    return command
+  }
+
+  function isSyncStep(input: MessageV2.ToolPart[]) {
+    if (!input.length) return false
+    let sync = false
+
+    for (const part of input) {
+      if (part.tool === "bash") {
+        const command = bashCommand(part)
+        if (!command) return false
+        if (!isGitSyncBashCommand(command)) return false
+        sync = true
+        continue
+      }
+      if (readTool.has(part.tool)) continue
+      return false
+    }
+
+    return sync
+  }
+
+  function steps(input: MessageV2.WithParts[]) {
+    const result: Step[] = []
+
+    for (const msg of input) {
+      if (msg.info.role !== "assistant") continue
+      let from: string | undefined
+      const tools: MessageV2.ToolPart[] = []
+
+      for (const part of msg.parts) {
+        if (part.type === "step-start") {
+          from = part.snapshot
+          tools.length = 0
+          continue
+        }
+        if (!from) continue
+        if (part.type === "tool") {
+          tools.push(part)
+          continue
+        }
+        if (part.type !== "step-finish") continue
+        if (part.snapshot) {
+          result.push({
+            from,
+            to: part.snapshot,
+            sync: isSyncStep(tools),
+          })
+        }
+        from = undefined
+        tools.length = 0
+      }
+    }
+
+    return result
+  }
+
+  export function diffWindow(input: { messages: MessageV2.WithParts[] }) {
+    const all = steps(input.messages)
+    if (!all.length) return
+
+    const local = all.map((step, index) => ({ step, index })).filter((item) => !item.step.sync)
+    if (!local.length) return
+
+    const end = local[local.length - 1]!.index
+    let boundary = -1
+    for (let i = end - 1; i >= 0; i--) {
+      if (!all[i]!.sync) continue
+      boundary = i
+      break
+    }
+
+    let start = -1
+    for (let i = boundary + 1; i <= end; i++) {
+      if (all[i]!.sync) continue
+      start = i
+      break
+    }
+    if (start < 0) return
+
+    return {
+      from: all[start]!.from,
+      to: all[end]!.to,
+    }
   }
 
   export const summarize = fn(
@@ -133,29 +340,8 @@ export namespace SessionSummary {
   )
 
   export async function computeDiff(input: { messages: MessageV2.WithParts[] }) {
-    let from: string | undefined
-    let to: string | undefined
-
-    // scan assistant messages to find earliest from and latest to
-    // snapshot
-    for (const item of input.messages) {
-      if (!from) {
-        for (const part of item.parts) {
-          if (part.type === "step-start" && part.snapshot) {
-            from = part.snapshot
-            break
-          }
-        }
-      }
-
-      for (const part of item.parts) {
-        if (part.type === "step-finish" && part.snapshot) {
-          to = part.snapshot
-        }
-      }
-    }
-
-    if (from && to) return Snapshot.diffFull(from, to)
+    const window = diffWindow(input)
+    if (window) return Snapshot.diffFull(window.from, window.to)
     return []
   }
 }

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -164,23 +164,27 @@ export namespace SessionSummary {
     return sub.toLowerCase()
   }
 
-  export function isGitSyncBashCommand(input: string) {
+  function gitCommand(input: string) {
     const list = commandParts(input)
-    if (!list.length) return false
+    if (!list.length) return
 
     let sync = false
     for (const item of list) {
       const sub = gitSubcommand(item)
-      if (!sub) return false
+      if (!sub) return
       if (syncGit.has(sub)) {
         sync = true
         continue
       }
       if (readGit.has(sub)) continue
-      return false
+      return
     }
 
-    return sync
+    return sync ? "sync" : "read"
+  }
+
+  export function isGitSyncBashCommand(input: string) {
+    return gitCommand(input) === "sync"
   }
 
   function bashCommand(input: MessageV2.ToolPart) {
@@ -198,8 +202,9 @@ export namespace SessionSummary {
       if (part.tool === "bash") {
         const command = bashCommand(part)
         if (!command) return false
-        if (!isGitSyncBashCommand(command)) return false
-        sync = true
+        const git = gitCommand(command)
+        if (!git) return false
+        if (git === "sync") sync = true
         continue
       }
       if (readTool.has(part.tool)) continue

--- a/packages/opencode/test/session/summary.test.ts
+++ b/packages/opencode/test/session/summary.test.ts
@@ -153,6 +153,20 @@ describe("SessionSummary.diffWindow", () => {
     expect(SessionSummary.diffWindow({ messages: [sync] })).toBeUndefined()
   })
 
+  test("treats git status followed by git pull as sync-only", () => {
+    const sync = step({
+      id: "sync",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [
+        tool({ id: "status", messageID, name: "bash", args: { command: "git status" } }),
+        tool({ id: "pull", messageID, name: "bash", args: { command: "git pull --ff-only" } }),
+      ],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [sync] })).toBeUndefined()
+  })
+
   test("resets baseline to the first local step after a sync step", () => {
     const sync = step({
       id: "1",

--- a/packages/opencode/test/session/summary.test.ts
+++ b/packages/opencode/test/session/summary.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test"
+import { SessionSummary } from "../../src/session/summary"
+import type { MessageV2 } from "../../src/session/message-v2"
+
+function assistant(input: { id: string; parts: MessageV2.Part[] }): MessageV2.WithParts {
+  return {
+    info: {
+      id: input.id,
+      sessionID: "s",
+      role: "assistant",
+      parentID: "u",
+      mode: "build",
+      agent: "build",
+      path: { cwd: "/tmp", root: "/tmp" },
+      time: { created: 0 },
+      cost: 0,
+      tokens: {
+        total: 0,
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: "model",
+      providerID: "provider",
+    },
+    parts: input.parts,
+  }
+}
+
+function start(input: { id: string; messageID: string; snapshot: string }): MessageV2.StepStartPart {
+  return {
+    id: input.id,
+    sessionID: "s",
+    messageID: input.messageID,
+    type: "step-start",
+    snapshot: input.snapshot,
+  }
+}
+
+function finish(input: { id: string; messageID: string; snapshot: string }): MessageV2.StepFinishPart {
+  return {
+    id: input.id,
+    sessionID: "s",
+    messageID: input.messageID,
+    type: "step-finish",
+    reason: "stop",
+    snapshot: input.snapshot,
+    cost: 0,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  }
+}
+
+function tool(input: {
+  id: string
+  messageID: string
+  name: string
+  args: Record<string, unknown>
+}): MessageV2.ToolPart {
+  return {
+    id: input.id,
+    sessionID: "s",
+    messageID: input.messageID,
+    type: "tool",
+    callID: `call-${input.id}`,
+    tool: input.name,
+    state: {
+      status: "completed",
+      input: input.args,
+      output: "",
+      title: "",
+      metadata: {},
+      time: { start: 0, end: 1 },
+    },
+  }
+}
+
+function step(input: {
+  id: string
+  from: string
+  to: string
+  tools: (messageID: string) => MessageV2.ToolPart[]
+}): MessageV2.WithParts {
+  const messageID = `m-${input.id}`
+  return assistant({
+    id: messageID,
+    parts: [
+      start({ id: `start-${input.id}`, messageID, snapshot: input.from }),
+      ...input.tools(messageID),
+      finish({ id: `finish-${input.id}`, messageID, snapshot: input.to }),
+    ],
+  })
+}
+
+describe("SessionSummary.isGitSyncBashCommand", () => {
+  test("matches git sync command chains", () => {
+    expect(SessionSummary.isGitSyncBashCommand("git switch dev && git pull --ff-only")).toBe(true)
+    expect(SessionSummary.isGitSyncBashCommand("git -C . status && git fetch origin dev")).toBe(true)
+  })
+
+  test("rejects non-sync shell commands", () => {
+    expect(SessionSummary.isGitSyncBashCommand("git pull && bun test")).toBe(false)
+    expect(SessionSummary.isGitSyncBashCommand("bun test")).toBe(false)
+  })
+})
+
+describe("SessionSummary.diffWindow", () => {
+  test("uses first and last local steps when no sync step exists", () => {
+    const one = step({
+      id: "1",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [tool({ id: "t1", messageID, name: "bash", args: { command: "bun test" } })],
+    })
+    const two = step({
+      id: "2",
+      from: "b",
+      to: "c",
+      tools: (messageID) => [
+        tool({
+          id: "t2",
+          messageID,
+          name: "edit",
+          args: { filePath: "README.md", oldString: "a", newString: "b" },
+        }),
+      ],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [one, two] })).toStrictEqual({ from: "a", to: "c" })
+  })
+
+  test("returns undefined for sync-only steps", () => {
+    const sync = step({
+      id: "sync",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [
+        tool({
+          id: "sync-tool",
+          messageID,
+          name: "bash",
+          args: { command: "git switch dev && git pull --ff-only" },
+        }),
+      ],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [sync] })).toBeUndefined()
+  })
+
+  test("resets baseline to the first local step after a sync step", () => {
+    const sync = step({
+      id: "1",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [
+        tool({
+          id: "t1",
+          messageID,
+          name: "bash",
+          args: { command: "git switch dev && git pull --ff-only" },
+        }),
+      ],
+    })
+    const local = step({
+      id: "2",
+      from: "b",
+      to: "c",
+      tools: (messageID) => [
+        tool({
+          id: "t2",
+          messageID,
+          name: "edit",
+          args: { filePath: "src/app.ts", oldString: "x", newString: "y" },
+        }),
+      ],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [sync, local] })).toStrictEqual({ from: "b", to: "c" })
+  })
+
+  test("keeps local range when sync step is trailing", () => {
+    const local = step({
+      id: "1",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [
+        tool({
+          id: "t1",
+          messageID,
+          name: "edit",
+          args: { filePath: "src/app.ts", oldString: "x", newString: "y" },
+        }),
+      ],
+    })
+    const sync = step({
+      id: "2",
+      from: "b",
+      to: "c",
+      tools: (messageID) => [tool({ id: "t2", messageID, name: "bash", args: { command: "git pull --ff-only" } })],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [local, sync] })).toStrictEqual({ from: "a", to: "b" })
+  })
+
+  test("uses the last local range after a sync boundary", () => {
+    const localBefore = step({
+      id: "1",
+      from: "a",
+      to: "b",
+      tools: (messageID) => [
+        tool({
+          id: "t1",
+          messageID,
+          name: "edit",
+          args: { filePath: "src/a.ts", oldString: "1", newString: "2" },
+        }),
+      ],
+    })
+    const sync = step({
+      id: "2",
+      from: "b",
+      to: "c",
+      tools: (messageID) => [
+        tool({ id: "t2", messageID, name: "bash", args: { command: "git switch dev && git pull" } }),
+      ],
+    })
+    const localAfter = step({
+      id: "3",
+      from: "c",
+      to: "d",
+      tools: (messageID) => [
+        tool({
+          id: "t3",
+          messageID,
+          name: "write",
+          args: { filePath: "src/b.ts", content: "ok" },
+        }),
+      ],
+    })
+
+    expect(SessionSummary.diffWindow({ messages: [localBefore, sync, localAfter] })).toStrictEqual({
+      from: "c",
+      to: "d",
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14384

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It fixes desktop Session Changes reporting so git sync/fast-forward-only updates are not counted as session file edits. This keeps the desktop Session Changes view focused on local edits made during the session.

### How did you verify your code works?

- `bun test test/session/summary.test.ts`
- Manual verification in desktop dev flow that sync-only operations no longer inflate session change counts

### Screenshots / recordings

N/A (non-UI logic change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR