### PR TITLE
fix(app): close mobile sidebar on session tap

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-session-links.spec.ts
@@ -29,3 +29,36 @@ test("sidebar session links navigate to the selected session", async ({ page, sl
     await sdk.session.delete({ sessionID: two.id }).catch(() => undefined)
   }
 })
+
+test("mobile sidebar closes after tapping a session link", async ({ page, slug, sdk, gotoSession }) => {
+  const stamp = Date.now()
+
+  const one = await sdk.session.create({ title: `e2e mobile sidebar nav 1 ${stamp}` }).then((r) => r.data)
+  const two = await sdk.session.create({ title: `e2e mobile sidebar nav 2 ${stamp}` }).then((r) => r.data)
+
+  if (!one?.id) throw new Error("Session create did not return an id")
+  if (!two?.id) throw new Error("Session create did not return an id")
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await gotoSession(one.id)
+
+    const toggle = page.getByRole("button", { name: /toggle menu/i }).first()
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+
+    const mobileNav = page.locator('[data-component="sidebar-nav-mobile"]').first()
+    await expect(mobileNav).toHaveClass(/translate-x-0/)
+
+    const target = page.locator(`[data-session-id="${two.id}"] a`).first()
+    await expect(target).toBeVisible()
+    await target.click()
+
+    await expect(page).toHaveURL(new RegExp(`/${slug}/session/${two.id}(?:\\?|#|$)`))
+    await expect(mobileNav).toHaveClass(/-translate-x-full/)
+    await expect(page.locator(promptSelector)).toBeVisible()
+  } finally {
+    await sdk.session.delete({ sessionID: one.id }).catch(() => undefined)
+    await sdk.session.delete({ sessionID: two.id }).catch(() => undefined)
+  }
+})

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -233,6 +233,13 @@ export default function Layout(props: ParentProps) {
     layout.mobileSidebar.hide()
   }
 
+  const hideMobileSidebarOnLinkTap = (event: MouseEvent) => {
+    const target = event.target
+    if (!(target instanceof Element)) return
+    if (!target.closest("a[href]")) return
+    layout.mobileSidebar.hide()
+  }
+
   function cycleTheme(direction = 1) {
     const ids = availableThemeEntries().map(([id]) => id)
     if (ids.length === 0) return
@@ -2018,7 +2025,10 @@ export default function Layout(props: ParentProps) {
               "translate-x-0": layout.mobileSidebar.opened(),
               "-translate-x-full": !layout.mobileSidebar.opened(),
             }}
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              hideMobileSidebarOnLinkTap(e)
+              e.stopPropagation()
+            }}
           >
             <SidebarContent
               mobile

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -86,6 +86,7 @@ const SessionRow = (props: {
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   scheduleHoverPrefetch: () => void
   cancelHoverPrefetch: () => void
+  closeMobileSidebar?: () => void
 }): JSX.Element => (
   <A
     href={`/${props.slug}/session/${props.session.id}`}
@@ -97,6 +98,7 @@ const SessionRow = (props: {
     onFocus={() => props.prefetchSession(props.session, "high")}
     onClick={() => {
       props.setHoverSession(undefined)
+      if (props.mobile) props.closeMobileSidebar?.()
       if (props.sidebarOpened()) return
       props.clearHoverProjectSoon()
     }}
@@ -268,6 +270,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       prefetchSession={props.prefetchSession}
       scheduleHoverPrefetch={scheduleHoverPrefetch}
       cancelHoverPrefetch={cancelHoverPrefetch}
+      closeMobileSidebar={() => layout.mobileSidebar.hide()}
     />
   )
 
@@ -356,6 +359,7 @@ export const NewSessionItem = (props: {
       class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
       onClick={() => {
         props.setHoverSession(undefined)
+        if (props.mobile) layout.mobileSidebar.hide()
         if (layout.sidebar.opened()) return
         props.clearHoverProjectSoon()
       }}


### PR DESCRIPTION
### Issue for this PR

Closes #14711

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On mobile web, tapping a session item in the sidebar navigated to that session but left the drawer open. This updates sidebar session click handlers to call `layout.mobileSidebar.hide()` on mobile so the drawer closes immediately after selection. It also keeps desktop behavior unchanged and adds an e2e regression test for the mobile flow.

### How did you verify your code works?

- `bun typecheck` in `packages/app`
- `bun test:e2e -- e2e/sidebar/sidebar-session-links.spec.ts` in `packages/app`

### Screenshots / recordings

N/A (behavioral fix covered by e2e test)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR