### PR TITLE
fix(opencode): remove OPENCODE_SERVER_PASSWORD from the env after read

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -28,9 +28,8 @@ export namespace Flag {
   export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
   export declare const OPENCODE_CLIENT: string
-  const password = process.env["OPENCODE_SERVER_PASSWORD"]
+  export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   delete process.env["OPENCODE_SERVER_PASSWORD"]
-  export const OPENCODE_SERVER_PASSWORD = password
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
   export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -28,7 +28,9 @@ export namespace Flag {
   export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
   export declare const OPENCODE_CLIENT: string
-  export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
+  const password = process.env["OPENCODE_SERVER_PASSWORD"]
+  delete process.env["OPENCODE_SERVER_PASSWORD"]
+  export const OPENCODE_SERVER_PASSWORD = password
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
   export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
 

--- a/packages/opencode/test/bun.test.ts
+++ b/packages/opencode/test/bun.test.ts
@@ -51,3 +51,25 @@ describe("BunProc registry configuration", () => {
     }
   })
 })
+
+describe("Flag server password", () => {
+  test("removes OPENCODE_SERVER_PASSWORD from env on load", async () => {
+    const key = "OPENCODE_SERVER_PASSWORD"
+    const original = process.env[key]
+    process.env[key] = "secret"
+
+    try {
+      const flagPath = path.join(__dirname, "../src/flag/flag.ts")
+      const tempPath = path.join(path.dirname(flagPath), `flag-${Date.now()}-${Math.random().toString(16).slice(2)}.ts`)
+      const content = await fs.readFile(flagPath, "utf-8")
+      await fs.writeFile(tempPath, content)
+
+      const { Flag } = await import(tempPath)
+      expect(Flag.OPENCODE_SERVER_PASSWORD).toBe("secret")
+      expect(process.env[key]).toBeUndefined()
+    } finally {
+      if (original === undefined) delete process.env[key]
+      else process.env[key] = original
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14567

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Clears the env variable OPENCODE_SERVER_PASSWORD from the process, as s security measure to prevent it from leaking into sub processes.

### How did you verify your code works?
Unit tests.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
