### PR TITLE
feat(cli): add --format json option to models command

### DIFF
--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -24,6 +24,12 @@ export const ModelsCommand = cmd({
         describe: "refresh the models cache from models.dev",
         type: "boolean",
       })
+      .option("format", {
+        describe: "output format",
+        type: "string",
+        choices: ["text", "json"] as const,
+        default: "text",
+      })
   },
   handler: async (args) => {
     if (args.refresh) {
@@ -35,6 +41,18 @@ export const ModelsCommand = cmd({
       directory: process.cwd(),
       async fn() {
         const providers = await Provider.list()
+
+        function collectModels(providerID: string) {
+          const provider = providers[providerID]
+          return Object.entries(provider.models)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([modelID, model]) => ({
+              id: `${providerID}/${modelID}`,
+              provider: providerID,
+              model: modelID,
+              ...model,
+            }))
+        }
 
         function printModels(providerID: string, verbose?: boolean) {
           const provider = providers[providerID]
@@ -49,18 +67,7 @@ export const ModelsCommand = cmd({
           }
         }
 
-        if (args.provider) {
-          const provider = providers[args.provider]
-          if (!provider) {
-            UI.error(`Provider not found: ${args.provider}`)
-            return
-          }
-
-          printModels(args.provider, args.verbose)
-          return
-        }
-
-        const providerIDs = Object.keys(providers).sort((a, b) => {
+        const targetProviderIDs = args.provider ? [args.provider] : Object.keys(providers).sort((a, b) => {
           const aIsOpencode = a.startsWith("opencode")
           const bIsOpencode = b.startsWith("opencode")
           if (aIsOpencode && !bIsOpencode) return -1
@@ -68,7 +75,19 @@ export const ModelsCommand = cmd({
           return a.localeCompare(b)
         })
 
-        for (const providerID of providerIDs) {
+        if (args.provider && !providers[args.provider]) {
+          UI.error(`Provider not found: ${args.provider}`)
+          return
+        }
+
+        if (args.format === "json") {
+          const models = targetProviderIDs.flatMap(collectModels)
+          process.stdout.write(JSON.stringify(models, null, 2))
+          process.stdout.write(EOL)
+          return
+        }
+
+        for (const providerID of targetProviderIDs) {
           printModels(providerID, args.verbose)
         }
       },

--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -47,10 +47,10 @@ export const ModelsCommand = cmd({
           return Object.entries(provider.models)
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([modelID, model]) => ({
+              ...model,
               id: `${providerID}/${modelID}`,
               provider: providerID,
               model: modelID,
-              ...model,
             }))
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #14550

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `--format json` option to `opencode models` command for machine-readable output. The `session list` command already supports this, so this brings consistency. When `--format json` is used, outputs a JSON array of model objects.

### How did you verify your code works?

Ran `opencode models --format json` locally and verified valid JSON output. Typecheck passes.

### Screenshots / recordings

_N/A - CLI output change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR