### PR TITLE
docs(ko): improve wording in gitlab, ide, index, keybinds, and lsp docs

### DIFF
--- a/packages/web/src/content/docs/ko/gitlab.mdx
+++ b/packages/web/src/content/docs/ko/gitlab.mdx
@@ -1,34 +1,34 @@
 ---
 title: GitLab
-description: GitLab 이슈 및 머지 리퀘스트에서 opencode를 사용하세요.
+description: GitLab 이슈와 merge request에서 OpenCode를 사용하세요.
 ---
 
-opencode는 GitLab CI/CD 파이프라인 또는 GitLab Duo를 통해 GitLab 워크플로우와 통합됩니다.
+OpenCode는 GitLab CI/CD 파이프라인 또는 GitLab Duo를 통해 GitLab 워크플로에 통합됩니다.
 
-두 경우, opencode는 GitLab runners에서 실행됩니다.
+두 경우 모두 OpenCode는 GitLab runner에서 실행됩니다.
 
 ---
 
-# GitLab CI 소개
+## GitLab CI
 
-opencode는 일반 GitLab 파이프라인에서 작동합니다. [CI 컴포넌트](https://docs.gitlab.com/ee/ci/components/)로 파이프라인에 구축할 수 있습니다.
+OpenCode는 일반 GitLab 파이프라인에서 작동합니다. [CI component](https://docs.gitlab.com/ee/ci/components/)로 파이프라인에 통합할 수 있습니다.
 
-여기에서 우리는 opencode에 대한 커뮤니티 생성 CI / CD 구성품을 사용하고 있습니다. [nagyv/gitlab-opencode](https://gitlab.com/nagyv/gitlab-opencode).
+여기서는 OpenCode용 커뮤니티 제작 CI/CD component인 [nagyv/gitlab-opencode](https://gitlab.com/nagyv/gitlab-opencode)를 사용합니다.
 
 ---
 
 ### 기능
 
-- **실행별 사용자 지정 구성 사용**: 사용자 정의 구성 디렉토리와 opencode 구성, 예를 들어 `./config/#custom-directory`는 opencode 실행마다 활성화하거나 비활성화 할 수 있습니다.
-- ** 최소 설정**: CI 구성 요소는 opencode를 배경으로 설정하면 opencode 구성과 초기 프롬프트를 만들 필요가 있습니다.
-- **Flexible**: CI 구성 요소는 여러 입력을 지원합니다.
+- **job별 custom config 사용**: custom config 디렉터리(예: `./config/#custom-directory`)를 사용해 OpenCode를 각 실행 단위로 설정하고 기능을 켜거나 끌 수 있습니다.
+- **최소 설정**: CI component가 백그라운드에서 OpenCode를 설정하므로 OpenCode config와 초기 prompt만 만들면 됩니다.
+- **유연함**: CI component는 동작을 사용자화할 수 있도록 여러 입력값을 지원합니다.
 
 ---
 
-## 설정
+### Setup
 
-1. opencode 인증 JSON을 **Settings** > **CI/CD** > **Variables**에서 파일 유형 CI 환경 변수로 저장하십시오. "Masked and hidden"로 표시하십시오.
-2. `.gitlab-ci.yml` 파일에 뒤에 추가하십시오.
+1. OpenCode 인증 JSON을 **Settings** > **CI/CD** > **Variables** 아래의 File 타입 CI 환경 변수로 저장하세요. 반드시 "Masked and hidden"으로 표시하세요.
+2. 아래 내용을 `.gitlab-ci.yml` 파일에 추가하세요.
 
    ```yaml title=".gitlab-ci.yml"
    include:
@@ -40,40 +40,40 @@ opencode는 일반 GitLab 파이프라인에서 작동합니다. [CI 컴포넌�
          message: "Your prompt here"
    ```
 
-더 많은 입력 및 사용 사례 [docs를 체크 아웃](https://gitlab.com/explore/catalog/nagyv/gitlab-opencode) 이 구성 요소에 대한.
+더 많은 입력값과 사용 사례는 이 component의 [docs](https://gitlab.com/explore/catalog/nagyv/gitlab-opencode)에서 확인하세요.
 
 ---
 
 ## GitLab Duo
 
-opencode는 GitLab 워크플로우와 통합됩니다.
-코멘트에 Mention `@opencode`, opencode는 GitLab CI 파이프라인 내에서 작업을 실행합니다.
+OpenCode는 GitLab 워크플로에 통합됩니다.
+댓글에서 `@opencode`를 멘션하면 OpenCode가 GitLab CI 파이프라인 안에서 작업을 실행합니다.
 
 ---
 
 ### 기능
 
-- **이슈**: opencode가 문제점을 보고 당신을 설명합니다.
-- **수정 및 구현**: 이슈를 수정하거나 기능을 구현하려면 opencode에 문의하십시오.
-  새로운 지점을 만들고 변화를 병합 요청을 제기합니다.
-- **보안**: opencode는 GitLab runners에서 실행됩니다.
+- **이슈 분류**: OpenCode에 이슈를 살펴보고 설명해 달라고 요청할 수 있습니다.
+- **수정 및 구현**: OpenCode에 이슈를 수정하거나 기능을 구현해 달라고 요청할 수 있습니다.
+  OpenCode는 새 브랜치를 만들고 변경 사항이 담긴 merge request를 생성합니다.
+- **보안**: OpenCode는 GitLab runner에서 실행됩니다.
 
 ---
 
-## 설정
+### Setup
 
-opencode는 GitLab CI/CD 파이프라인에서 실행되며, 여기서 설정해야 할 일은 다음과 같습니다.
+OpenCode는 GitLab CI/CD 파이프라인에서 실행되며, 설정에 필요한 항목은 다음과 같습니다.
 
 :::tip
-[**GitLab docs**](https://docs.gitlab.com/user/duo agent platform/agent assistant/) 를 체크 아웃하십시오.
+[최신 안내는 **GitLab docs**](https://docs.gitlab.com/user/duo_agent_platform/agent_assistant/)를 확인하세요.
 :::
 
-1.  GitLab 환경 설정
-2.  CI/CD 설치
-3.  AI 모형 공급자 API 열쇠를 얻으십시오
-4.  서비스 계정 만들기
-5.  CI/CD 변수 구성
-6.  Flow config 파일을 만들려면 다음과 같습니다.
+1.  GitLab 환경을 설정합니다.
+2.  CI/CD를 설정합니다.
+3.  AI model provider API 키를 준비합니다.
+4.  서비스 계정을 생성합니다.
+5.  CI/CD 변수를 설정합니다.
+6.  flow config 파일을 생성합니다. 예시는 다음과 같습니다.
 
         <details>
 
@@ -152,44 +152,44 @@ opencode는 GitLab CI/CD 파이프라인에서 실행되며, 여기서 설정해
 
         </details>
 
-자세한 지침에 대한 [GitLab CLI Agent docs](https://docs.gitlab.com/user/duo agent platform/agent assistant/)를 참조할 수 있습니다.
+[GitLab CLI agents docs](https://docs.gitlab.com/user/duo_agent_platform/agent_assistant/)에서 자세한 안내를 확인할 수 있습니다.
 
 ---
 
 ### 예제
 
-다음은 GitLab에서 opencode를 사용할 수있는 몇 가지 예입니다.
+다음은 GitLab에서 OpenCode를 사용하는 몇 가지 예시입니다.
 
 :::tip
-`@opencode`보다 다른 트리거 구문을 사용할 수 있습니다.
+`@opencode` 대신 다른 trigger phrase를 사용하도록 설정할 수 있습니다.
 :::
 
 - **이슈 설명**
 
-GitLab 문제에서이 코멘트를 추가하십시오.
+GitLab 이슈에 아래 댓글을 남기세요.
 
 ```
   @opencode explain this issue
 ```
 
-opencode는 문제와 대답을 명확하게 설명합니다.
+OpenCode가 이슈를 읽고 명확한 설명으로 답변합니다.
 
 - **이슈 해결**
 
-GitLab 문제에서, 말한다:
+GitLab 이슈에서 다음과 같이 요청하세요.
 
 ```
   @opencode fix this
 ```
 
-opencode는 새로운 지점을 만들 것이며 변경 사항을 구현하고 변경 사항을 병합 요청을 엽니다.
+OpenCode가 새 브랜치를 만들고 변경 사항을 구현한 뒤, 해당 변경 사항으로 merge request를 엽니다.
 
 - **머지 리퀘스트 검토**
 
-GitLab 병합 요청에 대한 다음 의견을 남겨주세요.
+GitLab merge request에 아래 댓글을 남기세요.
 
 ```
   @opencode review this merge request
 ```
 
-opencode는 병합 요청을 검토하고 피드백을 제공합니다.
+OpenCode가 merge request를 검토하고 피드백을 제공합니다.

--- a/packages/web/src/content/docs/ko/ide.mdx
+++ b/packages/web/src/content/docs/ko/ide.mdx
@@ -1,35 +1,36 @@
 ---
 title: IDE
-description: VS Code, Cursor 및 기타 IDE용 opencode 확장 프로그램.
+description: VS Code, Cursor 및 기타 IDE용 OpenCode 확장 프로그램
 ---
 
-opencode는 VS Code, Cursor, 또는 터미널을 지원하는 IDE와 통합됩니다. 시작하려면 terminal에서 `opencode`를 실행하십시오.
+OpenCode는 VS Code, Cursor, 또는 터미널을 지원하는 모든 IDE와 통합됩니다. 시작하려면 터미널에서 `opencode`를 실행하세요.
 
 ---
 
 ## 사용법
 
--**Quick Launch**: `Cmd+Esc` (Mac) 또는 `Ctrl+Esc` (Windows/Linux)를 사용하여 통합 터미널 뷰에 opencode를 열거나 기존 terminal 세션을 이미 실행하면 됩니다. -**New Session**: `Cmd+Shift+Esc` (Mac) 또는 `Ctrl+Shift+Esc` (Windows/Linux)를 사용하여 새로운 opencode terminal 세션을 시작하려면 이미 열리면 됩니다. UI에서 opencode 버튼을 클릭합니다. -**Context Awareness**: opencode로 현재 선택 또는 탭을 자동으로 공유합니다.
-
-- **파일 참조 단축키** : 파일 참조를 삽입하려면 `Cmd+Option+K` (Mac) 또는 `Alt+Ctrl+K` (Linux / Windows)를 사용하십시오. 예를 들어, `@File#L37-42`.
+- **Quick Launch**: `Cmd+Esc` (Mac) 또는 `Ctrl+Esc` (Windows/Linux)를 사용해 분할 터미널 뷰에서 OpenCode를 열거나, 이미 실행 중인 터미널 세션으로 포커스하세요.
+- **New Session**: `Cmd+Shift+Esc` (Mac) 또는 `Ctrl+Shift+Esc` (Windows/Linux)를 사용해 기존 세션이 열려 있어도 새 OpenCode 터미널 세션을 시작하세요. UI의 OpenCode 버튼을 클릭해도 됩니다.
+- **Context Awareness**: 현재 선택 영역이나 탭을 OpenCode와 자동으로 공유합니다.
+- **File Reference Shortcuts**: `Cmd+Option+K` (Mac) 또는 `Alt+Ctrl+K` (Linux/Windows)를 사용해 파일 참조를 삽입하세요. 예: `@File#L37-42`.
 
 ---
 
 ## 설치
 
-VS Code에 opencode를 설치하고 Cursor, Windsurf, VSCodium과 같은 인기있는 포크 :
+VS Code와 Cursor, Windsurf, VSCodium 같은 인기 포크에 OpenCode를 설치하려면:
 
-1. VS Code 열기
-2. 통합 terminal을 여십시오
-3. 실행 `opencode` - 확장 자동으로 설치
+1. VS Code를 여세요.4
+2. 통합 터미널을 여세요.
+3. `opencode`를 실행하세요. 확장 프로그램이 자동으로 설치됩니다.
 
-반면에 TUI에서 `/editor` 또는 `/export`를 실행할 때, 당신은 `export EDITOR="code --wait"`를 설정할 필요가 있을 것입니다. [Learn more](/docs/tui/#editor-setup).
+반면 TUI에서 `/editor` 또는 `/export`를 실행할 때 자체 IDE를 사용하려면 `export EDITOR="code --wait"`를 설정해야 합니다. [자세히 알아보기](/docs/tui/#editor-setup).
 
 ---
 
-## 수동 설치
+### 수동 설치
 
-확장 마켓 플레이스에서 **opencode**를 검색하고 **Install**를 클릭합니다.
+Extension Marketplace에서 **OpenCode**를 검색한 다음 **Install**을 클릭하세요.
 
 ---
 
@@ -37,11 +38,11 @@ VS Code에 opencode를 설치하고 Cursor, Windsurf, VSCodium과 같은 인기�
 
 확장이 자동으로 설치되지 않는 경우:
 
-- 통합 terminal에서 `opencode`를 실행하는 것을 보장합니다.
-- IDE용 CLI가 설치됩니다.
-- VS Code : `code` 명령
-- 커서: `cursor` 명령
-- 윈드 서핑을 위해: `windsurf` 명령
-- VSCodium의 경우: `codium` 명령
-- 만약 `Cmd+Shift+P` (Mac) 또는 `Ctrl+Shift+P` (Windows/Linux)를 실행하고 "Shell Command: PATH"에서 'code' 명령을 설치하십시오 (또는 IDE에 해당)
-- Ensure VS Code는 확장을 설치하는 권한이 있습니다.
+- 통합 터미널에서 `opencode`를 실행하고 있는지 확인하세요.
+- IDE용 CLI가 설치되어 있는지 확인하세요.
+  - VS Code: `code` command
+  - Cursor: `cursor` command
+  - Windsurf: `windsurf` command
+  - VSCodium: `codium` command
+  - 설치되어 있지 않다면 `Cmd+Shift+P` (Mac) 또는 `Ctrl+Shift+P` (Windows/Linux)를 실행하고 "Shell Command: Install 'code' command in PATH"(또는 IDE에 맞는 동등한 명령)를 검색하세요.
+- VS Code에 확장 프로그램 설치 권한이 있는지 확인하세요.

--- a/packages/web/src/content/docs/ko/index.mdx
+++ b/packages/web/src/content/docs/ko/index.mdx
@@ -7,19 +7,19 @@ import { Tabs, TabItem } from "@astrojs/starlight/components"
 import config from "../../../../config.mjs"
 export const console = config.console
 
-[**OpenCode**](/)는 터미널 기반 인터페이스, 데스크톱 앱, IDE 확장 형태로 사용할 수 있는 오픈 소스 AI 코딩 에이전트입니다.
+[**OpenCode**](/)는 오픈 소스 AI coding agent입니다. 터미널 기반 인터페이스, 데스크톱 앱, IDE 확장으로 사용할 수 있습니다.
 
 ![opencode TUI with the opencode theme](../../../assets/lander/screenshot.png)
 
-바로 시작해 봅시다.
+바로 시작해 보겠습니다.
 
 ---
 
-## 사전 준비
+#### 사전 준비
 
 터미널에서 OpenCode를 사용하려면 다음이 필요합니다.
 
-1. 최신 터미널 에뮬레이터 (예:)
+1. 다음과 같은 최신 터미널 에뮬레이터
    - [WezTerm](https://wezterm.org), 크로스 플랫폼
    - [Alacritty](https://alacritty.org), 크로스 플랫폼
    - [Ghostty](https://ghostty.org), Linux 및 macOS
@@ -31,13 +31,13 @@ export const console = config.console
 
 ## 설치
 
-가장 쉬운 설치 방법은 설치 스크립트를 사용하는 것입니다.
+OpenCode를 설치하는 가장 쉬운 방법은 설치 스크립트를 사용하는 것입니다.
 
 ```bash
 curl -fsSL https://opencode.ai/install | bash
 ```
 
-아래 명령으로도 설치할 수 있습니다.
+다음 명령으로도 설치할 수 있습니다.
 
 - **Node.js 사용**
 
@@ -79,9 +79,9 @@ curl -fsSL https://opencode.ai/install | bash
   brew install anomalyco/tap/opencode
   ```
 
-  > 최신 릴리스는 OpenCode tap 사용을 권장합니다. 공식 `brew install opencode` 포뮬러는 Homebrew 팀이 관리하므로 업데이트 주기가 더 긴 편입니다.
+  > 최신 릴리스를 사용하려면 OpenCode tap 사용을 권장합니다. 공식 `brew install opencode` formula는 Homebrew 팀이 관리하며 업데이트 주기가 더 깁니다.
 
-- **Arch Linux에서 Paru 사용**
+- **Arch Linux에 설치**
 
   ```bash
   sudo pacman -S opencode           # Arch Linux (Stable)
@@ -91,7 +91,7 @@ curl -fsSL https://opencode.ai/install | bash
 #### Windows
 
 :::tip[권장: WSL 사용]
-Windows에서는 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)을 사용하는 것이 가장 좋습니다. OpenCode 기능과의 호환성이 높고 성능도 더 좋습니다.
+Windows에서는 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl) 사용을 권장합니다. 성능이 더 좋고 OpenCode 기능과의 완전한 호환성을 제공합니다.
 :::
 
 - **Chocolatey 사용**
@@ -124,7 +124,7 @@ Windows에서는 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)을 사�
   docker run -it --rm ghcr.io/anomalyco/opencode
   ```
 
-Windows에서 Bun을 통한 OpenCode 설치는 아직 지원되지 않으며, 현재 지원을 준비 중입니다.
+현재 Windows에서 Bun을 사용한 OpenCode 설치 지원은 준비 중입니다.
 
 [Releases](https://github.com/anomalyco/opencode/releases)에서 바이너리를 직접 받아 설치할 수도 있습니다.
 
@@ -134,16 +134,16 @@ Windows에서 Bun을 통한 OpenCode 설치는 아직 지원되지 않으며, �
 
 OpenCode는 API 키를 설정하면 원하는 LLM 제공자를 사용할 수 있습니다.
 
-LLM 제공자(LLM Provider)를 처음 사용한다면 [OpenCode Zen](/docs/zen)을 추천합니다.
+LLM 제공자를 처음 사용한다면 [OpenCode Zen](/docs/zen) 사용을 권장합니다.
 OpenCode 팀이 테스트하고 검증한 모델 목록입니다.
 
-1. TUI에서 `/connect` 명령을 실행한 뒤 `opencode`를 선택하고 [opencode.ai/auth](https://opencode.ai/auth)로 이동합니다.
+1. TUI에서 `/connect` 명령을 실행하고 `opencode`를 선택한 다음 [opencode.ai/auth](https://opencode.ai/auth)로 이동합니다.
 
    ```txt
    /connect
    ```
 
-2. 로그인 후 결제 정보를 입력하고 API 키를 복사합니다.
+2. 로그인하고 결제 정보를 추가한 뒤 API 키를 복사합니다.
 
 3. API 키를 붙여 넣습니다.
 
@@ -154,13 +154,13 @@ OpenCode 팀이 테스트하고 검증한 모델 목록입니다.
    └ enter
    ```
 
-다른 제공자를 선택해도 됩니다. [더 알아보기](/docs/providers#directory).
+또는 다른 제공자 중 하나를 선택할 수도 있습니다. [더 알아보기](/docs/providers#directory).
 
 ---
 
 ## 초기화
 
-이제 제공자 구성이 끝났으니, 작업할 프로젝트 디렉터리로 이동합니다.
+이제 제공자 구성을 마쳤으니 작업하려는 프로젝트로 이동합니다.
 
 ```bash
 cd /path/to/project
@@ -172,19 +172,19 @@ cd /path/to/project
 opencode
 ```
 
-다음 명령으로 프로젝트용 OpenCode 초기화를 진행합니다.
+다음 명령을 실행해 프로젝트에서 OpenCode를 초기화합니다.
 
 ```bash frame="none"
 /init
 ```
 
-이 명령은 프로젝트를 분석하고 루트에 `AGENTS.md` 파일을 생성합니다.
+이 명령을 실행하면 OpenCode가 프로젝트를 분석하고 프로젝트 루트에 `AGENTS.md` 파일을 생성합니다.
 
 :::tip
-프로젝트의 `AGENTS.md`는 Git에 커밋해 두는 것을 권장합니다.
+프로젝트의 `AGENTS.md` 파일은 Git에 커밋하는 것을 권장합니다.
 :::
 
-그러면 OpenCode가 프로젝트 구조와 코딩 패턴을 더 잘 이해할 수 있습니다.
+이렇게 하면 OpenCode가 프로젝트 구조와 사용 중인 코딩 패턴을 더 잘 이해할 수 있습니다.
 
 ---
 
@@ -192,7 +192,7 @@ opencode
 
 이제 OpenCode로 프로젝트 작업을 시작할 준비가 되었습니다. 무엇이든 물어보세요.
 
-AI 코딩 에이전트를 처음 쓰는 경우 도움이 되는 예시를 소개합니다.
+AI coding agent를 처음 사용한다면 도움이 될 수 있는 예시를 소개합니다.
 
 ---
 
@@ -208,25 +208,25 @@ OpenCode에 코드베이스 설명을 요청할 수 있습니다.
 How is authentication handled in @packages/functions/src/api/index.ts
 ```
 
-직접 작업하지 않은 코드 영역을 이해할 때 특히 유용합니다.
+이 방법은 직접 작업하지 않은 코드 영역을 이해할 때 유용합니다.
 
 ---
 
 ### 기능 추가
 
-프로젝트에 새 기능을 추가해 달라고 요청할 수 있습니다. 다만 먼저 계획을 만들게 하는 것을 권장합니다.
+OpenCode에 프로젝트의 새 기능 추가를 요청할 수 있습니다. 다만 먼저 계획을 만들도록 요청하는 것을 권장합니다.
 
 1. **계획 만들기**
 
-   OpenCode에는 변경 작업을 비활성화하고 구현 방법을 제안만 하는 *Plan mode*가 있습니다.
+   OpenCode에는 변경 작업 기능을 비활성화하고 기능을 구현할 방법만 제안하는 *Plan mode*가 있습니다.
 
-   **Tab** 키로 전환하면 오른쪽 아래에 모드 표시가 나타납니다.
+   **Tab** 키를 눌러 전환하세요. 화면 오른쪽 아래에서 모드 표시를 확인할 수 있습니다.
 
    ```bash frame="none" title="Switch to Plan mode"
    <TAB>
    ```
 
-   이제 원하는 작업을 구체적으로 설명합니다.
+   이제 수행하길 원하는 작업을 설명해 보겠습니다.
 
    ```txt frame="none"
    When a user deletes a note, we'd like to flag it as deleted in the database.
@@ -234,15 +234,15 @@ How is authentication handled in @packages/functions/src/api/index.ts
    From this screen, the user can undelete a note or permanently delete it.
    ```
 
-   OpenCode가 정확히 이해할 만큼 충분한 맥락을 주는 것이 중요합니다. 팀의 주니어 개발자에게 설명하듯 요청하면 도움이 됩니다.
+   OpenCode가 원하는 작업을 이해할 수 있도록 충분한 세부 정보를 제공해야 합니다. 팀의 주니어 개발자에게 말하듯이 설명하면 도움이 됩니다.
 
    :::tip
-   맥락과 예시를 충분히 제공하면 원하는 결과를 얻기 쉽습니다.
+   OpenCode가 원하는 작업을 이해하도록 충분한 맥락과 예시를 제공하세요.
    :::
 
 2. **계획 다듬기**
 
-   계획이 나오면 피드백을 주거나 추가 요구사항을 붙일 수 있습니다.
+   계획이 나오면 피드백을 주거나 세부 사항을 더 추가할 수 있습니다.
 
    ```txt frame="none"
    We'd like to design this new screen using a design I've used before.
@@ -250,20 +250,20 @@ How is authentication handled in @packages/functions/src/api/index.ts
    ```
 
    :::tip
-   이미지를 터미널에 드래그 앤 드롭하면 프롬프트에 첨부할 수 있습니다.
+   이미지를 터미널에 드래그 앤 드롭해 prompt에 추가하세요.
    :::
 
-   OpenCode는 첨부한 이미지를 분석해 프롬프트에 포함합니다.
+   OpenCode는 제공한 이미지를 스캔해 prompt에 추가할 수 있습니다. 이미지를 터미널에 드래그 앤 드롭하면 됩니다.
 
 3. **기능 구현**
 
-   계획이 충분히 만족스러우면 **Tab** 키를 다시 눌러 *Build mode*로 돌아갑니다.
+   계획이 충분히 마음에 들면 **Tab** 키를 다시 눌러 *Build mode*로 전환하세요.
 
    ```bash frame="none"
    <TAB>
    ```
 
-   그리고 실제 변경을 요청합니다.
+   그리고 변경을 적용해 달라고 요청하세요.
 
    ```bash frame="none"
    Sounds good! Go ahead and make the changes.
@@ -273,7 +273,7 @@ How is authentication handled in @packages/functions/src/api/index.ts
 
 ### 바로 변경하기
 
-비교적 단순한 변경은 계획 검토 없이 바로 구현하도록 요청해도 됩니다.
+비교적 간단한 변경은 계획을 먼저 검토하지 않고 바로 구현하도록 요청할 수 있습니다.
 
 ```txt frame="none" "@packages/functions/src/settings.ts" "@packages/functions/src/notes.ts"
 We need to add authentication to the /settings route. Take a look at how this is
@@ -281,37 +281,37 @@ handled in the /notes route in @packages/functions/src/notes.ts and implement
 the same logic in @packages/functions/src/settings.ts
 ```
 
-원하는 변경이 정확히 반영되도록, 필요한 맥락을 충분히 제공하세요.
+OpenCode가 올바른 변경을 하도록 충분한 세부 정보를 제공해야 합니다.
 
 ---
 
 ### 변경 되돌리기
 
-예를 들어 OpenCode에 변경을 요청했다고 가정해 보겠습니다.
+예를 들어 OpenCode에 변경을 요청했다고 해보겠습니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-결과가 기대와 다르면 `/undo` 명령으로 **되돌릴 수** 있습니다.
+그런데 원하는 결과가 아니었다면 `/undo` 명령으로 변경을 **되돌릴 수** 있습니다.
 
 ```bash frame="none"
 /undo
 ```
 
-OpenCode는 방금 적용한 변경을 되돌리고 원래 메시지를 다시 보여줍니다.
+OpenCode가 방금 적용한 변경을 되돌리고 원래 메시지를 다시 보여줍니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-이 상태에서 프롬프트를 다듬어 다시 시도하면 됩니다.
+여기에서 prompt를 수정해 다시 요청할 수 있습니다.
 
 :::tip
 `/undo`는 여러 번 연속으로 실행할 수 있습니다.
 :::
 
-반대로 `/redo` 명령으로 **다시 적용**할 수도 있습니다.
+또는 `/redo` 명령으로 변경을 **다시 적용**할 수 있습니다.
 
 ```bash frame="none"
 /redo
@@ -327,18 +327,18 @@ OpenCode와의 대화는 [팀과 공유](/docs/share)할 수 있습니다.
 /share
 ```
 
-현재 대화 링크를 생성하고 클립보드에 복사합니다.
+이 명령을 실행하면 현재 대화 링크를 생성하고 클립보드에 복사합니다.
 
 :::note
 대화는 기본값으로 공유되지 않습니다.
 :::
 
-아래는 OpenCode [대화 예시](https://opencode.ai/s/4XP1fce5)입니다.
+다음은 OpenCode [대화 예시](https://opencode.ai/s/4XP1fce5)입니다.
 
 ---
 
 ## 사용자 지정
 
-이제 OpenCode 사용의 기본은 끝났습니다.
+이제 OpenCode 사용법을 익혔습니다.
 
-자신의 워크플로우에 맞추려면 [테마 선택](/docs/themes), [키바인드 사용자 지정](/docs/keybinds), [코드 포매터 설정](/docs/formatters), [커스텀 명령 작성](/docs/commands), [OpenCode 구성 조정](/docs/config)을 추천합니다.
+원하는 방식에 맞추려면 [테마 선택](/docs/themes), [키바인드 사용자 지정](/docs/keybinds), [코드 formatter 설정](/docs/formatters), [custom command 만들기](/docs/commands), [OpenCode config 설정](/docs/config)을 권장합니다.

--- a/packages/web/src/content/docs/ko/keybinds.mdx
+++ b/packages/web/src/content/docs/ko/keybinds.mdx
@@ -1,9 +1,9 @@
 ---
 title: 키바인드
-description: 키바인드를 사용자 지정하세요.
+description: 키바인드를 커스터마이즈하세요.
 ---
 
-opencode는 opencode config를 통해 사용자 정의 할 수있는 keybinds 목록을 가지고 있습니다.
+OpenCode에는 OpenCode config를 통해 커스터마이즈할 수 있는 keybinds 목록이 있습니다.
 
 ```json title="opencode.json"
 {
@@ -107,17 +107,17 @@ opencode는 opencode config를 통해 사용자 정의 할 수있는 keybinds �
 
 ## 리더 키
 
-opencode는 대부분의 keybinds에 대한 `leader` 키를 사용합니다. 이것은 당신의 terminal에 있는 충돌을 피합니다.
+OpenCode는 대부분의 keybinds에 `leader` 키를 사용합니다. 이렇게 하면 terminal에서 충돌을 피할 수 있습니다.
 
-기본적으로 `ctrl+x`는 리더 키이며 대부분의 작업은 리더 키를 먼저 누르고 단축키를 누릅니다. 예를 들어, 새 세션을 시작하려면 먼저 `ctrl+x`를 누르고 `n`를 누릅니다.
+기본값으로 `ctrl+x`가 리더 키이며, 대부분의 작업은 먼저 리더 키를 누른 뒤 단축키를 누릅니다. 예를 들어 새 세션을 시작하려면 먼저 `ctrl+x`를 누르고 `n`을 누릅니다.
 
-키바인드에 리더 키를 사용할 필요는 없지만, 사용하는 것을 권장합니다.
+keybinds에 리더 키를 꼭 사용할 필요는 없지만, 사용하는 것을 권장합니다.
 
 ---
 
 ## 키바인드 비활성화
 
-"none"의 값으로 구성에 키를 추가하여 keybind를 비활성화 할 수 있습니다.
+config에 해당 키를 값 `"none"`으로 추가하면 keybind를 비활성화할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -132,39 +132,39 @@ opencode는 대부분의 keybinds에 대한 `leader` 키를 사용합니다. 이
 
 ## 데스크탑 프롬프트 단축키
 
-opencode 데스크톱 앱 프롬프트 입력은 텍스트 편집을 위한 일반적인 Readline/Emacs-style 단축키를 지원합니다. 이들은 내장되어 있으며 현재 `opencode.json`를 통해 구성할 수 없습니다.
+OpenCode 데스크톱 앱의 프롬프트 입력은 텍스트 편집을 위한 일반적인 Readline/Emacs-style 단축키를 지원합니다. 이 단축키는 내장되어 있으며 현재 `opencode.json`으로는 설정할 수 없습니다.
 
-| 단축키   | 동작                       |
-| -------- | -------------------------- |
-| `ctrl+a` | 현재 행 시작으로 이동      |
-| `ctrl+e` | 현재선 끝으로 이동         |
-| `ctrl+b` | 커서를 다시 한 문자로 이동 |
-| `ctrl+f` | 한자 앞의 커서             |
-| `alt+b`  | 한 단어로 커서 이동        |
-| `alt+f`  | 한 단어를 넘겨 주세요      |
-| `ctrl+d` | 커서의 캐릭터 삭제         |
-| `ctrl+k` | 노선의 종료                |
-| `ctrl+u` | 노선 시작                  |
-| `ctrl+w` | 이전 단어                  |
-| `alt+d`  | 다음 단어를 죽이기         |
-| `ctrl+t` | 자가용 캐릭터              |
-| `ctrl+g` | 팝오버를 취소 / 응답 취소  |
+| 단축키   | 동작                              |
+| -------- | --------------------------------- |
+| `ctrl+a` | 현재 줄 시작으로 이동             |
+| `ctrl+e` | 현재 줄 끝으로 이동               |
+| `ctrl+b` | 커서를 문자 하나 뒤로 이동        |
+| `ctrl+f` | 커서를 문자 하나 앞으로 이동      |
+| `alt+b`  | 커서를 단어 하나 뒤로 이동        |
+| `alt+f`  | 커서를 단어 하나 앞으로 이동      |
+| `ctrl+d` | 커서 아래 문자 삭제               |
+| `ctrl+k` | 줄 끝까지 삭제                    |
+| `ctrl+u` | 줄 시작까지 삭제                  |
+| `ctrl+w` | 이전 단어 삭제                    |
+| `alt+d`  | 다음 단어 삭제                    |
+| `ctrl+t` | 문자 순서 바꾸기                  |
+| `ctrl+g` | 팝오버 취소 / 실행 중인 응답 중단 |
 
 ---
 
 ## Shift+Enter
 
-몇몇 terminal은 기본적으로 입력한 보조 키를 보내지 않습니다. `Shift+Enter`를 이스케이프 시퀀스로 보낼 terminal을 구성해야 할 수 있습니다.
+일부 terminal은 기본적으로 Enter와 modifier 키 조합을 전송하지 않습니다. `Shift+Enter`를 이스케이프 시퀀스로 전송하도록 terminal을 설정해야 할 수도 있습니다.
 
 ### Windows Terminal
 
-`settings.json`를 엽니다:
+다음 경로의 `settings.json`을 여세요:
 
 ```
 %LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_8wekyb3d8bbwe\LocalState\settings.json
 ```
 
-루트 레벨 `actions` 배열에 이것을 추가하십시오:
+루트 레벨 `actions` 배열에 다음을 추가하세요:
 
 ```json
 "actions": [
@@ -178,7 +178,7 @@ opencode 데스크톱 앱 프롬프트 입력은 텍스트 편집을 위한 일�
 ]
 ```
 
-루트 레벨 `keybindings` 배열에 이것을 추가하십시오:
+루트 레벨 `keybindings` 배열에 다음을 추가하세요:
 
 ```json
 "keybindings": [
@@ -189,4 +189,4 @@ opencode 데스크톱 앱 프롬프트 입력은 텍스트 편집을 위한 일�
 ]
 ```
 
-파일을 저장하고 Windows Terminal을 다시 시작하거나 새 탭을 엽니 다.
+파일을 저장한 뒤 Windows Terminal을 다시 시작하거나 새 탭을 여세요.

--- a/packages/web/src/content/docs/ko/lsp.mdx
+++ b/packages/web/src/content/docs/ko/lsp.mdx
@@ -1,62 +1,63 @@
 ---
 title: LSP 서버
-description: OpenCode는 LSP 서버와 통합되어 작동합니다.
+description: OpenCode는 LSP 서버와 통합됩니다.
 ---
 
-OpenCode는 언어 서버 프로토콜(LSP)과 통합되어 LLM이 코드베이스와 상호 작용할 수 있게 돕습니다. 이를 통해 진단 정보를 사용하여 LLM에 피드백을 제공합니다.
+OpenCode는 Language Server Protocol(LSP)과 통합되어 LLM이 코드베이스와 상호작용하도록 돕습니다. 진단 정보를 활용해 LLM에 피드백을 제공합니다.
 
 ---
 
 ## 기본 제공 (Built-in)
 
-OpenCode는 인기 있는 언어들에 대해 여러 내장 LSP 서버를 제공합니다.
+OpenCode는 널리 사용되는 언어를 위해 여러 built-in LSP 서버를 제공합니다.
 
-| LSP 서버           | 확장자                                                             | 요구사항                                              |
-| ------------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
-| astro              | .astro                                                             | Astro 프로젝트 자동 설치                              |
-| bash               | .sh, .bash, .zsh, .ksh                                             | bash-language-server 자동 설치                        |
-| clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++               | C/C++ 프로젝트용 자동 설치                            |
-| csharp             | .cs                                                                | `.NET SDK` 설치                                       |
-| clojure-lsp        | .clj, .cljs, .cljc, .edn                                           | `clojure-lsp` 명령 사용 가능                          |
-| dart               | .dart                                                              | `dart` 명령 사용 가능                                 |
-| deno               | .ts, .tsx, .js, .jsx, .mjs                                         | `deno` 명령 사용 가능(deno.json/deno.jsonc 자동 감지) |
-| elixir-ls          | .ex, .exs                                                          | `elixir` 명령 사용 가능                               |
-| eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                 | 프로젝트의 `eslint` 의존성                            |
-| fsharp             | .fs, .fsi, .fsx, .fsscript                                         | `.NET SDK` 설치                                       |
-| gleam              | .gleam                                                             | `gleam` 명령 사용 가능                                |
-| gopls              | .go                                                                | `go` 명령 사용 가능                                   |
-| hls                | .hs, .lhs                                                          | `haskell-language-server-wrapper` 명령 사용 가능      |
-| jdtls              | .java                                                              | `Java SDK (version 21+)` 설치                         |
-| kotlin-ls          | .kt, .kts                                                          | Kotlin 프로젝트용 자동 설치                           |
-| lua-ls             | .lua                                                               | Lua 프로젝트용 자동 설치                              |
-| nixd               | .nix                                                               | `nixd` 명령 사용 가능                                 |
-| ocaml-lsp          | .ml, .mli                                                          | `ocamllsp` 명령 사용 가능                             |
-| oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .ct, .vue, .astro, .svelte | 프로젝트의 `oxlint` 의존성                            |
-| PHP intelephense   | .php                                                               | PHP 프로젝트 자동 설치                                |
-| prisma             | .prisma                                                            | `prisma` 명령 사용 가능                               |
-| pyright            | .py, .pyi                                                          | `pyright` 의존성 설치                                 |
-| ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                          | `ruby` 및 `gem` 명령 사용 가능                        |
-| rust               | .rs                                                                | `rust-analyzer` 명령 사용 가능                        |
-| sourcekit-lsp      | .swift, .objc, .objcpp                                             | `swift` 설치 (macOS의 `xcode`)                        |
-| svelte             | .svelte                                                            | Svelte 프로젝트 자동 설치                             |
-| terraform          | .tf, .tfvars                                                       | GitHub 릴리스에서 자동 설치                           |
-| typst              | .typ, .typc                                                        | GitHub 릴리스에서 자동 설치                           |
-| typescript         | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts                       | 프로젝트의 `typescript` 의존성                        |
-| vue                | .vue                                                               | Vue 프로젝트 자동 설치                                |
-| yaml-ls            | .yaml, .yml                                                        | Red Hat yaml-language-server 자동 설치                |
-| zls                | .zig, .zon                                                         | `zig` 명령 사용 가능                                  |
+| LSP 서버           | 확장자                                                              | 요구 사항                                                  |
+| ------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| astro              | .astro                                                              | Astro 프로젝트에서 자동 설치                               |
+| bash               | .sh, .bash, .zsh, .ksh                                              | `bash-language-server` 자동 설치                           |
+| clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++                | C/C++ 프로젝트에서 자동 설치                               |
+| csharp             | .cs                                                                 | `.NET SDK` 설치됨                                          |
+| clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` 명령 사용 가능                               |
+| dart               | .dart                                                               | `dart` 명령 사용 가능                                      |
+| deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` 명령 사용 가능 (`deno.json`/`deno.jsonc` 자동 감지) |
+| elixir-ls          | .ex, .exs                                                           | `elixir` 명령 사용 가능                                    |
+| eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | 프로젝트에 `eslint` dependency 존재                        |
+| fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` 설치됨                                          |
+| gleam              | .gleam                                                              | `gleam` 명령 사용 가능                                     |
+| gopls              | .go                                                                 | `go` 명령 사용 가능                                        |
+| hls                | .hs, .lhs                                                           | `haskell-language-server-wrapper` 명령 사용 가능           |
+| jdtls              | .java                                                               | `Java SDK (version 21+)` 설치됨                            |
+| julials            | .jl                                                                 | `julia` 및 `LanguageServer.jl` 설치됨                      |
+| kotlin-ls          | .kt, .kts                                                           | Kotlin 프로젝트에서 자동 설치                              |
+| lua-ls             | .lua                                                                | Lua 프로젝트에서 자동 설치                                 |
+| nixd               | .nix                                                                | `nixd` 명령 사용 가능                                      |
+| ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` 명령 사용 가능                                  |
+| oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | 프로젝트에 `oxlint` dependency 존재                        |
+| php intelephense   | .php                                                                | PHP 프로젝트에서 자동 설치                                 |
+| prisma             | .prisma                                                             | `prisma` 명령 사용 가능                                    |
+| pyright            | .py, .pyi                                                           | `pyright` dependency 설치됨                                |
+| ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` 및 `gem` 명령 사용 가능                             |
+| rust               | .rs                                                                 | `rust-analyzer` 명령 사용 가능                             |
+| sourcekit-lsp      | .swift, .objc, .objcpp                                              | `swift` 설치됨 (macOS에서는 `xcode`)                       |
+| svelte             | .svelte                                                             | Svelte 프로젝트에서 자동 설치                              |
+| terraform          | .tf, .tfvars                                                        | GitHub releases에서 자동 설치                              |
+| tinymist           | .typ, .typc                                                         | GitHub releases에서 자동 설치                              |
+| typescript         | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts                        | 프로젝트에 `typescript` dependency 존재                    |
+| vue                | .vue                                                                | Vue 프로젝트에서 자동 설치                                 |
+| yaml-ls            | .yaml, .yml                                                         | Red Hat `yaml-language-server` 자동 설치                   |
+| zls                | .zig, .zon                                                          | `zig` 명령 사용 가능                                       |
 
-LSP 서버는 위 파일 확장자 중 하나가 감지되고 요구 사항이 충족되면 자동으로 활성화됩니다.
+위 확장자 중 하나가 감지되고 요구 사항이 충족되면 LSP 서버가 자동으로 활성화됩니다.
 
 :::note
-`OPENCODE_DISABLE_LSP_DOWNLOAD` 환경 변수를 `true`로 설정하여 자동 LSP 서버 다운로드를 비활성화 할 수 있습니다.
+`OPENCODE_DISABLE_LSP_DOWNLOAD` 환경 변수를 `true`로 설정하면 LSP 서버 자동 다운로드를 비활성화할 수 있습니다.
 :::
 
 ---
 
 ## 작동 방식
 
-OpenCode가 파일을 열 때, 다음과 같이 작동합니다:
+OpenCode가 파일을 열면 다음과 같이 동작합니다.
 
 1. 활성화된 모든 LSP 서버에 대해 파일 확장자를 확인합니다.
 2. 적절한 LSP 서버가 아직 실행 중이지 않다면 시작합니다.
@@ -65,7 +66,7 @@ OpenCode가 파일을 열 때, 다음과 같이 작동합니다:
 
 ## 구성
 
-OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 있습니다.
+OpenCode config의 `lsp` 섹션에서 LSP 서버를 사용자 정의할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -74,23 +75,23 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 }
 ```
 
-각 LSP 서버는 다음을 지원합니다:
+각 LSP 서버는 다음 속성을 지원합니다.
 
-| 속성             | 유형     | 설명                                    |
-| ---------------- | -------- | --------------------------------------- |
-| `disabled`       | boolean  | LSP 서버를 비활성화하려면 `true`로 설정 |
-| `command`        | string[] | LSP 서버를 시작하는 명령                |
-| `extensions`     | string[] | 이 LSP 서버의 확장자                    |
-| `env`            | object   | 서버 시작 시 설정할 환경 변수           |
-| `initialization` | object   | LSP 서버에 보내는 초기화 옵션           |
+| 속성             | 타입     | 설명                                          |
+| ---------------- | -------- | --------------------------------------------- |
+| `disabled`       | boolean  | LSP 서버를 비활성화하려면 `true`로 설정하세요 |
+| `command`        | string[] | LSP 서버를 시작하는 명령입니다                |
+| `extensions`     | string[] | 이 LSP 서버가 처리할 파일 확장자입니다        |
+| `env`            | object   | 서버 시작 시 설정할 환경 변수입니다           |
+| `initialization` | object   | LSP 서버로 전송할 초기화 옵션입니다           |
 
-몇 가지 예제를 살펴봅시다.
+예시를 살펴보겠습니다.
 
 ---
 
-## 환경 변수
+### 환경 변수
 
-`env` 속성을 사용하여 LSP 서버를 시작할 때 환경 변수를 설정합니다.
+`env` 속성을 사용하면 LSP 서버 시작 시 환경 변수를 설정할 수 있습니다.
 
 ```json title="opencode.json" {5-7}
 {
@@ -109,7 +110,7 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 
 ### 초기화 옵션
 
-`initialization` 속성을 사용하여 초기화 옵션을 LSP 서버에 전달합니다. 이들은 LSP `initialize` 요청에 보내진 서버 별 설정입니다.
+`initialization` 속성을 사용해 LSP 서버에 초기화 옵션을 전달하세요. 이 값은 LSP `initialize` 요청 중에 전송되는 서버별 설정입니다.
 
 ```json title="opencode.json" {5-9}
 {
@@ -127,14 +128,14 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 ```
 
 :::note
-초기화 옵션은 LSP 서버가 다릅니다. LSP 서버의 사용 가능한 옵션을 확인하세요.
+초기화 옵션은 LSP 서버마다 다릅니다. 사용 가능한 옵션은 해당 LSP 서버 문서를 확인하세요.
 :::
 
 ---
 
 ### LSP 서버 비활성화
 
-전역적으로 **모든** LSP 서버를 비활성화하려면 `lsp`를 `false`로 설정하십시오.
+전역에서 **모든** LSP 서버를 비활성화하려면 `lsp`를 `false`로 설정하세요.
 
 ```json title="opencode.json" {3}
 {
@@ -143,7 +144,7 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 }
 ```
 
-**특정** LSP 서버를 비활성화하려면 `disabled`를 `true`로 설정하십시오.
+**특정** LSP 서버를 비활성화하려면 `disabled`를 `true`로 설정하세요.
 
 ```json title="opencode.json" {5}
 {
@@ -160,7 +161,7 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 
 ## 사용자 정의 LSP 서버
 
-명령어와 파일 확장자를 지정하여 사용자 정의 LSP 서버를 추가할 수 있습니다.
+명령과 파일 확장자를 지정해 사용자 정의 LSP 서버를 추가할 수 있습니다.
 
 ```json title="opencode.json" {4-7}
 {
@@ -180,9 +181,9 @@ OpenCode 설정의 `lsp` 섹션을 통해 LSP 서버를 사용자 정의할 수 
 
 ### PHP Intelephense
 
-PHP Intelephense는 라이선스 키를 통해 프리미엄 기능을 제공합니다. 텍스트 파일에 키(만)를 저장하여 라이선스 키를 제공할 수 있습니다.
+PHP Intelephense는 라이선스 키를 통해 프리미엄 기능을 제공합니다. 텍스트 파일에 키만 저장해 라이선스 키를 제공할 수 있습니다.
 
 - macOS/Linux: `$HOME/intelephense/license.txt`
 - Windows: `%USERPROFILE%/intelephense/license.txt`
 
-파일에는 다른 내용이 없어야 합니다.
+파일에는 추가 내용 없이 라이선스 키만 포함하는 것이 좋습니다.


### PR DESCRIPTION
Refresh Korean docs for GitLab, IDE, index, keybinds, and LSP with smoother phrasing while preserving structure and terminology consistency.

### Issue for this PR

Closes #14516 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Korean docs wording improvements for the following pages:
- `packages/web/src/content/docs/ko/gitlab.mdx`
- `packages/web/src/content/docs/ko/ide.mdx`
- `packages/web/src/content/docs/ko/index.mdx`
- `packages/web/src/content/docs/ko/keybinds.mdx`
- `packages/web/src/content/docs/ko/lsp.mdx`

I rewrote awkward literal translations into more natural Korean while preserving technical meaning and document structure.
This PR only updates docs wording/terminology consistency and keeps code blocks, commands, links, and headings intact.

### How did you verify your code works?

- Reviewed each diff against the English source docs
- Checked MDX structure integrity (frontmatter, headings, tables, code blocks, links)
- Confirmed this PR is docs-only and does not change runtime behavior

### Screenshots / recordings
N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR



