### PR TITLE
feat(opencode): inject skill list via system-reminder, add skill usage guidance to system prompt

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -40,6 +40,7 @@ import { SessionProcessor } from "./processor"
 import { TaskTool } from "@/tool/task"
 import { Tool } from "@/tool/tool"
 import { PermissionNext } from "@/permission/next"
+import { Skill } from "@/skill"
 import { SessionStatus } from "./status"
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
@@ -648,7 +649,7 @@ export namespace SessionPrompt {
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
       // Build system prompt, adding structured output instruction if needed
-      const system = [...(await SystemPrompt.environment(model)), ...(await InstructionPrompt.system())]
+      const system = [...(await SystemPrompt.environment(model)), SystemPrompt.skills(), ...(await InstructionPrompt.system())]
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
@@ -1321,6 +1322,43 @@ export namespace SessionPrompt {
   async function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info; session: Session.Info }) {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
     if (!userMessage) return input.messages
+
+    // Inject available skills list as a system-reminder before all messages
+    const skills = await Skill.all()
+    const accessibleSkills = input.agent
+      ? skills.filter((skill) => {
+          const rule = PermissionNext.evaluate("skill", skill.name, input.agent.permission)
+          return rule.action !== "deny"
+        })
+      : skills
+
+    if (accessibleSkills.length > 0) {
+      const firstUserMessage = input.messages.find((msg) => msg.info.role === "user")
+      if (firstUserMessage) {
+        firstUserMessage.parts.unshift({
+          id: Identifier.ascending("part"),
+          messageID: firstUserMessage.info.id,
+          sessionID: firstUserMessage.info.sessionID,
+          type: "text",
+          text: [
+            "<system-reminder>",
+            "The following skills are available for use with the skill tool:",
+            "",
+            "<available_skills>",
+            ...accessibleSkills.flatMap((s) => [
+              `  <skill>`,
+              `    <name>${s.name}</name>`,
+              `    <description>${s.description}</description>`,
+              `    <location>${pathToFileURL(s.location).href}</location>`,
+              `  </skill>`,
+            ]),
+            "</available_skills>",
+            "</system-reminder>",
+          ].join("\n"),
+          synthetic: true,
+        })
+      }
+    }
 
     // Original logic when experimental plan mode is disabled
     if (!Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE) {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -26,6 +26,9 @@ export namespace SystemPrompt {
     return [PROMPT_ANTHROPIC_WITHOUT_TODO]
   }
 
+  export function skills() {
+    return `/<skill-name> is shorthand for users to invoke a skill. When executed, the skill gets expanded to a full prompt. Use the skill tool to execute them. IMPORTANT: Only use the skill tool for skills listed in the available skills - do not guess or use built-in CLI commands.`
+  }
   export async function environment(model: Provider.Model) {
     const project = Instance.project
     return [

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -23,26 +23,17 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
     accessibleSkills.length === 0
       ? "Load a specialized skill that provides domain-specific instructions and workflows. No skills are currently available."
       : [
-          "Load a specialized skill that provides domain-specific instructions and workflows.",
+          "Execute a skill within the current conversation.",
           "",
-          "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
-          "",
+          "When you recognize that a task matches one of the available skills, use this tool to load the full skill instructions.",
           "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
           "",
-          'Tool output includes a `<skill_content name="...">` block with the loaded content.',
+          "When users reference a slash command or /<name> (e.g., /" + accessibleSkills[0]?.name + "), they are referring to a skill. Use this tool to invoke it.",
           "",
-          "The following skills provide specialized sets of instructions for particular tasks",
-          "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
-          "",
-          "<available_skills>",
-          ...accessibleSkills.flatMap((skill) => [
-            `  <skill>`,
-            `    <name>${skill.name}</name>`,
-            `    <description>${skill.description}</description>`,
-            `    <location>${pathToFileURL(skill.location).href}</location>`,
-            `  </skill>`,
-          ]),
-          "</available_skills>",
+          "Important:",
+          "- Available skills are listed in <system-reminder> blocks in the conversation",
+          "- When a skill matches the user's request, invoke this tool BEFORE generating any other response about the task",
+          "- If a skill's content has already been loaded in the current conversation turn, follow the instructions directly instead of calling this tool again",
         ].join("\n")
 
   const examples = accessibleSkills

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -18,7 +18,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
 }
 
 describe("tool.skill", () => {
-  test("description lists skill location URL", async () => {
+  test("description lists available skills", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
@@ -44,8 +44,8 @@ description: Skill for tool tests.
         directory: tmp.path,
         fn: async () => {
           const tool = await SkillTool.init()
-          const skillPath = path.join(tmp.path, ".opencode", "skill", "tool-skill", "SKILL.md")
-          expect(tool.description).toContain(`<location>${pathToFileURL(skillPath).href}</location>`)
+          expect(tool.description).toContain("Execute a skill within the current conversation.")
+          expect(tool.description).toContain("Available skills are listed in <system-reminder> blocks")
         },
       })
     } finally {


### PR DESCRIPTION
### Issue for this PR

Closes #15653

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The skill tool currently lists available skills only inside its tool description. Models don't always read tool descriptions proactively, so skills are often overlooked — especially when the user types a slash command like `/skill-name`.

This PR injects the available skills list into a `<system-reminder>` block prepended to the first user message, so the model sees it as part of the conversation context rather than just the tool spec. It also adds a short skill usage hint to the system prompt (slash command syntax, priority invocation rule) that applies to all providers without touching any provider-specific template files.

The SkillTool description is simplified accordingly — it now points the model to the system-reminder for the skills list and focuses on behavioral rules.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/skill.test.ts` — 2 pass, 0 fail
- `bun typecheck` — no type errors

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._

