### PR TITLE
feat(opencode): add LiteLLM provider with auto model discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -655,6 +655,7 @@
         "tree-sitter-powershell": "0.25.10",
         "turndown": "7.2.0",
         "ulid": "catalog:",
+        "undici": "^7.13.0",
         "venice-ai-sdk-provider": "2.1.1",
         "vscode-jsonrpc": "8.2.1",
         "web-tree-sitter": "0.25.10",
@@ -5386,7 +5387,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+    "undici": ["undici@7.26.0", "", {}, "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -5896,6 +5897,8 @@
 
     "@dot/log/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@effect/platform-node/undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
     "@electron/asar/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -5905,8 +5908,6 @@
     "@electron/fuses/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@electron/fuses/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
-
-    "@electron/get/undici": ["undici@7.26.0", "", {}, "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg=="],
 
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
@@ -6381,8 +6382,6 @@
     "motion/framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
 
     "nitro/h3": ["h3@2.0.1-rc.5", "", { "dependencies": { "rou3": "^0.7.9", "srvx": "^0.9.1" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"] }, "sha512-qkohAzCab0nLzXNm78tBjZDvtKMTmtygS8BJLT3VPczAQofdqlFXDPkXdLMJN4r05+xqneG8snZJ0HgkERCZTg=="],
-
-    "nitro/undici": ["undici@7.26.0", "", {}, "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg=="],
 
     "node-gyp/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -623,6 +623,72 @@ function ProviderConnection(props: {
     )
   }
 
+  function LiteLLMAuthView() {
+    const [formStore, setFormStore] = createStore({
+      baseURL: "",
+      apiKey: "",
+      error: undefined as string | undefined,
+    })
+
+    async function handleSubmit(e: SubmitEvent) {
+      e.preventDefault()
+
+      const form = e.currentTarget as HTMLFormElement
+      const formData = new FormData(form)
+      const baseURL = (formData.get("baseURL") as string)?.trim() || "http://localhost:4000"
+      const apiKey = (formData.get("apiKey") as string)?.trim()
+
+      setFormStore("error", undefined)
+      await serverSync().updateConfig({
+        provider: {
+          litellm: {
+            options: { baseURL },
+          },
+        },
+      })
+      if (apiKey) {
+        await serverSDK().client.auth.set({
+          providerID: props.provider,
+          auth: { type: "api", key: apiKey },
+        })
+      }
+      await complete()
+    }
+
+    return (
+      <div class="flex flex-col gap-6">
+        <div class="text-14-regular text-text-base">
+          Connect to a LiteLLM proxy server. Models will be discovered automatically.
+        </div>
+        <form onSubmit={handleSubmit} class="flex flex-col items-start gap-4">
+          <TextField
+            autofocus
+            type="text"
+            label="Base URL"
+            placeholder="http://localhost:4000"
+            name="baseURL"
+            value={formStore.baseURL}
+            onChange={(v) => setFormStore("baseURL", v)}
+          />
+          <TextField
+            type="text"
+            label="API Key (optional)"
+            placeholder="sk-..."
+            name="apiKey"
+            value={formStore.apiKey}
+            onChange={(v) => setFormStore("apiKey", v)}
+          />
+          <Show when={formStore.error}>
+            <div class="text-14-regular text-text-critical-base">{formStore.error}</div>
+          </Show>
+          <Button class="w-auto" type="submit" size="large" variant="primary">
+            {language.t("common.submit")}
+          </Button>
+        </form>
+      </div>
+    )
+  }
+
   function OAuthCodeView() {
     const [formStore, setFormStore] = createStore({
       value: "",
@@ -782,6 +848,9 @@ function ProviderConnection(props: {
                   <span>{language.t("provider.connect.status.failed", { error: store.error ?? "" })}</span>
                 </div>
               </div>
+            </Match>
+            <Match when={method()?.type === "api" && props.provider === "litellm"}>
+              <LiteLLMAuthView />
             </Match>
             <Match when={method()?.type === "api"}>
               <ApiAuthView />

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -627,29 +627,26 @@ function ProviderConnection(props: {
     const [formStore, setFormStore] = createStore({
       baseURL: "",
       apiKey: "",
-      error: undefined as string | undefined,
     })
 
     async function handleSubmit(e: SubmitEvent) {
       e.preventDefault()
 
-      const form = e.currentTarget as HTMLFormElement
-      const formData = new FormData(form)
-      const baseURL = (formData.get("baseURL") as string)?.trim() || "http://localhost:4000"
-      const apiKey = (formData.get("apiKey") as string)?.trim()
+      const data = new FormData(e.currentTarget as HTMLFormElement)
+      const url = (data.get("baseURL") as string)?.trim() || "http://localhost:4000"
+      const key = (data.get("apiKey") as string)?.trim()
 
-      setFormStore("error", undefined)
       await serverSync().updateConfig({
         provider: {
           litellm: {
-            options: { baseURL },
+            options: { baseURL: url },
           },
         },
       })
-      if (apiKey) {
+      if (key) {
         await serverSDK().client.auth.set({
           providerID: props.provider,
-          auth: { type: "api", key: apiKey },
+          auth: { type: "api", key },
         })
       }
       await complete()
@@ -678,9 +675,6 @@ function ProviderConnection(props: {
             value={formStore.apiKey}
             onChange={(v) => setFormStore("apiKey", v)}
           />
-          <Show when={formStore.error}>
-            <div class="text-14-regular text-text-critical-base">{formStore.error}</div>
-          </Show>
           <Button class="w-auto" type="submit" size="large" variant="primary">
             {language.t("common.submit")}
           </Button>

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -624,11 +624,6 @@ function ProviderConnection(props: {
   }
 
   function LiteLLMAuthView() {
-    const [formStore, setFormStore] = createStore({
-      baseURL: "",
-      apiKey: "",
-    })
-
     async function handleSubmit(e: SubmitEvent) {
       e.preventDefault()
 
@@ -636,10 +631,12 @@ function ProviderConnection(props: {
       const url = (data.get("baseURL") as string)?.trim() || "http://localhost:4000"
       const key = (data.get("apiKey") as string)?.trim()
 
-      await serverSync().updateConfig({
-        provider: {
-          litellm: {
-            options: { baseURL: url },
+      await serverSDK().client.global.config.update({
+        config: {
+          provider: {
+            litellm: {
+              options: { baseURL: url },
+            },
           },
         },
       })
@@ -664,16 +661,12 @@ function ProviderConnection(props: {
             label="Base URL"
             placeholder="http://localhost:4000"
             name="baseURL"
-            value={formStore.baseURL}
-            onChange={(v) => setFormStore("baseURL", v)}
           />
           <TextField
             type="text"
             label="API Key (optional)"
             placeholder="sk-..."
             name="apiKey"
-            value={formStore.apiKey}
-            onChange={(v) => setFormStore("apiKey", v)}
           />
           <Button class="w-auto" type="submit" size="large" variant="primary">
             {language.t("common.submit")}

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -144,6 +144,7 @@
     "tree-sitter-powershell": "0.25.10",
     "turndown": "7.2.0",
     "ulid": "catalog:",
+    "undici": "^7.13.0",
     "venice-ai-sdk-provider": "2.1.1",
     "vscode-jsonrpc": "8.2.1",
     "web-tree-sitter": "0.25.10",

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -1,5 +1,4 @@
 import { Log } from "../util/log"
-import { Env } from "../env"
 import type { Provider } from "./provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -213,7 +212,7 @@ export namespace LiteLLM {
       timeout?: number
     },
   ): Promise<Record<string, Provider.Model> | undefined> {
-    const timeout = options?.timeout ?? Number(Env.get("LITELLM_TIMEOUT") ?? "5000")
+    const timeout = options?.timeout ?? 5000
     const base = host.replace(/\/+$/, "")
 
     const headers: Record<string, string> = {

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -1,0 +1,251 @@
+import { Log } from "../util/log"
+import { Env } from "../env"
+import type { Provider } from "./provider"
+
+export namespace LiteLLM {
+  const log = Log.create({ service: "litellm" })
+
+  interface ModelInfoEntry {
+    model_name: string
+    litellm_params?: {
+      model?: string
+      [key: string]: unknown
+    }
+    model_info?: {
+      id?: string
+      input_cost_per_token?: number | null
+      output_cost_per_token?: number | null
+      cache_read_input_token_cost?: number | null
+      cache_creation_input_token_cost?: number | null
+      input_cost_per_token_above_200k_tokens?: number | null
+      output_cost_per_token_above_200k_tokens?: number | null
+      max_tokens?: number | null
+      max_input_tokens?: number | null
+      max_output_tokens?: number | null
+      supports_function_calling?: boolean | null
+      supports_vision?: boolean | null
+      supports_pdf_input?: boolean | null
+      supports_audio_input?: boolean | null
+      supports_audio_output?: boolean | null
+      supports_video_input?: boolean | null
+      supports_prompt_caching?: boolean | null
+      supports_reasoning?: boolean | null
+      supported_openai_params?: string[] | null
+      [key: string]: unknown
+    }
+  }
+
+  const INTERLEAVED_MODELS = ["claude", "anthropic"]
+
+  function isWildcard(name: string): boolean {
+    return name.includes("*") || name.includes("/*")
+  }
+
+  function inferInterleaved(
+    underlyingModel: string | undefined,
+  ): Provider.Model["capabilities"]["interleaved"] {
+    if (!underlyingModel) return false
+    const lower = underlyingModel.toLowerCase()
+    if (INTERLEAVED_MODELS.some((m) => lower.includes(m))) return true
+    return false
+  }
+
+  function costPerMillion(costPerToken: number | null | undefined): number {
+    if (!costPerToken) return 0
+    return costPerToken * 1_000_000
+  }
+
+  function toModel(entry: ModelInfoEntry): Provider.Model | undefined {
+    if (isWildcard(entry.model_name)) return undefined
+
+    const info = entry.model_info ?? {}
+    const underlyingModel = entry.litellm_params?.model
+
+    const inputCost = costPerMillion(info.input_cost_per_token)
+    const outputCost = costPerMillion(info.output_cost_per_token)
+    const cacheReadCost = costPerMillion(info.cache_read_input_token_cost)
+    const cacheWriteCost = costPerMillion(info.cache_creation_input_token_cost)
+
+    const hasOver200K =
+      info.input_cost_per_token_above_200k_tokens != null ||
+      info.output_cost_per_token_above_200k_tokens != null
+
+    const supportsVision = info.supports_vision === true
+    const supportsPdf = info.supports_pdf_input === true
+    const supportsTemperature = info.supported_openai_params?.includes("temperature") ?? true
+
+    return {
+      id: entry.model_name,
+      providerID: "litellm",
+      name: entry.model_name,
+      api: {
+        id: entry.model_name,
+        url: "",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      status: "active",
+      headers: {},
+      options: {},
+      cost: {
+        input: inputCost,
+        output: outputCost,
+        cache: {
+          read: cacheReadCost,
+          write: cacheWriteCost,
+        },
+        experimentalOver200K: hasOver200K
+          ? {
+              input: costPerMillion(info.input_cost_per_token_above_200k_tokens),
+              output: costPerMillion(info.output_cost_per_token_above_200k_tokens),
+              cache: { read: 0, write: 0 },
+            }
+          : undefined,
+      },
+      limit: {
+        context: (info.max_input_tokens ?? info.max_tokens ?? 128_000) as number,
+        output: (info.max_output_tokens ?? 8_192) as number,
+      },
+      capabilities: {
+        temperature: supportsTemperature,
+        reasoning: info.supports_reasoning === true,
+        attachment: supportsVision || supportsPdf,
+        toolcall: info.supports_function_calling !== false,
+        input: {
+          text: true,
+          audio: info.supports_audio_input === true,
+          image: supportsVision,
+          video: info.supports_video_input === true,
+          pdf: supportsPdf,
+        },
+        output: {
+          text: true,
+          audio: info.supports_audio_output === true,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        interleaved: inferInterleaved(underlyingModel),
+      },
+      release_date: "",
+      variants: {},
+    }
+  }
+
+  function toBasicModel(id: string): Provider.Model {
+    return {
+      id,
+      providerID: "litellm",
+      name: id,
+      api: { id, url: "", npm: "@ai-sdk/openai-compatible" },
+      status: "active",
+      headers: {},
+      options: {},
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 128_000, output: 8_192 },
+      capabilities: {
+        temperature: true,
+        reasoning: false,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      release_date: "",
+      variants: {},
+    }
+  }
+
+  async function fetchModelInfo(
+    host: string,
+    headers: Record<string, string>,
+    timeout: number,
+  ): Promise<Record<string, Provider.Model> | undefined> {
+    const url = `${host}/model/info`
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(timeout),
+    }).catch(() => undefined)
+
+    if (!response?.ok) return undefined
+
+    const data = (await response.json()) as { data?: ModelInfoEntry[] }
+    const entries = data?.data
+    if (!Array.isArray(entries)) return undefined
+
+    const models: Record<string, Provider.Model> = {}
+    for (const entry of entries) {
+      const model = toModel(entry)
+      if (model) models[model.id] = model
+    }
+    return Object.keys(models).length > 0 ? models : undefined
+  }
+
+  async function fetchModelList(
+    host: string,
+    headers: Record<string, string>,
+    timeout: number,
+  ): Promise<Record<string, Provider.Model>> {
+    const url = `${host}/models`
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(timeout),
+    }).catch(() => undefined)
+
+    if (!response?.ok) return {}
+
+    const data = (await response.json()) as { data?: { id: string }[] }
+    const models: Record<string, Provider.Model> = {}
+    for (const item of data?.data ?? []) {
+      if (!item.id) continue
+      models[item.id] = toBasicModel(item.id)
+    }
+    return models
+  }
+
+  export async function discover(
+    host: string,
+    options?: {
+      apiKey?: string
+      headers?: Record<string, string>
+      timeout?: number
+    },
+  ): Promise<Record<string, Provider.Model> | undefined> {
+    const timeout = options?.timeout ?? Number(Env.get("LITELLM_TIMEOUT") ?? "5000")
+    const base = host.replace(/\/+$/, "")
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    }
+    if (options?.apiKey) {
+      headers["Authorization"] = `Bearer ${options.apiKey}`
+    }
+
+    try {
+      // Try /model/info first for rich metadata, fall back to /models
+      const rich = await fetchModelInfo(base, headers, timeout)
+      if (rich) {
+        log.info("discovered models from LiteLLM /model/info", {
+          count: Object.keys(rich).length,
+          host,
+        })
+        return rich
+      }
+
+      const basic = await fetchModelList(base, headers, timeout)
+      if (Object.keys(basic).length > 0) {
+        log.info("discovered models from /models (fallback)", {
+          count: Object.keys(basic).length,
+          host,
+        })
+        return basic
+      }
+
+      return undefined
+    } catch (e) {
+      log.warn("LiteLLM model discovery error", { error: e, host })
+      return undefined
+    }
+  }
+}

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -85,7 +85,7 @@ export namespace LiteLLM {
       },
       status: "active",
       headers: {},
-      options: {},
+      options: underlyingModel ? { underlyingModel } : {},
       cost: {
         input: inputCost,
         output: outputCost,

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -1,6 +1,8 @@
 import { Log } from "../util/log"
 import { Env } from "../env"
 import type { Provider } from "./provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 
 export namespace LiteLLM {
   const log = Log.create({ service: "litellm" })
@@ -75,8 +77,8 @@ export namespace LiteLLM {
     const supportsTemperature = info.supported_openai_params?.includes("temperature") ?? true
 
     return {
-      id: entry.model_name,
-      providerID: "litellm",
+      id: ModelV2.ID.make(entry.model_name),
+      providerID: ProviderV2.ID.make("litellm"),
       name: entry.model_name,
       api: {
         id: entry.model_name,
@@ -133,8 +135,8 @@ export namespace LiteLLM {
 
   function toBasicModel(id: string): Provider.Model {
     return {
-      id,
-      providerID: "litellm",
+      id: ModelV2.ID.make(id),
+      providerID: ProviderV2.ID.make("litellm"),
       name: id,
       api: { id, url: "", npm: "@ai-sdk/openai-compatible" },
       status: "active",

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -1,4 +1,4 @@
-import { Log } from "../util/log"
+import * as Log from "@opencode-ai/core/util/log"
 import type { Provider } from "./provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -222,30 +222,25 @@ export namespace LiteLLM {
       headers["Authorization"] = `Bearer ${options.apiKey}`
     }
 
-    try {
-      // Try /model/info first for rich metadata, fall back to /models
-      const rich = await fetchModelInfo(base, headers, timeout)
-      if (rich) {
-        log.info("discovered models from LiteLLM /model/info", {
-          count: Object.keys(rich).length,
-          host,
-        })
-        return rich
-      }
-
-      const basic = await fetchModelList(base, headers, timeout)
-      if (Object.keys(basic).length > 0) {
-        log.info("discovered models from /models (fallback)", {
-          count: Object.keys(basic).length,
-          host,
-        })
-        return basic
-      }
-
-      return undefined
-    } catch (e) {
-      log.warn("LiteLLM model discovery error", { error: e, host })
-      return undefined
+    // Try /model/info first for rich metadata, fall back to /models
+    const rich = await fetchModelInfo(base, headers, timeout)
+    if (rich) {
+      log.info("discovered models from LiteLLM /model/info", {
+        count: Object.keys(rich).length,
+        host,
+      })
+      return rich
     }
+
+    const basic = await fetchModelList(base, headers, timeout)
+    if (Object.keys(basic).length > 0) {
+      log.info("discovered models from /models (fallback)", {
+        count: Object.keys(basic).length,
+        host,
+      })
+      return basic
+    }
+
+    return undefined
   }
 }

--- a/packages/opencode/src/provider/litellm.ts
+++ b/packages/opencode/src/provider/litellm.ts
@@ -1,11 +1,8 @@
-import * as Log from "@opencode-ai/core/util/log"
 import type { Provider } from "./provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 
 export namespace LiteLLM {
-  const log = Log.create({ service: "litellm" })
-
   interface ModelInfoEntry {
     model_name: string
     litellm_params?: {
@@ -36,19 +33,8 @@ export namespace LiteLLM {
     }
   }
 
-  const INTERLEAVED_MODELS = ["claude", "anthropic"]
-
   function isWildcard(name: string): boolean {
     return name.includes("*") || name.includes("/*")
-  }
-
-  function inferInterleaved(
-    underlyingModel: string | undefined,
-  ): Provider.Model["capabilities"]["interleaved"] {
-    if (!underlyingModel) return false
-    const lower = underlyingModel.toLowerCase()
-    if (INTERLEAVED_MODELS.some((m) => lower.includes(m))) return true
-    return false
   }
 
   function costPerMillion(costPerToken: number | null | undefined): number {
@@ -125,7 +111,9 @@ export namespace LiteLLM {
           video: false,
           pdf: false,
         },
-        interleaved: inferInterleaved(underlyingModel),
+        interleaved: underlyingModel
+          ? ["claude", "anthropic"].some((model) => underlyingModel.toLowerCase().includes(model))
+          : false,
       },
       release_date: "",
       variants: {},
@@ -174,11 +162,12 @@ export namespace LiteLLM {
     const entries = data?.data
     if (!Array.isArray(entries)) return undefined
 
-    const models: Record<string, Provider.Model> = {}
-    for (const entry of entries) {
-      const model = toModel(entry)
-      if (model) models[model.id] = model
-    }
+    const models = Object.fromEntries(
+      entries
+        .map(toModel)
+        .filter((model): model is Provider.Model => model !== undefined)
+        .map((model) => [model.id, model]),
+    )
     return Object.keys(models).length > 0 ? models : undefined
   }
 
@@ -226,19 +215,11 @@ export namespace LiteLLM {
     // Try /model/info first for rich metadata, fall back to /models
     const rich = await fetchModelInfo(base, headers, timeout)
     if (rich) {
-      log.info("discovered models from LiteLLM /model/info", {
-        count: Object.keys(rich).length,
-        host,
-      })
       return rich
     }
 
     const basic = await fetchModelList(base, headers, timeout)
     if (Object.keys(basic).length > 0) {
-      log.info("discovered models from /models (fallback)", {
-        count: Object.keys(basic).length,
-        host,
-      })
       return basic
     }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -864,37 +864,40 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       const litellmAuth = yield* dep.auth("litellm")
 
-      // Skip discovery when there is no configuration at all
-      if (
-        !providerConfig &&
-        !Env.get("LITELLM_API_KEY") &&
-        !Env.get("LITELLM_HOST") &&
-        !Env.get("LITELLM_BASE_URL") &&
-        litellmAuth?.type !== "api"
+      const [apiKeyEnv, hostEnv, baseUrlEnv, customHeadersEnv, timeoutEnv] = yield* Effect.all(
+        [
+          dep.get("LITELLM_API_KEY"),
+          dep.get("LITELLM_HOST"),
+          dep.get("LITELLM_BASE_URL"),
+          dep.get("LITELLM_CUSTOM_HEADERS"),
+          dep.get("LITELLM_TIMEOUT"),
+        ],
+        { concurrency: "unbounded" },
       )
+
+      // Skip discovery when there is no configuration at all
+      if (!providerConfig && !apiKeyEnv && !hostEnv && !baseUrlEnv && litellmAuth?.type !== "api")
         return { autoload: false }
 
-      const baseURL =
-        providerConfig?.options?.baseURL ??
-        Env.get("LITELLM_HOST") ??
-        Env.get("LITELLM_BASE_URL") ??
-        "http://localhost:4000"
+      const baseURL = providerConfig?.options?.baseURL ?? hostEnv ?? baseUrlEnv ?? "http://localhost:4000"
 
       const apiKey = (() => {
         if (providerConfig?.options?.apiKey) return providerConfig.options.apiKey
-        const envKey = Env.get("LITELLM_API_KEY")
-        if (envKey) return envKey
+        if (apiKeyEnv) return apiKeyEnv
         if (litellmAuth?.type === "api") return litellmAuth.key
         return undefined
       })()
 
-      const customHeaders = yield* Effect.promise(() =>
-        Promise.resolve(Env.get("LITELLM_CUSTOM_HEADERS"))
-          .then((raw) => (raw ? (JSON.parse(raw) as Record<string, string>) : {}))
-          .catch(() => ({})),
-      )
+      const customHeaders = (() => {
+        if (!customHeadersEnv) return {}
+        try {
+          return JSON.parse(customHeadersEnv) as Record<string, string>
+        } catch {
+          return {}
+        }
+      })()
 
-      const timeout = Number(Env.get("LITELLM_TIMEOUT") ?? "5000")
+      const timeout = Number(timeoutEnv ?? "5000")
       const discovered = yield* Effect.promise(() =>
         LiteLLM.discover(baseURL, {
           apiKey,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -862,13 +862,17 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const cfg = yield* dep.config()
       const providerConfig = cfg.provider?.["litellm"]
 
-      const hasEnv = !!(Env.get("LITELLM_API_KEY") || Env.get("LITELLM_HOST") || Env.get("LITELLM_BASE_URL"))
-      const hasConfig = !!providerConfig
       const litellmAuth = yield* dep.auth("litellm")
-      const hasAuth = litellmAuth?.type === "api"
 
       // Skip discovery when there is no configuration at all
-      if (!hasEnv && !hasConfig && !hasAuth) return { autoload: false }
+      if (
+        !providerConfig &&
+        !Env.get("LITELLM_API_KEY") &&
+        !Env.get("LITELLM_HOST") &&
+        !Env.get("LITELLM_BASE_URL") &&
+        litellmAuth?.type !== "api"
+      )
+        return { autoload: false }
 
       const baseURL =
         providerConfig?.options?.baseURL ??
@@ -880,7 +884,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         if (providerConfig?.options?.apiKey) return providerConfig.options.apiKey
         const envKey = Env.get("LITELLM_API_KEY")
         if (envKey) return envKey
-        if (hasAuth) return litellmAuth.key
+        if (litellmAuth?.type === "api") return litellmAuth.key
         return undefined
       })()
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -869,16 +869,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       const litellmAuth = yield* dep.auth("litellm")
 
-      const [apiKeyEnv, hostEnv, baseUrlEnv, customHeadersEnv, timeoutEnv] = yield* Effect.all(
-        [
-          dep.get("LITELLM_API_KEY"),
-          dep.get("LITELLM_HOST"),
-          dep.get("LITELLM_BASE_URL"),
-          dep.get("LITELLM_CUSTOM_HEADERS"),
-          dep.get("LITELLM_TIMEOUT"),
-        ],
-        { concurrency: "unbounded" },
-      )
+      const env = yield* dep.env()
+      const apiKeyEnv = env["LITELLM_API_KEY"]
+      const hostEnv = env["LITELLM_HOST"]
+      const baseUrlEnv = env["LITELLM_BASE_URL"]
+      const timeoutEnv = env["LITELLM_TIMEOUT"]
 
       // Skip discovery when there is no configuration at all
       if (!providerConfig && !apiKeyEnv && !hostEnv && !baseUrlEnv && litellmAuth?.type !== "api")
@@ -886,21 +881,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
 
       const baseURL = providerConfig?.options?.baseURL ?? hostEnv ?? baseUrlEnv ?? "http://localhost:4000"
 
-      const apiKey = (() => {
-        if (providerConfig?.options?.apiKey) return providerConfig.options.apiKey
-        if (apiKeyEnv) return apiKeyEnv
-        if (litellmAuth?.type === "api") return litellmAuth.key
-        return undefined
-      })()
-
-      const customHeaders = (() => {
-        if (!customHeadersEnv) return {}
-        try {
-          return JSON.parse(customHeadersEnv) as Record<string, string>
-        } catch {
-          return {}
-        }
-      })()
+      const apiKey =
+        providerConfig?.options?.apiKey ?? apiKeyEnv ?? (litellmAuth?.type === "api" ? litellmAuth.key : undefined)
+      const customHeaders = providerConfig?.options?.headers ?? {}
 
       const timeout = Number(timeoutEnv ?? "5000")
       const discovered = yield* Effect.promise(() =>
@@ -926,7 +909,6 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         options: {
           baseURL,
           apiKey,
-          litellmProxy: true,
           fetch: (input: any, init?: any) =>
             undiciFetch(typeof input === "string" ? input : (input as Request).url, {
               ...init,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -888,15 +888,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         return undefined
       })()
 
-      const customHeaders = iife(() => {
-        const raw = Env.get("LITELLM_CUSTOM_HEADERS")
-        if (!raw) return {}
-        try {
-          return JSON.parse(raw) as Record<string, string>
-        } catch {
-          return {}
-        }
-      })
+      const customHeaders = yield* Effect.promise(() =>
+        Promise.resolve(Env.get("LITELLM_CUSTOM_HEADERS"))
+          .then((raw) => (raw ? (JSON.parse(raw) as Record<string, string>) : {}))
+          .catch(() => ({})),
+      )
 
       const timeout = Number(Env.get("LITELLM_TIMEOUT") ?? "5000")
       const discovered = yield* Effect.promise(() =>

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1155,7 +1155,11 @@ export function toPublicInfo(provider: Info): Info {
 }
 
 export function defaultModelIDs<T extends { models: Record<string, { id: string }> }>(providers: Record<string, T>) {
-  return mapValues(providers, (item) => sort(Object.values(item.models))[0].id)
+  return mapValues(providers, (item) => {
+    const models = Object.values(item.models)
+    if (models.length === 0) return undefined
+    return sort(models)[0].id
+  })
 }
 
 export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundError>()("ProviderModelNotFoundError", {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -19,6 +19,7 @@ import { Global } from "@opencode-ai/core/global"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema, Types } from "effect"
+import { Agent as UndiciAgent, fetch as undiciFetch } from "undici"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectPromise } from "@/effect/promise"
@@ -34,6 +35,10 @@ import { ProviderError } from "./error"
 import { LiteLLM } from "./litellm"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
+
+// Some LiteLLM deployments sit behind proxies (NGINX ingress, Azure App Gateway)
+// that buffer SSE on HTTP/1.1 but stream correctly on HTTP/2.
+const litellmDispatcher = new UndiciAgent({ allowH2: true })
 
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
@@ -922,6 +927,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           baseURL,
           apiKey,
           litellmProxy: true,
+          fetch: (input: any, init?: any) =>
+            undiciFetch(typeof input === "string" ? input : (input as Request).url, {
+              ...init,
+              dispatcher: litellmDispatcher,
+            }) as unknown as Promise<Response>,
           ...(Object.keys(customHeaders).length > 0 ? { headers: customHeaders } : {}),
         },
       }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,6 +31,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { LiteLLM } from "./litellm"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -857,6 +858,64 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    litellm: Effect.fnUntraced(function* (provider: Info) {
+      const cfg = yield* dep.config()
+      const providerConfig = cfg.provider?.["litellm"]
+
+      const baseURL =
+        providerConfig?.options?.baseURL ??
+        Env.get("LITELLM_HOST") ??
+        Env.get("LITELLM_BASE_URL") ??
+        "http://localhost:4000"
+
+      const apiKey = yield* Effect.gen(function* () {
+        if (providerConfig?.options?.apiKey) return providerConfig.options.apiKey
+        const envKey = Env.get("LITELLM_API_KEY")
+        if (envKey) return envKey
+        const auth = yield* dep.auth("litellm")
+        if (auth?.type === "api") return auth.key
+        return undefined
+      })
+
+      const customHeaders = iife(() => {
+        const raw = Env.get("LITELLM_CUSTOM_HEADERS")
+        if (!raw) return {}
+        try {
+          return JSON.parse(raw) as Record<string, string>
+        } catch {
+          return {}
+        }
+      })
+
+      const timeout = Number(Env.get("LITELLM_TIMEOUT") ?? "5000")
+      const discovered = yield* Effect.promise(() =>
+        LiteLLM.discover(baseURL, {
+          apiKey,
+          headers: customHeaders,
+          timeout,
+        }),
+      )
+
+      if (discovered) {
+        for (const [modelID, model] of Object.entries(discovered)) {
+          if (!provider.models[modelID]) {
+            provider.models[modelID] = model
+          }
+        }
+      }
+
+      if (Object.keys(provider.models).length === 0) return { autoload: false }
+
+      return {
+        autoload: true,
+        options: {
+          baseURL,
+          apiKey,
+          litellmProxy: true,
+          ...(Object.keys(customHeaders).length > 0 ? { headers: customHeaders } : {}),
+        },
+      }
+    }),
     "snowflake-cortex": Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
       const auth = yield* dep.auth(input.id)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1155,11 +1155,8 @@ export function toPublicInfo(provider: Info): Info {
 }
 
 export function defaultModelIDs<T extends { models: Record<string, { id: string }> }>(providers: Record<string, T>) {
-  return mapValues(providers, (item) => {
-    const models = Object.values(item.models)
-    if (models.length === 0) return undefined
-    return sort(models)[0].id
-  })
+  const populated = pickBy(providers, (item) => Object.keys(item.models).length > 0)
+  return mapValues(populated, (item) => sort(Object.values(item.models))[0].id)
 }
 
 export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundError>()("ProviderModelNotFoundError", {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -862,20 +862,27 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const cfg = yield* dep.config()
       const providerConfig = cfg.provider?.["litellm"]
 
+      const hasEnv = !!(Env.get("LITELLM_API_KEY") || Env.get("LITELLM_HOST") || Env.get("LITELLM_BASE_URL"))
+      const hasConfig = !!providerConfig
+      const litellmAuth = yield* dep.auth("litellm")
+      const hasAuth = litellmAuth?.type === "api"
+
+      // Skip discovery when there is no configuration at all
+      if (!hasEnv && !hasConfig && !hasAuth) return { autoload: false }
+
       const baseURL =
         providerConfig?.options?.baseURL ??
         Env.get("LITELLM_HOST") ??
         Env.get("LITELLM_BASE_URL") ??
         "http://localhost:4000"
 
-      const apiKey = yield* Effect.gen(function* () {
+      const apiKey = (() => {
         if (providerConfig?.options?.apiKey) return providerConfig.options.apiKey
         const envKey = Env.get("LITELLM_API_KEY")
         if (envKey) return envKey
-        const auth = yield* dep.auth("litellm")
-        if (auth?.type === "api") return auth.key
+        if (hasAuth) return litellmAuth.key
         return undefined
-      })
+      })()
 
       const customHeaders = iife(() => {
         const raw = Env.get("LITELLM_CUSTOM_HEADERS")
@@ -1446,6 +1453,17 @@ const layer = Layer.effect(
           return true
         }
 
+        // Seed LiteLLM provider so it is always available for interactive configuration
+        if (!database["litellm"]) {
+          database["litellm"] = {
+            id: ProviderV2.ID.make("litellm"),
+            name: "LiteLLM",
+            env: ["LITELLM_API_KEY"],
+            options: {},
+            source: "custom",
+            models: {},
+          }
+        }
         for (const hook of plugins) {
           const p = hook.provider
           const models = p?.models

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -186,7 +186,11 @@ function normalizeMessages(
       .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
   }
 
-  if (model.api.id.includes("claude")) {
+  const isClaudeToolCall =
+    model.api.id.includes("claude") ||
+    (model.providerID === "litellm" &&
+      ((model.options?.underlyingModel as string) ?? "").toLowerCase().includes("claude"))
+  if (isClaudeToolCall) {
     const scrub = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
     msgs = msgs.map((msg) => {
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
@@ -736,10 +740,23 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
 
   // LiteLLM proxied models: infer reasoning variant from the underlying model
-  // to avoid false-positive reasoning param injection for aliased models
+  // to avoid false-positive reasoning param injection for aliased models.
+  // Model aliases (e.g., "sonnet-4.5") may not contain "claude" or "anthropic",
+  // so we also check the underlying model stored in options.underlyingModel
+  // (e.g., "azure_ai/claude-sonnet-4-5").
   if (model.providerID === "litellm" && model.capabilities.reasoning) {
     const apiId = model.api.id.toLowerCase()
-    if (apiId.includes("claude") || apiId.includes("anthropic")) {
+    const underlying = ((model.options?.underlyingModel as string) ?? "").toLowerCase()
+    const isClaude = [apiId, underlying].some((s) => s.includes("claude") || s.includes("anthropic"))
+    if (isClaude) {
+      const isAdaptive = ["opus-4-6", "opus-4.6", "sonnet-4-6", "sonnet-4.6"].some(
+        (v) => apiId.includes(v) || underlying.includes(v),
+      )
+      if (isAdaptive) {
+        return Object.fromEntries(
+          ["low", "medium", "high", "max"].map((effort) => [effort, { thinking: { type: "adaptive" }, effort }]),
+        )
+      }
       return {
         high: {
           thinking: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -735,6 +735,29 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     }
   }
 
+  // LiteLLM proxied models: infer reasoning variant from the underlying model
+  // to avoid false-positive reasoning param injection for aliased models
+  if (model.providerID === "litellm" && model.capabilities.reasoning) {
+    const apiId = model.api.id.toLowerCase()
+    if (apiId.includes("claude") || apiId.includes("anthropic")) {
+      return {
+        high: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+          },
+        },
+        max: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: Math.min(31_999, model.limit.output - 1),
+          },
+        },
+      }
+    }
+    return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+  }
+
   switch (model.api.npm) {
     case "@openrouter/ai-sdk-provider":
       return Object.fromEntries(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -744,6 +744,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   // Model aliases (e.g., "sonnet-4.5") may not contain "claude" or "anthropic",
   // so we also check the underlying model stored in options.underlyingModel
   // (e.g., "azure_ai/claude-sonnet-4-5").
+  // NOTE: @ai-sdk/openai-compatible passes provider options as raw request body
+  // fields, so we must use snake_case (budget_tokens) not camelCase (budgetTokens)
+  // since LiteLLM forwards them directly to the upstream API.
   if (model.providerID === "litellm" && model.capabilities.reasoning) {
     const apiId = model.api.id.toLowerCase()
     const underlying = ((model.options?.underlyingModel as string) ?? "").toLowerCase()
@@ -754,20 +757,23 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       )
       if (isAdaptive) {
         return Object.fromEntries(
-          ["low", "medium", "high", "max"].map((effort) => [effort, { thinking: { type: "adaptive" }, effort }]),
+          ["low", "medium", "high", "max"].map((effort) => [
+            effort,
+            { thinking: { type: "enabled", budget_tokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)) } },
+          ]),
         )
       }
       return {
         high: {
           thinking: {
             type: "enabled",
-            budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+            budget_tokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
           },
         },
         max: {
           thinking: {
             type: "enabled",
-            budgetTokens: Math.min(31_999, model.limit.output - 1),
+            budget_tokens: Math.min(31_999, model.limit.output - 1),
           },
         },
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -434,6 +434,9 @@ function mapProviderOptions(
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  const underlying = ((model.options?.underlyingModel as string) ?? "").toLowerCase()
+  const isLiteLLMClaude =
+    model.providerID === "litellm" && (underlying.includes("claude") || underlying.includes("anthropic"))
   if (
     (model.providerID === "anthropic" ||
       model.providerID === "google-vertex-anthropic" ||
@@ -442,7 +445,8 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
       model.id.includes("anthropic") ||
       model.id.includes("claude") ||
       model.api.npm === "@ai-sdk/anthropic" ||
-      model.api.npm === "@ai-sdk/alibaba") &&
+      model.api.npm === "@ai-sdk/alibaba" ||
+      isLiteLLMClaude) &&
     model.api.npm !== "@ai-sdk/gateway"
   ) {
     msgs = applyCaching(msgs, model)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -42,6 +42,12 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
       const all = yield* ModelsDev.Service.use((s) => s.get())
       const disabled = new Set(config.disabled_providers ?? [])
       const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
+      all["litellm"] ??= {
+        id: "litellm",
+        name: "LiteLLM",
+        env: ["LITELLM_API_KEY"],
+        models: {},
+      }
       const filtered: Record<string, (typeof all)[string]> = {}
       for (const [key, value] of Object.entries(all)) {
         if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) filtered[key] = value

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -156,12 +156,19 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   ) {
     for (const key of Object.keys(tools)) tools[key] = { ...tools[key], strict: false }
   }
+
+  const isLiteLLMProxy =
+    input.model.providerID === "litellm" ||
+    input.provider.options?.["litellmProxy"] === true ||
+    input.model.providerID.toLowerCase().includes("litellm") ||
+    input.model.api.id.toLowerCase().includes("litellm")
+
   if (
-    input.model.providerID.includes("github-copilot") &&
+    (isLiteLLMProxy || input.model.providerID.includes("github-copilot")) &&
     Object.keys(tools).length === 0 &&
     hasToolCalls(input.messages)
   ) {
-    // Copilot needs a tools field when replaying prior tool calls, even if no tools are currently enabled.
+    // Copilot and LiteLLM need a tools field when replaying prior tool calls, even if no tools are currently enabled.
     tools["_noop"] = aiTool({
       description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
       inputSchema: jsonSchema({

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -157,14 +157,8 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     for (const key of Object.keys(tools)) tools[key] = { ...tools[key], strict: false }
   }
 
-  const isLiteLLMProxy =
-    input.model.providerID === "litellm" ||
-    input.provider.options?.["litellmProxy"] === true ||
-    input.model.providerID.toLowerCase().includes("litellm") ||
-    input.model.api.id.toLowerCase().includes("litellm")
-
   if (
-    (isLiteLLMProxy || input.model.providerID.includes("github-copilot")) &&
+    (input.model.providerID === "litellm" || input.model.providerID.includes("github-copilot")) &&
     Object.keys(tools).length === 0 &&
     hasToolCalls(input.messages)
   ) {

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -189,7 +189,10 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     system,
     messages,
     tools: Object.fromEntries(Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b))),
-    params,
+    params: {
+      ...params,
+      options: filterInternalOptions(params.options),
+    },
     messageTransformOptions: options,
     headers: {
       ...(input.model.providerID.startsWith("opencode")
@@ -218,6 +221,11 @@ function resolveTools(input: Pick<PrepareInput, "tools" | "agent" | "permission"
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+function filterInternalOptions(options: Record<string, any>) {
+  const { underlyingModel, ...rest } = options
+  return rest
 }
 
 export function hasToolCalls(messages: ModelMessage[]): boolean {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -26,6 +26,9 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 
 export function provider(model: Provider.Model) {
   if (model.api.id.includes("muse-spark")) return [PROMPT_META]
+  const underlying = ((model.options?.underlyingModel as string) ?? "").toLowerCase()
+  const isLiteLLMClaude =
+    model.providerID === "litellm" && (underlying.includes("claude") || underlying.includes("anthropic"))
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
     return [PROMPT_BEAST]
   if (model.api.id.includes("gpt")) {
@@ -35,7 +38,7 @@ export function provider(model: Provider.Model) {
     return [PROMPT_GPT]
   }
   if (model.api.id.includes("gemini-")) return [PROMPT_GEMINI]
-  if (model.api.id.includes("claude")) return [PROMPT_ANTHROPIC]
+  if (model.api.id.includes("claude") || isLiteLLMClaude) return [PROMPT_ANTHROPIC]
   if (model.api.id.toLowerCase().includes("trinity")) return [PROMPT_TRINITY]
   if (model.api.id.toLowerCase().includes("kimi")) return [PROMPT_KIMI]
   return [PROMPT_DEFAULT]

--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -494,10 +494,12 @@ function LiteLLMMethod() {
               <text fg={theme.textMuted}>Enter the API key for your LiteLLM proxy, or leave empty if not required.</text>
             )}
             onConfirm={async (apiKey) => {
-              await sdk.client.config.update({
-                provider: {
-                  litellm: {
-                    options: { baseURL: url },
+              await sdk.client.global.config.update({
+                config: {
+                  provider: {
+                    litellm: {
+                      options: { baseURL: url },
+                    },
                   },
                 },
               })

--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -207,6 +207,9 @@ export function createDialogProviderOptions() {
               }
             }
             if (method.type === "api") {
+              if (provider.id === "litellm") {
+                return dialog.replace(() => <LiteLLMMethod />)
+              }
               let metadata: Record<string, string> | undefined
               if (method.prompts?.length) {
                 const value = await PromptsMethod({ dialog, prompts: method.prompts })
@@ -466,4 +469,51 @@ async function PromptsMethod(props: PromptsMethodProps) {
     inputs[prompt.key] = value
   }
   return inputs
+}
+
+function LiteLLMMethod() {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const sync = useSync()
+  const { theme } = useTheme()
+
+  return (
+    <DialogPrompt
+      title="LiteLLM Base URL"
+      placeholder="http://localhost:4000"
+      description={() => (
+        <text fg={theme.textMuted}>Enter the base URL of your LiteLLM proxy server.</text>
+      )}
+      onConfirm={async (baseURL) => {
+        const url = baseURL?.trim() || "http://localhost:4000"
+        dialog.replace(() => (
+          <DialogPrompt
+            title="LiteLLM API Key"
+            placeholder="API key (optional)"
+            description={() => (
+              <text fg={theme.textMuted}>Enter the API key for your LiteLLM proxy, or leave empty if not required.</text>
+            )}
+            onConfirm={async (apiKey) => {
+              await sdk.client.config.update({
+                provider: {
+                  litellm: {
+                    options: { baseURL: url },
+                  },
+                },
+              })
+              if (apiKey?.trim()) {
+                await sdk.client.auth.set({
+                  providerID: "litellm",
+                  auth: { type: "api", key: apiKey.trim() },
+                })
+              }
+              await sdk.client.instance.dispose()
+              await sync.bootstrap()
+              dialog.replace(() => <DialogModel providerID="litellm" />)
+            }}
+          />
+        ))
+      }}
+    />
+  )
 }

--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -207,7 +207,7 @@ export function createDialogProviderOptions() {
               }
             }
             if (method.type === "api") {
-              if (provider.id === "litellm") {
+              if (provider.providerID === "litellm") {
                 return dialog.replace(() => <LiteLLMMethod />)
               }
               let metadata: Record<string, string> | undefined


### PR DESCRIPTION
### Issue for this PR

Closes #13891

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a native `litellm` provider that auto-discovers models from a LiteLLM proxy at startup. Previously users had to manually define every model in `opencode.json` — now setting `LITELLM_API_KEY` and `LITELLM_HOST` is enough.

**Discovery:** Fetches `/model/info` for rich metadata (pricing, limits, capabilities). Falls back to the standard `/models` endpoint for older LiteLLM versions or non-LiteLLM OpenAI-compatible proxies.

**What gets mapped from `/model/info`:**
- Per-token pricing → per-million-token (including over-200k tier)
- Context/output limits
- Capabilities: reasoning, vision, PDF, audio, video, tool calling
- Temperature support via `supported_openai_params`
- Interleaved thinking inference for Claude/Anthropic models

**Reasoning transforms:** Claude models behind LiteLLM get `thinking` budget variants, other models get `reasoningEffort`. This prevents false-positive reasoning param injection for aliased models (e.g. `o3-custom` → Mistral).

**Files changed:**
- **`litellm.ts`** (new): Discovery module — fetches, parses, maps model metadata
- **`provider.ts`**: Seeds `litellm` provider from env vars; custom loader calls discovery and injects models (user config takes precedence)
- **`transform.ts`**: LiteLLM-specific reasoning variant logic
- **`llm.ts`**: Adds explicit `providerID === "litellm"` to proxy detection

| Env var | Description | Default |
|---|---|---|
| `LITELLM_API_KEY` | API key for the proxy | — |
| `LITELLM_HOST` | Base URL of the proxy | `http://localhost:4000` |
| `LITELLM_BASE_URL` | Alias for `LITELLM_HOST` | — |
| `LITELLM_CUSTOM_HEADERS` | JSON string of extra headers | `{}` |
| `LITELLM_TIMEOUT` | Discovery timeout in ms | `5000` |

Builds on ideas from #13896 (fallback endpoint, over-200k pricing, temperature detection) and #14277 (clean fallback chain). Supersedes my earlier #14202 which was auto-closed for not following the PR template.

### How did you verify your code works?

1. Set `LITELLM_API_KEY` + `LITELLM_HOST` pointing to a running LiteLLM proxy
2. Run `opencode` — LiteLLM models appear in model picker
3. Select a model and send a message — streaming works
4. Test aliased reasoning model (e.g. `o3-custom` → Mistral) — reasoning params NOT injected
5. Test actual Claude reasoning model — `thinking` variants work
6. Test without proxy running — graceful fallback, provider hidden
7. Test with older proxy (no `/model/info`) — falls back to `/models` with sensible defaults

### Screenshots / recordings

N/A — no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR