### PR TITLE
fix(sdk): point v2 type exports at source files to fix typecheck

### DIFF
--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -12,18 +12,9 @@
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
     "./server": "./src/server.ts",
-    "./v2": {
-      "types": "./dist/v2/index.d.ts",
-      "default": "./src/v2/index.ts"
-    },
-    "./v2/client": {
-      "types": "./dist/v2/client.d.ts",
-      "default": "./src/v2/client.ts"
-    },
-    "./v2/gen/client": {
-      "types": "./dist/v2/gen/client/index.d.ts",
-      "default": "./src/v2/gen/client/index.ts"
-    },
+    "./v2": "./src/v2/index.ts",
+    "./v2/client": "./src/v2/client.ts",
+    "./v2/gen/client": "./src/v2/gen/client/index.ts",
     "./v2/server": "./src/v2/server.ts"
   },
   "files": [


### PR DESCRIPTION
### Issue for this PR

Closes #14688

### Type of change

- [x] Bug fix

### What does this PR do?

The `exports` map in `packages/sdk/js/package.json` for the `./v2`, `./v2/client`, and `./v2/gen/client` paths had a split config pointing `types` at `./dist/v2/*.d.ts` files and `default` at the source. The `dist/v2/` directory does not exist in the repo (it is a build artifact and is not committed), so TypeScript resolves the types to a missing file and fails with errors like:

```
Module '"@opencode-ai/sdk/v2"' has no exported member 'TextPart'
Module '"@opencode-ai/sdk/v2"' has no exported member 'AssistantMessage'
'@opencode-ai/sdk/v2' has no exported member named 'createOpencodeClient'
```

This is causing the typecheck job to fail on every PR that touches any file in `packages/opencode`. The fix points the `./v2` exports directly at the source `.ts` files, consistent with how `./v2/server` and the other top-level exports already work.

### How did you verify your code works?

Confirmed all the failing type names (`TextPart`, `AssistantMessage`, `Session`, `Event`, `Part`, `ToolPart`, `UserMessage`, `ReasoningPart`, `PermissionRequest`, `QuestionAnswer`, `QuestionRequest`, `FileDiff`, `Message`, `Model`, `createOpencodeClient`) are present in the source and will resolve correctly once TypeScript is pointed at the right path.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR