### PR TITLE
feat: add Kimi Code OAuth auth plugin (Device Flow)

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -12,6 +12,7 @@ import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-auth"
+import { KimiAuthPlugin } from "./kimi"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -19,7 +20,7 @@ export namespace Plugin {
   const BUILTIN = ["opencode-anthropic-auth@0.0.13"]
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin]
+  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, KimiAuthPlugin]
 
   const state = Instance.state(async () => {
     const client = createOpencodeClient({

--- a/packages/opencode/src/plugin/kimi.ts
+++ b/packages/opencode/src/plugin/kimi.ts
@@ -1,0 +1,163 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { Installation } from "@/installation"
+
+const CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+const OAUTH_HOST = "https://auth.kimi.com"
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+
+export async function KimiAuthPlugin(input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "kimi-for-coding",
+      async loader(getAuth, provider) {
+        const info = await getAuth()
+        if (!info || info.type !== "oauth") return {}
+
+        if (provider?.models) {
+          for (const model of Object.values(provider.models)) {
+            model.cost = { input: 0, output: 0, cache: { read: 0, write: 0 } }
+          }
+        }
+
+        return {
+          apiKey: info.access,
+          async fetch(request: RequestInfo | URL, init?: RequestInit) {
+            const auth = await getAuth()
+            if (auth.type !== "oauth") return fetch(request, init)
+
+            if (!auth.access || auth.expires < Date.now()) {
+              const res = await fetch(`${OAUTH_HOST}/api/oauth/token`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  "X-Msh-Platform": "opencode",
+                },
+                body: JSON.stringify({
+                  client_id: CLIENT_ID,
+                  refresh_token: auth.refresh,
+                  grant_type: "refresh_token",
+                }),
+              })
+
+              if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`)
+
+              const tokens = (await res.json()) as {
+                access_token: string
+                refresh_token: string
+                expires_in?: number
+              }
+
+              await input.client.auth.set({
+                path: { id: "kimi-for-coding" },
+                body: {
+                  type: "oauth",
+                  refresh: tokens.refresh_token,
+                  access: tokens.access_token,
+                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                },
+              })
+
+              auth.access = tokens.access_token
+            }
+
+            const headers = new Headers(init?.headers as HeadersInit)
+            headers.set("Authorization", `Bearer ${auth.access}`)
+            return fetch(request, { ...init, headers })
+          },
+        }
+      },
+      methods: [
+        {
+          type: "oauth",
+          label: "Login with Kimi Code",
+          async authorize() {
+            const deviceResponse = await fetch(`${OAUTH_HOST}/api/oauth/device_authorization`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-Msh-Platform": "opencode",
+                "User-Agent": `opencode/${Installation.VERSION}`,
+              },
+              body: JSON.stringify({ client_id: CLIENT_ID }),
+            })
+
+            if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
+
+            const deviceData = (await deviceResponse.json()) as {
+              verification_uri: string
+              verification_uri_complete: string
+              user_code: string
+              device_code: string
+              interval: number
+              expires_in: number
+            }
+
+            return {
+              url: deviceData.verification_uri_complete || deviceData.verification_uri,
+              instructions: `Enter code: ${deviceData.user_code}`,
+              method: "auto" as const,
+              async callback() {
+                const interval = (deviceData.interval || 5) * 1000
+
+                while (true) {
+                  const response = await fetch(`${OAUTH_HOST}/api/oauth/token`, {
+                    method: "POST",
+                    headers: {
+                      "Content-Type": "application/json",
+                      "X-Msh-Platform": "opencode",
+                      "User-Agent": `opencode/${Installation.VERSION}`,
+                    },
+                    body: JSON.stringify({
+                      client_id: CLIENT_ID,
+                      device_code: deviceData.device_code,
+                      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+                    }),
+                  })
+
+                  if (response.ok) {
+                    const data = (await response.json()) as {
+                      access_token: string
+                      refresh_token: string
+                      expires_in?: number
+                    }
+                    return {
+                      type: "success" as const,
+                      refresh: data.refresh_token,
+                      access: data.access_token,
+                      expires: Date.now() + (data.expires_in ?? 3600) * 1000,
+                    }
+                  }
+
+                  const error = (await response.json().catch(() => ({ error: "unknown" }))) as {
+                    error?: string
+                    interval?: number
+                  }
+
+                  if (error.error === "authorization_pending") {
+                    await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
+                    continue
+                  }
+
+                  if (error.error === "slow_down") {
+                    await Bun.sleep(
+                      (error.interval ?? deviceData.interval + 5) * 1000 + OAUTH_POLLING_SAFETY_MARGIN_MS,
+                    )
+                    continue
+                  }
+
+                  if (error.error) return { type: "failed" as const }
+
+                  await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "Manually enter API Key",
+          type: "api",
+        },
+      ],
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Add built-in OAuth auth plugin for `kimi-for-coding` provider using RFC 8628 Device Authorization Grant
- Users can now run `opencode auth kimi-for-coding` and select "Login with Kimi Code" for browser-based OAuth login (same flow as GitHub Copilot auth)
- API key fallback ("Manually enter API Key") is also available

## Details

### New file: `packages/opencode/src/plugin/kimi.ts`

Implements the `KimiAuthPlugin` following the same pattern as `copilot.ts` (Device Flow):

1. **Device Authorization** → `POST https://auth.kimi.com/api/oauth/device_authorization`
2. **Token Polling** → `POST https://auth.kimi.com/api/oauth/token` with `grant_type: urn:ietf:params:oauth:grant-type:device_code`
3. **Token Refresh** → automatic refresh via custom `fetch` wrapper when token expires
4. **Cost zeroing** → subscription models show $0 cost (included with Kimi Code subscription)

OAuth endpoints and client ID sourced from [kimi-cli KLIP-14](https://github.com/MoonshotAI/kimi-cli/blob/main/klips/klip-14-kimi-code-oauth-login.md) and [oauth.py](https://github.com/MoonshotAI/kimi-cli/blob/main/src/kimi_cli/auth/oauth.py).

### Modified file: `packages/opencode/src/plugin/index.ts`

- Import `KimiAuthPlugin`
- Register in `INTERNAL_PLUGINS` array

### Verification

- `bun run typecheck` passes (12/12 tasks successful)
- No new dependencies added
- No `as any` or `@ts-ignore` introduced