### PR TITLE
fix(web): dispose idle MCP server instances to prevent process accumulation

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -3,8 +3,12 @@ import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Instance } from "../../project/instance"
+import { Log } from "../../util/log"
 import open from "open"
 import { networkInterfaces } from "os"
+
+const log = Log.create({ service: "web" })
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -75,7 +79,18 @@ export const WebCommand = cmd({
       open(displayUrl).catch(() => {})
     }
 
+    // Graceful shutdown: dispose all instances (and their MCP servers) before exiting
+    async function shutdown(signal: string) {
+      log.info("received signal, shutting down", { signal })
+      await Promise.race([Instance.disposeAll(), new Promise((resolve) => setTimeout(resolve, 5000))])
+      server.stop(true)
+      process.exit(0)
+    }
+
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+      process.on(signal, () => shutdown(signal))
+    }
+
     await new Promise(() => {})
-    await server.stop()
   },
 })

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -13,6 +13,60 @@ interface Context {
 }
 const context = Context.create<Context>("instance")
 const cache = new Map<string, Promise<Context>>()
+const lastAccess = new Map<string, number>()
+
+/** How long an instance can be idle before it is eligible for eviction (ms). */
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+/** How often the idle-eviction sweep runs (ms). */
+const SWEEP_INTERVAL_MS = 60 * 1000 // 1 minute
+
+const sweep = {
+  timer: undefined as ReturnType<typeof setInterval> | undefined,
+  start() {
+    if (sweep.timer) return
+    sweep.timer = setInterval(async () => {
+      const now = Date.now()
+      for (const [directory, timestamp] of lastAccess) {
+        if (now - timestamp < IDLE_TIMEOUT_MS) continue
+        if (!cache.has(directory)) {
+          lastAccess.delete(directory)
+          continue
+        }
+
+        Log.Default.info("evicting idle instance", {
+          directory,
+          idleMs: now - timestamp,
+        })
+
+        const entry = cache.get(directory)
+        if (!entry) continue
+
+        const ctx = await entry.catch(() => undefined)
+        if (!ctx) {
+          cache.delete(directory)
+          lastAccess.delete(directory)
+          continue
+        }
+
+        // re-check — may have been accessed while awaiting
+        const current = lastAccess.get(directory)
+        if (current && now - current < IDLE_TIMEOUT_MS) continue
+
+        await context.provide(ctx, async () => {
+          await Instance.dispose()
+        })
+        lastAccess.delete(directory)
+      }
+    }, SWEEP_INTERVAL_MS)
+    sweep.timer.unref()
+  },
+  stop() {
+    if (!sweep.timer) return
+    clearInterval(sweep.timer)
+    sweep.timer = undefined
+  },
+}
 
 const disposal = {
   all: undefined as Promise<void> | undefined,
@@ -20,6 +74,9 @@ const disposal = {
 
 export const Instance = {
   async provide<R>(input: { directory: string; init?: () => Promise<any>; fn: () => R }): Promise<R> {
+    lastAccess.set(input.directory, Date.now())
+    sweep.start()
+
     let existing = cache.get(input.directory)
     if (!existing) {
       Log.Default.info("creating instance", { directory: input.directory })
@@ -70,6 +127,7 @@ export const Instance = {
     Log.Default.info("disposing instance", { directory: Instance.directory })
     await State.dispose(Instance.directory)
     cache.delete(Instance.directory)
+    lastAccess.delete(Instance.directory)
     GlobalBus.emit("event", {
       directory: Instance.directory,
       payload: {
@@ -85,6 +143,7 @@ export const Instance = {
 
     disposal.all = iife(async () => {
       Log.Default.info("disposing all instances")
+      sweep.stop()
       const entries = [...cache.entries()]
       for (const [key, value] of entries) {
         if (cache.get(key) !== value) continue
@@ -105,6 +164,7 @@ export const Instance = {
           await Instance.dispose()
         })
       }
+      lastAccess.clear()
     }).finally(() => {
       disposal.all = undefined
     })


### PR DESCRIPTION
### Issue for this PR

Closes #14091

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Same root cause as #14092 — `server.stop()` is unreachable dead code after `await new Promise(() => {})` in `web.ts`, and no signal handlers exist. I also added idle eviction of cached Instance entries, which #14092 doesn't cover: without it, each project switch accumulates MCP server processes (~200MB each) for the entire lifetime of the web server, even if those projects are never revisited.

Signal handlers (SIGINT/SIGTERM/SIGHUP) follow the existing `worker.ts` pattern. Idle eviction sweeps every 60s and disposes instances idle >5 minutes. I didn't touch `serve.ts` or the SSE cleanup — happy to add those if this gets traction, or #14092 can cover them.

### How did you verify your code works?

Ran patched and unpatched instances side by side on the same machine. After switching between 8 projects over ~30 minutes:
- Unpatched: 8 sets of MCP servers accumulated, ~1.65 GB RSS in leaked child processes
- Patched: 0 leaked processes after idle timeout

`bun turbo typecheck` (16/16 pass), `bun turbo test` (1172 pass, 0 fail).

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR