### PR TITLE
fix(ui): prevent filename and diff count overlap in session changes

### DIFF
--- a/packages/ui/src/components/session-review.css
+++ b/packages/ui/src/components/session-review.css
@@ -99,6 +99,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
+    min-width: 0;
     gap: 20px;
   }
 
@@ -115,9 +116,12 @@
     align-items: center;
     flex-grow: 1;
     min-width: 0;
+    overflow: hidden;
   }
 
   [data-slot="session-review-directory"] {
+    flex: 1 1 auto;
+    min-width: 0;
     color: var(--text-base);
     text-overflow: ellipsis;
     overflow: hidden;
@@ -129,6 +133,11 @@
   [data-slot="session-review-filename"] {
     color: var(--text-strong);
     flex-shrink: 0;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   [data-slot="session-review-view-button"] {
@@ -163,6 +172,7 @@
     gap: 16px;
     align-items: center;
     justify-content: flex-end;
+    margin-left: auto;
   }
 
   [data-slot="session-review-diff-chevron"] {


### PR DESCRIPTION
### Issue for this PR

Closes #14752

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a layout bug in the Session changes sidebar where long paths could overlap the diff count when the pane is narrow.

The change is scoped to `packages/ui/src/components/session-review.css`:
- allows the left filename section to shrink (`min-width: 0`)
- clips overflowing name content and applies ellipsis
- keeps right-side actions/counts pinned (`margin-left: auto`, non-shrinking actions)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR