### PR TITLE
fix(opencode): prevent Copilot 400 when tool description is empty

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-prepare-tools.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-prepare-tools.ts
@@ -50,7 +50,7 @@ export function prepareTools({
         type: "function",
         function: {
           name: tool.name,
-          description: tool.description,
+          description: tool.description?.trim() ? tool.description : undefined,
           parameters: tool.inputSchema,
         },
       })

--- a/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
@@ -1,6 +1,6 @@
 import { OpenAICompatibleChatLanguageModel } from "@/provider/sdk/copilot/chat/openai-compatible-chat-language-model"
 import { describe, test, expect, mock } from "bun:test"
-import type { LanguageModelV2Prompt } from "@ai-sdk/provider"
+import type { JSONSchema7, LanguageModelV2Prompt } from "@ai-sdk/provider"
 
 async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promise<T[]> {
   const reader = stream.getReader()
@@ -536,10 +536,18 @@ describe("doStream", () => {
 })
 
 describe("request body", () => {
-  test("should send tools in OpenAI format", async () => {
-    let capturedBody: unknown
+  const inputSchema: JSONSchema7 = {
+    type: "object",
+    properties: {
+      location: { type: "string" },
+    },
+    required: ["location"],
+  }
+
+  async function tools(description: string) {
+    let body: { tools: unknown[] } | undefined
     const mockFetch = mock(async (_url: string, init?: RequestInit) => {
-      capturedBody = JSON.parse(init?.body as string)
+      body = JSON.parse(init?.body as string)
       return new Response(
         new ReadableStream({
           start(controller) {
@@ -552,41 +560,41 @@ describe("request body", () => {
     })
 
     const model = createModel(mockFetch)
-
     await model.doStream({
       prompt: TEST_PROMPT,
       tools: [
         {
           type: "function",
           name: "get_weather",
-          description: "Get the weather for a location",
-          inputSchema: {
-            type: "object",
-            properties: {
-              location: { type: "string" },
-            },
-            required: ["location"],
-          },
+          description,
+          inputSchema,
         },
       ],
       includeRawChunks: false,
     })
+    return body?.tools ?? []
+  }
 
-    expect((capturedBody as { tools: unknown[] }).tools).toEqual([
+  test("should send tools in OpenAI format", async () => {
+    expect(await tools("Get the weather for a location")).toEqual([
       {
         type: "function",
         function: {
           name: "get_weather",
           description: "Get the weather for a location",
-          parameters: {
-            type: "object",
-            properties: {
-              location: { type: "string" },
-            },
-            required: ["location"],
-          },
+          parameters: inputSchema,
         },
       },
     ])
+  })
+
+  test("should omit function description when it is empty", async () => {
+    const body = await tools("")
+    expect((body[0] as { function: { description?: string } })?.function).not.toHaveProperty("description")
+  })
+
+  test("should omit function description when it is whitespace only", async () => {
+    const body = await tools("   ")
+    expect((body[0] as { function: { description?: string } })?.function).not.toHaveProperty("description")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #14488

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Copilot request validation failure when an MCP/OpenAI-compatible tool has an empty description.

Sending `tools[].function.description: ""` to Copilot Chat Completions returns `HTTP 400 Bad Request` (reproduced on 2026-02-22), while omitting `function.description` returns `HTTP 200`. Because the field is optional in Copilot SDK types, this PR normalizes empty/whitespace descriptions to `undefined` (field omission) instead of injecting synthetic text like `No description`. This keeps the original tool meaning and removes the 400 failure:

- `Tool.description?: string`  
  https://github.com/github/copilot-sdk/blob/main/nodejs/src/types.ts#L144
- `defineTool(..., { description?: string, ... })`  
  https://github.com/github/copilot-sdk/blob/main/nodejs/src/types.ts#L158

This PR omits empty/whitespace `function.description` values and adds two tests.

Changed code:
- `packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-prepare-tools.ts:53`
- `packages/opencode/test/provider/copilot/copilot-chat-model.test.ts:591`
- `packages/opencode/test/provider/copilot/copilot-chat-model.test.ts:596`

### How did you verify your code works?

Verification date: 2026-02-22

1. Reproduced issue with Copilot API (`claude-sonnet-4.6`, `stream=true`):
   - request with `function.description=""` -> `HTTP 400` (`Bad Request`)
2. Verified fix behavior:
   - same request with `function.description` omitted -> `HTTP 200` (SSE stream starts)
3. Ran local tests:
   - `bun test test/provider/copilot/copilot-chat-model.test.ts` (run from `packages/opencode`)
   - Result: `13 pass, 0 fail`
4. Reproduction + validation commands used:

```bash
cd <repo-root>
tok=$(gh auth token)

code=$(curl -sS -o /tmp/copilot_empty.txt -w "%{http_code}" https://api.githubcopilot.com/chat/completions \
  -H "Authorization: Bearer $tok" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t","description":"","parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}],"tool_choice":"auto","stream":true}')
echo "empty_description_status=$code"
head -n 3 /tmp/copilot_empty.txt

code=$(curl -sS -o /tmp/copilot_omit.txt -w "%{http_code}" https://api.githubcopilot.com/chat/completions \
  -H "Authorization: Bearer $tok" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-4.6","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"t","parameters":{"type":"object","properties":{"x":{"type":"string"}}}}}],"tool_choice":"auto","stream":true}')
echo "omit_description_status=$code"
head -n 3 /tmp/copilot_omit.txt

cd packages/opencode
bun test test/provider/copilot/copilot-chat-model.test.ts
```

### Screenshots / recordings

_N/A - no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR