### PR TITLE
fix: re-enable snapshot in acp

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -24,7 +24,7 @@ export namespace Snapshot {
   }
 
   export async function cleanup() {
-    if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") return
+    if (Instance.project.vcs !== "git") return
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
@@ -49,7 +49,7 @@ export namespace Snapshot {
   }
 
   export async function track() {
-    if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") return
+    if (Instance.project.vcs !== "git") return
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()


### PR DESCRIPTION
### Issue for this PR

Closes #14914

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Re-enables snapshots in ACP after they where disabled in https://github.com/anomalyco/opencode/pull/13222/changes#diff-d9dd4cc5e32b03159f882fad63c007fff125b489bd2ba2aeb6f6ef9e40454563R27

### How did you verify your code works?
Works for us on our acp client, when running against opencode running in **linux**. Need someone running windows to verify this does not break what https://github.com/anomalyco/opencode/pull/13222 was trying to fix with the whole git thing

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

