### PR TITLE
fix(opencode): show human-readable message for HTML error responses

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -76,6 +76,18 @@ export namespace ProviderError {
         }
       } catch {}
 
+      // If responseBody is HTML (e.g. from a gateway or proxy error page),
+      // provide a human-readable message instead of dumping raw markup
+      if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) {
+        if (e.statusCode === 401) {
+          return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
+        }
+        if (e.statusCode === 403) {
+          return "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings."
+        }
+        return msg
+      }
+
       return `${msg}: ${e.responseBody}`
     }).trim()
   }


### PR DESCRIPTION
### Issue for this PR

Closes #15406

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenCode is behind a gateway or proxy that returns HTML error pages (e.g. Cloudflare Access returning a 401), the error handler in `packages/opencode/src/provider/error.ts` dumps raw HTML into the terminal because `JSON.parse` fails on the response body and it falls through to `return \`\${msg}: \${e.responseBody}\``.

This adds a check after the JSON parse attempt: if the response body starts with `<!doctype` or `<html>`, return a clean message instead of the markup. For 401 it tells the user to run `opencode auth login`, for 403 it suggests checking account/provider settings, and for other status codes it returns the status text alone.

The regex only matches HTML — JSON error responses are completely unaffected.

### How did you verify your code works?

Reproduced the issue with a Cloudflare Access-protected provider endpoint where an expired token produces an HTML 401 response. Confirmed the new code path triggers and displays the clean message instead of raw HTML. Also confirmed that normal JSON API errors (e.g. from OpenAI, Anthropic) are unaffected since they don't match the HTML regex.

### Screenshots / recordings

**Before:**
```
Unauthorized: <html>
<head><title>401 Unauthorized</title></head>
<body>
<center><h1>401 Unauthorized</h1></center>
<hr><center>cloudflare</center>
</body>
</html>
```

**After:**
```
Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate.
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR