### PR TITLE
fix(app): display skill name in skill tool call

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -250,6 +250,11 @@ export function getToolInfo(tool: string, input: any = {}): ToolInfo {
         icon: "bubble-5",
         title: i18n.t("ui.tool.questions"),
       }
+    case "skill":
+      return {
+        icon: "brain",
+        title: input.name || "skill",
+      }
     default:
       return {
         icon: "mcp",
@@ -1898,5 +1903,27 @@ ToolRegistry.register({
         </Show>
       </BasicTool>
     )
+  },
+})
+
+ToolRegistry.register({
+  name: "skill",
+  render(props) {
+    const title = createMemo(() => props.input.name || "skill")
+    const running = createMemo(() => props.status === "pending" || props.status === "running")
+
+    const titleContent = () => <TextShimmer text={title()} active={running()} />
+
+    const trigger = () => (
+      <div data-slot="basic-tool-tool-info-structured">
+        <div data-slot="basic-tool-tool-info-main">
+          <span data-slot="basic-tool-tool-title" class="capitalize agent-title">
+            {titleContent()}
+          </span>
+        </div>
+      </div>
+    )
+
+    return <BasicTool icon="brain" status={props.status} trigger={trigger()} hideDetails />
   },
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15355

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the skill tool to display the actual skill name (e.g., "code reviewer") instead of the generic "skill" title. 



### How did you verify your code works?
manual test with the same skill file

### Screenshots / recordings

#### Before:
<img width="869" height="406" alt="image" src="https://github.com/user-attachments/assets/8758083c-93da-4b92-8793-6e72ca8a925d" />



#### After:
<img width="896" height="450" alt="image" src="https://github.com/user-attachments/assets/e2622bee-7f97-41fa-a06a-3dd8b144fbea" />


### Files changed
| File | Change |
|------|--------|
| `packages/ui/src/components/message-part.tsx` | Added "skill" case to `getToolInfo` (lines 253-257), Added `ToolRegistry.register` for "skill" (lines 1909-1929) |


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR