### PR TITLE
fix(cli): prevent truncated JSON when piping stdout in export

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -77,8 +77,14 @@ export const ExportCommand = cmd({
           })),
         }
 
-        process.stdout.write(JSON.stringify(exportData, null, 2))
-        process.stdout.write(EOL)
+        const json = JSON.stringify(exportData, null, 2) + EOL
+        await new Promise<void>((resolve, reject) => {
+          process.stdout.write(json, (err) => {
+            if (!err) return resolve()
+            if ((err as NodeJS.ErrnoException).code === "EPIPE") return resolve()
+            reject(err)
+          })
+        })
       } catch (error) {
         UI.error(`Session not found: ${sessionID!}`)
         process.exit(1)


### PR DESCRIPTION
### Issue for this PR
Closes #14948.


### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation


### What does this PR do?
The problem: `opencode export` produces truncated/invalid JSON for sessions with large attached PDF files when stdout is piped, e.g., `opencode export <sessionID> | jq .` may fail with `Unfinished string at EOF`.

At the same time, direct redirect to file works: `opencode export <sessionID> > export.json; jq . export.json`.
So the data exists and is valid, but piped stdout may be cut before completion.
`export` writes a large JSON payload to stdout without waiting for the write callback/drain.
In piped mode, this can end before all bytes are flushed, resulting in truncated output.

Changes:
- Updated `packages/opencode/src/cli/cmd/export.ts` to await completion of stdout write for the full JSON payload.
- Added safe handling for `EPIPE` (common when downstream process exits early).


### How did you verify your code works?
Checked on macOS 26.2 in the standard Terminal app that, after the fix, both piped and direct output produce valid JSON for a couple of sessions with different large attached PDFs.


### Checklist
- [x] Originally faced issue locally.
- [x] Implemented minimal scoped fix.
- [x] No unrelated changes in this PR.
- [x]  I have tested my changes locally.
- [x] `bun run --cwd packages/opencode test` passes.
- [x] `bun turbo typecheck` passes.
