### PR TITLE
fix(test): replace Unix-only assumptions with cross-platform alternatives

### DIFF
--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import os from "os"
 import path from "path"
 import { BashTool } from "../../src/tool/bash"
 import { Instance } from "../../src/project/instance"
@@ -138,14 +139,14 @@ describe("tool.bash permissions", () => {
         await bash.execute(
           {
             command: "ls",
-            workdir: "/tmp",
-            description: "List /tmp",
+            workdir: os.tmpdir(),
+            description: "List temp dir",
           },
           testCtx,
         )
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
-        expect(extDirReq!.patterns).toContain("/tmp/*")
+        expect(extDirReq!.patterns).toContain(path.join(os.tmpdir(), "*"))
       },
     })
   })
@@ -366,7 +367,8 @@ describe("tool.bash truncation", () => {
           ctx,
         )
         expect((result.metadata as any).truncated).toBe(false)
-        expect(result.output).toBe("hello\n")
+        const eol = process.platform === "win32" ? "\r\n" : "\n"
+        expect(result.output).toBe(`hello${eol}`)
       },
     })
   })

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -65,7 +65,7 @@ describe("tool.assertExternalDirectory", () => {
 
     const directory = "/tmp/project"
     const target = "/tmp/outside/file.txt"
-    const expected = path.join(path.dirname(target), "*")
+    const expected = path.join(path.dirname(target), "*").replaceAll("\\", "/")
 
     await Instance.provide({
       directory,
@@ -91,7 +91,7 @@ describe("tool.assertExternalDirectory", () => {
 
     const directory = "/tmp/project"
     const target = "/tmp/outside"
-    const expected = path.join(target, "*")
+    const expected = path.join(target, "*").replaceAll("\\", "/")
 
     await Instance.provide({
       directory,


### PR DESCRIPTION
## Summary
- **bash.test.ts** -- use `os.tmpdir()` instead of hardcoded `/tmp` for external directory permission test. Handle `\r\n` line endings on Windows for truncation test.
- **external-directory.test.ts** -- normalize `path.join` output with `.replaceAll("\\", "/")` to match the source code's normalization in `assertExternalDirectory`.
- **write.test.ts** -- replace `/etc/passwd` (doesn't exist on Windows) with a `chmod 0o444` read-only file to test write denial.

Fixes 5 Windows unit test failures. Split out from #14742.