### PR TITLE
feat: Replace elixir-ls with Expert, the official Elixir LSP

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -24,6 +24,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".dockerfile": "dockerfile",
   ".ex": "elixir",
   ".exs": "elixir",
+  ".heex": "phoenix-heex",
   ".erl": "erlang",
   ".ets": "typescript",
   ".hrl": "erlang",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -562,63 +562,73 @@ export namespace LSPServer {
     },
   }
 
-  export const ElixirLS: Info = {
-    id: "elixir-ls",
-    extensions: [".ex", ".exs"],
+  export const Expert: Info = {
+    id: "expert",
+    extensions: [".ex", ".exs", ".heex"],
     root: NearestRoot(["mix.exs", "mix.lock"]),
     async spawn(root) {
-      let binary = which("elixir-ls")
-      if (!binary) {
-        const elixirLsPath = path.join(Global.Path.bin, "elixir-ls")
-        binary = path.join(
-          Global.Path.bin,
-          "elixir-ls-master",
-          "release",
-          process.platform === "win32" ? "language_server.bat" : "language_server.sh",
-        )
+      let bin = which("expert", {
+        PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
+      })
 
-        if (!(await Filesystem.exists(binary))) {
-          const elixir = which("elixir")
-          if (!elixir) {
-            log.error("elixir is required to run elixir-ls")
-            return
-          }
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("downloading expert from GitHub releases")
 
-          if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
-          log.info("downloading elixir-ls from GitHub releases")
-
-          const response = await fetch("https://github.com/elixir-lsp/elixir-ls/archive/refs/heads/master.zip")
-          if (!response.ok) return
-          const zipPath = path.join(Global.Path.bin, "elixir-ls.zip")
-          if (response.body) await Filesystem.writeStream(zipPath, response.body)
-
-          const ok = await Archive.extractZip(zipPath, Global.Path.bin)
-            .then(() => true)
-            .catch((error) => {
-              log.error("Failed to extract elixir-ls archive", { error })
-              return false
-            })
-          if (!ok) return
-
-          await fs.rm(zipPath, {
-            force: true,
-            recursive: true,
-          })
-
-          const cwd = path.join(Global.Path.bin, "elixir-ls-master")
-          const env = { MIX_ENV: "prod", ...process.env }
-          await Process.run(["mix", "deps.get"], { cwd, env })
-          await Process.run(["mix", "compile"], { cwd, env })
-          await Process.run(["mix", "elixir_ls.release2", "-o", "release"], { cwd, env })
-
-          log.info(`installed elixir-ls`, {
-            path: elixirLsPath,
-          })
+        const releaseResponse = await fetch("https://api.github.com/repos/elixir-lang/expert/releases/latest")
+        if (!releaseResponse.ok) {
+          log.error("failed to fetch expert release info")
+          return
         }
+
+        const release = (await releaseResponse.json()) as any
+
+        const platform = process.platform
+        const arch = process.arch
+
+        let expertPlatform = platform as string
+        if (platform === "win32") expertPlatform = "windows"
+
+        let expertArch = arch as string
+        if (arch === "x64") expertArch = "amd64"
+
+        const ext = platform === "win32" ? ".exe" : ""
+        const assetName = `expert_${expertPlatform}_${expertArch}${ext}`
+
+        const supported = [
+          "expert_darwin_amd64",
+          "expert_darwin_arm64",
+          "expert_linux_amd64",
+          "expert_linux_arm64",
+          "expert_windows_amd64.exe",
+        ]
+
+        if (!supported.includes(assetName)) {
+          log.error(`platform ${platform} (${arch}) is not supported by expert`)
+          return
+        }
+
+        const asset = release.assets.find((a: any) => a.name === assetName)
+        if (!asset) {
+          log.error(`could not find asset ${assetName} in latest expert release`)
+          return
+        }
+
+        const response = await fetch(asset.browser_download_url)
+        if (!response.ok) {
+          log.error("failed to download expert")
+          return
+        }
+
+        bin = path.join(Global.Path.bin, platform === "win32" ? "expert.exe" : "expert")
+        if (response.body) await Filesystem.writeStream(bin, response.body)
+        await fs.chmod(bin, 0o755)
+
+        log.info("installed expert", { path: bin })
       }
 
       return {
-        process: spawn(binary, {
+        process: spawn(bin, ["--stdio"], {
           cwd: root,
         }),
       }

--- a/packages/web/src/content/docs/ar/lsp.mdx
+++ b/packages/web/src/content/docs/ar/lsp.mdx
@@ -20,7 +20,7 @@ description: يتكامل OpenCode مع خوادم LSP لديك.
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | توفر أمر `clojure-lsp`                               |
 | dart               | .dart                                                               | توفر أمر `dart`                                      |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | توفر أمر `deno` (يكتشف تلقائيا deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | توفر أمر `elixir`                                    |
+| expert             | .ex, .exs, .heex                                                    | تثبيت تلقائي من إصدارات GitHub                        |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | وجود تبعية `eslint` في المشروع                       |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | تثبيت `.NET SDK`                                     |
 | gleam              | .gleam                                                              | توفر أمر `gleam`                                     |

--- a/packages/web/src/content/docs/bs/lsp.mdx
+++ b/packages/web/src/content/docs/bs/lsp.mdx
@@ -18,7 +18,7 @@ OpenCode dolazi sa nekoliko ugrađenih LSP servera za popularne jezike:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` komanda dostupna                           |
 | dart               | .dart                                                               | `dart` komanda dostupna                                  |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` komanda dostupna (automatski detektuje deno.json) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` komanda dostupna                                |
+| expert             | .ex, .exs, .heex                                                    | Auto-instalacija sa GitHub izdanja                        |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` ovisnost u projektu                             |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` instaliran                                    |
 | gleam              | .gleam                                                              | `gleam` komanda dostupna                                 |

--- a/packages/web/src/content/docs/da/lsp.mdx
+++ b/packages/web/src/content/docs/da/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode leveres med flere indbyggede LSP-servere til populære sprog:
 | clojure-lsp        | .clj,.cljs,.cljc,.edn                                     | `clojure-lsp` kommando tilgængelig                              |
 | dart               | .dart                                                     | `dart` kommando tilgængelig                                     |
 | deno               | .ts,.tsx,.js,.jsx,.mjs                                    | `deno` kommando tilgængelig (auto-detects deno.json/deno.jsonc) |
-| elixir-ls          | .ex,.exs                                                  | `elixir` kommando tilgængelig                                   |
+| expert             | .ex, .exs, .heex                                                    | Auto-installerer fra GitHub-udgivelser                          |
 | eslint             | .ts,.tsx,.js,.jsx,.mjs,.cjs,.mts,.cts,.vue                | `eslint` afhængighed i projekt                                  |
 | fsharp             | .fs,.fsi,.fsx,.fsscript                                   | `.NET SDK` installere                                           |
 | gleam              | .gleam                                                    | `gleam` kommando tilgængelig                                    |

--- a/packages/web/src/content/docs/de/lsp.mdx
+++ b/packages/web/src/content/docs/de/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode verfügt über mehrere integrierte LSP-Server für gängige Sprachen:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp`-Befehl verfügbar                                            |
 | dart               | .dart                                                               | `dart`-Befehl verfügbar                                                   |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno`-Befehl verfügbar (automatische Erkennung von deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir`-Befehl verfügbar                                                 |
+| expert             | .ex, .exs, .heex                                                    | Automatische Installation von GitHub-Releases                             |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` dependency in project                                            |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                                      |
 | gleam              | .gleam                                                              | `gleam`-Befehl verfügbar                                                  |

--- a/packages/web/src/content/docs/es/lsp.mdx
+++ b/packages/web/src/content/docs/es/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode viene con varios servidores LSP integrados para idiomas populares:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | Comando `clojure-lsp` disponible                                         |
 | dart               | .dart                                                               | Comando `dart` disponible                                                |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | Comando `deno` disponible (detecta automáticamente deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | Comando `elixir` disponible                                              |
+| expert             | .ex, .exs, .heex                                                    | Auto-instala desde lanzamientos de GitHub                                |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` dependencia en proyecto                                         |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` instalado                                                     |
 | gleam              | .gleam                                                              | Comando `gleam` disponible                                               |

--- a/packages/web/src/content/docs/fr/lsp.mdx
+++ b/packages/web/src/content/docs/fr/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode est livré avec plusieurs serveurs LSP intégrés pour les langages pop
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | Commande `clojure-lsp` disponible                                       |
 | dart               | .dart                                                               | Commande `dart` disponible                                              |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | Commande `deno` disponible (détection automatique deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .ex                                                            | Commande `elixir` disponible                                            |
+| expert             | .ex, .exs, .heex                                                    | Installation automatique depuis les releases GitHub                     |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | Dépendance `eslint` dans le projet                                      |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installé                                                     |
 | gleam              | .gleam                                                              | Commande `gleam` disponible                                             |

--- a/packages/web/src/content/docs/it/lsp.mdx
+++ b/packages/web/src/content/docs/it/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode include diversi server LSP integrati per linguaggi popolari:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | comando `clojure-lsp` disponibile                                        |
 | dart               | .dart                                                               | comando `dart` disponibile                                               |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | comando `deno` disponibile (rileva automaticamente deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | comando `elixir` disponibile                                             |
+| expert             | .ex, .exs, .heex                                                    | Installazione automatica da rilasci GitHub                               |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | dipendenza `eslint` nel progetto                                         |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installato                                                    |
 | gleam              | .gleam                                                              | comando `gleam` disponibile                                              |

--- a/packages/web/src/content/docs/ja/lsp.mdx
+++ b/packages/web/src/content/docs/ja/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode には、一般的な言語用のいくつかの組み込み LSP サー
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` command available                              |
 | dart               | .dart                                                               | `dart` command available                                     |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` command available (auto-detects deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` command available                                   |
+| expert             | .ex, .exs, .heex                                                    | GitHubリリースから自動インストール                      |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` dependency in project                               |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                         |
 | gleam              | .gleam                                                              | `gleam` command available                                    |

--- a/packages/web/src/content/docs/ko/lsp.mdx
+++ b/packages/web/src/content/docs/ko/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode는 널리 사용되는 언어를 위해 여러 built-in LSP 서버를 �
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` 명령 사용 가능                               |
 | dart               | .dart                                                               | `dart` 명령 사용 가능                                      |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` 명령 사용 가능 (`deno.json`/`deno.jsonc` 자동 감지) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` 명령 사용 가능                                    |
+| expert             | .ex, .exs, .heex                                                    | GitHub 릴리스에서 자동 설치                               |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | 프로젝트에 `eslint` dependency 존재                        |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` 설치됨                                          |
 | gleam              | .gleam                                                              | `gleam` 명령 사용 가능                                     |

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` command available                              |
 | dart               | .dart                                                               | `dart` command available                                     |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` command available (auto-detects deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` command available                                   |
+| expert             | .ex, .exs, .heex                                                    | Auto-installs from GitHub releases                           |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` dependency in project                               |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                         |
 | gleam              | .gleam                                                              | `gleam` command available                                    |

--- a/packages/web/src/content/docs/nb/lsp.mdx
+++ b/packages/web/src/content/docs/nb/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode kommer med flere innebygde LSP-servere for populære språk:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` kommando tilgjengelig                                     |
 | dart               | .dart                                                               | `dart` kommando tilgjengelig                                            |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` kommando tilgjengelig (automatisk oppdager deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` kommando tilgjengelig                                          |
+| expert             | .ex, .exs, .heex                                                    | Auto-installerer fra GitHub-utgivelser                                  |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` avhengighet i prosjekt                                         |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installert                                                   |
 | gleam              | .gleam                                                              | `gleam` kommando tilgjengelig                                           |

--- a/packages/web/src/content/docs/pl/lsp.mdx
+++ b/packages/web/src/content/docs/pl/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode posiada kilka wbudowanych serwerów LSP dla następujących języków:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | Dostępne polecenie `clojure-lsp`                                         |
 | dart               | .dart                                                               | Dostępne polecenie `dart`                                                |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | Dostępne polecenie `deno` (automatyczne wykrywanie deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | Dostępne polecenie `elixir`                                              |
+| expert             | .ex, .exs, .heex                                                    | Automatyczna instalacja z wydań GitHub                                   |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | Zależność `eslint` w projekcie                                           |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | Zainstalowany `.NET SDK`                                                 |
 | gleam              | .gleam                                                              | Dostępne polecenie `gleam`                                               |

--- a/packages/web/src/content/docs/pt-br/lsp.mdx
+++ b/packages/web/src/content/docs/pt-br/lsp.mdx
@@ -20,7 +20,7 @@ O opencode vem com vários servidores LSP integrados para linguagens populares:
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | Comando `clojure-lsp` disponível                                         |
 | dart               | .dart                                                               | Comando `dart` disponível                                                |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | Comando `deno` disponível (detecta automaticamente deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | Comando `elixir` disponível                                              |
+| expert             | .ex, .exs, .heex                                                    | Instalação automática a partir de lançamentos do GitHub                  |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | Dependência `eslint` no projeto                                          |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` instalado                                                     |
 | gleam              | .gleam                                                              | Comando `gleam` disponível                                               |

--- a/packages/web/src/content/docs/ru/lsp.mdx
+++ b/packages/web/src/content/docs/ru/lsp.mdx
@@ -20,7 +20,7 @@ opencode поставляется с несколькими встроенным
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` команда доступна                                            |
 | dart               | .dart                                                               | `dart` команда доступна                                                   |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` команда доступна (автоматически обнаруживает deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` команда доступна                                                 |
+| expert             | .ex, .exs, .heex                                                    | Автоустановка из релизов GitHub                                           |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` зависимость в проекте                                            |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` установлен                                                     |
 | gleam              | .gleam                                                              | `gleam` команда доступна                                                  |

--- a/packages/web/src/content/docs/th/lsp.mdx
+++ b/packages/web/src/content/docs/th/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode มาพร้อมกับเซิร์ฟเวอร์ LSP ใ
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` คำสั่งใช้ได้                              |
 | dart               | .dart                                                               | `dart` คำสั่งใช้ได้                                     |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | มีคำสั่ง `deno` (ตรวจจับอัตโนมัติ deno.json/deno.jsonc) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` คำสั่งใช้ได้                                   |
+| expert             | .ex, .exs, .heex                                                    | ติดตั้งอัตโนมัติจาก GitHub releases                     |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | `eslint` การพึ่งพาในโครงการ                             |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` ติดตั้งแล้ว                                  |
 | gleam              | .gleam                                                              | `gleam` คำสั่งใช้ได้                                    |

--- a/packages/web/src/content/docs/tr/lsp.mdx
+++ b/packages/web/src/content/docs/tr/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode, popüler diller için çeşitli yerleşik LSP sunucularıyla birlikte 
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | `clojure-lsp` komutu mevcut                                           |
 | dart               | .dart                                                               | `dart` komutu mevcut                                                  |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | `deno` komutu mevcut (deno.json/deno.jsonc otomatik olarak algılanır) |
-| elixir-ls          | .ex, .exs                                                           | `elixir` komutu mevcut                                                |
+| expert             | .ex, .exs, .heex                                                    | GitHub sürümlerinden otomatik yükleme                                 |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | Projede `eslint` bağımlılığı                                          |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` kurulu                                                     |
 | gleam              | .gleam                                                              | `gleam` komutu mevcut                                                 |

--- a/packages/web/src/content/docs/zh-cn/lsp.mdx
+++ b/packages/web/src/content/docs/zh-cn/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode 内置了多种适用于主流语言的 LSP 服务器：
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | 需要 `clojure-lsp` 命令可用                           |
 | dart               | .dart                                                               | 需要 `dart` 命令可用                                  |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | 需要 `deno` 命令可用（自动检测 deno.json/deno.jsonc） |
-| elixir-ls          | .ex, .exs                                                           | 需要 `elixir` 命令可用                                |
+| expert             | .ex, .exs, .heex                                                    | 从 GitHub 发行版自动安装                               |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | 项目中需要 `eslint` 依赖                              |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | 需要已安装 `.NET SDK`                                 |
 | gleam              | .gleam                                                              | 需要 `gleam` 命令可用                                 |

--- a/packages/web/src/content/docs/zh-tw/lsp.mdx
+++ b/packages/web/src/content/docs/zh-tw/lsp.mdx
@@ -20,7 +20,7 @@ OpenCode 內建了多種適用於主流語言的 LSP 伺服器：
 | clojure-lsp        | .clj, .cljs, .cljc, .edn                                            | 需要 `clojure-lsp` 指令可用                           |
 | dart               | .dart                                                               | 需要 `dart` 指令可用                                  |
 | deno               | .ts, .tsx, .js, .jsx, .mjs                                          | 需要 `deno` 指令可用（自動偵測 deno.json/deno.jsonc） |
-| elixir-ls          | .ex, .exs                                                           | 需要 `elixir` 指令可用                                |
+| expert             | .ex, .exs, .heex                                                    | 從 GitHub 發行版自動安裝                               |
 | eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue                  | 專案中需要 `eslint` 相依套件                          |
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | 需要已安裝 `.NET SDK`                                 |
 | gleam              | .gleam                                                              | 需要 `gleam` 指令可用                                 |


### PR DESCRIPTION
### Issue for this PR

Closes #15512

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This updates the Elixir language server to use Expert and adds support for heex files.

### How did you verify your code works?

I ran my local version of and did some work in an Elixir repo.

### Screenshots / recordings

Here is a screenshot of me running a local version of OpenCode with expert running after opening an elixir file:
<img width="313" height="866" alt="image" src="https://github.com/user-attachments/assets/de4e2fe4-fef5-4398-a3eb-48372cbcd697" />

Here's a screenshot of the process details in Activity Monitor on MacOS:
<img width="541" height="295" alt="image" src="https://github.com/user-attachments/assets/2d79551b-f42d-4575-86dd-7c2159734b88" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
