### PR TITLE
fix(opencode): prevent prompt from stealing focus when dialog is open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -388,7 +388,7 @@ export function Prompt(props: PromptProps) {
   }
 
   createEffect(() => {
-    if (props.visible !== false) input?.focus()
+    if (props.visible !== false && dialog.stack.length === 0) input?.focus()
     if (props.visible === false) input?.blur()
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #14799

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prompt component has a `createEffect` that reactively calls `input.focus()` whenever `props.visible` re-evaluates. The `visible` prop depends on reactive signals (`session()?.parentID`, `permissions()`, `questions()`) that change when subagents spawn via SSE events. This causes the main prompt to steal focus from any open dialog (e.g., the rename dialog).

The fix adds a `dialog.stack.length === 0` guard so the prompt only grabs focus when no dialog is open. The `dialog` object was already imported and available in the component.

### How did you verify your code works?

1. Started a session and sent a prompt that triggers subagent spawning
2. While the agent was working, typed `/rename` to open the rename dialog
3. Confirmed the dialog retains focus when subagents spawn

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR