### PR TITLE
docs(ecosystem): add OC Remote (Android) listing

### DIFF
--- a/packages/web/src/content/docs/ar/ecosystem.mdx
+++ b/packages/web/src/content/docs/ar/ecosystem.mdx
@@ -65,6 +65,7 @@ description: مشاريع وتكاملات مبنية باستخدام OpenCode.
 | [OpenWork](https://github.com/different-ai/openwork)                                       | بديل مفتوح المصدر لـ Claude Cowork، مدعوم بـ OpenCode                    |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | مدير امتدادات OpenCode مع ملفات تعريف محمولة ومعزولة.                    |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | تطبيق عميل لسطح المكتب والويب والجوال وعن بُعد لـ OpenCode               |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | عميل Android أصلي لـ OpenCode مع دعم تعدد الخوادم، وتشغيل محلي عبر Termux، وتجربة دردشة/طرفية محسّنة للجوال. |
 
 ---
 

--- a/packages/web/src/content/docs/bs/ecosystem.mdx
+++ b/packages/web/src/content/docs/bs/ecosystem.mdx
@@ -61,6 +61,7 @@ Također možete pogledati [awesome-opencode](https://github.com/awesome-opencod
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa otvorenog koda Claudeu Coworku, pokretana pomoću OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode menadžer ekstenzija sa prenosivim, izolovanim profilima.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile i Remote Client aplikacija za OpenCode           |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Nativni Android klijent za OpenCode s podrškom za više servera, lokalnim runtime-om preko Termuxa i chat/terminal UX-om optimiziranim za mobilne uređaje. |
 
 ---
 

--- a/packages/web/src/content/docs/da/ecosystem.mdx
+++ b/packages/web/src/content/docs/da/ecosystem.mdx
@@ -65,6 +65,7 @@ Du kan også tjekke [awesome-opencode](https://github.com/awesome-opencode/aweso
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et open source-alternativ til Claude Cowork, drevet af OpenCode        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode udvidelsesmanager med bærbare, isolerede profiler.            |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop-, web-, mobil- og fjernklientapp til OpenCode                  |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Native Android-klient til OpenCode med understøttelse af flere servere, lokal runtime via Termux og mobiloptimeret chat-/terminal-UX. |
 
 ---
 

--- a/packages/web/src/content/docs/de/ecosystem.mdx
+++ b/packages/web/src/content/docs/de/ecosystem.mdx
@@ -65,6 +65,7 @@ Sie können sich auch [awesome-opencode](https://github.com/awesome-opencode/awe
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Eine Open-Source-Alternative zu Claude Cowork, unterstützt von OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode Erweiterungsmanager mit portablen, isolierten Profilen.             |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop-, Web-, Mobil- und Remote-Client-App für OpenCode                    |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Nativer Android-Client für OpenCode mit Multi-Server-Unterstützung, lokalem Runtime über Termux und mobiloptimierter Chat-/Terminal-UX. |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -65,6 +65,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Native Android client for OpenCode with multi-server support, local runtime via Termux, and mobile-optimized chat/terminal UX |
 
 ---
 

--- a/packages/web/src/content/docs/es/ecosystem.mdx
+++ b/packages/web/src/content/docs/es/ecosystem.mdx
@@ -65,6 +65,7 @@ También puedes consultar [awesome-opencode](https://github.com/awesome-opencode
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Una alternativa de código abierto a Claude Cowork, impulsada por OpenCode            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Administrador de extensiones OpenCode con perfiles portátiles y aislados.            |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplicación de escritorio, web, móvil y de cliente remoto para OpenCode               |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Cliente nativo de Android para OpenCode con compatibilidad con múltiples servidores, runtime local mediante Termux y UX de chat/terminal optimizada para móviles. |
 
 ---
 

--- a/packages/web/src/content/docs/fr/ecosystem.mdx
+++ b/packages/web/src/content/docs/fr/ecosystem.mdx
@@ -65,6 +65,7 @@ Vous pouvez également consulter [awesome-opencode](https://github.com/awesome-o
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Une alternative open source à Claude Cowork, propulsée par OpenCode            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestionnaire d'extensions OpenCode avec profils portables et isolés.           |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Application client de bureau, Web, mobile et distante pour OpenCode            |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Client Android natif pour OpenCode avec prise en charge multi-serveur, runtime local via Termux et UX chat/terminal optimisée pour mobile. |
 
 ---
 

--- a/packages/web/src/content/docs/it/ecosystem.mdx
+++ b/packages/web/src/content/docs/it/ecosystem.mdx
@@ -65,6 +65,7 @@ Puoi anche dare un'occhiata a [awesome-opencode](https://github.com/awesome-open
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa open source a Claude Cowork, alimentata da OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestore di estensioni OpenCode con profili portabili e isolati       |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | App client Desktop, Web, Mobile e remota per OpenCode                |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Client Android nativo per OpenCode con supporto multi-server, runtime locale tramite Termux e UX chat/terminale ottimizzata per mobile. |
 
 ---
 

--- a/packages/web/src/content/docs/ja/ecosystem.mdx
+++ b/packages/web/src/content/docs/ja/ecosystem.mdx
@@ -64,6 +64,7 @@ OpenCode 関連プロジェクトをこのリストに追加したいですか? 
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode を利用した、Claude Cowork に代わるオープンソース                        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 移植可能な独立したプロファイルを備えた OpenCode 拡張機能マネージャー。           |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 用のデスクトップ、Web、モバイル、およびリモートクライアントアプリ       |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | 複数サーバー対応、Termux 経由のローカルランタイム、モバイル最適化されたチャット/ターミナル UX を備えた OpenCode 用ネイティブ Android クライアント。 |
 
 ---
 

--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -65,6 +65,7 @@ OpenCode를 기반으로 만들어진 커뮤니티 프로젝트 모음입니다.
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode 기반의 Claude Cowork 대체 오픈소스 프로젝트입니다.            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 휴대형 격리 프로필을 지원하는 OpenCode extension manager입니다.        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode용 Desktop/Web/Mobile/Remote client app입니다.                 |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | 멀티 서버 지원, Termux 기반 로컬 런타임, 모바일 최적화 채팅/터미널 UX를 제공하는 OpenCode용 네이티브 Android 클라이언트입니다. |
 
 ---
 

--- a/packages/web/src/content/docs/nb/ecosystem.mdx
+++ b/packages/web/src/content/docs/nb/ecosystem.mdx
@@ -65,6 +65,7 @@ Du kan også sjekke ut [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et åpen kildekode-alternativ til Claude Cowork, drevet av OpenCode  |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode utvidelsesbehandler med bærbare, isolerte profiler.        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile og Remote Client App for OpenCode              |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Nativ Android-klient for OpenCode med støtte for flere servere, lokal runtime via Termux og mobiloptimalisert chat-/terminal-UX. |
 
 ---
 

--- a/packages/web/src/content/docs/pl/ecosystem.mdx
+++ b/packages/web/src/content/docs/pl/ecosystem.mdx
@@ -65,6 +65,7 @@ Możesz także sprawdzić [awesome-opencode](https://github.com/awesome-opencode
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternatywa typu open source dla Claude Cowork, obsługa przez opencode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Menedżer rozszerzony opencode z przenośnymi, izolowanymi profilami.         |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplikacja komputerowa, internetowa, mobilna i zdalna dla opencode           |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Natywny klient Android dla OpenCode z obsługą wielu serwerów, lokalnym runtime przez Termux oraz zoptymalizowanym mobilnie UX czatu/terminala. |
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -65,6 +65,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Uma alternativa de código aberto ao Claude Cowork, alimentada pelo opencode     |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gerenciador de extensões opencode com perfis portáteis e isolados.              |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplicativo Desktop, Web, Mobile e Cliente Remoto para opencode                  |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Cliente Android nativo para OpenCode com suporte a múltiplos servidores, runtime local via Termux e UX de chat/terminal otimizada para dispositivos móveis. |
 
 ---
 

--- a/packages/web/src/content/docs/ru/ecosystem.mdx
+++ b/packages/web/src/content/docs/ru/ecosystem.mdx
@@ -64,6 +64,7 @@ description: Проекты и интеграции, созданные с по�
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Альтернатива Claude Cowork с открытым исходным кодом на базе opencode.                       |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Менеджер расширений opencode с переносимыми изолированными профилями.                        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Настольное, веб-, мобильное и удаленное клиентское приложение для opencode                   |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | Нативный Android-клиент для OpenCode с поддержкой нескольких серверов, локальным запуском через Termux и мобильным UX чата/терминала. |
 
 ---
 

--- a/packages/web/src/content/docs/th/ecosystem.mdx
+++ b/packages/web/src/content/docs/th/ecosystem.mdx
@@ -65,6 +65,7 @@ description: โปรเจ็กต์และการผสานรวม�
 | [OpenWork](https://github.com/different-ai/openwork)                                       | ทางเลือกโอเพ่นซอร์สแทน Claude Cowork ซึ่งขับเคลื่อนโดย OpenCode           |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | ตัวจัดการส่วนขยาย OpenCode พร้อมโปรไฟล์แบบพกพาและแยกส่วน                  |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | แอปเดสก์ท็อป เว็บ มือถือ และไคลเอ็นต์ระยะไกลสำหรับ OpenCode               |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | ไคลเอนต์ Android แบบเนทีฟสำหรับ OpenCode พร้อมรองรับหลายเซิร์ฟเวอร์ รันไทม์ในเครื่องผ่าน Termux และ UX แชท/เทอร์มินัลที่ปรับให้เหมาะกับมือถือ |
 
 ---
 

--- a/packages/web/src/content/docs/tr/ecosystem.mdx
+++ b/packages/web/src/content/docs/tr/ecosystem.mdx
@@ -65,6 +65,7 @@ Ayrıca ekosistemi ve topluluğu bir araya getiren bir topluluk olan [awesome-op
 | [OpenWork](https://github.com/different-ai/openwork)                                       | opencode tarafından desteklenen, Claude Cowork'e açık kaynaklı bir alternatif     |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Taşınabilir, yalıtılmış profillere sahip opencode uzantı yöneticisi.              |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | opencode için Masaüstü, Web, Mobil ve Uzak İstemci Uygulaması                     |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | OpenCode için çoklu sunucu desteği, Termux üzerinden yerel çalışma zamanı ve mobil uyumlu sohbet/terminal deneyimi sunan yerel Android istemcisi. |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -65,6 +65,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的开源替代方案，由 OpenCode 驱动                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 扩展管理器，支持可移植的隔离配置                     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 的桌面、Web、移动和远程客户端应用                    |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | 面向 OpenCode 的原生 Android 客户端，支持多服务器、通过 Termux 的本地运行时，以及移动端优化的聊天/终端体验。 |
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-tw/ecosystem.mdx
@@ -65,6 +65,7 @@ description: 基於 OpenCode 建置的專案與整合。
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的開源替代方案，由 OpenCode 驅動                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 擴充功能管理器，支援可攜式的隔離設定                 |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 的桌面、Web、行動和遠端用戶端應用程式                |
+| [OC Remote (Android)](https://github.com/crim50n/oc-remote)                                | 適用於 OpenCode 的原生 Android 用戶端，支援多伺服器、透過 Termux 的本地執行環境，以及行動裝置最佳化的聊天/終端體驗。 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `OC Remote (Android)` to the Ecosystem `Projects` table in docs.
I added the same row to the main English page and every translated `ecosystem.mdx` page currently present, so the list stays consistent across locales.

### How did you verify your code works?

- Checked all `packages/web/src/content/docs/**/ecosystem.mdx` files.
- Confirmed `OC Remote (Android)` appears once in each ecosystem page and links to `https://github.com/crim50n/oc-remote`.

### Screenshots / recordings

N/A (docs table update only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR