### PR TITLE
feat(opencode): show item count when sidebar lists are collapsed

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -178,6 +178,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </Show>
                 <text fg={theme.text}>
                   <b>LSP</b>
+                  <Show when={!expanded.lsp}>
+                    <span style={{ fg: theme.textMuted }}> ({sync.data.lsp.length})</span>
+                  </Show>
                 </text>
               </box>
               <Show when={sync.data.lsp.length <= 2 || expanded.lsp}>
@@ -222,6 +225,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   </Show>
                   <text fg={theme.text}>
                     <b>Todo</b>
+                    <Show when={!expanded.todo}>
+                      <span style={{ fg: theme.textMuted }}> ({todo().length})</span>
+                    </Show>
                   </text>
                 </box>
                 <Show when={todo().length <= 2 || expanded.todo}>
@@ -241,6 +247,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   </Show>
                   <text fg={theme.text}>
                     <b>Modified Files</b>
+                    <Show when={!expanded.diff}>
+                      <span style={{ fg: theme.textMuted }}> ({diff().length})</span>
+                    </Show>
                   </text>
                 </box>
                 <Show when={diff().length <= 2 || expanded.diff}>


### PR DESCRIPTION
### Issue for this PR

Closes #14598

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When collapsible sidebar lists (LSP, Todo, Modified Files) are collapsed, the header now shows the item count in parentheses — e.g. `LSP (4)`, `Todo (3)`, `Modified Files (7)`. This matches the existing MCP section behavior which already shows `MCP (X active)` when collapsed.

Without this, collapsing a list hides all indication of how many items it contains, making the collapsed state less useful.

The change adds a `<Show when={!expanded.xxx}>` block to each of the three section headers, displaying the count in `theme.textMuted` — identical to the pattern MCP already uses.

### How did you verify your code works?

- Ran `bun typecheck` — all 12 packages pass
- Ran `prettier` — file unchanged (already formatted correctly)
- Verified the pattern matches the existing MCP collapsed header implementation

### Screenshots / recordings

_N/A — TUI change follows existing pattern. The collapsed headers will show e.g. `▶ LSP (3)` instead of just `▶ LSP`._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR