### PR TITLE
fix: set Windows console code page to UTF-8 for CJK input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -1,7 +1,7 @@
 import { cmd } from "../cmd"
 import { UI } from "@/cli/ui"
 import { tui } from "./app"
-import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32InstallCtrlCGuard, win32SetUtf8CodePage } from "./win32"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -40,6 +40,7 @@ export const AttachCommand = cmd({
     const unguard = win32InstallCtrlCGuard()
     try {
       win32DisableProcessedInput()
+      win32SetUtf8CodePage()
 
       if (args.fork && !args.continue && !args.session) {
         UI.error("--fork requires --continue or --session")

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -11,7 +11,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import { Filesystem } from "@/util/filesystem"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
-import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32InstallCtrlCGuard, win32SetUtf8CodePage } from "./win32"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -87,6 +87,7 @@ export const TuiThreadCommand = cmd({
       // Must be the very first thing — disables CTRL_C_EVENT before any Worker
       // spawn or async work so the OS cannot kill the process group.
       win32DisableProcessedInput()
+      win32SetUtf8CodePage()
 
       if (args.fork && !args.continue && !args.session) {
         UI.error("--fork requires --continue or --session")

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -2,6 +2,7 @@ import { dlopen, ptr } from "bun:ffi"
 
 const STD_INPUT_HANDLE = -10
 const ENABLE_PROCESSED_INPUT = 0x0001
+const CP_UTF8 = 65001
 
 const kernel = () =>
   dlopen("kernel32.dll", {
@@ -9,6 +10,8 @@ const kernel = () =>
     GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
     SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
     FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
+    SetConsoleCP: { args: ["u32"], returns: "i32" },
+    SetConsoleOutputCP: { args: ["u32"], returns: "i32" },
   })
 
 let k32: ReturnType<typeof kernel> | undefined
@@ -21,6 +24,18 @@ function load() {
   } catch {
     return false
   }
+}
+
+/**
+ * Set console code page to UTF-8 for proper Unicode input/output.
+ * This fixes character encoding issues when using CJK (Chinese, Japanese, Korean)
+ * and other non-ASCII input methods on Windows.
+ */
+export function win32SetUtf8CodePage() {
+  if (process.platform !== "win32") return
+  if (!load()) return
+  k32!.symbols.SetConsoleCP(CP_UTF8)
+  k32!.symbols.SetConsoleOutputCP(CP_UTF8)
 }
 
 /**


### PR DESCRIPTION
### Issue for this PR

Closes #14768

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes CJK character garbling in OpenCode TUI on Windows systems with non-UTF8 locales (e.g., Chinese GBK).

**Problem:** On Windows with Chinese/Japanese/Korean locale, typing CJK characters in the TUI results in garbled text (mojibake) because Windows console defaults to local code pages (e.g., GBK 936) instead of UTF-8.

**Solution:** Added `win32SetUtf8CodePage()` function that calls Windows API `SetConsoleCP(CP_UTF8)` and `SetConsoleOutputCP(CP_UTF8)` to set console code page to UTF-8 before TUI initialization.

**Changes:**

- `win32.ts`: Added `CP_UTF8 = 65001` constant, imported `SetConsoleCP`/`SetConsoleOutputCP`, added `win32SetUtf8CodePage()` function
- `thread.ts`: Call `win32SetUtf8CodePage()` after `win32DisableProcessedInput()` in TUI handler
- `attach.ts`: Call `win32SetUtf8CodePage()` after `win32DisableProcessedInput()` in attach handler

### How did you verify your code works?

1. Built locally with Bun
2. Ran on Windows 11 with Chinese locale (GBK code page 936)
3. Verified CJK characters (中文、日本語) display correctly in TUI input box
4. Verified normal ASCII input still works as expected

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
