### PR TITLE
feat(app): add file and folder path context actions to desktop app

### DIFF
--- a/packages/app/src/components/file-tree.test.ts
+++ b/packages/app/src/components/file-tree.test.ts
@@ -28,6 +28,16 @@ beforeAll(async () => {
   }))
   mock.module("@opencode-ai/ui/file-icon", () => ({ FileIcon: () => null }))
   mock.module("@opencode-ai/ui/icon", () => ({ Icon: () => null }))
+  mock.module("@opencode-ai/ui/context-menu", () => ({
+    ContextMenu: {
+      Trigger: (props: { children?: unknown }) => props.children,
+      Portal: (props: { children?: unknown }) => props.children,
+      Content: (props: { children?: unknown }) => props.children,
+      Item: (props: { children?: unknown }) => props.children,
+      ItemLabel: (props: { children?: unknown }) => props.children,
+      Separator: () => null,
+    },
+  }))
   mock.module("@opencode-ai/ui/tooltip", () => ({ Tooltip: (props: { children?: unknown }) => props.children }))
   const mod = await import("./file-tree")
   shouldListRoot = mod.shouldListRoot

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -529,23 +529,25 @@ export default function FileTree(props: {
                 >
                   <ContextMenu>
                     <ContextMenu.Trigger asChild>
-                      <Collapsible.Trigger>
-                        <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
-                          <FileTreeNode
-                            node={node}
-                            level={level}
-                            active={props.active}
-                            nodeClass={props.nodeClass}
-                            draggable={draggable()}
-                            kinds={kinds()}
-                            marks={marks()}
-                          >
-                            <div class="size-4 flex items-center justify-center text-icon-weak">
-                              <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
-                            </div>
-                          </FileTreeNode>
-                        </FileTreeNodeTooltip>
-                      </Collapsible.Trigger>
+                      <div>
+                        <Collapsible.Trigger>
+                          <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
+                            <FileTreeNode
+                              node={node}
+                              level={level}
+                              active={props.active}
+                              nodeClass={props.nodeClass}
+                              draggable={draggable()}
+                              kinds={kinds()}
+                              marks={marks()}
+                            >
+                              <div class="size-4 flex items-center justify-center text-icon-weak">
+                                <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
+                              </div>
+                            </FileTreeNode>
+                          </FileTreeNodeTooltip>
+                        </Collapsible.Trigger>
+                      </div>
                     </ContextMenu.Trigger>
                     <ContextMenu.Portal>
                       <ContextMenu.Content>
@@ -613,53 +615,55 @@ export default function FileTree(props: {
               <Match when={node.type === "file"}>
                 <ContextMenu>
                   <ContextMenu.Trigger asChild>
-                    <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
-                      <FileTreeNode
-                        node={node}
-                        level={level}
-                        active={props.active}
-                        nodeClass={props.nodeClass}
-                        draggable={draggable()}
-                        kinds={kinds()}
-                        marks={marks()}
-                        as="button"
-                        type="button"
-                        onClick={() => props.onFileClick?.(node)}
-                      >
-                        <div class="w-4 shrink-0" />
-                        <Switch>
-                          <Match when={node.ignored}>
-                            <FileIcon
-                              node={node}
-                              class="size-4 filetree-icon filetree-icon--mono"
-                              style="color: var(--icon-weak-base)"
-                              mono
-                            />
-                          </Match>
-                          <Match when={active()}>
-                            <FileIcon
-                              node={node}
-                              class="size-4 filetree-icon filetree-icon--mono"
-                              style={kindTextColor(kind()!)}
-                              mono
-                            />
-                          </Match>
-                          <Match when={!node.ignored}>
-                            <span class="filetree-iconpair size-4">
+                    <div>
+                      <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
+                        <FileTreeNode
+                          node={node}
+                          level={level}
+                          active={props.active}
+                          nodeClass={props.nodeClass}
+                          draggable={draggable()}
+                          kinds={kinds()}
+                          marks={marks()}
+                          as="button"
+                          type="button"
+                          onClick={() => props.onFileClick?.(node)}
+                        >
+                          <div class="w-4 shrink-0" />
+                          <Switch>
+                            <Match when={node.ignored}>
                               <FileIcon
                                 node={node}
-                                class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
-                              />
-                              <FileIcon
-                                node={node}
-                                class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                                class="size-4 filetree-icon filetree-icon--mono"
+                                style="color: var(--icon-weak-base)"
                                 mono
                               />
-                            </span>
-                          </Match>
-                        </Switch>
-                      </FileTreeNode>
-                    </FileTreeNodeTooltip>
+                            </Match>
+                            <Match when={active()}>
+                              <FileIcon
+                                node={node}
+                                class="size-4 filetree-icon filetree-icon--mono"
+                                style={kindTextColor(kind()!)}
+                                mono
+                              />
+                            </Match>
+                            <Match when={!node.ignored}>
+                              <span class="filetree-iconpair size-4">
+                                <FileIcon
+                                  node={node}
+                                  class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
+                                />
+                                <FileIcon
+                                  node={node}
+                                  class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                                  mono
+                                />
+                              </span>
+                            </Match>
+                          </Switch>
+                        </FileTreeNode>
+                      </FileTreeNodeTooltip>
+                    </div>
                   </ContextMenu.Trigger>
                   <ContextMenu.Portal>
                     <ContextMenu.Content>

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -3,6 +3,9 @@ import { encodeFilePath } from "@/context/file/path"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { showToast } from "@opencode-ai/ui/toast"
 import {
   createEffect,
   createMemo,
@@ -19,6 +22,11 @@ import {
 } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import type { FileNode } from "@opencode-ai/sdk/v2"
+import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
+import { useSDK } from "@/context/sdk"
+import { copyFile } from "@/utils/file-copy"
 
 const MAX_DEPTH = 128
 
@@ -191,6 +199,59 @@ const FileTreeNode = (
   )
 }
 
+const FileTreeNodeTooltip = (props: { enabled: boolean; node: FileNode; kind?: Kind; children: JSXElement }) => {
+  if (!props.enabled) return props.children
+
+  const parts = props.node.path.split("/")
+  const leaf = parts[parts.length - 1] ?? props.node.path
+  const head = parts.slice(0, -1).join("/")
+  const prefix = head ? `${head}/` : ""
+  const label =
+    props.kind === "add"
+      ? "Additions"
+      : props.kind === "del"
+        ? "Deletions"
+        : props.kind === "mix"
+          ? "Modifications"
+          : undefined
+
+  return (
+    <Tooltip
+      openDelay={2000}
+      placement="bottom-start"
+      class="w-full"
+      contentStyle={{ "max-width": "480px", width: "fit-content" }}
+      value={
+        <div class="flex items-center min-w-0 whitespace-nowrap text-12-regular">
+          <span
+            class="min-w-0 truncate text-text-invert-base"
+            style={{ direction: "rtl", "unicode-bidi": "plaintext" }}
+          >
+            {prefix}
+          </span>
+          <span class="shrink-0 text-text-invert-strong">{leaf}</span>
+          <Show when={label}>
+            {(text) => (
+              <>
+                <span class="mx-1 font-bold text-text-invert-strong">•</span>
+                <span class="shrink-0 text-text-invert-strong">{text()}</span>
+              </>
+            )}
+          </Show>
+          <Show when={props.node.type === "directory" && props.node.ignored}>
+            <>
+              <span class="mx-1 font-bold text-text-invert-strong">•</span>
+              <span class="shrink-0 text-text-invert-strong">Ignored</span>
+            </>
+          </Show>
+        </div>
+      }
+    >
+      {props.children}
+    </Tooltip>
+  )
+}
+
 export default function FileTree(props: {
   path: string
   class?: string
@@ -201,6 +262,7 @@ export default function FileTree(props: {
   modified?: readonly string[]
   kinds?: ReadonlyMap<string, Kind>
   draggable?: boolean
+  tooltip?: boolean
   onFileClick?: (file: FileNode) => void
 
   _filter?: Filter
@@ -210,8 +272,63 @@ export default function FileTree(props: {
   _chain?: readonly string[]
 }) {
   const file = useFile()
+  const language = useLanguage()
+  const platform = usePlatform()
+  const server = useServer()
+  const sdk = useSDK()
   const level = props.level ?? 0
   const draggable = () => props.draggable ?? true
+  const tooltip = () => props.tooltip ?? true
+  const local = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
+  const fail = (error: unknown) => {
+    showToast({
+      variant: "error",
+      title: language.t("common.requestFailed"),
+      description: error instanceof Error ? error.message : undefined,
+    })
+  }
+  const done = (value: string) => {
+    showToast({
+      variant: "success",
+      icon: "circle-check",
+      title: language.t("session.share.copy.copied"),
+      description: value,
+    })
+  }
+  const text = (value: string) => navigator.clipboard.writeText(value).then(() => done(value), fail)
+  const parent = (value: string) => {
+    const index = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"))
+    if (index === -1) return value
+    return value.slice(0, index)
+  }
+  const absolute = (value: string) => {
+    const root = sdk.directory.replace(/[\\/]+$/, "")
+    const next = value.replace(/^[\\/]+/, "")
+    if (root.includes("\\") && !root.includes("/")) return `${root}\\${next.replaceAll("/", "\\")}`
+    return `${root}/${next}`
+  }
+  const copy = (path: string) =>
+    copyFile({
+      path,
+      load: file.load,
+      get: file.get,
+      copied: language.t("toast.file.copy.success.title"),
+      failed: language.t("toast.file.copy.failed.title"),
+      binary: language.t("toast.file.copy.binary.title"),
+      binaryDescription: language.t("toast.file.copy.binary.description"),
+    })
+  const reveal = (absolute: string) => {
+    if (!local()) return
+    void platform.openPath!(parent(absolute)).catch(fail)
+  }
+  const revealDir = (absolute: string) => {
+    if (!local()) return
+    void platform.openPath!(absolute).catch(fail)
+  }
+  const open = (absolute: string) => {
+    if (!local()) return
+    void platform.openPath!(absolute).catch(fail)
+  }
 
   const key = (p: string) =>
     file
@@ -360,7 +477,7 @@ export default function FileTree(props: {
       out.push({
         name: leaf(dir),
         path: dir,
-        absolute: dir,
+        absolute: absolute(dir),
         type: "directory",
         ignored: false,
       })
@@ -373,7 +490,7 @@ export default function FileTree(props: {
       out.push({
         name: leaf(item),
         path: item,
-        absolute: item,
+        absolute: absolute(item),
         type: "file",
         ignored: false,
       })
@@ -410,21 +527,56 @@ export default function FileTree(props: {
                   open={expanded()}
                   onOpenChange={(open) => (open ? file.tree.expand(node.path) : file.tree.collapse(node.path))}
                 >
-                  <Collapsible.Trigger>
-                    <FileTreeNode
-                      node={node}
-                      level={level}
-                      active={props.active}
-                      nodeClass={props.nodeClass}
-                      draggable={draggable()}
-                      kinds={kinds()}
-                      marks={marks()}
-                    >
-                      <div class="size-4 flex items-center justify-center text-icon-weak">
-                        <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
-                      </div>
-                    </FileTreeNode>
-                  </Collapsible.Trigger>
+                  <ContextMenu>
+                    <ContextMenu.Trigger asChild>
+                      <Collapsible.Trigger>
+                        <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
+                          <FileTreeNode
+                            node={node}
+                            level={level}
+                            active={props.active}
+                            nodeClass={props.nodeClass}
+                            draggable={draggable()}
+                            kinds={kinds()}
+                            marks={marks()}
+                          >
+                            <div class="size-4 flex items-center justify-center text-icon-weak">
+                              <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
+                            </div>
+                          </FileTreeNode>
+                        </FileTreeNodeTooltip>
+                      </Collapsible.Trigger>
+                    </ContextMenu.Trigger>
+                    <ContextMenu.Portal>
+                      <ContextMenu.Content>
+                        <ContextMenu.Item onSelect={() => void text(node.path)}>
+                          <div class="flex size-5 shrink-0 items-center justify-center">
+                            <Icon name="copy" size="small" class="text-icon-weak" />
+                          </div>
+                          <ContextMenu.ItemLabel>{language.t("session.files.copyRelativePath")}</ContextMenu.ItemLabel>
+                        </ContextMenu.Item>
+                        <ContextMenu.Item onSelect={() => void text(node.absolute)}>
+                          <div class="flex size-5 shrink-0 items-center justify-center">
+                            <Icon name="copy" size="small" class="text-icon-weak" />
+                          </div>
+                          <ContextMenu.ItemLabel>{language.t("session.files.copyAbsolutePath")}</ContextMenu.ItemLabel>
+                        </ContextMenu.Item>
+                        <Show when={local()}>
+                          <>
+                            <ContextMenu.Separator />
+                            <ContextMenu.Item onSelect={() => void revealDir(node.absolute)}>
+                              <div class="flex size-5 shrink-0 items-center justify-center">
+                                <Icon name="folder" size="small" class="text-icon-weak" />
+                              </div>
+                              <ContextMenu.ItemLabel>
+                                {language.t("session.files.revealInFileManager")}
+                              </ContextMenu.ItemLabel>
+                            </ContextMenu.Item>
+                          </>
+                        </Show>
+                      </ContextMenu.Content>
+                    </ContextMenu.Portal>
+                  </ContextMenu>
                   <Collapsible.Content class="relative pt-0.5">
                     <div
                       classList={{
@@ -446,6 +598,7 @@ export default function FileTree(props: {
                         kinds={props.kinds}
                         active={props.active}
                         draggable={props.draggable}
+                        tooltip={props.tooltip}
                         onFileClick={props.onFileClick}
                         _filter={filter()}
                         _marks={marks()}
@@ -458,51 +611,101 @@ export default function FileTree(props: {
                 </Collapsible>
               </Match>
               <Match when={node.type === "file"}>
-                <FileTreeNode
-                  node={node}
-                  level={level}
-                  active={props.active}
-                  nodeClass={props.nodeClass}
-                  draggable={draggable()}
-                  kinds={kinds()}
-                  marks={marks()}
-                  as="button"
-                  type="button"
-                  onClick={() => props.onFileClick?.(node)}
-                >
-                  <div class="w-4 shrink-0" />
-                  <Switch>
-                    <Match when={node.ignored}>
-                      <FileIcon
+                <ContextMenu>
+                  <ContextMenu.Trigger asChild>
+                    <FileTreeNodeTooltip enabled={tooltip()} node={node} kind={kind()}>
+                      <FileTreeNode
                         node={node}
-                        class="size-4 filetree-icon filetree-icon--mono"
-                        style="color: var(--icon-weak-base)"
-                        mono
-                      />
-                    </Match>
-                    <Match when={active()}>
-                      <FileIcon
-                        node={node}
-                        class="size-4 filetree-icon filetree-icon--mono"
-                        style={kindTextColor(kind()!)}
-                        mono
-                      />
-                    </Match>
-                    <Match when={!node.ignored}>
-                      <span class="filetree-iconpair size-4">
-                        <FileIcon
-                          node={node}
-                          class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
-                        />
-                        <FileIcon
-                          node={node}
-                          class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
-                          mono
-                        />
-                      </span>
-                    </Match>
-                  </Switch>
-                </FileTreeNode>
+                        level={level}
+                        active={props.active}
+                        nodeClass={props.nodeClass}
+                        draggable={draggable()}
+                        kinds={kinds()}
+                        marks={marks()}
+                        as="button"
+                        type="button"
+                        onClick={() => props.onFileClick?.(node)}
+                      >
+                        <div class="w-4 shrink-0" />
+                        <Switch>
+                          <Match when={node.ignored}>
+                            <FileIcon
+                              node={node}
+                              class="size-4 filetree-icon filetree-icon--mono"
+                              style="color: var(--icon-weak-base)"
+                              mono
+                            />
+                          </Match>
+                          <Match when={active()}>
+                            <FileIcon
+                              node={node}
+                              class="size-4 filetree-icon filetree-icon--mono"
+                              style={kindTextColor(kind()!)}
+                              mono
+                            />
+                          </Match>
+                          <Match when={!node.ignored}>
+                            <span class="filetree-iconpair size-4">
+                              <FileIcon
+                                node={node}
+                                class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
+                              />
+                              <FileIcon
+                                node={node}
+                                class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                                mono
+                              />
+                            </span>
+                          </Match>
+                        </Switch>
+                      </FileTreeNode>
+                    </FileTreeNodeTooltip>
+                  </ContextMenu.Trigger>
+                  <ContextMenu.Portal>
+                    <ContextMenu.Content>
+                      <ContextMenu.Item onSelect={() => void text(node.path)}>
+                        <div class="flex size-5 shrink-0 items-center justify-center">
+                          <Icon name="copy" size="small" class="text-icon-weak" />
+                        </div>
+                        <ContextMenu.ItemLabel>{language.t("session.files.copyRelativePath")}</ContextMenu.ItemLabel>
+                      </ContextMenu.Item>
+                      <ContextMenu.Item onSelect={() => void text(node.absolute)}>
+                        <div class="flex size-5 shrink-0 items-center justify-center">
+                          <Icon name="copy" size="small" class="text-icon-weak" />
+                        </div>
+                        <ContextMenu.ItemLabel>{language.t("session.files.copyAbsolutePath")}</ContextMenu.ItemLabel>
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator />
+                      <ContextMenu.Item onSelect={() => void copy(node.path)}>
+                        <div class="flex size-5 shrink-0 items-center justify-center">
+                          <Icon name="copy" size="small" class="text-icon-weak" />
+                        </div>
+                        <ContextMenu.ItemLabel>{language.t("session.files.copyContents")}</ContextMenu.ItemLabel>
+                      </ContextMenu.Item>
+                      <Show when={local()}>
+                        <>
+                          <ContextMenu.Separator />
+                          <ContextMenu.Item onSelect={() => void reveal(node.absolute)}>
+                            <div class="flex size-5 shrink-0 items-center justify-center">
+                              <Icon name="folder" size="small" class="text-icon-weak" />
+                            </div>
+                            <ContextMenu.ItemLabel>
+                              {language.t("session.files.revealInFileManager")}
+                            </ContextMenu.ItemLabel>
+                          </ContextMenu.Item>
+                          <ContextMenu.Item onSelect={() => void open(node.absolute)}>
+                            <div class="flex size-5 shrink-0 items-center justify-center">
+                              <Icon name="folder" size="small" class="text-icon-weak" />
+                            </div>
+                            <ContextMenu.ItemLabel>
+                              {language.t("session.files.openInDefaultApp")}
+                            </ContextMenu.ItemLabel>
+                          </ContextMenu.Item>
+                        </>
+                      </Show>
+                    </ContextMenu.Content>
+                  </ContextMenu.Portal>
+                </ContextMenu>
               </Match>
             </Switch>
           )

--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -123,31 +123,29 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
       <div class="relative h-full">
         <ContextMenu>
           <ContextMenu.Trigger asChild>
-            <div class="h-full">
-              <Tabs.Trigger
-                value={props.tab}
-                closeButton={
-                  <TooltipKeybind
-                    title={language.t("common.closeTab")}
-                    keybind={command.keybind("tab.close")}
-                    placement="bottom"
-                    gutter={10}
-                  >
-                    <IconButton
-                      icon="close-small"
-                      variant="ghost"
-                      class="h-5 w-5"
-                      onClick={() => props.onTabClose(props.tab)}
-                      aria-label={language.t("common.closeTab")}
-                    />
-                  </TooltipKeybind>
-                }
-                hideCloseButton
-                onMiddleClick={() => props.onTabClose(props.tab)}
-              >
-                <Show when={content()}>{(value) => value()}</Show>
-              </Tabs.Trigger>
-            </div>
+            <Tabs.Trigger
+              value={props.tab}
+              closeButton={
+                <TooltipKeybind
+                  title={language.t("common.closeTab")}
+                  keybind={command.keybind("tab.close")}
+                  placement="bottom"
+                  gutter={10}
+                >
+                  <IconButton
+                    icon="close-small"
+                    variant="ghost"
+                    class="h-5 w-5"
+                    onClick={() => props.onTabClose(props.tab)}
+                    aria-label={language.t("common.closeTab")}
+                  />
+                </TooltipKeybind>
+              }
+              hideCloseButton
+              onMiddleClick={() => props.onTabClose(props.tab)}
+            >
+              <Show when={content()}>{(value) => value()}</Show>
+            </Tabs.Trigger>
           </ContextMenu.Trigger>
           <ContextMenu.Portal>
             <ContextMenu.Content>

--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -3,19 +3,12 @@ import type { JSX } from "solid-js"
 import { createSortable } from "@thisbeyond/solid-dnd"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
-import { Icon } from "@opencode-ai/ui/icon"
-import { ContextMenu } from "@opencode-ai/ui/context-menu"
-import { showToast } from "@opencode-ai/ui/toast"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { getFilename } from "@opencode-ai/util/path"
 import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useCommand } from "@/context/command"
-import { usePlatform } from "@/context/platform"
-import { useServer } from "@/context/server"
-import { useSDK } from "@/context/sdk"
-import { copyFile } from "@/utils/file-copy"
 
 export function FileVisual(props: { path: string; active?: boolean }): JSX.Element {
   return (
@@ -36,158 +29,39 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
   const file = useFile()
   const language = useLanguage()
   const command = useCommand()
-  const platform = usePlatform()
-  const server = useServer()
-  const sdk = useSDK()
   const sortable = createSortable(props.tab)
   const path = createMemo(() => file.pathFromTab(props.tab))
-  const local = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
-  const absolute = createMemo(() => {
-    const value = path()
-    if (!value) return
-    const root = sdk.directory.replace(/[\\/]+$/, "")
-    const next = value.replace(/^[\\/]+/, "")
-    if (root.includes("\\") && !root.includes("/")) return `${root}\\${next.replaceAll("/", "\\")}`
-    return `${root}/${next}`
-  })
   const content = createMemo(() => {
     const value = path()
     if (!value) return
     return <FileVisual path={value} />
   })
-
-  const fail = (error: unknown) => {
-    showToast({
-      variant: "error",
-      title: language.t("common.requestFailed"),
-      description: error instanceof Error ? error.message : undefined,
-    })
-  }
-  const done = (value: string) => {
-    showToast({
-      variant: "success",
-      icon: "circle-check",
-      title: language.t("session.share.copy.copied"),
-      description: value,
-    })
-  }
-  const text = (value: string) => navigator.clipboard.writeText(value).then(() => done(value), fail)
-  const parent = (value: string) => {
-    const index = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"))
-    if (index === -1) return value
-    return value.slice(0, index)
-  }
-
-  const copy = () => {
-    const value = path()
-    if (!value) return
-    void copyFile({
-      path: value,
-      load: file.load,
-      get: file.get,
-      copied: language.t("toast.file.copy.success.title"),
-      failed: language.t("toast.file.copy.failed.title"),
-      binary: language.t("toast.file.copy.binary.title"),
-      binaryDescription: language.t("toast.file.copy.binary.description"),
-    })
-  }
-
-  const reveal = () => {
-    const value = absolute()
-    if (!value) return
-    if (!local()) return
-    void platform.openPath!(parent(value)).catch(fail)
-  }
-
-  const open = () => {
-    const value = absolute()
-    if (!value) return
-    if (!local()) return
-    void platform.openPath!(value).catch(fail)
-  }
-
-  const relative = () => {
-    const value = path()
-    if (!value) return
-    void text(value)
-  }
-
-  const absolutePath = () => {
-    const value = absolute()
-    if (!value) return
-    void text(value)
-  }
-
   return (
-    <div use:sortable classList={{ "h-full": true, "opacity-0": sortable.isActiveDraggable }}>
-      <div class="relative h-full">
-        <ContextMenu>
-          <ContextMenu.Trigger asChild>
-            <Tabs.Trigger
-              value={props.tab}
-              closeButton={
-                <TooltipKeybind
-                  title={language.t("common.closeTab")}
-                  keybind={command.keybind("tab.close")}
-                  placement="bottom"
-                  gutter={10}
-                >
-                  <IconButton
-                    icon="close-small"
-                    variant="ghost"
-                    class="h-5 w-5"
-                    onClick={() => props.onTabClose(props.tab)}
-                    aria-label={language.t("common.closeTab")}
-                  />
-                </TooltipKeybind>
-              }
-              hideCloseButton
-              onMiddleClick={() => props.onTabClose(props.tab)}
+    <div use:sortable class="h-full flex items-center" classList={{ "opacity-0": sortable.isActiveDraggable }}>
+      <div class="relative">
+        <Tabs.Trigger
+          value={props.tab}
+          closeButton={
+            <TooltipKeybind
+              title={language.t("common.closeTab")}
+              keybind={command.keybind("tab.close")}
+              placement="bottom"
+              gutter={10}
             >
-              <Show when={content()}>{(value) => value()}</Show>
-            </Tabs.Trigger>
-          </ContextMenu.Trigger>
-          <ContextMenu.Portal>
-            <ContextMenu.Content>
-              <ContextMenu.Item onSelect={relative}>
-                <div class="flex size-5 shrink-0 items-center justify-center">
-                  <Icon name="copy" size="small" class="text-icon-weak" />
-                </div>
-                <ContextMenu.ItemLabel>{language.t("session.files.copyRelativePath")}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-              <ContextMenu.Item onSelect={absolutePath}>
-                <div class="flex size-5 shrink-0 items-center justify-center">
-                  <Icon name="copy" size="small" class="text-icon-weak" />
-                </div>
-                <ContextMenu.ItemLabel>{language.t("session.files.copyAbsolutePath")}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-              <ContextMenu.Separator />
-              <ContextMenu.Item onSelect={copy}>
-                <div class="flex size-5 shrink-0 items-center justify-center">
-                  <Icon name="copy" size="small" class="text-icon-weak" />
-                </div>
-                <ContextMenu.ItemLabel>{language.t("session.files.copyContents")}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-              <Show when={local()}>
-                <>
-                  <ContextMenu.Separator />
-                  <ContextMenu.Item onSelect={reveal}>
-                    <div class="flex size-5 shrink-0 items-center justify-center">
-                      <Icon name="folder" size="small" class="text-icon-weak" />
-                    </div>
-                    <ContextMenu.ItemLabel>{language.t("session.files.revealInFileManager")}</ContextMenu.ItemLabel>
-                  </ContextMenu.Item>
-                  <ContextMenu.Item onSelect={open}>
-                    <div class="flex size-5 shrink-0 items-center justify-center">
-                      <Icon name="folder" size="small" class="text-icon-weak" />
-                    </div>
-                    <ContextMenu.ItemLabel>{language.t("session.files.openInDefaultApp")}</ContextMenu.ItemLabel>
-                  </ContextMenu.Item>
-                </>
-              </Show>
-            </ContextMenu.Content>
-          </ContextMenu.Portal>
-        </ContextMenu>
+              <IconButton
+                icon="close-small"
+                variant="ghost"
+                class="h-5 w-5"
+                onClick={() => props.onTabClose(props.tab)}
+                aria-label={language.t("common.closeTab")}
+              />
+            </TooltipKeybind>
+          }
+          hideCloseButton
+          onMiddleClick={() => props.onTabClose(props.tab)}
+        >
+          <Show when={content()}>{(value) => value()}</Show>
+        </Tabs.Trigger>
       </div>
     </div>
   )

--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -3,12 +3,19 @@ import type { JSX } from "solid-js"
 import { createSortable } from "@thisbeyond/solid-dnd"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Icon } from "@opencode-ai/ui/icon"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
+import { showToast } from "@opencode-ai/ui/toast"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { getFilename } from "@opencode-ai/util/path"
 import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useCommand } from "@/context/command"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
+import { useSDK } from "@/context/sdk"
+import { copyFile } from "@/utils/file-copy"
 
 export function FileVisual(props: { path: string; active?: boolean }): JSX.Element {
   return (
@@ -29,39 +36,160 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
   const file = useFile()
   const language = useLanguage()
   const command = useCommand()
+  const platform = usePlatform()
+  const server = useServer()
+  const sdk = useSDK()
   const sortable = createSortable(props.tab)
   const path = createMemo(() => file.pathFromTab(props.tab))
+  const local = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
+  const absolute = createMemo(() => {
+    const value = path()
+    if (!value) return
+    const root = sdk.directory.replace(/[\\/]+$/, "")
+    const next = value.replace(/^[\\/]+/, "")
+    if (root.includes("\\") && !root.includes("/")) return `${root}\\${next.replaceAll("/", "\\")}`
+    return `${root}/${next}`
+  })
   const content = createMemo(() => {
     const value = path()
     if (!value) return
     return <FileVisual path={value} />
   })
+
+  const fail = (error: unknown) => {
+    showToast({
+      variant: "error",
+      title: language.t("common.requestFailed"),
+      description: error instanceof Error ? error.message : undefined,
+    })
+  }
+  const done = (value: string) => {
+    showToast({
+      variant: "success",
+      icon: "circle-check",
+      title: language.t("session.share.copy.copied"),
+      description: value,
+    })
+  }
+  const text = (value: string) => navigator.clipboard.writeText(value).then(() => done(value), fail)
+  const parent = (value: string) => {
+    const index = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"))
+    if (index === -1) return value
+    return value.slice(0, index)
+  }
+
+  const copy = () => {
+    const value = path()
+    if (!value) return
+    void copyFile({
+      path: value,
+      load: file.load,
+      get: file.get,
+      copied: language.t("toast.file.copy.success.title"),
+      failed: language.t("toast.file.copy.failed.title"),
+      binary: language.t("toast.file.copy.binary.title"),
+      binaryDescription: language.t("toast.file.copy.binary.description"),
+    })
+  }
+
+  const reveal = () => {
+    const value = absolute()
+    if (!value) return
+    if (!local()) return
+    void platform.openPath!(parent(value)).catch(fail)
+  }
+
+  const open = () => {
+    const value = absolute()
+    if (!value) return
+    if (!local()) return
+    void platform.openPath!(value).catch(fail)
+  }
+
+  const relative = () => {
+    const value = path()
+    if (!value) return
+    void text(value)
+  }
+
+  const absolutePath = () => {
+    const value = absolute()
+    if (!value) return
+    void text(value)
+  }
+
   return (
-    <div use:sortable class="h-full flex items-center" classList={{ "opacity-0": sortable.isActiveDraggable }}>
-      <div class="relative">
-        <Tabs.Trigger
-          value={props.tab}
-          closeButton={
-            <TooltipKeybind
-              title={language.t("common.closeTab")}
-              keybind={command.keybind("tab.close")}
-              placement="bottom"
-              gutter={10}
-            >
-              <IconButton
-                icon="close-small"
-                variant="ghost"
-                class="h-5 w-5"
-                onClick={() => props.onTabClose(props.tab)}
-                aria-label={language.t("common.closeTab")}
-              />
-            </TooltipKeybind>
-          }
-          hideCloseButton
-          onMiddleClick={() => props.onTabClose(props.tab)}
-        >
-          <Show when={content()}>{(value) => value()}</Show>
-        </Tabs.Trigger>
+    <div use:sortable classList={{ "h-full": true, "opacity-0": sortable.isActiveDraggable }}>
+      <div class="relative h-full">
+        <ContextMenu>
+          <ContextMenu.Trigger asChild>
+            <div class="h-full">
+              <Tabs.Trigger
+                value={props.tab}
+                closeButton={
+                  <TooltipKeybind
+                    title={language.t("common.closeTab")}
+                    keybind={command.keybind("tab.close")}
+                    placement="bottom"
+                    gutter={10}
+                  >
+                    <IconButton
+                      icon="close-small"
+                      variant="ghost"
+                      class="h-5 w-5"
+                      onClick={() => props.onTabClose(props.tab)}
+                      aria-label={language.t("common.closeTab")}
+                    />
+                  </TooltipKeybind>
+                }
+                hideCloseButton
+                onMiddleClick={() => props.onTabClose(props.tab)}
+              >
+                <Show when={content()}>{(value) => value()}</Show>
+              </Tabs.Trigger>
+            </div>
+          </ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Content>
+              <ContextMenu.Item onSelect={relative}>
+                <div class="flex size-5 shrink-0 items-center justify-center">
+                  <Icon name="copy" size="small" class="text-icon-weak" />
+                </div>
+                <ContextMenu.ItemLabel>{language.t("session.files.copyRelativePath")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+              <ContextMenu.Item onSelect={absolutePath}>
+                <div class="flex size-5 shrink-0 items-center justify-center">
+                  <Icon name="copy" size="small" class="text-icon-weak" />
+                </div>
+                <ContextMenu.ItemLabel>{language.t("session.files.copyAbsolutePath")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+              <ContextMenu.Separator />
+              <ContextMenu.Item onSelect={copy}>
+                <div class="flex size-5 shrink-0 items-center justify-center">
+                  <Icon name="copy" size="small" class="text-icon-weak" />
+                </div>
+                <ContextMenu.ItemLabel>{language.t("session.files.copyContents")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+              <Show when={local()}>
+                <>
+                  <ContextMenu.Separator />
+                  <ContextMenu.Item onSelect={reveal}>
+                    <div class="flex size-5 shrink-0 items-center justify-center">
+                      <Icon name="folder" size="small" class="text-icon-weak" />
+                    </div>
+                    <ContextMenu.ItemLabel>{language.t("session.files.revealInFileManager")}</ContextMenu.ItemLabel>
+                  </ContextMenu.Item>
+                  <ContextMenu.Item onSelect={open}>
+                    <div class="flex size-5 shrink-0 items-center justify-center">
+                      <Icon name="folder" size="small" class="text-icon-weak" />
+                    </div>
+                    <ContextMenu.ItemLabel>{language.t("session.files.openInDefaultApp")}</ContextMenu.ItemLabel>
+                  </ContextMenu.Item>
+                </>
+              </Show>
+            </ContextMenu.Content>
+          </ContextMenu.Portal>
+        </ContextMenu>
       </div>
     </div>
   )

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -414,6 +414,10 @@ export const dict = {
 
   "toast.file.loadFailed.title": "Failed to load file",
   "toast.file.listFailed.title": "Failed to list files",
+  "toast.file.copy.success.title": "File contents copied",
+  "toast.file.copy.failed.title": "Failed to copy file contents",
+  "toast.file.copy.binary.title": "Cannot copy binary file",
+  "toast.file.copy.binary.description": "Only text file contents can be copied.",
 
   "toast.context.noLineSelection.title": "No line selection",
   "toast.context.noLineSelection.description": "Select a line range in a file tab first.",
@@ -503,6 +507,11 @@ export const dict = {
   "session.files.selectToOpen": "Select a file to open",
   "session.files.all": "All files",
   "session.files.binaryContent": "Binary file (content cannot be displayed)",
+  "session.files.copyContents": "Copy file contents",
+  "session.files.copyRelativePath": "Copy relative path",
+  "session.files.copyAbsolutePath": "Copy absolute path",
+  "session.files.revealInFileManager": "Reveal in file explorer",
+  "session.files.openInDefaultApp": "Open in default app",
 
   "session.messages.renderEarlier": "Render earlier messages",
   "session.messages.loadingEarlier": "Loading earlier messages...",

--- a/packages/app/src/utils/file-copy.ts
+++ b/packages/app/src/utils/file-copy.ts
@@ -1,0 +1,61 @@
+import { showToast } from "@opencode-ai/ui/toast"
+import { decode64 } from "@/utils/base64"
+
+type Content = {
+  type: "text" | "binary"
+  content: string
+  encoding?: "base64"
+}
+
+type Entry = {
+  content?: Content
+}
+
+export async function copyFile(args: {
+  path: string
+  load: (path: string) => Promise<void>
+  get: (path: string) => Entry | undefined
+  copied: string
+  failed: string
+  binary: string
+  binaryDescription: string
+}) {
+  await args.load(args.path)
+
+  const value = args.get(args.path)?.content
+  if (!value) return
+
+  if (value.type === "binary") {
+    showToast({
+      variant: "error",
+      title: args.binary,
+      description: args.binaryDescription,
+    })
+    return
+  }
+
+  const text = value.encoding === "base64" ? decode64(value.content) : value.content
+  if (text === undefined) {
+    showToast({
+      variant: "error",
+      title: args.failed,
+    })
+    return
+  }
+
+  return navigator.clipboard.writeText(text).then(
+    () => {
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: args.copied,
+      })
+    },
+    () => {
+      showToast({
+        variant: "error",
+        title: args.failed,
+      })
+    },
+  )
+}

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -23,6 +23,11 @@ export namespace Pty {
     close: (code?: number, reason?: string) => void
   }
 
+  type Subscriber = {
+    ws: Socket
+    send: (data: string | Uint8Array | ArrayBuffer) => void
+  }
+
   // WebSocket control frame: 0x00 + UTF-8 JSON.
   const meta = (cursor: number) => {
     const json = JSON.stringify({ cursor })
@@ -87,7 +92,7 @@ export namespace Pty {
     buffer: string
     bufferCursor: number
     cursor: number
-    subscribers: Map<unknown, Socket>
+    subscribers: Map<unknown, Subscriber>
   }
 
   const state = Instance.state(
@@ -97,7 +102,8 @@ export namespace Pty {
         try {
           session.process.kill()
         } catch {}
-        for (const [key, ws] of session.subscribers.entries()) {
+        for (const [key, sub] of session.subscribers.entries()) {
+          const ws = sub.ws
           try {
             if (ws.data === key) ws.close()
           } catch {
@@ -170,7 +176,8 @@ export namespace Pty {
     ptyProcess.onData((chunk) => {
       session.cursor += chunk.length
 
-      for (const [key, ws] of session.subscribers.entries()) {
+      for (const [key, sub] of session.subscribers.entries()) {
+        const ws = sub.ws
         if (ws.readyState !== 1) {
           session.subscribers.delete(key)
           continue
@@ -182,7 +189,7 @@ export namespace Pty {
         }
 
         try {
-          ws.send(chunk)
+          sub.send(chunk)
         } catch {
           session.subscribers.delete(key)
         }
@@ -197,7 +204,8 @@ export namespace Pty {
     ptyProcess.onExit(({ exitCode }) => {
       log.info("session exited", { id, exitCode })
       session.info.status = "exited"
-      for (const [key, ws] of session.subscribers.entries()) {
+      for (const [key, sub] of session.subscribers.entries()) {
+        const ws = sub.ws
         try {
           if (ws.data === key) ws.close()
         } catch {
@@ -232,7 +240,8 @@ export namespace Pty {
     try {
       session.process.kill()
     } catch {}
-    for (const [key, ws] of session.subscribers.entries()) {
+    for (const [key, sub] of session.subscribers.entries()) {
+      const ws = sub.ws
       try {
         if (ws.data === key) ws.close()
       } catch {
@@ -272,7 +281,7 @@ export namespace Pty {
 
     // Optionally cleanup if the key somehow exists
     session.subscribers.delete(connectionKey)
-    session.subscribers.set(connectionKey, ws)
+    session.subscribers.set(connectionKey, { ws, send: ws.send.bind(ws) })
 
     const cleanup = () => {
       session.subscribers.delete(connectionKey)

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -207,6 +207,7 @@ export const BashTool = Tool.define("bash", async () => {
       let timedOut = false
       let aborted = false
       let exited = false
+      let exit: number | null = null
 
       const kill = () => Shell.killTree(proc, { exited: () => exited })
 
@@ -233,8 +234,9 @@ export const BashTool = Tool.define("bash", async () => {
           ctx.abort.removeEventListener("abort", abortHandler)
         }
 
-        proc.once("exit", () => {
+        proc.once("exit", (code) => {
           exited = true
+          exit = code
           cleanup()
           resolve()
         })
@@ -264,7 +266,7 @@ export const BashTool = Tool.define("bash", async () => {
         title: params.description,
         metadata: {
           output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
-          exit: proc.exitCode,
+          exit: exit ?? proc.exitCode,
           description: params.description,
         },
         output,


### PR DESCRIPTION
### Issue for this PR

Closes #14784
Closes #11820 
Closes #11620

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds desktop-focused context menu actions for session files/folders:

- Copy relative path
- Copy absolute path
- Copy file contents (files)
- Reveal in file explorer (desktop/local)
- Open in default app (desktop/local)

This improves desktop workflow by making common file actions available directly from the UI context menus.

### How did you verify your code works?

- Ran `bun run typecheck` in `packages/app`
- Pre-push checks ran `bun turbo typecheck` successfully
- Manually tested context menu actions in desktop/local flow

### Screenshots / recordings

https://github.com/user-attachments/assets/1105973f-ebe4-4f55-b370-076ecf72c3d8

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
