### PR TITLE
fix(core): permission spam

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -313,14 +313,26 @@ pub fn spawn_command(
         let sidecar = get_sidecar_path(app);
         let shell = get_user_shell();
 
-        let line = if shell.ends_with("/nu") {
+        let mut line = if shell.ends_with("/nu") {
             format!("^\"{}\" {}", sidecar.display(), args)
         } else {
             format!("\"{}\" {}", sidecar.display(), args)
         };
 
+        if shell.ends_with("/zsh") {
+            line = format!(
+                "[[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true; [[ -f \"${{ZDOTDIR:-$HOME}}/.zshrc\" ]] && source \"${{ZDOTDIR:-$HOME}}/.zshrc\" >/dev/null 2>&1 || true; {line}"
+            );
+        }
+
+        if shell.ends_with("/bash") {
+            line = format!(
+                "shopt -s expand_aliases; [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true; {line}"
+            );
+        }
+
         let mut cmd = Command::new(shell);
-        cmd.args(["-il", "-c", &line]);
+        cmd.args(["-l", "-c", &line]);
 
         for (key, value) in envs {
             cmd.env(key, value);

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -347,7 +347,17 @@ export namespace File {
         const dirs = new Set<string>()
         const ignore = new Set<string>()
 
-        if (process.platform === "darwin") ignore.add("Library")
+        if (process.platform === "darwin") {
+          ignore.add("Applications")
+          ignore.add("Desktop")
+          ignore.add("Documents")
+          ignore.add("Downloads")
+          ignore.add("Library")
+          ignore.add("Movies")
+          ignore.add("Music")
+          ignore.add("Pictures")
+          ignore.add("Public")
+        }
         if (process.platform === "win32") ignore.add("AppData")
 
         const ignoreNested = new Set(["node_modules", "dist", "build", "target", "vendor"])

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -348,15 +348,10 @@ export namespace File {
         const ignore = new Set<string>()
 
         if (process.platform === "darwin") {
-          ignore.add("Applications")
-          ignore.add("Desktop")
-          ignore.add("Documents")
-          ignore.add("Downloads")
           ignore.add("Library")
           ignore.add("Movies")
           ignore.add("Music")
           ignore.add("Pictures")
-          ignore.add("Public")
         }
         if (process.platform === "win32") ignore.add("AppData")
 


### PR DESCRIPTION
### Issue for this PR

Closes #15090  #14982

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

My thesis: after some changing in how the sidecar is spawned it is more tightly coupled with the desktop app
Due to this scanning the personal directories was requesting users for permission to personal folders. 
It never went away

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

We need some mac users to verify it 

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

not on mac hard to test, help me 

_If you do not follow this template your PR will be automatically rejected._
