### PR TITLE
fix: defer clearSelection after copy to prevent broken subsequent selections

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -19,7 +19,13 @@ export namespace Selection {
       .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
       .catch(toast.error)
 
-    renderer.clearSelection()
+    // Defer clearing the selection so that @opentui's finishSelection() can
+    // complete its lifecycle first (set isDragging=false, emit "selection"
+    // event, etc.). Clearing synchronously inside the onMouseUp handler
+    // nullifies currentSelection before finishSelection() runs, which can
+    // leave internal renderer state (e.g. capturedRenderable) stale and
+    // prevent subsequent text selections from starting.
+    queueMicrotask(() => renderer.clearSelection())
     return true
   }
 }


### PR DESCRIPTION
### Issue for this PR

Fixes #14420

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When copy-on-select triggers on mouseup, `Selection.copy()` calls `renderer.clearSelection()` synchronously inside the `onMouseUp` handler. This runs during `@opentui`'s `processMouseEvent` bubbling, before `finishSelection()` gets to execute. Nullifying `currentSelection` mid-event means the renderer can't finish its selection lifecycle (`isDragging=false`, emit `selection` event), leaving stale internal state that blocks subsequent text selections.

Fix: wrap `clearSelection()` in `queueMicrotask()` so the renderer's `handleMouseData` completes its full pipeline first. The microtask runs before the next mouse event arrives, so cleanup is still prompt.

### How did you verify your code works?

- Typecheck passes across all 12 packages
- All 1130 unit tests pass
- Manual testing: `bun dev .` from repo root, rapidly select-and-copy text multiple times -- selections now work consistently on every attempt

### Screenshots / recordings

_Not a UI change -- behavior fix only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR