### PR TITLE
feat(core): add WorkspaceContext

### DIFF
--- a/packages/opencode/src/control-plane/workspace-context.ts
+++ b/packages/opencode/src/control-plane/workspace-context.ts
@@ -1,0 +1,23 @@
+import { Context } from "../util/context"
+
+interface Context {
+  workspaceID?: string
+}
+
+const context = Context.create<Context>("workspace")
+
+export const WorkspaceContext = {
+  async provide<R>(input: { workspaceID?: string; fn: () => R }): Promise<R> {
+    return context.provide({ workspaceID: input.workspaceID }, async () => {
+      return input.fn()
+    })
+  },
+
+  get workspaceID() {
+    try {
+      return context.use().workspaceID
+    } catch (e) {
+      return undefined
+    }
+  },
+}


### PR DESCRIPTION
Breaking my latest work into small PRs. This one adds a new context that code that use to get the `workspaceID`

I didn't want to introduce a new concept initially, and tried to add a `workspaceID` getter to `Instance` instead. That turned out to cause all sorts of confusion though: sometimes only `directory` is available and no workspace id (that won't be the case long-term, but we will need a phase of migration), and the other way around too. In particular, it caused a lot of confusion due to caching of the context value internally; do we cache based on directory or workspace id? It should be workspace id, but sometimes that isn't available

Pulling it out into a new `WorkspaceContext` simplified everything. This is purely internal and publicly people won't be dealing with both instances and workspaces.

Similar to `directory`, this adds a new way to "route" requests: you can specify a `workspace` url param or use the `x-opencode-workspace` header to scope your action to a specific workspace. Eventually, everything will be a workspace, even your default local repo.

I have more work which builds on this to rework the router in `control-plane` to leverage it and will open more once this lands.