### PR TITLE
fix(opencode): show skill names instead of array indices in error message

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -62,7 +62,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
       const skill = await Skill.get(params.name)
 
       if (!skill) {
-        const available = await Skill.all().then((x) => Object.keys(x).join(", "))
+        const available = await Skill.all().then((x) => x.map((s) => s.name).join(", "))
         throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
       }
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -18,6 +18,51 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
 }
 
 describe("tool.skill", () => {
+  test("error message lists skill names not array indices", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const skillDir = path.join(dir, ".opencode", "skill", "existing-skill")
+        await Bun.write(
+          path.join(skillDir, "SKILL.md"),
+          `---
+name: existing-skill
+description: An existing skill.
+---
+
+# Existing Skill
+`,
+        )
+      },
+    })
+
+    const home = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tool = await SkillTool.init()
+          const ctx: Tool.Context = {
+            ...baseCtx,
+            ask: async () => {},
+          }
+
+          try {
+            await tool.execute({ name: "nonexistent-skill" }, ctx)
+            expect.unreachable("should have thrown")
+          } catch (err: any) {
+            expect(err.message).toContain("existing-skill")
+            expect(err.message).not.toContain("Available skills: 0")
+          }
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = home
+    }
+  })
+
   test("description lists skill location URL", async () => {
     await using tmp = await tmpdir({
       git: true,


### PR DESCRIPTION
## Summary

- `Skill.all()` returns an array, so `Object.keys()` on it produces numeric indices (`"0, 1, 2, ..."`) instead of skill names. Replaced with `.map((s) => s.name)`.
- Added a test that verifies the error message contains actual skill names.

Fixes #7080

## Verification

- Existing skill tests pass (`bun test test/tool/skill.test.ts test/skill/skill.test.ts` — 14 tests, 0 failures)
- New test creates a skill, attempts to load a nonexistent skill, and asserts the error message contains the real skill name rather than array indices