### PR TITLE
fix(ui): avoid truncating workspace paths in assistant text

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -148,17 +148,22 @@ function createThrottledValue(getValue: () => string) {
   return value
 }
 
-function relativizeProjectPaths(text: string, directory?: string) {
-  if (!text) return ""
-  if (!directory) return text
-  if (directory === "/") return text
-  if (directory === "\\") return text
-  return text.split(directory).join("")
+function relativizeProjectPath(path: string, directory?: string) {
+  if (!path) return ""
+  if (!directory) return path
+  if (directory === "/") return path
+  if (directory === "\\") return path
+  if (path === directory) return ""
+
+  const separator = directory.includes("\\") ? "\\" : "/"
+  const prefix = directory.endsWith(separator) ? directory : directory + separator
+  if (!path.startsWith(prefix)) return path
+  return path.slice(directory.length)
 }
 
 function getDirectory(path: string | undefined) {
   const data = useData()
-  return relativizeProjectPaths(_getDirectory(path), data.directory)
+  return relativizeProjectPath(_getDirectory(path), data.directory)
 }
 
 import type { IconProps } from "./icon"
@@ -1096,7 +1101,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     return items.filter((x) => !!x).join(" \u00B7 ")
   })
 
-  const displayText = () => relativizeProjectPaths((part.text ?? "").trim(), data.directory)
+  const displayText = () => (part.text ?? "").trim()
   const throttledText = createThrottledValue(displayText)
   const isLastTextPart = createMemo(() => {
     const last = (data.store.part?.[props.message.id] ?? [])
@@ -1198,7 +1203,7 @@ ToolRegistry.register({
             <div data-component="tool-loaded-file">
               <Icon name="enter" size="small" />
               <span>
-                {i18n.t("ui.tool.loaded")} {relativizeProjectPaths(filepath, data.directory)}
+                {i18n.t("ui.tool.loaded")} {relativizeProjectPath(filepath, data.directory)}
               </span>
             </div>
           )}


### PR DESCRIPTION
### Issue for this PR

Closes #14557

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Fixes a UI truncation bug where assistant message text replaced every occurrence of the working directory (for example `/workspace`) and unintentionally broke inline code and markdown links.
This PR removes path rewriting from assistant freeform text and keeps path relativization only for path-specific UI labels, using a safer prefix-based trim.

### How did you verify your code works?
N/A
### Screenshots / recordings
N/A
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR