### PR TITLE
fix(zen): guard against empty tool_result content in Anthropic provider

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/anthropic.ts
+++ b/packages/console/app/src/routes/zen/util/provider/anthropic.ts
@@ -402,13 +402,19 @@ export function toAnthropicRequest(body: CommonRequest) {
     }
 
     if ((m as any).role === "tool") {
+      const toolContent = (m as any).content
       msgsOut.push({
         role: "user",
         content: [
           {
             type: "tool_result",
             tool_use_id: (m as any).tool_call_id,
-            content: (m as any).content,
+            content:
+              typeof toolContent === "string" && toolContent.length > 0
+                ? toolContent
+                : Array.isArray(toolContent) && toolContent.length > 0
+                  ? toolContent
+                  : "(no output)",
             ...cc(),
           },
         ],


### PR DESCRIPTION
## Summary
Fixes #15371

- Guard against empty/null/undefined tool content in the `toAnthropicRequest` function
- When a tool call returns an empty string (`""`), `null`, or `undefined`, the Anthropic API rejects the request with `"content field is empty"` error
- Normalize empty tool content to `"(no output)"` before building the `tool_result` content block

## Changes
- `packages/console/app/src/routes/zen/util/provider/anthropic.ts`: Added content normalization in the `role === "tool"` branch of `toAnthropicRequest` — empty strings, null, undefined, and empty arrays now fall back to `"(no output)"` while non-empty strings and non-empty arrays pass through unchanged

## Test plan
- [ ] Configure a tool that returns an empty string (e.g. a write-only tool or command with no stdout)
- [ ] Verify the Anthropic API no longer rejects the request with "content field is empty"
- [ ] Verify tools with normal output still work correctly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)