### PR TITLE
feat: add stream.delta and stream.aborted plugin hooks

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -18,7 +18,18 @@ import { Question } from "@/question"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
+  const STREAM_ABORT_MAX_RETRIES = 3
   const log = Log.create({ service: "session.processor" })
+
+  export class StreamAbortedError extends Error {
+    constructor(
+      public readonly reason: string,
+      public readonly partialContent: string,
+    ) {
+      super(`Stream aborted by plugin: ${reason}`)
+      this.name = "StreamAbortedError"
+    }
+  }
 
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
@@ -30,9 +41,11 @@ export namespace SessionProcessor {
     abort: AbortSignal
   }) {
     const toolcalls: Record<string, MessageV2.ToolPart> = {}
+    const toolInputAccumulated: Record<string, string> = {}
     let snapshot: string | undefined
     let blocked = false
     let attempt = 0
+    let streamAbortRetries = 0
     let needsCompaction = false
 
     const result = {
@@ -42,9 +55,10 @@ export namespace SessionProcessor {
       partFromToolCall(toolCallID: string) {
         return toolcalls[toolCallID]
       },
-      async process(streamInput: LLM.StreamInput) {
+      async process(initialStreamInput: LLM.StreamInput) {
         log.info("process")
         needsCompaction = false
+        let streamInput = initialStreamInput
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
           try {
@@ -90,6 +104,22 @@ export namespace SessionProcessor {
                       field: "text",
                       delta: value.text,
                     })
+                    // Fire stream.delta hook for reasoning deltas
+                    const reasoningDeltaResult = await Plugin.trigger(
+                      "stream.delta",
+                      {
+                        sessionID: input.sessionID,
+                        messageID: input.assistantMessage.id,
+                        type: "reasoning-delta" as const,
+                        delta: value.text,
+                        accumulated: part.text,
+                      },
+                      { abort: false, reason: "" },
+                    )
+                    if (reasoningDeltaResult.abort) {
+                      log.info("stream aborted by hook (reasoning-delta)", { reason: reasoningDeltaResult.reason })
+                      throw new StreamAbortedError(reasoningDeltaResult.reason, part.text)
+                    }
                   }
                   break
 
@@ -125,8 +155,29 @@ export namespace SessionProcessor {
                   toolcalls[value.id] = part as MessageV2.ToolPart
                   break
 
-                case "tool-input-delta":
+                case "tool-input-delta": {
+                  const id = (value as any).id as string
+                  const delta = (value as any).delta as string
+                  if (id && delta) {
+                    toolInputAccumulated[id] = (toolInputAccumulated[id] ?? "") + delta
+                    const toolDeltaResult = await Plugin.trigger(
+                      "stream.delta",
+                      {
+                        sessionID: input.sessionID,
+                        messageID: input.assistantMessage.id,
+                        type: "tool-input-delta" as const,
+                        delta,
+                        accumulated: toolInputAccumulated[id],
+                      },
+                      { abort: false, reason: "" },
+                    )
+                    if (toolDeltaResult.abort) {
+                      log.info("stream aborted by hook (tool-input-delta)", { reason: toolDeltaResult.reason })
+                      throw new StreamAbortedError(toolDeltaResult.reason, toolInputAccumulated[id])
+                    }
+                  }
                   break
+                }
 
                 case "tool-input-end":
                   break
@@ -310,6 +361,22 @@ export namespace SessionProcessor {
                       field: "text",
                       delta: value.text,
                     })
+                    // Fire stream.delta hook for text deltas
+                    const textDeltaResult = await Plugin.trigger(
+                      "stream.delta",
+                      {
+                        sessionID: input.sessionID,
+                        messageID: input.assistantMessage.id,
+                        type: "text-delta" as const,
+                        delta: value.text,
+                        accumulated: currentText.text,
+                      },
+                      { abort: false, reason: "" },
+                    )
+                    if (textDeltaResult.abort) {
+                      log.info("stream aborted by hook (text-delta)", { reason: textDeltaResult.reason })
+                      throw new StreamAbortedError(textDeltaResult.reason, currentText.text)
+                    }
                   }
                   break
 
@@ -348,6 +415,47 @@ export namespace SessionProcessor {
               if (needsCompaction) break
             }
           } catch (e: any) {
+            // Handle stream abort from plugin hooks
+            if (e instanceof StreamAbortedError) {
+              log.info("handling stream abort", { reason: e.reason })
+              const abortedResult = await Plugin.trigger(
+                "stream.aborted",
+                {
+                  sessionID: input.sessionID,
+                  messageID: input.assistantMessage.id,
+                  reason: e.reason,
+                  partialContent: e.partialContent,
+                },
+                { retry: false, injectMessage: "" },
+              )
+              if (abortedResult.retry && streamAbortRetries < STREAM_ABORT_MAX_RETRIES) {
+                streamAbortRetries++
+                log.info("retrying after stream abort", {
+                  attempt: streamAbortRetries,
+                  injectMessage: abortedResult.injectMessage ? "yes" : "no",
+                })
+                if (abortedResult.injectMessage) {
+                  streamInput = {
+                    ...streamInput,
+                    messages: [
+                      ...streamInput.messages,
+                      {
+                        role: "user" as const,
+                        content: [{ type: "text" as const, text: abortedResult.injectMessage }],
+                      },
+                    ],
+                  }
+                }
+                continue
+              }
+              // Not retrying — fall through to normal error handling
+              log.info("stream abort not retried", {
+                retry: abortedResult.retry,
+                retries: streamAbortRetries,
+                maxRetries: STREAM_ABORT_MAX_RETRIES,
+              })
+            }
+
             log.error("process", {
               error: e,
               stack: JSON.stringify(e.stack),

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -231,4 +231,49 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Called on every streaming delta event (text-delta, reasoning-delta,
+   * tool-input-delta). Allows plugins to observe the stream in real time
+   * and optionally request an abort.
+   *
+   * Setting `output.abort` to `true` will cancel the current stream.
+   * The `stream.aborted` hook will then be called with the abort reason.
+   *
+   * Use cases: TTSR (Time-To-Stream Rules), content filtering, real-time
+   * monitoring, pattern detection.
+   */
+  "stream.delta"?: (
+    input: {
+      sessionID: string
+      messageID: string
+      type: "text-delta" | "reasoning-delta" | "tool-input-delta"
+      delta: string
+      accumulated: string
+    },
+    output: {
+      abort: boolean
+      reason: string
+    },
+  ) => Promise<void>
+  /**
+   * Called after a stream is aborted by a `stream.delta` hook. Allows
+   * plugins to decide whether to retry the request with optional
+   * corrective context injected into the conversation.
+   *
+   * Setting `output.retry` to `true` will discard the aborted response
+   * and start a new streaming request. If `output.injectMessage` is set,
+   * it will be added as a user message before the retry.
+   */
+  "stream.aborted"?: (
+    input: {
+      sessionID: string
+      messageID: string
+      reason: string
+      partialContent: string
+    },
+    output: {
+      retry: boolean
+      injectMessage: string
+    },
+  ) => Promise<void>
 }


### PR DESCRIPTION
## Summary

Adds two new plugin hooks for real-time stream observation and abort control:

- **`stream.delta`** — fires on every `text-delta`, `reasoning-delta`, and `tool-input-delta` event, allowing plugins to observe streaming content in real time and optionally request an abort
- **`stream.aborted`** — fires after a stream is aborted by a delta hook, allowing plugins to decide whether to retry with optional corrective context injected into the conversation

## Motivation

Currently, plugins can only observe completed text via `experimental.text.complete`. There is no way to:
1. Monitor streaming content in real time (e.g., for content filtering, pattern detection)
2. Abort a stream mid-flight based on content rules
3. Retry with corrective instructions after an abort

These hooks enable use cases like:
- **TTSR (Time-To-Stream Rules)** — enforce content policies during streaming
- **Content filtering** — detect and abort harmful/off-topic content before completion
- **Real-time monitoring** — observe token-by-token output for dashboards or logging
- **Self-correcting agents** — abort and retry with injected guidance when output drifts

## Changes

### `packages/plugin/src/index.ts`
- Added `stream.delta` hook type to `Hooks` interface with input (`sessionID`, `messageID`, `type`, `delta`, `accumulated`) and output (`abort`, `reason`)
- Added `stream.aborted` hook type with input (`sessionID`, `messageID`, `reason`, `partialContent`) and output (`retry`, `injectMessage`)

### `packages/opencode/src/session/processor.ts`
- Added `StreamAbortedError` class for clean abort signaling
- Added `Plugin.trigger("stream.delta", ...)` calls in all three delta cases:
  - `reasoning-delta` (line ~107)
  - `tool-input-delta` (line ~163)
  - `text-delta` (line ~365)
- Added `StreamAbortedError` handling in catch block:
  - Fires `Plugin.trigger("stream.aborted", ...)` with partial content
  - Supports retry (max 3 attempts) with optional message injection
  - Falls through to normal error handling when not retrying
- Added `toolInputAccumulated` map to track accumulated tool input per call ID

## Example Plugin Usage

```typescript
const myPlugin: Plugin = async (input) => ({
  "stream.delta": async (input, output) => {
    // Abort if the model starts outputting SQL injection patterns
    if (input.type === "text-delta" && /DROP\s+TABLE/i.test(input.accumulated)) {
      output.abort = true
      output.reason = "SQL injection pattern detected"
    }
  },
  "stream.aborted": async (input, output) => {
    // Retry with corrective instructions
    output.retry = true
    output.injectMessage = `Your previous response was aborted: ${input.reason}. Please try again without SQL statements.`
  },
})
```

## Verification

- TypeScript compilation: zero new errors introduced (pre-existing errors in unrelated packages remain)
- Follows existing patterns: mirrors `experimental.text.complete` hook trigger style
- Backward compatible: no changes to existing hook behavior; new hooks are optional

Ref: marcusquinn/aidevops#2130