### PR TITLE
fix(cli): set non-zero exit code when run command encounters errors

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -582,7 +582,7 @@ export const RunCommand = cmd({
       }
       await share(sdk, sessionID)
 
-      loop().catch((e) => {
+      const done = loop().catch((e) => {
         console.error(e)
         process.exit(1)
       })
@@ -606,6 +606,9 @@ export const RunCommand = cmd({
           parts: [...files, { type: "text", text: message }],
         })
       }
+
+      await done
+      if (error) process.exitCode = 1
     }
 
     if (args.attach) {


### PR DESCRIPTION
### Issue for this PR

Closes #14551

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` exits with code 0 even when the session encounters errors, breaking CI/CD pipelines. The fix awaits the event loop completion and sets `process.exitCode = 1` when errors occurred.

### How did you verify your code works?

Verified the exit code changes to 1 when the session produces errors. Only `run.ts` is modified.

### Screenshots / recordings

_N/A - no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR