### PR TITLE
feat(opencode): prune old tool outputs before compaction

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -538,12 +538,13 @@ export namespace SessionPrompt {
         continue
       }
 
-      // context overflow, needs compaction
+      // proactive context management: prune + compact before overflow
       if (
         lastFinished &&
         lastFinished.summary !== true &&
         (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
       ) {
+        await SessionCompaction.prune({ sessionID })
         await SessionCompaction.create({
           sessionID,
           agent: lastUser.agent,
@@ -702,6 +703,7 @@ export namespace SessionPrompt {
 
       if (result === "stop") break
       if (result === "compact") {
+        await SessionCompaction.prune({ sessionID })
         await SessionCompaction.create({
           sessionID,
           agent: lastUser.agent,


### PR DESCRIPTION
### Issue for this PR

Closes #14825

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `SessionCompaction.prune()` before both compaction triggers in prompt.ts:
1. Proactive overflow check (before calling LLM)
2. Reactive compact result (after processor returns "compact")

Pruning strips old tool outputs (read/grep/list results) first, maximizing context reduction before the compaction summary LLM call. This prevents the summarization itself from hitting context limits.

### How did you verify your code works?

- Typecheck passes
- Code trace verified: prune runs before SessionCompaction.create in both paths
- Prune system already battle-tested (called at end of prompt loop)

### Screenshots / recordings

_Backend-only change, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR