### PR TITLE
fix: resolve memory leak issues across multiple subsystems

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -252,7 +252,12 @@ export function applyDirectoryEvent(input: {
           const part = draft[result.index]
           const field = props.field as keyof typeof part
           const existing = part[field] as string | undefined
-          ;(part[field] as string) = (existing ?? "") + props.delta
+          const MAX_PART_STRING_LENGTH = 1_048_576 // 1 MB per part field
+          const combined = (existing ?? "") + props.delta
+          ;(part[field] as string) =
+            combined.length > MAX_PART_STRING_LENGTH
+              ? combined.slice(combined.length - MAX_PART_STRING_LENGTH)
+              : combined
         }),
       )
       break

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -3,7 +3,7 @@ import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, onCleanup, batch, Show, on } from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
@@ -668,11 +668,11 @@ function App() {
     }
   })
 
-  sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
+  const unsub1 = sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
     command.trigger(evt.properties.command)
   })
 
-  sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
+  const unsub2 = sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
     toast.show({
       title: evt.properties.title,
       message: evt.properties.message,
@@ -681,14 +681,14 @@ function App() {
     })
   })
 
-  sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
+  const unsub3 = sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
     route.navigate({
       type: "session",
       sessionID: evt.properties.sessionID,
     })
   })
 
-  sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
+  const unsub4 = sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
       route.navigate({ type: "home" })
       toast.show({
@@ -698,7 +698,7 @@ function App() {
     }
   })
 
-  sdk.event.on(SessionApi.Event.Error.type, (evt) => {
+  const unsub5 = sdk.event.on(SessionApi.Event.Error.type, (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
     const message = (() => {
@@ -720,13 +720,22 @@ function App() {
     })
   })
 
-  sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
+  const unsub6 = sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
     toast.show({
       variant: "info",
       title: "Update Available",
       message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
       duration: 10000,
     })
+  })
+
+  onCleanup(() => {
+    unsub1()
+    unsub2()
+    unsub3()
+    unsub4()
+    unsub5()
+    unsub6()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -96,7 +96,7 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
-  sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
+  const unsubPromptAppend = sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
     setTimeout(() => {
@@ -107,6 +107,7 @@ export function Prompt(props: PromptProps) {
       renderer.requestRender()
     }, 0)
   })
+  onCleanup(unsubPromptAppend)
 
   createEffect(() => {
     if (props.disabled) input.cursorColor = theme.backgroundElement

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,6 +7,7 @@ import {
   For,
   Match,
   on,
+  onCleanup,
   Show,
   Switch,
   useContext,
@@ -204,7 +205,7 @@ export function Session() {
   })
 
   let lastSwitch: string | undefined = undefined
-  sdk.event.on("message.part.updated", (evt) => {
+  const unsubPartUpdated = sdk.event.on("message.part.updated", (evt) => {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
@@ -219,6 +220,7 @@ export function Session() {
       lastSwitch = part.id
     }
   })
+  onCleanup(unsubPartUpdated)
 
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -48,6 +48,7 @@ export namespace LSPClient {
       new StreamMessageWriter(input.server.process.stdin as any),
     )
 
+    const MAX_DIAGNOSTICS_FILES = 2_000
     const diagnostics = new Map<string, Diagnostic[]>()
     connection.onNotification("textDocument/publishDiagnostics", (params) => {
       const filePath = Filesystem.normalizePath(fileURLToPath(params.uri))
@@ -56,6 +57,11 @@ export namespace LSPClient {
         count: params.diagnostics.length,
       })
       const exists = diagnostics.has(filePath)
+      if (!exists && diagnostics.size >= MAX_DIAGNOSTICS_FILES) {
+        // Evict the oldest entry to stay within the size limit
+        const oldest = diagnostics.keys().next().value
+        if (oldest !== undefined) diagnostics.delete(oldest)
+      }
       diagnostics.set(filePath, params.diagnostics)
       if (!exists && input.serverID === "typescript") return
       Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
@@ -132,6 +138,7 @@ export namespace LSPClient {
       })
     }
 
+    const MAX_OPEN_FILES = 1_000
     const files: {
       [path: string]: number
     } = {}
@@ -191,6 +198,11 @@ export namespace LSPClient {
 
           log.info("textDocument/didOpen", input)
           diagnostics.delete(input.path)
+          // Evict oldest tracked file if we're at the limit
+          if (Object.keys(files).length >= MAX_OPEN_FILES) {
+            const oldest = Object.keys(files)[0]
+            if (oldest) delete files[oldest]
+          }
           await connection.sendNotification("textDocument/didOpen", {
             textDocument: {
               uri: pathToFileURL(input.path).href,

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -150,6 +150,27 @@ export namespace MCP {
   // Store transports for OAuth servers to allow finishing auth
   type TransportWithAuth = StreamableHTTPClientTransport | SSEClientTransport
   const pendingOAuthTransports = new Map<string, TransportWithAuth>()
+  const pendingOAuthTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const OAUTH_TRANSPORT_TTL_MS = 5 * 60 * 1_000 // 5 minutes
+
+  function setPendingOAuthTransport(key: string, transport: TransportWithAuth) {
+    const existing = pendingOAuthTimers.get(key)
+    if (existing) clearTimeout(existing)
+    pendingOAuthTransports.set(key, transport)
+    const timer = setTimeout(() => {
+      pendingOAuthTransports.delete(key)
+      pendingOAuthTimers.delete(key)
+      log.info("evicted stale pending OAuth transport", { key })
+    }, OAUTH_TRANSPORT_TTL_MS)
+    pendingOAuthTimers.set(key, timer)
+  }
+
+  function deletePendingOAuthTransport(key: string) {
+    const timer = pendingOAuthTimers.get(key)
+    if (timer) clearTimeout(timer)
+    pendingOAuthTimers.delete(key)
+    pendingOAuthTransports.delete(key)
+  }
 
   // Prompt cache types
   type PromptInfo = Awaited<ReturnType<MCPClient["listPrompts"]>>["prompts"][number]
@@ -205,6 +226,8 @@ export namespace MCP {
           }),
         ),
       )
+      for (const timer of pendingOAuthTimers.values()) clearTimeout(timer)
+      pendingOAuthTimers.clear()
       pendingOAuthTransports.clear()
     },
   )
@@ -378,7 +401,7 @@ export namespace MCP {
               }).catch((e) => log.debug("failed to show toast", { error: e }))
             } else {
               // Store transport for later finishAuth call
-              pendingOAuthTransports.set(key, transport)
+              setPendingOAuthTransport(key, transport)
               status = { status: "needs_auth" as const }
               // Show toast for needs_auth
               Bus.publish(TuiEvent.ToastShow, {
@@ -772,7 +795,7 @@ export namespace MCP {
     } catch (error) {
       if (error instanceof UnauthorizedError && capturedUrl) {
         // Store transport for finishAuth
-        pendingOAuthTransports.set(mcpName, transport)
+        setPendingOAuthTransport(mcpName, transport)
         return { authorizationUrl: capturedUrl.toString() }
       }
       throw error
@@ -879,7 +902,7 @@ export namespace MCP {
       }
 
       // Re-add the MCP server to establish connection
-      pendingOAuthTransports.delete(mcpName)
+      deletePendingOAuthTransport(mcpName)
       const result = await add(mcpName, mcpConfig)
 
       const statusRecord = result.status as Record<string, Status>
@@ -899,7 +922,7 @@ export namespace MCP {
   export async function removeAuth(mcpName: string): Promise<void> {
     await McpAuth.remove(mcpName)
     McpOAuthCallback.cancelPending(mcpName)
-    pendingOAuthTransports.delete(mcpName)
+    deletePendingOAuthTransport(mcpName)
     await McpAuth.clearOAuthState(mcpName)
     log.info("removed oauth credentials", { mcpName })
   }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -283,4 +283,18 @@ export namespace PermissionNext {
     const s = await state()
     return Object.values(s.pending).map((x) => x.info)
   }
+
+  export async function clearSession(sessionID: string) {
+    const s = await state()
+    for (const [id, pending] of Object.entries(s.pending)) {
+      if (pending.info.sessionID !== sessionID) continue
+      delete s.pending[id]
+      pending.reject(new RejectedError())
+      Bus.publish(Event.Replied, {
+        sessionID,
+        requestID: id,
+        reply: "reject",
+      })
+    }
+  }
 }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -91,6 +91,11 @@ export namespace SessionCompaction {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()
+          // Clear tool output and attachments from both DB and in-memory store.
+          // toModelMessages already substitutes "[Old tool result content cleared]"
+          // for compacted parts, so this aligns stored data with model behavior.
+          part.state.output = "[compacted]"
+          part.state.attachments = undefined
           await Session.updatePart(part)
         }
       }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -653,6 +653,7 @@ export namespace Session {
         await remove(child.id)
       }
       await unshare(sessionID).catch(() => {})
+      await PermissionNext.clearSession(sessionID).catch(() => {})
       // CASCADE delete handles messages and parts automatically
       Database.use((db) => {
         db.delete(SessionTable).where(eq(SessionTable.id, sessionID)).run()

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -152,6 +152,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         "</task_result>",
       ].join("\n")
 
+      // Clean up subagent session to free in-memory state (messages, parts,
+      // event listeners). The task output has already been captured above.
+      // If the LLM later tries to resume via task_id, Session.get() will
+      // fail gracefully and a fresh session will be created instead.
+      Session.remove(session.id).catch(() => {})
+
       return {
         title: params.description,
         metadata: {

--- a/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
@@ -119,10 +119,16 @@ export const createSseClient = <TData = unknown>({
 
         signal.addEventListener("abort", abortHandler)
 
+        const MAX_BUFFER_SIZE = 10_485_760 // 10 MB
         try {
           while (true) {
             const { done, value } = await reader.read()
             if (done) break
+            if (buffer.length + value.length > MAX_BUFFER_SIZE) {
+              throw new Error(
+                `SSE buffer overflow: accumulated ${buffer.length + value.length} bytes (limit ${MAX_BUFFER_SIZE})`,
+              )
+            }
             buffer += value
 
             const chunks = buffer.split("\n\n")

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -75,10 +75,14 @@ export async function createOpencodeServer(options?: ServerOptions) {
       reject(error)
     })
     if (options.signal) {
-      options.signal.addEventListener("abort", () => {
-        clearTimeout(id)
-        reject(new Error("Aborted"))
-      })
+      options.signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(id)
+          reject(new Error("Aborted"))
+        },
+        { once: true },
+      )
     }
   })
 

--- a/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
@@ -146,10 +146,16 @@ export const createSseClient = <TData = unknown>({
 
         signal.addEventListener("abort", abortHandler)
 
+        const MAX_BUFFER_SIZE = 10_485_760 // 10 MB
         try {
           while (true) {
             const { done, value } = await reader.read()
             if (done) break
+            if (buffer.length + value.length > MAX_BUFFER_SIZE) {
+              throw new Error(
+                `SSE buffer overflow: accumulated ${buffer.length + value.length} bytes (limit ${MAX_BUFFER_SIZE})`,
+              )
+            }
             buffer += value
             // Normalize line endings: CRLF -> LF, then CR -> LF
             buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n")

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -75,10 +75,14 @@ export async function createOpencodeServer(options?: ServerOptions) {
       reject(error)
     })
     if (options.signal) {
-      options.signal.addEventListener("abort", () => {
-        clearTimeout(id)
-        reject(new Error("Aborted"))
-      })
+      options.signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(id)
+          reject(new Error("Aborted"))
+        },
+        { once: true },
+      )
     }
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #9385
Relates to #7046, #9151

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes 10 of the 15 memory leak sources tracked across issues #9385, #7046, #9151, and PR #14635. The two dominant drivers of unbounded RSS growth were subagent sessions never being deallocated (I-9385-A) and message delta strings accumulating without any cap (event-reducer). Together these caused observed GB-scale growth in long-running sessions.

**Changes by file:**

**Subagent deallocation** (`tool/task.ts`) — Call `Session.remove()` after extracting the subagent task output. This fires `session.deleted`, which triggers the existing `cleanupSessionCaches()` in the event-reducer, freeing all in-memory messages, parts, and status entries for completed subagent sessions. Resume via `task_id` degrades gracefully (creates a fresh session).

**Delta string cap** (`event-reducer.ts`) — Cap accumulated part field strings at 1 MB. On overflow the oldest bytes are dropped via `slice()`. This was the single largest contributor to absolute heap size.

**Tool output on compact** (`compaction.ts`) — When `prune()` compacts tool parts, clear `state.output` and `state.attachments` from both the DB row and in-memory store. `toModelMessages` already substituted placeholder text for compacted parts; this aligns stored data with that behavior.

**SSE buffer guard** (`serverSentEvents.gen.ts`, v1 + v2) — Add a 10 MB `MAX_BUFFER_SIZE` check before each `buffer += value`. Throws on overflow instead of growing unbounded during stalled or malformed streams.

**MCP OAuth transport TTL** (`mcp/index.ts`) — Replace bare `Map.set/delete` with helpers that attach a 5-minute auto-eviction timer per pending OAuth transport entry. Stale entries from failed or abandoned auth flows are cleaned up automatically.

**Pending permissions cleanup** (`permission/next.ts`, `session/index.ts`) — Add `PermissionNext.clearSession()` which rejects and removes all pending permission requests for a given session. Called from `Session.remove()` before the DB delete, so subagent sessions no longer leave dangling permission entries.

**TUI event listener cleanup** (`app.tsx`, `routes/session/index.tsx`, `component/prompt/index.tsx`) — Save the unsubscribe functions returned by all 8 `sdk.event.on()` calls across these three components and call them in `onCleanup()`. Previously `onCleanup` was not even imported in `app.tsx`. The session and prompt components mount/unmount during navigation, so each navigation was adding duplicate listeners.

**LSP diagnostics cap** (`lsp/client.ts`) — Enforce a 2,000-file cap on the diagnostics `Map` and a 1,000-file cap on the open-files tracking object. FIFO eviction on overflow.

**AbortSignal listener** (`sdk/js server.ts`, v1 + v2) — Pass `{ once: true }` to the abort listener added during startup so it self-removes after firing.

### How did you verify your code works?

Built a standalone binary (`./packages/opencode/script/build.ts --single`) and ran it against a real project for 2.5 hours with continuous subagent tasks, multi-step tool use, and session switching. Monitored RSS every 10 seconds (875 samples).

Results:
- **Active work phase** (first 20 min): RSS grew from 1,889 → 2,507 MB during heavy subagent + tool activity
- **Post-activity**: RSS stabilized at ~2,501-2,515 MB and held flat for over 2 hours
- **Subsequent active bursts**: Brief spikes (up to 2,572 MB) returned to baseline within minutes
- **Net drift over 2.5 hours idle+active**: ~8 MB (normal GC-managed creep, not a leak)
- **VSZ completely flat** at 80,467 MB after initial loading — no new virtual memory allocation

The previous behavior (per issue reports) showed continuous unbounded growth toward 25+ GB RSS under similar workloads.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR