### PR TITLE
docs(troubleshooting): clarify Shift+click behavior for opening TUI links

### DIFF
--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -298,3 +298,16 @@ export DISPLAY=:99.0
 ```
 
 opencode will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.
+
+---
+
+### Links not opening when clicked in the TUI
+
+If clicking links shown in the OpenCode TUI does not open them in your browser:
+
+1. When OpenCode is capturing the mouse, normal clicks are handled by the TUI instead of your terminal.
+2. Hold `Shift` while clicking to pass the click through to your terminal.
+3. In Ghostty on macOS, use `Shift+Cmd+Click`.
+4. In Ghostty on Linux, use `Shift+Ctrl+Click`.
+5. In many other Linux terminals, `Shift+Click` often works.
+6. Modifier keys vary by terminal and configuration, so check your terminal's hyperlink/link-open settings if needed.


### PR DESCRIPTION
### Issue for this PR

Closes #9024
Refs #1168
Refs #7926
Refs #6824
Refs #11362

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a troubleshooting section that explains why links in the OpenCode TUI may not open on normal click when mouse capture is active.

It documents the expected modifier-click behavior:
- Ghostty on macOS: `Shift+Cmd+Click`
- Ghostty on Linux: `Shift+Ctrl+Click`
- many other Linux terminals: `Shift+Click`

It also clarifies that modifier keys vary by terminal/configuration and users should check terminal hyperlink settings if needed.

### How did you verify your code works?

- Reproduced behavior in Ghostty.
- Confirmed normal click can be handled by the TUI while mouse capture is active.
- Confirmed modifier-click opens links (`Shift+Cmd+Click` on macOS Ghostty).
- Validated docs change in `packages/web/src/content/docs/troubleshooting.mdx`.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
