### PR TITLE
fix(zen): usage chart displays dates in local timezone

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/graph-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/graph-section.tsx
@@ -132,7 +132,7 @@ function formatDateLabel(dateStr: string): string {
   date.setDate(d)
   date.setHours(0, 0, 0, 0)
   const month = date.toLocaleDateString(undefined, { month: "short" })
-  const day = date.getUTCDate().toString().padStart(2, "0")
+  const day = date.getDate().toString().padStart(2, "0")
   return `${month} ${day}`
 }
 
@@ -188,7 +188,10 @@ export function GraphSection() {
     const daysInMonth = new Date(store.year, store.month + 1, 0).getDate()
     return Array.from({ length: daysInMonth }, (_, i) => {
       const date = new Date(store.year, store.month, i + 1)
-      return date.toISOString().split("T")[0]
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, "0")
+      const day = String(date.getDate()).padStart(2, "0")
+      return `${year}-${month}-${day}`
     })
   })
 


### PR DESCRIPTION
## Summary
- Fix issue #14988 where the Zen usage chart was displaying dates in UTC instead of the user's local timezone
- The chart was showing the next day when the user's local time was before midnight UTC

## Changes
- `getDates`: Use local date methods instead of `toISOString().split("T")[0]` which returns UTC dates
- `formatDateLabel`: Use `getDate()` instead of `getUTCDate()` to get local day

## Root Cause
- `toISOString()` always returns dates in UTC format
- `getUTCDate()` returns the day of the month in UTC, not local time
- When a user is in a timezone like EST (UTC-5), at 8pm local time on Feb 24, the UTC date is already Feb 25

## Testing
- [ ] Test with timezone before midnight UTC (e.g., EST, PST)
- [ ] Verify chart shows correct local date

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: N/A (UI-only change)
  - Metrics/Dashboards: N/A
- **Validation checks (queries/commands)**
  - View usage chart in a timezone before midnight UTC and verify correct date displays
- **Expected healthy behavior**
  - Chart displays dates in user's local timezone
- **Failure signal(s) /rollback trigger**
  - If chart still shows incorrect dates, revert this PR
- **Validation window & owner**
  - Window: One-time check after deploy
  - Owner: QA reviewer

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)