### PR TITLE
fix: filter question tool and auto-approve permissions in non-interactive mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -297,6 +297,11 @@ export const RunCommand = cmd({
         describe: "show thinking blocks",
         default: false,
       })
+      .option("auto-approve", {
+        type: "boolean",
+        describe: "auto-approve permission requests (use --no-auto-approve to reject instead)",
+        default: true,
+      })
   },
   handler: async (args) => {
     let message = [...args.message, ...(args["--"] || [])]
@@ -539,14 +544,15 @@ export const RunCommand = cmd({
           if (event.type === "permission.asked") {
             const permission = event.properties
             if (permission.sessionID !== sessionID) continue
+            const reply = args["auto-approve"] ? "once" : "reject"
             UI.println(
               UI.Style.TEXT_WARNING_BOLD + "!",
               UI.Style.TEXT_NORMAL +
-                `permission requested: ${permission.permission} (${permission.patterns.join(", ")}); auto-rejecting`,
+                `permission requested: ${permission.permission} (${permission.patterns.join(", ")}); auto-${reply === "once" ? "approving" : "rejecting"}`,
             )
             await sdk.permission.reply({
               requestID: permission.id,
-              reply: "reject",
+              reply,
             })
           }
         }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -39,6 +39,7 @@ export namespace LLM {
     tools: Record<string, Tool>
     retries?: number
     toolChoice?: "auto" | "required" | "none"
+    permission?: PermissionNext.Ruleset
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
@@ -255,8 +256,11 @@ export namespace LLM {
     })
   }
 
-  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user" | "permission">) {
+    const disabled = PermissionNext.disabled(
+      Object.keys(input.tools),
+      PermissionNext.merge(input.agent.permission, input.permission ?? []),
+    )
     for (const tool of Object.keys(input.tools)) {
       if (input.user.tools?.[tool] === false || disabled.has(tool)) {
         delete input.tools[tool]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -674,6 +674,7 @@ export namespace SessionPrompt {
         tools,
         model,
         toolChoice: format.type === "json_schema" ? "required" : undefined,
+        permission: session.permission ?? [],
       })
 
       // If structured output was captured, save it and exit immediately

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -13,7 +13,11 @@ export const QuestionTool = Tool.define("question", {
     try {
       await ctx.ask({ permission: "question", patterns: ["*"], metadata: {}, always: ["*"] })
     } catch (e) {
-      if (e instanceof PermissionNext.DeniedError || e instanceof PermissionNext.RejectedError) {
+      if (
+        e instanceof PermissionNext.DeniedError ||
+        e instanceof PermissionNext.RejectedError ||
+        e instanceof PermissionNext.CorrectedError
+      ) {
         return {
           title: "Question denied",
           output: "Cannot ask questions in this session. Make your best judgment and proceed.",

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import { Tool } from "./tool"
 import { Question } from "../question"
+import { PermissionNext } from "../permission/next"
 import DESCRIPTION from "./question.txt"
 
 export const QuestionTool = Tool.define("question", {
@@ -9,6 +10,19 @@ export const QuestionTool = Tool.define("question", {
     questions: z.array(Question.Info.omit({ custom: true })).describe("Questions to ask"),
   }),
   async execute(params, ctx) {
+    try {
+      await ctx.ask({ permission: "question", patterns: ["*"], metadata: {}, always: ["*"] })
+    } catch (e) {
+      if (e instanceof PermissionNext.DeniedError || e instanceof PermissionNext.RejectedError) {
+        return {
+          title: "Question denied",
+          output: "Cannot ask questions in this session. Make your best judgment and proceed.",
+          metadata: { answers: [] },
+        }
+      }
+      throw e
+    }
+
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: params.questions,


### PR DESCRIPTION
### Issue for this PR

Closes #11899
Closes #13851

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` has two compounding bugs that make it unusable for automation:

**Bug 1 — Question tool hangs (#11899):** `run.ts` sets `question: deny` on the session, but this never reaches the LLM tool-filtering layer. `LLM.resolveTools()` only checks agent-level permissions, and the `build` agent explicitly sets `question: "allow"`. The question tool also calls `Question.ask()` directly without going through `ctx.ask()`, so the session deny rule is never evaluated. Result: model calls question tool → `Question.ask()` returns a Promise waiting for `Question.reply()` which never comes → process hangs.

**Bug 2 — Permission blocking (#13851):** The `permission.asked` event handler in `run.ts` auto-rejects all permission requests. Any tool with `"ask"` permission (file writes in certain directories, .env reads, external directory access) fails immediately. The model gets errors, retries a few times, gives up. Users see: "starts loop, runs ls, exits."

**Fix 1 (3 files):**
- `llm.ts`: Added `permission` field to `StreamInput`. `resolveTools()` now merges session permissions with agent permissions, so `question: deny` from the session actually removes the question tool from the tool list.
- `prompt.ts`: Passes `session.permission` through to the LLM layer.
- `question.ts`: Added `ctx.ask()` call before `Question.ask()`. If denied, returns a message ("Make your best judgment and proceed") instead of hanging.

**Fix 2 (1 file):**
- `run.ts`: Changed the `permission.asked` handler reply from `"reject"` to `"once"` (auto-approve). This only affects `"ask"` rules — explicit `"deny"` rules throw `DeniedError` before the event handler is ever reached, so they're unaffected. Added `--no-auto-approve` flag for CI environments that want the old strict behavior.

I understand why these changes work: the permission system uses `findLast()` semantics (last matching rule wins). Session permissions appended after agent permissions override them. The `disabled()` function checks for `deny` + wildcard pattern `*` to filter tools pre-LLM. The event handler only sees `"ask"` rules because `"deny"` rules short-circuit with `DeniedError` in `PermissionNext.ask()`.

### How did you verify your code works?

- Typecheck passes across all 12 packages
- All 1136 existing tests pass (0 failures)
- Manual testing with `opencode run "Create a file called test.txt with 'hello world'" --format json`

### Screenshots / recordings

_N/A — CLI-only change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR