### PR TITLE
fix: sort glob results for deterministic load order across all callers

### DIFF
--- a/packages/opencode/src/util/glob.ts
+++ b/packages/opencode/src/util/glob.ts
@@ -21,11 +21,13 @@ export namespace Glob {
   }
 
   export async function scan(pattern: string, options: Options = {}): Promise<string[]> {
-    return glob(pattern, toGlobOptions(options)) as Promise<string[]>
+    const results = (await glob(pattern, toGlobOptions(options))) as string[]
+    return results.sort()
   }
 
   export function scanSync(pattern: string, options: Options = {}): string[] {
-    return globSync(pattern, toGlobOptions(options)) as string[]
+    const results = globSync(pattern, toGlobOptions(options)) as string[]
+    return results.sort()
   }
 
   export function match(pattern: string, filepath: string): boolean {

--- a/packages/opencode/test/util/glob.test.ts
+++ b/packages/opencode/test/util/glob.test.ts
@@ -14,7 +14,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("returns absolute paths when absolute option is true", async () => {
@@ -53,7 +53,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
 
     test("handles nested patterns", async () => {
@@ -93,7 +93,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("**/*.txt", { cwd: tmp.path, symlink: true })
 
-      expect(results.sort()).toEqual(["linkdir/file.txt", "realdir/file.txt"])
+      expect(results).toEqual(["linkdir/file.txt", "realdir/file.txt"])
     })
 
     test("includes dotfiles when dot option is true", async () => {
@@ -103,7 +103,7 @@ describe("Glob", () => {
 
       const results = await Glob.scan("*", { cwd: tmp.path, dot: true })
 
-      expect(results.sort()).toEqual([".hidden", "visible"])
+      expect(results).toEqual([".hidden", "visible"])
     })
 
     test("excludes dotfiles when dot option is false", async () => {
@@ -125,7 +125,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*.txt", { cwd: tmp.path })
 
-      expect(results.sort()).toEqual(["a.txt", "b.txt"])
+      expect(results).toEqual(["a.txt", "b.txt"])
     })
 
     test("respects options", async () => {
@@ -135,7 +135,7 @@ describe("Glob", () => {
 
       const results = Glob.scanSync("*", { cwd: tmp.path, include: "all" })
 
-      expect(results.sort()).toEqual(["file.txt", "subdir"])
+      expect(results).toEqual(["file.txt", "subdir"])
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #14492

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Glob.scan` and `Glob.scanSync` return results in filesystem `readdir` order, which varies across platforms and runs. This affects all callers — not just `loadPlugin`, but also `loadAgent`, `loadMode`, `loadCommand` (in `config.ts`), and custom tool loading (in `tool/registry.ts`).

This PR adds `.sort()` to both `Glob.scan` and `Glob.scanSync` in `util/glob.ts`, fixing the root cause at the utility level so all current and future callers get deterministic alphabetical order.

Also removes redundant `.sort()` calls in the existing glob tests — these were workarounds for the nondeterministic output and now serve as regression tests.

Note: This is an alternative to #14547, which only sorts in `loadPlugin`. This PR fixes the same issue at the source so all 5+ call sites benefit.

### How did you verify your code works?

- Reviewed all call sites of `Glob.scan`/`Glob.scanSync` to confirm none depend on filesystem ordering
- Updated existing glob tests to assert sorted output directly (removed workaround `.sort()` in 6 test assertions)
- `Array.prototype.sort()` is stable and deterministic for string arrays

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR