### PR TITLE
fix: use suffix matching for formatter file extensions

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -1,7 +1,7 @@
 import { Bus } from "../bus"
 import { File } from "../file"
 import { Log } from "../util/log"
-import path from "path"
+
 import z from "zod"
 
 import * as Formatter from "./formatter"
@@ -73,14 +73,14 @@ export namespace Format {
     return status
   }
 
-  async function getFormatter(ext: string) {
+  async function getFormatter(file: string) {
     const formatters = await state().then((x) => x.formatters)
     const result = []
     for (const item of Object.values(formatters)) {
-      log.info("checking", { name: item.name, ext })
-      if (!item.extensions.includes(ext)) continue
+      log.info("checking", { name: item.name, file })
+      if (!item.extensions.some((ext) => file.endsWith(ext))) continue
       if (!(await isEnabled(item))) continue
-      log.info("enabled", { name: item.name, ext })
+      log.info("enabled", { name: item.name, file })
       result.push(item)
     }
     return result
@@ -105,9 +105,8 @@ export namespace Format {
     Bus.subscribe(File.Event.Edited, async (payload) => {
       const file = payload.properties.file
       log.info("formatting", { file })
-      const ext = path.extname(file)
 
-      for (const item of await getFormatter(ext)) {
+      for (const item of await getFormatter(file)) {
         log.info("running", { command: item.command })
         try {
           const proc = Bun.spawn({


### PR DESCRIPTION
### Issue for this PR

Closes #3431

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`path.extname()` only returns the last segment of a file extension — for example, `path.extname("template.blade.php")` returns `.php` instead of `.blade.php`. This means formatters configured with compound extensions like `.blade.php` or `.html.erb` can never match.

I replaced `path.extname()` + `Array.includes()` with `String.endsWith()` matching against the full file path. This way `"template.blade.php".endsWith(".blade.php")` correctly returns `true`.

This also fixes a latent bug with the built-in `htmlbeautifier` formatter, which already declares `.html.erb` in its extensions array but could never actually match because of the same `path.extname()` limitation.

### How did you verify your code works?

- Checked that `path.extname("x.blade.php")` returns `.php` (confirming the bug)
- Checked that `"x.blade.php".endsWith(".blade.php")` returns `true` (confirming the fix)
- Verified `getFormatter` is only called internally within `format/index.ts`, so no other callers are affected
- Reviewed that single-segment extensions (`.go`, `.py`, etc.) still work correctly with `endsWith`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR