### PR TITLE
fix(session): scope session list to current directory

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { Session } from "../../session"
+import { Instance } from "../../project/instance"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
 import { Locale } from "../../util/locale"
@@ -86,7 +87,7 @@ export const SessionListCommand = cmd({
   },
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
-      const sessions = [...Session.list({ roots: true, limit: args.maxCount })]
+      const sessions = [...Session.list({ roots: true, limit: args.maxCount, directory: Instance.directory })]
 
       if (sessions.length === 0) {
         return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -26,7 +26,7 @@ export function DialogSessionList() {
 
   const [searchResults] = createResource(search, async (query) => {
     if (!query) return undefined
-    const result = await sdk.client.session.list({ search: query, limit: 30 })
+    const result = await sdk.client.session.list({ search: query, limit: 30, directory: sync.data.path.directory || undefined })
     return result.data ?? []
   })
 

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -96,6 +96,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    return { client: sdk, event: emitter, url: props.url, directory: props.directory }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -211,6 +211,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             setStore("session", result.index, reconcile(event.properties.info))
             break
           }
+          // Only insert new sessions if they belong to the current directory
+          if (sdk.directory && event.properties.info.directory !== sdk.directory) break
           setStore(
             "session",
             produce((draft) => {
@@ -350,7 +352,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
-        .list({ start: start })
+        .list({ start: start, directory: sdk.directory })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session


### PR DESCRIPTION
## Summary

`opencode session list` and the TUI `/sessions` dialog show sessions from **all** directories instead of only the current working directory. This is because four call sites don't pass the existing `directory` filter parameter to `Session.list()`.

This PR wires the `directory` parameter through all four missing call sites. No server, API, or schema changes required — the filtering infrastructure already exists and is already used by the web app.

Fixes #8836

## Problem

`Session.list()` accepts an optional `directory` parameter that filters sessions by working directory. The server route (`GET /session?directory=`) and the web app's `session-load.ts` already use this parameter correctly. However, four TUI/CLI entry points call `Session.list()` without it:

1. **CLI `session list` command** — fetches all sessions globally
2. **TUI bootstrap** — loads all sessions into state on startup
3. **TUI `/sessions` dialog** — searches all sessions when user opens session picker
4. **TUI SSE handler** — blindly inserts new sessions from `session.updated` events regardless of directory

For **git repositories**, this is partially masked because `project_id` is derived from the repo root. But for **non-git directories**, `project_id` is `"global"` — so sessions from every non-git directory get mixed together.

## Changes

| File | Change |
|------|--------|
| `packages/opencode/src/cli/cmd/session.ts` | Pass `directory: Instance.directory` to `Session.list()` |
| `packages/opencode/src/cli/cmd/tui/context/sync.tsx` | Pass `directory: sdk.directory` in bootstrap fetch (line ~353) |
| `packages/opencode/src/cli/cmd/tui/context/sync.tsx` | Add directory guard in SSE `session.updated` handler — only insert sessions matching current directory (lines ~208-220) |
| `packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx` | Pass `directory` to search call |
| `packages/opencode/src/cli/cmd/tui/context/sdk.tsx` | Expose `directory` property on SDK context return object (plumbing for the above) |

**+7 lines, -4 lines across 4 files.**

## Approach

This follows the same pattern the web app already uses in `packages/app/src/context/global-sync/session-load.ts`. Each caller explicitly passes the directory it cares about — no server-side default changes, no new CLI flags, no API contract modifications.

The SSE handler fix deserves a note: without it, a session created in directory B would still appear in the TUI running in directory A via the real-time event stream, even though the initial fetch was correctly filtered.

## Testing

- `tsgo --noEmit` passes for both `packages/opencode` and `packages/app` (full monorepo typecheck via turborepo: 12/12 packages pass)
- Existing test suite: 997 pass, 5 skip, 135 pre-existing failures (unrelated — caused by missing git user identity in test fixture `tmpdir()`)
- Verified via SQLite that `Instance.directory` stores the literal CWD, confirming exact-match filtering works correctly

## Related

- #3551 (original report)
- #6098 (duplicate)
- #8886 (stalled PR — client-side filter only, doesn't cover CLI or SSE)
- #6724 (stalled PR — changes server-side default, more invasive)