### PR TITLE
fix: most segfaults on windows with Bun v1.3.10 stable

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,10 +1,5 @@
 name: "Setup Bun"
 description: "Setup Bun with caching and install dependencies"
-inputs:
-  cross-compile:
-    description: "Pre-cache canary cross-compile binaries for all targets"
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -21,12 +16,13 @@ runs:
       shell: bash
       run: |
         if [ "$RUNNER_ARCH" = "X64" ]; then
+          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
           case "$RUNNER_OS" in
             macOS)   OS=darwin ;;
             Linux)   OS=linux ;;
             Windows) OS=windows ;;
           esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/canary/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup Bun
@@ -34,54 +30,6 @@ runs:
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
-
-    - name: Pre-cache canary cross-compile binaries
-      if: inputs.cross-compile == 'true'
-      shell: bash
-      run: |
-        BUN_VERSION=$(bun --revision)
-        if echo "$BUN_VERSION" | grep -q "canary"; then
-          SEMVER=$(echo "$BUN_VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
-          echo "Bun version: $BUN_VERSION (semver: $SEMVER)"
-          CACHE_DIR="$HOME/.bun/install/cache"
-          mkdir -p "$CACHE_DIR"
-          TMP_DIR=$(mktemp -d)
-          for TARGET in linux-aarch64 linux-x64 linux-x64-baseline linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline darwin-aarch64 darwin-x64 windows-x64 windows-x64-baseline; do
-            DEST="$CACHE_DIR/bun-${TARGET}-v${SEMVER}"
-            if [ -f "$DEST" ]; then
-              echo "Already cached: $DEST"
-              continue
-            fi
-            URL="https://github.com/oven-sh/bun/releases/download/canary/bun-${TARGET}.zip"
-            echo "Downloading $TARGET from $URL"
-            if curl -sfL -o "$TMP_DIR/bun.zip" "$URL"; then
-              unzip -qo "$TMP_DIR/bun.zip" -d "$TMP_DIR"
-              if echo "$TARGET" | grep -q "windows"; then
-                BIN_NAME="bun.exe"
-              else
-                BIN_NAME="bun"
-              fi
-              mv "$TMP_DIR/bun-${TARGET}/$BIN_NAME" "$DEST"
-              chmod +x "$DEST"
-              rm -rf "$TMP_DIR/bun-${TARGET}" "$TMP_DIR/bun.zip"
-              echo "Cached: $DEST"
-              # baseline bun resolves "bun-darwin-x64" to the baseline cache key
-              # so copy the modern binary there too
-              if [ "$TARGET" = "darwin-x64" ]; then
-                BASELINE_DEST="$CACHE_DIR/bun-darwin-x64-baseline-v${SEMVER}"
-                if [ ! -f "$BASELINE_DEST" ]; then
-                  cp "$DEST" "$BASELINE_DEST"
-                  echo "Cached (baseline alias): $BASELINE_DEST"
-                fi
-              fi
-            else
-              echo "Skipped: $TARGET (not available)"
-            fi
-          done
-          rm -rf "$TMP_DIR"
-        else
-          echo "Not a canary build ($BUN_VERSION), skipping pre-cache"
-        fi
 
     - name: Install dependencies
       run: bun install

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -11,10 +11,25 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
+    - name: Get baseline download URL
+      id: bun-url
+      shell: bash
+      run: |
+        if [ "$RUNNER_ARCH" = "X64" ]; then
+          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
+          case "$RUNNER_OS" in
+            macOS)   OS=darwin ;;
+            Linux)   OS=linux ;;
+            Windows) OS=windows ;;
+          esac
+          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version-file: package.json
+        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
+        bun-download-url: ${{ steps.bun-url.outputs.url }}
 
     - name: Install dependencies
       run: bun install

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -11,25 +11,10 @@ runs:
         restore-keys: |
           ${{ runner.os }}-bun-
 
-    - name: Get baseline download URL
-      id: bun-url
-      shell: bash
-      run: |
-        if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          case "$RUNNER_OS" in
-            macOS)   OS=darwin ;;
-            Linux)   OS=linux ;;
-            Windows) OS=windows ;;
-          esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
-        bun-download-url: ${{ steps.bun-url.outputs.url }}
+        bun-version-file: package.json
 
     - name: Install dependencies
       run: bun install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,8 +77,6 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/setup-bun
-        with:
-          cross-compile: "true"
 
       - name: Setup git committer
         id: committer
@@ -90,7 +88,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          ./packages/opencode/script/build.ts --all
+          ./packages/opencode/script/build.ts
         env:
           OPENCODE_VERSION: ${{ needs.version.outputs.version }}
           OPENCODE_RELEASE: ${{ needs.version.outputs.release }}

--- a/.github/workflows/sign-cli.yml
+++ b/.github/workflows/sign-cli.yml
@@ -20,12 +20,10 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/setup-bun
-        with:
-          cross-compile: "true"
 
       - name: Build
         run: |
-          ./packages/opencode/script/build.ts --all
+          ./packages/opencode/script/build.ts
 
       - name: Upload unsigned Windows CLI
         id: upload_unsigned_windows_cli

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.9",
+  "packageManager": "bun@1.3.10",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.9",
+      "@types/bun": "1.3.10",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "packages/slack"
     ],
     "catalog": {
-      "@types/bun": "1.3.10",
+      "@types/bun": "1.3.9",
       "@octokit/rest": "22.0.0",
       "@hono/zod-validator": "0.4.2",
       "ulid": "3.0.1",

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -8,7 +8,7 @@ export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; ass
   },
   {
     rustTarget: "x86_64-apple-darwin",
-    ocBinary: "opencode-darwin-x64",
+    ocBinary: "opencode-darwin-x64-baseline",
     assetExt: "zip",
   },
   {

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -56,7 +56,7 @@ const migrations = await Promise.all(
 )
 console.log(`Loaded ${migrations.length} migrations`)
 
-const singleFlag = process.argv.includes("--single") || (!!process.env.CI && !process.argv.includes("--all"))
+const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 
@@ -102,6 +102,11 @@ const allTargets: {
   {
     os: "darwin",
     arch: "x64",
+  },
+  {
+    os: "darwin",
+    arch: "x64",
+    avx2: false,
   },
   {
     os: "win32",


### PR DESCRIPTION
## Summary
- bump the repo to stable `bun@1.3.10` while keeping `@types/bun` on `1.3.9` because `1.3.10` is not published yet
- remove the canary-only setup logic and go back to stable baseline release downloads in `.github/actions/setup-bun/action.yml`
- drop the CI cross-compile workarounds and restore the baseline darwin x64 desktop sidecar/build target

## Context
This removes the canary support introduced across `bf57596ae`, `13973dd19`, `d250de632`, `61547f478`, `fe0c3ca82`, `d9ee41a56`, `e08bdeb65`, `4285c5018`, and `cf5cfb48c`.

## Verification
- `bun install`
- `./script/build.ts --single --skip-install` currently stops immediately on local Bun `1.3.9` because the build script now requires `^1.3.10`