### PR TITLE
feat(desktop): working indicator on project sidebar

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -19,7 +19,12 @@ import { agentColor } from "@/utils/agent"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
-export const ProjectIcon = (props: { project: LocalProject; class?: string; notify?: boolean }): JSX.Element => {
+export const ProjectIcon = (props: {
+  project: LocalProject
+  class?: string
+  notify?: boolean
+  working?: boolean
+}): JSX.Element => {
   const notification = useNotification()
   const dirs = createMemo(() => [props.project.worktree, ...(props.project.sandboxes ?? [])])
   const unseenCount = createMemo(() =>
@@ -48,6 +53,11 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
             "bg-text-interactive-base": !hasError(),
           }}
         />
+      </Show>
+      <Show when={props.working}>
+        <div class="absolute bottom-px right-px size-3 rounded-full bg-background-base z-10 flex items-center justify-center">
+          <Spinner class="size-[9px]" />
+        </div>
       </Show>
     </div>
   )

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -59,6 +59,7 @@ const ProjectTile = (props: {
   sidebarHovering: Accessor<boolean>
   selected: Accessor<boolean>
   active: Accessor<boolean>
+  isWorking: Accessor<boolean>
   overlay: Accessor<boolean>
   dirs: Accessor<string[]>
   onProjectMouseEnter: (worktree: string, event: MouseEvent) => void
@@ -120,7 +121,7 @@ const ProjectTile = (props: {
         onClick={() => props.navigateToProject(props.project.worktree)}
         onBlur={() => props.setOpen(false)}
       >
-        <ProjectIcon project={props.project} notify />
+        <ProjectIcon project={props.project} notify working={props.isWorking()} />
       </ContextMenu.Trigger>
       <ContextMenu.Portal mount={!props.mobile ? props.nav() : undefined}>
         <ContextMenu.Content>
@@ -309,6 +310,12 @@ export const SortableProject = (props: {
   }
 
   const projectStore = createMemo(() => globalSync.child(props.project.worktree, { bootstrap: false })[0])
+  const isWorking = createMemo(() =>
+    dirs().some((directory) => {
+      const [store] = globalSync.child(directory, { bootstrap: false })
+      return Object.values(store.session_status).some((status) => status?.type === "busy" || status?.type === "retry")
+    }),
+  )
   const projectSessions = createMemo(() => sortedRootSessions(projectStore(), props.sortNow()).slice(0, 2))
   const projectChildren = createMemo(() => childMapByParent(projectStore().session))
   const workspaceSessions = (directory: string) => {
@@ -327,6 +334,7 @@ export const SortableProject = (props: {
       sidebarHovering={props.ctx.sidebarHovering}
       selected={selected}
       active={active}
+      isWorking={isWorking}
       overlay={overlay}
       dirs={dirs}
       onProjectMouseEnter={props.ctx.onProjectMouseEnter}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -47,7 +47,7 @@ export function DialogSessionList() {
         }
         const isDeleting = toDelete() === x.id
         const status = sync.data.session_status?.[x.id]
-        const isWorking = status?.type === "busy"
+        const isWorking = status?.type === "busy" || status?.type === "retry"
         return {
           title: isDeleting ? `Press ${keybind.print("session_delete")} again to confirm` : x.title,
           bg: isDeleting ? theme.error : undefined,


### PR DESCRIPTION
### Issue for this PR

Fixes #14430 and fixes #12077

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Added a "AI is working" spinner in the bottom-right corner of the project icon in the sidebar list of projects.
This makes it much easier to keep track of multiple long-running tasks at the same time.
Previously, you needed to hover into the sessions for each project to see whether anything was working.

This feature matches the existing "new results" dot in the top-right corner of the project icon. By using a different corner for the spinner, you can see both, in case one session has new results and another is working.

While I was here, I noticed and fixed an inconsistent use of `status.type` in the TUI session list, where `"retry"` wasn't treated as working, whereas it was everywhere else.

### How did you verify your code works?

`bun run dev:desktop` and sending test messages

### Screenshots / recordings

<img width="164" height="462" alt="image" src="https://github.com/user-attachments/assets/f717e3a6-5508-4484-9bdb-196a02d07af8" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

@Hona You said to `@` you for future PRs, but no pressure!