### PR TITLE
fix(core): clear tool output and attachments on compaction prune

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -91,6 +91,8 @@ export namespace SessionCompaction {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()
+          part.state.output = ""
+          part.state.attachments = []
           await Session.updatePart(part)
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #5700, #3013

Related: #9385, #9151, #7046, #5363, #13796, #12255, #10248, #9156, #9140, #10913

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionCompaction.prune()` marks old tool outputs as compacted by setting `part.state.time.compacted = Date.now()`, but it never clears the actual `output` string or `attachments` array from the part. Since `toModelMessages` already replaces compacted output with `"[Old tool result content cleared]"` (message-v2.ts:620), the stored data is dead weight after compaction.

The problem is that every prompt loop iteration reloads all parts from storage into memory. In a long session with many tool calls (file reads, grep results, bash output), these compacted-but-still-full parts accumulate significant data that gets loaded into RAM repeatedly for no reason.

This clears both `output` and `attachments` on the part when pruning, so subsequent reloads don't bring dead data back into memory.

### How did you verify your code works?

I monitored RSS memory of the bun process over multiple long sessions using `/proc/<pid>/status` and `/proc/<pid>/smaps`. Before the fix, a session would climb to 14-22GB RSS over the course of extended use. After the fix, memory growth is noticeably slower because compacted parts no longer contribute to the reload size.

Also verified that `toModelMessages` already guards compacted parts at message-v2.ts:620-621 — it checks `part.state.time.compacted` and substitutes `"[Old tool result content cleared]"` regardless of what's in `output`, so clearing the field has no functional impact on the messages sent to the API.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR