### PR TITLE
fix(win32): fix plugin resolution with createRequire fallback

### DIFF
--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -689,7 +689,7 @@ test("resolves scoped npm plugins in config", async () => {
       const pluginEntries = config.plugin ?? []
 
       const baseUrl = pathToFileURL(path.join(tmp.path, "opencode.json")).href
-      const expected = import.meta.resolve("@scope/plugin", baseUrl)
+      const expected = pathToFileURL(path.join(tmp.path, "node_modules", "@scope", "plugin", "index.js")).href
 
       expect(pluginEntries.includes(expected)).toBe(true)
 


### PR DESCRIPTION
## Summary
- Remove 3s sleep after writing `package.json` in `installDependencies` — was unnecessary and caused test timeouts.
- Add `createRequire` fallback when `import.meta.resolve` fails for plugins in freshly created `node_modules` — `import.meta.resolve` sometimes can't find packages that were just installed on Windows.
- Use static expected path in config test assertion instead of mirroring production fallback logic.

Fixes 4 Windows unit test failures. Split out from #14742.