### PR TITLE
fix(tui): remove debug console.log calls leaking into TUI display

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -257,10 +257,6 @@ function App() {
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
 
-  createEffect(() => {
-    console.log(JSON.stringify(route.data))
-  })
-
   // Update terminal window title based on current route and session
   createEffect(() => {
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -31,7 +31,6 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
         return store
       },
       navigate(route: Route) {
-        console.log("navigate", route)
         setStore(route)
       },
     }

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -347,7 +347,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const args = useArgs()
 
     async function bootstrap() {
-      console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
         .list({ start: start })

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -317,13 +317,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     onMount(init)
 
     function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
       renderer
         .getPalette({
           size: 16,
         })
         .then((colors) => {
-          console.log(colors.palette)
           if (!colors.palette[0]) {
             if (store.active === "system") {
               setStore(

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -5,7 +5,10 @@ import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"
 import path from "path"
 import { Filesystem } from "../../../../util/filesystem"
+import { Log } from "../../../../util/log"
 import { Process } from "../../../../util/process"
+
+const log = Log.create({ service: "clipboard" })
 
 /**
  * Writes text to clipboard via OSC 52 escape sequence.
@@ -77,7 +80,7 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin" && Bun.which("osascript")) {
-      console.log("clipboard: using osascript")
+      log.info("copy method selected", { method: "osascript" })
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
         await $`osascript -e 'set the clipboard to "${escaped}"'`.nothrow().quiet()
@@ -86,7 +89,7 @@ export namespace Clipboard {
 
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && Bun.which("wl-copy")) {
-        console.log("clipboard: using wl-copy")
+        log.info("copy method selected", { method: "wl-copy" })
         return async (text: string) => {
           const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           if (!proc.stdin) return
@@ -96,7 +99,7 @@ export namespace Clipboard {
         }
       }
       if (Bun.which("xclip")) {
-        console.log("clipboard: using xclip")
+        log.info("copy method selected", { method: "xclip" })
         return async (text: string) => {
           const proc = Process.spawn(["xclip", "-selection", "clipboard"], {
             stdin: "pipe",
@@ -110,7 +113,7 @@ export namespace Clipboard {
         }
       }
       if (Bun.which("xsel")) {
-        console.log("clipboard: using xsel")
+        log.info("copy method selected", { method: "xsel" })
         return async (text: string) => {
           const proc = Process.spawn(["xsel", "--clipboard", "--input"], {
             stdin: "pipe",
@@ -126,7 +129,7 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
+      log.info("copy method selected", { method: "powershell" })
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Process.spawn(
@@ -151,7 +154,7 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
+    log.info("copy method selected", { method: "clipboardy" })
     return async (text: string) => {
       await clipboardy.write(text).catch(() => {})
     }


### PR DESCRIPTION
## Summary

- Remove leftover `console.log` debug statements in `app.tsx`, `route.tsx`, `sync.tsx`, and `theme.tsx` that were printing raw output directly into the TUI, corrupting the terminal display.
- Convert `console.log` calls in `clipboard.ts` to use the structured `Log` utility (`Log.create({ service: "clipboard" })`) so clipboard method selection is properly logged without polluting the TUI.

## Files Changed

- `packages/opencode/src/cli/cmd/tui/app.tsx` — removed `console.log(JSON.stringify(route.data))` debug effect
- `packages/opencode/src/cli/cmd/tui/context/route.tsx` — removed `console.log("navigate", route)` 
- `packages/opencode/src/cli/cmd/tui/context/sync.tsx` — removed `console.log("bootstrapping")`
- `packages/opencode/src/cli/cmd/tui/context/theme.tsx` — removed `console.log("resolveSystemTheme")` and `console.log(colors.palette)`
- `packages/opencode/src/cli/cmd/tui/util/clipboard.ts` — replaced all `console.log("clipboard: ...")` with `log.info("copy method selected", { method: "..." })`