### PR TITLE
fix(app): implement ctrl-y yank for killed text in prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -58,6 +58,8 @@ export type PromptRef = {
 const PLACEHOLDERS = ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"]
 const SHELL_PLACEHOLDERS = ["ls -la", "git status", "pwd"]
 
+let killRing = ""
+
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
@@ -833,6 +835,29 @@ export function Prompt(props: PromptProps) {
               keyBindings={textareaKeybindings()}
               onKeyDown={async (e) => {
                 if (props.disabled) {
+                  e.preventDefault()
+                  return
+                }
+                if (keybind.match("input_delete_to_line_end", e)) {
+                  const text = input.plainText
+                  const offset = input.cursorOffset
+                  const nextNewline = text.indexOf("\n", offset)
+                  const endOfLine = nextNewline === -1 ? text.length : nextNewline
+                  const killed = offset === endOfLine && nextNewline !== -1 ? "\n" : text.slice(offset, endOfLine)
+                  if (killed) killRing = killed
+                }
+                if (keybind.match("input_delete_to_line_start", e)) {
+                  const text = input.plainText
+                  const offset = input.cursorOffset
+                  const prevNewline = text.lastIndexOf("\n", offset - 1)
+                  const startOfLine = prevNewline === -1 ? 0 : prevNewline + 1
+                  const killed = text.slice(startOfLine, offset)
+                  if (killed) killRing = killed
+                }
+                if (keybind.match("input_yank", e)) {
+                  if (killRing) {
+                    input.insertText(killRing)
+                  }
                   e.preventDefault()
                   return
                 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -880,6 +880,7 @@ export namespace Config {
       input_delete_line: z.string().optional().default("ctrl+shift+d").describe("Delete line in input"),
       input_delete_to_line_end: z.string().optional().default("ctrl+k").describe("Delete to end of line in input"),
       input_delete_to_line_start: z.string().optional().default("ctrl+u").describe("Delete to start of line in input"),
+      input_yank: z.string().optional().default("ctrl+y").describe("Yank killed text in input"),
       input_backspace: z.string().optional().default("backspace,shift+backspace").describe("Backspace in input"),
       input_delete: z.string().optional().default("ctrl+d,delete,shift+delete").describe("Delete character in input"),
       input_undo: z.string().optional().default("ctrl+-,super+z").describe("Undo in input"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1296,6 +1296,10 @@ export type KeybindsConfig = {
    */
   input_delete_to_line_start?: string
   /**
+   * Yank killed text in input
+   */
+  input_yank?: string
+  /**
    * Backspace in input
    */
   input_backspace?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9030,6 +9030,11 @@
             "default": "ctrl+u",
             "type": "string"
           },
+          "input_yank": {
+            "description": "Yank killed text in input",
+            "default": "ctrl+y",
+            "type": "string"
+          },
           "input_backspace": {
             "description": "Backspace in input",
             "default": "backspace,shift+backspace",


### PR DESCRIPTION
### Issue for this PR

Closes #14577

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ctrl-k and ctrl-u kill text but it just disappears. There's no way to get it back with ctrl-y because nothing stores the killed text and no yank keybind exists.

The proper fix would probably be a kill ring inside opentui's textarea so every textarea in the app gets it for free. This takes the quicker route and handles it at the app level instead. Before the textarea processes a ctrl-k/ctrl-u, the `onKeyDown` handler grabs the text that's about to be deleted and stashes it. ctrl-y reads it back and inserts it. Happy to move this into opentui if that's preferred.

Also added `input_yank` to the keybinds config/schema/openapi so it's user-configurable like the other input bindings.

### How did you verify your code works?

- Ran `bun run dev` from `packages/opencode`, typed stuff, ctrl-a, ctrl-k, ctrl-y. Works
- ctrl-u then ctrl-y also works
- `bun turbo typecheck` passes

### Screenshots / recordings

No UI changes, keyboard behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR