### PR TITLE
fix: cleanup SDK event listeners to prevent memory leaks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -3,7 +3,7 @@ import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on, onCleanup } from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
@@ -668,11 +668,11 @@ function App() {
     }
   })
 
-  sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
+  const unsubCommandExecute = sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
     command.trigger(evt.properties.command)
   })
 
-  sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
+  const unsubToastShow = sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
     toast.show({
       title: evt.properties.title,
       message: evt.properties.message,
@@ -681,14 +681,14 @@ function App() {
     })
   })
 
-  sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
+  const unsubSessionSelect = sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
     route.navigate({
       type: "session",
       sessionID: evt.properties.sessionID,
     })
   })
 
-  sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
+  const unsubSessionDeleted = sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
       route.navigate({ type: "home" })
       toast.show({
@@ -698,7 +698,7 @@ function App() {
     }
   })
 
-  sdk.event.on(SessionApi.Event.Error.type, (evt) => {
+  const unsubSessionError = sdk.event.on(SessionApi.Event.Error.type, (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
     const message = (() => {
@@ -720,13 +720,22 @@ function App() {
     })
   })
 
-  sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
+  const unsubUpdateAvailable = sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
     toast.show({
       variant: "info",
       title: "Update Available",
       message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
       duration: 10000,
     })
+  })
+
+  onCleanup(() => {
+    unsubCommandExecute()
+    unsubToastShow()
+    unsubSessionSelect()
+    unsubSessionDeleted()
+    unsubSessionError()
+    unsubUpdateAvailable()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -96,7 +96,7 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
-  sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
+  const unsubPromptAppend = sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
     setTimeout(() => {
@@ -106,6 +106,10 @@ export function Prompt(props: PromptProps) {
       input.gotoBufferEnd()
       renderer.requestRender()
     }, 0)
+  })
+
+  onCleanup(() => {
+    unsubPromptAppend()
   })
 
   createEffect(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,6 +7,7 @@ import {
   For,
   Match,
   on,
+  onCleanup,
   Show,
   Switch,
   useContext,
@@ -204,7 +205,7 @@ export function Session() {
   })
 
   let lastSwitch: string | undefined = undefined
-  sdk.event.on("message.part.updated", (evt) => {
+  const unsubMessagePartUpdated = sdk.event.on("message.part.updated", (evt) => {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
@@ -218,6 +219,10 @@ export function Session() {
       local.agent.set("plan")
       lastSwitch = part.id
     }
+  })
+
+  onCleanup(() => {
+    unsubMessagePartUpdated()
   })
 
   let scroll: ScrollBoxRenderable


### PR DESCRIPTION
## Summary

This PR fixes memory leaks caused by event listeners not being properly cleaned up when TUI components unmount.

## Changes

### app.tsx
- Added `onCleanup` handler for 6 SDK event listeners:
  - `TuiEvent.CommandExecute`
  - `TuiEvent.ToastShow`
  - `TuiEvent.SessionSelect`
  - `SessionApi.Event.Deleted`
  - `SessionApi.Event.Error`
  - `Installation.Event.UpdateAvailable`

### session/index.tsx
- Added `onCleanup` for `message.part.updated` event listener

### prompt/index.tsx
- Added `onCleanup` for `TuiEvent.PromptAppend` event listener

## Why This Matters

Previously, these event listeners were registered in component render but never unregistered. If the TUI remounts these components, duplicate listeners accumulate. Over time with multiple sessions/remounts, this causes memory growth leading to the 98% memory usage reported in the issue.

## Testing

To verify the fix:
1. Build the project: `cd packages/opencode && bun run build`
2. Run opencode TUI
3. Monitor memory with `htop` or Activity Monitor
4. Create and switch between multiple sessions
5. Read files in different sessions
6. Memory should now stay stable instead of growing

You can also use the built-in heap snapshot feature:
- Run `opencode.status` command in TUI
- Select "Write heap snapshot"
- Compare snapshots to verify listener count decreases on component unmount