### PR TITLE
docs(mcp): add Exa auth examples and troubleshooting note

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,44 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Exa
+
+Add the [Exa MCP server](https://github.com/exa-labs/exa-mcp-server) for web search and code-context lookup.
+
+```json title="opencode.json" {4-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "exa": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "x-api-key": "{env:EXA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+If you prefer to run Exa locally, configure it like this:
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "exa": {
+      "type": "local",
+      "command": ["npx", "-y", "exa-mcp-server"],
+      "environment": {
+        "EXA_API_KEY": "{env:EXA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+If Exa returns an error like `x-api-key header is required`, check that `EXA_API_KEY` is available to the MCP process.

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -270,6 +270,49 @@ This will force opencode to download the most recent versions of provider packag
 
 ---
 
+### MCP server returns missing auth header
+
+If a remote MCP server returns an auth/header error (for example, `x-api-key header is required`):
+
+1. Confirm your API key is set in your environment (for example `EXA_API_KEY`)
+2. If using a remote MCP, pass headers explicitly in config
+3. If needed, switch to local MCP and set the key via `environment`
+
+Example remote config:
+
+```json
+{
+  "mcp": {
+    "exa": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "x-api-key": "{env:EXA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Example local config:
+
+```json
+{
+  "mcp": {
+    "exa": {
+      "type": "local",
+      "command": ["npx", "-y", "exa-mcp-server"],
+      "environment": {
+        "EXA_API_KEY": "{env:EXA_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+---
+
 ### Copy/paste not working on Linux
 
 Linux users need to have one of the following clipboard utilities installed for copy/paste functionality to work:


### PR DESCRIPTION
### Issue for this PR
Closes #14983

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds Exa-specific MCP docs to reduce setup friction:
- adds an Exa section to MCP servers docs with remote and local configuration examples
- shows explicit `x-api-key` header usage for remote Exa setup
- adds a troubleshooting section for missing MCP auth header errors (including `x-api-key header is required`)

### How did you verify your code works?
- verified the docs pages build content structure and markdown formatting in repo
- validated Exa setup path locally with `opencode run` and confirmed `exa_web_search_exa` works after applying the documented configuration

### Screenshots / recordings
N/A (docs-only change)

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR