### PR TITLE
feat: add model parameter to Task tool for dynamic subagent model selection

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { Provider } from "../provider/provider"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -22,6 +23,12 @@ const parameters = z.object({
     )
     .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
+  model: z
+    .string()
+    .describe(
+      "Optional model to use for this task in the format 'provider/model' (e.g. 'github-copilot/claude-sonnet-4.6'). Overrides the agent's default model.",
+    )
+    .optional(),
 })
 
 export const TaskTool = Tool.define("task", async (ctx) => {
@@ -103,7 +110,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 
-      const model = agent.model ?? {
+      const model = (params.model ? Provider.parseModel(params.model) : undefined) ?? agent.model ?? {
         modelID: msg.info.modelID,
         providerID: msg.info.providerID,
       }

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -18,6 +18,7 @@ When NOT to use the Task tool:
 Usage notes:
 1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
 2. When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result. The output includes a task_id you can reuse later to continue the same subagent session.
+7. You can optionally specify a `model` parameter to override the agent's default model. The format is "provider/model" (e.g. "github-copilot/claude-sonnet-4.6"). This is useful when orchestrating agents that need different model tiers for different tasks.
 3. Each agent invocation starts with a fresh context unless you provide task_id to resume the same subagent session (which continues with its previous messages and tool outputs). When starting fresh, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
 4. The agent's outputs should generally be trusted
 5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).


### PR DESCRIPTION
### Issue for this PR

Closes #6651

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `model` parameter to the Task tool so callers can specify which model a subagent runs on at invocation time, instead of relying solely on static agent config or parent session fallback.

The resolution order becomes: `params.model` > `agent.model` > parent session model. Existing behavior is unchanged when the parameter is omitted.

This is needed for orchestrator workflows (e.g. gsd-opencode) where different subagents should use different model tiers based on their role, determined dynamically at call time.

### How did you verify your code works?

Built from source on Windows, replaced the installed binary, and tested three scenarios:

| Test | `model` param | Agent frontmatter | Expected | Actual |
|------|--------------|-------------------|----------|--------|
| Dynamic override to Haiku | `github-copilot/claude-haiku-4.5` | *(none)* | Haiku | Haiku |
| Dynamic override to Sonnet | `github-copilot/claude-sonnet-4.6` | *(none)* | Sonnet | Sonnet |
| No param, no frontmatter | *(none)* | *(none)* | Opus (parent) | Opus |

Verified by spawning subagents and checking the model ID in their system prompt.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR