### PR TITLE
feat(agents): accept "inherit" as the model

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -685,7 +685,7 @@ export namespace Config {
 
   export const Agent = z
     .object({
-      model: ModelId.optional(),
+      model: z.union([ModelId, z.literal("inherit")]).optional(),
       variant: z
         .string()
         .optional()
@@ -760,8 +760,9 @@ export namespace Config {
 
       // Convert legacy maxSteps to steps
       const steps = agent.steps ?? agent.maxSteps
+      const model = agent.model === "inherit" ? undefined : agent.model
 
-      return { ...agent, options, permission, steps } as typeof agent & {
+      return { ...agent, model, options, permission, steps } as typeof agent & {
         options?: Record<string, unknown>
         permission?: Permission
         steps?: number

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -148,6 +148,30 @@ test("custom agent from config creates new agent", async () => {
   })
 })
 
+test("agent model inherit uses default model resolution", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        my_custom_agent: {
+          model: "inherit",
+          description: "My custom agent",
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const custom = await Agent.get("my_custom_agent")
+      expect(custom).toBeDefined()
+      expect(custom?.model).toBeUndefined()
+      expect(custom?.description).toBe("My custom agent")
+      expect(custom?.native).toBe(false)
+      expect(custom?.mode).toBe("all")
+    },
+  })
+})
+
 test("custom agent config overrides native agent properties", async () => {
   await using tmp = await tmpdir({
     config: {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -275,6 +275,31 @@ test("handles agent configuration", async () => {
   })
 })
 
+test("treats agent model inherit as unset", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        agent: {
+          test_agent: {
+            model: "inherit",
+            description: "test agent",
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const agent = config.agent?.["test_agent"]
+      expect(agent?.model).toBeUndefined()
+      expect(agent?.description).toBe("test agent")
+    },
+  })
+})
+
 test("treats agent variant as model-scoped setting (not provider option)", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Agents now accept the literal value "inherit" as the model, and treat it as unset during config normalization. It acts exactly as if the agent model was omitted.

This improves compatibility with Claude Code agents, which accept the "inherit" keyword for models.

It's simple and backward-compatible.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
New tests added:
- `packages/opencode/test/config/config.test.ts`: verifies model: "inherit" is parsed as unset (undefined)
- `packages/opencode/test/agent/agent.test.ts`: verifies an agent configured with model: "inherit" has no explicit model in resolved agent state

Run with: `bun test test/config/config.test.ts test/agent/agent.test.ts`

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._