### PR TITLE
fix(tui): use theme-aware color for dialog overlay on system theme

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -38,7 +38,7 @@ export function Dialog(
       paddingTop={dimensions().height / 4}
       left={0}
       top={0}
-      backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
+      backgroundColor={new RGBA(theme.text.r, theme.text.g, theme.text.b, 150 / 255)}
     >
       <box
         onMouseUp={(e) => {


### PR DESCRIPTION
### Issue for this PR

Closes #13363

### Type of change

- [x] Bug fix

### What does this PR do?

When using the system theme on a light terminal, dialogs and overlays were rendering with a solid black background instead of a subtle dimmer. The root cause is that the overlay backgroundColor was hardcoded to RGBA.fromInts(0, 0, 0, 150) -- a semi-transparent black. On dark terminals this looks fine, but on light terminals with a transparent background, compositing a semi-transparent black against a transparent buffer produces solid black.

The fix replaces the hardcoded black with a color derived from theme.text, which is the terminal's foreground color. On dark themes this is near-white, on light themes it is near-black -- so the overlay always dims in the right direction regardless of the terminal's color scheme.

### How did you verify your code works?

Tested by switching between system theme on dark and light terminal backgrounds -- the overlay now correctly dims without going solid black on light themes.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A -- visual fix that depends on terminal theme, but the logic is straightforward: theme.text is the terminal foreground color, which is always readable contrast against the terminal background.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR