### PR TITLE
fix(win32): normalize backslash paths in config rel() and file ignore

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -342,10 +342,11 @@ export namespace Config {
   }
 
   function rel(item: string, patterns: string[]) {
+    const normalizedItem = item.replaceAll("\\", "/")
     for (const pattern of patterns) {
-      const index = item.indexOf(pattern)
+      const index = normalizedItem.indexOf(pattern)
       if (index === -1) continue
-      return item.slice(index + pattern.length)
+      return normalizedItem.slice(index + pattern.length)
     }
   }
 

--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -67,7 +67,7 @@ export namespace FileIgnore {
       if (Glob.match(pattern, filepath)) return false
     }
 
-    const parts = filepath.split(sep)
+    const parts = filepath.split(/[/\\]/)
     for (let i = 0; i < parts.length; i++) {
       if (FOLDERS.has(parts[i])) return true
     }


### PR DESCRIPTION
## Summary
- **`Config.rel()`** -- normalize item path to `/` before matching against patterns, so agent/command keys like `nested/child` are produced consistently on Windows instead of `nested\child`.
- **`FileIgnore`** -- split filepath on `/[/\]/` instead of `sep` so folder exclusion matching works regardless of separator.

These are internal matching operations only — no user-facing path display is affected.

Fixes 4 Windows unit test failures (`loads agents`, `loads commands` x2, `match nested and non-nested`). Split out from #14742.