### PR TITLE
feat(tui): add plugins and formatters to sidebar, fix status dialog overflow

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "../context/theme"
 import { useDialog } from "@tui/ui/dialog"
 import { useSync } from "@tui/context/sync"
 import { For, Match, Switch, Show, createMemo } from "solid-js"
+import { useTerminalDimensions } from "@opentui/solid"
 
 export type DialogStatusProps = {}
 
@@ -11,6 +12,7 @@ export function DialogStatus() {
   const sync = useSync()
   const { theme } = useTheme()
   const dialog = useDialog()
+  const dimensions = useTerminalDimensions()
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
@@ -40,8 +42,8 @@ export function DialogStatus() {
   })
 
   return (
-    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
-      <box flexDirection="row" justifyContent="space-between">
+    <box paddingLeft={2} paddingRight={2} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between" paddingBottom={1}>
         <text fg={theme.text} attributes={TextAttributes.BOLD}>
           Status
         </text>
@@ -49,119 +51,131 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
-        <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
-          <For each={Object.entries(sync.data.mcp)}>
-            {([key, item]) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: (
-                      {
+      
+      <scrollbox 
+        maxHeight={Math.floor(dimensions().height * 0.7)}
+        gap={1}
+        verticalScrollbarOptions={{
+          trackOptions: {
+            backgroundColor: theme.background,
+            foregroundColor: theme.borderActive,
+          },
+        }}
+      >
+        <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+          <box>
+            <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
+            <For each={Object.entries(sync.data.mcp)}>
+              {([key, item]) => (
+                <box flexDirection="row" gap={1}>
+                  <text
+                    flexShrink={0}
+                    style={{
+                      fg: (
+                        {
+                          connected: theme.success,
+                          failed: theme.error,
+                          disabled: theme.textMuted,
+                          needs_auth: theme.warning,
+                          needs_client_registration: theme.error,
+                        } as Record<string, typeof theme.success>
+                      )[item.status],
+                    }}
+                  >
+                    •
+                  </text>
+                  <text fg={theme.text} wrapMode="word">
+                    <b>{key}</b>{" "}
+                    <span style={{ fg: theme.textMuted }}>
+                      <Switch fallback={item.status}>
+                        <Match when={item.status === "connected"}>Connected</Match>
+                        <Match when={item.status === "failed" && item}>{(val) => val().error}</Match>
+                        <Match when={item.status === "disabled"}>Disabled in configuration</Match>
+                        <Match when={(item.status as string) === "needs_auth"}>
+                          Needs authentication (run: opencode mcp auth {key})
+                        </Match>
+                        <Match when={(item.status as string) === "needs_client_registration" && item}>
+                          {(val) => (val() as { error: string }).error}
+                        </Match>
+                      </Switch>
+                    </span>
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+        {sync.data.lsp.length > 0 && (
+          <box>
+            <text fg={theme.text}>{sync.data.lsp.length} LSP Servers</text>
+            <For each={sync.data.lsp}>
+              {(item) => (
+                <box flexDirection="row" gap={1}>
+                  <text
+                    flexShrink={0}
+                    style={{
+                      fg: {
                         connected: theme.success,
-                        failed: theme.error,
-                        disabled: theme.textMuted,
-                        needs_auth: theme.warning,
-                        needs_client_registration: theme.error,
-                      } as Record<string, typeof theme.success>
-                    )[item.status],
-                  }}
-                >
-                  •
-                </text>
-                <text fg={theme.text} wrapMode="word">
-                  <b>{key}</b>{" "}
-                  <span style={{ fg: theme.textMuted }}>
-                    <Switch fallback={item.status}>
-                      <Match when={item.status === "connected"}>Connected</Match>
-                      <Match when={item.status === "failed" && item}>{(val) => val().error}</Match>
-                      <Match when={item.status === "disabled"}>Disabled in configuration</Match>
-                      <Match when={(item.status as string) === "needs_auth"}>
-                        Needs authentication (run: opencode mcp auth {key})
-                      </Match>
-                      <Match when={(item.status as string) === "needs_client_registration" && item}>
-                        {(val) => (val() as { error: string }).error}
-                      </Match>
-                    </Switch>
-                  </span>
-                </text>
-              </box>
-            )}
-          </For>
-        </box>
-      </Show>
-      {sync.data.lsp.length > 0 && (
-        <box>
-          <text fg={theme.text}>{sync.data.lsp.length} LSP Servers</text>
-          <For each={sync.data.lsp}>
-            {(item) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: {
-                      connected: theme.success,
-                      error: theme.error,
-                    }[item.status],
-                  }}
-                >
-                  •
-                </text>
-                <text fg={theme.text} wrapMode="word">
-                  <b>{item.id}</b> <span style={{ fg: theme.textMuted }}>{item.root}</span>
-                </text>
-              </box>
-            )}
-          </For>
-        </box>
-      )}
-      <Show when={enabledFormatters().length > 0} fallback={<text fg={theme.text}>No Formatters</text>}>
-        <box>
-          <text fg={theme.text}>{enabledFormatters().length} Formatters</text>
-          <For each={enabledFormatters()}>
-            {(item) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: theme.success,
-                  }}
-                >
-                  •
-                </text>
-                <text wrapMode="word" fg={theme.text}>
-                  <b>{item.name}</b>
-                </text>
-              </box>
-            )}
-          </For>
-        </box>
-      </Show>
-      <Show when={plugins().length > 0} fallback={<text fg={theme.text}>No Plugins</text>}>
-        <box>
-          <text fg={theme.text}>{plugins().length} Plugins</text>
-          <For each={plugins()}>
-            {(item) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: theme.success,
-                  }}
-                >
-                  •
-                </text>
-                <text wrapMode="word" fg={theme.text}>
-                  <b>{item.name}</b>
-                  {item.version && <span style={{ fg: theme.textMuted }}> @{item.version}</span>}
-                </text>
-              </box>
-            )}
-          </For>
-        </box>
-      </Show>
+                        error: theme.error,
+                      }[item.status],
+                    }}
+                  >
+                    •
+                  </text>
+                  <text fg={theme.text} wrapMode="word">
+                    <b>{item.id}</b> <span style={{ fg: theme.textMuted }}>{item.root}</span>
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        )}
+        <Show when={enabledFormatters().length > 0} fallback={<text fg={theme.text}>No Formatters</text>}>
+          <box>
+            <text fg={theme.text}>{enabledFormatters().length} Formatters</text>
+            <For each={enabledFormatters()}>
+              {(item) => (
+                <box flexDirection="row" gap={1}>
+                  <text
+                    flexShrink={0}
+                    style={{
+                      fg: theme.success,
+                    }}
+                  >
+                    •
+                  </text>
+                  <text wrapMode="word" fg={theme.text}>
+                    <b>{item.name}</b>
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+        <Show when={plugins().length > 0} fallback={<text fg={theme.text}>No Plugins</text>}>
+          <box>
+            <text fg={theme.text}>{plugins().length} Plugins</text>
+            <For each={plugins()}>
+              {(item) => (
+                <box flexDirection="row" gap={1}>
+                  <text
+                    flexShrink={0}
+                    style={{
+                      fg: theme.success,
+                    }}
+                  >
+                    •
+                  </text>
+                  <text wrapMode="word" fg={theme.text}>
+                    <b>{item.name}</b>
+                    {item.version && <span style={{ fg: theme.textMuted }}> @{item.version}</span>}
+                  </text>
+                </box>
+              )}
+            </For>
+          </box>
+        </Show>
+      </scrollbox>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -3,6 +3,7 @@ import { createMemo, For, Show, Switch, Match } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
+import { fileURLToPath } from "bun"
 import path from "path"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
@@ -25,6 +26,8 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     diff: true,
     todo: true,
     lsp: true,
+    formatters: true,
+    plugins: true,
   })
 
   // Sort MCP servers alphabetically for consistent display order
@@ -39,6 +42,34 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
           item.status === "failed" || item.status === "needs_auth" || item.status === "needs_client_registration",
       ).length,
   )
+
+
+  const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
+
+  const plugins = createMemo(() => {
+    const list = sync.data.config.plugin ?? []
+    const result = list.map((value) => {
+      if (value.startsWith("file://")) {
+        const fileURLPath = fileURLToPath(value)
+        const parts = fileURLPath.split("/")
+        const filename = parts.pop() || fileURLPath
+        if (!filename.includes(".")) return { name: filename }
+        const basename = filename.split(".")[0]
+        if (basename === "index") {
+          const dirname = parts.pop()
+          const name = dirname || basename
+          return { name }
+        }
+        return { name: basename }
+      }
+      const index = value.lastIndexOf("@")
+      if (index <= 0) return { name: value, version: "latest" }
+      const name = value.substring(0, index)
+      const version = value.substring(index + 1)
+      return { name, version }
+    })
+    return result.toSorted((a, b) => a.name.localeCompare(b.name))
+  })
 
   const cost = createMemo(() => {
     const total = messages().reduce((sum, x) => sum + (x.role === "assistant" ? x.cost : 0), 0)
@@ -210,6 +241,78 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </For>
               </Show>
             </box>
+            
+            <Show when={enabledFormatters().length > 0}>
+              <box>
+                <box
+                  flexDirection="row"
+                  gap={1}
+                  onMouseDown={() => enabledFormatters().length > 2 && setExpanded("formatters", !expanded.formatters)}
+                >
+                  <Show when={enabledFormatters().length > 2}>
+                    <text fg={theme.text}>{expanded.formatters ? "▼" : "▶"}</text>
+                  </Show>
+                  <text fg={theme.text}>
+                    <b>Formatters</b>
+                  </text>
+                </box>
+                <Show when={enabledFormatters().length <= 2 || expanded.formatters}>
+                  <For each={enabledFormatters()}>
+                    {(item) => (
+                      <box flexDirection="row" gap={1}>
+                        <text
+                          flexShrink={0}
+                          style={{
+                            fg: theme.success,
+                          }}
+                        >
+                          •
+                        </text>
+                        <text wrapMode="word" fg={theme.textMuted}>
+                          {item.name}
+                        </text>
+                      </box>
+                    )}
+                  </For>
+                </Show>
+              </box>
+            </Show>
+            <Show when={plugins().length > 0}>
+              <box>
+                <box
+                  flexDirection="row"
+                  gap={1}
+                  onMouseDown={() => plugins().length > 2 && setExpanded("plugins", !expanded.plugins)}
+                >
+                  <Show when={plugins().length > 2}>
+                    <text fg={theme.text}>{expanded.plugins ? "▼" : "▶"}</text>
+                  </Show>
+                  <text fg={theme.text}>
+                    <b>Plugins</b>
+                  </text>
+                </box>
+                <Show when={plugins().length <= 2 || expanded.plugins}>
+                  <For each={plugins()}>
+                    {(item) => (
+                      <box flexDirection="row" gap={1}>
+                        <text
+                          flexShrink={0}
+                          style={{
+                            fg: theme.success,
+                          }}
+                        >
+                          •
+                        </text>
+                        <text wrapMode="word" fg={theme.textMuted}>
+                          {item.name}
+                          {item.version && <span style={{ fg: theme.textMuted }}> @{item.version}</span>}
+                        </text>
+                      </box>
+                    )}
+                  </For>
+                </Show>
+              </box>
+            </Show>
             <Show when={todo().length > 0 && todo().some((t) => t.status !== "completed")}>
               <box>
                 <box


### PR DESCRIPTION
### Issue for this PR
Closes #13622
Closes #9314

### Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. **Status Dialog Overflow (#9314)**: Wraps the contents of the `/status` dialog (MCP, LSP, Formatters, Plugins) inside a `<scrollbox>` component with `maxHeight` bounded to 70% of the terminal height. This completely resolves the issue where too many servers/plugins would cause the dialog to get cut off on smaller terminals without any way to scroll.
2. **Sidebar Additions**: Plumbs the existing logic from `dialog-status.tsx` into the global `sidebar.tsx`. Users can now see a collapsable list of active Formatters and enabled Plugins directly within the right sidebar, right underneath the LSP section. 

### How did you verify your code works?

Built and ran `opencode` locally. Activated multiple LSPs and verified that the `/status` dialog correctly shows a scrollbar and handles arrow key/mouse wheel scrolling. Opened the sidebar and confirmed that both the `Formatters` and `Plugins` panels correctly expand/collapse and reflect the state of `.opencode/config.json`.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR