### PR TITLE
fix(core): reinforce project instructions in Task tool sub-agent prompts

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -7,6 +7,7 @@ import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "../config"
 import { Effect, Schema } from "effect"
+import { Instruction } from "../session/instruction"
 
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): void
@@ -128,6 +129,16 @@ export const TaskTool = Tool.define(
         () =>
           Effect.gen(function* () {
             const parts = yield* ops.resolvePromptParts(params.prompt)
+
+            const instructions = yield* Effect.promise(() => Instruction.systemPaths())
+            if (instructions.size > 0) {
+              const names = [...instructions].map((p) => p.split("/").pop()).join(", ")
+              parts.push({
+                type: "text",
+                text: `IMPORTANT: You must follow all project-level instructions from your system prompt (${names}). These rules apply to this task.`,
+              })
+            }
+
             const result = yield* ops.prompt({
               messageID,
               sessionID: nextSession.id,


### PR DESCRIPTION
### Issue for this PR

Closes #14633

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When Task tool spawns sub-agents for parallel batch processing, AGENTS.md/CLAUDE.md instructions are loaded into the system prompt correctly, but the task user message doesn't reference them. Sub-agents start with a fresh single-message context, so the model deprioritizes system-level instructions in favor of the immediate task — attention dilution causes instruction loss.

The fix appends a short reminder to the task prompt parts telling the sub-agent to follow its system prompt instructions, including the filenames of discovered instruction files. This costs ~2 lines of model context and bridges the gap between system instructions and the user task message.

Changed file: `packages/opencode/src/tool/task.ts` (+10 lines, 0 deletions).

### How did you verify your code works?

- `tsgo --noEmit` — zero type errors
- `bun test test/session/instruction.test.ts` — 6/6 pass
- `bun test test/session/llm.test.ts` — 10/10 pass
- `bun test test/session/prompt.test.ts` — 2/4 pass (2 pre-existing failures on clean main, unrelated)
- Verified pre-existing test failures exist on clean `d848c9b` by stash/pop

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR