### PR TITLE
fix: add onprogress callback to MCP tool calls for timeout renewal

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -139,6 +139,7 @@ export namespace MCP {
           },
           CallToolResultSchema,
           {
+            onprogress: () => undefined,
             resetTimeoutOnProgress: true,
             timeout,
           },

--- a/packages/opencode/test/mcp/progress-token.test.ts
+++ b/packages/opencode/test/mcp/progress-token.test.ts
@@ -1,0 +1,111 @@
+import { test, expect, mock, beforeEach } from "bun:test"
+
+const callToolOptions: Array<Record<string, unknown>> = []
+const listToolsCalls: Array<string> = []
+
+mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: class MockStreamableHTTP {
+    constructor(_url: URL, _options?: { authProvider?: unknown; requestInit?: RequestInit }) {}
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: class MockSSE {
+    constructor(_url: URL, _options?: { authProvider?: unknown; requestInit?: RequestInit }) {}
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class MockClient {
+    setNotificationHandler() {}
+    async connect(_transport: unknown) {}
+    async close() {}
+    async listTools() {
+      listToolsCalls.push("list")
+      return {
+        tools: [
+          {
+            name: "review",
+            description: "mock review tool",
+            inputSchema: {
+              type: "object",
+              properties: {},
+            },
+          },
+        ],
+      }
+    }
+    async callTool(
+      _params: unknown,
+      _resultSchema: unknown,
+      options?: Record<string, unknown>,
+    ) {
+      callToolOptions.push(options ?? {})
+      return {
+        content: [
+          {
+            type: "text",
+            text: "ok",
+          },
+        ],
+      }
+    }
+  },
+}))
+
+beforeEach(() => {
+  callToolOptions.length = 0
+  listToolsCalls.length = 0
+})
+
+const { MCP } = await import("../../src/mcp/index")
+const { Instance } = await import("../../src/project/instance")
+const { tmpdir } = await import("../fixture/fixture")
+
+test("mcp callTool options should include progress handler and timeout reset", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "test-server": {
+              type: "remote",
+              url: "https://example.com/mcp",
+              oauth: false,
+              timeout: 45678,
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await MCP.add("test-server", {
+        type: "remote",
+        url: "https://example.com/mcp",
+        oauth: false,
+        timeout: 45678,
+      }).catch(() => {})
+
+      const tools = await MCP.tools()
+      const key = Object.keys(tools).find((item) => item.endsWith("_review"))
+      expect(key).toBeDefined()
+
+      const tool = tools[key!]
+      await (tool.execute as (args: unknown) => Promise<unknown>)({})
+
+      expect(listToolsCalls.length).toBeGreaterThan(0)
+      expect(callToolOptions.length).toBe(1)
+      expect(callToolOptions[0]["resetTimeoutOnProgress"]).toBe(true)
+      expect(callToolOptions[0]["timeout"]).toBe(45678)
+      expect(typeof callToolOptions[0]["onprogress"]).toBe("function")
+
+      await MCP.disconnect("test-server")
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14499

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the `-32001` timeout error that occurs during long-running MCP tool calls (10~20 minutes) by adding the `onprogress` callback to the MCP client's `callTool` options.

**Root Cause:**
The MCP SDK only injects a `progressToken` into the request when an `onprogress` callback is provided. Without this token:
1. The MCP server cannot send progress notifications (heartbeat)
2. The client's timeout timer never resets
3. Long requests hit the default timeout limit

**The Fix:**
Added a lightweight `onprogress: () => undefined` callback in `convertMcpTool` function. This enables:
- SDK to inject `_meta.progressToken` into the request
- MCP server to send periodic progress/heartbeat notifications
- Client timeout to reset when progress is received (via `resetTimeoutOnProgress: true`)

**Why it works:**
The progress token chain is now complete:
1. Client includes `onprogress` callback
2. SDK injects `_meta.progressToken` into request
3. Server reads token and sends progress notifications
4. SDK resets timeout on each progress notification
5. Long-running requests can complete without timing out

### How did you verify your code works?

Added unit test `packages/opencode/test/mcp/progress-token.test.ts` that verifies:
- `callTool` options include `onprogress` callback
- `resetTimeoutOnProgress` is still `true`
- `timeout` is correctly passed through

Test result: ✅ Pass

### Screenshots / recordings

N/A - backend fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR