### PR TITLE
fix(session): scope session list and TUI to current directory

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import { cmd } from "./cmd"
 import { Session } from "../../session"
+import { Instance } from "../../project/instance"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
 import { Locale } from "../../util/locale"
@@ -86,7 +87,7 @@ export const SessionListCommand = cmd({
   },
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
-      const sessions = [...Session.list({ roots: true, limit: args.maxCount })]
+      const sessions = [...Session.list({ roots: true, limit: args.maxCount, directory: Instance.directory })]
 
       if (sessions.length === 0) {
         return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -26,7 +26,7 @@ export function DialogSessionList() {
 
   const [searchResults] = createResource(search, async (query) => {
     if (!query) return undefined
-    const result = await sdk.client.session.list({ search: query, limit: 30 })
+    const result = await sdk.client.session.list({ search: query, limit: 30, directory: sdk.directory || sync.data.path.directory || undefined })
     return result.data ?? []
   })
 

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -96,6 +96,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    return { client: sdk, event: emitter, url: props.url, directory: props.directory }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -211,6 +211,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             setStore("session", result.index, reconcile(event.properties.info))
             break
           }
+          // Only insert new sessions if they belong to the current directory
+          if (sdk.directory && event.properties.info.directory !== sdk.directory) break
           setStore(
             "session",
             produce((draft) => {
@@ -350,7 +352,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
-        .list({ start: start })
+        .list({ start: start, directory: sdk.directory })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -163,6 +163,7 @@ export const TuiThreadCommand = cmd({
 
       const tuiPromise = tui({
         url,
+        directory: cwd,
         fetch: customFetch,
         events,
         args: {


### PR DESCRIPTION
### Issue for this PR

Closes #8836

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI and CLI session list show sessions from ALL directories instead of scoping to the current working directory.

The root cause is in `thread.ts` — the normal TUI startup path never passes `directory` to `tui()`, so `sdk.directory` is `undefined` throughout the entire TUI lifecycle. All downstream directory filtering silently becomes a no-op. Only `attach.ts` (remote attach) correctly passed `directory`.

The fix:

1. **`thread.ts`** — Pass `directory: cwd` to `tui()`. This is the root fix that makes everything else work.
2. **`sdk.tsx`** — Expose `directory` on the SDK context return so downstream consumers can read it.
3. **`sync.tsx`** — Pass `sdk.directory` to the bootstrap `session.list()` call so the initial load is filtered. Also guard SSE session inserts — if the incoming session's directory doesn't match `sdk.directory`, don't insert it (existing sessions can still update).
4. **`dialog-session-list.tsx`** — Pass `sdk.directory` to search queries, with `sync.data.path.directory` as fallback.
5. **`session.ts`** — CLI `session list` passes `Instance.directory` to `Session.list()`.

The server already supports `directory` filtering in `Session.list()` (line 518-520 of `session/index.ts`) — it just was never being passed from the TUI path.

Supersedes #14443 (closed — missed the `thread.ts` root cause).

### How did you verify your code works?

- Built a patched binary and installed it locally
- CLI verification: patched binary shows **13 sessions** for a specific directory vs **25 sessions** (all directories leaked) with the stock binary, from the same working directory
- TUI verification: opened opencode from two different project directories, `/sessions` dialog shows only sessions belonging to each respective directory
- `bun turbo typecheck` passes 12/12 packages
- No new dependencies added

### Screenshots / recordings

_N/A — this is a data filtering fix, not a UI change. The session list looks identical, it just shows the correct subset of sessions._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR