### PR TITLE
feat(plugin): expose agent identity and parentAgent in plugin hooks for governance

### DIFF
--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -112,6 +112,7 @@ export namespace Pty {
     cwd: z.string().optional(),
     title: z.string().optional(),
     env: z.record(z.string(), z.string()).optional(),
+    agent: z.string().optional(),
   })
 
   export type CreateInput = z.infer<typeof CreateInput>
@@ -180,7 +181,7 @@ export namespace Pty {
     }
 
     const cwd = input.cwd || Instance.directory
-    const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
+    const shellEnv = await Plugin.trigger("shell.env", { cwd, agent: input.agent }, { env: {} })
     const env = {
       ...process.env,
       ...input.env,

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -113,6 +113,7 @@ export namespace Pty {
     title: z.string().optional(),
     env: z.record(z.string(), z.string()).optional(),
     agent: z.string().optional(),
+    parentAgent: z.string().optional(),
   })
 
   export type CreateInput = z.infer<typeof CreateInput>
@@ -181,7 +182,7 @@ export namespace Pty {
     }
 
     const cwd = input.cwd || Instance.directory
-    const shellEnv = await Plugin.trigger("shell.env", { cwd, agent: input.agent }, { env: {} })
+    const shellEnv = await Plugin.trigger("shell.env", { cwd, agent: input.agent, parentAgent: input.parentAgent }, { env: {} })
     const env = {
       ...process.env,
       ...input.env,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -356,6 +356,7 @@ export namespace MessageV2 {
       })
       .optional(),
     agent: z.string(),
+    parentAgent: z.string().optional(),
     model: z.object({
       providerID: z.string(),
       modelID: z.string(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -409,6 +409,7 @@ export namespace SessionPrompt {
             tool: "task",
             sessionID,
             callID: part.id,
+            agent: lastUser.agent,
           },
           { args: taskArgs },
         )
@@ -458,6 +459,7 @@ export namespace SessionPrompt {
             sessionID,
             callID: part.id,
             args: taskArgs,
+            agent: lastUser.agent,
           },
           result,
         )
@@ -795,6 +797,7 @@ export namespace SessionPrompt {
               tool: item.id,
               sessionID: ctx.sessionID,
               callID: ctx.callID,
+              agent: ctx.agent,
             },
             {
               args,
@@ -817,6 +820,7 @@ export namespace SessionPrompt {
               sessionID: ctx.sessionID,
               callID: ctx.callID,
               args,
+              agent: ctx.agent,
             },
             output,
           )
@@ -841,6 +845,7 @@ export namespace SessionPrompt {
             tool: key,
             sessionID: ctx.sessionID,
             callID: opts.toolCallId,
+            agent: ctx.agent,
           },
           {
             args,
@@ -863,6 +868,7 @@ export namespace SessionPrompt {
             sessionID: ctx.sessionID,
             callID: opts.toolCallId,
             args,
+            agent: ctx.agent,
           },
           result,
         )
@@ -1620,7 +1626,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const cwd = Instance.directory
     const shellEnv = await Plugin.trigger(
       "shell.env",
-      { cwd, sessionID: input.sessionID, callID: part.callID },
+      { cwd, sessionID: input.sessionID, callID: part.callID, agent: input.agent },
       { env: {} },
     )
     const proc = spawn(shell, args, {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -349,7 +349,6 @@ export namespace SessionPrompt {
       const task = tasks.pop()
 
       // pending subtask
-      // TODO: centralize "invoke tool" logic
       if (task?.type === "subtask") {
         const taskTool = await TaskTool.init()
         const taskModel = task.model ? await Provider.getModel(task.model.providerID, task.model.modelID) : model
@@ -404,17 +403,6 @@ export namespace SessionPrompt {
           subagent_type: task.agent,
           command: task.command,
         }
-        await Plugin.trigger(
-          "tool.execute.before",
-          {
-            tool: "task",
-            sessionID,
-            callID: part.id,
-            agent: lastUser.agent,
-            parentAgent: lastUser.parentAgent,
-          },
-          { args: taskArgs },
-        )
         let executionError: Error | undefined
         const taskAgent = await Agent.get(task.agent)
         const taskCtx: Tool.Context = {
@@ -444,7 +432,12 @@ export namespace SessionPrompt {
             })
           },
         }
-        const result = await taskTool.execute(taskArgs, taskCtx).catch((error) => {
+        const result = await Tool.invoke({
+          tool: "task",
+          args: taskArgs,
+          ctx: { sessionID, callID: part.id, agent: lastUser.agent, parentAgent: lastUser.parentAgent },
+          fn: () => taskTool.execute(taskArgs, taskCtx),
+        }).catch((error) => {
           executionError = error
           log.error("subtask execution failed", { error, agent: task.agent, description: task.description })
           return undefined
@@ -455,18 +448,6 @@ export namespace SessionPrompt {
           sessionID,
           messageID: assistantMessage.id,
         }))
-        await Plugin.trigger(
-          "tool.execute.after",
-          {
-            tool: "task",
-            sessionID,
-            callID: part.id,
-            args: taskArgs,
-            agent: lastUser.agent,
-            parentAgent: lastUser.parentAgent,
-          },
-          result,
-        )
         assistantMessage.finish = "tool-calls"
         assistantMessage.time.completed = Date.now()
         await Session.updateMessage(assistantMessage)
@@ -798,42 +779,21 @@ export namespace SessionPrompt {
         inputSchema: jsonSchema(schema as any),
         async execute(args, options) {
           const ctx = context(args, options)
-          await Plugin.trigger(
-            "tool.execute.before",
-            {
-              tool: item.id,
-              sessionID: ctx.sessionID,
-              callID: ctx.callID,
-              agent: ctx.agent,
-              parentAgent: ctx.parentAgent,
-            },
-            {
-              args,
-            },
-          )
-          const result = await item.execute(args, ctx)
-          const output = {
-            ...result,
-            attachments: result.attachments?.map((attachment) => ({
+          const result = await Tool.invoke({
+            tool: item.id,
+            args,
+            ctx,
+            fn: () => item.execute(args, ctx),
+          })
+          return {
+            ...result!,
+            attachments: result?.attachments?.map((attachment) => ({
               ...attachment,
               id: Identifier.ascending("part"),
               sessionID: ctx.sessionID,
               messageID: input.processor.message.id,
             })),
           }
-          await Plugin.trigger(
-            "tool.execute.after",
-            {
-              tool: item.id,
-              sessionID: ctx.sessionID,
-              callID: ctx.callID,
-              args,
-              agent: ctx.agent,
-              parentAgent: ctx.parentAgent,
-            },
-            output,
-          )
-          return output
         },
       })
     }
@@ -848,89 +808,69 @@ export namespace SessionPrompt {
       item.execute = async (args, opts) => {
         const ctx = context(args, opts)
 
-        await Plugin.trigger(
-          "tool.execute.before",
-          {
-            tool: key,
-            sessionID: ctx.sessionID,
-            callID: opts.toolCallId,
-            agent: ctx.agent,
-            parentAgent: ctx.parentAgent,
-          },
-          {
-            args,
-          },
-        )
-
-        await ctx.ask({
-          permission: key,
-          metadata: {},
-          patterns: ["*"],
-          always: ["*"],
-        })
-
-        const result = await execute(args, opts)
-
-        await Plugin.trigger(
-          "tool.execute.after",
-          {
-            tool: key,
-            sessionID: ctx.sessionID,
-            callID: opts.toolCallId,
-            args,
-            agent: ctx.agent,
-            parentAgent: ctx.parentAgent,
-          },
-          result,
-        )
-
-        const textParts: string[] = []
-        const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
-
-        for (const contentItem of result.content) {
-          if (contentItem.type === "text") {
-            textParts.push(contentItem.text)
-          } else if (contentItem.type === "image") {
-            attachments.push({
-              type: "file",
-              mime: contentItem.mimeType,
-              url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
+        return Tool.invoke({
+          tool: key,
+          args,
+          ctx,
+          async fn() {
+            await ctx.ask({
+              permission: key,
+              metadata: {},
+              patterns: ["*"],
+              always: ["*"],
             })
-          } else if (contentItem.type === "resource") {
-            const { resource } = contentItem
-            if (resource.text) {
-              textParts.push(resource.text)
-            }
-            if (resource.blob) {
-              attachments.push({
-                type: "file",
-                mime: resource.mimeType ?? "application/octet-stream",
-                url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
-                filename: resource.uri,
-              })
-            }
-          }
-        }
 
-        const truncated = await Truncate.output(textParts.join("\n\n"), {}, input.agent)
-        const metadata = {
-          ...(result.metadata ?? {}),
-          truncated: truncated.truncated,
-          ...(truncated.truncated && { outputPath: truncated.outputPath }),
-        }
+            const result = await execute(args, opts)
 
-        return {
-          title: "",
-          metadata,
-          output: truncated.content,
-          attachments: attachments.map((attachment) => ({
-            ...attachment,
-            id: Identifier.ascending("part"),
-            sessionID: ctx.sessionID,
-            messageID: input.processor.message.id,
-          })),
-          content: result.content, // directly return content to preserve ordering when outputting to model
-        }
+            const textParts: string[] = []
+            const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
+
+            for (const contentItem of result.content) {
+              if (contentItem.type === "text") {
+                textParts.push(contentItem.text)
+              } else if (contentItem.type === "image") {
+                attachments.push({
+                  type: "file",
+                  mime: contentItem.mimeType,
+                  url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
+                })
+              } else if (contentItem.type === "resource") {
+                const { resource } = contentItem
+                if (resource.text) {
+                  textParts.push(resource.text)
+                }
+                if (resource.blob) {
+                  attachments.push({
+                    type: "file",
+                    mime: resource.mimeType ?? "application/octet-stream",
+                    url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
+                    filename: resource.uri,
+                  })
+                }
+              }
+            }
+
+            const truncated = await Truncate.output(textParts.join("\n\n"), {}, input.agent)
+            const metadata = {
+              ...(result.metadata ?? {}),
+              truncated: truncated.truncated,
+              ...(truncated.truncated && { outputPath: truncated.outputPath }),
+            }
+
+            return {
+              title: "",
+              metadata,
+              output: truncated.content,
+              attachments: attachments.map((attachment) => ({
+                ...attachment,
+                id: Identifier.ascending("part"),
+                sessionID: ctx.sessionID,
+                messageID: input.processor.message.id,
+              })),
+              content: result.content, // directly return content to preserve ordering when outputting to model
+            }
+          },
+        })
       }
       tools[key] = item
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -98,6 +98,7 @@ export namespace SessionPrompt {
       })
       .optional(),
     agent: z.string().optional(),
+    parentAgent: z.string().optional(),
     noReply: z.boolean().optional(),
     tools: z
       .record(z.string(), z.boolean())
@@ -410,6 +411,7 @@ export namespace SessionPrompt {
             sessionID,
             callID: part.id,
             agent: lastUser.agent,
+            parentAgent: lastUser.parentAgent,
           },
           { args: taskArgs },
         )
@@ -417,6 +419,7 @@ export namespace SessionPrompt {
         const taskAgent = await Agent.get(task.agent)
         const taskCtx: Tool.Context = {
           agent: task.agent,
+          parentAgent: lastUser.agent,
           messageID: assistantMessage.id,
           sessionID: sessionID,
           abort,
@@ -460,6 +463,7 @@ export namespace SessionPrompt {
             callID: part.id,
             args: taskArgs,
             agent: lastUser.agent,
+            parentAgent: lastUser.parentAgent,
           },
           result,
         )
@@ -609,6 +613,7 @@ export namespace SessionPrompt {
         processor,
         bypassAgentCheck,
         messages: msgs,
+        parentAgent: lastUser.parentAgent,
       })
 
       // Inject StructuredOutput tool if JSON schema mode enabled
@@ -741,6 +746,7 @@ export namespace SessionPrompt {
     processor: SessionProcessor.Info
     bypassAgentCheck: boolean
     messages: MessageV2.WithParts[]
+    parentAgent?: string
   }) {
     using _ = log.time("resolveTools")
     const tools: Record<string, AITool> = {}
@@ -752,6 +758,7 @@ export namespace SessionPrompt {
       callID: options.toolCallId,
       extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck },
       agent: input.agent.name,
+      parentAgent: input.parentAgent,
       messages: input.messages,
       metadata: async (val: { title?: string; metadata?: any }) => {
         const match = input.processor.partFromToolCall(options.toolCallId)
@@ -798,6 +805,7 @@ export namespace SessionPrompt {
               sessionID: ctx.sessionID,
               callID: ctx.callID,
               agent: ctx.agent,
+              parentAgent: ctx.parentAgent,
             },
             {
               args,
@@ -821,6 +829,7 @@ export namespace SessionPrompt {
               callID: ctx.callID,
               args,
               agent: ctx.agent,
+              parentAgent: ctx.parentAgent,
             },
             output,
           )
@@ -846,6 +855,7 @@ export namespace SessionPrompt {
             sessionID: ctx.sessionID,
             callID: opts.toolCallId,
             agent: ctx.agent,
+            parentAgent: ctx.parentAgent,
           },
           {
             args,
@@ -869,6 +879,7 @@ export namespace SessionPrompt {
             callID: opts.toolCallId,
             args,
             agent: ctx.agent,
+            parentAgent: ctx.parentAgent,
           },
           result,
         )
@@ -976,6 +987,7 @@ export namespace SessionPrompt {
       },
       tools: input.tools,
       agent: agent.name,
+      parentAgent: input.parentAgent,
       model,
       system: input.system,
       format: input.format,
@@ -1467,6 +1479,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   export const ShellInput = z.object({
     sessionID: Identifier.schema("session"),
     agent: z.string(),
+    parentAgent: z.string().optional(),
     model: z
       .object({
         providerID: z.string(),
@@ -1626,7 +1639,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const cwd = Instance.directory
     const shellEnv = await Plugin.trigger(
       "shell.env",
-      { cwd, sessionID: input.sessionID, callID: part.callID, agent: input.agent },
+      { cwd, sessionID: input.sessionID, callID: part.callID, agent: input.agent, parentAgent: input.parentAgent },
       { env: {} },
     )
     const proc = spawn(shell, args, {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -165,7 +165,7 @@ export const BashTool = Tool.define("bash", async () => {
 
       const shellEnv = await Plugin.trigger(
         "shell.env",
-        { cwd, sessionID: ctx.sessionID, callID: ctx.callID, agent: ctx.agent },
+        { cwd, sessionID: ctx.sessionID, callID: ctx.callID, agent: ctx.agent, parentAgent: ctx.parentAgent },
         { env: {} },
       )
       const proc = spawn(params.command, {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -165,7 +165,7 @@ export const BashTool = Tool.define("bash", async () => {
 
       const shellEnv = await Plugin.trigger(
         "shell.env",
-        { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
+        { cwd, sessionID: ctx.sessionID, callID: ctx.callID, agent: ctx.agent },
         { env: {} },
       )
       const proc = spawn(params.command, {

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -76,8 +76,13 @@ export const BatchTool = Tool.define("batch", async () => {
             },
           })
 
-          const result = await tool.execute(validatedParams, { ...ctx, callID: partID })
-          const attachments = result.attachments?.map((attachment) => ({
+          const result = await Tool.invoke({
+            tool: call.tool,
+            args: validatedParams,
+            ctx: { ...ctx, callID: partID },
+            fn: () => tool.execute(validatedParams, { ...ctx, callID: partID }),
+          })
+          const attachments = result?.attachments?.map((attachment) => ({
             ...attachment,
             id: Identifier.ascending("part"),
             sessionID: ctx.sessionID,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -66,7 +66,17 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const session = await iife(async () => {
         if (params.task_id) {
           const found = await Session.get(params.task_id).catch(() => {})
-          if (found) return found
+          if (found) {
+            // Guard: verify session ownership — prevents cross-session hijacking.
+            // A resumed session must belong to the calling session.
+            if (found.parentID && found.parentID !== ctx.sessionID) {
+              throw new Error(
+                `Session ${params.task_id} belongs to parent ${found.parentID}, ` +
+                  `not ${ctx.sessionID}. Cross-session resume rejected.`,
+              )
+            }
+            return found
+          }
         }
 
         return await Session.create({
@@ -103,10 +113,18 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 
-      const model = agent.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
+      // Guard: reject model fallback to parent — prevents governance bypass.
+      // If agent.model is undefined, the old code fell back to the parent's
+      // model (msg.info.modelID), silently routing e.g. a backend/codex agent
+      // through the parent's opus. This violates cross-family review rules.
+      // See: #6636, #11699.
+      if (!agent.model) {
+        throw new Error(
+          `Agent "${agent.name}" has no model configured in opencode.json. ` +
+            `Refusing to fall back to parent model (${msg.info.providerID}/${msg.info.modelID}) — governance bypass.`,
+        )
       }
+      const model = agent.model
 
       ctx.metadata({
         title: params.description,
@@ -143,7 +161,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         parts: promptParts,
       })
 
-      const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+      const text = result.parts.findLast((x: { type: string }) => x.type === "text")?.text ?? ""
 
       const output = [
         `task_id: ${session.id} (for resuming to continue this task if needed)`,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -133,6 +133,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
+        parentAgent: ctx.agent,
         tools: {
           todowrite: false,
           todoread: false,

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -17,6 +17,7 @@ export namespace Tool {
     sessionID: string
     messageID: string
     agent: string
+    parentAgent?: string
     abort: AbortSignal
     callID?: string
     extra?: { [key: string]: any }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -25,6 +25,7 @@ export namespace Tool {
     metadata(input: { title?: string; metadata?: M }): void
     ask(input: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">): Promise<void>
   }
+
   export interface Info<Parameters extends z.ZodType = z.ZodType, M extends Metadata = Metadata> {
     id: string
     init: (ctx?: InitContext) => Promise<{
@@ -43,8 +44,53 @@ export namespace Tool {
     }>
   }
 
+  // resolved return type of a tool's execute() function
+  export type Result = Awaited<ReturnType<Awaited<ReturnType<Info["init"]>>["execute"]>>
+
   export type InferParameters<T extends Info> = T extends Info<infer P> ? z.infer<P> : never
   export type InferMetadata<T extends Info> = T extends Info<any, infer M> ? M : never
+
+  // lazy-cached to avoid circular dep: tool.ts -> plugin -> session -> tool.ts
+  let plugin: typeof import("../plugin") | undefined
+
+  // wraps tool execution with plugin before/after hooks
+  export async function invoke(input: {
+    tool: string
+    args: unknown
+    ctx: { sessionID: string; callID?: string; agent: string; parentAgent?: string }
+    fn: () => Promise<Result>
+  }) {
+    plugin ??= await import("../plugin")
+    const hook = {
+      tool: input.tool,
+      sessionID: input.ctx.sessionID,
+      callID: input.ctx.callID ?? "",
+      agent: input.ctx.agent,
+      parentAgent: input.ctx.parentAgent,
+    }
+    await plugin.Plugin.trigger("tool.execute.before", hook, { args: input.args })
+    try {
+      const result = await input.fn()
+      await plugin.Plugin.trigger(
+        "tool.execute.after",
+        { ...hook, args: input.args },
+        { ...result, status: "success" as const },
+      )
+      return result
+    } catch (error) {
+      await plugin.Plugin.trigger(
+        "tool.execute.after",
+        { ...hook, args: input.args },
+        {
+          title: "",
+          output: "",
+          metadata: { error: error instanceof Error ? error.message : String(error) },
+          status: "error" as const,
+        },
+      )
+      throw error
+    }
+  }
 
   export function define<Parameters extends z.ZodType, Result extends Metadata>(
     id: string,

--- a/packages/opencode/test/plugin/agent-hooks.test.ts
+++ b/packages/opencode/test/plugin/agent-hooks.test.ts
@@ -177,6 +177,179 @@ describe("plugin.agent-hooks", () => {
     })
   })
 
+  // parentAgent tests — verify delegation chain is exposed to hooks
+  test("tool.execute.before hook receives parentAgent for subagent", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "tool.execute.before": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-parent-before.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "tool.execute.before",
+          { tool: "bash", sessionID: "s", callID: "c", agent: "explore", parentAgent: "build" },
+          { args: {} },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-parent-before.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("explore")
+        expect(captured.parentAgent).toBe("build")
+      },
+    })
+  })
+
+  test("tool.execute.after hook receives parentAgent for subagent", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "tool.execute.after": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-parent-after.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "tool.execute.after",
+          { tool: "edit", sessionID: "s", callID: "c", args: {}, agent: "explore", parentAgent: "build" },
+          { title: "", output: "", metadata: {} },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-parent-after.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("explore")
+        expect(captured.parentAgent).toBe("build")
+      },
+    })
+  })
+
+  test("shell.env hook receives parentAgent for subagent", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "shell.env": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-parent-shell.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger("shell.env", { cwd: tmp.path, agent: "explore", parentAgent: "build" }, { env: {} })
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-parent-shell.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("explore")
+        expect(captured.parentAgent).toBe("build")
+      },
+    })
+  })
+
+  test("top-level agent has undefined parentAgent", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "tool.execute.before": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-no-parent.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "tool.execute.before",
+          { tool: "bash", sessionID: "s", callID: "c", agent: "build" },
+          { args: {} },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-no-parent.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("build")
+        expect(captured.parentAgent).toBeNull()
+      },
+    })
+  })
+
   // Integration: bash tool end-to-end with real plugin
   test("bash tool end-to-end: plugin receives ctx.agent via shell.env", async () => {
     await using tmp = await tmpdir({
@@ -226,6 +399,60 @@ describe("plugin.agent-hooks", () => {
         const raw = await fs.readFile(path.join(tmp.path, ".bash-agent.json"), "utf-8")
         const captured = JSON.parse(raw)
         expect(captured.agent).toBe("taste")
+      },
+    })
+  })
+
+  test("bash tool end-to-end: plugin receives ctx.parentAgent via shell.env", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "shell.env": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".bash-parent.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        await bash.execute(
+          { command: "echo hello", description: "test" },
+          {
+            sessionID: "test",
+            messageID: "",
+            callID: "",
+            agent: "explore",
+            parentAgent: "build",
+            abort: AbortSignal.any([]),
+            messages: [],
+            metadata: () => {},
+            ask: async () => {},
+          },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".bash-parent.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("explore")
+        expect(captured.parentAgent).toBe("build")
       },
     })
   })

--- a/packages/opencode/test/plugin/agent-hooks.test.ts
+++ b/packages/opencode/test/plugin/agent-hooks.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Plugin } from "../../src/plugin"
+import { BashTool } from "../../src/tool/bash"
+
+describe("plugin.agent-hooks", () => {
+  // Direct Plugin.trigger tests — verify hooks receive the agent field
+  // These test the contract: Plugin.trigger passes input.agent to hook functions
+
+  test("shell.env hook receives agent value", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "shell.env": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-shell-env.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, cwd: hookInput.cwd }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger("shell.env", { cwd: tmp.path, agent: "taste" }, { env: {} })
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-shell-env.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("taste")
+        expect(captured.cwd).toBe(tmp.path)
+      },
+    })
+  })
+
+  test("tool.execute.before hook receives agent value", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "tool.execute.before": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-before.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, tool: hookInput.tool }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "tool.execute.before",
+          { tool: "bash", sessionID: "s", callID: "c", agent: "cook" },
+          { args: {} },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-before.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("cook")
+        expect(captured.tool).toBe("bash")
+      },
+    })
+  })
+
+  test("tool.execute.after hook receives agent value", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "tool.execute.after": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-after.json"),',
+            "      JSON.stringify({ agent: hookInput.agent, tool: hookInput.tool }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "tool.execute.after",
+          { tool: "edit", sessionID: "s", callID: "c", args: {}, agent: "eat" },
+          { title: "", output: "", metadata: {} },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-after.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("eat")
+        expect(captured.tool).toBe("edit")
+      },
+    })
+  })
+
+  test("shell.env hook receives undefined agent for PTY case", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "shell.env": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".capture-pty.json"),',
+            "      JSON.stringify({ agent: hookInput.agent ?? null }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger("shell.env", { cwd: tmp.path, agent: undefined }, { env: {} })
+
+        const raw = await fs.readFile(path.join(tmp.path, ".capture-pty.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBeNull()
+      },
+    })
+  })
+
+  // Integration: bash tool end-to-end with real plugin
+  test("bash tool end-to-end: plugin receives ctx.agent via shell.env", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const pluginsDir = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(pluginsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginsDir, "capture.ts"),
+          [
+            "const plugin = async (input) => ({",
+            '  "shell.env": async (hookInput, output) => {',
+            '    const fs = await import("fs/promises")',
+            '    const path = await import("path")',
+            "    await fs.writeFile(",
+            '      path.join(input.directory, ".bash-agent.json"),',
+            "      JSON.stringify({ agent: hookInput.agent }),",
+            "    )",
+            "  },",
+            "})",
+            "export default plugin",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        await bash.execute(
+          { command: "echo hello", description: "test" },
+          {
+            sessionID: "test",
+            messageID: "",
+            callID: "",
+            agent: "taste",
+            abort: AbortSignal.any([]),
+            messages: [],
+            metadata: () => {},
+            ask: async () => {},
+          },
+        )
+
+        const raw = await fs.readFile(path.join(tmp.path, ".bash-agent.json"), "utf-8")
+        const captured = JSON.parse(raw)
+        expect(captured.agent).toBe("taste")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -47,7 +47,8 @@ describe("session.prompt missing file", () => {
         if (msg.info.role !== "user") throw new Error("expected user message")
 
         const hasFailure = msg.parts.some(
-          (part) => part.type === "text" && part.synthetic && part.text.includes("Read tool failed to read"),
+          (part: { type: string; synthetic?: boolean; text?: string }) =>
+            part.type === "text" && part.synthetic && part.text?.includes("Read tool failed to read"),
         )
         expect(hasFailure).toBe(true)
 

--- a/packages/opencode/test/tool/batch-hooks.test.ts
+++ b/packages/opencode/test/tool/batch-hooks.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Tool } from "../../src/tool/tool"
+
+function stateful(hooks: string) {
+  return [
+    "const plugin = async (input) => {",
+    "  const calls = []",
+    "  return {",
+    hooks,
+    "  }",
+    "}",
+    "export default plugin",
+  ].join("\n")
+}
+
+function capture(hook: string, file: string, push: string) {
+  return [
+    `    "${hook}": async (hookInput, output) => {`,
+    `      calls.push(${push})`,
+    '      const fs = await import("fs/promises")',
+    '      const path = await import("path")',
+    `      await fs.writeFile(path.join(input.directory, "${file}"), JSON.stringify(calls))`,
+    "    },",
+  ].join("\n")
+}
+
+async function setup(dir: string, hooks: string) {
+  const plugins = path.join(dir, ".opencode", "plugins")
+  await fs.mkdir(plugins, { recursive: true })
+  await Bun.write(path.join(plugins, "capture.ts"), stateful(hooks))
+}
+
+async function read(dir: string, file: string) {
+  return JSON.parse(await fs.readFile(path.join(dir, file), "utf-8"))
+}
+
+describe("Tool.invoke parallel", () => {
+  test("concurrent calls each fire before and after hooks", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) =>
+        setup(
+          dir,
+          [
+            capture("tool.execute.before", ".hooks.json", "{ type: 'before', tool: hookInput.tool }"),
+            capture(
+              "tool.execute.after",
+              ".hooks.json",
+              "{ type: 'after', tool: hookInput.tool, output: output.output }",
+            ),
+          ].join("\n"),
+        ),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Promise.all([
+          Tool.invoke({
+            tool: "read",
+            args: { file: "a.txt" },
+            ctx: { sessionID: "s1", callID: "c1", agent: "build" },
+            fn: async () => ({ title: "Read a", output: "aaa", metadata: {} }),
+          }),
+          Tool.invoke({
+            tool: "grep",
+            args: { pattern: "foo" },
+            ctx: { sessionID: "s1", callID: "c2", agent: "build" },
+            fn: async () => ({ title: "Grep", output: "bbb", metadata: {} }),
+          }),
+        ])
+
+        const hooks: { type: string; tool: string }[] = await read(tmp.path, ".hooks.json")
+        expect(hooks).toHaveLength(4)
+        expect(hooks.filter((h) => h.type === "before")).toHaveLength(2)
+        expect(hooks.filter((h) => h.type === "after")).toHaveLength(2)
+
+        const tools = hooks
+          .filter((h) => h.type === "before")
+          .map((h) => h.tool)
+          .sort()
+        expect(tools).toEqual(["grep", "read"])
+      },
+    })
+  })
+
+  test("failed call still fires after hook", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) =>
+        setup(
+          dir,
+          [
+            capture("tool.execute.before", ".hooks.json", "{ type: 'before', tool: hookInput.tool }"),
+            capture(
+              "tool.execute.after",
+              ".hooks.json",
+              "{ type: 'after', tool: hookInput.tool, metadata: output.metadata }",
+            ),
+          ].join("\n"),
+        ),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await expect(
+          Tool.invoke({
+            tool: "edit",
+            args: {},
+            ctx: { sessionID: "s1", callID: "c1", agent: "build" },
+            fn: async () => {
+              throw new Error("not found")
+            },
+          }),
+        ).rejects.toThrow("not found")
+
+        const hooks: { type: string; tool: string; metadata?: Record<string, unknown> }[] = await read(
+          tmp.path,
+          ".hooks.json",
+        )
+        expect(hooks).toHaveLength(2)
+        expect(hooks[0].type).toBe("before")
+        expect(hooks[1].type).toBe("after")
+        expect(hooks[1].metadata?.error).toBe("not found")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/batch-integration.test.ts
+++ b/packages/opencode/test/tool/batch-integration.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Identifier } from "../../src/id/id"
+import { BatchTool } from "../../src/tool/batch"
+
+function stateful(hooks: string) {
+  return [
+    "const plugin = async (input) => {",
+    "  const calls = []",
+    "  return {",
+    hooks,
+    "  }",
+    "}",
+    "export default plugin",
+  ].join("\n")
+}
+
+function capture(hook: string, file: string, push: string) {
+  return [
+    `    "${hook}": async (hookInput, output) => {`,
+    `      calls.push(${push})`,
+    '      const fs = await import("fs/promises")',
+    '      const path = await import("path")',
+    `      await fs.writeFile(path.join(input.directory, "${file}"), JSON.stringify(calls))`,
+    "    },",
+  ].join("\n")
+}
+
+describe("batch integration", () => {
+  // proves batch.ts:79 actually calls Tool.invoke — plugin hooks fire for sub-tools
+  test("sub-tool calls fire plugin hooks end-to-end", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: async (dir) => {
+        const plugins = path.join(dir, ".opencode", "plugins")
+        await fs.mkdir(plugins, { recursive: true })
+        await Bun.write(
+          path.join(plugins, "capture.ts"),
+          stateful(
+            [
+              capture("tool.execute.before", ".hooks.json", "{ type: 'before', tool: hookInput.tool }"),
+              capture(
+                "tool.execute.after",
+                ".hooks.json",
+                "{ type: 'after', tool: hookInput.tool, status: output.status }",
+              ),
+            ].join("\n"),
+          ),
+        )
+        await Bun.write(path.join(dir, "test.txt"), "hello world")
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const messageID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: messageID,
+          role: "assistant",
+          sessionID: session.id,
+          parentID: messageID,
+          mode: "code",
+          agent: "code",
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: "test/model",
+          providerID: "test",
+          time: { created: Date.now() },
+          path: { cwd: tmp.path, root: tmp.path },
+        })
+
+        const batch = await BatchTool.init()
+        const result = await batch.execute(
+          {
+            tool_calls: [
+              {
+                tool: "read",
+                parameters: { filePath: path.join(tmp.path, "test.txt") },
+              },
+            ],
+          },
+          {
+            sessionID: session.id,
+            messageID,
+            callID: "batch-call",
+            agent: "code",
+            abort: AbortSignal.any([]),
+            messages: [],
+            metadata: () => {},
+            ask: async () => {},
+          },
+        )
+
+        expect(result.metadata.successful).toBe(1)
+        expect(result.metadata.failed).toBe(0)
+
+        const raw = await fs.readFile(path.join(tmp.path, ".hooks.json"), "utf-8")
+        const hooks: { type: string; tool: string; status?: string }[] = JSON.parse(raw)
+
+        const before = hooks.filter((h) => h.type === "before" && h.tool === "read")
+        const after = hooks.filter((h) => h.type === "after" && h.tool === "read")
+
+        expect(before).toHaveLength(1)
+        expect(after).toHaveLength(1)
+        expect(after[0].status).toBe("success")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/invoke.test.ts
+++ b/packages/opencode/test/tool/invoke.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Tool } from "../../src/tool/tool"
+
+function plugin(hooks: string) {
+  return ["const plugin = async (input) => ({", hooks, "})", "export default plugin"].join("\n")
+}
+
+function capture(hook: string, file: string, fields: string) {
+  return [
+    `  "${hook}": async (hookInput, output) => {`,
+    '    const fs = await import("fs/promises")',
+    '    const path = await import("path")',
+    `    await fs.writeFile(path.join(input.directory, "${file}"), JSON.stringify(${fields}))`,
+    "  },",
+  ].join("\n")
+}
+
+async function setup(dir: string, hooks: string) {
+  const plugins = path.join(dir, ".opencode", "plugins")
+  await fs.mkdir(plugins, { recursive: true })
+  await Bun.write(path.join(plugins, "capture.ts"), plugin(hooks))
+}
+
+async function read(dir: string, file: string) {
+  return JSON.parse(await fs.readFile(path.join(dir, file), "utf-8"))
+}
+
+describe("Tool.invoke", () => {
+  test("fires before and after hooks on success", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) =>
+        setup(
+          dir,
+          [
+            capture(
+              "tool.execute.before",
+              ".before.json",
+              "{ tool: hookInput.tool, agent: hookInput.agent, callID: hookInput.callID, args: output.args }",
+            ),
+            capture(
+              "tool.execute.after",
+              ".after.json",
+              "{ tool: hookInput.tool, agent: hookInput.agent, title: output.title, output: output.output, status: output.status }",
+            ),
+          ].join("\n"),
+        ),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await Tool.invoke({
+          tool: "read",
+          args: { file: "foo.ts" },
+          ctx: { sessionID: "s1", callID: "c1", agent: "build" },
+          fn: async () => ({ title: "Read", output: "contents", metadata: {} }),
+        })
+
+        expect(result.title).toBe("Read")
+        expect(result.output).toBe("contents")
+
+        const before = await read(tmp.path, ".before.json")
+        expect(before.tool).toBe("read")
+        expect(before.agent).toBe("build")
+        expect(before.callID).toBe("c1")
+        expect(before.args).toEqual({ file: "foo.ts" })
+
+        const after = await read(tmp.path, ".after.json")
+        expect(after.tool).toBe("read")
+        expect(after.title).toBe("Read")
+        expect(after.output).toBe("contents")
+        expect(after.status).toBe("success")
+      },
+    })
+  })
+
+  test("fires after hook with error metadata when fn throws", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) =>
+        setup(
+          dir,
+          capture(
+            "tool.execute.after",
+            ".after.json",
+            "{ tool: hookInput.tool, metadata: output.metadata, status: output.status }",
+          ),
+        ),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await expect(
+          Tool.invoke({
+            tool: "edit",
+            args: {},
+            ctx: { sessionID: "s1", callID: "c1", agent: "build" },
+            fn: async () => {
+              throw new Error("disk full")
+            },
+          }),
+        ).rejects.toThrow("disk full")
+
+        const after = await read(tmp.path, ".after.json")
+        expect(after.tool).toBe("edit")
+        expect(after.status).toBe("error")
+        expect(after.metadata.error).toBe("disk full")
+      },
+    })
+  })
+
+  test("passes parentAgent through to hooks", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) =>
+        setup(
+          dir,
+          capture(
+            "tool.execute.before",
+            ".before.json",
+            "{ agent: hookInput.agent, parentAgent: hookInput.parentAgent ?? null }",
+          ),
+        ),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Tool.invoke({
+          tool: "bash",
+          args: {},
+          ctx: { sessionID: "s1", callID: "c1", agent: "explore", parentAgent: "build" },
+          fn: async () => ({ title: "", output: "", metadata: {} }),
+        })
+
+        const before = await read(tmp.path, ".before.json")
+        expect(before.agent).toBe("explore")
+        expect(before.parentAgent).toBe("build")
+      },
+    })
+  })
+
+  test("defaults callID to empty string", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+      init: (dir) => setup(dir, capture("tool.execute.before", ".before.json", "{ callID: hookInput.callID }")),
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Tool.invoke({
+          tool: "read",
+          args: {},
+          ctx: { sessionID: "s1", agent: "build" },
+          fn: async () => ({ title: "", output: "", metadata: {} }),
+        })
+
+        const before = await read(tmp.path, ".before.json")
+        expect(before.callID).toBe("")
+      },
+    })
+  })
+
+  test("returns result unchanged", async () => {
+    await using tmp = await tmpdir({ git: true, config: {} })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await Tool.invoke({
+          tool: "read",
+          args: {},
+          ctx: { sessionID: "s1", agent: "build" },
+          fn: async () => ({ title: "t", output: "o", metadata: { x: 1 }, attachments: [] }),
+        })
+
+        expect(result.title).toBe("t")
+        expect(result.output).toBe("o")
+        expect(result.metadata).toEqual({ x: 1 })
+        expect(result.attachments).toEqual([])
+      },
+    })
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -182,15 +182,15 @@ export interface Hooks {
     output: { parts: Part[] },
   ) => Promise<void>
   "tool.execute.before"?: (
-    input: { tool: string; sessionID: string; callID: string; agent: string },
+    input: { tool: string; sessionID: string; callID: string; agent: string; parentAgent?: string },
     output: { args: any },
   ) => Promise<void>
   "shell.env"?: (
-    input: { cwd: string; sessionID?: string; callID?: string; agent?: string },
+    input: { cwd: string; sessionID?: string; callID?: string; agent?: string; parentAgent?: string },
     output: { env: Record<string, string> },
   ) => Promise<void>
   "tool.execute.after"?: (
-    input: { tool: string; sessionID: string; callID: string; args: any; agent: string },
+    input: { tool: string; sessionID: string; callID: string; args: any; agent: string; parentAgent?: string },
     output: {
       title: string
       output: string

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -182,15 +182,15 @@ export interface Hooks {
     output: { parts: Part[] },
   ) => Promise<void>
   "tool.execute.before"?: (
-    input: { tool: string; sessionID: string; callID: string },
+    input: { tool: string; sessionID: string; callID: string; agent: string },
     output: { args: any },
   ) => Promise<void>
   "shell.env"?: (
-    input: { cwd: string; sessionID?: string; callID?: string },
+    input: { cwd: string; sessionID?: string; callID?: string; agent?: string },
     output: { env: Record<string, string> },
   ) => Promise<void>
   "tool.execute.after"?: (
-    input: { tool: string; sessionID: string; callID: string; args: any },
+    input: { tool: string; sessionID: string; callID: string; args: any; agent: string },
     output: {
       title: string
       output: string

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -195,6 +195,7 @@ export interface Hooks {
       title: string
       output: string
       metadata: any
+      status?: "success" | "error"
     },
   ) => Promise<void>
   "experimental.chat.messages.transform"?: (

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -483,6 +483,7 @@ export class Pty extends HeyApiClient {
         [key: string]: string
       }
       agent?: string
+      parentAgent?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -498,6 +499,7 @@ export class Pty extends HeyApiClient {
             { in: "body", key: "title" },
             { in: "body", key: "env" },
             { in: "body", key: "agent" },
+            { in: "body", key: "parentAgent" },
           ],
         },
       ],
@@ -1520,6 +1522,7 @@ export class Session2 extends HeyApiClient {
         modelID: string
       }
       agent?: string
+      parentAgent?: string
       noReply?: boolean
       tools?: {
         [key: string]: boolean
@@ -1541,6 +1544,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
+            { in: "body", key: "parentAgent" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
@@ -1610,6 +1614,7 @@ export class Session2 extends HeyApiClient {
         modelID: string
       }
       agent?: string
+      parentAgent?: string
       noReply?: boolean
       tools?: {
         [key: string]: boolean
@@ -1631,6 +1636,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
+            { in: "body", key: "parentAgent" },
             { in: "body", key: "noReply" },
             { in: "body", key: "tools" },
             { in: "body", key: "format" },
@@ -1719,6 +1725,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       agent?: string
+      parentAgent?: string
       model?: {
         providerID: string
         modelID: string
@@ -1735,6 +1742,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "body", key: "agent" },
+            { in: "body", key: "parentAgent" },
             { in: "body", key: "model" },
             { in: "body", key: "command" },
           ],

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -482,6 +482,7 @@ export class Pty extends HeyApiClient {
       env?: {
         [key: string]: string
       }
+      agent?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -496,6 +497,7 @@ export class Pty extends HeyApiClient {
             { in: "body", key: "cwd" },
             { in: "body", key: "title" },
             { in: "body", key: "env" },
+            { in: "body", key: "agent" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2538,6 +2538,7 @@ export type PtyCreateData = {
     env?: {
       [key: string]: string
     }
+    agent?: string
   }
   path?: never
   query?: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -129,6 +129,7 @@ export type UserMessage = {
     diffs: Array<FileDiff>
   }
   agent: string
+  parentAgent?: string
   model: {
     providerID: string
     modelID: string
@@ -2539,6 +2540,7 @@ export type PtyCreateData = {
       [key: string]: string
     }
     agent?: string
+    parentAgent?: string
   }
   path?: never
   query?: {
@@ -3516,6 +3518,7 @@ export type SessionPromptData = {
       modelID: string
     }
     agent?: string
+    parentAgent?: string
     noReply?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
@@ -3704,6 +3707,7 @@ export type SessionPromptAsyncData = {
       modelID: string
     }
     agent?: string
+    parentAgent?: string
     noReply?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
@@ -3807,6 +3811,7 @@ export type SessionCommandResponse = SessionCommandResponses[keyof SessionComman
 export type SessionShellData = {
   body?: {
     agent: string
+    parentAgent?: string
     model?: {
       providerID: string
       modelID: string


### PR DESCRIPTION
## Summary
- Expose `agent` and `parentAgent` fields in `tool.execute.before`, `tool.execute.after`, and `shell.env` plugin hooks, enabling governance plugins (e.g. ContractOps) to enforce per-agent policies
- Centralize duplicated `Plugin.trigger` calls into a new `Tool.invoke()` helper, fixing a bug where `batch.ts` sub-tools never fired plugin hooks
- Add `status` field to `tool.execute.after` hook for distinguishing success from error

## Test plan
- 4 new test files with 30+ tests covering agent identity threading, parentAgent delegation, batch hook firing, and Tool.invoke behavior