### PR TITLE
fix(web): clear changes views after deleting all sessions

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -436,6 +436,18 @@ export default function Page() {
     ),
   )
 
+  createEffect(
+    on(
+      () => params.id,
+      (id) => {
+        if (!id) {
+          setTree({ reviewScroll: undefined, pendingDiff: undefined, activeDiff: undefined })
+        }
+      },
+      { defer: true },
+    ),
+  )
+
   const showAllFiles = () => {
     if (fileTreeTab() !== "changes") return
     setFileTreeTab("all")

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -194,6 +194,12 @@ export const SessionReview = (props: SessionReviewProps) => {
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
 
+  createEffect(() => {
+    if (props.diffs.length === 0 && store.open.length > 0) {
+      setStore("open", [])
+    }
+  })
+
   const handleChange = (open: string[]) => {
     props.onOpenChange?.(open)
     if (props.open !== undefined) return


### PR DESCRIPTION
### Issue for this PR

Closes #14860

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem:** After deleting all sessions and navigating back to the session list (where `params.id` is `undefined`), the following views still display stale content instead of being empty:
- Session changes view
- Last turn changes view
- Changes view

**Root Cause:**
1. The `SessionReview` component's local store is initialized with initial diffs and doesn't clear itself when diffs become empty
2. The `tree` state (tracking `activeDiff`, `pendingDiff`, `reviewScroll`) is only cleared when `sessionKey` changes, but not when `params.id` becomes `undefined`

**Changes:**
1. **SessionReview component** (`packages/ui/src/components/session-review.tsx`):
   - Added effect to clear local `store.open` state when `props.diffs` becomes empty
   - This ensures the component's internal state resets when no diffs are available

2. **Session page** (`packages/app/src/pages/session.tsx`):
   - Added effect to clear `tree` state (`reviewScroll`, `pendingDiff`, `activeDiff`) when `params.id` is `undefined`
   - This ensures diff tracking state is cleared when navigating away from a session

### How did you verify your code works?

Verified that after deleting all sessions and navigating back to the session list:
- All changes views are completely empty
- No stale content is displayed
- The review panel shows the empty state

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR