### PR TITLE
fix(opencode): use api.npm to detect Anthropic SDK for cache control

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -194,7 +194,9 @@ export namespace ProviderTransform {
     }
 
     for (const msg of unique([...system, ...final])) {
-      const useMessageLevelOptions = model.providerID === "anthropic" || model.providerID.includes("bedrock")
+      const isAnthropicSdk =
+        model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic"
+      const useMessageLevelOptions = isAnthropicSdk || model.providerID.includes("bedrock")
       const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
 
       if (shouldUseContentOptions) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1527,6 +1527,34 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
     })
   })
+
+  test("non-claude model via @ai-sdk/anthropic uses message-level cache control", () => {
+    const model = createModel({
+      id: "kimi/kimi-k2.5",
+      providerID: "kimi",
+      api: {
+        id: "kimi-k2.5",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const msgs = [
+      {
+        role: "system",
+        content: "You are a helpful assistant",
+      },
+      {
+        role: "user",
+        content: "Hello",
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+
+    expect(result[0].providerOptions?.anthropic?.cacheControl).toEqual({
+      type: "ephemeral",
+    })
+  })
 })
 
 describe("ProviderTransform.variants", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #14642

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `applyCaching` function incorrectly used `model.providerID === "anthropic"` to detect Anthropic SDK models. This fails for non-Claude models (e.g. kimi-k2.5) that use `@ai-sdk/anthropic` but have a different `providerID`.

Changed detection to use `model.api.npm`:
```ts
const isAnthropicSdk = model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic"
const useMessageLevelOptions = isAnthropicSdk || model.providerID.includes("bedrock")
```

### How did you verify your code works?

- Typecheck passes (`bun turbo typecheck`)
- 104 tests pass (including new test for kimi-k2.5 scenario)

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR