### PR TITLE
fix(app): preserve native path separators in file path helpers

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -15,10 +15,10 @@ describe("file path helpers", () => {
 
   test("normalizes Windows absolute paths with mixed separators", () => {
     const path = createPathHelpers(() => "C:\\repo")
-    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src/app.ts")
+    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src\\app.ts")
     expect(path.normalize("C:/repo/src/app.ts")).toBe("src/app.ts")
     expect(path.normalize("file://C:/repo/src/app.ts")).toBe("src/app.ts")
-    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src/app.ts")
+    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src\\app.ts")
   })
 
   test("keeps query/hash stripping behavior stable", () => {


### PR DESCRIPTION
## Summary

The Cygwin fix (a74fedd) normalized all paths to `/` in the frontend path helpers to fix change detection with mixed separators. This caused the web UI to show `/` instead of `\` on Windows — a UI regression.

**Fix:** Canonicalize to `/` only for the prefix-stripping comparison, but slice from the original path to preserve native separators.

- Cygwin paths (`/c/Users/...`, `C:/Users/...`) still match against native roots (`C:\Users\...`)
- Windows users see `\` in file paths (matching native behavior and the TUI)
- Linux/Mac unchanged

Reverts the UI regression from #13659 while keeping the Cygwin compatibility.