### PR TITLE
fix(app): prevent streaming content duplication during event coalescing

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -49,6 +49,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     let queue: Queued[] = []
     let buffer: Queued[] = []
     const coalesced = new Map<string, number>()
+    const voided = new Set<number>()
     let timer: ReturnType<typeof setTimeout> | undefined
     let last = 0
 
@@ -58,6 +59,19 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       if (payload.type === "message.part.updated") {
         const part = payload.properties.part
         return `message.part.updated:${directory}:${part.messageID}:${part.id}`
+      }
+    }
+
+    const voidStaleDeltasForPart = (messageID: string, partID: string) => {
+      for (let i = 0; i < queue.length; i++) {
+        const entry = queue[i]
+        if (
+          entry.payload.type === "message.part.delta" &&
+          (entry.payload.properties as { messageID: string; partID: string }).messageID === messageID &&
+          (entry.payload.properties as { messageID: string; partID: string }).partID === partID
+        ) {
+          voided.add(i)
+        }
       }
     }
 
@@ -75,11 +89,13 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
 
       last = Date.now()
       batch(() => {
-        for (const event of events) {
-          emitter.emit(event.directory, event.payload)
+        for (let i = 0; i < events.length; i++) {
+          if (voided.has(i)) continue
+          emitter.emit(events[i].directory, events[i].payload)
         }
       })
 
+      voided.clear()
       buffer.length = 0
     }
 
@@ -144,6 +160,10 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
               const i = coalesced.get(k)
               if (i !== undefined) {
                 queue[i] = { directory, payload }
+                if (payload.type === "message.part.updated") {
+                  const part = (payload.properties as { part: { messageID: string; id: string } }).part
+                  voidStaleDeltasForPart(part.messageID, part.id)
+                }
                 continue
               }
               coalesced.set(k, queue.length)


### PR DESCRIPTION
### Issue for this PR

Closes #14822

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

During streaming, SSE events are batched in 16ms windows. `message.part.updated` events coalesce (text-end replaces text-start at same queue index), but `message.part.delta` events never coalesce. When both land in the same batch, the full text gets applied via reconcile, then stale deltas append on top — doubling the content.

The fix adds a `voided` Set in global-sdk.tsx. When a `message.part.updated` coalesces, all stale `message.part.delta` events for that messageID+partID are voided. Voided indices are skipped during flush. Zero overhead when no coalescing occurs (the common case).

### How did you verify your code works?

- All 12 typecheck tasks pass
- Tested locally with `bun run --cwd packages/desktop tauri dev`
- Sent messages during streaming, confirmed no duplication
- Quit and reopened app, confirmed content still correct
- Linux E2E tests pass (2 failing checks are pre-existing: Windows @mention flaky test + Linux test infra issue)

### Screenshots / recordings

_Text-only change in event batching layer, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR