### PR TITLE
fix(app): Cannot approve/deny long bash commands

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -812,6 +812,8 @@
     gap: 4px;
     flex: 1;
     min-height: 0;
+    max-height: 50vh;
+    overflow: scroll;
   }
 
   [data-slot="permission-hint"] {


### PR DESCRIPTION
### Issue for this PR

Closes #14964

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes approve/deny buttons pushed out of container by long bash commands.

Adds a max-height to the permission-content as a proportion of the viewport height and makes scrollable.

### How did you verify your code works?

```
 bun run --cwd packages/opencode --conditions=browser ./src/index.ts serve --port 4096
 bun --cwd packages/app dev -- --port 4444
```

Verified in Safari and Chrome

### Screenshots / recordings

Before:
<img width="650" height="989" alt="Screenshot 2026-02-24 at 21 45 03" src="https://github.com/user-attachments/assets/2f1de40f-27c6-4a9e-bafb-58de221b6ef3" />


After:
<img width="610" height="707" alt="Screenshot 2026-02-24 at 21 46 14" src="https://github.com/user-attachments/assets/a4791ebc-ec04-434e-bc70-14cf65739802" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Thanks
