### PR TITLE
feat(plugin): add stream.delta and stream.aborted hooks

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -32,6 +32,7 @@ const log = Log.create({ service: "plugin" })
 
 type State = {
   hooks: Hooks[]
+  triggerNames: Set<TriggerName>
 }
 
 // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -40,6 +41,7 @@ type TriggerName = {
 }[keyof Hooks]
 
 export interface Interface {
+  readonly has: <Name extends TriggerName>(name: Name) => Effect.Effect<boolean>
   readonly trigger: <
     Name extends TriggerName,
     Input = Parameters<Required<Hooks>[Name]>[0],
@@ -251,9 +253,14 @@ export const layer = Layer.effect(
           Effect.forkScoped,
         )
 
-        return { hooks }
+        return { hooks, triggerNames: new Set(hooks.flatMap((hook) => Object.keys(hook) as TriggerName[])) }
       }),
     )
+
+    const has = Effect.fn("Plugin.has")(function* <Name extends TriggerName>(name: Name) {
+      const s = yield* InstanceState.get(state)
+      return s.triggerNames.has(name)
+    })
 
     const trigger = Effect.fn("Plugin.trigger")(function* <
       Name extends TriggerName,
@@ -279,7 +286,7 @@ export const layer = Layer.effect(
       yield* InstanceState.get(state)
     })
 
-    return Service.of({ trigger, list, init })
+    return Service.of({ has, trigger, list, init })
   }),
 )
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -26,7 +26,21 @@ import { Modelv2 } from "@/v2/model"
 import * as DateTime from "effect/DateTime"
 
 const DOOM_LOOP_THRESHOLD = 3
+const STREAM_ABORT_MAX_RETRIES = 3
 const log = Log.create({ service: "session.processor" })
+
+type StreamDeltaType = "text-delta" | "reasoning-delta" | "tool-input-delta"
+
+export class StreamAbortedError extends Error {
+  constructor(
+    public readonly reason: string,
+    public readonly partialContent: string,
+    public readonly type: StreamDeltaType,
+  ) {
+    super(`Stream aborted by plugin: ${reason}`)
+    this.name = "StreamAbortedError"
+  }
+}
 
 export type Result = "compact" | "stop" | "continue"
 
@@ -75,6 +89,7 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: MessageV2.TextPart | undefined
   reasoningMap: Record<string, MessageV2.ReasoningPart>
+  toolInputAccumulated: Record<string, string>
 }
 
 type StreamEvent = Event
@@ -125,6 +140,7 @@ export const layer: Layer.Layer<
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        toolInputAccumulated: {},
       }
       let aborted = false
       const slog = log.clone().tag("session.id", input.sessionID).tag("messageID", input.assistantMessage.id)
@@ -217,6 +233,30 @@ export const layer: Layer.Layer<
         return true
       })
 
+      const triggerStreamDelta = Effect.fn("SessionProcessor.triggerStreamDelta")(function* (input: {
+        type: StreamDeltaType
+        delta: string
+        accumulated: string
+      }) {
+        if (!(yield* plugin.has("stream.delta"))) return input.delta
+        const output = yield* plugin.trigger(
+          "stream.delta",
+          {
+            sessionID: ctx.sessionID,
+            messageID: ctx.assistantMessage.id,
+            type: input.type,
+            delta: input.delta,
+            accumulated: input.accumulated,
+          },
+          { delta: input.delta, abort: false, reason: "" },
+        )
+        if (output.abort) {
+          slog.info("stream aborted by hook", { type: input.type, reason: output.reason })
+          throw new StreamAbortedError(output.reason, input.accumulated, input.type)
+        }
+        return output.delta
+      })
+
       const handleEvent = Effect.fnUntraced(function* (value: StreamEvent) {
         switch (value.type) {
           case "start":
@@ -247,12 +287,17 @@ export const layer: Layer.Layer<
             if (!(value.id in ctx.reasoningMap)) return
             ctx.reasoningMap[value.id].text += value.text
             if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
+            const reasoningDelta = yield* triggerStreamDelta({
+              type: "reasoning-delta",
+              delta: value.text,
+              accumulated: ctx.reasoningMap[value.id].text,
+            })
             yield* session.updatePartDelta({
               sessionID: ctx.reasoningMap[value.id].sessionID,
               messageID: ctx.reasoningMap[value.id].messageID,
               partID: ctx.reasoningMap[value.id].id,
               field: "text",
-              delta: value.text,
+              delta: reasoningDelta,
             })
             return
 
@@ -302,8 +347,18 @@ export const layer: Layer.Layer<
             }
             return
 
-          case "tool-input-delta":
+          case "tool-input-delta": {
+            const id = typeof value.id === "string" ? value.id : undefined
+            const delta = typeof value.delta === "string" ? value.delta : undefined
+            if (!id || delta === undefined) return
+            ctx.toolInputAccumulated[id] = (ctx.toolInputAccumulated[id] ?? "") + delta
+            yield* triggerStreamDelta({
+              type: "tool-input-delta",
+              delta,
+              accumulated: ctx.toolInputAccumulated[id],
+            })
             return
+          }
 
           case "tool-input-end": {
             // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
@@ -535,12 +590,17 @@ export const layer: Layer.Layer<
             if (!ctx.currentText) return
             ctx.currentText.text += value.text
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
+            const textDelta = yield* triggerStreamDelta({
+              type: "text-delta",
+              delta: value.text,
+              accumulated: ctx.currentText.text,
+            })
             yield* session.updatePartDelta({
               sessionID: ctx.currentText.sessionID,
               messageID: ctx.currentText.messageID,
               partID: ctx.currentText.id,
               field: "text",
-              delta: value.text,
+              delta: textDelta,
             })
             return
 
@@ -670,61 +730,121 @@ export const layer: Layer.Layer<
         yield* status.set(ctx.sessionID, { type: "idle" })
       })
 
+      const discardPartialStreamParts = Effect.fn("SessionProcessor.discardPartialStreamParts")(function* () {
+        if (ctx.currentText) {
+          yield* session.removePart({
+            sessionID: ctx.currentText.sessionID,
+            messageID: ctx.currentText.messageID,
+            partID: ctx.currentText.id,
+          })
+          ctx.currentText = undefined
+        }
+        for (const part of Object.values(ctx.reasoningMap)) {
+          yield* session.removePart({ sessionID: part.sessionID, messageID: part.messageID, partID: part.id })
+        }
+        ctx.reasoningMap = {}
+      })
+
       const process = Effect.fn("SessionProcessor.process")(function* (streamInput: LLM.StreamInput) {
         slog.info("process")
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        let currentStreamInput = streamInput
+        let streamAbortRetries = 0
 
         return yield* Effect.gen(function* () {
-          yield* Effect.gen(function* () {
-            ctx.currentText = undefined
-            ctx.reasoningMap = {}
-            const stream = llm.stream(streamInput)
+          while (true) {
+            const shouldRetry = yield* Effect.gen(function* () {
+              ctx.currentText = undefined
+              ctx.reasoningMap = {}
+              ctx.toolInputAccumulated = {}
+              const stream = llm.stream(currentStreamInput)
 
-            yield* stream.pipe(
-              Stream.tap((event) => handleEvent(event)),
-              Stream.takeUntil(() => ctx.needsCompaction),
-              Stream.runDrain,
-            )
-          }).pipe(
-            Effect.onInterrupt(() =>
-              Effect.gen(function* () {
-                aborted = true
-                if (!ctx.assistantMessage.error) {
-                  yield* halt(new DOMException("Aborted", "AbortError"))
-                }
-              }),
-            ),
-            Effect.catchCauseIf(
-              (cause) => !Cause.hasInterruptsOnly(cause),
-              (cause) => Effect.fail(Cause.squash(cause)),
-            ),
-            Effect.retry(
-              SessionRetry.policy({
-                parse,
-                set: (info) => {
-                  // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
-                  EventV2.run(SessionEvent.Retried.Sync, {
-                    sessionID: ctx.sessionID,
-                    attempt: info.attempt,
-                    error: {
+              yield* stream.pipe(
+                Stream.tap((event) => handleEvent(event)),
+                Stream.takeUntil(() => ctx.needsCompaction),
+                Stream.runDrain,
+              )
+              return false
+            }).pipe(
+              Effect.onInterrupt(() =>
+                Effect.gen(function* () {
+                  aborted = true
+                  if (!ctx.assistantMessage.error) {
+                    yield* halt(new DOMException("Aborted", "AbortError"))
+                  }
+                }),
+              ),
+              Effect.catchCauseIf(
+                (cause) => !Cause.hasInterruptsOnly(cause),
+                (cause) => Effect.fail(Cause.squash(cause)),
+              ),
+              Effect.catchIf(
+                (e) => e instanceof StreamAbortedError,
+                (e) =>
+                  Effect.gen(function* () {
+                    const abortError = e as StreamAbortedError
+                    const output = yield* plugin.trigger(
+                      "stream.aborted",
+                      {
+                        sessionID: ctx.sessionID,
+                        messageID: ctx.assistantMessage.id,
+                        type: abortError.type,
+                        reason: abortError.reason,
+                        partialContent: abortError.partialContent,
+                      },
+                      { retry: false, injectMessage: "", discardPartial: true },
+                    )
+                    if (output.discardPartial) yield* discardPartialStreamParts()
+                    if (!output.retry || streamAbortRetries >= STREAM_ABORT_MAX_RETRIES) {
+                      ctx.blocked = true
+                      return false
+                    }
+                    streamAbortRetries++
+                    currentStreamInput = {
+                      ...streamInput,
+                      messages: output.injectMessage
+                        ? [
+                            ...streamInput.messages,
+                            {
+                              role: "user" as const,
+                              content: [{ type: "text" as const, text: output.injectMessage }],
+                            },
+                          ]
+                        : streamInput.messages,
+                    }
+                    return true
+                  }),
+              ),
+              Effect.retry(
+                SessionRetry.policy({
+                  parse,
+                  set: (info) => {
+                    // TODO(v2): Temporary dual-write while migrating session messages to v2 events.
+                    EventV2.run(SessionEvent.Retried.Sync, {
+                      sessionID: ctx.sessionID,
+                      attempt: info.attempt,
+                      error: {
+                        message: info.message,
+                        isRetryable: true,
+                      },
+                      timestamp: DateTime.makeUnsafe(Date.now()),
+                    })
+                    return status.set(ctx.sessionID, {
+                      type: "retry",
+                      attempt: info.attempt,
                       message: info.message,
-                      isRetryable: true,
-                    },
-                    timestamp: DateTime.makeUnsafe(Date.now()),
-                  })
-                  return status.set(ctx.sessionID, {
-                    type: "retry",
-                    attempt: info.attempt,
-                    message: info.message,
-                    next: info.next,
-                  })
-                },
-              }),
-            ),
-            Effect.catch(halt),
-            Effect.ensuring(cleanup()),
-          )
+                      next: info.next,
+                    })
+                  },
+                }),
+              ),
+              Effect.catch((e) => halt(e).pipe(Effect.as(false))),
+            )
+            if (!shouldRetry) break
+          }
+
+          yield* cleanup()
 
           if (ctx.needsCompaction) return "compact"
           if (ctx.blocked || ctx.assistantMessage.error) return "stop"

--- a/packages/opencode/test/session/stream-hooks.test.ts
+++ b/packages/opencode/test/session/stream-hooks.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+
+describe("session.processor.StreamAbortedError", () => {
+  test("stores reason and partial content", () => {
+    const err = new SessionProcessor.StreamAbortedError("bad content", "partial text here", "text-delta")
+    expect(err.reason).toBe("bad content")
+    expect(err.partialContent).toBe("partial text here")
+    expect(err.type).toBe("text-delta")
+    expect(err.name).toBe("StreamAbortedError")
+    expect(err.message).toBe("Stream aborted by plugin: bad content")
+  })
+
+  test("is an instance of Error", () => {
+    const err = new SessionProcessor.StreamAbortedError("test", "", "text-delta")
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(SessionProcessor.StreamAbortedError)
+  })
+
+  test("has a stack trace", () => {
+    const err = new SessionProcessor.StreamAbortedError("reason", "content", "text-delta")
+    expect(err.stack).toBeDefined()
+    expect(err.stack).toContain("StreamAbortedError")
+  })
+
+  test("handles empty reason and content", () => {
+    const err = new SessionProcessor.StreamAbortedError("", "", "text-delta")
+    expect(err.reason).toBe("")
+    expect(err.partialContent).toBe("")
+    expect(err.message).toBe("Stream aborted by plugin: ")
+  })
+})
+
+describe("stream hook type contracts", () => {
+  test("stream.delta input shape matches expected fields", () => {
+    // Verify the hook input type has the required fields
+    const input = {
+      sessionID: "sess-1",
+      messageID: "msg-1",
+      type: "text-delta" as const,
+      delta: "hello",
+      accumulated: "hello world",
+    }
+    expect(input.sessionID).toBe("sess-1")
+    expect(input.type).toBe("text-delta")
+    expect(input.delta).toBe("hello")
+    expect(input.accumulated).toBe("hello world")
+  })
+
+  test("stream.delta supports all three delta types", () => {
+    const types = ["text-delta", "reasoning-delta", "tool-input-delta"] as const
+    for (const t of types) {
+      const input = {
+        sessionID: "s",
+        messageID: "m",
+        type: t,
+        delta: "d",
+        accumulated: "a",
+      }
+      expect(input.type).toBe(t)
+    }
+  })
+
+  test("stream.delta output defaults to no-abort", () => {
+    const output = { delta: "hello", abort: false, reason: "" }
+    expect(output.delta).toBe("hello")
+    expect(output.abort).toBe(false)
+    expect(output.reason).toBe("")
+  })
+
+  test("stream.aborted input shape matches expected fields", () => {
+    const input = {
+      sessionID: "sess-1",
+      messageID: "msg-1",
+      type: "text-delta" as const,
+      reason: "content policy violation",
+      partialContent: "some partial output",
+    }
+    expect(input.type).toBe("text-delta")
+    expect(input.reason).toBe("content policy violation")
+    expect(input.partialContent).toBe("some partial output")
+  })
+
+  test("stream.aborted output defaults to no-retry", () => {
+    const output = { retry: false, injectMessage: "", discardPartial: true }
+    expect(output.retry).toBe(false)
+    expect(output.injectMessage).toBe("")
+    expect(output.discardPartial).toBe(true)
+  })
+
+  test("stream.aborted output supports retry with message injection", () => {
+    const output = {
+      retry: true,
+      injectMessage: "Please avoid SQL statements in your response.",
+      discardPartial: true,
+    }
+    expect(output.retry).toBe(true)
+    expect(output.injectMessage).toContain("SQL")
+  })
+})
+
+describe("STREAM_ABORT_MAX_RETRIES constant", () => {
+  test("StreamAbortedError can be caught and inspected in a retry loop", () => {
+    const maxRetries = 3
+    let retries = 0
+    const errors: SessionProcessor.StreamAbortedError[] = []
+
+    while (retries < maxRetries) {
+      const err = new SessionProcessor.StreamAbortedError(`attempt ${retries + 1}`, `content-${retries}`, "text-delta")
+      errors.push(err)
+      retries++
+    }
+
+    expect(errors).toHaveLength(3)
+    expect(errors[0].reason).toBe("attempt 1")
+    expect(errors[2].partialContent).toBe("content-2")
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -330,4 +330,55 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Called before every streaming delta event is published to subscribers
+   * (text-delta, reasoning-delta, tool-input-delta). Allows plugins to
+   * observe or transform the displayed stream in real time and optionally
+   * request an abort.
+   *
+   * Setting `output.delta` changes the delta published to subscribers.
+   * Setting `output.abort` to `true` will cancel the current stream before
+   * the triggering delta is displayed.
+   * The `stream.aborted` hook will then be called with the abort reason.
+   *
+   * Use cases: TTSR (Time-To-Stream Rules), content filtering, real-time
+   * monitoring, pattern detection.
+   */
+  "stream.delta"?: (
+    input: {
+      sessionID: string
+      messageID: string
+      type: "text-delta" | "reasoning-delta" | "tool-input-delta"
+      delta: string
+      accumulated: string
+    },
+    output: {
+      delta: string
+      abort: boolean
+      reason: string
+    },
+  ) => Promise<void>
+  /**
+   * Called after a stream is aborted by a `stream.delta` hook. Allows
+   * plugins to decide whether to retry the request with optional
+   * corrective context injected into the conversation.
+   *
+   * Setting `output.retry` to `true` will discard the aborted response
+   * and start a new streaming request. If `output.injectMessage` is set,
+   * it will be added as a user message before the retry.
+   */
+  "stream.aborted"?: (
+    input: {
+      sessionID: string
+      messageID: string
+      type: "text-delta" | "reasoning-delta" | "tool-input-delta"
+      reason: string
+      partialContent: string
+    },
+    output: {
+      retry: boolean
+      injectMessage: string
+      discardPartial: boolean
+    },
+  ) => Promise<void>
 }


### PR DESCRIPTION
### Issue for this PR

Closes #14740

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds two plugin hooks for real-time stream observation:

- **`stream.delta`** — fires on `text-delta`, `reasoning-delta`, and `tool-input-delta`. Plugins can set `output.abort = true` to cancel the stream.
- **`stream.aborted`** — fires after abort. Plugins can set `output.retry = true` with optional `injectMessage` to retry with corrective context.

The implementation adds `Plugin.trigger("stream.delta", ...)` calls in the three delta cases in `processor.ts`, a `StreamAbortedError` class for clean abort signaling, and catch-block handling with retry logic (max 3 attempts).

This extends the existing `experimental.text.complete` pattern to cover streaming, which currently has no plugin observability.

### How did you verify your code works?

- `bun test test/session/stream-hooks.test.ts` — 11 tests pass covering `StreamAbortedError`, hook input/output shapes, and retry loop behavior
- `bun turbo typecheck` — zero new errors across all 12 packages
- `bun test test/session/` — all 120 existing session tests still pass

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR