### PR TITLE
fix(desktop): keep permission actions visible with long copy

### DIFF
--- a/packages/app/src/pages/session/composer/session-permission-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-permission-dock.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from "solid-js"
+import { For, Show, onCleanup, onMount } from "solid-js"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
 import { Button } from "@opencode-ai/ui/button"
 import { DockPrompt } from "@opencode-ai/ui/dock-prompt"
@@ -11,6 +11,56 @@ export function SessionPermissionDock(props: {
   onDecide: (response: "once" | "always" | "reject") => void
 }) {
   const language = useLanguage()
+  let root: HTMLDivElement | undefined
+
+  const measure = () => {
+    if (!root) return
+
+    const scroller = document.querySelector(".scroll-view__viewport")
+    const head = scroller instanceof HTMLElement ? scroller.firstElementChild : undefined
+    const top =
+      head instanceof HTMLElement && head.classList.contains("sticky") ? head.getBoundingClientRect().bottom : 0
+    if (!top) {
+      root.style.removeProperty("--permission-prompt-max-height")
+      return
+    }
+
+    const dock = root.closest('[data-component="session-prompt-dock"]')
+    if (!(dock instanceof HTMLElement)) return
+
+    const dockBottom = dock.getBoundingClientRect().bottom
+    const below = Math.max(0, dockBottom - root.getBoundingClientRect().bottom)
+    const gap = 8
+    const max = Math.max(240, Math.floor(dockBottom - top - gap - below))
+    root.style.setProperty("--permission-prompt-max-height", `${max}px`)
+  }
+
+  onMount(() => {
+    let raf: number | undefined
+    const update = () => {
+      if (raf !== undefined) cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        raf = undefined
+        measure()
+      })
+    }
+
+    update()
+    window.addEventListener("resize", update)
+
+    const dock = root?.closest('[data-component="session-prompt-dock"]')
+    const scroller = document.querySelector(".scroll-view__viewport")
+    const observer = new ResizeObserver(update)
+    if (dock instanceof HTMLElement) observer.observe(dock)
+    if (scroller instanceof HTMLElement) observer.observe(scroller)
+
+    onCleanup(() => {
+      window.removeEventListener("resize", update)
+      observer.disconnect()
+      if (raf !== undefined) cancelAnimationFrame(raf)
+      root?.style.removeProperty("--permission-prompt-max-height")
+    })
+  })
 
   const toolDescription = () => {
     const key = `settings.permissions.tool.${props.request.permission}.description`
@@ -22,6 +72,7 @@ export function SessionPermissionDock(props: {
   return (
     <DockPrompt
       kind="permission"
+      ref={(el) => (root = el)}
       header={
         <div data-slot="permission-row" data-variant="header">
           <span data-slot="permission-icon">

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -669,7 +669,7 @@
   flex-direction: column;
   gap: 0;
   min-height: 0;
-  max-height: 100dvh;
+  max-height: var(--permission-prompt-max-height, 100dvh);
 
   [data-slot="permission-body"] {
     display: flex;
@@ -720,6 +720,8 @@
     gap: 4px;
     flex: 1;
     min-height: 0;
+    overflow-y: auto;
+    padding-right: 8px;
   }
 
   [data-slot="permission-hint"] {


### PR DESCRIPTION
### Issue for this PR
Closes #15497

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
### What does this PR do?
Fixes a desktop UI bug where the permission modal could hide the action buttons (`Reject`, `Allow always`, `Allow once`) when the permission description was long (for example, "Run shell commands" in some locales or wrapped cases).
The fix does two things:
1. Constrains permission prompt height to available dock space (same pattern used by the question prompt), so it does not grow past the visible area.
2. Makes permission content scrollable with a small right padding so long text can scroll without colliding with the scrollbar.
This keeps the footer actions visible and usable while still allowing long content to be read.
### How did you verify your code works?
- Reproduced the issue by triggering a permission request with long/wrapping description text.
- Confirmed that before the change, footer buttons could be pushed out of view.
- Confirmed after the change that footer buttons remain visible and content scrolls instead.
- Ran package type checks for affected UI packages during validation.
### Screenshots / recordings
Before: permission modal with long description and hidden footer actions  
<img width="1919" height="1028" alt="image" src="https://github.com/user-attachments/assets/62b584b5-7971-4b7c-977c-3735cb434be8" />

After: permission modal with visible `Reject`, `Allow always`, `Allow once` and scrollable content
<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/3c47f624-8eb1-4aa0-9168-ea8ecf1f57c7" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR