### PR TITLE
github action: redact secrets from posted comments and PR bodies

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -8,6 +8,7 @@ import type { Context as GitHubContext } from "@actions/github/lib/context"
 import type { IssueCommentEvent, PullRequestReviewCommentEvent } from "@octokit/webhooks-types"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { spawn } from "node:child_process"
+import { sanitizeForGitHubOutput } from "./sanitize"
 
 type GitHubAuthor = {
   login: string
@@ -788,11 +789,12 @@ async function updateComment(body: string) {
   console.log("Updating comment...")
 
   const { repo } = useContext()
+  const safe = sanitizeForGitHubOutput(body)
   return await octoRest.rest.issues.updateComment({
     owner: repo.owner,
     repo: repo.repo,
     comment_id: commentId,
-    body,
+    body: safe,
   })
 }
 
@@ -800,13 +802,14 @@ async function createPR(base: string, branch: string, title: string, body: strin
   console.log("Creating pull request...")
   const { repo } = useContext()
   const truncatedTitle = title.length > 256 ? title.slice(0, 253) + "..." : title
+  const safe = sanitizeForGitHubOutput(body)
   const pr = await octoRest.rest.pulls.create({
     owner: repo.owner,
     repo: repo.repo,
     head: branch,
     base,
     title: truncatedTitle,
-    body,
+    body: safe,
   })
   return pr.data.number
 }

--- a/github/sanitize.test.ts
+++ b/github/sanitize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test"
+import { sanitizeForGitHubOutput } from "./sanitize"
+
+describe("sanitizeForGitHubOutput", () => {
+  it("redacts sensitive env assignments", () => {
+    const result = sanitizeForGitHubOutput(
+      ["GITHUB_TOKEN=ghs_123456789012345678901234567890123456", "ZHIPU_API_KEY: secret", "SAFE_VAR=value"].join("\n"),
+    )
+    expect(result).toContain("GITHUB_TOKEN=***")
+    expect(result).toContain("ZHIPU_API_KEY: ***")
+    expect(result).toContain("SAFE_VAR=value")
+  })
+
+  it("redacts inline token formats", () => {
+    const result = sanitizeForGitHubOutput(
+      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc1234567890.xyz1234567890",
+    )
+    expect(result).toContain("Authorization: Bearer ***")
+  })
+
+  it("redacts token query params", () => {
+    const result = sanitizeForGitHubOutput("url=https://example.com?a=1&access_token=abc12345678901234567890&x=2")
+    expect(result).toContain("access_token=***")
+  })
+})

--- a/github/sanitize.ts
+++ b/github/sanitize.ts
@@ -1,0 +1,37 @@
+const TOKEN = [
+  /github_pat_[A-Za-z0-9_]{20,}/g,
+  /gh[opus]_[A-Za-z0-9]{20,}/g,
+  /\bBearer\s+[A-Za-z0-9._-]{20,}/gi,
+  /x-access-token:[^\s"']+/gi,
+  /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+]
+
+const PARAM = [/(^|[?&])(token|access_token)=([^&\s]+)/gi]
+const KEY = /(?:^|_)(TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY|ACCESS_KEY|ID_TOKEN)(?:$|_)/i
+
+function secure(line: string) {
+  let out = line
+  for (const re of TOKEN) out = out.replace(re, (m) => `${m.split(/\s+/)[0]} ***`)
+  for (const re of PARAM) out = out.replace(re, (_m, p1, p2) => `${p1}${p2}=***`)
+  return out
+}
+
+function hidden(key: string) {
+  const value = key.toUpperCase()
+  if (value.startsWith("GITHUB_")) return true
+  if (value.startsWith("ACTIONS_")) return true
+  return KEY.test(value)
+}
+
+export function sanitizeForGitHubOutput(input: string) {
+  return input
+    .split("\n")
+    .map((line) => {
+      const hit = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*[:=]\s*)(.*)$/)
+      if (!hit) return secure(line)
+      const [, pad, key, sep, value] = hit
+      if (hidden(key)) return `${pad}${key}${sep}***`
+      return `${pad}${key}${sep}${secure(value)}`
+    })
+    .join("\n")
+}


### PR DESCRIPTION
## Summary
- add `github/sanitize.ts` with `sanitizeForGitHubOutput()` to redact sensitive env-style values and token formats before posting GitHub comments/PR bodies
- route `updateComment()` and `createPR()` through the sanitizer in `github/index.ts`
- add regression tests in `github/sanitize.test.ts` for env assignment redaction, bearer/JWT masking, and token query param masking

## Why
Fixes the risk described in #11166 where action output can leak sensitive runtime values into issue/PR comments.

## Validation
- `npx -y tsx -e "import assert from 'node:assert/strict'; import { sanitizeForGitHubOutput } from './github/sanitize.ts'; const a=sanitizeForGitHubOutput('GITHUB_TOKEN=ghs_123456789012345678901234567890123456\nSAFE=value'); assert(a.includes('GITHUB_TOKEN=***')); assert(a.includes('SAFE=value')); const b=sanitizeForGitHubOutput('Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc1234567890.xyz1234567890'); assert(b.includes('Authorization: Bearer ***')); console.log('sanitize checks passed');"`

