### PR TITLE
feat: add xhigh for Azure gpt-5.2/5.3

### DIFF
--- a/packages/opencode/evals/azure_xhigh_eval.ts
+++ b/packages/opencode/evals/azure_xhigh_eval.ts
@@ -63,7 +63,7 @@ type ProviderInfo = {
 }
 
 const list = await client.provider.list()
-const all = (list?.data?.all ?? list?.all ?? []) as ProviderInfo[]
+const all = (list.data?.all ?? []) as ProviderInfo[]
 const azure = all.find((item) => item.id === "azure")
 if (!azure) {
   console.error("Azure provider not found in opencode provider list.")
@@ -85,9 +85,8 @@ if (!variants.includes("xhigh")) {
   process.exit(1)
 }
 
-type IdResult = { data?: { id?: string }; id?: string }
-const created = (await client.session.create({ body: { title: `azure-xhigh-${Date.now()}` } })) as IdResult
-const sessionId = created.data?.id ?? created.id
+const created = await client.session.create({ body: { title: `azure-xhigh-${Date.now()}` } })
+const sessionId = created.data?.id
 if (!sessionId) {
   console.error("Failed to create session.")
   server.close()

--- a/packages/opencode/evals/azure_xhigh_eval.ts
+++ b/packages/opencode/evals/azure_xhigh_eval.ts
@@ -1,0 +1,178 @@
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { createOpencode } from "@opencode-ai/sdk"
+
+const file = Bun.file(path.join(os.homedir(), ".env.d", "codex.env"))
+const ok = await file.exists()
+if (!ok) {
+  console.error("Missing ~/.env.d/codex.env for Azure evaluation credentials.")
+  process.exit(1)
+}
+
+const text = await file.text()
+text.split(/\r?\n/).forEach((raw) => {
+  const line = raw.trim()
+  if (!line) return
+  if (line.startsWith("#")) return
+  const index = line.indexOf("=")
+  if (index <= 0) return
+  const key = line.slice(0, index).trim()
+  if (!key) return
+  const value = line.slice(index + 1).trim()
+  process.env[key] = value
+})
+
+const base = process.env.AZURE_OPENAI_BASE_URL
+if (base) {
+  const url = new URL(base)
+  const host = `${url.protocol}//${url.host}`
+  if (!process.env.AZURE_API_BASE_URL) process.env.AZURE_API_BASE_URL = host
+  if (!process.env.AZURE_OPENAI_API_BASE_URL) process.env.AZURE_OPENAI_API_BASE_URL = host
+}
+
+if (process.env.AZURE_OPENAI_API_KEY && !process.env.AZURE_API_KEY) {
+  process.env.AZURE_API_KEY = process.env.AZURE_OPENAI_API_KEY
+}
+
+const model = process.env.AZURE_EVAL_MODEL || process.env.AZURE_OPENAI_DEPLOYMENT_NAME || "gpt-5.2-codex"
+const version = process.env.AZURE_OPENAI_API_VERSION || process.env.AZURE_API_VERSION || "preview"
+if (!process.env.AZURE_API_VERSION) process.env.AZURE_API_VERSION = version
+if (!process.env.AZURE_OPENAI_API_VERSION) process.env.AZURE_OPENAI_API_VERSION = version
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-eval-"))
+
+const prompt = `You are working in the current directory.\n\n1) Create hello.py that prints exactly: Hello, world!\n2) Create test_hello.py using Python's unittest. It must run hello.py, capture stdout, and assert the output equals \"Hello, world!\" plus a trailing newline.\n3) Run: python -m unittest -q\n4) In your final response, include the test command output and a brief confirmation.`
+
+const tools = {
+  bash: true,
+  edit: true,
+  write: true,
+  read: true,
+  list: true,
+  glob: true,
+  grep: true,
+}
+
+const { client, server } = await createOpencode()
+
+type ProviderInfo = {
+  id: string
+  models?: Record<string, { variants?: Record<string, Record<string, unknown>> }>
+}
+
+const list = await client.provider.list()
+const all = (list?.data?.all ?? list?.all ?? []) as ProviderInfo[]
+const azure = all.find((item) => item.id === "azure")
+if (!azure) {
+  console.error("Azure provider not found in opencode provider list.")
+  server.close()
+  process.exit(1)
+}
+
+const info = azure.models?.[model]
+if (!info) {
+  console.error(`Azure model not found: ${model}`)
+  server.close()
+  process.exit(1)
+}
+
+const variants = info.variants ? Object.keys(info.variants) : []
+if (!variants.includes("xhigh")) {
+  console.error(`Azure model ${model} does not expose xhigh reasoning effort.`)
+  server.close()
+  process.exit(1)
+}
+
+type IdResult = { data?: { id?: string }; id?: string }
+const created = (await client.session.create({ body: { title: `azure-xhigh-${Date.now()}` } })) as IdResult
+const sessionId = created.data?.id ?? created.id
+if (!sessionId) {
+  console.error("Failed to create session.")
+  server.close()
+  process.exit(1)
+}
+
+const url = new URL(`/session/${sessionId}/message`, server.url)
+url.searchParams.set("directory", dir)
+
+const body = {
+  model: {
+    providerID: "azure",
+    modelID: model,
+  },
+  variant: "xhigh",
+  tools,
+  parts: [
+    {
+      type: "text",
+      text: prompt,
+    },
+  ],
+}
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+})
+
+if (!res.ok) {
+  const msg = await res.text()
+  console.error(`Prompt failed: ${res.status} ${res.statusText}\n${msg}`)
+  server.close()
+  process.exit(1)
+}
+
+type PromptResponse = {
+  info?: { variant?: string; error?: unknown; tokens?: { reasoning?: number } }
+  parts?: Array<{ type?: string; text?: string }>
+}
+
+const data = (await res.json()) as PromptResponse
+if (!data.info) {
+  console.error("Prompt response missing info.")
+  server.close()
+  process.exit(1)
+}
+
+if (data.info.error) {
+  console.error(`Prompt returned error: ${JSON.stringify(data.info.error)}`)
+  server.close()
+  process.exit(1)
+}
+
+if (data.info.variant !== "xhigh") {
+  console.error(`Expected variant xhigh, got: ${data.info.variant ?? "missing"}`)
+  server.close()
+  process.exit(1)
+}
+
+const parts = data.parts ?? []
+const reasoning = parts.filter((part) => part.type === "reasoning")
+const reasoningTokens = data.info.tokens?.reasoning ?? 0
+if (reasoning.length === 0 && reasoningTokens <= 0) {
+  console.error("No reasoning parts or reasoning tokens returned for xhigh request.")
+  server.close()
+  process.exit(1)
+}
+
+const run = spawnSync("python", ["-m", "unittest", "-q"], { cwd: dir, encoding: "utf8" })
+if (run.error) {
+  console.error(String(run.error))
+  server.close()
+  process.exit(1)
+}
+
+const out = (run.stdout ?? "") + (run.stderr ?? "")
+if (run.status !== 0) {
+  console.error(out.trim() || `unittest failed with status ${run.status}`)
+  server.close()
+  process.exit(1)
+}
+
+console.log(out.trim() || "unittest passed")
+console.log("Eval passed: azure gpt-5.2-codex xhigh reasoning works.")
+server.close()
+process.exit(0)

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -292,6 +292,10 @@ export const RunCommand = cmd({
         type: "string",
         describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       })
+      .option("reasoning-effort", {
+        type: "string",
+        describe: "reasoning effort (alias for --variant)",
+      })
       .option("thinking", {
         type: "boolean",
         describe: "show thinking blocks",
@@ -299,6 +303,13 @@ export const RunCommand = cmd({
       })
   },
   handler: async (args) => {
+    const reasoningEffort = args.reasoningEffort
+    if (args.variant && reasoningEffort && args.variant !== reasoningEffort) {
+      UI.error("Conflicting values: --variant and --reasoning-effort must match")
+      process.exit(1)
+    }
+    const variant = args.variant ?? reasoningEffort
+
     let message = [...args.message, ...(args["--"] || [])]
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")
@@ -594,7 +605,7 @@ export const RunCommand = cmd({
           model: args.model,
           command: args.command,
           arguments: message,
-          variant: args.variant,
+          variant,
         })
       } else {
         const model = args.model ? Provider.parseModel(args.model) : undefined
@@ -602,7 +613,7 @@ export const RunCommand = cmd({
           sessionID,
           agent,
           model,
-          variant: args.variant,
+          variant,
           parts: [...files, { type: "text", text: message }],
         })
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -473,6 +473,9 @@ export namespace ProviderTransform {
         if (id.includes("gpt-5-") || id === "gpt-5") {
           azureEfforts.unshift("minimal")
         }
+        if (id.includes("5.2") || id.includes("5.3")) {
+          azureEfforts.push("xhigh")
+        }
         return Object.fromEntries(
           azureEfforts.map((effort) => [
             effort,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2055,6 +2055,20 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(Object.keys(result)).toEqual(["minimal", "low", "medium", "high"])
     })
+
+    test("gpt-5.2-codex includes xhigh", () => {
+      const model = createMockModel({
+        id: "gpt-5.2-codex",
+        providerID: "azure",
+        api: {
+          id: "gpt-5.2-codex",
+          url: "https://azure.com",
+          npm: "@ai-sdk/azure",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh"])
+    })
   })
 
   describe("@ai-sdk/openai", () => {


### PR DESCRIPTION
## Summary
- add `xhigh` reasoning effort for Azure GPT-5.2/5.3 models
- add Azure variant test coverage for gpt-5.2-codex

## Rationale
Azure Codex endpoint accepts `xhigh`, but opencode only exposed low/medium/high for Azure, so the variant could not be selected.

## Testing
- bun install
- bun run --cwd packages/opencode script/build.ts