### PR TITLE
fix(opencode): support interleaved reasoning_content for anthropic protocol non-Claude models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1085,6 +1085,29 @@ export namespace Provider {
           opts.signal = combined
         }
 
+        // For anthropic protocol non-Claude models with interleaved reasoning,
+        // convert thinking blocks to reasoning_content on assistant messages
+        if (
+          typeof model.capabilities.interleaved === "object" &&
+          model.capabilities.interleaved.field &&
+          (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
+          opts.body &&
+          opts.method === "POST"
+        ) {
+          const body = JSON.parse(opts.body as string)
+          if (Array.isArray(body.messages)) {
+            const field = model.capabilities.interleaved.field
+            for (const msg of body.messages) {
+              if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue
+              const thinking = msg.content.filter((b: any) => b.type === "thinking")
+              const rest = msg.content.filter((b: any) => b.type !== "thinking")
+              msg[field] = thinking.map((b: any) => b.thinking).join("") || ""
+              msg.content = rest
+            }
+            opts.body = JSON.stringify(body)
+          }
+        }
+
         // Strip openai itemId metadata following what codex does
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:
         // Message, Reasoning, FunctionCall, LocalShellCall, CustomToolCall, WebSearchCall

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1101,7 +1101,7 @@ export namespace Provider {
               if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue
               const thinking = msg.content.filter((b: any) => b.type === "thinking")
               const rest = msg.content.filter((b: any) => b.type !== "thinking")
-              msg[field] = thinking.map((b: any) => b.thinking).join("") || ""
+              msg[field] = thinking.map((b: any) => b.thinking).join("")
               msg.content = rest
             }
             opts.body = JSON.stringify(body)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -135,36 +135,42 @@ export namespace ProviderTransform {
 
     if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
       const field = model.capabilities.interleaved.field
+      const isAnthropic = model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic"
       return msgs.map((msg) => {
-        if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
-          const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+        if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg
 
-          // Filter out reasoning parts from content
-          const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
+        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
+        const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
-            return {
-              ...msg,
-              content: filteredContent,
-              providerOptions: {
-                ...msg.providerOptions,
-                openaiCompatible: {
-                  ...(msg.providerOptions as any)?.openaiCompatible,
-                  [field]: reasoningText,
+        // For anthropic protocol non-Claude models, inject a fake signature so the SDK
+        // emits thinking blocks. The fetch wrapper converts them to reasoning_content.
+        if (isAnthropic) {
+          const parts = reasoningText
+            ? [
+                {
+                  type: "reasoning" as const,
+                  text: reasoningText,
+                  providerOptions: { anthropic: { signature: "interleaved-placeholder" } },
                 },
-              },
-            }
-          }
-
-          return {
-            ...msg,
-            content: filteredContent,
-          }
+                ...filteredContent,
+              ]
+            : msg.content
+          return { ...msg, content: parts }
         }
 
-        return msg
+        if (!reasoningText) return { ...msg, content: filteredContent }
+        return {
+          ...msg,
+          content: filteredContent,
+          providerOptions: {
+            ...msg.providerOptions,
+            openaiCompatible: {
+              ...(msg.providerOptions as any)?.openaiCompatible,
+              [field]: reasoningText,
+            },
+          },
+        }
       })
     }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -139,30 +139,33 @@ export namespace ProviderTransform {
       return msgs.map((msg) => {
         if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg
 
-        const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
-        const reasoningText = reasoningParts.map((part: any) => part.text).join("")
-        const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
+        const reasoningText = msg.content
+          .filter((part: any) => part.type === "reasoning")
+          .map((part: any) => part.text)
+          .join("")
+        if (!reasoningText) return msg
+
+        const filtered = msg.content.filter((part: any) => part.type !== "reasoning")
 
         // For anthropic protocol non-Claude models, inject a fake signature so the SDK
         // emits thinking blocks. The fetch wrapper converts them to reasoning_content.
         if (isAnthropic) {
-          const parts = reasoningText
-            ? [
-                {
-                  type: "reasoning" as const,
-                  text: reasoningText,
-                  providerOptions: { anthropic: { signature: "interleaved-placeholder" } },
-                },
-                ...filteredContent,
-              ]
-            : msg.content
-          return { ...msg, content: parts }
+          return {
+            ...msg,
+            content: [
+              {
+                type: "reasoning" as const,
+                text: reasoningText,
+                providerOptions: { anthropic: { signature: "interleaved-placeholder" } },
+              },
+              ...filtered,
+            ],
+          }
         }
 
-        if (!reasoningText) return { ...msg, content: filteredContent }
         return {
           ...msg,
-          content: filteredContent,
+          content: filtered,
           providerOptions: {
             ...msg.providerOptions,
             openaiCompatible: {


### PR DESCRIPTION
### Issue for this PR

Closes #14638

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When non-Claude models (e.g. kimi-k2.5) are used via the Anthropic SDK (`@ai-sdk/anthropic` / `@ai-sdk/google-vertex/anthropic`) with `interleaved` reasoning enabled, previous assistant messages containing reasoning content fail to round-trip correctly. The Anthropic SDK doesn't natively support a `reasoning_content` field on messages — it only serializes `thinking` blocks.

This PR fixes it with a two-phase approach:

1. **`transform.ts`**: Converts stored `reasoning` parts into `thinking` blocks with a placeholder signature, so the Anthropic SDK will serialize them into the request body.
2. **`provider.ts` (fetch wrapper)**: Intercepts the outgoing HTTP request, extracts the `thinking` blocks from assistant messages, and moves them to the top-level `reasoning_content` (or `reasoning_details`) field that the upstream API expects.

> **Note**: This is a workaround. The proper fix is proposed in #14641, which adds upstream SDK support for spreading `providerOptions.anthropic` onto assistant messages (vercel/ai#12760). Once that lands, this workaround can be reverted in favor of the cleaner approach.

### How did you verify your code works?

- Typecheck passes (`bun turbo typecheck` — all 12 packages green)
- Test suite passes (1135 pass, 1 unrelated timeout)
- Manually verified with kimi-k2.5 via Anthropic SDK: reasoning content from previous turns is now correctly sent as `reasoning_content` on assistant messages

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR