### PR TITLE
fix(zen): usage chart displays dates in local timezone

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/graph-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/graph-section.tsx
@@ -132,7 +132,7 @@ function formatDateLabel(dateStr: string): string {
   date.setDate(d)
   date.setHours(0, 0, 0, 0)
   const month = date.toLocaleDateString(undefined, { month: "short" })
-  const day = date.getUTCDate().toString().padStart(2, "0")
+  const day = date.getDate().toString().padStart(2, "0")
   return `${month} ${day}`
 }
 
@@ -188,7 +188,10 @@ export function GraphSection() {
     const daysInMonth = new Date(store.year, store.month + 1, 0).getDate()
     return Array.from({ length: daysInMonth }, (_, i) => {
       const date = new Date(store.year, store.month, i + 1)
-      return date.toISOString().split("T")[0]
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, "0")
+      const day = String(date.getDate()).padStart(2, "0")
+      return `${year}-${month}-${day}`
     })
   })
 


### PR DESCRIPTION
Fix issue #14988 where the usage chart was showing dates in UTC instead of the user's local timezone. This caused the chart to display the next day when the user's local time was before midnight UTC.

Changes:
- getDates: Use local date methods instead of toISOString()
- formatDateLabel: Use getDate() instead of getUTCDate()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
