### PR TITLE
Prevent grep tool from using match-all globs

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -10,6 +10,19 @@ import { assertExternalDirectory } from "./external-directory"
 
 const MAX_LINE_LENGTH = 2000
 
+function normalizeInclude(include?: string) {
+  if (!include) return undefined
+  const v = include.trim()
+  if (!v) return undefined
+
+  // Treat “match everything” globs as redundant. Passing them via --glob can
+  // act as an override/whitelist and may cause ignored paths to be searched.
+  const redundant = new Set(["*", "*.*", "**", "**/*", "./**", "./**/*"])
+  if (redundant.has(v)) return undefined
+
+  return v
+}
+
 export const GrepTool = Tool.define("grep", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -22,6 +35,8 @@ export const GrepTool = Tool.define("grep", {
       throw new Error("pattern is required")
     }
 
+    const include = normalizeInclude(params.include)
+
     await ctx.ask({
       permission: "grep",
       patterns: [params.pattern],
@@ -29,7 +44,7 @@ export const GrepTool = Tool.define("grep", {
       metadata: {
         pattern: params.pattern,
         path: params.path,
-        include: params.include,
+        include: include,
       },
     })
 
@@ -39,8 +54,8 @@ export const GrepTool = Tool.define("grep", {
 
     const rgPath = await Ripgrep.filepath()
     const args = ["-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
-    if (params.include) {
-      args.push("--glob", params.include)
+    if (include) {
+      args.push("--glob", include)
     }
     args.push(searchPath)
 


### PR DESCRIPTION
ripgrep with match-all globs leak gitignored files.
May be ripgrep issue, match-all globs are helping nothing, exclude such globs when asked by LLM.

.gitignore, relevant line (no !entries there)
```
.clj-kondo/.*
```

tool-call:
```
{
  "type": "tool-call",
  "toolName": "grep",
  "input": {
    "pattern": "request-instructions",
    "path": "/workspace",
    "include": "*.*"
  }
}
```

command generated & called:
```
rg -nH --hidden --no-messages --field-match-separator='|' --regexp 'request-instructions' --glob '*.*' /workspace
```

called with --debug
```
DEBUG|ignore::walk|/usr/share/cargo/registry/ripgrep-13.0.0/debian/cargo_registry/ignore-0.4.18/src/walk.rs:1744: 
whitelisting /workspace/.clj-kondo/.cache/v1/java/io.grpc.netty.shaded.io.netty.handler.codec.socks.SocksRequest.transit.json: Whitelist(IgnoreMatch(Override(Glob(Matched(Glob { from: None, original: "*.*", actual: "**/*.*", is_whitelist: false, is_only_dir: false })))))
```

### Issue for this PR

Closes #14298
https://github.com/anomalyco/opencode/issues/14298
https://github.com/anomalyco/opencode/issues/4694

in case of conflict, rg's last glob has the last word:
https://github.com/BurntSushi/ripgrep/issues/689#issuecomment-346332090

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ignore match-all globs when asked by LLM

### How did you verify your code works?

```
/workspace$ rg -nH --hidden --no-messages --field-match-separator='|' --regexp 'request-instructions' /workspace | wc -l
46
/workspace$ rg -nH --hidden --no-messages --field-match-separator='|' --regexp 'request-instructions' --glob '*.*' /workspace | wc -l
52
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
