### PR TITLE
docs(web): add opencode-responsive-tables to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -31,6 +31,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
+| [opencode-responsive-tables](https://github.com/mrm007/opencode-responsive-tables)                       | Responsive tables — stacked cards when too wide, passthrough when they fit                         |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |


### PR DESCRIPTION
### Issue for this PR

N/A — ecosystem addition

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-responsive-tables](https://github.com/mrm007/opencode-responsive-tables) to the Plugins table in the ecosystem page, placed below `opencode-md-table-formatter` since it complements that plugin. Tables that fit the terminal pass through unchanged; tables that overflow get reformatted as stacked key-value cards.

### How did you verify your code works?

Verified the markdown table row renders correctly in a local preview.

### Screenshots / recordings

N/A — single table row addition to ecosystem.mdx

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR