### PR TITLE
fix(desktop): add sidecar shell mode toggle

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -2,6 +2,8 @@
 
 Native OpenCode desktop app, built with Tauri v2.
 
+---
+
 ## Development
 
 From the repo root:
@@ -19,6 +21,8 @@ If you only want the web dev server (no native shell):
 bun run --cwd packages/desktop dev
 ```
 
+---
+
 ## Build
 
 To create a production `dist/` and build the native app bundle:
@@ -26,6 +30,27 @@ To create a production `dist/` and build the native app bundle:
 ```bash
 bun run --cwd packages/desktop tauri build
 ```
+
+---
+
+## Configure shell
+
+Set `OPENCODE_SIDECAR_SHELL` to `login` (default) or `interactive` (`il`).
+Use `interactive` if the desktop terminal can’t find tools (e.g., `bun`, `node`, `git`, `python`) because your PATH is initialized in `.zshrc`/`.bashrc`.
+
+Login shell example:
+
+```bash
+export OPENCODE_SIDECAR_SHELL=login
+```
+
+Interactive shell example:
+
+```bash
+export OPENCODE_SIDECAR_SHELL=interactive
+```
+
+---
 
 ## Prerequisites
 

--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -217,6 +217,25 @@ fn get_user_shell() -> String {
     std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string())
 }
 
+enum ShellMode {
+    Login,
+    Interactive,
+}
+
+fn shell_mode() -> ShellMode {
+    match std::env::var("OPENCODE_SIDECAR_SHELL").as_deref() {
+        Ok("interactive") | Ok("il") => ShellMode::Interactive,
+        _ => ShellMode::Login,
+    }
+}
+
+fn shell_flag(mode: ShellMode) -> &'static str {
+    match mode {
+        ShellMode::Interactive => "-il",
+        ShellMode::Login => "-l",
+    }
+}
+
 fn is_wsl_enabled(_app: &tauri::AppHandle) -> bool {
     get_wsl_config(_app.clone()).is_ok_and(|v| v.enabled)
 }
@@ -320,7 +339,7 @@ pub fn spawn_command(
         };
 
         let mut cmd = Command::new(shell);
-        cmd.args(["-il", "-c", &line]);
+        cmd.args([shell_flag(shell_mode()), "-c", &line]);
 
         for (key, value) in envs {
             cmd.env(key, value);


### PR DESCRIPTION
### Issue for this PR

Closes #14704

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows for users to change the shell mode used during desktop startup. Since I had the issue with the dev instance of the desktop app running with the interactive shell when it only works with the login shell. Other users had issues with their PATHs working which the interactive shell was the solution. This way both can coexist, and the interactive shell being a solution and an opt-in by users.

Also adds docs explaining when users should go for setting the variable.

### How did you verify your code works?

Tested on my local machine, but might need assistance on the side of users with the issue to test if setting the env var works for them.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR