### PR TITLE
desktop: bundle vc redistributables on windows

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -34,6 +34,7 @@
     "active": true,
     "targets": ["deb", "rpm", "dmg", "nsis", "app"],
     "externalBin": ["sidecars/opencode-cli"],
+    "resources": ["resources/vc_redist.x64.exe"],
     "linux": {
       "rpm": {
         "compression": {
@@ -48,7 +49,8 @@
       "nsis": {
         "installerIcon": "icons/dev/icon.ico",
         "headerImage": "assets/nsis-header.bmp",
-        "sidebarImage": "assets/nsis-sidebar.bmp"
+        "sidebarImage": "assets/nsis-sidebar.bmp",
+        "installerHooks": "./windows/hooks.nsh"
       }
     }
   },

--- a/packages/desktop/src-tauri/tauri.prod.conf.json
+++ b/packages/desktop/src-tauri/tauri.prod.conf.json
@@ -11,9 +11,11 @@
       "icons/prod/icon.icns",
       "icons/prod/icon.ico"
     ],
+    "resources": ["resources/vc_redist.x64.exe"],
     "windows": {
       "nsis": {
-        "installerIcon": "icons/prod/icon.ico"
+        "installerIcon": "icons/prod/icon.ico",
+        "installerHooks": "./windows/hooks.nsh"
       }
     },
     "linux": {

--- a/packages/desktop/src-tauri/windows/hooks.nsh
+++ b/packages/desktop/src-tauri/windows/hooks.nsh
@@ -1,0 +1,24 @@
+!include "FileFunc.nsh"
+
+!macro NSIS_HOOK_POSTINSTALL
+  ReadRegDWord $0 HKLM "SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" "Installed"
+  ${If} $0 == 1
+    DetailPrint "Visual C++ Redistributable already installed"
+    Goto vcredist_done
+  ${EndIf}
+
+  ${If} ${FileExists} "$INSTDIR\resources\vc_redist.x64.exe"
+    DetailPrint "Installing Visual C++ Redistributable..."
+    CopyFiles "$INSTDIR\resources\vc_redist.x64.exe" "$TEMP\vc_redist.x64.exe"
+    ExecWait '"$TEMP\vc_redist.x64.exe" /install /quiet /norestart' $0
+    ${If} $0 == 0
+      DetailPrint "Visual C++ Redistributable installed successfully"
+    ${Else}
+      MessageBox MB_ICONEXCLAMATION "Visual C++ installation failed. Some features may not work."
+    ${EndIf}
+    Delete "$TEMP\vc_redist.x64.exe"
+    Delete "$INSTDIR\resources\vc_redist.x64.exe"
+  ${EndIf}
+
+  vcredist_done:
+!macroend


### PR DESCRIPTION
Adds an NSIS postinstall hook to install VC Redistributables for environments that don't already have them.

TODO:
- Download binary in `predev` and `prepare` instead of having it in the repo
- Ensure that the binary is downloaded and used