### PR TITLE
fix(tui): default attach cwd when --dir is omitted

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -48,7 +48,7 @@ export const AttachCommand = cmd({
       }
 
       const directory = (() => {
-        if (!args.dir) return undefined
+        if (!args.dir) return process.cwd()
         try {
           process.chdir(args.dir)
           return process.cwd()


### PR DESCRIPTION
### Issue for this PR

Closes #14460

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Small regression fix for `opencode attach`.

When I run `opencode attach <url>` without `--dir`, attach starts in the server process directory (where `opencode serve` was started), not in the directory where I ran `attach`.

It seems the attach request is missing the client directory context when `--dir` is omitted, so the attached session defaults to the server-side working directory.
This change restores the previous behavior by defaulting to client `process.cwd()` when `--dir` is omitted.

### How did you verify your code works?

I started `serve` in one folder and ran `attach` from another.

Before this change, attach used the server folder.
After this change, attach uses the folder where I ran `attach`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR