### PR TITLE
fix(llm): repair malformed unicode escapes in tool call args via jsonrepair

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -329,6 +329,7 @@
         "hono-openapi": "catalog:",
         "ignore": "7.0.5",
         "jsonc-parser": "3.3.1",
+        "jsonrepair": "3.13.2",
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
         "open": "10.1.2",
@@ -2995,6 +2996,8 @@
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
+
+    "jsonrepair": ["jsonrepair@3.13.2", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -114,6 +114,7 @@
     "hono-openapi": "catalog:",
     "ignore": "7.0.5",
     "jsonc-parser": "3.3.1",
+    "jsonrepair": "3.13.2",
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
     "open": "10.1.2",

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -1,3 +1,4 @@
+import { jsonrepair } from "jsonrepair"
 import { Installation } from "@/installation"
 import { Provider } from "@/provider/provider"
 import { Log } from "@/util/log"
@@ -186,6 +187,18 @@ export namespace LLM {
             ...failed.toolCall,
             toolName: lower,
           }
+        }
+        // Attempt to repair malformed JSON args (e.g. invalid unicode escapes
+        // like \u6\uC218 produced by CJK tokenization drift in the model)
+        try {
+          const repaired = jsonrepair(failed.toolCall.args)
+          JSON.parse(repaired) // validate it actually parses
+          l.info("repaired malformed tool call args via jsonrepair", {
+            tool: failed.toolCall.toolName,
+          })
+          return { ...failed.toolCall, args: repaired }
+        } catch {
+          // jsonrepair could not fix it, fall through to invalid
         }
         return {
           ...failed.toolCall,


### PR DESCRIPTION
## Problem

When a model generates tool call arguments containing **invalid unicode escape sequences** (e.g. `\u6수` instead of `\u6536` for the Chinese character 收), `JSON.parse()` throws a parse error. The call then falls through to the `invalid` tool, showing the user:

```
invalid [tool=edit, error=Invalid input for tool edit: JSON parsing failed: ...]
```

This happens reliably when editing files with CJK (Chinese/Japanese/Korean) content in `lines[]` arguments — the model occasionally conflates hex digits with visually similar CJK characters during tokenization.

## Root Cause

In `packages/opencode/src/session/llm.ts`, `experimental_repairToolCall` only handles two cases:
1. Tool name case mismatch (e.g. `Edit` → `edit`)  
2. Everything else → route to `invalid` tool

There is no attempt to repair malformed JSON before giving up.

## Fix

Add a `jsonrepair` pass between the case-repair check and the `invalid` fallback:

```typescript
// Attempt to repair malformed JSON args (e.g. invalid unicode escapes
// like \u6\uC218 produced by CJK tokenization drift in the model)
try {
  const repaired = jsonrepair(failed.toolCall.args)
  JSON.parse(repaired) // validate it actually parses
  l.info("repaired malformed tool call args via jsonrepair", { tool: failed.toolCall.toolName })
  return { ...failed.toolCall, args: repaired }
} catch {
  // jsonrepair could not fix it, fall through to invalid
}
```

`jsonrepair` is a battle-tested library specifically designed to fix common JSON syntax errors including invalid escape sequences, unquoted strings, trailing commas, etc.

## Changes

- `packages/opencode/package.json` — add `jsonrepair@3.13.2` dependency
- `packages/opencode/src/session/llm.ts` — import `jsonrepair`, add repair attempt in `experimental_repairToolCall`
- `bun.lock` — updated

## Testing

Reproduce by asking the model to edit a Python file containing Chinese comments. Before this fix the edit fails with a JSON parse error; after this fix the repair succeeds and the edit proceeds normally.