### PR TITLE
fix(tui): enable OSC 8 hyperlink detection for tree-sitter markdown

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -27,6 +27,7 @@ import {
   type ScrollAcceleration,
   TextAttributes,
   RGBA,
+  detectLinks,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
@@ -1467,6 +1468,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
               fg={theme.text}
+              onChunks={detectLinks}
             />
           </Match>
         </Switch>


### PR DESCRIPTION
## Summary

Enables OSC 8 hyperlink sequences for URLs rendered via the tree-sitter markdown path, making Cmd/Ctrl+Click work correctly for wrapped links in terminal emulators.

Closes #14966

## Changes

- Import `detectLinks` from `@opentui/core`
- Pass `onChunks={detectLinks}` to the markdown `<code>` renderable in `TextPart`

This is a 2-line change that wires up the new `onChunks` hook added in [anomalyco/opentui#736](https://github.com/anomalyco/opentui/pull/736).

## Dependencies

⚠️ **Blocked on**: [anomalyco/opentui#736](https://github.com/anomalyco/opentui/pull/736) being merged and a new `@opentui/core` release that exports `detectLinks`.

## How It Works

1. Tree-sitter highlights markdown content, identifying URL scopes
2. `treeSitterToTextChunks` creates styled text chunks (no link info)
3. **`detectLinks`** (our new hook) runs post-processing: scans highlights for URL scopes, sets `chunk.link = { url }` on matching chunks
4. The renderer emits OSC 8 escape sequences for chunks with `link` set
5. Terminal emulators (iTerm2, Ghostty, kitty, WezTerm, Alacritty) make URLs Cmd/Ctrl+clickable

## Testing

- Manually verified in iTerm2: Cmd+Click opens the full correct URL even when the link wraps across multiple terminal lines
- All existing tests pass