### PR TITLE
fix(app): fix issue with scroll jumping when pressing escape in comment text area

### DIFF
--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -243,6 +243,7 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
             event.stopPropagation()
             if (e.key === "Escape") {
               event.preventDefault()
+              e.currentTarget.blur()
               split.onCancel()
               return
             }


### PR DESCRIPTION
### Issue for this PR

Closes #15373

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This blurs the textarea before triggering the onCancel. It appears Safari/Webkit has some kind of focus recovery behaviour if the currently focused textarea is removed, which was causing the issue. Blurring/unfocusing the textarea before removing it appears to fix the issue.

### How did you verify your code works?

Tested in Safari and in Desktop view locally.

### Screenshots / recordings

Before:

https://github.com/user-attachments/assets/b89ed3ba-5cb2-4d1f-9e33-153c52396589

After: 

https://github.com/user-attachments/assets/f450748c-5c97-4b9c-aa8b-3007ae13b147

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
