### PR TITLE
feat(config): add theme mode override option

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -282,9 +282,16 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   init: (props: { mode: "dark" | "light" }) => {
     const sync = useSync()
     const kv = useKV()
+
+    function configMode(): "dark" | "light" | undefined {
+      const override = sync.data.config.theme_mode as "light" | "dark" | "system" | undefined
+      if (override === "light" || override === "dark") return override
+      return undefined
+    }
+
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
-      mode: kv.get("theme_mode", props.mode),
+      mode: configMode() ?? kv.get("theme_mode", props.mode),
       active: (sync.data.config.theme ?? kv.get("theme", "opencode")) as string,
       ready: false,
     })
@@ -292,6 +299,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     createEffect(() => {
       const theme = sync.data.config.theme
       if (theme) setStore("active", theme)
+    })
+
+    createEffect(() => {
+      const override = configMode()
+      if (override) setStore("mode", override)
     })
 
     function init() {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -284,7 +284,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const kv = useKV()
 
     function configMode(): "dark" | "light" | undefined {
-      const override = sync.data.config.theme_mode as "light" | "dark" | "system" | undefined
+      const override = sync.data.config.theme_mode
       if (override === "light" || override === "dark") return override
       return undefined
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1018,6 +1018,12 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
+      theme_mode: z
+        .enum(["light", "dark", "system"])
+        .optional()
+        .describe(
+          "Override the detected terminal color scheme. Set to 'light' or 'dark' to force a mode, or 'system' to auto-detect from terminal.",
+        ),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1181,6 +1181,10 @@ export type Config = {
    * Theme name to use for the interface
    */
   theme?: string
+  /**
+   * Override the detected terminal color scheme. Set to 'light' or 'dark' to force a mode, or 'system' to auto-detect from terminal.
+   */
+  theme_mode?: "light" | "dark" | "system"
   keybinds?: KeybindsConfig
   /**
    * Log level

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1676,6 +1676,10 @@ export type Config = {
    * Theme name to use for the interface
    */
   theme?: string
+  /**
+   * Override the detected terminal color scheme. Set to 'light' or 'dark' to force a mode, or 'system' to auto-detect from terminal.
+   */
+  theme_mode?: "light" | "dark" | "system"
   keybinds?: KeybindsConfig
   logLevel?: LogLevel
   /**


### PR DESCRIPTION
### Issue for this PR

Closes #4464

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `theme_mode` config option (`light` / `dark` / `system`) so users can override terminal theme auto-detection. Terminals like Zellij and JetBrains IDEs misreport the system theme, making the TUI unreadable.

When set to `light` or `dark`, the config value takes priority over terminal detection.

### How did you verify your code works?

Set `theme_mode: "light"` in opencode.json and verified the TUI renders in light mode regardless of terminal setting.

### Screenshots / recordings

_N/A - would need specific terminal to demo._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR