### PR TITLE
chore(script): source team members from TEAM_MEMBERS

### DIFF
--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -46,23 +46,14 @@ const VERSION = await (async () => {
   return `${major}.${minor}.${patch + 1}`
 })()
 
+const bot = ["actions-user", "opencode", "opencode-agent[bot]"]
+const teamPath = path.resolve(import.meta.dir, "../../../.github/TEAM_MEMBERS")
 const team = [
-  "actions-user",
-  "opencode",
-  "rekram1-node",
-  "thdxr",
-  "kommander",
-  "jayair",
-  "fwang",
-  "MrMushrooooom",
-  "adamdotdevin",
-  "iamdavidhill",
-  "Brendonovich",
-  "nexxeln",
-  "Hona",
-  "jlongster",
-  "opencode-agent[bot]",
-  "R44VC0RP",
+  ...(await Bun.file(teamPath)
+    .text()
+    .then((x) => x.split(/\r?\n/).map((x) => x.trim()))
+    .then((x) => x.filter((x) => x && !x.startsWith("#")))),
+  ...bot,
 ]
 
 export const Script = {


### PR DESCRIPTION
## Summary
- Read human team members from `.github/TEAM_MEMBERS` in `@opencode-ai/script` and keep bot accounts in code.