### PR TITLE
fix(app): connect font size setting to CSS variables and terminal

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -267,6 +267,36 @@ export const SettingsGeneral: Component = () => {
             )}
           </Select>
         </SettingsRow>
+
+        <SettingsRow
+          title="Font Size"
+          description="Adjust the editor and terminal font size"
+        >
+          <div class="flex items-center gap-2">
+            <Button
+              size="small"
+              variant="secondary"
+              disabled={settings.appearance.fontSize() <= 10}
+              onClick={() => settings.appearance.setFontSize(Math.max(10, settings.appearance.fontSize() - 1))}
+            >
+              −
+            </Button>
+            <span
+              class="text-14-medium text-text-strong tabular-nums"
+              style={{ "min-width": "32px", "text-align": "center" }}
+            >
+              {settings.appearance.fontSize()}
+            </span>
+            <Button
+              size="small"
+              variant="secondary"
+              disabled={settings.appearance.fontSize() >= 24}
+              onClick={() => settings.appearance.setFontSize(Math.min(24, settings.appearance.fontSize() + 1))}
+            >
+              +
+            </Button>
+          </div>
+        </SettingsRow>
       </div>
     </div>
   )

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -337,7 +337,7 @@ export const Terminal = (props: TerminalProps) => {
         cursorStyle: "bar",
         cols: restoreSize?.cols,
         rows: restoreSize?.rows,
-        fontSize: 14,
+        fontSize: settings.appearance.fontSize(),
         fontFamily: monoFontFamily(settings.appearance.font()),
         allowTransparency: false,
         convertEol: false,

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -112,6 +112,14 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
       document.documentElement.style.setProperty("--font-family-mono", monoFontFamily(store.appearance?.font))
     })
 
+    createEffect(() => {
+      if (typeof document === "undefined") return
+      const size = store.appearance?.fontSize ?? defaultSettings.appearance.fontSize
+      document.documentElement.style.setProperty("--font-size-base", `${size}px`)
+      document.documentElement.style.setProperty("--font-size-small", `${size - 1}px`)
+      document.documentElement.style.setProperty("--font-size-large", `${size + 2}px`)
+    })
+
     return {
       ready,
       get current() {


### PR DESCRIPTION
### Issue for this PR

Closes #14823

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `appearance.fontSize` setting existed in the data model (default: 14) but was disconnected — never applied to the DOM, terminal hardcoded 14, and no UI control existed.

Three fixes:
1. **settings.tsx** — Added `createEffect` that applies fontSize to CSS custom properties (`--font-size-base`, `--font-size-small`, `--font-size-large`)
2. **terminal.tsx** — Replaced hardcoded `fontSize: 14` with `settings.appearance.fontSize()`
3. **settings-general.tsx** — Added font size stepper (−/+ buttons, 10-24px range) under Appearance section

### How did you verify your code works?

- All 12 typecheck tasks pass
- Tested locally with `bun run --cwd packages/desktop tauri dev`
- Changed font size via Settings > Appearance, confirmed chat text and terminal update live
- Confirmed setting persists after app reload

### Screenshots / recordings

_Font size stepper appears in Settings > General > Appearance, below the font family picker._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR