### PR TITLE
fix(mcp): improve diagnostics for remote MCP connection failures

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1258,7 +1258,14 @@ export namespace Config {
     const isFile = "path" in options
 
     text = text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-      return process.env[varName] || ""
+      const value = process.env[varName]
+      if (value === undefined) {
+        log.info("env var referenced in config is not set", {
+          variable: varName,
+          source,
+        })
+      }
+      return value ?? ""
     })
 
     const fileMatches = text.match(/\{file:[^}]+\}/g)

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -403,6 +403,13 @@ export namespace MCP {
           }
         }
       }
+      if (status?.status === "failed" && lastError) {
+        log.warn("all transports failed for remote mcp server", {
+          key,
+          url: mcp.url,
+          error: lastError.message,
+        })
+      }
     }
 
     if (mcp.type === "local") {


### PR DESCRIPTION
## Summary

- **config**: `log.info` when `{env:VAR}` resolves to `undefined` — currently silently substitutes empty string, causing hard-to-debug MCP auth failures
- **mcp**: `log.warn` only when ALL transports fail (not on individual attempts) — avoids false-positive warnings during expected StreamableHTTP→SSE fallback

## Problem

When configuring remote MCP servers with `{env:SOME_API_KEY}`, if the env var isn't exported in the shell where opencode was launched, the value silently becomes `""`. The MCP server then returns auth errors (401/406), but transport failures were only logged at `debug` level — invisible at default log level.

Additionally, the original empty-env-var check used `!value` which conflates `undefined` (var not set) with `""` (var explicitly set to empty string), producing misleading warnings.

## Changes

### `packages/opencode/src/config/config.ts`
- Emit `log.info` with variable name and config source when `{env:VAR}` resolves to `undefined`
- Use `value === undefined` (not `!value`) to avoid false positives on intentionally empty vars
- Use `value ?? ""` (nullish coalescing) instead of `value || ""` for correctness

### `packages/opencode/src/mcp/index.ts`
- Keep individual transport attempt failures at `log.debug` (expected during StreamableHTTP→SSE fallback)
- Add `log.warn` after the transport loop when ALL transports are exhausted — the actual failure case users need to see

Closes #15103