### PR TITLE
fix(test): use path.sep in discovery test for cross-platform path matching

### DIFF
--- a/packages/opencode/test/skill/discovery.test.ts
+++ b/packages/opencode/test/skill/discovery.test.ts
@@ -77,7 +77,7 @@ describe("Discovery.pull", () => {
   test("downloads reference files alongside SKILL.md", async () => {
     const dirs = await Discovery.pull(CLOUDFLARE_SKILLS_URL)
     // find a skill dir that should have reference files (e.g. agents-sdk)
-    const agentsSdk = dirs.find((d) => d.endsWith("/agents-sdk"))
+    const agentsSdk = dirs.find((d) => d.endsWith(path.sep + "agents-sdk"))
     expect(agentsSdk).toBeDefined()
     if (agentsSdk) {
       const refs = path.join(agentsSdk, "references")


### PR DESCRIPTION
## Summary
- `Discovery.pull` test used hardcoded `/` to match directory suffix. Use `path.sep` so it matches on Windows too.

Split out from #14742.