### PR TITLE
feat: adds a visual indicator (spinner) to project icons in the sidebar to show when a project has active AI sessions in progress

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -21,12 +21,25 @@ const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
 export const ProjectIcon = (props: { project: LocalProject; class?: string; notify?: boolean }): JSX.Element => {
   const notification = useNotification()
+  const globalSync = useGlobalSync()
   const dirs = createMemo(() => [props.project.worktree, ...(props.project.sandboxes ?? [])])
   const unseenCount = createMemo(() =>
     dirs().reduce((total, directory) => total + notification.project.unseenCount(directory), 0),
   )
   const hasError = createMemo(() => dirs().some((directory) => notification.project.unseenHasError(directory)))
   const name = createMemo(() => props.project.name || getFilename(props.project.worktree))
+
+  const hasActiveSessions = createMemo(() => {
+    for (const dir of dirs()) {
+      const [store] = globalSync.child(dir)
+      for (const session of store.session) {
+        const status = store.session_status[session.id]
+        if (status?.type === "busy" || status?.type === "retry") return true
+      }
+    }
+    return false
+  })
+
   return (
     <div class={`relative size-8 shrink-0 rounded ${props.class ?? ""}`}>
       <div class="size-full rounded overflow-clip">
@@ -40,6 +53,23 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
           classList={{ "badge-mask": unseenCount() > 0 && props.notify }}
         />
       </div>
+      <Show when={hasActiveSessions()}>
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "10px",
+            height: "10px",
+            "z-index": 100,
+            display: "flex",
+            "align-items": "center",
+            "justify-content": "center",
+          }}
+        >
+          <Spinner class="size-2.5 text-text-interactive-base" />
+        </div>
+      </Show>
       <Show when={unseenCount() > 0 && props.notify}>
         <div
           classList={{


### PR DESCRIPTION
Closes #14400

## Type of change
- [x] New feature

## What does this PR do?
Adds a visual indicator (spinner) to project icons in the sidebar to show when a project has active AI sessions in progress. The indicator appears in the top-left corner of the project icon and is displayed when any session in the project or its sandboxes has a "busy" or "retry" status.

## How did you verify your code works?
- Manually tested that the spinner appears correctly for projects with active sessions
- Verified that the spinner is hidden when no sessions are active
- Confirmed the indicator displays correctly in both project worktrees and sandboxes

## Screenshots / recordings
<img width="89" height="229" alt="image" src="https://github.com/user-attachments/assets/6a07812d-8b18-4ce9-8b0d-de91f4ad73f5" />


## Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
