### PR TITLE
Add Greek translation (README.gr.md) and language link to main README

### DIFF
--- a/README.gr.md
+++ b/README.gr.md
@@ -1,0 +1,139 @@
+<p align="center">
+  <a href="https://opencode.ai">
+    <picture>
+      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+    </picture>
+  </a>
+</p>
+<p align="center">Ο ανοιχτού κώδικα AI coding agent.</p>
+<p align="center">
+  <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
+  <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
+  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh.md">简体中文</a> |
+  <a href="README.zht.md">繁體中文</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.de.md">Deutsch</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.it.md">Italiano</a> |
+  <a href="README.da.md">Dansk</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.pl.md">Polski</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.bs.md">Bosanski</a> |
+  <a href="README.ar.md">العربية</a> |
+  <a href="README.no.md">Norsk</a> |
+  <a href="README.br.md">Português (Brasil)</a> |
+  <a href="README.th.md">ไทย</a> |
+  <a href="README.tr.md">Türkçe</a> |
+  <a href="README.uk.md">Українська</a> |
+  <a href="README.bn.md">বাংলা</a>
+</p>
+
+[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+
+---
+
+### Εγκατάσταση
+
+```bash
+# YOLO
+curl -fsSL https://opencode.ai/install | bash
+
+# Διαχειριστές πακέτων
+npm i -g opencode-ai@latest        # ή bun/pnpm/yarn
+scoop install opencode             # Windows
+choco install opencode             # Windows
+brew install anomalyco/tap/opencode # macOS και Linux (συνιστάται, πάντα ενημερωμένο)
+brew install opencode              # macOS και Linux (επίσημο brew formula, ενημερώνεται λιγότερο συχνά)
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Τελευταία έκδοση από AUR)
+mise use -g opencode               # Οποιοδήποτε ΛΣ
+nix run nixpkgs#opencode           # ή github:anomalyco/opencode για την τελευταία dev έκδοση
+```
+
+> [!TIP]
+> Αφαιρέστε εκδόσεις παλαιότερες από 0.1.x πριν από την εγκατάσταση.
+
+### Εφαρμογή Επιτραπέζιου Υπολογιστή (BETA)
+
+Το OpenCode είναι επίσης διαθέσιμο ως εφαρμογή επιτραπέζιου υπολογιστή. Κατεβάστε το απευθείας από τη [σελίδα εκδόσεων](https://github.com/anomalyco/opencode/releases) ή από [opencode.ai/download](https://opencode.ai/download).
+
+| Πλατφόρμα              | Λήψη                               |
+| --------------------- | ------------------------------------- |
+| macOS (Apple Silicon) | `opencode-desktop-darwin-aarch64.dmg` |
+| macOS (Intel)         | `opencode-desktop-darwin-x64.dmg`     |
+| Windows               | `opencode-desktop-windows-x64.exe`    |
+| Linux                 | `.deb`, `.rpm`, ή AppImage           |
+
+```bash
+# macOS (Homebrew)
+brew install --cask opencode-desktop
+# Windows (Scoop)
+scoop bucket add extras; scoop install extras/opencode-desktop
+```
+
+#### Κατάλογος Εγκατάστασης
+
+Το σενάριο εγκατάστασης ακολουθεί την ακόλουθη σειρά προτεραιότητας για τη διαδρομή εγκατάστασης:
+
+1. `$OPENCODE_INSTALL_DIR` - Προσαρμοσμένος κατάλογος εγκατάστασης
+2. `$XDG_BIN_DIR` - Διαδρομή συμβατή με την Προδιαγραφή Βασικής Διεύθυνσης XDG
+3. `$HOME/bin` - Τυπικός κατάλογος δυαδικών αρχείων χρήστη (αν υπάρχει ή μπορεί να δημιουργηθεί)
+4. `$HOME/.opencode/bin` - Προεπιλεγμένη εναλλακτική
+
+```bash
+# Παραδείγματα
+OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
+XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
+```
+
+### Agents
+
+Το OpenCode περιλαμβάνει δύο ενσωματωμένους agents μεταξύ των οποίων μπορείτε να κάνετε εναλλαγή με το πλήκτρο `Tab`.
+
+- **build** - Προεπιλεγμένος agent πλήρους πρόσβασης για εργασίες ανάπτυξης
+- **plan** - Agent μόνο για ανάγνωση για ανάλυση και εξερεύνηση κώδικα
+  - Απορρίπτει την επεξεργασία αρχείων από προεπιλογή
+  - Ζητά άδεια πριν εκτελέσει εντολές bash
+  - Ιδανικός για εξερεύνηση άγνωστων βάσεων κώδικα ή σχεδιασμό αλλαγών
+
+Επίσης περιλαμβάνεται ένας **general** subagent για σύνθετες αναζητήσεις και εργασίες πολλών βημάτων.
+Αυτός χρησιμοποιείται εσωτερικά και μπορεί να κληθεί χρησιμοποιώντας `@general` στα μηνύματα.
+
+Μάθετε περισσότερα για τους [agents](https://opencode.ai/docs/agents).
+
+### Τεκμηρίωση
+
+Για περισσότερες πληροφορίες σχετικά με το πώς να ρυθμίσετε το OpenCode, [**μεταβείτε στην τεκμηρίωσή μας**](https://opencode.ai/docs).
+
+### Συνεισφορά
+
+Αν ενδιαφέρεστε να συνεισφέρετε στο OpenCode, παρακαλούμε διαβάστε τα [έγγραφα συνεισφοράς](./CONTRIBUTING.md) μας πριν υποβάλετε ένα αίτημα έλξης.
+
+### Ανάπτυξη Πάνω στο OpenCode
+
+Εάν εργάζεστε σε ένα έργο που σχετίζεται με το OpenCode και χρησιμοποιεί το "opencode" ως μέρος του ονόματός του, για παράδειγμα "opencode-dashboard" ή "opencode-mobile", προσθέστε μια σημείωση στο README σας για να διευκρινίσετε ότι δεν έχει κατασκευαστεί από την ομάδα του OpenCode και δεν συνδέεται με εμάς με κανέναν τρόπο.
+
+### Συχνές Ερωτήσεις
+
+#### Σε τι διαφέρει αυτό από το Claude Code;
+
+Είναι πολύ παρόμοιο με το Claude Code ως προς τις δυνατότητες. Ακολουθούν οι βασικές διαφορές:
+
+- 100% ανοιχτού κώδικα
+- Δεν είναι συνδεδεμένο με κάποιον πάροχο. Αν και προτείνουμε τα μοντέλα που παρέχουμε μέσω του [OpenCode Zen](https://opencode.ai/zen), το OpenCode μπορεί να χρησιμοποιηθεί με Claude, OpenAI, Google ή ακόμα και τοπικά μοντέλα. Καθώς τα μοντέλα εξελίσσονται, τα κενά μεταξύ τους θα κλείσουν και η τιμολόγηση θα μειωθεί, επομένως το να είσαι ανεξάρτητος από πάροχο είναι σημαντικό.
+- Υποστήριξη LSP out-of-the-box
+- Εστίαση στο TUI. Το OpenCode δημιουργείται από χρήστες neovim και τους δημιουργούς του [terminal.shop](https://terminal.shop); θα πιέσουμε τα όρια του τι είναι δυνατό στο τερματικό.
+- Αρχιτεκτονική πελάτη/διακομιστή. Αυτό, για παράδειγμα, μπορεί να επιτρέψει στο OpenCode να εκτελείται στον υπολογιστή σας ενώ το οδηγείτε εξ αποστάσεως από μια εφαρμογή κινητού, πράγμα που σημαίνει ότι το TUI frontend είναι μόνο ένας από τους πιθανούς πελάτες.
+
+---
+
+**Γίνετε μέλος της κοινότητάς μας** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 <p align="center">
   <a href="README.md">English</a> |
+  <a href="README.gr.md">Ελληνικά</a> |
   <a href="README.zh.md">简体中文</a> |
   <a href="README.zht.md">繁體中文</a> |
   <a href="README.ko.md">한국어</a> |


### PR DESCRIPTION
### Issue for this PR

Closes # (N/A - This is a documentation improvement for internationalization)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds Greek language support for OpenCode by:

1. Creating `README.gr.md` with a complete Greek translation of the main README content
2. Adding a Greek (Ελληνικά) language link to the main `README.md` file in the language selection section

The translation maintains all original content including installation instructions, desktop app information, agent descriptions, and FAQ. The language link follows the same format as other translations (using the `.gr.md` extension which is the standard for Greek).

### How did you verify your code works?

- [x] Verified the Greek translation is complete and accurate
- [x] Confirmed the link in main README points to README.gr.md
- [x] Checked that all formatting (code blocks, badges, alerts) is preserved in the Greek version
- [x] Verified the link appears correctly in the language selection section

### Screenshots / recordings

N/A - Documentation change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR