### PR TITLE
fix(config): skip {file:} substitution only when no active lines match

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1265,10 +1265,8 @@ export namespace Config {
       const lines = text.split("\n")
 
       for (const match of fileMatches) {
-        const lineIndex = lines.findIndex((line) => line.includes(match))
-        if (lineIndex !== -1 && lines[lineIndex].trim().startsWith("//")) {
-          continue
-        }
+        const lineIndex = lines.findIndex((line) => line.includes(match) && !line.trim().startsWith("//"))
+        if (lineIndex === -1) continue
         let filePath = match.replace(/^\{file:/, "").replace(/\}$/, "")
         if (filePath.startsWith("~/")) {
           filePath = path.join(os.homedir(), filePath.slice(2))


### PR DESCRIPTION
### Issue for this PR

Closes #14478

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`load()` in config.ts uses `lines.findIndex()` to locate `{file:...}` tokens for substitution. If the first line containing the token is a comment, `continue` skips substitution for that token entirely — even when the same token appears on a later non-comment line.

Moved the comment check into the `findIndex` predicate so it finds the first *non-comment* line with the token. If no non-comment line contains it, the token is correctly skipped.

Before:
```ts
const lineIndex = lines.findIndex((line) => line.includes(match))
if (lineIndex !== -1 && lines[lineIndex].trim().startsWith("//")) {
  continue
}
```

After:
```ts
const lineIndex = lines.findIndex((line) => line.includes(match) && !line.trim().startsWith("//"))
if (lineIndex === -1) continue
```

### How did you verify your code works?

Tested with a jsonc config containing both a commented and active `{file:...}` token pointing to the same path. Before the fix the token stayed literal; after, it resolves correctly.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR