### PR TITLE
feat: add streaming option to provider config to support non-streaming backends

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -989,6 +989,12 @@ export namespace Config {
           baseURL: z.string().optional(),
           enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
           setCacheKey: z.boolean().optional().describe("Enable promptCacheKey for this provider (default false)"),
+          streaming: z
+            .boolean()
+            .optional()
+            .describe(
+              "Enable or disable streaming for this provider. When set to false, uses non-streaming requests and simulates streaming output. Useful for backends that do not support streaming. Default is true.",
+            ),
           timeout: z
             .union([
               z

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -4,6 +4,7 @@ import { Log } from "@/util/log"
 import {
   streamText,
   wrapLanguageModel,
+  simulateStreamingMiddleware,
   type ModelMessage,
   type StreamTextResult,
   type Tool,
@@ -243,6 +244,10 @@ export namespace LLM {
               return args.params
             },
           },
+          // When streaming is disabled for the provider, use the AI SDK's
+          // simulateStreamingMiddleware to make non-streaming (generateText)
+          // requests and convert the result into a simulated stream.
+          ...(provider?.options?.streaming === false ? [simulateStreamingMiddleware()] : []),
         ],
       }),
       experimental_telemetry: {


### PR DESCRIPTION
### Issue for this PR

Closes #785

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds a `streaming` boolean option to the provider configuration schema (`Provider.options.streaming`)
- When `streaming` is set to `false`, uses the AI SDK's `simulateStreamingMiddleware()` to convert `streamText()` calls into `generateText()` + simulated stream responses
- This enables OpenCode to work with OpenAI-compatible backends that don't support streaming (e.g. custom/self-hosted inference servers)

### How did you verify your code works?

Checked against CatGPT

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Usage

```json
{
  "provider": {
    "my-backend": {
      "options": {
        "streaming": false
      }
    }
  }
}
```

### Implementation

The implementation leverages the existing `wrapLanguageModel` middleware system. When `streaming: false` is configured for a provider, `simulateStreamingMiddleware()` from the `ai` package is added to the middleware chain. This middleware intercepts `doStream` calls, calls `doGenerate` instead, and converts the result back into stream events — making it a transparent drop-in that requires no changes to the rest of the codebase.
