### PR TITLE
fix: enable media in tool results for GitHub Copilot Gemini 3 models

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -509,6 +509,10 @@ export namespace MessageV2 {
         const id = model.api.id.toLowerCase()
         return id.includes("gemini-3") && !id.includes("gemini-2")
       }
+      if (model.api.npm === "@ai-sdk/github-copilot") {
+        const id = model.api.id.toLowerCase()
+        return id.includes("gemini-3") && !id.includes("gemini-2")
+      }
       return false
     })()
 


### PR DESCRIPTION
Fixes #14514

Adds `@ai-sdk/github-copilot` to `supportsMediaInToolResults` with the same Gemini 3 pattern matching as `@ai-sdk/google`.

**Verified:** Tested all model ID combinations - Gemini 3 models return `true`, non-Gemini models return `false`, existing providers unaffected.