### PR TITLE
feat(mcp): support independent timeout_connect for MCP servers

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -548,7 +548,13 @@ export namespace Config {
         .int()
         .positive()
         .optional()
-        .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+        .describe("Timeout in ms for MCP tool execution requests. Defaults to 30000 (30 seconds) if not specified."),
+      timeout_connect: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Timeout in ms specifically for the initial connection/handshake with the MCP server"),
     })
     .strict()
     .meta({
@@ -587,7 +593,13 @@ export namespace Config {
         .int()
         .positive()
         .optional()
-        .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
+        .describe("Timeout in ms for MCP tool execution requests. Defaults to 30000 (30 seconds) if not specified."),
+      timeout_connect: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Timeout in ms specifically for the initial connection/handshake with the MCP server"),
     })
     .strict()
     .meta({
@@ -1201,7 +1213,13 @@ export namespace Config {
             .int()
             .positive()
             .optional()
-            .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+            .describe("Timeout in milliseconds for model context protocol (MCP) tool execution requests"),
+          mcp_timeout_connect: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Timeout in milliseconds for the initial MCP server connection"),
         })
         .optional(),
     })

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -289,6 +289,7 @@ export namespace MCP {
   }
 
   async function create(key: string, mcp: Config.Mcp) {
+    const cfg = await Config.get()
     if (mcp.enabled === false) {
       log.info("mcp server disabled", { key })
       return {
@@ -343,7 +344,7 @@ export namespace MCP {
       ]
 
       let lastError: Error | undefined
-      const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
+      const connectTimeout = mcp.timeout_connect ?? cfg.experimental?.mcp_timeout_connect ?? mcp.timeout ?? cfg.experimental?.mcp_timeout ?? DEFAULT_TIMEOUT
       for (const { name, transport } of transports) {
         try {
           const client = new Client({
@@ -423,7 +424,7 @@ export namespace MCP {
         log.info(`mcp stderr: ${chunk.toString()}`, { key })
       })
 
-      const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
+      const connectTimeout = mcp.timeout_connect ?? cfg.experimental?.mcp_timeout_connect ?? mcp.timeout ?? cfg.experimental?.mcp_timeout ?? DEFAULT_TIMEOUT
       try {
         const client = new Client({
           name: "opencode",
@@ -463,7 +464,7 @@ export namespace MCP {
       }
     }
 
-    const result = await withTimeout(mcpClient.listTools(), mcp.timeout ?? DEFAULT_TIMEOUT).catch((err) => {
+    const result = await withTimeout(mcpClient.listTools(), mcp.timeout ?? cfg.experimental?.mcp_timeout ?? DEFAULT_TIMEOUT).catch((err) => {
       log.error("failed to get tools from client", { key, error: err })
       return undefined
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1613,9 +1613,13 @@ export type McpLocalConfig = {
    */
   enabled?: boolean
   /**
-   * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
+   * Timeout in ms for MCP tool execution requests. Defaults to 30000 (30 seconds) if not specified.
    */
   timeout?: number
+  /**
+   * Timeout in ms specifically for the initial connection/handshake with the MCP server
+   */
+  timeout_connect?: number
 }
 
 export type McpOAuthConfig = {
@@ -1657,9 +1661,13 @@ export type McpRemoteConfig = {
    */
   oauth?: McpOAuthConfig | false
   /**
-   * Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified.
+   * Timeout in ms for MCP tool execution requests. Defaults to 30000 (30 seconds) if not specified.
    */
   timeout?: number
+  /**
+   * Timeout in ms specifically for the initial connection/handshake with the MCP server
+   */
+  timeout_connect?: number
 }
 
 /**
@@ -1884,9 +1892,13 @@ export type Config = {
      */
     continue_loop_on_deny?: boolean
     /**
-     * Timeout in milliseconds for model context protocol (MCP) requests
+     * Timeout in milliseconds for model context protocol (MCP) tool execution requests
      */
     mcp_timeout?: number
+    /**
+     * Timeout in milliseconds for the initial MCP server connection
+     */
+    mcp_timeout_connect?: number
   }
 }
 


### PR DESCRIPTION
### Issue for this PR
Closes #11584
Closes #13672

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Introduces the ability to independently configure the timeout for connecting to an MCP server (`timeout_connect`) versus the timeout for tool executions/requests (`timeout`). 

Currently, OpenCode uses a single `timeout` config for both the initial handshake (which can take a long time if a `uvx` or `npx` server needs to cold-start) and subsequent tool executions (which might need to be short or infinite). This PR separates them:
1. Adds `timeout_connect` to `McpLocal` and `McpRemote` schemas.
2. Adds `experimental.mcp_timeout_connect` as a global fallback.
3. Fixes `src/mcp/index.ts` to use `timeout_connect` when calling `client.connect()` and preserves `timeout` for `mcpClient.listTools()` and `convertMcpTool()`.

### How did you verify your code works?

Locally built and ran typecheck/tests successfully. Verified that setting `timeout_connect` in `opencode.json` correctly applies to the connection phase without interfering with tool request timeouts.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR