### PR TITLE
fix(app): correct inverted chevron direction in todo list

### DIFF
--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -87,7 +87,7 @@ export function SessionTodoDock(props: { todos: Todo[]; title: string; collapseL
             icon="chevron-down"
             size="normal"
             variant="ghost"
-            classList={{ "rotate-180": !store.collapsed }}
+            classList={{ "rotate-180": store.collapsed }}
             onMouseDown={(event) => {
               event.preventDefault()
               event.stopPropagation()


### PR DESCRIPTION
### Issue for this PR

Closes #14619

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The todo list chevron was inverted — pointing down when collapsed and up when expanded. Flipped the condition from `!store.collapsed` to `store.collapsed` so the chevron-down icon rotates 180° when collapsed (pointing up) and stays default when expanded (pointing down).

### How did you verify your code works?

Visual inspection of the classList logic against the icon name (`chevron-down`). Default = points down = expanded state. Rotated 180 = points up = collapsed state.

### Screenshots / recordings

_Before: chevron down when collapsed, up when expanded (wrong)_
_After: chevron up when collapsed, down when expanded (correct)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR