### PR TITLE
feat: add jump-to-message keybind in timeline dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
@@ -5,6 +5,7 @@ import type { TextPart } from "@opencode-ai/sdk/v2"
 import { Locale } from "@/util/locale"
 import { DialogMessage } from "./dialog-message"
 import { useDialog } from "../../ui/dialog"
+import { useKeybind } from "../../context/keybind"
 import type { PromptInfo } from "../../component/prompt/history"
 
 export function DialogTimeline(props: {
@@ -14,6 +15,7 @@ export function DialogTimeline(props: {
 }) {
   const sync = useSync()
   const dialog = useDialog()
+  const keybind = useKeybind()
 
   onMount(() => {
     dialog.setSize("large")
@@ -43,5 +45,21 @@ export function DialogTimeline(props: {
     return result
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Timeline" options={options()} />
+  return (
+    <DialogSelect
+      onMove={(option) => props.onMove(option.value)}
+      title="Timeline"
+      options={options()}
+      keybind={[
+        {
+          keybind: keybind.all.session_timeline_jump?.[0],
+          title: "Jump",
+          onTrigger: (option) => {
+            props.onMove(option.value)
+            dialog.clear()
+          },
+        },
+      ]}
+    />
+  )
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -786,6 +786,7 @@ export namespace Config {
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),
       session_list: z.string().optional().default("<leader>l").describe("List all sessions"),
       session_timeline: z.string().optional().default("<leader>g").describe("Show session timeline"),
+      session_timeline_jump: z.string().optional().default("tab").describe("Jump to message from timeline"),
       session_fork: z.string().optional().default("none").describe("Fork session from message"),
       session_rename: z.string().optional().default("ctrl+r").describe("Rename session"),
       session_delete: z.string().optional().default("ctrl+d").describe("Delete session"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1044,6 +1044,10 @@ export type KeybindsConfig = {
    */
   session_timeline?: string
   /**
+   * Jump to message from timeline
+   */
+  session_timeline_jump?: string
+  /**
    * Fork session from message
    */
   session_fork?: string


### PR DESCRIPTION
### Issue for this PR

No existing issue — this addresses a usability gap in the `/timeline` command.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `/timeline` command lets you browse through your past messages in a session. As you navigate the list, it already scrolls the conversation in the background to the highlighted message (`onMove`). However, pressing Enter forces a second dialog (`DialogMessage`) with three actions: Revert, Copy, or Fork. There is no way to simply jump to a message and stay in the conversation.

This PR adds a secondary keybind ("Jump", default `tab`) inside the timeline dialog. When triggered, it scrolls to the selected message and closes the dialog — the user stays exactly where they jumped to, without any forced action.

The existing Enter behavior is unchanged (still opens the message actions dialog), so this is not a breaking change.

**Implementation details:**
- `dialog-timeline.tsx`: passes the `keybind` prop to `DialogSelect` (same pattern used in `dialog-session-list.tsx` for delete/rename). The keybind calls `props.onMove(option.value)` to scroll, then `dialog.clear()` to close.
- `config.ts`: adds `session_timeline_jump` keybind entry (default: `tab`), so users can remap it.
- `types.gen.ts`: regenerated SDK types to include the new keybind field.

### How did you verify your code works?

- TypeScript type check passes (`bun tsc --noEmit` in `packages/opencode`)
- SDK regenerated successfully with `./packages/sdk/js/script/build.ts`
- Reviewed the `DialogSelect` keybind pattern in `dialog-session-list.tsx` to ensure consistency

### Screenshots / recordings

_N/A — TUI change, the "Jump tab" hint appears at the bottom of the timeline dialog._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR