### PR TITLE
feat(cli): add --dangerously-skip-permissions flag

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -62,7 +62,15 @@ const cli = yargs(hideBin(process.argv))
     type: "string",
     choices: ["DEBUG", "INFO", "WARN", "ERROR"],
   })
+  .option("dangerously-skip-permissions", {
+    describe: "skip all permission prompts (allow everything)",
+    type: "boolean",
+    default: false,
+  })
   .middleware(async (opts) => {
+    if (opts.dangerouslySkipPermissions) {
+      process.env.OPENCODE_PERMISSION = JSON.stringify({ "*": "allow" })
+    }
     await Log.init({
       print: process.argv.includes("--print-logs"),
       dev: Installation.isLocal(),


### PR DESCRIPTION
## Summary
- Adds a `--dangerously-skip-permissions` CLI flag that auto-accepts all permission prompts
- Works by setting `OPENCODE_PERMISSION={"*":"allow"}` in yargs middleware before any command handler runs
- Leverages the existing permission pipeline — no changes needed to config, agents, or permission evaluation

## How it works
The flag is defined as a global yargs option. When passed, the middleware sets `process.env.OPENCODE_PERMISSION` which is already read by `flag.ts` → parsed by `config.ts` → evaluated by `permission/next.ts` to skip all prompts. The TUI worker inherits the env var automatically via the existing `Object.fromEntries(process.env)` spread in `thread.ts`.

## Usage
```bash
# TUI mode
opencode --dangerously-skip-permissions

# Non-interactive
opencode run --dangerously-skip-permissions "list files"
```

Equivalent to `OPENCODE_PERMISSION='{"*":"allow"}' opencode` but more discoverable and ergonomic.

## Test plan
- [ ] `opencode --dangerously-skip-permissions` launches TUI without permission prompts
- [ ] `opencode run --dangerously-skip-permissions "ls"` executes without asking
- [ ] `opencode` (without flag) still prompts as normal
- [ ] `opencode --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)