### PR TITLE
fix: preserve tool argument descriptions in schema conversion

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -23,6 +23,7 @@ import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
 import { defer } from "../util/defer"
 import { ToolRegistry } from "../tool/registry"
+import { zodToJsonSchema } from "zod-to-json-schema"
 import { MCP } from "../mcp"
 import { LSP } from "../lsp"
 import { ReadTool } from "../tool/read"
@@ -782,7 +783,7 @@ export namespace SessionPrompt {
       { modelID: input.model.api.id, providerID: input.model.providerID },
       input.agent,
     )) {
-      const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+      const schema = ProviderTransform.schema(input.model, zodToJsonSchema(item.parameters) as any)
       tools[item.id] = tool({
         id: item.id as any,
         description: item.description,


### PR DESCRIPTION
### Issue for this PR

Closes #4357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom tools using `.describe()` on Zod schema properties lose those descriptions before they reach the LLM. This happens because `session/prompt.ts` uses `z.toJSONSchema()` which strips description metadata from schema properties.

The fix swaps it for `zodToJsonSchema()` from the `zod-to-json-schema` package, which correctly preserves `.describe()` metadata. This is the same function already used in `server/routes/experimental.ts` for the same purpose, and `zod-to-json-schema` is already a dependency.

### How did you verify your code works?

- Full typecheck passes (`bun turbo typecheck` — all 12 packages pass)
- `bun dev` starts without issues
- Verified `zodToJsonSchema()` output includes `description` fields for properties with `.describe()`, while `z.toJSONSchema()` drops them

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR