### PR TITLE
fix(win32): scripts/turbo commands would not run

### DIFF
--- a/packages/plugin/script/publish.ts
+++ b/packages/plugin/script/publish.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env bun
 import { Script } from "@opencode-ai/script"
 import { $ } from "bun"
+import { fileURLToPath } from "url"
 
-const dir = new URL("..", import.meta.url).pathname
+const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
 
 await $`bun tsc`

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit",
-    "build": "./script/build.ts"
+    "build": "bun ./script/build.ts"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
+import { fileURLToPath } from "url"
 
-const dir = new URL("..", import.meta.url).pathname
+const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
 
 import { $ } from "bun"

--- a/packages/sdk/js/script/publish.ts
+++ b/packages/sdk/js/script/publish.ts
@@ -2,8 +2,9 @@
 
 import { Script } from "@opencode-ai/script"
 import { $ } from "bun"
+import { fileURLToPath } from "url"
 
-const dir = new URL("..", import.meta.url).pathname
+const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)
 
 const pkg = (await import("../package.json").then((m) => m.default)) as {

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -2,6 +2,7 @@
 
 import { $ } from "bun"
 import { Script } from "@opencode-ai/script"
+import { fileURLToPath } from "url"
 
 const highlightsTemplate = `
 <!--
@@ -46,7 +47,7 @@ for (const file of pkgjsons) {
   await Bun.file(file).write(pkg)
 }
 
-const extensionToml = new URL("../packages/extensions/zed/extension.toml", import.meta.url).pathname
+const extensionToml = fileURLToPath(new URL("../packages/extensions/zed/extension.toml", import.meta.url))
 let toml = await Bun.file(extensionToml).text()
 toml = toml.replace(/^version = "[^"]+"/m, `version = "${Script.version}"`)
 toml = toml.replaceAll(/releases\/download\/v[^/]+\//g, `releases/download/v${Script.version}/`)
@@ -78,5 +79,5 @@ await import(`../packages/sdk/js/script/publish.ts`)
 console.log("\n=== plugin ===\n")
 await import(`../packages/plugin/script/publish.ts`)
 
-const dir = new URL("..", import.meta.url).pathname
+const dir = fileURLToPath(new URL("..", import.meta.url))
 process.chdir(dir)


### PR DESCRIPTION
## Summary
- Replace `new URL(...).pathname` with `fileURLToPath(new URL(...))` across all build/publish scripts — `.pathname` produces `/C:/...` on Windows which breaks path resolution entirely
- Add explicit `bun` prefix to SDK build script in `package.json` so turbo can invoke it on Windows (bare `./script/build.ts` isn't executable there)

**Files changed:**
- `packages/plugin/script/publish.ts`
- `packages/sdk/js/script/build.ts`
- `packages/sdk/js/script/publish.ts`
- `packages/sdk/js/package.json`
- `script/publish.ts`

Split out from #14742.