### PR TITLE
fix(provider): add thinking level variants for GitHub Copilot Claude models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -434,7 +434,10 @@ export namespace ProviderTransform {
         }
         if (model.id.includes("claude")) {
           return {
-            thinking: { thinking_budget: 4000 },
+            low: { thinking_budget: 1024 },
+            medium: { thinking_budget: 4000 },
+            high: { thinking_budget: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)) },
+            max: { thinking_budget: Math.min(31_999, model.limit.output - 1) },
           }
         }
         const copilotEfforts = iife(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #11627

### Type of change

- [x] Bug fix

### What does this PR do?

Restores thinking level variant selection for Claude models on the GitHub Copilot provider. In v1.1.48, the variant regressed to a single hardcoded `thinking_budget: 4000` under a non-standard `"thinking"` key.

This change:
- Adds `low` (1024), `medium` (4000), `high`, and `max` thinking budget variants
- Dynamically caps `high` at `min(16_000, floor(output_limit / 2 - 1))` and `max` at `min(31_999, output_limit - 1)`, matching the direct `@ai-sdk/anthropic` provider logic
- This ensures correct budgets across models with different output limits (e.g. Sonnet 32k vs Opus 64k)

### How did you verify your code works?

- Typecheck passes (`bun turbo typecheck`)
- Build passes (`bun turbo build`)
- Verified the dynamic budget logic matches the existing `@ai-sdk/anthropic` pattern at lines 543/549 of `transform.ts`

### Screenshots / recordings

_N/A - no UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR