### PR TITLE
fix: add SIGHUP/SIGTERM/SIGPIPE handlers to prevent orphaned processes

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -45,6 +45,18 @@ process.on("uncaughtException", (e) => {
   })
 })
 
+// Handle terminal death signals to prevent orphaned processes.
+// When a controlling terminal is destroyed (SSH disconnect, tmux pane close, etc.),
+// the kernel sends SIGHUP. Without this handler, the process continues running
+// indefinitely because the TUI event loop blocks on stdin that will never arrive,
+// preventing the `process.exit()` in the finally block from ever executing.
+// This was observed to leak ~4.7 GB per orphaned instance.
+for (const sig of ["SIGHUP", "SIGTERM", "SIGPIPE"] as const) {
+  process.on(sig, () => {
+    process.exit(1)
+  })
+}
+
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")


### PR DESCRIPTION
## Summary

- Add signal handlers for `SIGHUP`, `SIGTERM`, and `SIGPIPE` in `index.ts` to call `process.exit(1)` on terminal death
- Prevents orphaned opencode processes that leak ~4.7 GB RAM each when controlling terminal is destroyed

## Problem

When a terminal dies (SSH disconnect, tmux pane close, terminal crash), the kernel sends `SIGHUP` to the process group. Without a handler, the Bun event loop continues running because:

1. The TUI promise in `thread.ts` blocks on stdin that will never produce input
2. `cli.parse()` in `index.ts` never resolves
3. `process.exit()` in the `finally` block never executes
4. Process runs indefinitely as an orphan (`PPID=1`)

On a system using oh-my-opencode with tmux, this accumulated **14 orphaned processes consuming ~66 GB of RAM total**.

## Fix

```typescript
for (const sig of ["SIGHUP", "SIGTERM", "SIGPIPE"] as const) {
  process.on(sig, () => {
    process.exit(1)
  })
}
```

Placed after the existing `unhandledRejection`/`uncaughtException` handlers and before `cli.parse()`.

## Testing

- Verified no LSP diagnostics/errors on the changed file
- The fix is minimal and follows the same pattern as the existing `process.exit()` call in the `finally` block (line 202)

Fixes #14504