### PR TITLE
feat(acp): surface tool metadata in in_progress notifications

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -318,6 +318,9 @@ export namespace ACP {
                       title: part.tool,
                       locations: toLocations(part.tool, part.state.input),
                       rawInput: part.state.input,
+                      ...(part.state.metadata && {
+                        rawOutput: { metadata: part.state.metadata },
+                      }),
                     },
                   })
                   .catch((error) => {


### PR DESCRIPTION
### Issue for this PR

Closes #14592

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The ACP agent forwards tool metadata (`part.state.metadata`) in `completed` `tool_call_update` notifications via `rawOutput.metadata`, but drops it for `in_progress` notifications.

The task tool calls `ctx.metadata({ sessionId: session.id, model })` right after creating the child session — before the subagent runs. This persists the metadata on the part (`ToolStateRunning` already has an optional `metadata` field) and fires a `PartUpdated` event. The ACP agent receives the event but the `running` case in `src/acp/agent.ts` never includes `rawOutput`, so the child `sessionId` is invisible to clients until completion.

This adds a 3-line conditional spread to the `running` case so that when `part.state.metadata` is present, it's forwarded as `rawOutput: { metadata: part.state.metadata }` — the same shape used by the `completed` case. Clients that don't inspect `rawOutput` on `in_progress` are unaffected.

Our use case: we're building an ACP client that displays subagent sessions in a TUI. We want to hook into the child session while it's still running so users can watch subagent progress live, rather than waiting for it to finish.

### How did you verify your code works?

1. Wrote a test script that spawns `opencode acp`, sends a prompt triggering a task tool subagent, and captures every `tool_call`/`tool_call_update` notification — recording where `sessionId` appears. Confirmed that before this change, `sessionId` only appears on `completed`.
2. Ran the existing ACP test suite (`bun test test/acp/`) — all 6 tests pass.
3. Full `bun turbo typecheck` passes across all 12 packages.

### Screenshots / recordings

_N/A — backend-only change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR