### PR TITLE
upgrade to bun 1.3.10 canary and force baseline builds always

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,5 +1,10 @@
 name: "Setup Bun"
 description: "Setup Bun with caching and install dependencies"
+inputs:
+  cross-compile:
+    description: "Pre-cache canary cross-compile binaries for all targets"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -29,6 +34,34 @@ runs:
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Pre-cache canary cross-compile binaries
+      if: inputs.cross-compile == 'true'
+      shell: bash
+      run: |
+        BUN_VERSION=$(bun --version)
+        if echo "$BUN_VERSION" | grep -q "canary"; then
+          SEMVER=$(echo "$BUN_VERSION" | grep -oP '^\d+\.\d+\.\d+')
+          CANARY_NPM=$(curl -sf https://registry.npmjs.org/@oven/bun-linux-x64 | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))['dist-tags'].canary")
+          CACHE_DIR="$HOME/.bun/install/cache"
+          mkdir -p "$CACHE_DIR"
+          for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 darwin-x64-baseline windows-x64 windows-x64-baseline; do
+            DEST="$CACHE_DIR/bun-${TARGET}-v${SEMVER}"
+            if [ -f "$DEST" ]; then
+              echo "Already cached: $DEST"
+              continue
+            fi
+            URL="https://registry.npmjs.org/@oven/bun-${TARGET}/-/bun-${TARGET}-${CANARY_NPM}.tgz"
+            echo "Downloading $TARGET..."
+            if curl -sfL "$URL" | tar xz --strip-components=2 -C "$CACHE_DIR" "package/bin/bun"; then
+              mv "$CACHE_DIR/bun" "$DEST"
+              chmod +x "$DEST"
+              echo "Cached: $DEST"
+            else
+              echo "Skipped: $TARGET (not available)"
+            fi
+          done
+        fi
 
     - name: Install dependencies
       run: bun install

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -55,8 +55,13 @@ runs:
             fi
             URL="https://registry.npmjs.org/@oven/bun-${TARGET}/-/bun-${TARGET}-${CANARY_NPM}.tgz"
             echo "Downloading $TARGET from $URL"
-            if curl -sfL "$URL" | tar xz --strip-components=2 -C "$CACHE_DIR" "package/bin/bun"; then
-              mv "$CACHE_DIR/bun" "$DEST"
+            if echo "$TARGET" | grep -q "windows"; then
+              BIN_NAME="bun.exe"
+            else
+              BIN_NAME="bun"
+            fi
+            if curl -sfL "$URL" | tar xz --strip-components=2 -C "$CACHE_DIR" "package/bin/$BIN_NAME"; then
+              mv "$CACHE_DIR/$BIN_NAME" "$DEST"
               chmod +x "$DEST"
               echo "Cached: $DEST"
             else

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         BUN_VERSION=$(bun --version)
         if echo "$BUN_VERSION" | grep -q "canary"; then
-          SEMVER=$(echo "$BUN_VERSION" | grep -oP '^\d+\.\d+\.\d+')
+          SEMVER=$(echo "$BUN_VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
           CANARY_NPM=$(curl -sf https://registry.npmjs.org/@oven/bun-linux-x64 | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))['dist-tags'].canary")
           CACHE_DIR="$HOME/.bun/install/cache"
           mkdir -p "$CACHE_DIR"

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -46,7 +46,7 @@ runs:
           CACHE_DIR="$HOME/.bun/install/cache"
           mkdir -p "$CACHE_DIR"
           TMP_DIR=$(mktemp -d)
-          for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 darwin-x64-baseline windows-x64 windows-x64-baseline; do
+          for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 windows-x64 windows-x64-baseline; do
             DEST="$CACHE_DIR/bun-${TARGET}-v${SEMVER}"
             if [ -f "$DEST" ]; then
               echo "Already cached: $DEST"
@@ -65,6 +65,15 @@ runs:
               chmod +x "$DEST"
               rm -rf "$TMP_DIR/bun-${TARGET}" "$TMP_DIR/bun.zip"
               echo "Cached: $DEST"
+              # baseline bun resolves "bun-darwin-x64" to the baseline cache key
+              # so copy the modern binary there too
+              if [ "$TARGET" = "darwin-x64" ]; then
+                BASELINE_DEST="$CACHE_DIR/bun-darwin-x64-baseline-v${SEMVER}"
+                if [ ! -f "$BASELINE_DEST" ]; then
+                  cp "$DEST" "$BASELINE_DEST"
+                  echo "Cached (baseline alias): $BASELINE_DEST"
+                fi
+              fi
             else
               echo "Skipped: $TARGET (not available)"
             fi

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -22,7 +22,7 @@ runs:
             Linux)   OS=linux ;;
             Windows) OS=windows ;;
           esac
-          echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Bun

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -11,10 +11,18 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
+    - name: Get baseline download URL
+      id: bun-url
+      shell: bash
+      run: |
+        V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+        OS=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+        echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version-file: package.json
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
 
     - name: Install dependencies
       run: bun install

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -39,7 +39,7 @@ runs:
       if: inputs.cross-compile == 'true'
       shell: bash
       run: |
-        BUN_VERSION=$(bun --version)
+        BUN_VERSION=$(bun --revision)
         if echo "$BUN_VERSION" | grep -q "canary"; then
           SEMVER=$(echo "$BUN_VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
           echo "Bun version: $BUN_VERSION (semver: $SEMVER)"

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -15,17 +15,20 @@ runs:
       id: bun-url
       shell: bash
       run: |
-        V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-        case "$RUNNER_OS" in
-          macOS)   OS=darwin ;;
-          Linux)   OS=linux ;;
-          Windows) OS=windows ;;
-        esac
-        echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+        if [ "$RUNNER_ARCH" = "X64" ]; then
+          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          case "$RUNNER_OS" in
+            macOS)   OS=darwin ;;
+            Linux)   OS=linux ;;
+            Windows) OS=windows ;;
+          esac
+          echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
 
     - name: Install dependencies

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -22,7 +22,12 @@ runs:
             Linux)   OS=linux ;;
             Windows) OS=windows ;;
           esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+          if [ "$V" = "canary" ]; then
+            TAG=canary
+          else
+            TAG="bun-v${V}"
+          fi
+          echo "url=https://github.com/oven-sh/bun/releases/download/${TAG}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Bun

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -43,31 +43,33 @@ runs:
         if echo "$BUN_VERSION" | grep -q "canary"; then
           SEMVER=$(echo "$BUN_VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
           echo "Bun version: $BUN_VERSION (semver: $SEMVER)"
-          CANARY_NPM=$(curl -sf https://registry.npmjs.org/@oven/bun-linux-x64 | bun -e "process.stdout.write(JSON.parse(await Bun.stdin.text())['dist-tags'].canary)")
-          echo "Canary npm version: $CANARY_NPM"
           CACHE_DIR="$HOME/.bun/install/cache"
           mkdir -p "$CACHE_DIR"
+          TMP_DIR=$(mktemp -d)
           for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 darwin-x64-baseline windows-x64 windows-x64-baseline; do
             DEST="$CACHE_DIR/bun-${TARGET}-v${SEMVER}"
             if [ -f "$DEST" ]; then
               echo "Already cached: $DEST"
               continue
             fi
-            URL="https://registry.npmjs.org/@oven/bun-${TARGET}/-/bun-${TARGET}-${CANARY_NPM}.tgz"
+            URL="https://github.com/oven-sh/bun/releases/download/canary/bun-${TARGET}.zip"
             echo "Downloading $TARGET from $URL"
-            if echo "$TARGET" | grep -q "windows"; then
-              BIN_NAME="bun.exe"
-            else
-              BIN_NAME="bun"
-            fi
-            if curl -sfL "$URL" | tar xz --strip-components=2 -C "$CACHE_DIR" "package/bin/$BIN_NAME"; then
-              mv "$CACHE_DIR/$BIN_NAME" "$DEST"
+            if curl -sfL -o "$TMP_DIR/bun.zip" "$URL"; then
+              unzip -qo "$TMP_DIR/bun.zip" -d "$TMP_DIR"
+              if echo "$TARGET" | grep -q "windows"; then
+                BIN_NAME="bun.exe"
+              else
+                BIN_NAME="bun"
+              fi
+              mv "$TMP_DIR/bun-${TARGET}/$BIN_NAME" "$DEST"
               chmod +x "$DEST"
+              rm -rf "$TMP_DIR/bun-${TARGET}" "$TMP_DIR/bun.zip"
               echo "Cached: $DEST"
             else
               echo "Skipped: $TARGET (not available)"
             fi
           done
+          rm -rf "$TMP_DIR"
         else
           echo "Not a canary build ($BUN_VERSION), skipping pre-cache"
         fi

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -42,7 +42,9 @@ runs:
         BUN_VERSION=$(bun --version)
         if echo "$BUN_VERSION" | grep -q "canary"; then
           SEMVER=$(echo "$BUN_VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
-          CANARY_NPM=$(curl -sf https://registry.npmjs.org/@oven/bun-linux-x64 | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))['dist-tags'].canary")
+          echo "Bun version: $BUN_VERSION (semver: $SEMVER)"
+          CANARY_NPM=$(curl -sf https://registry.npmjs.org/@oven/bun-linux-x64 | bun -e "process.stdout.write(JSON.parse(await Bun.stdin.text())['dist-tags'].canary)")
+          echo "Canary npm version: $CANARY_NPM"
           CACHE_DIR="$HOME/.bun/install/cache"
           mkdir -p "$CACHE_DIR"
           for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 darwin-x64-baseline windows-x64 windows-x64-baseline; do
@@ -52,7 +54,7 @@ runs:
               continue
             fi
             URL="https://registry.npmjs.org/@oven/bun-${TARGET}/-/bun-${TARGET}-${CANARY_NPM}.tgz"
-            echo "Downloading $TARGET..."
+            echo "Downloading $TARGET from $URL"
             if curl -sfL "$URL" | tar xz --strip-components=2 -C "$CACHE_DIR" "package/bin/bun"; then
               mv "$CACHE_DIR/bun" "$DEST"
               chmod +x "$DEST"
@@ -61,6 +63,8 @@ runs:
               echo "Skipped: $TARGET (not available)"
             fi
           done
+        else
+          echo "Not a canary build ($BUN_VERSION), skipping pre-cache"
         fi
 
     - name: Install dependencies

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -16,18 +16,12 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
           case "$RUNNER_OS" in
             macOS)   OS=darwin ;;
             Linux)   OS=linux ;;
             Windows) OS=windows ;;
           esac
-          if [ "$V" = "canary" ]; then
-            TAG=canary
-          else
-            TAG="bun-v${V}"
-          fi
-          echo "url=https://github.com/oven-sh/bun/releases/download/${TAG}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/oven-sh/bun/releases/download/canary/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Bun

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -16,7 +16,11 @@ runs:
       shell: bash
       run: |
         V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-        OS=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+        case "$RUNNER_OS" in
+          macOS)   OS=darwin ;;
+          Linux)   OS=linux ;;
+          Windows) OS=windows ;;
+        esac
         echo "url=https://bun.sh/download/${V}/${OS}/x64?avx2=false&profile=false" >> "$GITHUB_OUTPUT"
 
     - name: Setup Bun

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          ./packages/opencode/script/build.ts
+          ./packages/opencode/script/build.ts --all
         env:
           OPENCODE_VERSION: ${{ needs.version.outputs.version }}
           OPENCODE_RELEASE: ${{ needs.version.outputs.release }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,8 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/setup-bun
+        with:
+          cross-compile: "true"
 
       - name: Setup git committer
         id: committer

--- a/.github/workflows/sign-cli.yml
+++ b/.github/workflows/sign-cli.yml
@@ -20,10 +20,12 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/setup-bun
+        with:
+          cross-compile: "true"
 
       - name: Build
         run: |
-          ./packages/opencode/script/build.ts
+          ./packages/opencode/script/build.ts --all
 
       - name: Upload unsigned Windows CLI
         id: upload_unsigned_windows_cli

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.9",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.8",
+      "@types/bun": "1.3.9",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.8",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.9",
+      "@types/bun": "1.3.8",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.5",
+      "@types/bun": "1.3.9",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@canary",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@canary",
+  "packageManager": "bun@1.3.9",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.5",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.8",
+      "@types/bun": "1.3.5",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -8,7 +8,7 @@ export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; ass
   },
   {
     rustTarget: "x86_64-apple-darwin",
-    ocBinary: "opencode-darwin-x64-baseline",
+    ocBinary: "opencode-darwin-x64",
     assetExt: "zip",
   },
   {

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -56,7 +56,7 @@ const migrations = await Promise.all(
 )
 console.log(`Loaded ${migrations.length} migrations`)
 
-const singleFlag = process.argv.includes("--single") || (!!process.env.CI && !process.argv.includes("--all"))
+const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -56,7 +56,7 @@ const migrations = await Promise.all(
 )
 console.log(`Loaded ${migrations.length} migrations`)
 
-const singleFlag = process.argv.includes("--single")
+const singleFlag = process.argv.includes("--single") || (!!process.env.CI && !process.argv.includes("--all"))
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -60,13 +60,6 @@ const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 
-// Resolve canary npm version for cross-compilation tarball override
-const canary = Bun.version.includes("canary")
-  ? await fetch("https://registry.npmjs.org/@oven/bun-linux-x64")
-      .then((r) => r.json())
-      .then((d) => d["dist-tags"].canary as string)
-  : undefined
-
 const allTargets: {
   os: string
   arch: "arm64" | "x64"
@@ -167,14 +160,6 @@ for (const item of targets) {
     .join("-")
   console.log(`building ${name}`)
   await $`mkdir -p dist/${name}/bin`
-
-  if (canary) {
-    const os = item.os === "win32" ? "windows" : item.os
-    const arch = item.arch === "arm64" ? "aarch64" : item.arch
-    const suffix = (item.abi ? `-${item.abi}` : "") + (item.avx2 === false ? "-baseline" : "")
-    const npmPkg = `bun-${os}-${arch}${suffix}`
-    process.env.BUN_COMPILE_TARGET_TARBALL_URL = `https://registry.npmjs.org/@oven/${npmPkg}/-/${npmPkg}-${canary}.tgz`
-  }
 
   const parserWorker = fs.realpathSync(path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"))
   const workerPath = "./src/cli/cmd/tui/worker.ts"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -60,6 +60,13 @@ const singleFlag = process.argv.includes("--single") || (!!process.env.CI && !pr
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 
+// Resolve canary npm version for cross-compilation tarball override
+const canary = Bun.version.includes("canary")
+  ? await fetch("https://registry.npmjs.org/@oven/bun-linux-x64")
+      .then((r) => r.json())
+      .then((d) => d["dist-tags"].canary as string)
+  : undefined
+
 const allTargets: {
   os: string
   arch: "arm64" | "x64"
@@ -160,6 +167,14 @@ for (const item of targets) {
     .join("-")
   console.log(`building ${name}`)
   await $`mkdir -p dist/${name}/bin`
+
+  if (canary) {
+    const os = item.os === "win32" ? "windows" : item.os
+    const arch = item.arch === "arm64" ? "aarch64" : item.arch
+    const suffix = (item.abi ? `-${item.abi}` : "") + (item.avx2 === false ? "-baseline" : "")
+    const npmPkg = `bun-${os}-${arch}${suffix}`
+    process.env.BUN_COMPILE_TARGET_TARBALL_URL = `https://registry.npmjs.org/@oven/${npmPkg}/-/${npmPkg}-${canary}.tgz`
+  }
 
   const parserWorker = fs.realpathSync(path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"))
   const workerPath = "./src/cli/cmd/tui/worker.ts"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -104,11 +104,6 @@ const allTargets: {
     arch: "x64",
   },
   {
-    os: "darwin",
-    arch: "x64",
-    avx2: false,
-  },
-  {
     os: "win32",
     arch: "x64",
   },


### PR DESCRIPTION
requesting baseline builds for bun on 1.3.9 doesnt work and gives you modern builds


1.3.5, 1.3.8, 1.3.9 modern + baseline builds all segfault.

trying canary now..?