### PR TITLE
fix(webfetch): use honest User-Agent to identify as OpenCode instead …

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -3,6 +3,7 @@ import { Tool } from "./tool"
 import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
 import { abortAfterAny } from "../util/abort"
+import { Installation } from "../installation"
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
@@ -56,18 +57,24 @@ export const WebFetchTool = Tool.define("webfetch", {
           "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
     }
     const headers = {
-      "User-Agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+      "User-Agent": Installation.USER_AGENT,
       Accept: acceptHeader,
       "Accept-Language": "en-US,en;q=0.9",
     }
 
     const initial = await fetch(params.url, { signal, headers })
 
-    // Retry with honest UA if blocked by Cloudflare bot detection (TLS fingerprint mismatch)
+    // Retry with browser-like UA if blocked by Cloudflare bot detection
     const response =
       initial.status === 403 && initial.headers.get("cf-mitigated") === "challenge"
-        ? await fetch(params.url, { signal, headers: { ...headers, "User-Agent": "opencode" } })
+        ? await fetch(params.url, {
+            signal,
+            headers: {
+              ...headers,
+              "User-Agent":
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+            },
+          })
         : initial
 
     clearTimeout()

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import { Instance } from "../../src/project/instance"
+import { Installation } from "../../src/installation"
 import { WebFetchTool } from "../../src/tool/webfetch"
 
 const projectRoot = path.join(import.meta.dir, "../..")
@@ -71,6 +72,66 @@ describe("tool.webfetch", () => {
             const result = await webfetch.execute({ url: "https://example.com/image.svg", format: "html" }, ctx)
             expect(result.output).toContain("<svg")
             expect(result.attachments).toBeUndefined()
+          },
+        })
+      },
+    )
+  })
+
+  test("sends opencode user-agent by default instead of browser UA", async () => {
+    let capturedUA = ""
+    await withFetch(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        capturedUA = (init?.headers as Record<string, string>)?.["User-Agent"] ?? ""
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            await webfetch.execute({ url: "https://example.com", format: "text" }, ctx)
+            expect(capturedUA).toBe(Installation.USER_AGENT)
+            expect(capturedUA).not.toContain("Mozilla")
+            expect(capturedUA).toStartWith("opencode/")
+          },
+        })
+      },
+    )
+  })
+
+  test("retries with browser UA when Cloudflare blocks the request", async () => {
+    let callCount = 0
+    let retryUA = ""
+    await withFetch(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        callCount++
+        const ua = (init?.headers as Record<string, string>)?.["User-Agent"] ?? ""
+        if (callCount === 1) {
+          // First call: simulate Cloudflare bot detection block
+          return new Response("Blocked", {
+            status: 403,
+            headers: { "cf-mitigated": "challenge" },
+          })
+        }
+        // Second call: capture the retry UA and return success
+        retryUA = ua
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            await webfetch.execute({ url: "https://example.com", format: "text" }, ctx)
+            expect(callCount).toBe(2)
+            expect(retryUA).toContain("Mozilla")
           },
         })
       },


### PR DESCRIPTION

## Summary

The WebFetch tool currently sends a hardcoded Chrome browser User-Agent string (`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36`), making it indistinguishable from regular browser traffic. This prevents website operators from identifying requests as originating from an AI coding agent and making informed decisions about how to handle such traffic.

This PR changes the default User-Agent to use `Installation.USER_AGENT` (format: `opencode/<channel>/<version>/<client>`), which is already defined in the codebase and used by other components like `models.ts` for API calls. The browser-like UA is preserved as a fallback only when Cloudflare bot detection explicitly blocks the honest UA (403 + `cf-mitigated: challenge` header).

## Problem

As reported in #14453, the WebFetch tool impersonates a human browser by default. This is problematic because:

1. **Lack of transparency** - Websites cannot distinguish OpenCode requests from regular browser traffic, preventing operators from making informed decisions about bot traffic handling.
2. **Industry misalignment** - Other AI tools like ChatGPT (`ChatGPT-User/1.0`), Perplexity, and others already send proper bot-identifying User-Agents. OpenCode should follow the same responsible practice.
3. **robots.txt compliance** - Without a unique, identifiable UA, websites cannot selectively manage OpenCode access via robots.txt or server-side rules.

## Changes

### `packages/opencode/src/tool/webfetch.ts`

- **Added** import for `Installation` from `../installation`
- **Replaced** the hardcoded Chrome browser User-Agent with `Installation.USER_AGENT` as the default for all outgoing requests
- **Inverted the Cloudflare retry logic**: The default is now the honest UA, with the browser-like UA used as a fallback only when Cloudflare's bot detection (TLS fingerprint mismatch) blocks the initial request

### `packages/opencode/test/tool/webfetch.test.ts`

- **Added** test: `sends opencode user-agent by default instead of browser UA` - Verifies that the initial request uses `Installation.USER_AGENT`, starts with `opencode/`, and does not contain `Mozilla`
- **Added** test: `retries with browser UA when Cloudflare blocks the request` - Verifies that when a 403 with `cf-mitigated: challenge` is received, the tool retries with a browser-like UA

## Behavior Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Default request | Chrome browser UA (impersonates human) | `opencode/<channel>/<version>/<client>` (honest identification) |
| Cloudflare blocks | Retries with `"opencode"` string | Retries with Chrome browser UA (to preserve functionality) |
| Website operators | Cannot identify OpenCode traffic | Can identify and manage OpenCode traffic via UA string |

## Design Decisions

**Why invert the fallback rather than just change the default?**

The previous code used a browser UA by default and fell back to `"opencode"` when Cloudflare blocked. Since we now use the honest UA first, the Cloudflare retry naturally needs a browser-like UA to bypass TLS fingerprint-based bot detection. This maintains the same level of accessibility while making the default behavior transparent.

**Why use `Installation.USER_AGENT` instead of a custom string?**

The codebase already defines this constant (in `packages/opencode/src/installation/index.ts`) and uses it in `packages/opencode/src/provider/models.ts`. Reusing it ensures consistency and automatically includes the correct version and channel information.

## Test Plan

- [x] Existing WebFetch tests pass (image, SVG, text responses)
- [x] New test verifies honest UA is sent by default
- [x] New test verifies Cloudflare fallback uses browser UA
- [x] Type checking passes across all packages (`bun typecheck`)

## Related Issues

- Fixes #14453
- Related to #9013 (feature request for overriding the default UA - this PR changes the default, which is complementary)
