### PR TITLE
fix: sort glob results for deterministic plugin load order

### DIFF
--- a/packages/opencode/src/util/glob.ts
+++ b/packages/opencode/src/util/glob.ts
@@ -21,11 +21,13 @@ export namespace Glob {
   }
 
   export async function scan(pattern: string, options: Options = {}): Promise<string[]> {
-    return glob(pattern, toGlobOptions(options)) as Promise<string[]>
+    const results = (await glob(pattern, toGlobOptions(options))) as string[]
+    return results.sort()
   }
 
   export function scanSync(pattern: string, options: Options = {}): string[] {
-    return globSync(pattern, toGlobOptions(options)) as string[]
+    const results = globSync(pattern, toGlobOptions(options)) as string[]
+    return results.sort()
   }
 
   export function match(pattern: string, filepath: string): boolean {

--- a/packages/opencode/test/util/glob.test.ts
+++ b/packages/opencode/test/util/glob.test.ts
@@ -14,7 +14,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("returns absolute paths when absolute option is true", async () => {
@@ -53,7 +53,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
 
     test("handles nested patterns", async () => {
@@ -93,7 +93,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("**/*.txt", { cwd: tmp.path, symlink: true })
 
-      expect(results.sort()).toEqual(["linkdir/file.txt", "realdir/file.txt"])
+      expect(results).toEqual(["linkdir/file.txt", "realdir/file.txt"])
     })
 
     test("includes dotfiles when dot option is true", async () => {
@@ -103,7 +103,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, dot: true })
 
-      expect(results.sort()).toEqual([".hidden", "visible"])
+      expect(results).toEqual([".hidden", "visible"])
     })
 
     test("excludes dotfiles when dot option is false", async () => {
@@ -125,7 +125,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("respects options", async () => {
@@ -135,7 +135,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
   })
 


### PR DESCRIPTION
## Summary

- Sort `Glob.scan` and `Glob.scanSync` results alphabetically so plugins, agents, modes, commands, and custom tools load in deterministic order
- Remove redundant `.sort()` calls in glob tests, which now serve as regression tests for the sorted output guarantee

## Problem

`Glob.scan` and `Glob.scanSync` returned results in filesystem `readdir` order, which varies across platforms and runs. This caused nondeterministic load order for:
- Plugins (`config.ts:loadPlugin`)
- Agents (`config.ts:loadAgent`)
- Modes (`config.ts:loadMode`)
- Commands (`config.ts:loadCommand`)
- Custom tools (`tool/registry.ts`)

## Fix

Added `.sort()` to both `Glob.scan` and `Glob.scanSync` return values in `packages/opencode/src/util/glob.ts`. This fixes the root cause at the utility level rather than patching individual call sites.

## Test plan

- [ ] Existing glob tests pass (assertions updated to verify sorted output directly)
- [ ] Plugin/agent/tool load order is now consistent across runs

Closes #14492

🤖 Generated with [Claude Code](https://claude.com/claude-code)