### PR TITLE
docs: clarify auth precedence, storage layout, and app/CLI sync troubleshooting

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -150,6 +150,11 @@ The config file has a schema that's defined in [**`opencode.ai/config.json`**](h
 
 Your editor should be able to validate and autocomplete based on the schema.
 
+:::note
+`config.json` is a schema reference, not a config template to paste directly into `opencode.json`.
+If you copy keys from other tools, OpenCode will fail fast on unknown keys.
+:::
+
 ---
 
 ### TUI

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -22,6 +22,24 @@ in `~/.local/share/opencode/auth.json`.
 
 ---
 
+### Authentication precedence
+
+For API key based providers, OpenCode resolves credentials in this order (highest to lowest):
+
+1. `provider.<id>.options.apiKey` in your config
+2. Stored credentials from `/connect` or `opencode auth login` (in `auth.json`)
+3. Provider environment variables (for example `OPENAI_API_KEY`)
+
+If `provider.<id>.options.apiKey` is set, OpenCode skips OAuth auth-plugin overrides for that provider. This is useful when targeting custom endpoints or proxies with explicit API keys.
+
+Use these commands to verify and troubleshoot auth source conflicts:
+
+- `opencode auth list` (shows the active credential file path and configured credentials)
+- `opencode auth logout` (remove a stored credential interactively)
+- `opencode debug config` (inspect resolved provider config)
+
+---
+
 ### Config
 
 You can customize the providers through the `provider` section in your OpenCode

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -24,16 +24,20 @@ You can set the log level with the `--log-level` command-line option to get more
 
 opencode stores session data and other application data on disk at:
 
-- **macOS/Linux**: `~/.local/share/opencode/`
+- **macOS/Linux**: `~/.local/share/opencode/` (or `${XDG_DATA_HOME}/opencode` if `XDG_DATA_HOME` is set)
 - **Windows**: Press `WIN+R` and paste `%USERPROFILE%\.local\share\opencode`
 
-This directory contains:
+Common files and folders:
 
 - `auth.json` - Authentication data like API keys, OAuth tokens
+- `mcp-auth.json` - MCP OAuth token storage
+- `opencode.db` - Main SQLite database
+- `bin/` - Downloaded helper binaries (ripgrep, LSP tools, etc.)
 - `log/` - Application logs
-- `project/` - Project-specific data like session and message data
-  - If the project is within a Git repo, it is stored in `./<project-slug>/storage/`
-  - If it is not a Git repo, it is stored in `./global/storage/`
+- `storage/` - JSON storage used by migrations and compatibility layers
+- `snapshot/` - Git snapshots by project ID
+- `tool-output/` - Pruned tool output cache
+- `worktree/` - Temporary project worktree metadata
 
 ---
 
@@ -169,6 +173,24 @@ To find the directory quickly:
 
 ---
 
+### Desktop and CLI show different providers or sessions
+
+OpenCode Desktop and CLI only stay in sync if they read the same data/config directories.
+
+Check this first:
+
+1. Run `opencode auth list` in each environment and compare the `Credentials .../auth.json` path shown at the top.
+2. Run `opencode debug config` in each environment and compare resolved settings.
+3. Verify `XDG_DATA_HOME` and `XDG_CONFIG_HOME` are the same (or unset) in both environments.
+
+Common causes of split state:
+
+- Sandboxed terminals (for example Snap/Flatpak) using a different home/data path
+- Different shell startup files exporting different `XDG_*` variables
+- Launching desktop app and terminal under different OS users
+
+---
+
 ## Getting help
 
 If you're experiencing issues with OpenCode:
@@ -200,6 +222,27 @@ Here are some common issues and how to resolve them.
 1. Check the logs for error messages
 2. Try running with `--print-logs` to see output in the terminal
 3. Ensure you have the latest version with `opencode upgrade`
+
+---
+
+### Configuration is invalid
+
+If startup fails with `Configuration is invalid`, your config shape does not match the schema.
+
+Quick validation checklist:
+
+1. Ensure your config is actual config data, not a copied JSON schema file.
+2. Add `"$schema": "https://opencode.ai/config.json"` at the top of your config.
+3. Run `opencode debug config` after each change to verify the merged result.
+
+Common mistakes:
+
+- `model` must be a string like `openai/gpt-5`, not an object
+- `command.<name>` must be an object with `template` (string)
+- `agent.<name>.tools` must be an object map (`{ "bash": true }`), not an array
+- Custom `lsp` entries require an `extensions` array
+
+If you are migrating from another tool's config format, copy only supported keys from the [config schema](https://opencode.ai/config.json) and rebuild incrementally.
 
 ---
 


### PR DESCRIPTION
## Summary
- add provider authentication precedence section (config apiKey vs stored auth vs env)
- document auth conflict debugging commands (`auth list`, `auth logout`, `debug config`)
- update troubleshooting storage layout to match current directories/files
- add app/CLI desync troubleshooting for different XDG/sandbox paths
- add invalid config troubleshooting checklist for common schema mismatch errors
- add config schema note to avoid pasting schema JSON as runtime config

## Why
This addresses recurring confusion in support/issues around:
- OAuth/API-key precedence conflicts
- stale storage path docs
- desktop vs CLI state desync
- migration from non-OpenCode custom config formats

Refs #11560, #7483, #13869.
