### PR TITLE
fix(core): reject queued loop callbacks on cancel

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -78,8 +78,6 @@ export namespace SessionPrompt {
     },
     async (current) => {
       for (const item of Object.values(current)) {
-        // Avoid unhandled rejections during process/Instance teardown.
-        // Active loops/shells will observe abort and run their own deferred cleanup.
         item.callbacks = []
         item.abort.abort()
       }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -78,12 +78,9 @@ export namespace SessionPrompt {
     },
     async (current) => {
       for (const item of Object.values(current)) {
-        const error = new Error("Instance disposed")
-        const queued = item.callbacks
+        // Avoid unhandled rejections during process/Instance teardown.
+        // Active loops/shells will observe abort and run their own deferred cleanup.
         item.callbacks = []
-        for (const q of queued) {
-          q.reject(error)
-        }
         item.abort.abort()
       }
     },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -78,6 +78,12 @@ export namespace SessionPrompt {
     },
     async (current) => {
       for (const item of Object.values(current)) {
+        const error = new Error("Instance disposed")
+        const queued = item.callbacks
+        item.callbacks = []
+        for (const q of queued) {
+          q.reject(error)
+        }
         item.abort.abort()
       }
     },
@@ -261,6 +267,14 @@ export namespace SessionPrompt {
       SessionStatus.set(sessionID, { type: "idle" })
       return
     }
+
+    const error = new Error("Session cancelled")
+    const queued = match.callbacks
+    match.callbacks = []
+    for (const q of queued) {
+      q.reject(error)
+    }
+
     match.abort.abort()
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
@@ -714,7 +728,9 @@ export namespace SessionPrompt {
     SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
-      const queued = state()[sessionID]?.callbacks ?? []
+      const match = state()[sessionID]
+      const queued = match?.callbacks ?? []
+      if (match) match.callbacks = []
       for (const q of queued) {
         q.resolve(item)
       }

--- a/packages/opencode/test/session/prompt-cancel.test.ts
+++ b/packages/opencode/test/session/prompt-cancel.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("session.prompt cancel", () => {
+  test("rejects queued loop callbacks", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const command = process.platform === "win32" ? "ping -n 6 127.0.0.1 >nul" : "sleep 5"
+
+        const running = SessionPrompt.shell({
+          sessionID: session.id,
+          agent: "build",
+          command,
+        })
+        void running.catch(() => {})
+
+        const queued = SessionPrompt.loop({ sessionID: session.id })
+        SessionPrompt.cancel(session.id)
+
+        const result = await Promise.race([
+          queued.then(
+            () => ({ type: "resolved" as const }),
+            (error) => ({ type: "rejected" as const, error }),
+          ),
+          Bun.sleep(200).then(() => ({ type: "timeout" as const })),
+        ])
+
+        expect(result.type).toBe("rejected")
+        if (result.type === "rejected") {
+          expect(result.error).toBeInstanceOf(Error)
+          expect((result.error as Error).message).toBe("Session cancelled")
+        }
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14565 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a hang where concurrent callers waiting on` SessionPrompt.loop()` could wait forever if the session is cancelled (or the Instance is disposed) while callbacks are queued.

### How did you verify your code works?

Run the added tests 

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
