### PR TITLE
fix: gracefully handle well-known provider being down

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -88,20 +88,25 @@ export namespace Config {
       if (value.type === "wellknown") {
         const url = key.replace(/\/+$/, "")
         process.env[value.key] = value.token
-        log.debug("fetching remote config", { url: `${url}/.well-known/opencode` })
-        const response = await fetch(`${url}/.well-known/opencode`)
-        if (!response.ok) {
-          throw new Error(`failed to fetch remote config from ${url}: ${response.status}`)
+        const wellknownUrl = `${url}/.well-known/opencode`
+        const cached = path.join(Global.Path.cache, "wellknown", url.replaceAll(/[^a-zA-Z0-9.-]/g, "_") + ".json")
+        log.debug("fetching remote config", { url: wellknownUrl })
+        const response = await fetch(wellknownUrl, { signal: AbortSignal.timeout(10_000) }).catch(() => undefined)
+        const fetched = response?.ok ? await response.json().catch(() => undefined) : undefined
+        if (fetched) await Filesystem.writeJson(cached, fetched)
+        if (!fetched) log.warn("failed to fetch remote config, trying cache", { url: wellknownUrl })
+        const wellknown = fetched ?? (await Filesystem.readJson(cached).catch(() => undefined))
+        if (!wellknown) {
+          log.warn("no cached remote config available", { url: wellknownUrl })
+          continue
         }
-        const wellknown = (await response.json()) as any
         const remoteConfig = wellknown.config ?? {}
-        // Add $schema to prevent load() from trying to write back to a non-existent file
         if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
         result = mergeConfigConcatArrays(
           result,
           await load(JSON.stringify(remoteConfig), {
-            dir: path.dirname(`${url}/.well-known/opencode`),
-            source: `${url}/.well-known/opencode`,
+            dir: path.dirname(wellknownUrl),
+            source: wellknownUrl,
           }),
         )
         log.debug("loaded remote config from well-known", { url })


### PR DESCRIPTION
### Issue for this PR

Closes #10930

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes issue where opencode crashes if a previously authed `.well-known/opencode` endpoint becomes unavailable.

Actually adds error handling and caching so transient errors, or downtime doesn't brick your opencode.


### How did you verify your code works?

1. Run a  `localhost/.well-known/opencode` stub server,
2. Run `opencode auth login http://localhost`
3. Stop stub server
4. opencode no longer crashes

### Screenshots / recordings

```
# Server running
% opencode auth login http://localhost:3456

┌  Add credential
│
●  Running `echo stub-token`
│
◆  Logged into http://localhost:3456
│
└  Done

# Server stopped (old behavior)
% opencode
{
  "name": "UnknownError",
  "data": {
    "message": "Error: Unable to connect. Is the computer able to access the url?"
  }
}

% opencode run 'immediately return'
Error: Unexpected error, check log file at /Users/./.local/share/opencode/log/2026-02-21T052204.log for more details

Unable to connect. Is the computer able to access the url?

% bun run --cwd packages/opencode dev run 'immediately return'
$ bun run --conditions=browser ./src/index.ts run "immediately return"

> build · Claude Opus 4.6

Could you clarify what you mean? Are you referring to something in the codebase, a code pattern, or something else?
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
