### PR TITLE
fix: sort glob results for deterministic plugin load order

### DIFF
--- a/packages/opencode/src/util/glob.ts
+++ b/packages/opencode/src/util/glob.ts
@@ -21,11 +21,13 @@ export namespace Glob {
   }
 
   export async function scan(pattern: string, options: Options = {}): Promise<string[]> {
-    return glob(pattern, toGlobOptions(options)) as Promise<string[]>
+    const results = (await glob(pattern, toGlobOptions(options))) as string[]
+    return results.sort()
   }
 
   export function scanSync(pattern: string, options: Options = {}): string[] {
-    return globSync(pattern, toGlobOptions(options)) as string[]
+    const results = globSync(pattern, toGlobOptions(options)) as string[]
+    return results.sort()
   }
 
   export function match(pattern: string, filepath: string): boolean {

--- a/packages/opencode/test/util/glob.test.ts
+++ b/packages/opencode/test/util/glob.test.ts
@@ -14,7 +14,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("returns absolute paths when absolute option is true", async () => {
@@ -53,7 +53,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
 
     test("handles nested patterns", async () => {
@@ -93,7 +93,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("**/*.txt", { cwd: tmp.path, symlink: true })
 
-      expect(results.sort()).toEqual(["linkdir/file.txt", "realdir/file.txt"])
+      expect(results).toEqual(["linkdir/file.txt", "realdir/file.txt"])
     })
 
     test("includes dotfiles when dot option is true", async () => {
@@ -103,7 +103,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, dot: true })
 
-      expect(results.sort()).toEqual([".hidden", "visible"])
+      expect(results).toEqual([".hidden", "visible"])
     })
 
     test("excludes dotfiles when dot option is false", async () => {
@@ -125,7 +125,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("respects options", async () => {
@@ -135,7 +135,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #14492

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Glob.scan` and `Glob.scanSync` return results in filesystem `readdir` order, which is nondeterministic across platforms and runs. This causes plugins, agents, modes, commands, and custom tools to load in unpredictable order depending on the OS and filesystem state.

The fix adds `.sort()` to both `Glob.scan` and `Glob.scanSync` return values in `packages/opencode/src/util/glob.ts`. Sorting at the utility level fixes the root cause for all 5 call sites (loadPlugin, loadAgent, loadMode, loadCommand, ToolRegistry) without needing to patch each one individually.

The existing tests already compensated for this by calling `.sort()` on results before asserting. I removed those redundant `.sort()` calls so the tests now directly verify that sorted output is returned — serving as regression tests for this behavior.

### How did you verify your code works?

- Reviewed all 5 call sites that use `Glob.scan`/`Glob.scanSync` to confirm none depend on filesystem ordering
- Updated existing glob tests to assert sorted output directly (removing the workaround `.sort()` calls in test assertions)
- `Array.prototype.sort()` is stable and deterministic for string arrays

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR