### PR TITLE
docs: add opencode-channels to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -52,19 +52,20 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Projects
 
-| Name                                                                                       | Description                                                      |
-| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
-| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
-| [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
-| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |
-| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent  |
-| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
-| [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
-| [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
-| [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
-| [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
-| [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| Name                                                                                       | Description                                                                                      |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK                                       |
+| [opencode-channels](https://github.com/kortix-ai/opencode-channels)                        | Slack chatbot for OpenCode with streaming, slash commands, and reactions via the Chat SDK         |
+| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API                                         |
+| [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN                                              |
+| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                                                           |
+| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent                                  |
+| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk                                   |
+| [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode                                             |
+| [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI                                            |
+| [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode                                 |
+| [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.                                     |
+| [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode                                          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes N/A — this adds a community project to the ecosystem page as encouraged by the docs.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-channels](https://github.com/kortix-ai/opencode-channels) to the Projects table in the ecosystem docs page.

opencode-channels is a Slack chatbot that connects any OpenCode instance to Slack. It uses the [Vercel Chat SDK](https://github.com/vercel/chat) to handle streaming responses, reactions, slash commands, and file uploads. A single webhook endpoint receives all Slack events, creates/reuses OpenCode sessions per thread, and streams responses back with live message editing.

The change is one table row added to `ecosystem.mdx` in the Projects section.

### How did you verify your code works?

- Confirmed the added row matches the existing table format (pipe-delimited, same column widths)
- Verified the repo URL https://github.com/kortix-ai/opencode-channels resolves correctly
- No code changes, documentation only

### Screenshots / recordings

_N/A — single table row addition, no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR