### PR TITLE
fix: prevent infinite retry loop from orphaned tool_use blocks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -249,9 +249,79 @@ export namespace ProviderTransform {
     })
   }
 
+  /**
+   * Defensive validation: ensures every tool_use (tool-call) in an assistant message
+   * has a corresponding tool_result in the immediately following tool message.
+   * If orphaned tool_use blocks are found, injects synthetic error tool_results.
+   * This prevents Anthropic API errors:
+   *   "tool_use ids were found without tool_result blocks immediately after"
+   */
+  function repairOrphanedToolUse(msgs: ModelMessage[]): ModelMessage[] {
+    const result: ModelMessage[] = []
+
+    for (let i = 0; i < msgs.length; i++) {
+      const msg = msgs[i]
+      result.push(msg)
+
+      // Only check assistant messages with tool-call parts
+      if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue
+      const toolCallIds = msg.content
+        .filter((p): p is Extract<typeof p, { type: "tool-call" }> => p.type === "tool-call")
+        .map((p) => p.toolCallId)
+      if (toolCallIds.length === 0) continue
+
+      // Collect tool-result IDs from the next tool message
+      const next = msgs[i + 1]
+      const existingResultIds = new Set<string>()
+      if (next && next.role === "tool" && Array.isArray(next.content)) {
+        for (const part of next.content) {
+          if (part.type === "tool-result") {
+            existingResultIds.add(part.toolCallId)
+          }
+        }
+      }
+
+      // Find orphaned tool calls (no matching tool result)
+      const orphaned = toolCallIds.filter((id) => !existingResultIds.has(id))
+      if (orphaned.length === 0) continue
+
+      // If there's already a tool message, inject missing results into it
+      if (next && next.role === "tool" && Array.isArray(next.content)) {
+        const syntheticResults = orphaned.map((id) => ({
+          type: "tool-result" as const,
+          toolCallId: id,
+          content: "[Tool execution was interrupted]",
+          isError: true as const,
+        }))
+        const patched = {
+          ...next,
+          content: [...next.content, ...syntheticResults],
+        }
+        // Replace the next message with the patched version
+        i++ // skip the original next message
+        result.push(patched as typeof next)
+      } else {
+        // No tool message follows - insert a synthetic one
+        const syntheticResults = orphaned.map((id) => ({
+          type: "tool-result" as const,
+          toolCallId: id,
+          content: "[Tool execution was interrupted]",
+          isError: true as const,
+        }))
+        result.push({
+          role: "tool" as const,
+          content: syntheticResults,
+        } as ModelMessage)
+      }
+    }
+
+    return result
+  }
+
   export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
     msgs = unsupportedParts(msgs, model)
     msgs = normalizeMessages(msgs, model, options)
+    msgs = repairOrphanedToolUse(msgs)
     if (
       (model.providerID === "anthropic" ||
         model.api.id.includes("anthropic") ||

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -39,6 +39,8 @@ export namespace LLM {
     tools: Record<string, Tool>
     retries?: number
     toolChoice?: "auto" | "required" | "none"
+    /** Optional callback to rebuild messages from DB on retry, ensuring orphaned tool_use blocks are cleaned up */
+ rebuildMessages?: () => Promise<ModelMessage[]>
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -358,6 +358,32 @@ export namespace SessionProcessor {
             }
             const retry = SessionRetry.retryable(error)
             if (retry !== undefined) {
+              // Clean up orphaned tool calls before retrying - any pending/running tools
+              // from the failed stream must be marked as errors, otherwise the retry will
+              // send orphaned tool_use blocks without matching tool_result blocks, causing
+              // Anthropic API errors ("tool_use ids were found without tool_result blocks")
+              const orphanedParts = await MessageV2.parts(input.assistantMessage.id)
+              for (const part of orphanedParts) {
+                if (part.type === "tool" && part.state.status !== "completed" && part.state.status !== "error") {
+                  await Session.updatePart({
+                    ...part,
+                    state: {
+                      ...part.state,
+                      status: "error",
+                      error: "Tool execution aborted",
+                      time: {
+                        start: Date.now(),
+                        end: Date.now(),
+                      },
+                    },
+                  })
+                }
+              }
+              // Rebuild messages from DB to reflect the cleaned-up orphaned tool calls.
+              // Without this, the retry would send stale messages with orphaned tool_use blocks.
+              if (streamInput.rebuildMessages) {
+                streamInput.messages = await streamInput.rebuildMessages()
+              }
               attempt++
               const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
               SessionStatus.set(input.sessionID, {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -674,6 +674,21 @@ export namespace SessionPrompt {
         tools,
         model,
         toolChoice: format.type === "json_schema" ? "required" : undefined,
+        // Rebuild messages from DB on retry to pick up orphaned tool_use cleanup
+        rebuildMessages: async () => {
+          const fresh = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+          return [
+            ...MessageV2.toModelMessages(fresh, model),
+            ...(isLastStep
+              ? [
+                  {
+                    role: "assistant" as const,
+                    content: MAX_STEPS,
+                  },
+                ]
+              : []),
+          ]
+        },
       })
 
       // If structured output was captured, save it and exit immediately

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -84,6 +84,13 @@ export namespace SessionRetry {
       if (!json || typeof json !== "object") return undefined
       const code = typeof json.code === "string" ? json.code : ""
 
+      // invalid_request_error should never be retried - these are structural issues
+      // with the request (e.g., orphaned tool_use blocks without tool_result) that
+      // will fail identically on every retry attempt, causing an infinite loop
+      if (json.type === "error" && json.error?.type === "invalid_request_error") {
+        return undefined
+      }
+
       if (json.type === "error" && json.error?.type === "too_many_requests") {
         return "Too Many Requests"
       }
@@ -93,7 +100,10 @@ export namespace SessionRetry {
       if (json.type === "error" && json.error?.code?.includes("rate_limit")) {
         return "Rate Limited"
       }
-      return JSON.stringify(json)
+      // Only retry errors that are explicitly recognized as transient.
+      // The previous catch-all `return JSON.stringify(json)` caused infinite retry
+      // loops for non-transient errors like invalid_request_error.
+      return undefined
     } catch {
       return undefined
     }


### PR DESCRIPTION
## Summary

Fixes an unrecoverable session crash caused by orphaned `tool_use` blocks triggering an infinite retry loop against the Anthropic API.

**Error:** `tool_use ids were found without tool_result blocks immediately after: toolu_vrtx_...`

## Root Cause

Three bugs combine to create the infinite loop:

1. **Retry loop skips orphan cleanup** (`processor.ts`): The `continue` statement in the retry path jumps back to `while(true)`, bypassing the orphan cleanup code (lines 393-409) that marks pending/running tools as errors. Orphaned `tool_use` blocks persist in message history.

2. **Stale messages on retry** (`processor.ts`): `streamInput.messages` is built once before the retry loop and never refreshed from the database. Even if orphan cleanup ran, retries send the same broken messages.

3. **`invalid_request_error` incorrectly classified as retryable** (`retry.ts`): The catch-all `return JSON.stringify(json)` makes ALL JSON error bodies retryable, including `invalid_request_error` — a structural issue that fails identically on every attempt.

## Fixes

| File | Change |
|---|---|
| `processor.ts` | Move orphan cleanup **before** the retry `continue`; rebuild messages from DB on retry via new `rebuildMessages` callback |
| `llm.ts` | Add optional `rebuildMessages` callback to `StreamInput` interface |
| `prompt.ts` | Wire up `rebuildMessages` to re-read messages from DB and convert via `toModelMessages()` |
| `retry.ts` | Mark `invalid_request_error` as non-retryable; replace catch-all `return JSON.stringify(json)` with `return undefined` |
| `transform.ts` | Add defensive `repairOrphanedToolUse()` validation as last-resort before API calls — injects synthetic error `tool_result` for any orphaned `tool_use` blocks |

## Defense in Depth

The fix operates at three layers:
1. **Prevention**: Orphan cleanup runs before retry, messages rebuilt from clean DB state
2. **Circuit breaker**: `invalid_request_error` stops the retry loop immediately
3. **Last resort**: `repairOrphanedToolUse()` in the transform layer catches any orphans that slip through other defenses

## Reproduction

1. Start a session with tools enabled
2. Trigger a tool call, then interrupt/abort mid-execution (timeout, network error, etc.)
3. The session enters an infinite retry loop showing the `invalid_request_error` repeatedly
4. The session becomes unrecoverable — no way to continue without starting fresh