### PR TITLE
feat(vscode): configurable TUI location

### DIFF
--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -78,7 +78,21 @@
         "win": "ctrl+alt+K",
         "linux": "ctrl+alt+K"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "opencode",
+      "properties": {
+        "opencode.tuiLocation": {
+          "type": "string",
+          "default": "editor",
+          "enum": [
+            "editor",
+            "terminal"
+          ],
+          "description": "Where to open the opencode TUI: beside the current editor or in the terminal panel."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "bun run package",

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -40,10 +40,12 @@ export function activate(context: vscode.ExtensionContext) {
     }
   })
 
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
+  context.subscriptions.push(openNewTerminalDisposable, openTerminalDisposable, addFilepathDisposable)
 
   async function openTerminal() {
     // Create a new terminal in split screen
+    const config = vscode.workspace.getConfiguration("opencode")
+    const tuiLocation = config.get<string>("tuiLocation", "editor")
     const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
     const terminal = vscode.window.createTerminal({
       name: TERMINAL_NAME,
@@ -51,10 +53,13 @@ export function activate(context: vscode.ExtensionContext) {
         light: vscode.Uri.file(context.asAbsolutePath("images/button-dark.svg")),
         dark: vscode.Uri.file(context.asAbsolutePath("images/button-light.svg")),
       },
-      location: {
-        viewColumn: vscode.ViewColumn.Beside,
-        preserveFocus: false,
-      },
+      location:
+        tuiLocation === "terminal"
+          ? vscode.TerminalLocation.Panel
+          : {
+              viewColumn: vscode.ViewColumn.Beside,
+              preserveFocus: false,
+            },
       env: {
         _EXTENSION_OPENCODE_PORT: port.toString(),
         OPENCODE_CALLER: "vscode",


### PR DESCRIPTION
### Issue for this PR

Closes #15503

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `opencode.tuiLocation` to the vscode extension. Defaults to 'editor' which keeps the previous behavior. Adds 'terminal' to spawn the TUI to vscode Terminal panel instead.

### How did you verify your code works?
```
cd opencode\sdks\vscode
bun compile
[...]
npx @vscode/vsce package --no-git-tag-version --no-update-package-json --no-dependencies --skip-license -o dist/opencode.vsix 1.2.15
[...]
```
Then installed the vsix in vscode to validate that the default behavior was kept and that the new behavior properly spawned the TUI in the terminal panel.


### Screenshots / recordings

In VSCode Setting UI
<img width="886" height="394" alt="image" src="https://github.com/user-attachments/assets/066819ed-952a-481e-8b2f-97e7802a644a" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
