### PR TITLE
fix: OpenCode was injecting reasoningSummary for GPT-5 and forwarding it through the openai-compatible chat adapter

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -30,6 +30,8 @@ import { defaultOpenAICompatibleErrorStructure, type ProviderErrorStructure } fr
 import type { MetadataExtractor } from "./openai-compatible-metadata-extractor"
 import { prepareTools } from "./openai-compatible-prepare-tools"
 
+const UNSUPPORTED_CHAT_COMPLETIONS_OPTIONS = new Set(["reasoningSummary"])
+
 export type OpenAICompatibleChatConfig = {
   provider: string
   headers: () => Record<string, string | undefined>
@@ -168,7 +170,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
         seed,
         ...Object.fromEntries(
           Object.entries(providerOptions?.[this.providerOptionsName] ?? {}).filter(
-            ([key]) => !Object.keys(openaiCompatibleProviderOptions.shape).includes(key),
+            ([key]) =>
+              !Object.keys(openaiCompatibleProviderOptions.shape).includes(key) &&
+              !UNSUPPORTED_CHAT_COMPLETIONS_OPTIONS.has(key),
           ),
         ),
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -759,7 +759,9 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
+        if (input.model.api.npm !== "@ai-sdk/openai-compatible") {
+          result["reasoningSummary"] = "auto"
+        }
       }
 
       // Only set textVerbosity for non-chat gpt-5.x models

--- a/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
+++ b/packages/opencode/test/provider/copilot/copilot-chat-model.test.ts
@@ -589,4 +589,38 @@ describe("request body", () => {
       },
     ])
   })
+
+  test("should strip reasoningSummary but keep reasoning effort and custom options", async () => {
+    let capturedBody: any
+    const mockFetch = mock(async (_url: string, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string)
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: [DONE]\n\n`))
+            controller.close()
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      )
+    })
+
+    const model = createModel(mockFetch)
+
+    await model.doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        copilot: {
+          reasoningEffort: "high",
+          reasoningSummary: "auto",
+          custom_field: true,
+        },
+      },
+      includeRawChunks: false,
+    })
+
+    expect(capturedBody.reasoning_effort).toBe("high")
+    expect(capturedBody.reasoningSummary).toBeUndefined()
+    expect(capturedBody.custom_field).toBe(true)
+  })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -132,6 +132,32 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
       headers: {},
     }) as any
 
+  const createOpenAICompatibleGpt5Model = (apiId: string) =>
+    ({
+      id: `myprovider/${apiId}`,
+      providerID: "myprovider",
+      api: {
+        id: apiId,
+        url: "https://inference.do-ai.run/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
   test("gpt-5.2 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.2")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
@@ -172,6 +198,19 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     const model = createGpt5Model("gpt-5.2-codex")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
     expect(result.textVerbosity).toBeUndefined()
+  })
+
+  test("openai gpt-5 should include reasoningSummary by default", () => {
+    const model = createGpt5Model("gpt-5")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningSummary).toBe("auto")
+  })
+
+  test("openai-compatible gpt-5 should not include reasoningSummary by default", () => {
+    const model = createOpenAICompatibleGpt5Model("openai-gpt-5")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Fixes #13546

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode was injecting reasoningSummary for GPT-5 and forwarding it through the openai-compatible chat adapter, which broke OpenAI-compatible /chat/completions requests with Unknown parameter: reasoningSummary. This keeps reasoning enabled (reasoningEffort) while blocking reasoningSummary for openai-compatible providers and adds regression tests.

### How did you verify your code works?

I `bun install`'d the binary, and `bun run dev` with my custom opencode config which broke with the unpatched version. It worked fine. 


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


