### PR TITLE
feat: print concrete plugin versions in status

### DIFF
--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -188,7 +188,7 @@ export function StatusPopover() {
   const mcpConnected = createMemo(() => mcpNames().filter((name) => mcpStatus(name) === "connected").length)
   const lspItems = createMemo(() => sync.data.lsp ?? [])
   const lspCount = createMemo(() => lspItems().length)
-  const plugins = createMemo(() => sync.data.config.plugin ?? [])
+  const plugins = createMemo(() => sync.data.plugin ?? [])
   const pluginCount = createMemo(() => plugins().length)
   const pluginEmpty = createMemo(() => pluginEmptyMessage(language.t("dialog.plugins.empty"), "opencode.json"))
   const overallHealthy = createMemo(() => {
@@ -408,7 +408,10 @@ export function StatusPopover() {
                     {(plugin) => (
                       <div class="flex items-center gap-2 w-full px-2 py-1">
                         <div class="size-1.5 rounded-full shrink-0 bg-icon-success-base" />
-                        <span class="text-14-regular text-text-base truncate">{plugin}</span>
+                        <span class="text-14-regular text-text-base truncate">
+                          {plugin.name}
+                          {plugin.version && <span class="text-text-weak">@{plugin.version}</span>}
+                        </span>
                       </div>
                     )}
                   </For>

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -155,6 +155,7 @@ export async function bootstrapDirectory(input: {
     input.loadSessions(input.directory),
     input.sdk.mcp.status().then((x) => input.setStore("mcp", x.data!)),
     input.sdk.lsp.status().then((x) => input.setStore("lsp", x.data!)),
+    input.sdk.plugin.status().then((x) => input.setStore("plugin", x.data!)),
     input.sdk.vcs.get().then((x) => {
       const next = x.data ?? input.store.vcs
       input.setStore("vcs", next)

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -179,6 +179,7 @@ export function createChildStoreManager(input: {
             limit: 5,
             message: {},
             part: {},
+            plugin: [],
           })
           children[directory] = child
           disposers.set(directory, dispose)

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -9,6 +9,7 @@ import type {
   Part,
   Path,
   PermissionRequest,
+  PluginStatusResponse,
   Project,
   ProviderListResponse,
   QuestionRequest,
@@ -62,6 +63,7 @@ export type State = {
     [name: string]: McpStatus
   }
   lsp: LspStatus[]
+  plugin: PluginStatusResponse
   vcs: VcsInfo | undefined
   limit: number
   message: {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -1,5 +1,4 @@
 import { TextAttributes } from "@opentui/core"
-import { fileURLToPath } from "bun"
 import { useTheme } from "../context/theme"
 import { useDialog } from "@tui/ui/dialog"
 import { useSync } from "@tui/context/sync"
@@ -15,28 +14,8 @@ export function DialogStatus() {
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
   const plugins = createMemo(() => {
-    const list = sync.data.config.plugin ?? []
-    const result = list.map((value) => {
-      if (value.startsWith("file://")) {
-        const path = fileURLToPath(value)
-        const parts = path.split("/")
-        const filename = parts.pop() || path
-        if (!filename.includes(".")) return { name: filename }
-        const basename = filename.split(".")[0]
-        if (basename === "index") {
-          const dirname = parts.pop()
-          const name = dirname || basename
-          return { name }
-        }
-        return { name: basename }
-      }
-      const index = value.lastIndexOf("@")
-      if (index <= 0) return { name: value, version: "latest" }
-      const name = value.substring(0, index)
-      const version = value.substring(index + 1)
-      return { name, version }
-    })
-    return result.toSorted((a, b) => a.name.localeCompare(b.name))
+    const list = sync.data.plugin ?? []
+    return list.toSorted((a, b) => a.name.localeCompare(b.name))
   })
 
   return (
@@ -155,7 +134,7 @@ export function DialogStatus() {
                 </text>
                 <text wrapMode="word" fg={theme.text}>
                   <b>{item.name}</b>
-                  {item.version && <span style={{ fg: theme.textMuted }}> @{item.version}</span>}
+                  {item.version && <span style={{ fg: theme.textMuted }}>@{item.version}</span>}
                 </text>
               </box>
             )}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -17,6 +17,7 @@ import type {
   ProviderListResponse,
   ProviderAuthMethod,
   VcsInfo,
+  PluginStatusResponse,
 } from "@opencode-ai/sdk/v2"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
@@ -75,6 +76,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       vcs: VcsInfo | undefined
       path: Path
       workspaceList: Workspace[]
+      plugin: PluginStatusResponse
     }>({
       provider_next: {
         all: [],
@@ -103,6 +105,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
       workspaceList: [],
+      plugin: [],
     })
 
     const sdk = useSDK()
@@ -414,6 +417,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
+            sdk.client.plugin.status().then((x) => setStore("plugin", reconcile(x.data!))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),
             sdk.client.session.status().then((x) => {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -12,6 +12,10 @@ import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-auth"
+import z from "zod"
+import path from "path"
+import { Global } from "../global"
+import { Filesystem } from "../util/filesystem"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -20,6 +24,13 @@ export namespace Plugin {
 
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin]
+
+  export const Status = z.object({
+    name: z.string(),
+    version: z.string().optional(),
+    source: z.enum(["npm", "file", "builtin"]),
+  })
+  export type Status = z.infer<typeof Status>
 
   const state = Instance.state(async () => {
     const client = createOpencodeClient({
@@ -145,5 +156,50 @@ export namespace Plugin {
         })
       }
     })
+  }
+
+  export async function status(): Promise<Status[]> {
+    const config = await Config.get()
+    const plugins = config.plugin ?? []
+    if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
+      plugins.unshift(...BUILTIN)
+    }
+
+    const result: Status[] = []
+
+    for (const plugin of plugins) {
+      if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue
+
+      if (plugin.startsWith("file://")) {
+        const filePath = plugin.replace("file://", "")
+        const parts = filePath.split("/")
+        const filename = parts.pop() || filePath
+        const name = filename.includes(".") ? filename.split(".")[0] : filename
+        result.push({ name, source: "file" })
+        continue
+      }
+
+      const lastAtIndex = plugin.lastIndexOf("@")
+      const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
+
+      // Read resolved version from installed package.json
+      try {
+        const pkgPath = path.join(Global.Path.cache, "node_modules", pkg, "package.json")
+        const pkgJson = await Filesystem.readJson<{ version?: string }>(pkgPath)
+        result.push({
+          name: pkg,
+          version: pkgJson.version,
+          source: BUILTIN.includes(plugin) ? "builtin" : "npm",
+        })
+      } catch {
+        // If package.json cannot be read, still add the plugin without version
+        result.push({
+          name: pkg,
+          source: BUILTIN.includes(plugin) ? "builtin" : "npm",
+        })
+      }
+    }
+
+    return result
   }
 }

--- a/packages/opencode/src/server/routes/plugin.ts
+++ b/packages/opencode/src/server/routes/plugin.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import { Plugin } from "../../plugin"
+import { lazy } from "../../util/lazy"
+
+export const PluginRoutes = lazy(() =>
+  new Hono().get(
+    "/",
+    describeRoute({
+      summary: "Get plugin status",
+      description: "Get the status of all installed plugins with their resolved versions.",
+      operationId: "plugin.status",
+      responses: {
+        200: {
+          description: "Plugin status",
+          content: {
+            "application/json": {
+              schema: resolver(Plugin.Status.array()),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      return c.json(await Plugin.status())
+    },
+  ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -30,6 +30,7 @@ import { ProjectRoutes } from "./routes/project"
 import { SessionRoutes } from "./routes/session"
 import { PtyRoutes } from "./routes/pty"
 import { McpRoutes } from "./routes/mcp"
+import { PluginRoutes } from "./routes/plugin"
 import { FileRoutes } from "./routes/file"
 import { ConfigRoutes } from "./routes/config"
 import { ExperimentalRoutes } from "./routes/experimental"
@@ -251,6 +252,7 @@ export namespace Server {
       .route("/provider", ProviderRoutes())
       .route("/", FileRoutes())
       .route("/mcp", McpRoutes())
+      .route("/plugin", PluginRoutes())
       .route("/tui", TuiRoutes())
       .post(
         "/instance/dispose",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -76,6 +76,7 @@ import type {
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
+  PluginStatusResponses,
   ProjectCurrentResponses,
   ProjectInitGitResponses,
   ProjectListResponses,
@@ -3116,6 +3117,27 @@ export class Mcp extends HeyApiClient {
   }
 }
 
+export class Plugin extends HeyApiClient {
+  /**
+   * Get plugin status
+   *
+   * Get the status of all installed plugins with their resolved versions.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<PluginStatusResponses, unknown, ThrowOnError>({
+      url: "/plugin",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Control extends HeyApiClient {
   /**
    * Get next TUI request
@@ -3980,6 +4002,11 @@ export class OpencodeClient extends HeyApiClient {
   private _mcp?: Mcp
   get mcp(): Mcp {
     return (this._mcp ??= new Mcp({ client: this.client }))
+  }
+
+  private _plugin?: Plugin
+  get plugin(): Plugin {
+    return (this._plugin ??= new Plugin({ client: this.client }))
   }
 
   private _tui?: Tui

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4432,6 +4432,28 @@ export type McpDisconnectResponses = {
 
 export type McpDisconnectResponse = McpDisconnectResponses[keyof McpDisconnectResponses]
 
+export type PluginStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/plugin"
+}
+
+export type PluginStatusResponses = {
+  /**
+   * Plugin status
+   */
+  200: Array<{
+    name: string
+    version?: string
+    source: "npm" | "file" | "builtin"
+  }>
+}
+
+export type PluginStatusResponse = PluginStatusResponses[keyof PluginStatusResponses]
+
 export type TuiAppendPromptData = {
   body?: {
     text: string


### PR DESCRIPTION
### Issue for this PR

Closes #8280

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The status dialogue in the TUI and the status popover in the desktop app currently print the version specifier for each installed plugin, but not concrete, resolved (actually installed) plugin version. This can make troubleshooting issues unnecessarily complex. Fix this by adding a new plug-ins and points to the server which returns the actually resolved versions and calling this from both clients.

### How did you verify your code works?

Built and ran both the TUI and the desktop app locally.

### Screenshots / recordings

#### TUI

<img width="533" height="415" alt="image" src="https://github.com/user-attachments/assets/b60d3c41-2941-438d-8ab9-b9b522689a13" />

#### Desktop

<img width="389" height="327" alt="image" src="https://github.com/user-attachments/assets/93cbb257-43cc-4208-a35c-99df898cf237" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
