### PR TITLE
ci: use bun baseline build to avoid segfaults

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -11,10 +11,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
+    - name: Get baseline download URL
+      id: bun-url
+      shell: bash
+      run: |
+        V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        OS=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+        echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version-file: package.json
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
 
     - name: Install dependencies
       run: bun install

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -15,17 +15,20 @@ runs:
       id: bun-url
       shell: bash
       run: |
-        V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-        case "$RUNNER_OS" in
-          macOS)   OS=darwin ;;
-          Linux)   OS=linux ;;
-          Windows) OS=windows ;;
-        esac
-        echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+        if [ "$RUNNER_ARCH" = "X64" ]; then
+          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          case "$RUNNER_OS" in
+            macOS)   OS=darwin ;;
+            Linux)   OS=linux ;;
+            Windows) OS=windows ;;
+          esac
+          echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
 
     - name: Install dependencies

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -16,7 +16,11 @@ runs:
       shell: bash
       run: |
         V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-        OS=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+        case "$RUNNER_OS" in
+          macOS)   OS=darwin ;;
+          Linux)   OS=linux ;;
+          Windows) OS=windows ;;
+        esac
         echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
 
     - name: Setup Bun


### PR DESCRIPTION
## Summary
- Use the bun baseline build (no AVX2) in CI to fix segfaults on GitHub Actions runners
- Constructs the download URL via `bun.sh/download` with `avx2=false` using the version from `package.json`
- Passes it to `oven-sh/setup-bun` via `bun-download-url`, bypassing AVX2 detection
- Only applies to x64 runners; ARM64 runners (e.g. `macos-latest`) fall back to default `bun-version-file` since baseline builds don't exist for aarch64