### PR TITLE
fix(desktop): remove interactive shell flag from sidecar spawn to prevent hang on macOS

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -320,7 +320,7 @@ pub fn spawn_command(
         };
 
         let mut cmd = Command::new(shell);
-        cmd.args(["-il", "-c", &line]);
+        cmd.args(["-l", "-c", &line]);
 
         for (key, value) in envs {
             cmd.env(key, value);


### PR DESCRIPTION
### Issue for this PR

Closes #15050

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop app spawns the CLI sidecar using `$SHELL -il -c "opencode-cli serve --port=..."`. The `-i` (interactive) flag causes the shell to load interactive-mode plugins (zsh-syntax-highlighting, zsh-autosuggestions, etc.) that depend on ZLE/TTY. Since the Tauri sidecar runs without a TTY, these plugins hang indefinitely waiting for terminal features that don't exist, causing the health check to timeout and the app to show an infinite loading screen.

This is an extremely common setup — oh-my-zsh with syntax highlighting and autosuggestions is one of the most popular shell configurations. The sidecar doesn't need an interactive shell; it only needs login shell environment variables (PATH, etc.) which `-l` alone provides.

The fix removes `-i` from the shell args, changing `"-il"` to `"-l"`. This preserves the login shell behavior (loading `.zprofile`/`.zshrc` PATH exports) while avoiding interactive-mode plugin initialization that requires a TTY.

**Why this works:** `zsh -l -c "command"` loads login environment (PATH, brew, cargo, etc.) without initializing ZLE, prompt themes, or terminal-dependent plugins. The sidecar only needs the environment — not an interactive session.

### How did you verify your code works?

1. Confirmed root cause by comparing `zsh -c "echo ok"` (instant) vs `zsh -il -c "echo ok"` (hangs) with a typical oh-my-zsh + zsh-syntax-highlighting + zsh-autosuggestions setup
2. Verified `zsh -l -c "echo $PATH"` correctly loads login environment variables
3. Tested the desktop app launches successfully after the change with the same shell configuration that previously caused infinite loading

### Screenshots / recordings

_N/A — backend change, no UI modification._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR