### PR TITLE
fix: use suffix matching for formatter file extensions

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -1,7 +1,7 @@
 import { Bus } from "../bus"
 import { File } from "../file"
 import { Log } from "../util/log"
-import path from "path"
+
 import z from "zod"
 
 import * as Formatter from "./formatter"
@@ -73,14 +73,14 @@ export namespace Format {
     return status
   }
 
-  async function getFormatter(ext: string) {
+  async function getFormatter(file: string) {
     const formatters = await state().then((x) => x.formatters)
     const result = []
     for (const item of Object.values(formatters)) {
-      log.info("checking", { name: item.name, ext })
-      if (!item.extensions.includes(ext)) continue
+      log.info("checking", { name: item.name, file })
+      if (!item.extensions.some((ext) => file.endsWith(ext))) continue
       if (!(await isEnabled(item))) continue
-      log.info("enabled", { name: item.name, ext })
+      log.info("enabled", { name: item.name, file })
       result.push(item)
     }
     return result
@@ -105,9 +105,8 @@ export namespace Format {
     Bus.subscribe(File.Event.Edited, async (payload) => {
       const file = payload.properties.file
       log.info("formatting", { file })
-      const ext = path.extname(file)
 
-      for (const item of await getFormatter(ext)) {
+      for (const item of await getFormatter(file)) {
         log.info("running", { command: item.command })
         try {
           const proc = Bun.spawn({


### PR DESCRIPTION
Fixes #3431

`path.extname()` only returns the last extension segment, so compound extensions like `.blade.php` or `.html.erb` never match their configured formatters.

Switched to suffix matching with `endsWith` so multi-part extensions work as expected. This also fixes the existing `htmlbeautifier` formatter which already declares `.html.erb` but could never actually match it.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How has this been verified?
Confirmed that `path.extname("template.blade.php")` returns `.php` (missing `.blade.php`), and that `"template.blade.php".endsWith(".blade.php")` correctly returns `true`. The change is limited to `getFormatter()` in `packages/opencode/src/format/index.ts` — no other callers exist.