### PR TITLE
fix(acp): omit sessionId from loadSession response

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -640,7 +640,12 @@ export namespace ACP {
 
         await sendUsageUpdate(this.connection, this.sdk, sessionId, directory)
 
-        return result
+        // Return only fields defined by the ACP spec LoadSessionResponse (no sessionId)
+        return {
+          models: result.models,
+          modes: result.modes,
+          _meta: result._meta,
+        }
       } catch (e) {
         const error = MessageV2.fromError(e, {
           providerID: this.config.defaultModel?.providerID ?? "unknown",


### PR DESCRIPTION
### Issue for this PR

Closes #14746

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The ACP spec's `LoadSessionResponse` does not include a `sessionId` field. However, `loadSession()` was returning the raw object from the private `loadSessionMode()` helper, which includes `sessionId`. In contrast, `newSession()` correctly constructs its own return with `sessionId` explicitly included.

Fixed by making `loadSession()` return only the fields defined by the ACP spec (`models`, `modes`, `_meta`), dropping `sessionId`.

### How did you verify your code works?

Traced the call path manually:
- `loadSessionMode()` returns `{ sessionId, models, modes, _meta }`
- `newSession()` destructures and adds its own `sessionId`
- `loadSession()` was returning `result` directly; now returns `{ models, modes, _meta }`

### Screenshots / recordings

N/A — backend-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR