### PR TITLE
fix(opencode): skip overflow check on compaction summaries

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -279,7 +279,7 @@ export namespace SessionProcessor {
                     sessionID: input.sessionID,
                     messageID: input.assistantMessage.parentID,
                   })
-                  if (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model })) {
+                  if (!input.assistantMessage.summary && await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model })) {
                     needsCompaction = true
                   }
                   break


### PR DESCRIPTION
### Issue for this PR

Closes #13946

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In headless mode (`opencode run`), the process exits cleanly after compaction when the compaction model generates a large response. The root cause is in `processor.ts` line 282: `isOverflow()` runs on the compaction model's *own* response tokens. When that response exceeds the overflow threshold, `needsCompaction` is set to `true`, the processor returns `"compact"` instead of `"continue"`, the synthetic continuation message is never created, and the prompt loop exits.

The fix is a one-line guard: skip the `isOverflow()` check when `input.assistantMessage.summary === true` (i.e., the current message is already a compaction summary). Re-compacting a compaction is never the intended behavior.

This was 100% reproducible in my testing — across 82 compaction events, all 11 "deaths" (clean exits after compaction) correlated with compaction responses where total tokens exceeded the overflow threshold.

### How did you verify your code works?

- All 109 session tests pass (`bun test packages/opencode/test/session/`)
- Full test suite: 1157/1158 pass (1 pre-existing failure in `write.test.ts` — environment-specific umask issue, unrelated)
- Manual verification: ran multiple headless sessions with compaction — no more premature exits

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR