### PR TITLE
fix(cli): missing plugin deps cause TUI to black screen

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -279,7 +279,9 @@ export namespace Config {
         ...(proxied() ? ["--no-cache"] : []),
       ],
       { cwd: dir },
-    ).catch(() => {})
+    ).catch((err) => {
+      log.warn("failed to install dependencies", { dir, error: err })
+    })
   }
 
   async function isWritable(dir: string) {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -40,13 +40,11 @@ export namespace Plugin {
     }
 
     for (const plugin of INTERNAL_PLUGINS) {
-      try {
-        log.info("loading internal plugin", { name: plugin.name })
-        const init = await plugin(input)
-        hooks.push(init)
-      } catch (err) {
+      log.info("loading internal plugin", { name: plugin.name })
+      const init = await plugin(input).catch((err) => {
         log.error("failed to load internal plugin", { name: plugin.name, error: err })
-      }
+      })
+      if (init) hooks.push(init)
     }
 
     let plugins = config.plugin ?? []
@@ -76,27 +74,27 @@ export namespace Plugin {
         })
         if (!plugin) continue
       }
-      try {
-        const mod = await import(plugin)
-        // Prevent duplicate initialization when plugins export the same function
-        // as both a named export and default export (e.g., `export const X` and `export default X`).
-        // Object.entries(mod) would return both entries pointing to the same function reference.
-        const seen = new Set<PluginInstance>()
-        for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
-          if (seen.has(fn)) continue
-          seen.add(fn)
-          const init = await fn(input)
-          hooks.push(init)
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        log.error("failed to load plugin", { path: plugin, error: message })
-        Bus.publish(Session.Event.Error, {
-          error: new NamedError.Unknown({
-            message: `Failed to load plugin ${plugin}: ${message}`,
-          }).toObject(),
+      // Prevent duplicate initialization when plugins export the same function
+      // as both a named export and default export (e.g., `export const X` and `export default X`).
+      // Object.entries(mod) would return both entries pointing to the same function reference.
+      await import(plugin)
+        .then(async (mod) => {
+          const seen = new Set<PluginInstance>()
+          for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+            if (seen.has(fn)) continue
+            seen.add(fn)
+            hooks.push(await fn(input))
+          }
         })
-      }
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err)
+          log.error("failed to load plugin", { path: plugin, error: message })
+          Bus.publish(Session.Event.Error, {
+            error: new NamedError.Unknown({
+              message: `Failed to load plugin ${plugin}: ${message}`,
+            }).toObject(),
+          })
+        })
     }
 
     return {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -40,9 +40,13 @@ export namespace Plugin {
     }
 
     for (const plugin of INTERNAL_PLUGINS) {
-      log.info("loading internal plugin", { name: plugin.name })
-      const init = await plugin(input)
-      hooks.push(init)
+      try {
+        log.info("loading internal plugin", { name: plugin.name })
+        const init = await plugin(input)
+        hooks.push(init)
+      } catch (err) {
+        log.error("failed to load internal plugin", { name: plugin.name, error: err })
+      }
     }
 
     let plugins = config.plugin ?? []
@@ -59,36 +63,39 @@ export namespace Plugin {
         const lastAtIndex = plugin.lastIndexOf("@")
         const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
         const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
-        const builtin = BUILTIN.some((x) => x.startsWith(pkg + "@"))
         plugin = await BunProc.install(pkg, version).catch((err) => {
-          if (!builtin) throw err
-
-          const message = err instanceof Error ? err.message : String(err)
-          log.error("failed to install builtin plugin", {
-            pkg,
-            version,
-            error: message,
-          })
+          const cause = err instanceof Error ? err.cause : err
+          const detail = cause instanceof Error ? cause.message : String(cause ?? err)
+          log.error("failed to install plugin", { pkg, version, error: detail })
           Bus.publish(Session.Event.Error, {
             error: new NamedError.Unknown({
-              message: `Failed to install built-in plugin ${pkg}@${version}: ${message}`,
+              message: `Failed to install plugin ${pkg}@${version}: ${detail}`,
             }).toObject(),
           })
-
           return ""
         })
         if (!plugin) continue
       }
-      const mod = await import(plugin)
-      // Prevent duplicate initialization when plugins export the same function
-      // as both a named export and default export (e.g., `export const X` and `export default X`).
-      // Object.entries(mod) would return both entries pointing to the same function reference.
-      const seen = new Set<PluginInstance>()
-      for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
-        if (seen.has(fn)) continue
-        seen.add(fn)
-        const init = await fn(input)
-        hooks.push(init)
+      try {
+        const mod = await import(plugin)
+        // Prevent duplicate initialization when plugins export the same function
+        // as both a named export and default export (e.g., `export const X` and `export default X`).
+        // Object.entries(mod) would return both entries pointing to the same function reference.
+        const seen = new Set<PluginInstance>()
+        for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+          if (seen.has(fn)) continue
+          seen.add(fn)
+          const init = await fn(input)
+          hooks.push(init)
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        log.error("failed to load plugin", { path: plugin, error: message })
+        Bus.publish(Session.Event.Error, {
+          error: new NamedError.Unknown({
+            message: `Failed to load plugin ${plugin}: ${message}`,
+          }).toObject(),
+        })
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #14433

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a plugin dependency can't be resolved (e.g. `node_modules` missing for `@opencode-ai/plugin`), the `import()` in plugin loading throws. `State.create()` caches the rejected promise, every subsequent API request fails, and the TUI stalls on a black screen indefinitely. In non-interactive mode (`opencode run --print-logs`) the error surfaces in logs, but TUI mode gives zero feedback.

- wrap `import(plugin)` and plugin init in `.catch()` so a broken plugin is skipped instead of crashing the whole `state()` initializer
- catch internal plugin init failures (CodexAuth, CopilotAuth, GitlabAuth) with `.catch()` + log
- unify builtin and non-builtin install failure handling — all install failures log, publish `Session.Event.Error` for the TUI, and continue
- extract the underlying `.cause` from `BunInstallFailedError` so the user-facing message includes the real failure reason
- log `bun install` failures in `config.ts` `installDependencies` instead of swallowing with `.catch(() => {})`

After the fix, a missing dependency shows as an error event in the TUI and in logs, and the app starts with remaining plugins.

### How did you verify your code works?

- `tsc --noEmit` passes
- manually tested with a plugin config pointing at a file:// plugin whose `@opencode-ai/plugin` dependency is missing — opencode now starts, shows the error in the session, and loads remaining plugins

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR