### PR TITLE
fix(provider): honor explicit config apiKey over auth plugin OAuth

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -779,6 +779,11 @@ export namespace Provider {
     log.info("init")
 
     const configProviders = Object.entries(config.provider ?? {})
+    const explicitApiKeyProviders = new Set(
+      configProviders
+        .filter(([, provider]) => provider.options?.apiKey !== undefined)
+        .map(([providerID]) => providerID),
+    )
 
     // Add GitHub Copilot Enterprise provider that inherits from GitHub Copilot
     if (database["github-copilot"]) {
@@ -917,6 +922,10 @@ export namespace Provider {
       if (!plugin.auth) continue
       const providerID = plugin.auth.provider
       if (disabled.has(providerID)) continue
+      if (explicitApiKeyProviders.has(providerID)) {
+        log.debug("skipping auth plugin due to explicit provider apiKey", { providerID })
+        continue
+      }
 
       // For github-copilot plugin, check if auth exists for either github-copilot or github-copilot-enterprise
       let hasAuth = false
@@ -944,6 +953,10 @@ export namespace Provider {
       if (providerID === "github-copilot") {
         const enterpriseProviderID = "github-copilot-enterprise"
         if (!disabled.has(enterpriseProviderID)) {
+          if (explicitApiKeyProviders.has(enterpriseProviderID)) {
+            log.debug("skipping auth plugin due to explicit provider apiKey", { providerID: enterpriseProviderID })
+            continue
+          }
           const enterpriseAuth = await Auth.get(enterpriseProviderID)
           if (enterpriseAuth) {
             const enterpriseOptions = await plugin.auth.loader(

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
 import { Env } from "../../src/env"
+import { Auth } from "../../src/auth"
 
 test("provider loaded from env variable", async () => {
   await using tmp = await tmpdir({
@@ -279,6 +280,47 @@ test("env variable takes precedence, config merges options", async () => {
       expect(providers["anthropic"].options.timeout).toBe(60000)
     },
   })
+})
+
+test("explicit provider apiKey bypasses OAuth plugin auth overrides", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              options: {
+                apiKey: "config-api-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Auth.set("openai", {
+    type: "oauth",
+    access: "oauth-access-token",
+    refresh: "oauth-refresh-token",
+    expires: Date.now() + 60_000,
+  })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        expect(providers["openai"]).toBeDefined()
+        expect(providers["openai"].options.apiKey).toBe("config-api-key")
+        expect(providers["openai"].models["gpt-4o"]).toBeDefined()
+      },
+    })
+  } finally {
+    await Auth.remove("openai")
+  }
 })
 
 test("getModel returns model for valid provider/model", async () => {


### PR DESCRIPTION
## Summary
- skip auth plugin loader when a provider has explicit `provider.<id>.options.apiKey` in config
- preserve explicit API-key flows for custom endpoints/proxies even when OAuth credentials are stored
- add provider regression test for OpenAI OAuth + explicit config apiKey

## Why
Stored OAuth/plugin auth behavior can override explicit provider API-key configuration and break custom endpoint setups. Explicit config should be the source of truth in that case.

Fixes #10950.

## Testing
- bun test test/provider/provider.test.ts
