### PR TITLE
fix(ui): remove aria-hidden from assistant content

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -364,7 +364,7 @@ export function SessionTurn(
                   <Message message={msg()} parts={parts()} interrupted={interrupted()} />
                 </div>
                 <Show when={assistantMessages().length > 0}>
-                  <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
+                  <div data-slot="session-turn-assistant-content">
                     <AssistantParts
                       messages={assistantMessages()}
                       showAssistantCopyPartID={assistantCopyPartID()}


### PR DESCRIPTION
### Issue for this PR

Closes #14763

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes aria-hidden={working()} from the assistant message container in SessionTurn so assistant content remains available to assistive technologies while the turn is running.

### How did you verify your code works?

Verified locally that assistant content still renders during and after working state, and that no unrelated behavior changed.

### Screenshots / recordings

N/A (accessibility attribute-only change, no visual UI difference).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
