### PR TITLE
fix(opencode): prevent cross-drive path bypass in Filesystem.contains on Windows

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -497,7 +497,6 @@ export namespace File {
     const full = path.join(Instance.directory, file)
 
     // TODO: Filesystem.contains is lexical only - symlinks inside the project can escape.
-    // TODO: On Windows, cross-drive paths bypass this check. Consider realpath canonicalization.
     if (!Instance.containsPath(full)) {
       throw new Error(`Access denied: path escapes project directory`)
     }
@@ -573,7 +572,6 @@ export namespace File {
     const resolved = dir ? path.join(Instance.directory, dir) : Instance.directory
 
     // TODO: Filesystem.contains is lexical only - symlinks inside the project can escape.
-    // TODO: On Windows, cross-drive paths bypass this check. Consider realpath canonicalization.
     if (!Instance.containsPath(resolved)) {
       throw new Error(`Access denied: path escapes project directory`)
     }

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -120,6 +120,14 @@ export namespace Filesystem {
   }
 
   export function contains(parent: string, child: string) {
+    // On Windows, path.relative across different drive letters (e.g. D:\project vs C:\evil)
+    // returns the absolute child path instead of a ".." prefixed relative path,
+    // which causes a false positive (the check thinks the child is inside the parent).
+    if (process.platform === "win32") {
+      const parentRoot = parent.slice(0, 3).toUpperCase()
+      const childRoot = child.slice(0, 3).toUpperCase()
+      if (parentRoot !== childRoot) return false
+    }
     return !relative(parent, child).startsWith("..")
   }
 

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -29,6 +29,28 @@ describe("Filesystem.contains", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
   })
+
+  if (process.platform === "win32") {
+    test("blocks cross-drive paths on Windows", () => {
+      expect(Filesystem.contains("D:\\project", "C:\\evil\\file.txt")).toBe(false)
+      expect(Filesystem.contains("D:\\project", "C:\\Windows\\System32\\config")).toBe(false)
+      expect(Filesystem.contains("C:\\Users\\user\\project", "D:\\other\\file")).toBe(false)
+    })
+
+    test("allows same-drive paths on Windows", () => {
+      expect(Filesystem.contains("D:\\project", "D:\\project\\src\\file.ts")).toBe(true)
+      expect(Filesystem.contains("C:\\Users\\project", "C:\\Users\\project\\file.ts")).toBe(true)
+    })
+
+    test("handles case-insensitive drive letters on Windows", () => {
+      expect(Filesystem.contains("d:\\project", "D:\\project\\file.ts")).toBe(true)
+      expect(Filesystem.contains("D:\\project", "d:\\project\\file.ts")).toBe(true)
+    })
+
+    test("blocks cross-drive with forward slashes on Windows", () => {
+      expect(Filesystem.contains("D:/project", "C:/evil/file.txt")).toBe(false)
+    })
+  }
 })
 
 /*


### PR DESCRIPTION
### Issue for this PR

Closes #14579

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Filesystem.contains()` uses `path.relative(parent, child).startsWith("..")` to check if a child path is inside a parent directory. On Windows, when the paths are on different drive letters, `path.relative()` returns the absolute child path instead of a `..`-prefixed relative path:

```js
path.relative("D:\project", "C:\evil\file.txt")
// Returns: "C:\evil\file.txt"  (no ".." prefix!)
```

This means `contains()` incorrectly returns `true`, allowing `File.read()` and `File.list()` to access files on any drive.

The fix adds a drive letter comparison before the `path.relative()` call. This is simpler than `realpathSync`-based approaches (like #8316) because it doesn't depend on the target file existing and has no fallback path that reintroduces the bug.

### How did you verify your code works?

1. Wrote a reproduction script confirming `Filesystem.contains("D:\project", "C:\evil\file.txt")` returns `true` (bug) on Windows
2. After the fix, same call returns `false`
3. Ran existing test suite: `bun test test/file/path-traversal.test.ts` — 19/19 pass
4. Ran `bun test test/util/filesystem.test.ts` — 38/38 pass
5. Added 4 new Windows-specific tests covering: cross-drive block, same-drive allow, case-insensitive drive letters, forward slash variant

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR