### PR TITLE
fix(test): replace structuredClone with spread for process.env

### DIFF
--- a/packages/opencode/test/ide/ide.test.ts
+++ b/packages/opencode/test/ide/ide.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, afterEach } from "bun:test"
 import { Ide } from "../../src/ide"
 
 describe("ide", () => {
-  const original = structuredClone(process.env)
+  const original = { ...process.env }
 
   afterEach(() => {
     Object.keys(process.env).forEach((key) => {


### PR DESCRIPTION
## Summary
- `structuredClone(process.env)` throws `DataCloneError` on Windows in Bun. Use object spread instead.

Split out from #14742.