### PR TITLE
fix(desktop): remove interactive shell flag from sidecar spawn to prevent hang on macOS

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -320,7 +320,7 @@ pub fn spawn_command(
         };
 
         let mut cmd = Command::new(shell);
-        cmd.args(["-il", "-c", &line]);
+        cmd.args(["-l", "-c", &line]);
 
         for (key, value) in envs {
             cmd.env(key, value);


### PR DESCRIPTION
### What does this PR do?

Removes the `-i` (interactive) flag from the shell invocation used to spawn the sidecar CLI process on non-Windows platforms.

**Before:** `$SHELL -il -c "opencode-cli serve --port=..."`  
**After:** `$SHELL -l -c "opencode-cli serve --port=..."`

The `-i` flag forces the shell into interactive mode, which triggers initialization of ZLE (Zsh Line Editor) hooks and interactive plugins from `~/.zshrc` (e.g. `zsh-syntax-highlighting`, `zsh-autosuggestions`, oh-my-zsh themes). Since the desktop app spawns this process without a TTY, these ZLE-dependent plugins hang indefinitely during initialization, causing the "Starting server..." infinite loading screen.

The `-l` (login) flag alone is sufficient to source `~/.zprofile` for PATH setup (Homebrew, nvm, etc.) without triggering interactive-only initialization.

**Reproduction:**
```bash
# Works (non-interactive):
zsh -l -c "/Applications/OpenCode.app/Contents/MacOS/opencode-cli debug config"

# Hangs (interactive, no TTY):
zsh -il -c "/Applications/OpenCode.app/Contents/MacOS/opencode-cli debug config"
```

Fixes #15050

Related: #13926, #9505, #8716, #13597

### How did you verify your code works?

1. Confirmed `zsh -l -c "opencode-cli debug config"` completes instantly while `zsh -il -c "opencode-cli debug config"` hangs indefinitely on macOS with oh-my-zsh + zsh-syntax-highlighting + zsh-autosuggestions installed.
2. Verified the desktop app starts successfully after applying the equivalent workaround (TTY guards in `~/.zshrc` for the same blocking code paths).
3. Verified Windows path is unaffected (uses direct sidecar execution, not shell wrapper).