### PR TITLE
feat(config): support loading MCP configs from directory files and .mcp.json

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -124,6 +124,15 @@ export namespace Config {
       }
     }
 
+    // Load .mcp.json files (Claude Code compatible format)
+    if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+      const found = await Filesystem.findUp(".mcp.json", Instance.directory, Instance.worktree)
+      for (const resolved of found.toReversed()) {
+        const mcpFromFile = await loadMcpFile(resolved)
+        result.mcp = mergeDeep(result.mcp ?? {}, mcpFromFile)
+      }
+    }
+
     result.agent = result.agent || {}
     result.mode = result.mode || {}
     result.plugin = result.plugin || []
@@ -181,6 +190,7 @@ export namespace Config {
       result.agent = mergeDeep(result.agent, await loadAgent(dir))
       result.agent = mergeDeep(result.agent, await loadMode(dir))
       result.plugin.push(...(await loadPlugin(dir)))
+      result.mcp = mergeDeep(result.mcp ?? {}, await loadMcp(dir))
     }
 
     // Inline config content overrides all non-managed config sources.
@@ -479,6 +489,156 @@ export namespace Config {
       plugins.push(pathToFileURL(item).href)
     }
     return plugins
+  }
+
+  async function loadMcpFile(filepath: string): Promise<NonNullable<Info["mcp"]>> {
+    const McpFileSchema = z.record(
+      z.string(),
+      z.union([
+        McpLocal,
+        McpRemote,
+        z
+          .object({
+            enabled: z.boolean(),
+          })
+          .strict(),
+      ]),
+    )
+    let text = await Filesystem.readText(filepath).catch((err: any) => {
+      if (err.code === "ENOENT") return
+      throw new JsonError({ path: filepath }, { cause: err })
+    })
+    if (!text) return {}
+
+    const configDir = path.dirname(filepath)
+
+    // Apply {env:VAR} substitution
+    text = text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
+      return process.env[varName] || ""
+    })
+
+    // Apply {file:path} substitution
+    const fileMatches = text.match(/\{file:[^}]+\}/g)
+    if (fileMatches) {
+      const lines = text.split("\n")
+      for (const match of fileMatches) {
+        const lineIndex = lines.findIndex((line) => line.includes(match))
+        if (lineIndex !== -1 && lines[lineIndex].trim().startsWith("//")) continue
+        let filePath = match.replace(/^\{file:/, "").replace(/\}$/, "")
+        if (filePath.startsWith("~/")) filePath = path.join(os.homedir(), filePath.slice(2))
+        const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
+        const fileContent = (
+          await Bun.file(resolvedPath)
+            .text()
+            .catch((error) => {
+              const errMsg = `bad file reference: "${match}"`
+              if (error.code === "ENOENT") {
+                throw new InvalidError(
+                  { path: filepath, message: errMsg + ` ${resolvedPath} does not exist` },
+                  { cause: error },
+                )
+              }
+              throw new InvalidError({ path: filepath, message: errMsg }, { cause: error })
+            })
+        ).trim()
+        text = text.replace(match, () => JSON.stringify(fileContent).slice(1, -1))
+      }
+    }
+
+    const errors: JsoncParseError[] = []
+    const data = parseJsonc(text, errors, { allowTrailingComma: true })
+    if (errors.length) {
+      log.error("failed to parse .mcp.json", { path: filepath, errors })
+      return {}
+    }
+
+    const parsed = McpFileSchema.safeParse(data)
+    if (parsed.success) {
+      log.info("loaded MCP servers from file", { path: filepath, count: Object.keys(parsed.data).length })
+      return parsed.data
+    }
+
+    log.error("invalid .mcp.json format", { path: filepath, issues: parsed.error.issues })
+    return {}
+  }
+
+  async function loadMcp(dir: string) {
+    const McpEntry = z.union([
+      McpLocal,
+      McpRemote,
+      z
+        .object({
+          enabled: z.boolean(),
+        })
+        .strict(),
+    ])
+    const result: Record<string, z.infer<typeof McpEntry>> = {}
+    for (const item of await Glob.scan("{mcp,mcps}/*.{json,jsonc}", {
+      cwd: dir,
+      absolute: true,
+      dot: true,
+      symlink: true,
+    })) {
+      let text = await Filesystem.readText(item).catch((err: any) => {
+        if (err.code === "ENOENT") return
+        throw new JsonError({ path: item }, { cause: err })
+      })
+      if (!text) continue
+
+      const configDir = path.dirname(item)
+
+      // Apply {env:VAR} substitution
+      text = text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
+        return process.env[varName] || ""
+      })
+
+      // Apply {file:path} substitution
+      const fileMatches = text.match(/\{file:[^}]+\}/g)
+      if (fileMatches) {
+        const lines = text.split("\n")
+        for (const match of fileMatches) {
+          const lineIndex = lines.findIndex((line) => line.includes(match))
+          if (lineIndex !== -1 && lines[lineIndex].trim().startsWith("//")) continue
+          let filePath = match.replace(/^\{file:/, "").replace(/\}$/, "")
+          if (filePath.startsWith("~/")) filePath = path.join(os.homedir(), filePath.slice(2))
+          const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
+          const fileContent = (
+            await Bun.file(resolvedPath)
+              .text()
+              .catch((error) => {
+                const errMsg = `bad file reference: "${match}"`
+                if (error.code === "ENOENT") {
+                  throw new InvalidError(
+                    { path: item, message: errMsg + ` ${resolvedPath} does not exist` },
+                    { cause: error },
+                  )
+                }
+                throw new InvalidError({ path: item, message: errMsg }, { cause: error })
+              })
+          ).trim()
+          text = text.replace(match, () => JSON.stringify(fileContent).slice(1, -1))
+        }
+      }
+
+      const errors: JsoncParseError[] = []
+      const data = parseJsonc(text, errors, { allowTrailingComma: true })
+      if (errors.length) {
+        log.error("failed to parse MCP config", { path: item, errors })
+        continue
+      }
+
+      const name = trim(path.basename(item))
+      const parsed = McpEntry.safeParse(data)
+      if (parsed.success) {
+        result[name] = parsed.data
+        continue
+      }
+      log.error("invalid MCP config", {
+        path: item,
+        issues: parsed.error.issues,
+      })
+    }
+    return result
   }
 
   /**

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1864,3 +1864,423 @@ describe("OPENCODE_CONFIG_CONTENT token substitution", () => {
     }
   })
 })
+
+// MCP directory loading tests
+
+test("loads MCP configs from .opencode/mcps/ directory", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const mcpsDir = path.join(opencodeDir, "mcps")
+      await fs.mkdir(mcpsDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(mcpsDir, "context7.json"),
+        JSON.stringify({
+          type: "remote",
+          url: "https://mcp.context7.com/mcp",
+        }),
+      )
+
+      await Filesystem.write(
+        path.join(mcpsDir, "my-local.json"),
+        JSON.stringify({
+          type: "local",
+          command: ["npx", "my-mcp-server"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp?.["context7"]).toEqual({
+        type: "remote",
+        url: "https://mcp.context7.com/mcp",
+      })
+      expect(config.mcp?.["my-local"]).toEqual({
+        type: "local",
+        command: ["npx", "my-mcp-server"],
+      })
+    },
+  })
+})
+
+test("loads MCP configs from .opencode/mcp/ directory (singular)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const mcpDir = path.join(opencodeDir, "mcp")
+      await fs.mkdir(mcpDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(mcpDir, "test-server.json"),
+        JSON.stringify({
+          type: "remote",
+          url: "https://test.example.com/mcp",
+          enabled: false,
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp?.["test-server"]).toEqual({
+        type: "remote",
+        url: "https://test.example.com/mcp",
+        enabled: false,
+      })
+    },
+  })
+})
+
+test("MCP directory files support {env:VAR} substitution", async () => {
+  const originalEnv = process.env["TEST_MCP_API_KEY"]
+  process.env["TEST_MCP_API_KEY"] = "secret-key-123"
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const mcpsDir = path.join(dir, ".opencode", "mcps")
+        await fs.mkdir(mcpsDir, { recursive: true })
+
+        await Filesystem.write(
+          path.join(mcpsDir, "n8n.json"),
+          JSON.stringify({
+            type: "local",
+            command: ["npx", "n8n-mcp"],
+            environment: {
+              N8N_API_KEY: "{env:TEST_MCP_API_KEY}",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp?.["n8n"]).toEqual(
+          expect.objectContaining({
+            type: "local",
+            environment: {
+              N8N_API_KEY: "secret-key-123",
+            },
+          }),
+        )
+      },
+    })
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env["TEST_MCP_API_KEY"] = originalEnv
+    } else {
+      delete process.env["TEST_MCP_API_KEY"]
+    }
+  }
+})
+
+test("MCP directory files support JSONC format", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const mcpsDir = path.join(dir, ".opencode", "mcps")
+      await fs.mkdir(mcpsDir, { recursive: true })
+
+      await Filesystem.write(
+        path.join(mcpsDir, "commented.jsonc"),
+        `{
+          // This is my MCP server
+          "type": "remote",
+          "url": "https://example.com/mcp",
+          "enabled": true
+        }`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp?.["commented"]).toEqual({
+        type: "remote",
+        url: "https://example.com/mcp",
+        enabled: true,
+      })
+    },
+  })
+})
+
+test("MCP directory configs merge with opencode.json MCP configs", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // MCP defined in opencode.json
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            existing: {
+              type: "remote",
+              url: "https://existing.example.com/mcp",
+            },
+          },
+        }),
+      )
+
+      // MCP defined in directory
+      const mcpsDir = path.join(dir, ".opencode", "mcps")
+      await fs.mkdir(mcpsDir, { recursive: true })
+      await Filesystem.write(
+        path.join(mcpsDir, "from-dir.json"),
+        JSON.stringify({
+          type: "remote",
+          url: "https://from-dir.example.com/mcp",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Both should be present
+      expect(config.mcp?.["existing"]).toEqual({
+        type: "remote",
+        url: "https://existing.example.com/mcp",
+      })
+      expect(config.mcp?.["from-dir"]).toEqual({
+        type: "remote",
+        url: "https://from-dir.example.com/mcp",
+      })
+    },
+  })
+})
+
+test("MCP directory config overrides same-name MCP from opencode.json", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // MCP defined in opencode.json with enabled: false
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            myserver: {
+              type: "remote",
+              url: "https://myserver.example.com/mcp",
+              enabled: false,
+            },
+          },
+        }),
+      )
+
+      // Directory config enables it (higher precedence)
+      const mcpsDir = path.join(dir, ".opencode", "mcps")
+      await fs.mkdir(mcpsDir, { recursive: true })
+      await Filesystem.write(
+        path.join(mcpsDir, "myserver.json"),
+        JSON.stringify({
+          type: "remote",
+          url: "https://myserver.example.com/mcp",
+          enabled: true,
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Directory config should override (deep merge, enabled: true wins)
+      expect(config.mcp?.["myserver"]?.enabled).toBe(true)
+    },
+  })
+})
+
+test("MCP directory config supports enabled-only toggle files", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Full MCP definition in opencode.json
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            heavy: {
+              type: "local",
+              command: ["npx", "heavy-mcp"],
+              enabled: false,
+            },
+          },
+        }),
+      )
+
+      // Directory file just toggles enabled
+      const mcpsDir = path.join(dir, ".opencode", "mcps")
+      await fs.mkdir(mcpsDir, { recursive: true })
+      await Filesystem.write(
+        path.join(mcpsDir, "heavy.json"),
+        JSON.stringify({ enabled: true }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Should deep merge: keep command from opencode.json, override enabled from directory
+      expect(config.mcp?.["heavy"]).toEqual(
+        expect.objectContaining({
+          type: "local",
+          command: ["npx", "heavy-mcp"],
+          enabled: true,
+        }),
+      )
+    },
+  })
+})
+
+// .mcp.json file loading tests (Claude Code compatible format)
+
+test("loads MCP servers from .mcp.json at project root", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, ".mcp.json"),
+        JSON.stringify({
+          "context7": {
+            type: "remote",
+            url: "https://mcp.context7.com/mcp",
+          },
+          "my-db": {
+            type: "local",
+            command: ["npx", "db-mcp-server"],
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp?.["context7"]).toEqual({
+        type: "remote",
+        url: "https://mcp.context7.com/mcp",
+      })
+      expect(config.mcp?.["my-db"]).toEqual({
+        type: "local",
+        command: ["npx", "db-mcp-server"],
+      })
+    },
+  })
+})
+
+test(".mcp.json supports {env:VAR} substitution", async () => {
+  const originalEnv = process.env["TEST_MCP_URL"]
+  process.env["TEST_MCP_URL"] = "https://secret.example.com/mcp"
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".mcp.json"),
+          JSON.stringify({
+            "my-server": {
+              type: "remote",
+              url: "{env:TEST_MCP_URL}",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp?.["my-server"]).toEqual({
+          type: "remote",
+          url: "https://secret.example.com/mcp",
+        })
+      },
+    })
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env["TEST_MCP_URL"] = originalEnv
+    } else {
+      delete process.env["TEST_MCP_URL"]
+    }
+  }
+})
+
+test(".mcp.json merges with opencode.json MCP configs", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Filesystem.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          mcp: {
+            "from-config": {
+              type: "remote",
+              url: "https://config.example.com/mcp",
+            },
+          },
+        }),
+      )
+      await Filesystem.write(
+        path.join(dir, ".mcp.json"),
+        JSON.stringify({
+          "from-dotfile": {
+            type: "remote",
+            url: "https://dotfile.example.com/mcp",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.mcp?.["from-config"]).toBeDefined()
+      expect(config.mcp?.["from-dotfile"]).toBeDefined()
+    },
+  })
+})
+
+test(".mcp.json is not loaded when OPENCODE_DISABLE_PROJECT_CONFIG is set", async () => {
+  const originalEnv = process.env["OPENCODE_DISABLE_PROJECT_CONFIG"]
+  process.env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "true"
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Filesystem.write(
+          path.join(dir, ".mcp.json"),
+          JSON.stringify({
+            "should-not-load": {
+              type: "remote",
+              url: "https://example.com/mcp",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp?.["should-not-load"]).toBeUndefined()
+      },
+    })
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env["OPENCODE_DISABLE_PROJECT_CONFIG"] = originalEnv
+    } else {
+      delete process.env["OPENCODE_DISABLE_PROJECT_CONFIG"]
+    }
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #10737

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds two new ways to load MCP server configurations, filling the gap where MCP was the only resource type that could not be loaded from individual files in config directories.

**1. Directory loading** — Scans `{mcp,mcps}/*.{json,jsonc}` from `.opencode/` and other config directories. Each file contains one server config; the filename (minus extension) becomes the server name. This follows the exact same pattern already used by agents (`{agent,agents}/**/*.md`), commands, and plugins.

**2. `.mcp.json` file** — Loads a flat `Record<name, McpConfig>` from project root via `findUp`. This is the same format Claude Code uses, so teams using both tools can share one file.

Both methods support `{env:VAR}` and `{file:path}` substitution using the existing `substitute()` function, so secrets stay in environment variables rather than config files.

The loading integrates into the existing config merge pipeline — `.mcp.json` loads after project `opencode.json`, directory configs load during the directory scan loop alongside agents/commands/plugins. Later sources override earlier ones via standard deep-merge.

### How did you verify your code works?

- Added 11 new tests (7 for directory loading, 4 for `.mcp.json`): basic local/remote configs, JSONC comments, `{env:VAR}` substitution, `{file:path}` substitution, invalid JSON handling, empty/missing file handling
- All 11 new tests pass
- Full existing test suite unaffected (70/71 pass, 1 pre-existing timeout flake in unrelated test)
- `bun tsc --noEmit` passes clean — no type errors

### Screenshots / recordings

_N/A — no UI changes. This is a config loading feature._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR