### PR TITLE
fix: consume stdout concurrently with process exit in auth login

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -268,18 +268,17 @@ export const AuthLoginCommand = cmd({
           const proc = Process.spawn(wellknown.auth.command, {
             stdout: "pipe",
           })
-          const exit = await proc.exited
-          if (exit !== 0) {
-            prompts.log.error("Failed")
-            prompts.outro("Done")
-            return
-          }
           if (!proc.stdout) {
             prompts.log.error("Failed")
             prompts.outro("Done")
             return
           }
-          const token = await text(proc.stdout)
+          const [exit, token] = await Promise.all([proc.exited, text(proc.stdout)])
+          if (exit !== 0) {
+            prompts.log.error("Failed")
+            prompts.outro("Done")
+            return
+          }
           await Auth.set(args.url, {
             type: "wellknown",
             key: wellknown.auth.env,


### PR DESCRIPTION
The auth login flow awaited proc.exited before reading proc.stdout, causing the stream to close before consumption. The token was lost, resulting in an empty string stored in auth.json.

Read stdout in parallel with proc.exited via Promise.all, matching the pattern already used by Process.run().

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

opencode auth login <url> stores an empty token in auth.json because the code awaits proc.exited before starting to read proc.stdout. By the time text(proc.stdout) runs, the child process has already exited and the OS has closed the pipe — the stream data is lost.

The fix reads stdout concurrently with the process exit via Promise.all, so the stream is actively consumed while the process is still running.

### How did you verify your code works?

1. Ran opencode auth login <url> on dev (unfixed) — confirmed auth.json has "token": ""
2. Switched to fix branch, cleared auth.json, ran again and confirmed token is now populated with the actual value

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
