### PR TITLE
fix(test): normalize git excludesFile path for Windows

### DIFF
--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -548,7 +548,7 @@ test("git info exclude keeps global excludes", async () => {
       const global = `${tmp.path}/global.ignore`
       const config = `${tmp.path}/global.gitconfig`
       await Bun.write(global, "global.tmp\n")
-      await Bun.write(config, `[core]\n\texcludesFile = ${global}\n`)
+      await Bun.write(config, `[core]\n\texcludesFile = ${global.replaceAll("\\", "/")}\n`)
 
       const prev = process.env.GIT_CONFIG_GLOBAL
       process.env.GIT_CONFIG_GLOBAL = config


### PR DESCRIPTION
## Summary
- Git config `excludesFile` value had Windows backslashes (`C:\...\global.ignore`) which git interprets as escape sequences. Normalize to `/` so the path is read correctly.

Split out from #14742.