### PR TITLE
fix(e2e): rewrite @mention test to use withProject and retry for file index

### DIFF
--- a/packages/app/e2e/prompt/prompt-mention.spec.ts
+++ b/packages/app/e2e/prompt/prompt-mention.spec.ts
@@ -1,26 +1,38 @@
+import fs from "node:fs/promises"
+import path from "node:path"
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 
-test("smoke @mention inserts file pill token", async ({ page, gotoSession }) => {
-  await gotoSession()
+test("smoke @mention inserts file pill token", async ({ page, withProject }) => {
+  await withProject(async ({ directory, gotoSession }) => {
+    // Scaffold nested file to test slashes and subdirectories
+    await fs.mkdir(path.join(directory, "packages", "app"), { recursive: true })
+    await fs.writeFile(path.join(directory, "packages", "app", "package.json"), "{}")
 
-  await page.locator(promptSelector).click()
-  const sep = process.platform === "win32" ? "\\" : "/"
-  const file = ["packages", "app", "package.json"].join(sep)
-  const filePattern = /packages[\\/]+app[\\/]+\s*package\.json/
+    await gotoSession()
 
-  await page.keyboard.type(`@${file}`)
+    const file = "packages/app/package.json"
+    const filePattern = /packages[\\/]+app[\\/]+\s*package\.json/
 
-  const suggestion = page.getByRole("button", { name: filePattern }).first()
-  await expect(suggestion).toBeVisible()
-  await suggestion.hover()
+    const suggestion = page.getByRole("button", { name: filePattern }).first()
 
-  await page.keyboard.press("Tab")
+    await expect(async () => {
+      await page.locator(promptSelector).click()
+      await page.keyboard.press("Control+A")
+      await page.keyboard.press("Backspace")
+      await page.keyboard.type(`@${file}`)
+      await expect(suggestion).toBeVisible({ timeout: 500 })
+    }).toPass({ timeout: 10_000 })
 
-  const pill = page.locator(`${promptSelector} [data-type="file"]`).first()
-  await expect(pill).toBeVisible()
-  await expect(pill).toHaveAttribute("data-path", filePattern)
+    await suggestion.hover()
 
-  await page.keyboard.type(" ok")
-  await expect(page.locator(promptSelector)).toContainText("ok")
+    await page.keyboard.press("Tab")
+
+    const pill = page.locator(`${promptSelector} [data-type="file"]`).first()
+    await expect(pill).toBeVisible()
+    await expect(pill).toHaveAttribute("data-path", filePattern)
+
+    await page.keyboard.type(" ok")
+    await expect(page.locator(promptSelector)).toContainText("ok")
+  })
 })


### PR DESCRIPTION
## Summary
- Use `withProject` to create an isolated project with a known scaffolded file (`packages/app/package.json`) instead of relying on the repo's own files.
- Use `/` for the `@mention` input since the web UI always displays `/`-separated paths.
- Wrap the type + suggestion visibility check in a `toPass` retry loop since the file index may not be ready immediately after session creation.

Split out from #14742.