### PR TITLE
fix: prevent LSP stderr and prompt dock overlap from corrupting TUI display

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, Show, Match, Switch, createMemo, createEffect, on, onMount } from "solid-js"
+import { onCleanup, Show, Match, Switch, createMemo, createEffect, on, onMount, createSignal } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocal } from "@/context/local"
@@ -283,7 +283,7 @@ export default function Page() {
 
   let inputRef!: HTMLDivElement
   let promptDock: HTMLDivElement | undefined
-  let dockHeight = 0
+  const [dockHeight, setDockHeight] = createSignal(0)
   let scroller: HTMLDivElement | undefined
   let content: HTMLDivElement | undefined
 
@@ -982,13 +982,13 @@ export default function Page() {
     ({ height }) => {
       const next = Math.ceil(height)
 
-      if (next === dockHeight) return
+      if (next === dockHeight()) return
 
       const el = scroller
-      const delta = next - dockHeight
+      const delta = next - dockHeight()
       const stick = el ? el.scrollHeight - el.clientHeight - el.scrollTop < 10 + Math.max(0, delta) : false
 
-      dockHeight = next
+      setDockHeight(next)
 
       if (stick) autoScroll.forceScrollToBottom()
 
@@ -1100,6 +1100,7 @@ export default function Page() {
                     onRegisterMessage={scrollSpy.register}
                     onUnregisterMessage={scrollSpy.unregister}
                     lastUserMessageID={lastUserMessage()?.id}
+                    dockHeight={dockHeight()}
                   />
                 </Show>
               </Match>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -106,6 +106,7 @@ export function MessageTimeline(props: {
   onRegisterMessage: (el: HTMLDivElement, id: string) => void
   onUnregisterMessage: (id: string) => void
   lastUserMessageID?: string
+  dockHeight?: number
 }) {
   let touchGesture: number | undefined
 
@@ -522,7 +523,10 @@ export function MessageTimeline(props: {
           <div
             ref={props.setContentRef}
             role="log"
-            class="flex flex-col gap-12 items-start justify-start pb-16 transition-[margin]"
+            class="flex flex-col gap-12 items-start justify-start transition-[margin,padding-bottom]"
+            style={{
+              "padding-bottom": props.dockHeight ? `${props.dockHeight + 16}px` : "4rem",
+            }}
             classList={{
               "w-full": true,
               "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
+import { spawn as _spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "child_process"
 import path from "path"
 import os from "os"
 import { Global } from "../global"
@@ -12,6 +12,16 @@ import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { Archive } from "../util/archive"
 import { Process } from "../util/process"
+
+// Wrapper that always pipes stderr to prevent LSP server output from leaking to the terminal
+function spawn(cmd: string, opts?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams
+function spawn(cmd: string, args: readonly string[], opts?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams
+function spawn(cmd: string, argsOrOpts?: readonly string[] | SpawnOptionsWithoutStdio, opts?: SpawnOptionsWithoutStdio): ChildProcessWithoutNullStreams {
+  if (Array.isArray(argsOrOpts)) {
+    return _spawn(cmd, argsOrOpts as string[], { stderr: "pipe", ...opts }) as ChildProcessWithoutNullStreams
+  }
+  return _spawn(cmd, { stderr: "pipe", ...(argsOrOpts as SpawnOptionsWithoutStdio) }) as ChildProcessWithoutNullStreams
+}
 
 export namespace LSPServer {
   const log = Log.create({ service: "lsp.server" })


### PR DESCRIPTION
## Problem

Two separate issues cause content to appear over the prompt input area in the TUI:

### 1. LSP server stderr leaks to terminal
LSP server processes (`typescript-language-server`, `deno lsp`, etc.) were spawned without `stderr: 'pipe'`, causing their stderr output to leak directly to the terminal and corrupt the TUI display.

Notably, `bun x typescript-language-server --stdio` prints its package installation/check output (e.g. `bun install v1.3.10`, `Checked N installs across M packages`) to stderr. Without piping, this output appeared over the prompt input area.

### 2. Prompt dock overlaps message content
When the prompt dock grows taller than the fixed `pb-16` (64px) bottom padding — for example when the todo dock is visible, the user types multiple lines, or a permission/question prompt appears — the last tool call entries and messages at the bottom of the message timeline are hidden behind the dock overlay.

Related: #6730

## Fix

### Commit 1: LSP stderr piping (`packages/opencode/src/lsp/server.ts`)
Replace the direct `child_process.spawn` import with a local wrapper that always sets `stderr: 'pipe'` as a default, covering all 40+ LSP server spawn calls in the file without requiring individual changes.

### Commit 2: Dynamic prompt dock padding (`packages/app/src/pages/session.tsx`, `message-timeline.tsx`)
- Convert `dockHeight` from a plain `let` variable to a reactive `createSignal` so SolidJS can track changes
- Pass `dockHeight` as an optional prop to `MessageTimeline`
- Replace the static `pb-16` Tailwind class with an inline `padding-bottom` style that equals `dockHeight + 16px` (16px buffer), falling back to `4rem` when no dock height is known
- Add `padding-bottom` to the CSS transition list for a smooth resize animation