### PR TITLE
feat(mcp): add mcp restart tool for autonomous agent recovery

### DIFF
--- a/packages/opencode/src/tool/mcp_restart.ts
+++ b/packages/opencode/src/tool/mcp_restart.ts
@@ -1,0 +1,27 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { MCP } from "../mcp/index"
+
+export const McpRestartTool = Tool.define("mcp_restart", {
+  description: "Restart an MCP server by name. Use this tool when an MCP server stops working or the user explicitly asks to restart it.",
+  parameters: z.object({
+    name: z.string().describe("The name of the MCP server to restart"),
+  }),
+  async execute(params, ctx) {
+    try {
+      await MCP.disconnect(params.name)
+      await MCP.connect(params.name)
+      return {
+        title: "mcp_restart",
+        metadata: ctx.metadata,
+        output: `Successfully restarted MCP server '${params.name}'`
+      }
+    } catch (error) {
+      return {
+        title: "mcp_restart",
+        metadata: ctx.metadata,
+        output: `Failed to restart MCP server '${params.name}': ${error}`
+      }
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -28,6 +28,7 @@ import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 
 import { ApplyPatchTool } from "./apply_patch"
+import { McpRestartTool } from "./mcp_restart"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
 
@@ -120,6 +121,7 @@ export namespace ToolRegistry {
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool] : []),
+      McpRestartTool,
       ...custom,
     ]
   }

--- a/packages/opencode/test/tool/mcp_restart.test.ts
+++ b/packages/opencode/test/tool/mcp_restart.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test"
+import { McpRestartTool } from "../../src/tool/mcp_restart"
+import { MCP } from "../../src/mcp/index"
+
+describe("tool.mcp_restart", () => {
+  let disconnectMock: any
+  let connectMock: any
+  let originalDisconnect: any
+  let originalConnect: any
+
+  beforeEach(() => {
+    originalDisconnect = MCP.disconnect
+    originalConnect = MCP.connect
+    disconnectMock = mock(async () => {})
+    connectMock = mock(async () => {})
+    MCP.disconnect = disconnectMock
+    MCP.connect = connectMock
+  })
+
+  afterEach(() => {
+    MCP.disconnect = originalDisconnect
+    MCP.connect = originalConnect
+  })
+
+  test("successfully restarts an MCP server", async () => {
+    const params = { name: "test-server" }
+    const ctx = { metadata: { source: "test" }, ask: async () => {} } as any
+    const tool = await McpRestartTool.init(ctx)
+    
+    const result = await tool.execute(params, ctx)
+    
+    expect(disconnectMock).toHaveBeenCalledWith("test-server")
+    expect(connectMock).toHaveBeenCalledWith("test-server")
+    expect(result.output).toContain("Successfully restarted")
+  })
+
+  test("handles errors during restart", async () => {
+    disconnectMock.mockRejectedValue(new Error("Connection error"))
+    
+    const params = { name: "test-server" }
+    const ctx = { metadata: { source: "test" }, ask: async () => {} } as any
+    const tool = await McpRestartTool.init(ctx)
+    
+    const result = await tool.execute(params, ctx)
+    
+    expect(disconnectMock).toHaveBeenCalledWith("test-server")
+    expect(result.output).toContain("Failed to restart")
+    expect(result.output).toContain("Connection error")
+  })
+})


### PR DESCRIPTION
### Issue for this PR
Closes #10290

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `McpRestartTool` to the system tools registry. This enables the autonomous agent to gracefully disconnect and reconnect an MCP server when it detects errors or when explicitly requested by the user, significantly improving the agent's self-healing capabilities without requiring manual user intervention.

### How did you verify your code works?

Tested locally via TUI and confirmed the tool executes successfully by manually verifying the MCP connection states before and after execution. Also added and ran full unit tests with `bun test test/tool/mcp_restart.test.ts`.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR