### PR TITLE
fix(tui): retain model and agent selection when switching sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { batch, createEffect, createMemo } from "solid-js"
+import { batch, createEffect, createMemo, on } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { uniqueBy } from "remeda"
@@ -13,6 +13,7 @@ import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util/filesystem"
+import { useRoute } from "@tui/context/route"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -20,6 +21,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const sdk = useSDK()
     const toast = useToast()
+    const route = useRoute()
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)
@@ -90,6 +92,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           return colors()[index % colors().length]
         },
+        // internal setter used for session restore without validation toast
+        _set(name: string) {
+          setAgentStore("current", name)
+        },
       }
     })
 
@@ -112,12 +118,20 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           modelID: string
         }[]
         variant: Record<string, string | undefined>
+        session: Record<
+          string,
+          {
+            model?: { providerID: string; modelID: string }
+            agent?: string
+          }
+        >
       }>({
         ready: false,
         model: {},
         recent: [],
         favorite: [],
         variant: {},
+        session: {},
       })
 
       const filePath = path.join(Global.Path.state, "model.json")
@@ -135,6 +149,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           recent: modelStore.recent,
           favorite: modelStore.favorite,
           variant: modelStore.variant,
+          session: modelStore.session,
         })
       }
 
@@ -143,6 +158,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (Array.isArray(x.recent)) setModelStore("recent", x.recent)
           if (Array.isArray(x.favorite)) setModelStore("favorite", x.favorite)
           if (typeof x.variant === "object" && x.variant !== null) setModelStore("variant", x.variant)
+          if (typeof x.session === "object" && x.session !== null) setModelStore("session", x.session)
         })
         .catch(() => {})
         .finally(() => {
@@ -358,6 +374,28 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             this.set(variants[index + 1])
           },
         },
+        saveForSession(sessionID: string) {
+          const currentModelVal = currentModel()
+          const currentAgentName = agent.current()?.name
+          setModelStore("session", sessionID, {
+            model: currentModelVal,
+            agent: currentAgentName,
+          })
+          save()
+        },
+        restoreForSession(sessionID: string) {
+          const saved = modelStore.session[sessionID]
+          if (!saved) return
+          if (saved.agent) {
+            const agents = sync.data.agent.filter((x) => x.mode !== "subagent" && !x.hidden)
+            if (agents.some((x) => x.name === saved.agent)) {
+              agent._set(saved.agent)
+            }
+          }
+          if (saved.model && isModelValid(saved.model)) {
+            setModelStore("model", agent.current().name, saved.model)
+          }
+        },
       }
     })
 
@@ -395,6 +433,22 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
       }
     })
+
+    // Save model/agent when leaving a session, restore when entering one
+    createEffect(
+      on(
+        () => route.data,
+        (current, previous) => {
+          if (previous?.type === "session") {
+            model.saveForSession(previous.sessionID)
+          }
+          if (current.type === "session") {
+            model.restoreForSession(current.sessionID)
+          }
+        },
+        { defer: true },
+      ),
+    )
 
     const result = {
       model,


### PR DESCRIPTION
### Issue for this PR

Closes #4930

### Type of change

- [x] Bug fix

### What does this PR do?

When switching between sessions, the selected model and agent were always reset to defaults. There was no per-session memory, so if you had `gpt-4o` selected in one session and switched to another, you'd have to re-select it every time you came back.

The fix adds a `session` map to the existing `model.json` state file (the same file that already stores recent models, favorites, and variants). When you navigate away from a session, the current model and agent are saved under that session's ID. When you navigate back to it, they're restored.

Sessions with no saved state fall back to the existing default behaviour, so there's no change for new sessions.

### How did you verify your code works?

Manually tested by switching between sessions with different models and agents selected -- each session correctly restores its last used model and agent on return.

### Screenshots / recordings

_N/A -- this is a state persistence fix with no visual UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR