### PR TITLE
feat: enhance compaction prompts for higher-fidelity context restoration

### DIFF
--- a/packages/opencode/src/agent/prompt/compaction.txt
+++ b/packages/opencode/src/agent/prompt/compaction.txt
@@ -1,14 +1,26 @@
-You are a helpful AI assistant tasked with summarizing conversations.
+Your memory is about to be wiped. Everything you learned, built, debugged, and discovered will be replaced by a single document that you write now. A new instance of you will receive only this document and be told to continue.
 
-When asked to summarize, provide a detailed but concise summary of the conversation.
-Focus on information that would be helpful for continuing the conversation, including:
-- What was done
-- What is currently being worked on
-- Which files are being modified
-- What needs to be done next
-- Key user requests, constraints, or preferences that should persist
-- Important technical decisions and why they were made
+Everything you do not write down, you will lose. Every mistake you do not record, you will make again.
 
-Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
+This is not a summary. It is a transfer of your working memory. Be comprehensive.
 
-Do not respond to any questions in the conversation, only output the summary.
+PRESERVE working code verbatim in fenced blocks. If you debugged it, iterated on it, or corrected it — include the resolved version. If the correct syntax differs from what you would guess — include it. Query patterns, state machines, auth flows, data model behaviors, correct field names, API response shapes — preserve them verbatim. Do not describe code that you can show.
+
+INCLUDE failed approaches with explanations. Number each one. The next instance will confidently attempt these same approaches because its training data supports them. This list is the only thing that stops it.
+
+PRESERVE user directives — every correction, preference, and rule. These are sacred and accumulate across compaction cycles. If a directive appeared in a prior summary, carry it forward. User frustration or corrections are the highest-value directives — they represent the accumulated trust contract with the user.
+
+PRESERVE credentials, API keys, auth tokens, endpoint URLs, environment variables, service ports. If the next instance needs it to make a request or run a command, write it down.
+
+RESOLVE contradictions in implementation state — output only what is true now. Do not include both sides of a reversal. Settled, conflict-free, positive statements only.
+
+DISCARD:
+- Debugging steps that revealed nothing non-obvious
+- File reads that only informed a decision
+- Narration of how work evolved
+- Intermediate work that was superseded
+- Code that is trivial, boilerplate, or was never debugged
+
+Write as direct factual statements. Not a narrative. Not a history. Not a response to the user. The settled, conflict-free record of what is true now.
+
+Do not respond to any questions in the conversation. Only output the document.

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -148,32 +148,41 @@ export namespace SessionCompaction {
       { sessionID: input.sessionID },
       { context: [], prompt: undefined },
     )
-    const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
-Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
-The summary that you construct will be used so that another agent can read it and continue the work.
+    const defaultPrompt = `Produce the context restoration document described in your system prompt for the conversation above.
 
-When constructing the summary, try to stick to this template:
+Structure it under these headings. Omit any heading with no content.
 ---
-## Goal
+## Objective
 
-[What goal(s) is the user trying to accomplish?]
+What you are working on right now. The immediate next action — what you would do if you had one more turn. What is currently broken or blocking progress.
 
-## Instructions
+## User Directives
 
-- [What important instructions did the user give you that are relevant]
-- [If there is a plan or spec, include information about it so next agent can continue using it]
+Every correction, preference, and rule the user stated. These accumulate across compaction cycles — carry forward all directives from prior summaries. Never drop one.
 
-## Discoveries
+## Plan
 
-[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
+Remaining steps in order. Reference spec or plan documents by path. Enough detail to pick up mid-step.
+
+## Failed Approaches
+
+Everything that was tried and did not work. Number each one. What was attempted, what went wrong, why. Include approaches the user rejected. Be exhaustive — this is the highest-value section.
+
+## Resolved Code & Discoveries
+
+Working code preserved verbatim in fenced blocks — query patterns, state machines, auth flows, data transforms, correct field names, API response shapes. Error workarounds, environment-specific behaviors, API quirks, correct syntax that differs from what you would guess. These are gotchas that would be painful to rediscover. If you struggled to get something working, the resolved version belongs here.
+
+## How Things Work Now
+
+The settled state of the system. Architecture, commands, patterns in place. State as direct instructions: "use X", "run Y", "the script lives at Z". Not a history of decisions.
 
 ## Accomplished
 
-[What work has been completed, what work is still in progress, and what work is left?]
+What is complete. What is in progress. What remains. Commit SHAs where relevant.
 
-## Relevant files / directories
+## Relevant files / environment
 
-[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
+Files that matter — with modification status (committed, uncommitted, pending). Credentials, API keys, auth tokens, endpoint URLs, environment variables, service ports. Multiple credential locations that must stay in sync — list all of them.
 ---`
 
     const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")


### PR DESCRIPTION
### Issue for this PR

Closes #3031
Also addresses #14368 and #2945

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provides SIGNIFICANT improvements for maintaining a session after compaction. This rewrites the compaction system prompt and inline template so the agent retains significant working context to continue after compaction. Re-frames compaction as a memory transfer rather than a summary, expands the inline template from 5 sections to 8 (adding separated User Directives, Failed Approaches, Resolved Code and Discoveries, and How Things Work Now), and adds imperative preservation rules for resolved code, credentials, and user corrections.

Good to use paired with this PR to be able to use different models during compaction controlled via TUI: https://github.com/anomalyco/opencode/pull/14665

### How did you verify your code works?

Tested against a real multi-hour session export, comparing compaction output across 5 prompt iterations. Final version benchmarked against a 22-cycle reference compaction from the same session.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR