### PR TITLE
fix: render think tags as reasoning blocks + increase MCP MaxListeners

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { splitThinkBlocks } from "../../util/format"
 
 type ToolProps<T extends Tool.Info> = {
   input: Tool.InferParameters<T>
@@ -490,7 +491,18 @@ export const RunCommand = cmd({
 
             if (part.type === "text" && part.time?.end) {
               if (emit("text", { part })) continue
-              const text = part.text.trim()
+              const { reasoning, text: displayText } = splitThinkBlocks(part.text)
+              if (reasoning && args.thinking) {
+                const line = `Thinking: ${reasoning}`
+                if (process.stdout.isTTY) {
+                  UI.empty()
+                  UI.println(`${UI.Style.TEXT_DIM}\u001b[3m${line}\u001b[0m${UI.Style.TEXT_NORMAL}`)
+                  UI.empty()
+                } else {
+                  process.stdout.write(line + EOL)
+                }
+              }
+              const text = displayText.trim()
               if (!text) continue
               if (!process.stdout.isTTY) {
                 process.stdout.write(text + EOL)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -79,6 +79,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { splitThinkBlocks } from "@/util/format"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 
@@ -1438,33 +1439,58 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, subtleSyntax } = useTheme()
+  const parsed = createMemo(() => splitThinkBlocks(props.part.text))
+  const displayText = createMemo(() => parsed().text.trim())
+  const reasoning = createMemo(() => parsed().reasoning.trim())
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <Switch>
-          <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-            />
-          </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
-              syntaxStyle={syntax()}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.text}
-            />
-          </Match>
-        </Switch>
-      </box>
-    </Show>
+    <>
+      <Show when={reasoning() && ctx.showThinking()}>
+        <box
+          paddingLeft={2}
+          marginTop={1}
+          flexDirection="column"
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={"_Thinking:_ " + reasoning()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
+      </Show>
+      <Show when={displayText()}>
+        <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+          <Switch>
+            <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={true}
+                content={displayText()}
+                conceal={ctx.conceal()}
+              />
+            </Match>
+            <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <code
+                filetype="markdown"
+                drawUnstyledText={false}
+                streaming={true}
+                syntaxStyle={syntax()}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.text}
+              />
+            </Match>
+          </Switch>
+        </box>
+      </Show>
+    </>
   )
 }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -23,6 +23,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import { EventEmitter } from "node:events"
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -188,6 +189,24 @@ export namespace MCP {
       const config = cfg.mcp ?? {}
       const clients: Record<string, MCPClient> = {}
       const status: Record<string, Status> = {}
+
+      // Increase MaxListeners to prevent EventEmitter warnings when many
+      // MCP servers are connected. Each StdioClientTransport spawns a child
+      // process and adds listeners to its stdin/stdout/stderr pipes; the MCP
+      // protocol layer may also send many concurrent requests (getPrompt,
+      // listTools, etc.) that each add a 'drain' listener on the child
+      // process's stdin. The default limit of ~10 is easily exceeded.
+      const localCount = Object.values(config).filter(
+        (mcp) => typeof mcp === "object" && mcp !== null && "type" in mcp && mcp.type === "local",
+      ).length
+      if (localCount > 0) {
+        const needed = Math.max(localCount * 6, 30) // generous headroom for concurrent requests
+        EventEmitter.defaultMaxListeners = Math.max(EventEmitter.defaultMaxListeners, needed)
+        for (const stream of [process.stdin, process.stdout, process.stderr]) {
+          const current = stream.getMaxListeners()
+          if (current < needed) stream.setMaxListeners(needed)
+        }
+      }
 
       await Promise.all(
         Object.entries(config).map(async ([key, mcp]) => {

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -18,3 +18,35 @@ export function formatDuration(secs: number) {
   const weeks = Math.floor(secs / 604800)
   return weeks === 1 ? "~1 week" : `~${weeks} weeks`
 }
+
+
+/**
+ * Regex to match <think>...</think> and <thinking>...</thinking> blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): { reasoning: string; text: string } {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -32,6 +32,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
+import { splitThinkBlocks } from "@opencode-ai/util/think"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
@@ -1047,7 +1048,9 @@ PART_MAPPING["compaction"] = function CompactionPartDisplay() {
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const part = () => props.part as TextPart
 
-  const displayText = () => (part().text ?? "").trim()
+  const parsed = createMemo(() => splitThinkBlocks(part().text ?? ""))
+  const displayText = () => parsed().text.trim()
+  const thinkReasoning = () => parsed().reasoning.trim()
   const throttledText = createThrottledValue(displayText)
   const summary = createMemo(() => {
     if (props.message.role !== "assistant") return
@@ -1059,6 +1062,11 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   return (
     <Show when={throttledText()}>
       <div data-component="text-part">
+        <Show when={thinkReasoning()}>
+          <div data-component="reasoning-part">
+            <Markdown text={thinkReasoning()} cacheKey={part().id + "-reasoning"} />
+          </div>
+        </Show>
         <div data-slot="text-part-body">
           <Markdown text={throttledText()} cacheKey={part().id} />
         </div>

--- a/packages/util/src/think.ts
+++ b/packages/util/src/think.ts
@@ -1,0 +1,40 @@
+/**
+ * Utilities for handling `<think>`/`<thinking>` tags in LLM responses.
+ *
+ * These tags are kept in storage to preserve multi-turn LLM context,
+ * but should be stripped or separated at the rendering layer.
+ */
+
+/**
+ * Regex to match `<think>...</think>` and `<thinking>...</thinking>` blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): {
+  reasoning: string
+  text: string
+} {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #11439

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Models like DeepSeek R1, QwQ, and other reasoning models emit `<think>`/`<thinking>` tags inline in text parts instead of using the dedicated reasoning content block. These tags leak into rendered output as raw HTML in both the TUI and web UI.

**Think-tag fix:**
- Added `splitThinkBlocks()` / `stripThinkTags()` utilities in `packages/util/src/think.ts` and `packages/opencode/src/util/format.ts`
- TUI `TextPart` now extracts reasoning and renders it as a dimmed/bordered block (only when thinking display is enabled)
- Web UI `TextPartDisplay` renders extracted reasoning in a `reasoning-part` div
- CLI `run.ts` strips think tags from output; shows reasoning with `--thinking` flag

**MCP MaxListeners fix (related):**
- With 7+ local MCP servers, the default `EventEmitter` limit of 10 is easily exceeded because each `StdioClientTransport` adds listeners to stdin/stdout/stderr plus `drain` listeners for concurrent protocol requests
- Dynamically calculates the needed limit from the local MCP server count and raises `EventEmitter.defaultMaxListeners` + per-stream limits before connecting

### How did you verify your code works?

Tested locally with DeepSeek R1 and QwQ models that emit `<think>` tags in streaming responses. Verified tags no longer leak into TUI/web rendered output and reasoning blocks display correctly. MCP fix verified with 8 local MCP servers — no more MaxListeners warnings.

### Screenshots / recordings

_N/A — TUI text rendering change; reasoning blocks render with dim/italic styling behind a left border._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
