### PR TITLE
docs(tui): correct typo in TUI documentation

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -235,7 +235,7 @@ Share current session. [Learn more](/docs/share).
 List available themes.
 
 ```bash frame="none"
-/theme
+/themes
 ```
 
 **Keybind:** `ctrl+x t`


### PR DESCRIPTION
### Issue for this PR

Closes #14600 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Previously, here has been a refactor of tui in PR #9115, but in documentation it is not changed. 
This PR changes `/theme` -> `/themes` in tui documentation.

### How did you verify your code works?

I tested the change locally as shown in screenshot below.
### Screenshots / recordings

PR #9115 
Removed
<img width="1325" height="712" alt="image" src="https://github.com/user-attachments/assets/e40a54e2-5fee-4935-ad5e-afb44aaf4d55" />

Added
<img width="1341" height="711" alt="image" src="https://github.com/user-attachments/assets/4554002b-3152-4137-9271-7224620f6cc7" />

Production
<img width="1226" height="830" alt="image" src="https://github.com/user-attachments/assets/f87e4ed0-f2b7-4c12-9be1-0ee4a5b4bfed" />

Local
<img width="1028" height="576" alt="image" src="https://github.com/user-attachments/assets/640c88b3-1455-489f-a138-a6c8d8a161a8" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
