### PR TITLE
fix(project): await git id cache write

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -138,7 +138,7 @@ export namespace Project {
 
           id = roots[0]
           if (id) {
-            void Filesystem.write(path.join(dotgit, "opencode"), id).catch(() => undefined)
+            await Filesystem.write(path.join(dotgit, "opencode"), id).catch(() => undefined)
           }
         }
 


### PR DESCRIPTION
## Summary
- await writing `.git/opencode` when caching the root commit id in `Project.fromDirectory`
- fixes a race where `fromDirectory()` returned before the cache file existed, causing flaky unit tests
- makes `Project.fromDirectory > should handle git repository with commits` deterministic across Linux/Windows