### PR TITLE
fix: bypass bun global cache on CI/E2E to prevent lock contention

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -289,7 +289,9 @@ export namespace Config {
       [
         "install",
         // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-        ...(proxied() ? ["--no-cache"] : []),
+        // Bypass global cache on CI and E2E to prevent concurrent lock contention
+        // when multiple processes install simultaneously.
+        ...(proxied() || !!process.env.CI || !!process.env.OPENCODE_E2E_PROJECT_DIR ? ["--no-cache"] : []),
       ],
       { cwd: dir },
     ).catch((err) => {


### PR DESCRIPTION
## Summary
- Add `--no-cache` to `bun install` when running on CI or E2E (`process.env.CI` or `process.env.OPENCODE_E2E_PROJECT_DIR`) to prevent concurrent processes from fighting over the global bun cache lock.

Fixes 3 Windows unit test failures (`loads agents`, `loads commands` x2). Split out from #14742.