### PR TITLE
docs: add opencode-cmux to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -35,6 +35,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | Desktop notifications and sound alerts for permission, completion, and error events               |
+| [opencode-cmux](https://github.com/0xCaso/opencode-cmux)                                                  | cmux sidebar status pills and desktop notifications — session status, subagent detection, permission and question hooks |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Persistent memory across sessions using Supermemory                                               |


### PR DESCRIPTION
### Issue for this PR
Closes #15239 

### Type of change
- [x] Documentation

### What does this PR do?
Adds `opencode-cmux` to the ecosystem plugins table.
It's a plugin that bridges OpenCode session events to [cmux](https://github.com/manaflow-ai/cmux), showing real-time status pills in the cmux sidebar and triggering desktop notifications for permission requests, questions, and errors.
- npm: https://www.npmjs.com/package/opencode-cmux
- GitHub: https://github.com/0xCaso/opencode-cmux

### How did you verify your code works?
The plugin is live on npm (`opencode-cmux@0.1.1`) and running locally. The change is a single table row addition to `ecosystem.mdx`.
 Screenshots / recordings
N/A — docs-only change.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR