### PR TITLE
feat(tui): make paste summary thresholds configurable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -962,8 +962,10 @@ export function Prompt(props: PromptProps) {
                 }
 
                 const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
+                const minLines = sync.data.config.experimental?.paste_min_lines ?? 3
+                const minLength = sync.data.config.experimental?.paste_min_length ?? 150
                 if (
-                  (lineCount >= 3 || pastedContent.length > 150) &&
+                  (lineCount >= minLines || pastedContent.length > minLength) &&
                   !sync.data.config.experimental?.disable_paste_summary
                 ) {
                   event.preventDefault()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1201,6 +1201,18 @@ export namespace Config {
             .positive()
             .optional()
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+          paste_min_lines: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Minimum number of lines in pasted content before it is summarized (default: 3)"),
+          paste_min_length: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Minimum character length of pasted content before it is summarized (default: 150)"),
         })
         .optional(),
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1887,6 +1887,14 @@ export type Config = {
      * Timeout in milliseconds for model context protocol (MCP) requests
      */
     mcp_timeout?: number
+    /**
+     * Minimum number of lines in pasted content before it is summarized (default: 3)
+     */
+    paste_min_lines?: number
+    /**
+     * Minimum character length of pasted content before it is summarized (default: 150)
+     */
+    paste_min_length?: number
   }
 }
 


### PR DESCRIPTION
Closes #14712

## What this does

Adds two optional fields to the `experimental` config block:

- `paste_min_lines` — minimum line count before pasted content is summarised (default: `3`)
- `paste_min_length` — minimum character length before pasted content is summarised (default: `150`)

Both default to the current hardcoded values, so existing behaviour is fully preserved for anyone who doesn't set them.

## Why

The current thresholds are too aggressive for users of voice dictation software (e.g. Whisper Flow, [Whispering](https://github.com/EpicenterHQ/epicenter)). A single dictated utterance frequently exceeds 150 characters, causing it to be immediately collapsed into `[Pasted ~1 lines]` — making it impossible to spot and correct small transcription errors. The existing `disable_paste_summary` flag is a blunt workaround that sacrifices the feature entirely, which is painful when you then paste a large file or stack trace.

## Configuration example

```json
{
  "experimental": {
    "paste_min_lines": 6,
    "paste_min_length": 500
  }
}
```

## Notes

- Flat key naming is consistent with existing experimental config style
- No new tests added — no other experimental config fields have tests
- Prior art: PR #1960 attempted this with a nested `experimental.editor.summary_thresholds` structure; this uses flat keys for consistency