### PR TITLE
feat(app): show parent directory name above project icons in sidebar

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1680,6 +1680,7 @@ export default function Layout(props: ParentProps) {
     setStore("activeWorkspace", undefined)
   }
 
+
   const createWorkspace = async (project: LocalProject) => {
     clearSidebarHoverState()
     const created = await globalSDK.client.worktree

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1680,7 +1680,6 @@ export default function Layout(props: ParentProps) {
     setStore("activeWorkspace", undefined)
   }
 
-
   const createWorkspace = async (project: LocalProject) => {
     clearSidebarHoverState()
     const created = await globalSDK.client.worktree

--- a/packages/app/src/pages/layout/sidebar-project-helpers.ts
+++ b/packages/app/src/pages/layout/sidebar-project-helpers.ts
@@ -10,7 +10,6 @@ export const projectTileActive = (args: {
   worktree: string
 }) => args.menu || (args.preview ? args.open : args.overlay && args.hoverProject === args.worktree)
 
-
 export const parentName = (path: string) => {
   const clean = path.replace(/[\\/]+$/, "")
   const idx = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\"))

--- a/packages/app/src/pages/layout/sidebar-project-helpers.ts
+++ b/packages/app/src/pages/layout/sidebar-project-helpers.ts
@@ -9,3 +9,11 @@ export const projectTileActive = (args: {
   hoverProject?: string
   worktree: string
 }) => args.menu || (args.preview ? args.open : args.overlay && args.hoverProject === args.worktree)
+
+
+export const parentName = (path: string) => {
+  const clean = path.replace(/[\\/]+$/, "")
+  const idx = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\"))
+  if (idx <= 0) return ""
+  return clean.slice(0, idx).replace(/^.*[\\/]/, "")
+}

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createMemo, For, Show, type Accessor, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { base64Encode } from "@opencode-ai/util/encode"
+import { getFilename } from "@opencode-ai/util/path"
 import { Button } from "@opencode-ai/ui/button"
 import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { HoverCard } from "@opencode-ai/ui/hover-card"
@@ -369,41 +370,54 @@ export const SortableProject = (props: {
     />
   )
 
+
+  const parentName = (path: string) => {
+    const clean = path.replace(/[\\/]+$/, "")
+    const idx = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\"))
+    if (idx <= 0) return ""
+    return getFilename(clean.slice(0, idx))
+  }
+
   return (
     // @ts-ignore
     <div use:sortable classList={{ "opacity-30": sortable.isActiveDraggable }}>
-      <Show when={preview() && !selected()} fallback={tile()}>
-        <HoverCard
-          open={!state.suppressHover && state.open && !state.menu}
-          openDelay={0}
-          closeDelay={0}
-          placement="right-start"
-          gutter={6}
-          trigger={tile()}
-          onOpenChange={(value) => {
-            if (state.menu) return
-            if (value && state.suppressHover) return
-            setState("open", value)
-            if (value) props.ctx.setHoverSession(undefined)
-          }}
-        >
-          <ProjectPreviewPanel
-            project={props.project}
-            mobile={props.mobile}
-            selected={selected}
-            workspaceEnabled={workspaceEnabled}
-            workspaces={workspaces}
-            label={label}
-            projectSessions={projectSessions}
-            projectChildren={projectChildren}
-            workspaceSessions={workspaceSessions}
-            workspaceChildren={workspaceChildren}
-            setOpen={(value) => setState("open", value)}
-            ctx={props.ctx}
-            language={language}
-          />
-        </HoverCard>
-      </Show>
+      <div class="flex flex-col items-center">
+        <span class="text-[10px] leading-tight text-text-base text-center truncate w-10" title={parentName(props.project.worktree)}>
+          {parentName(props.project.worktree)}
+        </span>
+        <Show when={preview() && !selected()} fallback={tile()}>
+          <HoverCard
+            open={!state.suppressHover && state.open && !state.menu}
+            openDelay={0}
+            closeDelay={0}
+            placement="right-start"
+            gutter={6}
+            trigger={tile()}
+            onOpenChange={(value) => {
+              if (state.menu) return
+              if (value && state.suppressHover) return
+              setState("open", value)
+              if (value) props.ctx.setHoverSession(undefined)
+            }}
+          >
+            <ProjectPreviewPanel
+              project={props.project}
+              mobile={props.mobile}
+              selected={selected}
+              workspaceEnabled={workspaceEnabled}
+              workspaces={workspaces}
+              label={label}
+              projectSessions={projectSessions}
+              projectChildren={projectChildren}
+              workspaceSessions={workspaceSessions}
+              workspaceChildren={workspaceChildren}
+              setOpen={(value) => setState("open", value)}
+              ctx={props.ctx}
+              language={language}
+            />
+          </HoverCard>
+        </Show>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -1,7 +1,6 @@
 import { createEffect, createMemo, For, Show, type Accessor, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { base64Encode } from "@opencode-ai/util/encode"
-import { getFilename } from "@opencode-ai/util/path"
 import { Button } from "@opencode-ai/ui/button"
 import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { HoverCard } from "@opencode-ai/ui/hover-card"
@@ -15,7 +14,7 @@ import { useLanguage } from "@/context/language"
 import { useNotification } from "@/context/notification"
 import { ProjectIcon, SessionItem, type SessionItemProps } from "./sidebar-items"
 import { childMapByParent, displayName, sortedRootSessions } from "./helpers"
-import { projectSelected, projectTileActive } from "./sidebar-project-helpers"
+import { parentName, projectSelected, projectTileActive } from "./sidebar-project-helpers"
 
 export type ProjectSidebarContext = {
   currentDir: Accessor<string>
@@ -369,14 +368,6 @@ export const SortableProject = (props: {
       language={language}
     />
   )
-
-
-  const parentName = (path: string) => {
-    const clean = path.replace(/[\\/]+$/, "")
-    const idx = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\"))
-    if (idx <= 0) return ""
-    return getFilename(clean.slice(0, idx))
-  }
 
   return (
     // @ts-ignore


### PR DESCRIPTION
### Issue for this PR

Closes #14757

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a small parent directory name label above each project icon in the sidebar. When multiple projects share the same name but live under different directories (e.g. `rluisr/opencode` vs `exxinc/opencode`), the icons alone are indistinguishable. The label shows the parent folder name to differentiate them.

### How did you verify your code works?

Ran `bun dev` locally and verified the label renders correctly on desktop and mobile viewports.

### Screenshots / recordings

#### Before
![before](https://github.com/rluisr/opencode/releases/download/screenshots-pr-14758/before.png)

#### After
![after](https://github.com/rluisr/opencode/releases/download/screenshots-pr-14758/after.png)

#### Mobile
![mobile](https://github.com/rluisr/opencode/releases/download/screenshots-pr-14758/mobile.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR