### PR TITLE
fix(tui): handle ESC to return to provider list rather than closing modal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -72,18 +72,54 @@ export function createDialogProviderOptions() {
               method: index,
             })
             if (result.data?.method === "code") {
-              dialog.replace(() => (
-                <CodeMethod providerID={provider.id} title={method.label} index={index} authorization={result.data!} />
-              ))
+              const back = () => {
+                dialog.replace(() => <DialogProvider />)
+                return false
+              }
+              dialog.replace(
+                () => (
+                  <CodeMethod
+                    providerID={provider.id}
+                    title={method.label}
+                    index={index}
+                    authorization={result.data!}
+                    onBack={back}
+                  />
+                ),
+                undefined,
+                back,
+              )
             }
             if (result.data?.method === "auto") {
-              dialog.replace(() => (
-                <AutoMethod providerID={provider.id} title={method.label} index={index} authorization={result.data!} />
-              ))
+              const back = () => {
+                dialog.replace(() => <DialogProvider />)
+                return false
+              }
+              dialog.replace(
+                () => (
+                  <AutoMethod
+                    providerID={provider.id}
+                    title={method.label}
+                    index={index}
+                    authorization={result.data!}
+                    onBack={back}
+                  />
+                ),
+                undefined,
+                back,
+              )
             }
           }
           if (method.type === "api") {
-            return dialog.replace(() => <ApiMethod providerID={provider.id} title={method.label} />)
+            const back = () => {
+              dialog.replace(() => <DialogProvider />)
+              return false
+            }
+            return dialog.replace(
+              () => <ApiMethod providerID={provider.id} title={method.label} onBack={back} />,
+              undefined,
+              back,
+            )
           }
         },
       })),
@@ -102,6 +138,7 @@ interface AutoMethodProps {
   providerID: string
   title: string
   authorization: ProviderAuthAuthorization
+  onBack?: () => void
 }
 function AutoMethod(props: AutoMethodProps) {
   const { theme } = useTheme()
@@ -116,6 +153,12 @@ function AutoMethod(props: AutoMethodProps) {
       Clipboard.copy(code)
         .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
         .catch(toast.error)
+    }
+    if (evt.name === "escape") {
+      if (props.onBack) {
+        evt.preventDefault()
+        props.onBack()
+      }
     }
   })
 
@@ -139,7 +182,16 @@ function AutoMethod(props: AutoMethodProps) {
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
           {props.title}
         </text>
-        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+        <text
+          fg={theme.textMuted}
+          onMouseUp={() => {
+            if (props.onBack) {
+              props.onBack()
+            } else {
+              dialog.clear()
+            }
+          }}
+        >
           esc
         </text>
       </box>
@@ -160,6 +212,7 @@ interface CodeMethodProps {
   title: string
   providerID: string
   authorization: ProviderAuthAuthorization
+  onBack?: () => void
 }
 function CodeMethod(props: CodeMethodProps) {
   const { theme } = useTheme()
@@ -172,6 +225,7 @@ function CodeMethod(props: CodeMethodProps) {
     <DialogPrompt
       title={props.title}
       placeholder="Authorization code"
+      onCancel={props.onBack}
       onConfirm={async (value) => {
         const { error } = await sdk.client.provider.oauth.callback({
           providerID: props.providerID,
@@ -202,6 +256,7 @@ function CodeMethod(props: CodeMethodProps) {
 interface ApiMethodProps {
   providerID: string
   title: string
+  onBack?: () => void
 }
 function ApiMethod(props: ApiMethodProps) {
   const dialog = useDialog()
@@ -213,6 +268,7 @@ function ApiMethod(props: ApiMethodProps) {
     <DialogPrompt
       title={props.title}
       placeholder="API key"
+      onCancel={props.onBack}
       description={
         props.providerID === "opencode" ? (
           <box gap={1}>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -22,6 +22,12 @@ export function DialogPrompt(props: DialogPromptProps) {
     if (evt.name === "return") {
       props.onConfirm?.(textarea.plainText)
     }
+    if (evt.name === "escape") {
+      if (props.onCancel) {
+        evt.preventDefault()
+        props.onCancel()
+      }
+    }
   })
 
   onMount(() => {
@@ -39,7 +45,16 @@ export function DialogPrompt(props: DialogPromptProps) {
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
           {props.title}
         </text>
-        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+        <text
+          fg={theme.textMuted}
+          onMouseUp={() => {
+            if (props.onCancel) {
+              props.onCancel()
+            } else {
+              dialog.clear()
+            }
+          }}
+        >
           esc
         </text>
       </box>
@@ -72,7 +87,15 @@ DialogPrompt.show = (dialog: DialogContext, title: string, options?: Omit<Dialog
   return new Promise<string | null>((resolve) => {
     dialog.replace(
       () => (
-        <DialogPrompt title={title} {...options} onConfirm={(value) => resolve(value)} onCancel={() => resolve(null)} />
+        <DialogPrompt
+          title={title}
+          {...options}
+          onConfirm={(value) => resolve(value)}
+          onCancel={() => {
+            resolve(null)
+            dialog.clear()
+          }}
+        />
       ),
       () => resolve(null),
     )

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -61,6 +61,7 @@ function init() {
     stack: [] as {
       element: JSX.Element
       onClose?: () => void
+      onEscape?: () => boolean | void
     }[],
     size: "medium" as "medium" | "large",
   })
@@ -73,6 +74,11 @@ function init() {
     if ((evt.name === "escape" || (evt.ctrl && evt.name === "c")) && renderer.getSelection()) return
     if (evt.name === "escape" || (evt.ctrl && evt.name === "c")) {
       const current = store.stack.at(-1)!
+      if (current.onEscape && current.onEscape() === false) {
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
       current.onClose?.()
       setStore("stack", store.stack.slice(0, -1))
       evt.preventDefault()
@@ -110,7 +116,7 @@ function init() {
       })
       refocus()
     },
-    replace(input: any, onClose?: () => void) {
+    replace(input: any, onClose?: () => void, onEscape?: () => boolean | void) {
       if (store.stack.length === 0) {
         focus = renderer.currentFocusedRenderable
         focus?.blur()
@@ -123,6 +129,7 @@ function init() {
         {
           element: input,
           onClose,
+          onEscape,
         },
       ])
     },


### PR DESCRIPTION
### Issue for this PR

Closes #14931

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When adding a provider, pressing `ESC` inside the API key input or authorization code dialog previously closed the *entire* provider modal stack.

This happened because the root `<Dialog />` layout ([dialog.tsx](cci:7://file:///D:/open-source/opencode/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx:0:0-0:0)) was trapping the `Escape` key globally and popping the stack by default. 

To fix this:
1. I updated `dialog.replace()` to accept an optional `onEscape` handler. If the handler returns `false`, the root dialog skips its default closing behavior.
2. I passed a custom `onBack` handler to the [ApiMethod](cci:1://file:///D:/open-source/opencode/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx:260:0-298:1), [CodeMethod](cci:1://file:///D:/open-source/opencode/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx:216:0-253:1), and [AutoMethod](cci:1://file:///D:/open-source/opencode/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx:142:0-207:1) views that pushes `<DialogProvider />` back onto the view stack and halts the default closing behavior. 

### How did you verify your code works?

I ran the TUI (`bun dev`), opened the "Connect a provider" menu, selected a provider, and hit `ESC` while in the API key / Auth Code prompt. I verified that it successfully returned me to the provider list without closing the modal.

### Screenshots / recordings
Before

https://github.com/user-attachments/assets/70e2c0dd-f54d-4a2f-9188-bc2e80cc3150

After

https://github.com/user-attachments/assets/605f462b-9f2c-414a-802a-ae8f962ffe2c




### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
