### PR TITLE
feat(opencode): add STEER support for busy TUI sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -34,6 +34,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { isSteerKey, isSubmitRequestSuccess, routeSubmit, type SubmitIntent } from "./submit-routing"
 
 export type PromptProps = {
   sessionID?: string
@@ -383,7 +384,7 @@ export function Prompt(props: PromptProps) {
       setStore("extmarkToPartIndex", new Map())
     },
     submit() {
-      submit()
+      void submit()
     },
   }
 
@@ -525,7 +526,15 @@ export function Prompt(props: PromptProps) {
     },
   ])
 
-  async function submit() {
+  function send(intent: SubmitIntent) {
+    void submitInner(intent)
+  }
+
+  function submit() {
+    send("default")
+  }
+
+  async function submitInner(intent: SubmitIntent) {
     if (props.disabled) return
     if (autocomplete?.visible) return
     if (!store.prompt.input) return
@@ -570,6 +579,47 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    const parts = [
+      {
+        id: Identifier.ascending("part"),
+        type: "text" as const,
+        text: inputText,
+      },
+      ...nonTextParts.map((x) => ({
+        id: Identifier.ascending("part"),
+        ...x,
+      })),
+    ]
+
+    let sent = false
+    const prompt = async () => {
+      const asyncPrompt = !props.sessionID || (!!props.sessionID && status().type !== "idle")
+      const call = asyncPrompt ? sdk.client.session.promptAsync : sdk.client.session.prompt
+      const result = await call
+        .bind(sdk.client.session)({
+          sessionID,
+          ...selectedModel,
+          messageID,
+          agent: local.agent.current().name,
+          model: selectedModel,
+          variant,
+          parts,
+        })
+        .catch((error) => {
+          toast.error(error)
+          return null
+        })
+      if (result === null) return false
+      if (!isSubmitRequestSuccess(result)) {
+        toast.show({
+          variant: "error",
+          message: "Failed to send prompt",
+          duration: 3000,
+        })
+        return false
+      }
+      return true
+    }
 
     if (store.mode === "shell") {
       sdk.client.session.shell({
@@ -582,6 +632,7 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
+      sent = true
     } else if (
       inputText.startsWith("/") &&
       iife(() => {
@@ -612,29 +663,55 @@ export function Prompt(props: PromptProps) {
             ...x,
           })),
       })
+      sent = true
     } else {
-      sdk.client.session
-        .prompt({
-          sessionID,
-          ...selectedModel,
-          messageID,
-          agent: local.agent.current().name,
-          model: selectedModel,
-          variant,
-          parts: [
-            {
-              id: Identifier.ascending("part"),
-              type: "text",
-              text: inputText,
-            },
-            ...nonTextParts.map((x) => ({
-              id: Identifier.ascending("part"),
-              ...x,
-            })),
-          ],
+      const busy = !!props.sessionID && status().type !== "idle"
+      const route = routeSubmit({
+        busy,
+        intent,
+        hasNonText: nonTextParts.length > 0,
+      })
+      if (route === "reject-steer-nontext") {
+        toast.show({
+          variant: "warning",
+          message: "Steer while busy only supports plain text",
+          duration: 3000,
         })
-        .catch(() => {})
+        return
+      }
+      if (route === "steer") {
+        const result = await sdk.client.session
+          .steer({
+            sessionID,
+            text: inputText,
+          })
+          .catch((error) => {
+            toast.error(error)
+            return null
+          })
+        if (result === null) return
+        if (!result.data || result.error) {
+          toast.show({
+            variant: "error",
+            message: "Failed to send steer message",
+            duration: 3000,
+          })
+          return
+        }
+        if (result.data.accepted) {
+          sent = true
+        }
+        if (!result.data.accepted) {
+          sent = await prompt()
+          if (!sent) return
+        }
+      }
+      if (route === "prompt") {
+        sent = await prompt()
+        if (!sent) return
+      }
     }
+    if (!sent) return
     history.append({
       ...store.prompt,
       mode: currentMode,
@@ -834,6 +911,17 @@ export function Prompt(props: PromptProps) {
               onKeyDown={async (e) => {
                 if (props.disabled) {
                   e.preventDefault()
+                  return
+                }
+                if (
+                  isSteerKey({
+                    busy: !!props.sessionID && status().type !== "idle",
+                    mode: store.mode,
+                    matched: !!keybind.match("input_steer_submit", e),
+                  })
+                ) {
+                  e.preventDefault()
+                  send("steer")
                   return
                 }
                 // Handle clipboard paste (Ctrl+V) - check for images first on Windows
@@ -1116,12 +1204,19 @@ export function Prompt(props: PromptProps) {
                   })()}
                 </box>
               </box>
-              <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
-                esc{" "}
-                <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
-                  {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                </span>
-              </text>
+              <box flexDirection="row" gap={2}>
+                <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
+                  esc{" "}
+                  <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
+                    {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                  </span>
+                </text>
+                <Show when={store.mode === "normal"}>
+                  <text fg={theme.text}>
+                    {keybind.print("input_steer_submit")} <span style={{ fg: theme.textMuted }}>steer</span>
+                  </text>
+                </Show>
+              </box>
             </box>
           </Show>
           <Show when={status().type !== "retry"}>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/submit-routing.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/submit-routing.ts
@@ -1,0 +1,40 @@
+export type SubmitIntent = "default" | "steer"
+
+export type SubmitRoute = "prompt" | "steer" | "reject-steer-nontext"
+
+export function routeSubmit(input: {
+  busy: boolean
+  intent: SubmitIntent
+  hasNonText: boolean
+}): SubmitRoute {
+  if (!input.busy) return "prompt"
+  if (input.intent === "default") return "prompt"
+  if (input.hasNonText) return "reject-steer-nontext"
+  return "steer"
+}
+
+export function isSteerKey(input: {
+  busy: boolean
+  mode: "normal" | "shell"
+  matched: boolean
+}) {
+  return input.busy && input.mode === "normal" && input.matched
+}
+
+export function isSubmitRequestSuccess(result: unknown) {
+  if (result === null || result === undefined) return false
+  if (typeof result !== "object") return true
+
+  const obj = result as Record<string, unknown>
+  if ("error" in obj && obj.error !== undefined) return false
+
+  if ("response" in obj) {
+    const response = obj.response
+    if (response && typeof response === "object") {
+      const res = response as Record<string, unknown>
+      if ("ok" in res) return !!res.ok
+    }
+  }
+
+  return true
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -260,18 +260,18 @@ export function Session() {
     const messagesList = messages()
     const scrollTop = scroll.y
 
-    // Get visible messages sorted by position, filtering for valid non-synthetic, non-ignored content
+    // Get visible messages sorted by position, filtering for valid visible user text content
     const visibleMessages = children
       .filter((c) => {
         if (!c.id) return false
         const message = messagesList.find((m) => m.id === c.id)
         if (!message) return false
 
-        // Check if message has valid non-synthetic, non-ignored text parts
+        // Check if message has valid visible text parts (normal text or steer)
         const parts = sync.data.part[message.id]
         if (!parts || !Array.isArray(parts)) return false
 
-        return parts.some((part) => part && part.type === "text" && !part.synthetic && !part.ignored)
+        return parts.some((part) => text(part))
       })
       .sort((a, b) => a.y - b.y)
 
@@ -709,7 +709,7 @@ export function Session() {
         const messages = sync.data.message[route.sessionID]
         if (!messages || !messages.length) return
 
-        // Find the most recent user message with non-ignored, non-synthetic text parts
+        // Find the most recent user message with visible text parts (normal text or steer)
         for (let i = messages.length - 1; i >= 0; i--) {
           const message = messages[i]
           if (!message || message.role !== "user") continue
@@ -717,9 +717,7 @@ export function Session() {
           const parts = sync.data.part[message.id]
           if (!parts || !Array.isArray(parts)) continue
 
-          const hasValidTextPart = parts.some(
-            (part) => part && part.type === "text" && !part.synthetic && !part.ignored,
-          )
+          const hasValidTextPart = parts.some((part) => text(part))
 
           if (hasValidTextPart) {
             const child = scroll.getChildren().find((child) => {
@@ -1172,6 +1170,14 @@ const MIME_BADGE: Record<string, string> = {
   "application/x-directory": "dir",
 }
 
+function steer(part: Part | undefined): part is TextPart {
+  return !!(part && part.type === "text" && part.synthetic && !part.ignored && part.metadata?.steer)
+}
+
+function text(part: Part | undefined): part is TextPart {
+  return !!(part && part.type === "text" && !part.ignored && (!part.synthetic || steer(part)))
+}
+
 function UserMessage(props: {
   message: UserMessage
   parts: Part[]
@@ -1181,21 +1187,23 @@ function UserMessage(props: {
 }) {
   const ctx = use()
   const local = useLocal()
-  const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
+  const body = createMemo(() => props.parts.flatMap((x) => (text(x) ? [x] : []))[0])
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
   const sync = useSync()
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
-  const queued = createMemo(() => props.pending && props.message.id > props.pending)
+  const steering = createMemo(() => !!body()?.metadata?.steer)
+  const queued = createMemo(() => !steering() && !!props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
-  const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
+  const badge = createMemo(() => (steering() ? "STEER" : queued() ? "QUEUED" : undefined))
+  const metadataVisible = createMemo(() => !!badge() || ctx.showTimestamps())
 
   const compaction = createMemo(() => props.parts.find((x) => x.type === "compaction"))
 
   return (
     <>
-      <Show when={text()}>
+      <Show when={body()}>
         <box
           id={props.message.id}
           border={["left"]}
@@ -1217,7 +1225,7 @@ function UserMessage(props: {
             backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
             flexShrink={0}
           >
-            <text fg={theme.text}>{text()?.text}</text>
+            <text fg={theme.text}>{body()?.text}</text>
             <Show when={files().length}>
               <box flexDirection="row" paddingBottom={metadataVisible() ? 1 : 0} paddingTop={1} gap={1} flexWrap="wrap">
                 <For each={files()}>
@@ -1238,7 +1246,7 @@ function UserMessage(props: {
               </box>
             </Show>
             <Show
-              when={queued()}
+              when={badge()}
               fallback={
                 <Show when={ctx.showTimestamps()}>
                   <text fg={theme.textMuted}>
@@ -1249,9 +1257,11 @@ function UserMessage(props: {
                 </Show>
               }
             >
-              <text fg={theme.textMuted}>
-                <span style={{ bg: color(), fg: queuedFg(), bold: true }}> QUEUED </span>
-              </text>
+              {(val) => (
+                <text fg={theme.textMuted}>
+                  <span style={{ bg: color(), fg: queuedFg(), bold: true }}> {val()} </span>
+                </text>
+              )}
             </Show>
           </box>
         </box>

--- a/packages/opencode/src/cli/cmd/tui/util/transcript.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/transcript.ts
@@ -68,8 +68,10 @@ export function formatAssistantHeader(msg: AssistantMessage, includeMetadata: bo
 }
 
 export function formatPart(part: Part, options: TranscriptOptions): string {
-  if (part.type === "text" && !part.synthetic) {
-    return `${part.text}\n\n`
+  if (part.type === "text") {
+    if (!part.synthetic) return `${part.text}\n\n`
+    if (part.metadata?.steer) return `**Steer:** ${part.text}\n\n`
+    return ""
   }
 
   if (part.type === "reasoning") {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -836,6 +836,11 @@ export namespace Config {
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
+      input_steer_submit: z
+        .string()
+        .optional()
+        .default("alt+return,super+return,ctrl+return")
+        .describe("Submit steer guidance while session is busy"),
       input_newline: z
         .string()
         .optional()

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -381,6 +381,56 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .post(
+      "/:sessionID/steer",
+      describeRoute({
+        summary: "Steer session",
+        description: "Queue user guidance for the current active turn without aborting in-flight execution.",
+        operationId: "session.steer",
+        responses: {
+          202: {
+            description: "Steer message queued",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    accepted: z.boolean(),
+                    queued: z.object({
+                      id: z.string(),
+                      text: z.string(),
+                      timestamp: z.number(),
+                    }),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string(),
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          text: z.string().trim().min(1),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.get(sessionID)
+        const body = c.req.valid("json")
+        const result = await SessionPrompt.steer({
+          sessionID,
+          text: body.text,
+        })
+        return c.json(result, 202)
+      },
+    )
+    .post(
       "/:sessionID/share",
       describeRoute({
         summary: "Share session",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -68,6 +68,11 @@ export namespace SessionPrompt {
         string,
         {
           abort: AbortController
+          steerQueue: {
+            id: string
+            text: string
+            timestamp: number
+          }[]
           callbacks: {
             resolve(input: MessageV2.WithParts): void
             reject(reason?: any): void
@@ -241,6 +246,7 @@ export namespace SessionPrompt {
     const controller = new AbortController()
     s[sessionID] = {
       abort: controller,
+      steerQueue: [],
       callbacks: [],
     }
     return controller.signal
@@ -265,6 +271,67 @@ export namespace SessionPrompt {
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
     return
+  }
+
+  export function isBusy(sessionID: string) {
+    return !!state()[sessionID]
+  }
+
+  export const SteerInput = z.object({
+    sessionID: Identifier.schema("session"),
+    text: z.string().trim().min(1),
+  })
+
+  export const steer = fn(SteerInput, async (input) => {
+    const timestamp = Date.now()
+    const queued = {
+      id: ulid(timestamp),
+      text: input.text,
+      timestamp,
+    }
+    const match = state()[input.sessionID]
+    if (!match) {
+      await prompt({
+        sessionID: input.sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: input.text }],
+      })
+      return {
+        accepted: false,
+        queued,
+      }
+    }
+    await writeSteer({
+      sessionID: input.sessionID,
+      queued,
+    })
+    match.steerQueue.push(queued)
+    return {
+      accepted: true,
+      queued,
+    }
+  })
+
+  async function drainSteerQueue(input: {
+    sessionID: string
+    user: MessageV2.User
+  }) {
+    const match = state()[input.sessionID]
+    if (!match || match.steerQueue.length === 0) return false
+    return match.steerQueue.splice(0).length > 0
+  }
+
+  /** @internal Test helpers for steer queue behavior */
+  export const testing = {
+    startBusy(sessionID: string) {
+      start(sessionID)
+    },
+    drainSteer(input: {
+      sessionID: string
+      user: MessageV2.User
+    }) {
+      return drainSteerQueue(input)
+    },
   }
 
   export const LoopInput = z.object({
@@ -315,6 +382,8 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+      const pendingTask = tasks[tasks.length - 1]
+      if (pendingTask?.type !== "compaction" && (await drainSteerQueue({ sessionID, user: lastUser }))) continue
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
@@ -708,7 +777,9 @@ export namespace SessionPrompt {
           model: lastUser.model,
           auto: true,
         })
+        continue
       }
+      if (await drainSteerQueue({ sessionID, user: lastUser })) continue
       continue
     }
     SessionCompaction.prune({ sessionID })
@@ -722,6 +793,45 @@ export namespace SessionPrompt {
     }
     throw new Error("Impossible")
   })
+
+  async function writeSteer(input: {
+    sessionID: string
+    queued: {
+      id: string
+      text: string
+      timestamp: number
+    }
+  }) {
+    const msgs = await MessageV2.filterCompacted(MessageV2.stream(input.sessionID))
+    const last = [...msgs].reverse().find((msg): msg is MessageV2.WithParts & { info: MessageV2.User } => msg.info.role === "user")
+    if (!last) throw new Error("No user message found to attach steer metadata")
+
+    const user = await Session.updateMessage({
+      id: Identifier.ascending("message"),
+      role: "user",
+      sessionID: input.sessionID,
+      time: {
+        created: input.queued.timestamp,
+      },
+      agent: last.info.agent,
+      model: last.info.model,
+      variant: last.info.variant,
+    })
+
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: user.id,
+      sessionID: input.sessionID,
+      type: "text",
+      text: input.queued.text,
+      synthetic: true,
+      metadata: {
+        steer: true,
+        steer_id: input.queued.id,
+        steer_timestamp: input.queued.timestamp,
+      },
+    } satisfies MessageV2.TextPart)
+  }
 
   async function lastModel(sessionID: string) {
     for await (const item of MessageV2.stream(sessionID)) {

--- a/packages/opencode/test/cli/tui/prompt-submit-routing.test.ts
+++ b/packages/opencode/test/cli/tui/prompt-submit-routing.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { isSteerKey, isSubmitRequestSuccess, routeSubmit } from "../../../src/cli/cmd/tui/component/prompt/submit-routing"
+
+describe("tui prompt submit routing", () => {
+  test("routes busy default submit to normal prompt", () => {
+    expect(
+      routeSubmit({
+        busy: true,
+        intent: "default",
+        hasNonText: true,
+      }),
+    ).toBe("prompt")
+  })
+
+  test("routes busy steer submit to steer when text only", () => {
+    expect(
+      routeSubmit({
+        busy: true,
+        intent: "steer",
+        hasNonText: false,
+      }),
+    ).toBe("steer")
+  })
+
+  test("rejects busy steer submit when non-text parts are present", () => {
+    expect(
+      routeSubmit({
+        busy: true,
+        intent: "steer",
+        hasNonText: true,
+      }),
+    ).toBe("reject-steer-nontext")
+  })
+
+  test("routes idle default submit to normal prompt", () => {
+    expect(
+      routeSubmit({
+        busy: false,
+        intent: "default",
+        hasNonText: false,
+      }),
+    ).toBe("prompt")
+  })
+})
+
+describe("tui prompt steer shortcut", () => {
+  test("uses configured steer shortcut only when busy and in normal mode", () => {
+    expect(
+      isSteerKey({
+        busy: true,
+        mode: "normal",
+        matched: true,
+      }),
+    ).toBe(true)
+  })
+
+  test("does not steer when shortcut did not match", () => {
+    expect(
+      isSteerKey({
+        busy: true,
+        mode: "normal",
+        matched: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("does not steer when idle", () => {
+    expect(
+      isSteerKey({
+        busy: false,
+        mode: "normal",
+        matched: true,
+      }),
+    ).toBe(false)
+  })
+
+  test("does not steer in shell mode", () => {
+    expect(
+      isSteerKey({
+        busy: true,
+        mode: "shell",
+        matched: true,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("tui prompt submit request success detection", () => {
+  test("accepts data-style empty object (204 promptAsync)", () => {
+    expect(isSubmitRequestSuccess({})).toBe(true)
+  })
+
+  test("accepts fields-style success result", () => {
+    expect(
+      isSubmitRequestSuccess({
+        data: {},
+        error: undefined,
+        response: { ok: true },
+      }),
+    ).toBe(true)
+  })
+
+  test("rejects undefined result", () => {
+    expect(isSubmitRequestSuccess(undefined)).toBe(false)
+  })
+
+  test("rejects null result", () => {
+    expect(isSubmitRequestSuccess(null)).toBe(false)
+  })
+
+  test("rejects fields-style error result", () => {
+    expect(
+      isSubmitRequestSuccess({
+        data: undefined,
+        error: { message: "oops" },
+        response: { ok: false },
+      }),
+    ).toBe(false)
+  })
+
+  test("rejects non-ok response without error", () => {
+    expect(
+      isSubmitRequestSuccess({
+        data: {},
+        error: undefined,
+        response: { ok: false },
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/cli/tui/tmux-harness.ts
+++ b/packages/opencode/test/cli/tui/tmux-harness.ts
@@ -1,0 +1,72 @@
+function text(buf: string | Uint8Array | undefined) {
+  if (!buf) return ""
+  if (typeof buf === "string") return buf
+  return Buffer.from(buf).toString("utf8")
+}
+
+function run(args: string[]) {
+  const out = Bun.spawnSync(["tmux", ...args])
+  if (out.exitCode === 0) {
+    return {
+      stdout: text(out.stdout),
+      stderr: text(out.stderr),
+    }
+  }
+  throw new Error(`tmux ${args.join(" ")} failed (${out.exitCode})\n${text(out.stderr) || text(out.stdout)}`)
+}
+
+export function capturePane(name: string) {
+  return run(["capture-pane", "-p", "-J", "-S", "-", "-t", name]).stdout
+}
+
+export function sendKeys(name: string, ...keys: string[]) {
+  if (!keys.length) return
+  run(["send-keys", "-t", name, ...keys])
+}
+
+export async function waitForText(
+  name: string,
+  match: string,
+  opts?: {
+    timeout?: number
+    interval?: number
+  },
+) {
+  const timeout = opts?.timeout ?? 10_000
+  const interval = opts?.interval ?? 100
+  const end = Date.now() + timeout
+  let last = ""
+  while (Date.now() < end) {
+    last = capturePane(name)
+    if (last.includes(match)) return last
+    await Bun.sleep(interval)
+  }
+  throw new Error(`timed out waiting for "${match}"\n${last.slice(-4000)}`)
+}
+
+export function startSession(input?: {
+  name?: string
+  cwd?: string
+  width?: number
+  height?: number
+  command?: string
+}) {
+  const name = input?.name ?? `opencode-tui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const width = input?.width ?? 220
+  const height = input?.height ?? 60
+  const args = ["new-session", "-d", "-s", name, "-x", String(width), "-y", String(height)]
+  if (input?.cwd) args.push("-c", input.cwd)
+  if (input?.command) args.push(input.command)
+  run(args)
+  return {
+    name,
+    sendKeys: (...keys: string[]) => sendKeys(name, ...keys),
+    capturePane: () => capturePane(name),
+    waitForText: (match: string, opts?: { timeout?: number; interval?: number }) => waitForText(name, match, opts),
+    cleanup: () => {
+      try {
+        run(["kill-session", "-t", name])
+      } catch {}
+    },
+  }
+}

--- a/packages/opencode/test/cli/tui/tmux.e2e.test.ts
+++ b/packages/opencode/test/cli/tui/tmux.e2e.test.ts
@@ -1,0 +1,108 @@
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../../src/project/instance"
+import { Session } from "../../../src/session"
+import { SessionPrompt } from "../../../src/session/prompt"
+import { tmpdir } from "../../fixture/fixture"
+import { startSession } from "./tmux-harness"
+
+const skip = !Bun.which("tmux") || process.env.OPENCODE_TUI_E2E !== "1"
+const pkg = path.resolve(import.meta.dir, "../../..")
+
+function quote(value: string) {
+  return `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+function command(input: {
+  project: string
+  route?: unknown
+}) {
+  const vars = [
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_STATE_HOME",
+    "OPENCODE_TEST_HOME",
+    "OPENCODE_TEST_MANAGED_CONFIG_DIR",
+    "OPENCODE_MODELS_PATH",
+  ]
+  const env = [
+    `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT=1`,
+    input.route ? `OPENCODE_ROUTE=${quote(JSON.stringify(input.route))}` : undefined,
+    ...vars.flatMap((key) => (process.env[key] ? [`${key}=${quote(process.env[key]!)}`] : [])),
+  ].filter((x) => x !== undefined)
+  return `${env.join(" ")} ${quote(process.execPath)} run dev -- ${quote(input.project)}`
+}
+
+describe("tui tmux e2e", () => {
+  test.skipIf(skip)("renders the home screen and opens the command palette", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const tmux = startSession({
+      cwd: pkg,
+    })
+
+    try {
+      tmux.sendKeys(
+        command({
+          project: tmp.path,
+        }),
+        "Enter",
+      )
+      await tmux.waitForText("commands", { timeout: 25_000 })
+      tmux.sendKeys("C-p")
+      const pane = await tmux.waitForText("tips", { timeout: 5_000 })
+      expect(pane.includes("Hide tips") || pane.includes("Show tips")).toBe(true)
+    } finally {
+      tmux.cleanup()
+    }
+  })
+
+  test.skipIf(skip)("renders a pre-seeded session route from OPENCODE_ROUTE", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    const text = "tmux seeded user message"
+    const sessionID = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text }],
+        })
+        return session.id
+      },
+    })
+
+    const tmux = startSession({
+      cwd: pkg,
+    })
+
+    try {
+      tmux.sendKeys(
+        command({
+          project: tmp.path,
+          route: {
+            type: "session",
+            sessionID,
+          },
+        }),
+        "Enter",
+      )
+      const pane = await tmux.waitForText(text, { timeout: 25_000 })
+      expect(pane).toContain(text)
+    } finally {
+      tmux.cleanup()
+    }
+  })
+})

--- a/packages/opencode/test/cli/tui/transcript.test.ts
+++ b/packages/opencode/test/cli/tui/transcript.test.ts
@@ -50,6 +50,22 @@ describe("transcript", () => {
   describe("formatPart", () => {
     const options = { thinking: true, toolDetails: true, assistantMetadata: true }
 
+    test("formats synthetic steer text parts with markdown characters", () => {
+      const part: Part = {
+        id: "part_1",
+        sessionID: "ses_123",
+        messageID: "msg_123",
+        type: "text",
+        text: "change `const x = 1` to `let x = 2` and **bold** this section",
+        synthetic: true,
+        metadata: {
+          steer: true,
+        },
+      }
+      const result = formatPart(part, options)
+      expect(result).toBe("**Steer:** change `const x = 1` to `let x = 2` and **bold** this section\n\n")
+    })
+
     test("formats text part", () => {
       const part: Part = {
         id: "part_1",
@@ -73,6 +89,22 @@ describe("transcript", () => {
       }
       const result = formatPart(part, options)
       expect(result).toBe("")
+    })
+
+    test("formats synthetic steer text parts", () => {
+      const part: Part = {
+        id: "part_1",
+        sessionID: "ses_123",
+        messageID: "msg_123",
+        type: "text",
+        text: "make it about cats instead",
+        synthetic: true,
+        metadata: {
+          steer: true,
+        },
+      }
+      const result = formatPart(part, options)
+      expect(result).toBe("**Steer:** make it about cats instead\n\n")
     })
 
     test("formats reasoning when thinking enabled", () => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -32,6 +32,7 @@ test("loads config with defaults when no files exist", async () => {
     fn: async () => {
       const config = await Config.get()
       expect(config.username).toBeDefined()
+      expect(config.keybinds?.input_steer_submit).toBe("alt+return,super+return,ctrl+return")
     },
   })
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -209,3 +209,202 @@ describe("session.prompt agent variant", () => {
     }
   })
 })
+
+
+describe("session.prompt steer", () => {
+  test("falls back to a no-reply user message when session is idle", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const result = await SessionPrompt.steer({
+          sessionID: session.id,
+          text: "please focus on tests next",
+        })
+
+        expect(result.accepted).toBe(false)
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        const user = msgs.find((msg) => msg.info.role === "user")
+        expect(user?.parts.some((part) => part.type === "text" && part.text === "please focus on tests next")).toBe(true)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("drains queued steer messages in timestamp order when session is busy", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const seed = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [{ type: "text", text: "seed" }],
+        })
+        if (seed.info.role !== "user") throw new Error("expected user message")
+
+        SessionPrompt.testing.startBusy(session.id)
+
+        const now = Date.now
+        let idx = 0
+        const times = [2001, 1001, 2002, 1003, 2003, 1002]
+        Date.now = () => {
+          const next = times[idx]
+          idx += 1
+          return next ?? times[times.length - 1]
+        }
+
+        try {
+          await SessionPrompt.steer({
+            sessionID: session.id,
+            text: "first",
+          })
+          await SessionPrompt.steer({
+            sessionID: session.id,
+            text: "third",
+          })
+          await SessionPrompt.steer({
+            sessionID: session.id,
+            text: "second",
+          })
+        } finally {
+          Date.now = now
+        }
+
+        const drained = await SessionPrompt.testing.drainSteer({
+          sessionID: session.id,
+          user: seed.info,
+        })
+        expect(drained).toBe(true)
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        const parts = msgs
+          .filter((msg) => msg.info.role === "user")
+          .map((msg) =>
+            msg.parts.find(
+              (part): part is MessageV2.TextPart =>
+                part.type === "text" && part.synthetic === true && part.metadata?.steer === true,
+            ),
+          )
+          .filter((part): part is MessageV2.TextPart => !!part)
+
+        expect(parts.length).toBe(3)
+        const timestamps = parts.map((part) => part.metadata?.steer_timestamp)
+        expect(timestamps.every((x) => typeof x === "number")).toBe(true)
+        expect(parts.map((part) => part.text).toSorted()).toEqual(["first", "second", "third"])
+
+        for (const part of parts) {
+          expect(part.synthetic).toBe(true)
+          expect(part.metadata).toMatchObject({
+            steer: true,
+          })
+          const data = part.metadata
+          expect(typeof data?.steer_id).toBe("string")
+          expect(typeof data?.steer_timestamp).toBe("number")
+        }
+
+        const empty = await SessionPrompt.testing.drainSteer({
+          sessionID: session.id,
+          user: seed.info,
+        })
+        expect(empty).toBe(false)
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("persists busy steer immediately and does not duplicate on drain", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const seed = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [{ type: "text", text: "seed" }],
+        })
+        if (seed.info.role !== "user") throw new Error("expected user message")
+
+        SessionPrompt.testing.startBusy(session.id)
+
+        const first = await SessionPrompt.steer({
+          sessionID: session.id,
+          text: "focus on tests",
+        })
+        const second = await SessionPrompt.steer({
+          sessionID: session.id,
+          text: "only touch prompt code",
+        })
+
+        expect(first.accepted).toBe(true)
+        expect(second.accepted).toBe(true)
+
+        const steerParts = async () =>
+          (await Session.messages({ sessionID: session.id }))
+            .flatMap((msg) => msg.parts)
+            .filter(
+              (part): part is MessageV2.TextPart =>
+                part.type === "text" && part.synthetic === true && part.metadata?.steer === true,
+            )
+
+        const beforeDrain = await steerParts()
+        expect(beforeDrain.map((part) => part.text).toSorted()).toEqual(["focus on tests", "only touch prompt code"])
+
+        const drained = await SessionPrompt.testing.drainSteer({
+          sessionID: session.id,
+          user: seed.info,
+        })
+        expect(drained).toBe(true)
+
+        const afterDrain = await steerParts()
+        expect(afterDrain.length).toBe(beforeDrain.length)
+        expect(afterDrain.map((part) => part.text).toSorted()).toEqual(["focus on tests", "only touch prompt code"])
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("draining steer queue is a no-op when no steer is queued", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const seed = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [{ type: "text", text: "seed" }],
+        })
+        if (seed.info.role !== "user") throw new Error("expected user message")
+
+        SessionPrompt.testing.startBusy(session.id)
+        const before = (await Session.messages({ sessionID: session.id })).length
+
+        const drained = await SessionPrompt.testing.drainSteer({
+          sessionID: session.id,
+          user: seed.info,
+        })
+        expect(drained).toBe(false)
+
+        const after = (await Session.messages({ sessionID: session.id })).length
+        expect(after).toBe(before)
+
+        SessionPrompt.cancel(session.id)
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -131,6 +131,8 @@ import type {
   SessionShellResponses,
   SessionStatusErrors,
   SessionStatusResponses,
+  SessionSteerErrors,
+  SessionSteerResponses,
   SessionSummarizeErrors,
   SessionSummarizeResponses,
   SessionTodoErrors,
@@ -1335,6 +1337,43 @@ export class Session2 extends HeyApiClient {
       url: "/session/{sessionID}/abort",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Steer session
+   *
+   * Queue user guidance for the current active turn without aborting in-flight execution.
+   */
+  public steer<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      text?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "body", key: "text" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionSteerResponses, SessionSteerErrors, ThrowOnError>({
+      url: "/session/{sessionID}/steer",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1200,6 +1200,10 @@ export type KeybindsConfig = {
    */
   input_submit?: string
   /**
+   * Submit steer guidance while session is busy
+   */
+  input_steer_submit?: string
+  /**
    * Insert newline in input
    */
   input_newline?: string
@@ -3339,6 +3343,48 @@ export type SessionAbortResponses = {
 }
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
+
+export type SessionSteerData = {
+  body?: {
+    text: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/steer"
+}
+
+export type SessionSteerErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionSteerError = SessionSteerErrors[keyof SessionSteerErrors]
+
+export type SessionSteerResponses = {
+  /**
+   * Steer message queued
+   */
+  202: {
+    accepted: boolean
+    queued: {
+      id: string
+      text: string
+      timestamp: number
+    }
+  }
+}
+
+export type SessionSteerResponse = SessionSteerResponses[keyof SessionSteerResponses]
 
 export type SessionUnshareData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #9454

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds STEER support for busy sessions in `opencode` (TUI + API path).

Included in this PR:
- `session.steer` server route / SDK generation support used by the TUI
- busy-session steer submission in the TUI with a configurable shortcut (`input_steer_submit`)
- immediate steer message visibility in the transcript while the agent is still running
- transcript export support for steer messages
- prompt-dispatch fixes touched during STEER integration (Home->session transition timing and queued prompt input clearing)
- opt-in local `tmux` TUI E2E harness + basic coverage

### How did you verify your code works?

- manual TUI verification of the busy-session STEER flow and related prompt-dispatch behavior touched by this change
- `cd packages/opencode && ~/.bun/bin/bun test --timeout 120000 test/cli/tui/prompt-submit-routing.test.ts test/cli/tui/transcript.test.ts test/session/prompt.test.ts test/config/config.test.ts test/cli/tui/tmux.e2e.test.ts`
- `cd packages/opencode && OPENCODE_TUI_E2E=1 ~/.bun/bin/bun test --timeout 60000 test/cli/tui/tmux.e2e.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun turbo typecheck`

### Screenshots / recordings

Not included (TUI keyboard/timing behavior change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
