### PR TITLE
fix(tui): resolve streaming freeze from unhandled finish event, missing timeouts, and unguarded effects

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -52,10 +52,10 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       const elapsed = Date.now() - last
 
       if (timer) return
-      // If we just flushed recently (within 16ms), batch this with future events
+      // If we just flushed recently (within 50ms), batch this with future events
       // Otherwise, process immediately to avoid latency
-      if (elapsed < 16) {
-        timer = setTimeout(flush, 16)
+      if (elapsed < 50) {
+        timer = setTimeout(flush, 50)
         return
       }
       flush()

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -577,7 +577,9 @@ export namespace MCP {
 
     const toolsResults = await Promise.all(
       connectedClients.map(async ([clientName, client]) => {
-        const toolsResult = await client.listTools().catch((e) => {
+        const mcpEntry = config[clientName]
+        const timeout = (isMcpConfigured(mcpEntry) ? mcpEntry.timeout : undefined) ?? defaultTimeout ?? DEFAULT_TIMEOUT
+        const toolsResult = await withTimeout(client.listTools(), timeout).catch((e) => {
           log.error("failed to get tools", { clientName, error: e.message })
           const failedStatus = {
             status: "failed" as const,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -50,6 +50,7 @@ export namespace SessionProcessor {
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
+    let finished = false
             const stream = await LLM.stream(streamInput)
 
             for await (const value of stream.fullStream) {
@@ -337,6 +338,8 @@ export namespace SessionProcessor {
                   break
 
                 case "finish":
+                  log.info("stream finish event received")
+                  finished = true
                   break
 
                 default:
@@ -345,7 +348,7 @@ export namespace SessionProcessor {
                   })
                   continue
               }
-              if (needsCompaction) break
+              if (needsCompaction || finished) break
             }
           } catch (e: any) {
             log.error("process", {

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -122,7 +122,7 @@ export namespace Database {
       if (err instanceof Context.NotFound) {
         const effects: (() => void | Promise<void>)[] = []
         const result = ctx.provide({ effects, tx: Client() }, () => callback(Client()))
-        for (const effect of effects) effect()
+        for (const effect of effects) Promise.resolve(effect()).catch((e) => log.error("effect failed", { error: e }))
         return result
       }
       throw err
@@ -146,7 +146,7 @@ export namespace Database {
         const result = Client().transaction((tx) => {
           return ctx.provide({ tx, effects }, () => callback(tx))
         })
-        for (const effect of effects) effect()
+        for (const effect of effects) Promise.resolve(effect()).catch((e) => log.error("effect failed", { error: e }))
         return result
       }
       throw err


### PR DESCRIPTION
### Issue for this PR

Closes #15310

### Related upstream issues

- **Bun**: oven-sh/bun#27490 — bmalloc SYSCALL macro spins at 100% CPU on EAGAIN with zero delay
- **WebKit**: oven-sh/WebKit#169 — bmalloc: add backoff to SYSCALL EAGAIN loops + remove MADV_DONTDUMP

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes four independent bugs that cause TUI freezes/hangs during and after LLM streaming:

1. **`processor.ts`** — The `for await (stream.fullStream)` loop never broke on the `finish` event, only on `needsCompaction`. After the LLM finishes, the loop hung at 0% CPU waiting for more events that would never come. Fix: added `finished` flag that breaks the loop on the `finish` case.

2. **`sdk.tsx`** — The 16ms event batch window caused excessive render churn at high token rates (10+ tokens/sec). Each render re-parses accumulated markdown, generating O(n) garbage that pressures the GC. Fix: increased to 50ms, which still feels instant but cuts renders by ~3x during bursts.

3. **`mcp/index.ts`** — `client.listTools()` had no timeout. If an MCP server stalls, this blocks indefinitely. Fix: wrapped in `withTimeout()` using the configured or default timeout.

4. **`db.ts`** — Fire-and-forget effects could reject silently. `Promise.resolve(effect())` was called without `.catch()`, causing unhandled rejections. Fix: added `.catch()` with error logging.

The stream termination bug (#1) is the most impactful — it's the direct cause of the "TUI hangs after response completes" behavior. The underlying GC contention that amplifies these bugs is tracked in the Bun/WebKit issues above.

### How did you verify your code works?

- `turbo typecheck` passes across all 18 packages
- `turbo build` succeeds
- LSP diagnostics clean on all 4 changed files
- Manual testing: streamed long responses against a large project, TUI remained responsive and stream exited cleanly on completion

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR