### PR TITLE
feat: enable tool-input-delta streaming in processor

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -108,25 +108,41 @@ export namespace SessionProcessor {
                   }
                   break
 
-                case "tool-input-start":
+                case "tool-input-start": {
+                  const toolCallId = (value as any).toolCallId ?? value.id
                   const part = await Session.updatePart({
-                    id: toolcalls[value.id]?.id ?? Identifier.ascending("part"),
+                    id: toolcalls[toolCallId]?.id ?? Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,
                     sessionID: input.assistantMessage.sessionID,
                     type: "tool",
                     tool: value.toolName,
-                    callID: value.id,
+                    callID: toolCallId,
                     state: {
                       status: "pending",
                       input: {},
                       raw: "",
                     },
                   })
-                  toolcalls[value.id] = part as MessageV2.ToolPart
+                  toolcalls[toolCallId] = part as MessageV2.ToolPart
                   break
+                }
 
-                case "tool-input-delta":
+                case "tool-input-delta": {
+                  const deltaCallId = (value as any).toolCallId ?? value.id
+                  const deltaText = (value as any).inputTextDelta ?? (value as any).delta ?? ""
+                  const deltaMatch = toolcalls[deltaCallId]
+                  if (deltaMatch && deltaMatch.state.status === "pending") {
+                    deltaMatch.state.raw += deltaText
+                    await Session.updatePartDelta({
+                      sessionID: deltaMatch.sessionID,
+                      messageID: deltaMatch.messageID,
+                      partID: deltaMatch.id,
+                      field: "raw",
+                      delta: deltaText,
+                    })
+                  }
                   break
+                }
 
                 case "tool-input-end":
                   break


### PR DESCRIPTION
## Summary

Enable real-time streaming of tool call arguments to clients by wiring up the previously no-op `tool-input-delta` handler in the session processor.

## Problem

The `tool-input-delta` events from the AI SDK (backed by Anthropic's `fine-grained-tool-streaming` beta header, which is already set in `provider.ts`) were being silently discarded:

```typescript
case "tool-input-delta":
  break;  // All streaming data thrown away
```

This forced clients to wait for the complete `tool-call` event before showing any tool arguments — creating a noticeable lag for tools with large inputs (file writes, long commands, etc.).

## Solution

- **`tool-input-start`**: Resolve `toolCallId` via `value.toolCallId ?? value.id` to handle both `fullStream` field naming conventions from the AI SDK
- **`tool-input-delta`**: Accumulate streaming argument text into `state.raw` and publish `PartDelta` events using the existing `updatePartDelta` infrastructure (same pattern as `text-delta` streaming)

The `raw` field on `ToolStatePending` already exists in the schema (`message-v2.ts:265`) — it was always initialized to `""` but never populated.

## How it works

```
Anthropic API (fine-grained-tool-streaming beta)
  → @ai-sdk/anthropic emits tool-input-start / tool-input-delta / tool-input-end
  → AI SDK passes through to fullStream
  → processor.ts accumulates raw text, publishes PartDelta
  → Bus → SSE endpoint → Frontend
  → Frontend parses partial JSON from raw field → shows tool args in real-time
```

## Frontend impact

Frontends can now use `part.state.raw` (during `status: "pending"`) to parse and display partial tool arguments as they stream in. The `delta` field on PartDelta events allows efficient incremental updates.

## Changes

- `packages/opencode/src/session/processor.ts` — Wire up `tool-input-start` (toolCallId resolution) and `tool-input-delta` (accumulate raw + publish PartDelta)

No schema changes needed — the `raw` field and `PartDelta` event infrastructure already exist.