### PR TITLE
feat(lsp): enable ty and add ruff lsp support for python

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -70,9 +70,7 @@ export namespace LSP {
       }
     } else {
       // If experimental flag is disabled, disable ty
-      if (servers["ty"]) {
-        delete servers["ty"]
-      }
+      if (servers["ty"]) delete servers["ty"]
     }
   }
 

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -451,10 +451,6 @@ export namespace LSPServer {
       "pyrightconfig.json",
     ]),
     async spawn(root) {
-      if (!Flag.OPENCODE_EXPERIMENTAL_LSP_TY) {
-        return undefined
-      }
-
       let binary = Bun.which("ty")
 
       const initialization: Record<string, string> = {}
@@ -498,6 +494,36 @@ export namespace LSPServer {
       return {
         process: proc,
         initialization,
+      }
+    },
+  }
+
+  export const Ruff: Info = {
+    id: "ruff",
+    extensions: [".py", ".pyi"],
+    root: NearestRoot([
+      "pyproject.toml",
+      "ruff.toml",
+      ".ruff.toml",
+      "setup.py",
+      "setup.cfg",
+      "requirements.txt",
+      "Pipfile",
+    ]),
+    async spawn(root) {
+      let binary = Bun.which("ruff")
+
+      if (!binary) {
+        log.error("ruff not found, please install ruff first")
+        return
+      }
+
+      const proc = spawn(binary, ["server"], {
+        cwd: root,
+      })
+
+      return {
+        process: proc,
       }
     },
   }


### PR DESCRIPTION
### Issue for this PR
Closes #5345

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Enables the experimental `ty` LSP (by removing the strict experimental flag constraint) and introduces `ruff` as a fully supported LSP server for Python. This significantly improves Python linting and formatting speeds in large codebases.

### How did you verify your code works?

Verified locally with a mock python project and `dev.log` confirmed that `ruff` starts properly.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR