### PR TITLE
feat: add streaming option to provider config to support non-streamin…

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -989,6 +989,12 @@ export namespace Config {
           baseURL: z.string().optional(),
           enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
           setCacheKey: z.boolean().optional().describe("Enable promptCacheKey for this provider (default false)"),
+          streaming: z
+            .boolean()
+            .optional()
+            .describe(
+              "Enable or disable streaming for this provider. When set to false, uses non-streaming requests and simulates streaming output. Useful for backends that do not support streaming. Default is true.",
+            ),
           timeout: z
             .union([
               z

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -4,6 +4,7 @@ import { Log } from "@/util/log"
 import {
   streamText,
   wrapLanguageModel,
+  simulateStreamingMiddleware,
   type ModelMessage,
   type StreamTextResult,
   type Tool,
@@ -243,6 +244,10 @@ export namespace LLM {
               return args.params
             },
           },
+          // When streaming is disabled for the provider, use the AI SDK's
+          // simulateStreamingMiddleware to make non-streaming (generateText)
+          // requests and convert the result into a simulated stream.
+          ...(provider?.options?.streaming === false ? [simulateStreamingMiddleware()] : []),
         ],
       }),
       experimental_telemetry: {


### PR DESCRIPTION
### Issue for this PR

Closes #785

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add a 'streaming' boolean option to the provider configuration schema.
When set to false, the AI SDK's simulateStreamingMiddleware is used to make non-streaming (doGenerate) requests and convert the response into a simulated stream, allowing the rest of the processing pipeline to work unchanged.

Tested with CatGPT

### How did you verify your code works?

Used it with CatGPT which does not support streaming. After this change it worked

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
