### PR TITLE
fix(app): test fix for permission spam - add beta for testing purposes pls

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -329,6 +329,11 @@ pub fn spawn_command(
         cmd
     };
 
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"));
+    if let Some(home) = home {
+        cmd.current_dir(home);
+    }
+
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     cmd.stdin(Stdio::null());

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -74,6 +74,11 @@ export namespace FileWatcher {
       const subs: ParcelWatcher.AsyncSubscription[] = []
       const cfgIgnores = cfg.watcher?.ignore ?? []
 
+      if (Instance.directory === path.parse(Instance.directory).root) {
+        log.warn("skipping watcher for filesystem root", { directory: Instance.directory })
+        return { subs }
+      }
+
       if (Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
         const pending = w.subscribe(Instance.directory, subscribe, {
           ignore: [...FileIgnore.PATTERNS, ...cfgIgnores],


### PR DESCRIPTION
### Issue for this PR

Closes #15090 #14982
### Type of change

makes the working directory to home instead of / 
file watcher ignores scanning for system root 

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

thesis: file watcher triggers permissions 

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

"for me it happens when i open apps like the music app
the permission comes up" - try doing that

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

not on mac, can you add beta tag 

_If you do not follow this template your PR will be automatically rejected._
