### PR TITLE
fix: update createOpenReviewFile test to match new call order

### DIFF
--- a/packages/app/src/pages/session/helpers.test.ts
+++ b/packages/app/src/pages/session/helpers.test.ts
@@ -16,7 +16,7 @@ describe("createOpenReviewFile", () => {
 
     openReviewFile("src/a.ts")
 
-    expect(calls).toEqual(["show", "tab:src/a.ts", "open:file://src/a.ts", "load:src/a.ts"])
+    expect(calls).toEqual(["show", "load:src/a.ts", "tab:src/a.ts", "open:file://src/a.ts"])
   })
 })
 


### PR DESCRIPTION
## Summary

- Updates the `createOpenReviewFile` test assertion to reflect the new call order introduced in eda71373b ("wait for loadFile before opening file tab")
- The test was asserting the old order (`show → tab → open → load`) but the implementation now calls `loadFile` before `openTab` when synchronous, producing `show → load → tab → open`
- The call order within the `batch()` doesn't affect observable behavior since SolidJS defers all reactive updates until the batch completes