### PR TITLE
fix(tui): improve ctrl+_ undo behavior and silence offline models.dev startup noise

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -836,6 +836,11 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                if (keybind.match("input_undo", e)) {
+                  if (input.undo()) input.gotoBufferEnd()
+                  e.preventDefault()
+                  return
+                }
                 // Handle clipboard paste (Ctrl+V) - check for images first on Windows
                 // This is needed because Windows terminal doesn't properly send image data
                 // through bracketed paste, so we need to intercept the keypress and

--- a/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
@@ -48,14 +48,23 @@ function mapTextareaKeybindings(
   const configKey = `input_${action.replace(/-/g, "_")}`
   const bindings = keybinds[configKey]
   if (!bindings) return []
-  return bindings.map((binding) => ({
-    name: binding.name,
-    ctrl: binding.ctrl || undefined,
-    meta: binding.meta || undefined,
-    shift: binding.shift || undefined,
-    super: binding.super || undefined,
-    action,
-  }))
+  const result: KeyBinding[] = []
+  for (const binding of bindings) {
+    result.push({
+      name: binding.name,
+      ctrl: binding.ctrl || undefined,
+      meta: binding.meta || undefined,
+      shift: binding.shift || undefined,
+      super: binding.super || undefined,
+      action,
+    })
+    // Terminals encode ctrl+_ as \x1F without modifier flags, so add a
+    // raw binding so opentui's key matcher can recognise the sequence.
+    if (binding.name === "_" && binding.ctrl) {
+      result.push({ name: "\x1F", action })
+    }
+  }
+  return result
 }
 
 export function useTextareaKeybindings() {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -882,7 +882,7 @@ export namespace Config {
       input_delete_to_line_start: z.string().optional().default("ctrl+u").describe("Delete to start of line in input"),
       input_backspace: z.string().optional().default("backspace,shift+backspace").describe("Backspace in input"),
       input_delete: z.string().optional().default("ctrl+d,delete,shift+delete").describe("Delete character in input"),
-      input_undo: z.string().optional().default("ctrl+-,super+z").describe("Undo in input"),
+      input_undo: z.string().optional().default("ctrl+-,ctrl+_,super+z").describe("Undo in input"),
       input_redo: z.string().optional().default("ctrl+.,super+shift+z").describe("Redo in input"),
       input_word_forward: z
         .string()

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -1,5 +1,4 @@
 import { Global } from "../global"
-import { Log } from "../util/log"
 import path from "path"
 import z from "zod"
 import { Installation } from "../installation"
@@ -12,7 +11,6 @@ import { Filesystem } from "../util/filesystem"
 /* @ts-ignore */
 
 export namespace ModelsDev {
-  const log = Log.create({ service: "models.dev" })
   const filepath = path.join(Global.Path.cache, "models.json")
 
   export const Model = z.object({
@@ -94,7 +92,10 @@ export namespace ModelsDev {
       .catch(() => undefined)
     if (snapshot) return snapshot
     if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-    const json = await fetch(`${url()}/api.json`).then((x) => x.text())
+    const json = await fetch(`${url()}/api.json`)
+      .then((x) => x.text())
+      .catch(() => undefined)
+    if (!json) return {}
     return JSON.parse(json)
   })
 
@@ -109,11 +110,7 @@ export namespace ModelsDev {
         "User-Agent": Installation.USER_AGENT,
       },
       signal: AbortSignal.timeout(10 * 1000),
-    }).catch((e) => {
-      log.error("Failed to fetch models.dev", {
-        error: e,
-      })
-    })
+    }).catch(() => undefined)
     if (result && result.ok) {
       await Filesystem.write(filepath, await result.text())
       ModelsDev.Data.reset()


### PR DESCRIPTION
### Issue for this PR

Closes #14452 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. **Fixed:** When launching `opencode` offline (or due to DNS failure), startup prints `models.dev` fetch errors twice before the TUI rendered.
2. **Improved:** `ctrl+_` undo behavior in the TUI input was inconsistent with readline/bash expectations.

No dependency or build-system changes.

### How did you verify your code works?

Verified changes by locally running the `bun dev` build on my machine.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR