### PR TITLE
fix(opencode): show MCP tool output in non-interactive run mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -68,10 +68,15 @@ function fallback(part: ToolPart) {
   const title =
     ("title" in state && state.title ? state.title : undefined) ||
     (input && typeof input === "object" && Object.keys(input).length > 0 ? JSON.stringify(input) : "Unknown")
-  inline({
-    icon: "⚙",
-    title: `${part.tool} ${title}`,
-  })
+  const raw = state.status === "completed" && "output" in state ? state.output : undefined
+  const output = typeof raw === "string" ? raw.trim() : undefined
+  block(
+    {
+      icon: "⚙",
+      title: `${part.tool} ${title}`,
+    },
+    output,
+  )
 }
 
 function glob(info: ToolProps<typeof GlobTool>) {
@@ -582,7 +587,7 @@ export const RunCommand = cmd({
       }
       await share(sdk, sessionID)
 
-      loop().catch((e) => {
+      const loopPromise = loop().catch((e) => {
         console.error(e)
         process.exit(1)
       })
@@ -606,6 +611,8 @@ export const RunCommand = cmd({
           parts: [...files, { type: "text", text: message }],
         })
       }
+
+      await loopPromise
     }
 
     if (args.attach) {


### PR DESCRIPTION
### Issue for this PR

Closes #6604
Closes #13946

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two fixes in `packages/opencode/src/cli/cmd/run.ts`:

**1. MCP tool output not shown:** The `fallback()` handler (used for all MCP tools) only displayed tool name + input JSON via `inline()`. It never read `part.state.output`. Changed to extract output with a runtime type check and display via `block()` — same pattern as the existing `bash()` handler.

**2. Race condition — premature exit:** `loop()` was started fire-and-forget while the handler returned right after `sdk.session.prompt()` completed its HTTP request. The process could exit before the LLM finished generating. Fixed by storing the loop promise and awaiting it after prompt/command.

### How did you verify your code works?

- TypeScript typecheck passes for the opencode package (`bunx tsc --noEmit`)
- Tested `bun dev run` with MCP tools (filesystem server) — output now appears
- Tested plain knowledge questions — no regression
- Note: CI typecheck failure is pre-existing in `@opencode-ai/enterprise` (unrelated `custom-elements.d.ts` error on dev branch)

### Screenshots / recordings

_CLI change, no UI affected._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR