### PR TITLE
feat(opencode): add MCP resource subscriptions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -738,21 +738,37 @@ function App() {
       duration: 5000,
     })
 
-    // If current session is idle, trigger AI with updated resource info
-    if (route.data.type === "session") {
-      const status = sync.data.session_status?.[route.data.sessionID]
-      if (!status || status.type === "idle") {
+    // If autoprompt is enabled for this server, trigger AI with updated resource info
+    const mcp = sync.data.config.mcp?.[evt.properties.server]
+    if (mcp && typeof mcp === "object" && "autoprompt" in mcp && mcp.autoprompt) {
+      const prompt = {
+        system: `An MCP resource has been updated. Resource URI: "${evt.properties.uri}" from server "${evt.properties.server}". Read the resource to review the latest content and take appropriate action.`,
+        parts: [
+          {
+            type: "text" as const,
+            text: `Resource updated: ${evt.properties.uri} (${evt.properties.server})`,
+          },
+        ],
+      }
+      if (route.data.type === "session") {
+        const status = sync.data.session_status?.[route.data.sessionID]
+        if (!status || status.type === "idle") {
+          sdk.client.session
+            .promptAsync({ sessionID: route.data.sessionID, ...prompt })
+            .catch((e) => console.error("failed to trigger AI for resource update", e))
+        }
+      } else {
         sdk.client.session
-          .prompt({
-            sessionID: route.data.sessionID,
-            parts: [
-              {
-                type: "text",
-                text: `[System: MCP resource updated]\nResource "${evt.properties.uri}" from server "${evt.properties.server}" has been updated. Please review the changes.`,
-              },
-            ],
+          .create({})
+          .then((res) => {
+            const id = res.data?.id
+            if (!id) return
+            route.navigate({ type: "session", sessionID: id })
+            sdk.client.session
+              .promptAsync({ sessionID: id, ...prompt })
+              .catch((e) => console.error("failed to trigger AI for resource update", e))
           })
-          .catch(() => {})
+          .catch((e) => console.error("failed to create session for resource update", e))
       }
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -731,26 +731,24 @@ function App() {
   })
 
   sdk.event.on(MCP.ResourceUpdated.type, (evt) => {
-    const { server, uri } = evt.properties
     toast.show({
       title: "Resource Updated",
-      message: `${uri} (${server})`,
+      message: `${evt.properties.uri} (${evt.properties.server})`,
       variant: "info",
       duration: 5000,
     })
 
     // If current session is idle, trigger AI with updated resource info
     if (route.data.type === "session") {
-      const sessionID = route.data.sessionID
-      const status = sync.data.session_status?.[sessionID]
+      const status = sync.data.session_status?.[route.data.sessionID]
       if (!status || status.type === "idle") {
         sdk.client.session
           .prompt({
-            sessionID,
+            sessionID: route.data.sessionID,
             parts: [
               {
                 type: "text",
-                text: `[System: MCP resource updated]\nResource "${uri}" from server "${server}" has been updated. Please review the changes.`,
+                text: `[System: MCP resource updated]\nResource "${evt.properties.uri}" from server "${evt.properties.server}" has been updated. Please review the changes.`,
               },
             ],
           })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -6,6 +6,7 @@ import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
+import { MCP } from "@/mcp"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
@@ -726,6 +727,44 @@ function App() {
       title: "Update Available",
       message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
       duration: 10000,
+    })
+  })
+
+  sdk.event.on(MCP.ResourceUpdated.type, (evt) => {
+    const { server, uri } = evt.properties
+    toast.show({
+      title: "Resource Updated",
+      message: `${uri} (${server})`,
+      variant: "info",
+      duration: 5000,
+    })
+
+    // If current session is idle, trigger AI with updated resource info
+    if (route.data.type === "session") {
+      const sessionID = route.data.sessionID
+      const status = sync.data.session_status?.[sessionID]
+      if (!status || status.type === "idle") {
+        sdk.client.session
+          .prompt({
+            sessionID,
+            parts: [
+              {
+                type: "text" as const,
+                text: `[System: MCP resource updated]\nResource "${uri}" from server "${server}" has been updated. Please review the changes.`,
+              },
+            ],
+          })
+          .catch(() => {})
+      }
+    }
+  })
+
+  sdk.event.on(MCP.ResourceListChanged.type, (evt) => {
+    toast.show({
+      title: "MCP Resources Changed",
+      message: `Server "${evt.properties.server}" resource list updated`,
+      variant: "info",
+      duration: 3000,
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -749,7 +749,7 @@ function App() {
             sessionID,
             parts: [
               {
-                type: "text" as const,
+                type: "text",
                 text: `[System: MCP resource updated]\nResource "${uri}" from server "${server}" has been updated. Please review the changes.`,
               },
             ],

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -546,6 +546,10 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+      subscriptions: z
+        .array(z.string())
+        .optional()
+        .describe("Resource URIs to automatically subscribe to for update notifications"),
     })
     .strict()
     .meta({
@@ -585,6 +589,10 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+      subscriptions: z
+        .array(z.string())
+        .optional()
+        .describe("Resource URIs to automatically subscribe to for update notifications"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -550,6 +550,10 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe("Resource URIs to automatically subscribe to for update notifications"),
+      autoprompt: z
+        .boolean()
+        .optional()
+        .describe("Automatically prompt the AI when a subscribed resource is updated. Defaults to false."),
     })
     .strict()
     .meta({
@@ -593,6 +597,10 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe("Resource URIs to automatically subscribe to for update notifications"),
+      autoprompt: z
+        .boolean()
+        .optional()
+        .describe("Automatically prompt the AI when a subscribed resource is updated. Defaults to false."),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -8,6 +8,8 @@ import {
   CallToolResultSchema,
   type Tool as MCPToolDef,
   ToolListChangedNotificationSchema,
+  ResourceUpdatedNotificationSchema,
+  ResourceListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "../config/config"
 import { Log } from "../util/log"
@@ -51,6 +53,21 @@ export namespace MCP {
     z.object({
       mcpName: z.string(),
       url: z.string(),
+    }),
+  )
+
+  export const ResourceUpdated = BusEvent.define(
+    "mcp.resource.updated",
+    z.object({
+      server: z.string(),
+      uri: z.string(),
+    }),
+  )
+
+  export const ResourceListChanged = BusEvent.define(
+    "mcp.resource.list.changed",
+    z.object({
+      server: z.string(),
     }),
   )
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -735,6 +735,82 @@ export namespace MCP {
     return result
   }
 
+  export async function subscribe(clientName: string, uri: string): Promise<boolean> {
+    const clientsSnapshot = await clients()
+    const client = clientsSnapshot[clientName]
+
+    if (!client) {
+      log.warn("client not found for subscription", { clientName })
+      return false
+    }
+
+    if (!supportsSubscriptions(client)) {
+      log.debug("server does not support resource subscriptions", { clientName })
+      return false
+    }
+
+    const s = await state()
+    const serverSubs = s.subscriptions.get(clientName)
+    if (serverSubs?.has(uri)) {
+      return true // already subscribed
+    }
+
+    try {
+      await client.subscribeResource({ uri })
+      if (!s.subscriptions.has(clientName)) {
+        s.subscriptions.set(clientName, new Set())
+      }
+      s.subscriptions.get(clientName)!.add(uri)
+      log.info("subscribed to resource", { clientName, uri })
+      return true
+    } catch (e) {
+      log.error("failed to subscribe to resource", {
+        clientName,
+        uri,
+        error: e instanceof Error ? e.message : String(e),
+      })
+      return false
+    }
+  }
+
+  export async function unsubscribe(clientName: string, uri: string): Promise<boolean> {
+    const clientsSnapshot = await clients()
+    const client = clientsSnapshot[clientName]
+    const s = await state()
+
+    // Remove from tracking regardless of whether the server call succeeds
+    s.subscriptions.get(clientName)?.delete(uri)
+
+    if (!client) {
+      log.warn("client not found for unsubscription", { clientName })
+      return false
+    }
+
+    try {
+      await client.unsubscribeResource({ uri })
+      log.info("unsubscribed from resource", { clientName, uri })
+      return true
+    } catch (e) {
+      log.error("failed to unsubscribe from resource", {
+        clientName,
+        uri,
+        error: e instanceof Error ? e.message : String(e),
+      })
+      return false
+    }
+  }
+
+  export async function subscriptions(): Promise<Record<string, string[]>> {
+    const s = await state()
+    const result: Record<string, string[]> = {}
+    for (const [server, uris] of s.subscriptions) {
+      if (uris.size > 0) {
+        result[server] = [...uris]
+      }
+    }
+    return result
+  }
+
   /**
    * Start OAuth authentication flow for an MCP server.
    * Returns the authorization URL that should be opened in a browser.

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -131,6 +131,21 @@ export namespace MCP {
       log.info("tools list changed notification received", { server: serverName })
       Bus.publish(ToolsChanged, { server: serverName })
     })
+
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, async (notification) => {
+      const uri = notification.params.uri
+      log.info("resource updated notification received", { server: serverName, uri })
+      Bus.publish(ResourceUpdated, { server: serverName, uri })
+    })
+
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+      log.info("resource list changed notification received", { server: serverName })
+      Bus.publish(ResourceListChanged, { server: serverName })
+    })
+  }
+
+  function supportsSubscriptions(client: MCPClient): boolean {
+    return client.getServerCapabilities()?.resources?.subscribe === true
   }
 
   // Convert MCP tool definition to AI SDK Tool type
@@ -210,6 +225,7 @@ export namespace MCP {
       return {
         status,
         clients,
+        subscriptions: new Map<string, Set<string>>(),
       }
     },
     async (state) => {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -732,6 +732,11 @@ export namespace MCP {
         return undefined
       })
 
+    // Auto-subscribe to the resource for update notifications (fire-and-forget)
+    if (result) {
+      subscribe(clientName, resourceUri).catch(() => {})
+    }
+
     return result
   }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -222,10 +222,38 @@ export namespace MCP {
           }
         }),
       )
+      const subscriptionMap = new Map<string, Set<string>>()
+
+      // Set up config-based subscriptions for connected clients
+      for (const [key, client] of Object.entries(clients)) {
+        if (status[key]?.status !== "connected") continue
+        const mcp = config[key]
+        if (!isMcpConfigured(mcp) || !mcp.subscriptions?.length) continue
+        if (!supportsSubscriptions(client)) continue
+
+        const uris = new Set<string>()
+        for (const uri of mcp.subscriptions) {
+          client
+            .subscribeResource({ uri })
+            .then(() => {
+              uris.add(uri)
+              log.info("subscribed to config resource", { key, uri })
+            })
+            .catch((e) => {
+              log.error("failed to subscribe to config resource", {
+                key,
+                uri,
+                error: e instanceof Error ? e.message : String(e),
+              })
+            })
+        }
+        subscriptionMap.set(key, uris)
+      }
+
       return {
         status,
         clients,
-        subscriptions: new Map<string, Set<string>>(),
+        subscriptions: subscriptionMap,
       }
     },
     async (state) => {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -231,15 +231,15 @@ export namespace MCP {
         if (!isMcpConfigured(mcp) || !mcp.subscriptions?.length) continue
         if (!supportsSubscriptions(client)) continue
 
-        const uris = new Set<string>()
+        const uris = new Set<string>(mcp.subscriptions)
         for (const uri of mcp.subscriptions) {
           client
             .subscribeResource({ uri })
             .then(() => {
-              uris.add(uri)
               log.info("subscribed to config resource", { key, uri })
             })
             .catch((e) => {
+              uris.delete(uri)
               log.error("failed to subscribe to config resource", {
                 key,
                 uri,
@@ -616,15 +616,15 @@ export namespace MCP {
       const allSubs = new Set([...previousSubs, ...configSubs])
 
       if (allSubs.size > 0 && supportsSubscriptions(result.mcpClient)) {
-        const activeSubs = new Set<string>()
+        const activeSubs = new Set<string>(allSubs)
         for (const uri of allSubs) {
           result.mcpClient
             .subscribeResource({ uri })
             .then(() => {
-              activeSubs.add(uri)
               log.info("re-subscribed to resource", { name, uri })
             })
             .catch((e) => {
+              activeSubs.delete(uri)
               log.error("failed to re-subscribe to resource", {
                 name,
                 uri,
@@ -767,7 +767,7 @@ export namespace MCP {
     const client = clientsSnapshot[clientName]
 
     if (!client) {
-      log.warn("client not found for prompt", {
+      log.warn("client not found for resource", {
         clientName: clientName,
       })
       return undefined
@@ -778,7 +778,7 @@ export namespace MCP {
         uri: resourceUri,
       })
       .catch((e) => {
-        log.error("failed to get prompt from MCP server", {
+        log.error("failed to read resource from MCP server", {
           clientName: clientName,
           resourceUri: resourceUri,
           error: e.message,
@@ -843,6 +843,10 @@ export namespace MCP {
     if (!client) {
       log.warn("client not found for unsubscription", { clientName })
       return false
+    }
+
+    if (!supportsSubscriptions(client)) {
+      return true // already removed from tracking above
     }
 
     try {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -225,30 +225,32 @@ export namespace MCP {
       const subscriptionMap = new Map<string, Set<string>>()
 
       // Set up config-based subscriptions for connected clients
-      for (const [key, client] of Object.entries(clients)) {
-        if (status[key]?.status !== "connected") continue
-        const mcp = config[key]
-        if (!isMcpConfigured(mcp) || !mcp.subscriptions?.length) continue
-        if (!supportsSubscriptions(client)) continue
-
-        const uris = new Set<string>(mcp.subscriptions)
-        for (const uri of mcp.subscriptions) {
-          client
-            .subscribeResource({ uri })
-            .then(() => {
-              log.info("subscribed to config resource", { key, uri })
-            })
-            .catch((e) => {
-              uris.delete(uri)
-              log.error("failed to subscribe to config resource", {
-                key,
-                uri,
-                error: e instanceof Error ? e.message : String(e),
+      Object.entries(clients)
+        .filter(([key]) => status[key]?.status === "connected")
+        .filter(([key]) => {
+          const mcp = config[key]
+          return isMcpConfigured(mcp) && mcp.subscriptions?.length && supportsSubscriptions(clients[key])
+        })
+        .forEach(([key]) => {
+          const mcp = config[key] as Config.Mcp
+          const uris = new Set<string>(mcp.subscriptions!)
+          mcp.subscriptions!.forEach((uri) => {
+            clients[key]
+              .subscribeResource({ uri })
+              .then(() => {
+                log.info("subscribed to config resource", { key, uri })
               })
-            })
-        }
-        subscriptionMap.set(key, uris)
-      }
+              .catch((e) => {
+                uris.delete(uri)
+                log.error("failed to subscribe to config resource", {
+                  key,
+                  uri,
+                  error: e instanceof Error ? e.message : String(e),
+                })
+              })
+          })
+          subscriptionMap.set(key, uris)
+        })
 
       return {
         status,
@@ -611,28 +613,28 @@ export namespace MCP {
       s.clients[name] = result.mcpClient
 
       // Re-subscribe to previously tracked resources and config-based subscriptions
-      const previousSubs = s.subscriptions.get(name) ?? new Set<string>()
-      const configSubs = new Set(isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : [])
-      const allSubs = new Set([...previousSubs, ...configSubs])
+      const tracked = new Set([
+        ...(s.subscriptions.get(name) ?? []),
+        ...(isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : []),
+      ])
 
-      if (allSubs.size > 0 && supportsSubscriptions(result.mcpClient)) {
-        const activeSubs = new Set<string>(allSubs)
-        for (const uri of allSubs) {
-          result.mcpClient
+      if (tracked.size > 0 && supportsSubscriptions(result.mcpClient)) {
+        ;[...tracked].forEach((uri) => {
+          result.mcpClient!
             .subscribeResource({ uri })
             .then(() => {
               log.info("re-subscribed to resource", { name, uri })
             })
             .catch((e) => {
-              activeSubs.delete(uri)
+              tracked.delete(uri)
               log.error("failed to re-subscribe to resource", {
                 name,
                 uri,
                 error: e instanceof Error ? e.message : String(e),
               })
             })
-        }
-        s.subscriptions.set(name, activeSubs)
+        })
+        s.subscriptions.set(name, tracked)
       }
     }
   }
@@ -795,8 +797,7 @@ export namespace MCP {
   }
 
   export async function subscribe(clientName: string, uri: string): Promise<boolean> {
-    const clientsSnapshot = await clients()
-    const client = clientsSnapshot[clientName]
+    const client = (await clients())[clientName]
 
     if (!client) {
       log.warn("client not found for subscription", { clientName })
@@ -809,32 +810,32 @@ export namespace MCP {
     }
 
     const s = await state()
-    const serverSubs = s.subscriptions.get(clientName)
-    if (serverSubs?.has(uri)) {
+    if (s.subscriptions.get(clientName)?.has(uri)) {
       return true // already subscribed
     }
 
-    try {
-      await client.subscribeResource({ uri })
-      if (!s.subscriptions.has(clientName)) {
-        s.subscriptions.set(clientName, new Set())
-      }
-      s.subscriptions.get(clientName)!.add(uri)
-      log.info("subscribed to resource", { clientName, uri })
-      return true
-    } catch (e) {
-      log.error("failed to subscribe to resource", {
-        clientName,
-        uri,
-        error: e instanceof Error ? e.message : String(e),
+    return client
+      .subscribeResource({ uri })
+      .then(() => {
+        if (!s.subscriptions.has(clientName)) {
+          s.subscriptions.set(clientName, new Set())
+        }
+        s.subscriptions.get(clientName)!.add(uri)
+        log.info("subscribed to resource", { clientName, uri })
+        return true
       })
-      return false
-    }
+      .catch((e) => {
+        log.error("failed to subscribe to resource", {
+          clientName,
+          uri,
+          error: e instanceof Error ? e.message : String(e),
+        })
+        return false
+      })
   }
 
   export async function unsubscribe(clientName: string, uri: string): Promise<boolean> {
-    const clientsSnapshot = await clients()
-    const client = clientsSnapshot[clientName]
+    const client = (await clients())[clientName]
     const s = await state()
 
     // Remove from tracking regardless of whether the server call succeeds
@@ -849,29 +850,29 @@ export namespace MCP {
       return true // already removed from tracking above
     }
 
-    try {
-      await client.unsubscribeResource({ uri })
-      log.info("unsubscribed from resource", { clientName, uri })
-      return true
-    } catch (e) {
-      log.error("failed to unsubscribe from resource", {
-        clientName,
-        uri,
-        error: e instanceof Error ? e.message : String(e),
+    return client
+      .unsubscribeResource({ uri })
+      .then(() => {
+        log.info("unsubscribed from resource", { clientName, uri })
+        return true
       })
-      return false
-    }
+      .catch((e) => {
+        log.error("failed to unsubscribe from resource", {
+          clientName,
+          uri,
+          error: e instanceof Error ? e.message : String(e),
+        })
+        return false
+      })
   }
 
   export async function subscriptions(): Promise<Record<string, string[]>> {
     const s = await state()
-    const result: Record<string, string[]> = {}
-    for (const [server, uris] of s.subscriptions) {
-      if (uris.size > 0) {
-        result[server] = [...uris]
-      }
-    }
-    return result
+    return Object.fromEntries(
+      [...s.subscriptions]
+        .filter(([, uris]) => uris.size > 0)
+        .map(([server, uris]) => [server, [...uris]]),
+    )
   }
 
   /**

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -609,6 +609,31 @@ export namespace MCP {
         })
       }
       s.clients[name] = result.mcpClient
+
+      // Re-subscribe to previously tracked resources and config-based subscriptions
+      const previousSubs = s.subscriptions.get(name) ?? new Set<string>()
+      const configSubs = new Set(isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : [])
+      const allSubs = new Set([...previousSubs, ...configSubs])
+
+      if (allSubs.size > 0 && supportsSubscriptions(result.mcpClient)) {
+        const activeSubs = new Set<string>()
+        for (const uri of allSubs) {
+          result.mcpClient
+            .subscribeResource({ uri })
+            .then(() => {
+              activeSubs.add(uri)
+              log.info("re-subscribed to resource", { name, uri })
+            })
+            .catch((e) => {
+              log.error("failed to re-subscribe to resource", {
+                name,
+                uri,
+                error: e instanceof Error ? e.message : String(e),
+              })
+            })
+        }
+        s.subscriptions.set(name, activeSubs)
+      }
     }
   }
 
@@ -621,6 +646,7 @@ export namespace MCP {
       })
       delete s.clients[name]
     }
+    s.subscriptions.delete(name)
     s.status[name] = { status: "disabled" }
   }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -141,6 +141,30 @@ export namespace MCP {
     client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
       log.info("resource list changed notification received", { server: serverName })
       Bus.publish(ResourceListChanged, { server: serverName })
+      // Subscribe to any newly listed resources
+      if (supportsSubscriptions(client)) {
+        const s = await state()
+        const existing = s.subscriptions.get(serverName) ?? new Set()
+        const listed = await client.listResources().catch((e) => {
+          log.warn("failed to list resources after list changed", { server: serverName, error: e instanceof Error ? e.message : String(e) })
+          return undefined
+        })
+        listed?.resources
+          .filter((r) => !existing.has(r.uri))
+          .forEach((r) => {
+            existing.add(r.uri)
+            client
+              .subscribeResource({ uri: r.uri })
+              .then(() => {
+                log.info("subscribed to new resource", { server: serverName, uri: r.uri })
+              })
+              .catch((e) => {
+                existing.delete(r.uri)
+                log.error("failed to subscribe to new resource", { server: serverName, uri: r.uri, error: e instanceof Error ? e.message : String(e) })
+              })
+          })
+        if (existing.size > 0) s.subscriptions.set(serverName, existing)
+      }
     })
   }
 
@@ -224,33 +248,37 @@ export namespace MCP {
       )
       const subscriptionMap = new Map<string, Set<string>>()
 
-      // Set up config-based subscriptions for connected clients
-      Object.entries(clients)
-        .filter(([key]) => status[key]?.status === "connected")
-        .filter(([key]) => {
-          const mcp = config[key]
-          return isMcpConfigured(mcp) && mcp.subscriptions?.length && supportsSubscriptions(clients[key])
-        })
-        .forEach(([key]) => {
-          const mcp = config[key] as Config.Mcp
-          const uris = new Set<string>(mcp.subscriptions!)
-          mcp.subscriptions!.forEach((uri) => {
-            clients[key]
-              .subscribeResource({ uri })
-              .then(() => {
-                log.info("subscribed to config resource", { key, uri })
-              })
-              .catch((e) => {
-                uris.delete(uri)
-                log.error("failed to subscribe to config resource", {
-                  key,
-                  uri,
-                  error: e instanceof Error ? e.message : String(e),
+      // Auto-subscribe to all resources for servers that support subscriptions
+      await Promise.all(
+        Object.entries(clients)
+          .filter(([key]) => status[key]?.status === "connected" && supportsSubscriptions(clients[key]))
+          .map(async ([key, client]) => {
+            const mcp = config[key]
+            const cfg = isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : []
+            const listed = await client.listResources().catch((e) => {
+              log.warn("failed to list resources for auto-subscribe", { key, error: e instanceof Error ? e.message : String(e) })
+              return undefined
+            })
+            const uris = new Set([...cfg, ...(listed?.resources.map((r) => r.uri) ?? [])])
+            if (uris.size === 0) return
+            uris.forEach((uri) => {
+              client
+                .subscribeResource({ uri })
+                .then(() => {
+                  log.info("auto-subscribed to resource", { key, uri })
                 })
-              })
-          })
-          subscriptionMap.set(key, uris)
-        })
+                .catch((e) => {
+                  uris.delete(uri)
+                  log.error("failed to auto-subscribe to resource", {
+                    key,
+                    uri,
+                    error: e instanceof Error ? e.message : String(e),
+                  })
+                })
+            })
+            subscriptionMap.set(key, uris)
+          }),
+      )
 
       return {
         status,
@@ -612,29 +640,36 @@ export namespace MCP {
       }
       s.clients[name] = result.mcpClient
 
-      // Re-subscribe to previously tracked resources and config-based subscriptions
-      const tracked = new Set([
-        ...(s.subscriptions.get(name) ?? []),
-        ...(isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : []),
-      ])
-
-      if (tracked.size > 0 && supportsSubscriptions(result.mcpClient)) {
-        ;[...tracked].forEach((uri) => {
-          result.mcpClient!
-            .subscribeResource({ uri })
-            .then(() => {
-              log.info("re-subscribed to resource", { name, uri })
-            })
-            .catch((e) => {
-              tracked.delete(uri)
-              log.error("failed to re-subscribe to resource", {
-                name,
-                uri,
-                error: e instanceof Error ? e.message : String(e),
-              })
-            })
+      // Re-subscribe: merge previous subscriptions, config URIs, and freshly listed resources
+      if (supportsSubscriptions(result.mcpClient)) {
+        const cfg = isMcpConfigured(mcp) && mcp.subscriptions ? mcp.subscriptions : []
+        const listed = await result.mcpClient.listResources().catch((e) => {
+          log.warn("failed to list resources on reconnect", { name, error: e instanceof Error ? e.message : String(e) })
+          return undefined
         })
-        s.subscriptions.set(name, tracked)
+        const tracked = new Set([
+          ...(s.subscriptions.get(name) ?? []),
+          ...cfg,
+          ...(listed?.resources.map((r) => r.uri) ?? []),
+        ])
+        if (tracked.size > 0) {
+          tracked.forEach((uri) => {
+            result.mcpClient!
+              .subscribeResource({ uri })
+              .then(() => {
+                log.info("re-subscribed to resource", { name, uri })
+              })
+              .catch((e) => {
+                tracked.delete(uri)
+                log.error("failed to re-subscribe to resource", {
+                  name,
+                  uri,
+                  error: e instanceof Error ? e.message : String(e),
+                })
+              })
+          })
+          s.subscriptions.set(name, tracked)
+        }
       }
     }
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -784,6 +784,21 @@ export type EventMcpBrowserOpenFailed = {
   }
 }
 
+export type EventMcpResourceUpdated = {
+  type: "mcp.resource.updated"
+  properties: {
+    server: string
+    uri: string
+  }
+}
+
+export type EventMcpResourceListChanged = {
+  type: "mcp.resource.list.changed"
+  properties: {
+    server: string
+  }
+}
+
 export type EventCommandExecuted = {
   type: "command.executed"
   properties: {
@@ -972,6 +987,8 @@ export type Event =
   | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
+  | EventMcpResourceUpdated
+  | EventMcpResourceListChanged
   | EventCommandExecuted
   | EventSessionCreated
   | EventSessionUpdated
@@ -1616,6 +1633,14 @@ export type McpLocalConfig = {
    * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
    */
   timeout?: number
+  /**
+   * Resource URIs to automatically subscribe to for update notifications
+   */
+  subscriptions?: Array<string>
+  /**
+   * Automatically prompt the AI when a subscribed resource is updated. Defaults to false.
+   */
+  autoprompt?: boolean
 }
 
 export type McpOAuthConfig = {
@@ -1660,6 +1685,14 @@ export type McpRemoteConfig = {
    * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
    */
   timeout?: number
+  /**
+   * Resource URIs to automatically subscribe to for update notifications
+   */
+  subscriptions?: Array<string>
+  /**
+   * Automatically prompt the AI when a subscribed resource is updated. Defaults to false.
+   */
+  autoprompt?: boolean
 }
 
 /**


### PR DESCRIPTION
### Issue for this PR

Closes #12092

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds MCP resource subscription support to opencode. It's experimental — my side project sends message updates over MCP and I want the client to react when  resources (in this case the user's inbox) change.

What it does in practice: when an MCP server publishes a notifications/resources/updated or notifications/resources/list_changed, opencode intercepts and handles, showing a toast and if configured it kicks the AI with the updated resource. If there's no active session it creates one.

  Where the changes live:

  - `mcp/index.ts` — the bulk of it. On connect, opencode auto-subscribes to every resource the server lists (plus any explicit URIs from config). Notification handlers publish bus events. On reconnect it merges  previous subscription state + config + a fresh listResources() call so nothing gets lost. On disconnect it  cleans up.
  - `config/config.ts` — two new optional fields on both local and remote MCP server configs: subscriptions:
  string[] (explicit URIs to subscribe to) and autoprompt: boolean (whether to trigger AI on updates).
  - `app.tsx `— TUI subscribes to the bus events. Shows toasts. If autoprompt is enabled for that server and the session is idle (or there's no session), it prompts the AI with context about what changed.
  - `sdk/js/.../types.gen.ts` — regenerated SDK types for the two new event types (`mcp.resource.updated`,  `mcp.resource.list.changed`).

  Key decisions and why:

  - Auto-subscribe to everything, not just config-specified URIs. In my project, the server exposes an inbox resource and we want to know the moment it changes. Requiring users to manually list every URI in config felt like unnecessary friction — if a server supports subscriptions, you probably want them. Config subscriptions still works for adding URIs that aren't in `listResources()`.
  - autoprompt is opt-in and per-server. 
  - MCP layer is event-only, TUI owns session logic. Followed the existing pattern — `mcp/index.ts` publishes bus events, `app.tsx` decides what to do with session context. Keeps the separation clean.
  - Fire-and-forget subscriptions with error logging. A failed subscription to one resource shouldn't block everything else. Errors get logged, the URI gets removed from tracking.
  - Three-way merge on reconnect. Previous in-memory state + config URIs + fresh listResources(). Handles the case where a server adds new resources while disconnected, or where config changed between connections.

 context / why this matters beyond my project:

  Resource subscriptions are part of the MCP spec but no-one seems to have implemented them yet. Any MCP server that exposes mutable resources (databases, message queues, config files, monitoring dashboards) benefits from this. The autoprompt pattern is more opinionated — it's basically "AI-on-interrupt" — but it's opt-in.

  Mainly wanted to show one way it could work!

### How did you verify your code works?

 Tested locally with my project (llmsg.com) as a remote MCP server (autoprompt: true). Verified:
  - Subscriptions are established on connect
  - Toast notifications appear on resource updates
  - AI gets triggered when session is idle and autoprompt is enabled
  - Reconnection re-subscribes correctly
  - No subscriptions attempted for servers that don't advertise the capability

  No automated tests — this is touching the MCP client integration layer and I wasn't sure what test patterns you prefer here.
  
  I've built some test functions on my site to simulate resource updates, which might be helpful if you want to play around. On https://llmsg.com/agents you should see the ability to trigger synthetic updates to any agent with a live connection.

### Screenshots / recordings

https://asciinema.org/a/qXsZ8NbiPJnyGznx

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._