### PR TITLE
fix: render think tags as reasoning blocks + fix MCP MaxListeners overflow

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { splitThinkBlocks } from "../../util/format"
 
 type ToolProps<T extends Tool.Info> = {
   input: Tool.InferParameters<T>
@@ -490,7 +491,18 @@ export const RunCommand = cmd({
 
             if (part.type === "text" && part.time?.end) {
               if (emit("text", { part })) continue
-              const text = part.text.trim()
+              const { reasoning, text: displayText } = splitThinkBlocks(part.text)
+              if (reasoning && args.thinking) {
+                const line = `Thinking: ${reasoning}`
+                if (process.stdout.isTTY) {
+                  UI.empty()
+                  UI.println(`${UI.Style.TEXT_DIM}\u001b[3m${line}\u001b[0m${UI.Style.TEXT_NORMAL}`)
+                  UI.empty()
+                } else {
+                  process.stdout.write(line + EOL)
+                }
+              }
+              const text = displayText.trim()
               if (!text) continue
               if (!process.stdout.isTTY) {
                 process.stdout.write(text + EOL)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { splitThinkBlocks } from "@/util/format"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 
@@ -1425,33 +1426,58 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, subtleSyntax } = useTheme()
+  const parsed = createMemo(() => splitThinkBlocks(props.part.text))
+  const displayText = createMemo(() => parsed().text.trim())
+  const reasoning = createMemo(() => parsed().reasoning.trim())
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <Switch>
-          <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-            />
-          </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
-              syntaxStyle={syntax()}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.text}
-            />
-          </Match>
-        </Switch>
-      </box>
-    </Show>
+    <>
+      <Show when={reasoning() && ctx.showThinking()}>
+        <box
+          paddingLeft={2}
+          marginTop={1}
+          flexDirection="column"
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={"_Thinking:_ " + reasoning()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
+      </Show>
+      <Show when={displayText()}>
+        <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+          <Switch>
+            <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={true}
+                content={displayText()}
+                conceal={ctx.conceal()}
+              />
+            </Match>
+            <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <code
+                filetype="markdown"
+                drawUnstyledText={false}
+                streaming={true}
+                syntaxStyle={syntax()}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.text}
+              />
+            </Match>
+          </Switch>
+        </box>
+      </Show>
+    </>
   )
 }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -23,6 +23,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import { EventEmitter } from "node:events"
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -166,6 +167,24 @@ export namespace MCP {
       const config = cfg.mcp ?? {}
       const clients: Record<string, MCPClient> = {}
       const status: Record<string, Status> = {}
+
+      // Increase MaxListeners to prevent EventEmitter warnings when many
+      // MCP servers are connected. Each StdioClientTransport spawns a child
+      // process and adds listeners to its stdin/stdout/stderr pipes; the MCP
+      // protocol layer may also send many concurrent requests (getPrompt,
+      // listTools, etc.) that each add a 'drain' listener on the child
+      // process's stdin. The default limit of ~10 is easily exceeded.
+      const localCount = Object.values(config).filter(
+        (mcp) => typeof mcp === "object" && mcp !== null && "type" in mcp && mcp.type === "local",
+      ).length
+      if (localCount > 0) {
+        const needed = Math.max(localCount * 6, 30) // generous headroom for concurrent requests
+        EventEmitter.defaultMaxListeners = Math.max(EventEmitter.defaultMaxListeners, needed)
+        for (const stream of [process.stdin, process.stdout, process.stderr]) {
+          const current = stream.getMaxListeners()
+          if (current < needed) stream.setMaxListeners(needed)
+        }
+      }
 
       await Promise.all(
         Object.entries(config).map(async ([key, mcp]) => {

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -18,3 +18,35 @@ export function formatDuration(secs: number) {
   const weeks = Math.floor(secs / 604800)
   return weeks === 1 ? "~1 week" : `~${weeks} weeks`
 }
+
+
+/**
+ * Regex to match <think>...</think> and <thinking>...</thinking> blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): { reasoning: string; text: string } {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -44,6 +44,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
+import { splitThinkBlocks } from "@opencode-ai/util/think"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
@@ -1078,7 +1079,9 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     return items.filter((x) => !!x).join(" \u00B7 ")
   })
 
-  const displayText = () => (part.text ?? "").trim()
+  const parsed = createMemo(() => splitThinkBlocks(part.text ?? ""))
+  const displayText = () => parsed().text.trim()
+  const thinkReasoning = () => parsed().reasoning.trim()
   const throttledText = createThrottledValue(displayText)
   const isLastTextPart = createMemo(() => {
     const last = (data.store.part?.[props.message.id] ?? [])
@@ -1105,6 +1108,11 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   return (
     <Show when={throttledText()}>
       <div data-component="text-part">
+        <Show when={thinkReasoning()}>
+          <div data-component="reasoning-part">
+            <Markdown text={thinkReasoning()} cacheKey={part.id + "-reasoning"} />
+          </div>
+        </Show>
         <div data-slot="text-part-body">
           <Markdown text={throttledText()} cacheKey={part.id} />
         </div>

--- a/packages/util/src/think.ts
+++ b/packages/util/src/think.ts
@@ -1,0 +1,40 @@
+/**
+ * Utilities for handling `<think>`/`<thinking>` tags in LLM responses.
+ *
+ * These tags are kept in storage to preserve multi-turn LLM context,
+ * but should be stripped or separated at the rendering layer.
+ */
+
+/**
+ * Regex to match `<think>...</think>` and `<thinking>...</thinking>` blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): {
+  reasoning: string
+  text: string
+} {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. Render `<think>` tags as reasoning blocks at display layer

Models like Kimi K2 Thinking embed reasoning in raw `<think>...</think>` tags within text parts. Previously these were displayed as raw HTML to the user.

**Approach:** Parse and render `<think>` / `<thinking>` tags at the display layer (TUI, Web UI, CLI) rather than stripping them from the message storage. This preserves the full model output for multi-turn context while giving users clean, styled reasoning blocks.

**Changes:**
- **`packages/util/src/think.ts`** -- Shared utility: `stripThinkTags()`, `splitThinkBlocks()` with regex matching both `<think>` and `<thinking>` variants
- **`packages/opencode/src/util/format.ts`** -- Same utilities for the core package (`@/util/format` path alias)
- **`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`** -- `TextPart` renders think blocks with dim/italic/bordered styling matching `ReasoningPart`
- **`packages/ui/src/components/message-part.tsx`** -- `TextPartDisplay` renders think blocks in `<div data-component="reasoning-part">`
- **`packages/opencode/src/cli/cmd/run.ts`** -- CLI strips think tags from output, shows reasoning with `--thinking` flag

### 2. Fix MCP MaxListeners overflow with many servers

When 7+ stdio-based MCP servers are configured, the default Node.js EventEmitter limit of ~10 is exceeded. Each `StdioClientTransport` spawns a child process and adds listeners to its stdin/stdout/stderr pipes. The MCP protocol layer also sends many concurrent requests (`getPrompt`, `listTools`, etc.) that each add a `drain` listener.

**Fix:** Dynamically calculate the needed listener limit based on the number of configured local MCP servers and increase both `EventEmitter.defaultMaxListeners` and process stream limits before connecting.

**Changes:**
- **`packages/opencode/src/mcp/index.ts`** -- Count local MCP servers, set `EventEmitter.defaultMaxListeners` and process stream limits proportionally

## Related Issues
- Fixes #11439 (think tag rendering regression from removal of `extractReasoningMiddleware`)
- Related: #4033, #7779

## Testing
- Type-check passes: `bun turbo typecheck` -- 0 errors in opencode and ui packages
- Tested with Kimi K2 Thinking via NVIDIA NIM -- thinking content renders correctly in TUI
- Tested with 7 MCP servers connected -- no MaxListeners overflow warnings
