### PR TITLE
fix(tui): guard against undefined prompt ref in onMount

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -78,6 +78,7 @@ export function Home() {
   const args = useArgs()
   onMount(() => {
     if (once) return
+    if (!prompt) return
     if (route.initialPrompt) {
       prompt.set(route.initialPrompt)
       once = true


### PR DESCRIPTION
### Issue for this PR

Closes #7839 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows Terminal, renderer.getPalette() resolves asynchronously and triggers a setStore update in theme.tsx. This causes SolidJS to flush pending effects — including onMount in home.tsx — before the <Prompt> ref callback has executed, leaving prompt as undefined and crashing with "undefined is not an object (evaluating 'prompt.set')".
Added an early return guard `if (!prompt) return` in onMount to prevent calling prompt.set() before the ref is assigned.

### How did you verify your code works?

Ran opencode --prompt "hello" in a Docker container (Linux). No crash. The bug is Windows-specific due to async terminal palette detection, but the guard prevents the crash regardless of platform.

### Screenshots / recordings

not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
