### PR TITLE
feat(tui): add width_method config option for ZWJ emoji handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -182,6 +182,7 @@ export function tui(input: {
       },
       {
         targetFps: 60,
+        widthMethod: input.config.width_method,
         gatherStats: false,
         exitOnCtrlC: false,
         useKittyKeyboard: {},

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -22,6 +22,12 @@ export const TuiOptions = z.object({
     .enum(["auto", "stacked"])
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+  width_method: z
+    .enum(["unicode", "wcwidth", "no_zwj"])
+    .optional()
+    .describe(
+      "Character width calculation method. Use 'no_zwj' if ZWJ emoji sequences cause layout corruption in your terminal (common with tmux and older terminals). Default: 'unicode'",
+    ),
 })
 
 export const TuiInfo = z


### PR DESCRIPTION
## Problem

ZWJ emoji sequences (family emoji, profession emoji, pride flag, etc.) cause layout corruption in terminals that don't render them as joined glyphs — most notably tmux, but also many older terminals. Text after a ZWJ sequence shifts across the screen, wraps incorrectly, and input box spacing breaks.

This affects anyone running OpenCode inside tmux with a pane split, and is a long-standing source of reports (see #6210).

## Solution

OpenTUI's Zig layer already has a fully implemented and tested `no_zwj` width calculation mode that handles this correctly. This PR exposes it as a user-configurable option via `opencode.json`.

**Depends on**: anomalyco/opentui#751 — which wires `no_zwj` through the TypeScript→FFI chain. No default is changed in OpenTUI; this PR just passes the user's preference through.

### Changes

- **`packages/opencode/src/config/tui-schema.ts`**: Add `width_method` to `TuiOptions` schema (`"unicode" | "wcwidth" | "no_zwj"`, optional)
- **`packages/opencode/src/cli/cmd/tui/app.tsx`**: Pass `input.config.width_method` to the `render()` call as `widthMethod`

### Usage

Users experiencing layout corruption add one line to their `opencode.json`:

```jsonc
{
  "tui": {
    "width_method": "no_zwj"
  }
}
```

## Behavior

`no_zwj` breaks ZWJ-joined emoji into their component glyphs (👩‍🚀 renders as 👩 + 🚀), which is visually imperfect but **correctly laid out**. Skin tone modifiers, regional indicator flags, combining accents, and CJK characters are completely unaffected.

| Mode | Effect |
|---|---|
| `unicode` (default) | ZWJ sequences as single glyph — correct on modern terminals, corrupts tmux |
| `no_zwj` (opt-in) | ZWJ sequences split — safe everywhere, slightly less pretty |
| `wcwidth` | Existing option, unchanged |

## No Breaking Changes

Default is still `"unicode"`. Users who don't set `width_method` see identical behavior to today.