### PR TITLE
fix(server): redact API keys from provider API responses

### DIFF
--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -84,7 +84,7 @@ export const ConfigRoutes = lazy(() =>
         using _ = log.time("providers")
         const providers = await Provider.list().then((x) => mapValues(x, (item) => item))
         return c.json({
-          providers: Object.values(providers),
+          providers: Object.values(providers).map(({ key, ...rest }) => rest),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
         })
       },

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -53,7 +53,7 @@ export const ProviderRoutes = lazy(() =>
           connected,
         )
         return c.json({
-          all: Object.values(providers),
+          all: Object.values(providers).map(({ key, ...rest }) => rest),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
           connected: Object.keys(connected),
         })


### PR DESCRIPTION

## Summary

- Strip raw API key values from `Provider.Info` objects before returning them in `GET /config/providers` and `GET /provider` HTTP responses
- The `key` field on the `Provider.Info` schema holds the actual API key string (e.g., `sk-...`) and was being sent unredacted to browser clients
- This prevents API key exposure through browser dev tools, extensions, or any client-side code with access to the network layer

## Problem

When using the OpenCode web or desktop interface, API keys for all configured providers are exposed to the frontend via two endpoints:

- `GET /config/providers` — returns an array of `Provider.Info` objects with the `key` field containing the raw API key
- `GET /provider` — returns all providers (both from models.dev catalog and connected providers) with the same `key` field present

The `Provider.Info` Zod schema includes `key: z.string().optional()` which is populated with actual API key values from environment variables and the auth store during `Provider.list()`. Both route handlers return these objects directly to the client without stripping sensitive fields.

Any code running in the browser context — including third-party extensions, injected scripts, or anyone with access to the browser developer tools — can read these API keys from the network responses.

## Root Cause

In `packages/opencode/src/provider/provider.ts`, the internal `state()` function populates the `key` field with raw API key values:

```typescript
// From environment variables:
mergeProvider(providerID, {
  source: "env",
  key: provider.env.length === 1 ? apiKey : undefined,
})

// From stored auth credentials:
mergeProvider(providerID, {
  source: "api",
  key: provider.key,
})
```

The `list()` function returns `state.providers` as-is, and both route handlers forward these objects to the client without any field redaction.

## Fix

In both route handlers, the `key` field is destructured out of each provider object before including it in the JSON response:

```typescript
// Before:
providers: Object.values(providers)

// After:
providers: Object.values(providers).map(({ key, ...rest }) => rest)
```

This removes the `key` field from the HTTP response while keeping it available server-side for SDK initialization in `getSDK()` where it's actually needed (`options["apiKey"] = provider.key`).

The frontend does not need the raw API key value. Authentication status is already conveyed by:
- The `source` field (`"env"` or `"api"` indicates the provider has credentials configured)
- The `connected` array in the `/provider` response (lists provider IDs that have active credentials)

## Files Changed

| File | Change |
|------|--------|
| `packages/opencode/src/server/routes/config.ts` | Strip `key` from provider objects in `GET /config/providers` response |
| `packages/opencode/src/server/routes/provider.ts` | Strip `key` from provider objects in `GET /provider` response |

## Test Plan

- [ ] Run `bun dev serve` and verify `curl http://localhost:4096/config/providers | jq '.providers[0]'` does not include a `key` field
- [ ] Verify `curl http://localhost:4096/provider | jq '.all[0]'` does not include a `key` field
- [ ] Open the web UI, configure a provider with an API key, and inspect the Network tab — confirm the key is not present in any response
- [ ] Verify that LLM calls still function correctly (keys are resolved server-side in `getSDK()`, not from the API response)
- [ ] Verify that the provider connection status still displays correctly in the UI (uses `source` field and `connected` array, not `key`)

Fixes #14401
