### PR TITLE
fix(win32): handle CRLF line endings in markdown frontmatter parsing

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -22,7 +22,7 @@ export namespace ConfigMarkdown {
     if (!match) return content
 
     const frontmatter = match[1]
-    const lines = frontmatter.split("\n")
+    const lines = frontmatter.split(/\r?\n/)
     const result: string[] = []
 
     for (const line of lines) {

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -197,7 +197,7 @@ describe("ConfigMarkdown: frontmatter parsing w/ Markdown header", async () => {
   test("should parse and match", () => {
     expect(result).toBeDefined()
     expect(result.data).toEqual({})
-    expect(result.content.trim()).toBe(`# Response Formatting Requirements
+    expect(result.content.trim().replace(/\r\n/g, "\n")).toBe(`# Response Formatting Requirements
 
 Always structure your responses using clear markdown formatting:
 


### PR DESCRIPTION
## Summary
- Frontmatter parser split on `\n` which fails on Windows where files have `\r\n` — changed to split on `/\r?\n/` so field extraction works cross-platform.
- Test assertion for markdown header content also normalized to handle `\r\n`.

Fixes 16 Windows unit test failures. Split out from #14742.