### PR TITLE
fix(enterprise): support virtual hosted and path-style S3 endpoints

### DIFF
--- a/packages/enterprise/src/core/storage.ts
+++ b/packages/enterprise/src/core/storage.ts
@@ -10,7 +10,13 @@ export namespace Storage {
   }
 
   function createAdapter(client: AwsClient, endpoint: string, bucket: string): Adapter {
-    const base = `${endpoint}/${bucket}`
+    const normalizedEndpoint = endpoint.replace(/\/$/, "")
+    const normalizedBucket = bucket.replace(/^\//, "")
+
+    const base = normalizedEndpoint.includes(normalizedBucket)
+      ? normalizedEndpoint
+      : `${normalizedEndpoint}/${normalizedBucket}`
+
     return {
       async read(path: string): Promise<string | undefined> {
         const response = await client.fetch(`${base}/${path}`)
@@ -66,12 +72,14 @@ export namespace Storage {
   function s3(): Adapter {
     const bucket = process.env.OPENCODE_STORAGE_BUCKET!
     const region = process.env.OPENCODE_STORAGE_REGION || "us-east-1"
+    const endpoint = process.env.OPENCODE_STORAGE_ENDPOINT || `https://s3.${region}.amazonaws.com`
     const client = new AwsClient({
+      service: "s3",
       region,
       accessKeyId: process.env.OPENCODE_STORAGE_ACCESS_KEY_ID!,
       secretAccessKey: process.env.OPENCODE_STORAGE_SECRET_ACCESS_KEY!,
     })
-    return createAdapter(client, `https://s3.${region}.amazonaws.com`, bucket)
+    return createAdapter(client, endpoint, bucket)
   }
 
   function r2() {


### PR DESCRIPTION
### Issue for this PR

Closes #7808

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The enterprise package storage for /share API only supported path-style S3 URLs. This caused issues with S3-compatible providers that use virtual hosted-style URLs.

Then this PR add support for virtual hosted style for S3 providers  and maintains current support for path-style.

The changes:

- Added `OPENCODE_STORAGE_ENDPOINT` environment variable to allow custom S3 endpoints
- Added logic to detect if the endpoint already includes the bucket name (virtual hosted style) vs. needs the bucket appended (path style)

### How did you verify your code works?

You should test locally with your S3 provider using virtual hosted-style endpoint

### Screenshots / recordings

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
