### PR TITLE
chore: use standard logger

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -6,6 +6,7 @@ import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
+import { Log } from "@/util/log"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
@@ -253,7 +254,7 @@ function App() {
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
 
   createEffect(() => {
-    console.log(JSON.stringify(route.data))
+    Log.Default.debug("tui: app init", { data: route.data })
   })
 
   // Update terminal window title based on current route and session

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -1,4 +1,5 @@
 import { createStore } from "solid-js/store"
+import { Log } from "@/util/log"
 import { createSimpleContext } from "./helper"
 import type { PromptInfo } from "../component/prompt/history"
 
@@ -31,7 +32,7 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
         return store
       },
       navigate(route: Route) {
-        console.log("navigate", route)
+        Log.Default.debug("tui: navigate", { route })
         setStore(route)
       },
     }

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -347,7 +347,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const args = useArgs()
 
     async function bootstrap() {
-      console.log("bootstrapping")
+      Log.Default.debug("tui: bootstrapping")
+
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
         .list({ start: start })

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,7 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
 import { createEffect, createMemo, onMount } from "solid-js"
+import { Log } from "@/util/log"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import { Glob } from "../../../../util/glob"
@@ -317,13 +318,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     onMount(init)
 
     function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
+      Log.Default.debug("tui: resolving system theme")
       renderer
         .getPalette({
           size: 16,
         })
         .then((colors) => {
-          console.log(colors.palette)
+          Log.Default.debug("tui: get system palette", { palette: colors.palette })
           if (!colors.palette[0]) {
             if (store.active === "system") {
               setStore(

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -2,6 +2,7 @@ import { $ } from "bun"
 import { platform, release } from "os"
 import clipboardy from "clipboardy"
 import { lazy } from "../../../../util/lazy.js"
+import { Log } from "@/util/log"
 import { tmpdir } from "os"
 import path from "path"
 import { Filesystem } from "../../../../util/filesystem"
@@ -76,7 +77,7 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin" && Bun.which("osascript")) {
-      console.log("clipboard: using osascript")
+      Log.Default.info("clipboard: using osascript")
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
         await $`osascript -e 'set the clipboard to "${escaped}"'`.nothrow().quiet()
@@ -85,7 +86,7 @@ export namespace Clipboard {
 
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && Bun.which("wl-copy")) {
-        console.log("clipboard: using wl-copy")
+        Log.Default.info("clipboard: using wl-copy")
         return async (text: string) => {
           const proc = Bun.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           proc.stdin.write(text)
@@ -94,7 +95,7 @@ export namespace Clipboard {
         }
       }
       if (Bun.which("xclip")) {
-        console.log("clipboard: using xclip")
+        Log.Default.info("clipboard: using xclip")
         return async (text: string) => {
           const proc = Bun.spawn(["xclip", "-selection", "clipboard"], {
             stdin: "pipe",
@@ -107,7 +108,7 @@ export namespace Clipboard {
         }
       }
       if (Bun.which("xsel")) {
-        console.log("clipboard: using xsel")
+        Log.Default.info("clipboard: using xsel")
         return async (text: string) => {
           const proc = Bun.spawn(["xsel", "--clipboard", "--input"], {
             stdin: "pipe",
@@ -122,7 +123,7 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
+      Log.Default.info("clipboard: using powershell")
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Bun.spawn(
@@ -146,7 +147,7 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
+    Log.Default.info("clipboard: no native support")
     return async (text: string) => {
       await clipboardy.write(text).catch(() => {})
     }


### PR DESCRIPTION
### Issue for this PR

Closes #14418

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces raw `console.log` calls in 5 TUI files with `Log.Default.debug` (for debug traces) and `Log.Default.info` (for clipboard backend detection). This stops debug text from cluttering the debug panel and fixes inconsistency where some files (e.g. `sync.tsx`) were already using `Log.Default` alongside stray `console.log` calls.

### How did you verify your code works?

Ran the TUI locally, confirmed no stray console output in the debug panel. Verified log messages appear at appropriate levels. `bun typecheck` passes.

### Screenshots / recordings

_N/A — no UI changes, this removes unwanted console output._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR