### PR TITLE
refactor: consolidate README translations into docs/translations directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@
 
 <p align="center">
   <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="docs/translations/zh.md">简体中文</a> |
+  <a href="docs/translations/zht.md">繁體中文</a> |
+  <a href="docs/translations/ko.md">한국어</a> |
+  <a href="docs/translations/de.md">Deutsch</a> |
+  <a href="docs/translations/es.md">Español</a> |
+  <a href="docs/translations/fr.md">Français</a> |
+  <a href="docs/translations/it.md">Italiano</a> |
+  <a href="docs/translations/da.md">Dansk</a> |
+  <a href="docs/translations/ja.md">日本語</a> |
+  <a href="docs/translations/pl.md">Polski</a> |
+  <a href="docs/translations/ru.md">Русский</a> |
+  <a href="docs/translations/bs.md">Bosanski</a> |
+  <a href="docs/translations/ar.md">العربية</a> |
+  <a href="docs/translations/no.md">Norsk</a> |
+  <a href="docs/translations/br.md">Português (Brasil)</a> |
+  <a href="docs/translations/th.md">ไทย</a> |
+  <a href="docs/translations/tr.md">Türkçe</a> |
+  <a href="docs/translations/uk.md">Українська</a> |
+  <a href="docs/translations/bn.md">বাংলা</a> |
+  <a href="docs/translations/gr.md">Ελληνικά</a>
 </p>
 
 [![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)

--- a/docs/translations/ar.md
+++ b/docs/translations/ar.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="شعار OpenCode">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="شعار OpenCode">
     </picture>
   </a>
 </p>
@@ -15,30 +15,30 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="bs.md">Bosanski</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -117,7 +117,7 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### المساهمة
 
-اذا كنت مهتما بالمساهمة في OpenCode، يرجى قراءة [contributing docs](./CONTRIBUTING.md) قبل ارسال pull request.
+اذا كنت مهتما بالمساهمة في OpenCode، يرجى قراءة [contributing docs](../../CONTRIBUTING.md) قبل ارسال pull request.
 
 ### البناء فوق OpenCode
 

--- a/docs/translations/bn.md
+++ b/docs/translations/bn.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,30 +15,30 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="bs.md">Bosanski</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -117,7 +117,7 @@ OpenCode এ দুটি বিল্ট-ইন এজেন্ট রয়ে
 
 ### অবদান (Contributing)
 
-আপনি যদি OpenCode এ অবদান রাখতে চান, অনুগ্রহ করে একটি পুল রিকোয়েস্ট সাবমিট করার আগে আমাদের [কন্ট্রিবিউটিং ডকস](./CONTRIBUTING.md) পড়ে নিন।
+আপনি যদি OpenCode এ অবদান রাখতে চান, অনুগ্রহ করে একটি পুল রিকোয়েস্ট সাবমিট করার আগে আমাদের [কন্ট্রিবিউটিং ডকস](../../CONTRIBUTING.md) পড়ে নিন।
 
 ### OpenCode এর উপর বিল্ডিং (Building on OpenCode)
 

--- a/docs/translations/br.md
+++ b/docs/translations/br.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo do OpenCode">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo do OpenCode">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Para mais informações sobre como configurar o OpenCode, [**veja nossa document
 
 ### Contribuir
 
-Se você tem interesse em contribuir com o OpenCode, leia os [contributing docs](./CONTRIBUTING.md) antes de enviar um pull request.
+Se você tem interesse em contribuir com o OpenCode, leia os [contributing docs](../../CONTRIBUTING.md) antes de enviar um pull request.
 
 ### Construindo com OpenCode
 

--- a/docs/translations/bs.md
+++ b/docs/translations/bs.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,30 +15,30 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="bs.md">Bosanski</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -117,7 +117,7 @@ Za više informacija o konfiguraciji OpenCode-a, [**pogledaj dokumentaciju**](ht
 
 ### Doprinosi
 
-Ako želiš doprinositi OpenCode-u, pročitaj [upute za doprinošenje](./CONTRIBUTING.md) prije slanja pull requesta.
+Ako želiš doprinositi OpenCode-u, pročitaj [upute za doprinošenje](../../CONTRIBUTING.md) prije slanja pull requesta.
 
 ### Gradnja na OpenCode-u
 

--- a/docs/translations/da.md
+++ b/docs/translations/da.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ For mere info om konfiguration af OpenCode, [**se vores docs**](https://opencode
 
 ### Bidrag
 
-Hvis du vil bidrage til OpenCode, så læs vores [contributing docs](./CONTRIBUTING.md) før du sender en pull request.
+Hvis du vil bidrage til OpenCode, så læs vores [contributing docs](../../CONTRIBUTING.md) før du sender en pull request.
 
 ### Bygget på OpenCode
 

--- a/docs/translations/de.md
+++ b/docs/translations/de.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Mehr Infos zur Konfiguration von OpenCode findest du in unseren [**Docs**](https
 
 ### Beitragen
 
-Wenn du zu OpenCode beitragen möchtest, lies bitte unsere [Contributing Docs](./CONTRIBUTING.md), bevor du einen Pull Request einreichst.
+Wenn du zu OpenCode beitragen möchtest, lies bitte unsere [Contributing Docs](../../CONTRIBUTING.md), bevor du einen Pull Request einreichst.
 
 ### Auf OpenCode aufbauen
 

--- a/docs/translations/es.md
+++ b/docs/translations/es.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Para más información sobre cómo configurar OpenCode, [**ve a nuestra document
 
 ### Contribuir
 
-Si te interesa contribuir a OpenCode, lee nuestras [docs de contribución](./CONTRIBUTING.md) antes de enviar un pull request.
+Si te interesa contribuir a OpenCode, lee nuestras [docs de contribución](../../CONTRIBUTING.md) antes de enviar un pull request.
 
 ### Construyendo sobre OpenCode
 

--- a/docs/translations/fr.md
+++ b/docs/translations/fr.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo OpenCode">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo OpenCode">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Pour plus d'informations sur la configuration d'OpenCode, [**consultez notre doc
 
 ### Contribuer
 
-Si vous souhaitez contribuer à OpenCode, lisez nos [docs de contribution](./CONTRIBUTING.md) avant de soumettre une pull request.
+Si vous souhaitez contribuer à OpenCode, lisez nos [docs de contribution](../../CONTRIBUTING.md) avant de soumettre une pull request.
 
 ### Construire avec OpenCode
 

--- a/docs/translations/gr.md
+++ b/docs/translations/gr.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,30 +15,30 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="bs.md">Bosanski</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -117,7 +117,7 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### Συνεισφορά
 
-Εάν ενδιαφέρεσαι να συνεισφέρεις στο OpenCode, διαβάστε τα [οδηγό χρήσης συνεισφοράς](./CONTRIBUTING.md) πριν υποβάλεις ένα pull request.
+Εάν ενδιαφέρεσαι να συνεισφέρεις στο OpenCode, διαβάστε τα [οδηγό χρήσης συνεισφοράς](../../CONTRIBUTING.md) πριν υποβάλεις ένα pull request.
 
 ### Δημιουργία πάνω στο OpenCode
 

--- a/docs/translations/it.md
+++ b/docs/translations/it.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo OpenCode">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="Logo OpenCode">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Per maggiori informazioni su come configurare OpenCode, [**consulta la nostra do
 
 ### Contribuire
 
-Se sei interessato a contribuire a OpenCode, leggi la nostra [guida alla contribuzione](./CONTRIBUTING.md) prima di inviare una pull request.
+Se sei interessato a contribuire a OpenCode, leggi la nostra [guida alla contribuzione](../../CONTRIBUTING.md) prima di inviare una pull request.
 
 ### Costruire su OpenCode
 

--- a/docs/translations/ja.md
+++ b/docs/translations/ja.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ OpenCode の設定については [**ドキュメント**](https://opencode.ai/d
 
 ### コントリビュート
 
-OpenCode に貢献したい場合は、Pull Request を送る前に [contributing docs](./CONTRIBUTING.md) を読んでください。
+OpenCode に貢献したい場合は、Pull Request を送る前に [contributing docs](../../CONTRIBUTING.md) を読んでください。
 
 ### OpenCode の上に構築する
 

--- a/docs/translations/ko.md
+++ b/docs/translations/ko.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ OpenCode 설정에 대한 자세한 내용은 [**문서**](https://opencode.ai/d
 
 ### 기여하기
 
-OpenCode 에 기여하고 싶다면, Pull Request 를 제출하기 전에 [contributing docs](./CONTRIBUTING.md) 를 읽어주세요.
+OpenCode 에 기여하고 싶다면, Pull Request 를 제출하기 전에 [contributing docs](../../CONTRIBUTING.md) 를 읽어주세요.
 
 ### OpenCode 기반으로 만들기
 

--- a/docs/translations/no.md
+++ b/docs/translations/no.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ For mer info om hvordan du konfigurerer OpenCode, [**se dokumentasjonen**](https
 
 ### Bidra
 
-Hvis du vil bidra til OpenCode, les [contributing docs](./CONTRIBUTING.md) før du sender en pull request.
+Hvis du vil bidra til OpenCode, les [contributing docs](../../CONTRIBUTING.md) før du sender en pull request.
 
 ### Bygge på OpenCode
 

--- a/docs/translations/pl.md
+++ b/docs/translations/pl.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ Więcej informacji o konfiguracji OpenCode znajdziesz w [**dokumentacji**](https
 
 ### Współtworzenie
 
-Jeśli chcesz współtworzyć OpenCode, przeczytaj [contributing docs](./CONTRIBUTING.md) przed wysłaniem pull requesta.
+Jeśli chcesz współtworzyć OpenCode, przeczytaj [contributing docs](../../CONTRIBUTING.md) przed wysłaniem pull requesta.
 
 ### Budowanie na OpenCode
 

--- a/docs/translations/ru.md
+++ b/docs/translations/ru.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### Вклад
 
-Если вы хотите внести вклад в OpenCode, прочитайте [contributing docs](./CONTRIBUTING.md) перед тем, как отправлять pull request.
+Если вы хотите внести вклад в OpenCode, прочитайте [contributing docs](../../CONTRIBUTING.md) перед тем, как отправлять pull request.
 
 ### Разработка на базе OpenCode
 

--- a/docs/translations/th.md
+++ b/docs/translations/th.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ OpenCode รวมเอเจนต์ในตัวสองตัวที�
 
 ### การมีส่วนร่วม
 
-หากคุณสนใจที่จะมีส่วนร่วมใน OpenCode โปรดอ่าน [เอกสารการมีส่วนร่วม](./CONTRIBUTING.md) ก่อนส่ง Pull Request
+หากคุณสนใจที่จะมีส่วนร่วมใน OpenCode โปรดอ่าน [เอกสารการมีส่วนร่วม](../../CONTRIBUTING.md) ก่อนส่ง Pull Request
 
 ### การสร้างบน OpenCode
 

--- a/docs/translations/tr.md
+++ b/docs/translations/tr.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -116,7 +116,7 @@ OpenCode'u nasıl yapılandıracağınız hakkında daha fazla bilgi için [**do
 
 ### Katkıda Bulunma
 
-OpenCode'a katkıda bulunmak istiyorsanız, lütfen bir pull request göndermeden önce [katkıda bulunma dokümanlarımızı](./CONTRIBUTING.md) okuyun.
+OpenCode'a katkıda bulunmak istiyorsanız, lütfen bir pull request göndermeden önce [katkıda bulunma dokümanlarımızı](../../CONTRIBUTING.md) okuyun.
 
 ### OpenCode Üzerine Geliştirme
 

--- a/docs/translations/uk.md
+++ b/docs/translations/uk.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,30 +15,30 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="bs.md">Bosanski</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -117,7 +117,7 @@ OpenCode містить два вбудовані агенти, між яким�
 
 ### Внесок
 
-Якщо ви хочете зробити внесок в OpenCode, будь ласка, прочитайте нашу [документацію для контриб'юторів](./CONTRIBUTING.md) перед надсиланням pull request.
+Якщо ви хочете зробити внесок в OpenCode, будь ласка, прочитайте нашу [документацію для контриб'юторів](../../CONTRIBUTING.md) перед надсиланням pull request.
 
 ### Проєкти на базі OpenCode
 

--- a/docs/translations/zh.md
+++ b/docs/translations/zh.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -115,7 +115,7 @@ OpenCode 内置两种 Agent，可用 `Tab` 键快速切换：
 
 ### 参与贡献
 
-如有兴趣贡献代码，请在提交 PR 前阅读 [贡献指南 (Contributing Docs)](./CONTRIBUTING.md)。
+如有兴趣贡献代码，请在提交 PR 前阅读 [贡献指南 (Contributing Docs)](../../CONTRIBUTING.md)。
 
 ### 基于 OpenCode 进行开发
 

--- a/docs/translations/zht.md
+++ b/docs/translations/zht.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://opencode.ai">
     <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="../../packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="../../packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
     </picture>
   </a>
 </p>
@@ -15,29 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a>
+  <a href="../../README.md">English</a> |
+  <a href="zh.md">简体中文</a> |
+  <a href="zht.md">繁體中文</a> |
+  <a href="ko.md">한국어</a> |
+  <a href="de.md">Deutsch</a> |
+  <a href="es.md">Español</a> |
+  <a href="fr.md">Français</a> |
+  <a href="it.md">Italiano</a> |
+  <a href="da.md">Dansk</a> |
+  <a href="ja.md">日本語</a> |
+  <a href="pl.md">Polski</a> |
+  <a href="ru.md">Русский</a> |
+  <a href="ar.md">العربية</a> |
+  <a href="no.md">Norsk</a> |
+  <a href="br.md">Português (Brasil)</a> |
+  <a href="th.md">ไทย</a> |
+  <a href="tr.md">Türkçe</a> |
+  <a href="uk.md">Українська</a> |
+  <a href="bn.md">বাংলা</a> |
+  <a href="gr.md">Ελληνικά</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![OpenCode Terminal UI](../../packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
 
 ---
 
@@ -115,7 +115,7 @@ OpenCode 內建了兩種 Agent，您可以使用 `Tab` 鍵快速切換。
 
 ### 參與貢獻
 
-如果您有興趣參與 OpenCode 的開發，請在提交 Pull Request 前先閱讀我們的 [貢獻指南 (Contributing Docs)](./CONTRIBUTING.md)。
+如果您有興趣參與 OpenCode 的開發，請在提交 Pull Request 前先閱讀我們的 [貢獻指南 (Contributing Docs)](../../CONTRIBUTING.md)。
 
 ### 基於 OpenCode 進行開發
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

## Summary

- Move all README translation files from root (`README.{lang}.md`) to `docs/translations/{lang}.md`
- Update all language navigation links in README.md and translation files to reflect new paths
- Fix asset and link paths in translation files to work from new location

## Changes

This PR consolidates 20 translation files into a single `docs/translations/` directory for better organization and maintainability:


## Benefits

- Cleaner root directory structure
- Easier to manage and maintain translations in one place
- Follows common convention for documentation organization
