### PR TITLE
feat(UI): Add /login slash command for in-session authentication

### DIFF
--- a/packages/app/src/components/dialog-login-provider.tsx
+++ b/packages/app/src/components/dialog-login-provider.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@opencode-ai/ui/button"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { showToast } from "@opencode-ai/ui/toast"
+import { createSignal } from "solid-js"
+import { useLanguage } from "@/context/language"
+import { useSDK } from "@/context/sdk"
+
+export function DialogLoginProvider(props: { initialUrl?: string }) {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const language = useLanguage()
+  const [url, setUrl] = createSignal(props.initialUrl ?? "")
+  const [loading, setLoading] = createSignal(false)
+
+  async function handleLogin() {
+    const value = url().trim()
+    if (!value) {
+      showToast({ title: "URL is required", variant: "error" })
+      return
+    }
+    setLoading(true)
+    try {
+      const response = await fetch(`${sdk.url}/auth/wellknown`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: value }),
+      })
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({ message: "Unknown error" }))
+        throw new Error(error.data?.message || error.message || "Login failed")
+      }
+      const result = await response.json()
+      showToast({
+        title: language.t("provider.login.success"),
+        description: result.message || `Logged in to ${value}`,
+        variant: "success",
+      })
+      dialog.close()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Login failed"
+      showToast({ title: language.t("provider.login.failed"), description: message, variant: "error" })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog
+      title={language.t("provider.login.title")}
+      description={language.t("provider.login.description")}
+    >
+      <div class="flex flex-col gap-4">
+        <TextField
+          placeholder="https://gateway.example.com"
+          value={url()}
+          onInput={(e) => setUrl(e.currentTarget.value)}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === "Enter") handleLogin()
+          }}
+          autofocus
+        />
+        <div class="flex justify-end gap-2">
+          <Button variant="secondary" onClick={() => dialog.close()}>
+            {language.t("common.cancel")}
+          </Button>
+          <Button onClick={handleLogin} disabled={loading()}>
+            {loading() ? language.t("common.loading") : language.t("provider.login.submit")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.sidebar.toggle": "Toggle sidebar",
   "command.project.open": "Open project",
   "command.provider.connect": "Connect provider",
+  "command.provider.login": "Login to provider URL",
   "command.server.switch": "Switch server",
   "command.settings.open": "Open settings",
   "command.session.previous": "Previous session",
@@ -192,6 +193,12 @@ export const dict = {
 
   "provider.disconnect.toast.disconnected.title": "{{provider}} disconnected",
   "provider.disconnect.toast.disconnected.description": "{{provider}} models are no longer available.",
+
+  "provider.login.title": "Login to Provider",
+  "provider.login.description": "Enter the base URL of your provider (e.g. https://gateway.example.com)",
+  "provider.login.submit": "Login",
+  "provider.login.success": "Login successful",
+  "provider.login.failed": "Login failed",
 
   "model.tag.free": "Free",
   "model.tag.latest": "Latest",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -49,6 +49,7 @@ import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme"
 import { DialogSelectProvider } from "@/components/dialog-select-provider"
 import { DialogSelectServer } from "@/components/dialog-select-server"
 import { DialogSettings } from "@/components/dialog-settings"
+import { DialogLoginProvider } from "@/components/dialog-login-provider"
 import { useCommand, type CommandOption } from "@/context/command"
 import { ConstrainDragXAxis } from "@/utils/solid-dnd"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
@@ -914,6 +915,13 @@ export default function Layout(props: ParentProps) {
         onSelect: () => connectProvider(),
       },
       {
+        id: "provider.login",
+        title: language.t("command.provider.login"),
+        category: language.t("command.category.provider"),
+        slash: "login",
+        onSelect: () => loginProvider(),
+      },
+      {
         id: "server.switch",
         title: language.t("command.server.switch"),
         category: language.t("command.category.server"),
@@ -1064,6 +1072,10 @@ export default function Layout(props: ParentProps) {
 
   function connectProvider() {
     dialog.show(() => <DialogSelectProvider />)
+  }
+
+  function loginProvider() {
+    dialog.show(() => <DialogLoginProvider />)
   }
 
   function openServer() {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -9,6 +9,7 @@ import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
+import { DialogLogin } from "@tui/component/dialog-login"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
@@ -504,6 +505,18 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogProviderList />)
+      },
+      category: "Provider",
+    },
+    {
+      title: "Login to provider URL",
+      value: "provider.login",
+      slash: {
+        name: "login",
+        aliases: ["auth"],
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogLogin />)
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-login.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-login.tsx
@@ -1,0 +1,56 @@
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
+import { useDialog } from "@tui/ui/dialog"
+import { useSDK } from "../context/sdk"
+import { useSync } from "../context/sync"
+import { useToast } from "../ui/toast"
+
+interface DialogLoginProps {
+  initialUrl?: string
+}
+
+export function DialogLogin(props: DialogLoginProps) {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const sync = useSync()
+  const toast = useToast()
+
+  return (
+    <DialogPrompt
+      title="Login to Provider"
+      placeholder="https://example.com"
+      value={props.initialUrl}
+      description={() => (
+        <text>
+          Enter the base URL of your provider (e.g. https://gateway.example.com)
+        </text>
+      )}
+      onConfirm={async (url) => {
+        if (!url || !url.trim()) {
+          toast.show({ message: "URL is required", variant: "error" })
+          return
+        }
+        dialog.clear()
+        toast.show({ message: `Logging in to ${url}...`, variant: "info" })
+        try {
+          const response = await sdk.fetch(`${sdk.url}/auth/wellknown`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ url: url.trim() }),
+          })
+          if (!response.ok) {
+            const error = await response.json().catch(() => ({ message: "Unknown error" }))
+            throw new Error(error.data?.message || error.message || "Login failed")
+          }
+          const result = await response.json()
+          await sdk.client.instance.dispose()
+          await sync.bootstrap()
+          toast.show({ message: result.message || `Logged in to ${url}`, variant: "success", duration: 5000 })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Login failed"
+          toast.show({ message, variant: "error", duration: 5000 })
+        }
+      }}
+      onCancel={() => dialog.clear()}
+    />
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -96,6 +96,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    return { client: sdk, event: emitter, url: props.url, fetch: props.fetch ?? fetch }
   },
 })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -192,6 +192,65 @@ export namespace Server {
             return c.json(true)
           },
         )
+        .post(
+          "/auth/wellknown",
+          describeRoute({
+            summary: "Login via wellknown URL",
+            description:
+              "Authenticate with an external provider using their .well-known/opencode endpoint. Fetches the wellknown config, runs the auth command, and stores the resulting token.",
+            operationId: "auth.wellknown",
+            responses: {
+              200: {
+                description: "Successfully authenticated",
+                content: {
+                  "application/json": {
+                    schema: resolver(
+                      z.object({
+                        success: z.boolean(),
+                        message: z.string().optional(),
+                      }),
+                    ),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator(
+            "json",
+            z.object({
+              url: z.string().meta({ description: "The base URL of the provider (e.g. https://example.com)" }),
+            }),
+          ),
+          async (c) => {
+            const { url } = c.req.valid("json")
+            const wellknownUrl = `${url}/.well-known/opencode`
+            const wellknown = await fetch(wellknownUrl).then((x) => {
+              if (!x.ok) throw new NamedError.Unknown({ message: `Failed to fetch ${wellknownUrl}: ${x.status}` })
+              return x.json() as Promise<{ auth: { command: string[]; env: string } }>
+            })
+            if (!wellknown.auth?.command || !wellknown.auth?.env) {
+              throw new NamedError.Unknown({ message: "Invalid wellknown response: missing auth.command or auth.env" })
+            }
+            const proc = Bun.spawn({
+              cmd: wellknown.auth.command,
+              stdout: "pipe",
+              stderr: "pipe",
+            })
+            const exit = await proc.exited
+            if (exit !== 0) {
+              const stderr = await new Response(proc.stderr).text()
+              throw new NamedError.Unknown({ message: `Auth command failed: ${stderr || "exit code " + exit}` })
+            }
+            const token = await new Response(proc.stdout).text()
+            await Auth.set(url, {
+              type: "wellknown",
+              key: wellknown.auth.env,
+              token: token.trim(),
+            })
+            return c.json({ success: true, message: `Logged into ${url}` })
+          },
+        )
         .use(async (c, next) => {
           if (c.req.path === "/log") return next()
           const raw = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -163,6 +163,16 @@ Create or update `AGENTS.md` file. [Learn more](/docs/rules).
 
 ---
 
+### login
+
+Login to a provider using a wellknown URL. This allows you to authenticate with external AI providers or gateways that support the `.well-known/opencode` endpoint without leaving the TUI. _Alias_: `/auth`
+
+```bash frame="none"
+/login
+```
+
+---
+
 ### models
 
 List available models.


### PR DESCRIPTION
### Issue for this PR

Closes #14436 

### Type of change
 - [ ] Bug fix
 - [x] New feature
 - [ ] Refactor / code improvement
 - [ ] Documentation



### What does this PR do?

At my workplace, I have opencode configured to use an AI gateway. I also have to re-authenticate with that gateway every 24 hours.

Although it's a minor issue, I find that when I'm doing work in OpenCode and my token expires whilst I'm in deep work or in the middle of a session, I begin to get HTTP 401 authorisation errors.

The way to fix that at the moment seems to be to either open another terminal tab and run `opencode auth login` and re-join the existing session you had, or to close OpenCode, run the above command and re-open it again.

Not a major issue by any means, but this commit adds a `/login` slash command so that you can quickly re-authenticate in-place and then continue doing work with minimal disruption.

Apologies I appreciate in your contributing guidelines it mentioned to hold off on implementation if it's a UI change  until it's maybe been discussed more in the Github issue, but was hoping it would be helpful to implement and include alongside the issue given it's quite a small feature, easy to reason about and follows the existing design of everything else in place.

Please do let me know if I've missed anything that said or if there's anything else you'd like me to change/check.

Thank you once again!


### How did you verify your code works?

I've been running this locally over the past 2 days and it behaves as I expect and been very useful. Screenshots are attached below. 

### Screenshots / recordings
<img width="1444" height="159" alt="Screenshot 2026-02-20 at 12 33 25" src="https://github.com/user-attachments/assets/0615c0a6-0fbc-4bdd-861e-c474a9ab2899" />

<img width="1477" height="863" alt="Screenshot 2026-02-20 at 12 33 34" src="https://github.com/user-attachments/assets/c5aca27c-3a76-4cb3-96c8-187312e868a8" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
