### PR TITLE
feat(cli): add --dangerously-skip-permissions flag

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -62,7 +62,15 @@ const cli = yargs(hideBin(process.argv))
     type: "string",
     choices: ["DEBUG", "INFO", "WARN", "ERROR"],
   })
+  .option("dangerously-skip-permissions", {
+    describe: "skip all permission prompts (allow everything)",
+    type: "boolean",
+    default: false,
+  })
   .middleware(async (opts) => {
+    if (opts.dangerouslySkipPermissions) {
+      process.env.OPENCODE_PERMISSION = JSON.stringify({ "*": "allow" })
+    }
     await Log.init({
       print: process.argv.includes("--print-logs"),
       dev: Installation.isLocal(),


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `--dangerously-skip-permissions` CLI flag as a global yargs option. When passed, the middleware sets `process.env.OPENCODE_PERMISSION` to `{"*":"allow"}` before any command handler runs. This is the same mechanism that already works via `OPENCODE_PERMISSION='{"*":"allow"}' opencode`, just exposed as a CLI flag for discoverability.

No changes to the permission system, config, or agents — the existing pipeline in `flag.ts` → `config.ts` → `permission/next.ts` already handles this env var. The TUI worker inherits it automatically via `Object.fromEntries(process.env)` in `thread.ts`.

### How did you verify your code works?

- Ran `opencode --dangerously-skip-permissions` — TUI launches without permission prompts
- Ran `opencode run --dangerously-skip-permissions "ls"` — executes without asking
- Ran `opencode` without the flag — still prompts as normal
- Ran `opencode --help` — new flag appears in output

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR