### PR TITLE
feat(ui): add dynamic plugin settings interface

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/settings/index.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/settings/index.tsx
@@ -1,10 +1,23 @@
+import { Tabs } from "@kobalte/core/tabs"
 import { SettingsSection } from "./settings-section"
+import { PluginSettingsSection } from "./plugin-settings-section"
 
 export default function () {
   return (
     <div data-page="workspace-[id]">
       <div data-slot="sections">
-        <SettingsSection />
+        <Tabs defaultValue="general" data-component="tabs">
+          <Tabs.List data-slot="tablist">
+            <Tabs.Trigger value="general" data-slot="tab">General</Tabs.Trigger>
+            <Tabs.Trigger value="plugins" data-slot="tab">Plugins</Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="general">
+            <SettingsSection />
+          </Tabs.Content>
+          <Tabs.Content value="plugins">
+            <PluginSettingsSection />
+          </Tabs.Content>
+        </Tabs>
       </div>
     </div>
   )

--- a/packages/console/app/src/routes/workspace/[id]/settings/plugin-settings-section.module.css
+++ b/packages/console/app/src/routes/workspace/[id]/settings/plugin-settings-section.module.css
@@ -1,0 +1,161 @@
+.root {
+  max-width: 40rem;
+
+  [data-slot="section-title"] {
+    margin-bottom: var(--space-4);
+
+    h2 {
+      margin: 0 0 var(--space-1) 0;
+    }
+
+    p {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: var(--font-size-sm);
+    }
+  }
+
+  [data-slot="section-content"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  [data-slot="status"] {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    margin: 0;
+
+    &[data-color="danger"] {
+      color: var(--color-danger);
+    }
+  }
+
+  [data-slot="plugin-card"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-md);
+
+    h3 {
+      margin: 0;
+      font-size: var(--font-size-base);
+      font-weight: 600;
+    }
+  }
+
+  [data-slot="plugin-fields"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  [data-slot="setting-field"] {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    [data-slot="field-title"] {
+      font-size: var(--font-size-sm);
+      font-weight: 500;
+      color: var(--color-text);
+    }
+
+    [data-slot="field-description"] {
+      font-size: var(--font-size-xs);
+      color: var(--color-text-muted);
+      line-height: 1.4;
+    }
+
+    input[data-component="input"],
+    select[data-component="input"] {
+      padding: var(--space-2) var(--space-3);
+      border: 1px solid var(--color-border);
+      border-radius: var(--border-radius-sm);
+      background-color: var(--color-bg);
+      color: var(--color-text);
+      font-size: var(--font-size-sm);
+      line-height: 1.5;
+      width: 100%;
+
+      &:focus {
+        outline: none;
+        border-color: var(--color-accent);
+        box-shadow: 0 0 0 3px var(--color-accent-alpha);
+      }
+
+      &::placeholder {
+        color: var(--color-text-disabled);
+      }
+    }
+
+    select[data-component="input"] {
+      cursor: pointer;
+    }
+  }
+
+  [data-slot="toggle"] {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    align-self: flex-start;
+
+    input[type="checkbox"] {
+      position: absolute;
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    [data-slot="toggle-track"] {
+      width: 2.5rem;
+      height: 1.375rem;
+      background-color: var(--color-border);
+      border-radius: 999px;
+      transition: background-color 150ms ease;
+      display: flex;
+      align-items: center;
+      padding: 2px;
+    }
+
+    input:checked + [data-slot="toggle-track"] {
+      background-color: var(--color-accent);
+    }
+
+    [data-slot="toggle-thumb"] {
+      width: 1rem;
+      height: 1rem;
+      background-color: white;
+      border-radius: 50%;
+      transition: transform 150ms ease;
+    }
+
+    input:checked + [data-slot="toggle-track"] [data-slot="toggle-thumb"] {
+      transform: translateX(1.125rem);
+    }
+  }
+
+  [data-slot="plugin-actions"] {
+    display: flex;
+    gap: var(--space-2);
+
+    button {
+      align-self: flex-start;
+    }
+  }
+
+  [data-slot="form-error"] {
+    color: var(--color-danger);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+  }
+}

--- a/packages/console/app/src/routes/workspace/[id]/settings/plugin-settings-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/settings/plugin-settings-section.tsx
@@ -1,0 +1,187 @@
+import { createSignal, createResource, For, Show, Switch, Match } from "solid-js"
+import styles from "./plugin-settings-section.module.css"
+
+type SettingDefinition = {
+  type: "string" | "number" | "boolean" | "select" | "secret"
+  title: string
+  description?: string
+  default?: unknown
+  required?: boolean
+  placeholder?: string
+  enum?: string[]
+  enumLabels?: string[]
+}
+
+type PluginSchema = {
+  id: string
+  title: string
+  properties: Record<string, SettingDefinition>
+}
+
+type PluginSettingsData = {
+  schemas: PluginSchema[]
+  values: Record<string, Record<string, unknown>>
+}
+
+async function fetchSettings(): Promise<PluginSettingsData> {
+  const res = await fetch("/config/plugin-settings")
+  if (!res.ok) throw new Error("Failed to fetch plugin settings")
+  return res.json()
+}
+
+export function PluginSettingsSection() {
+  const [data, { refetch }] = createResource(fetchSettings)
+  const [saving, setSaving] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string | null>(null)
+  const [draft, setDraft] = createSignal<Record<string, Record<string, unknown>>>({})
+
+  function val(pluginId: string, key: string) {
+    const local = draft()[pluginId]
+    if (local && key in local) return local[key]
+    return data()?.values[pluginId]?.[key]
+  }
+
+  function update(pluginId: string, key: string, v: unknown) {
+    setDraft((prev: Record<string, Record<string, unknown>>) => ({
+      ...prev,
+      [pluginId]: { ...(prev[pluginId] ?? {}), [key]: v },
+    }))
+  }
+
+  function dirty(pluginId: string) {
+    const d = draft()[pluginId]
+    return !!d && Object.keys(d).length > 0
+  }
+
+  async function save(pluginId: string) {
+    setSaving(pluginId)
+    setError(null)
+    try {
+      const current = data()?.values[pluginId] ?? {}
+      const merged = { ...current, ...draft()[pluginId] }
+      const res = await fetch("/config/plugin-settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plugin_id: pluginId, settings: merged }),
+      })
+      if (!res.ok) throw new Error("Failed to save")
+      setDraft((prev: Record<string, Record<string, unknown>>) => {
+        const next = { ...prev }
+        delete next[pluginId]
+        return next
+      })
+      await refetch()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed")
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  return (
+    <section class={styles.root}>
+      <div data-slot="section-title">
+        <h2>Plugin Settings</h2>
+        <p>Configure settings for installed plugins.</p>
+      </div>
+      <div data-slot="section-content">
+        <Show when={data.loading}>
+          <p data-slot="status">Loading plugin settings…</p>
+        </Show>
+        <Show when={data.error}>
+          <p data-slot="status" data-color="danger">
+            Failed to load plugin settings. Make sure the OpenCode server is running.
+          </p>
+        </Show>
+        <Show when={data() && !data()!.schemas.length && !data.loading}>
+          <p data-slot="status">No plugins with configurable settings found.</p>
+        </Show>
+        <For each={data()?.schemas ?? []}>
+          {(schema: PluginSchema) => (
+            <div data-slot="plugin-card">
+              <h3>{schema.title}</h3>
+              <div data-slot="plugin-fields">
+                <For each={Object.entries(schema.properties)}>
+                  {([key, def]: [string, SettingDefinition]) => (
+                    <div data-slot="setting-field">
+                      <label>
+                        <span data-slot="field-title">{def.title}</span>
+                        <Show when={def.description}>
+                          <span data-slot="field-description">{def.description}</span>
+                        </Show>
+                      </label>
+                      <Switch>
+                        <Match when={def.type === "boolean"}>
+                          <label data-slot="toggle">
+                            <input
+                              type="checkbox"
+                              checked={(val(schema.id, key) as boolean) ?? (def.default as boolean) ?? false}
+                              onChange={(e: Event & { target: HTMLInputElement }) => update(schema.id, key, e.target.checked)}
+                            />
+                            <span data-slot="toggle-track">
+                              <span data-slot="toggle-thumb" />
+                            </span>
+                          </label>
+                        </Match>
+                        <Match when={def.type === "select"}>
+                          <select
+                            data-component="input"
+                            value={(val(schema.id, key) as string) ?? (def.default as string) ?? ""}
+                            onChange={(e: Event & { target: HTMLSelectElement }) => update(schema.id, key, e.target.value)}
+                          >
+                            <For each={def.enum ?? []}>
+                              {(opt: string, i: () => number) => <option value={opt}>{def.enumLabels?.[i()] ?? opt}</option>}
+                            </For>
+                          </select>
+                        </Match>
+                        <Match when={def.type === "secret"}>
+                          <input
+                            data-component="input"
+                            type="password"
+                            placeholder={def.placeholder ?? ""}
+                            value={(val(schema.id, key) as string) ?? ""}
+                            onInput={(e: Event & { target: HTMLInputElement }) => update(schema.id, key, e.target.value)}
+                          />
+                        </Match>
+                        <Match when={def.type === "number"}>
+                          <input
+                            data-component="input"
+                            type="number"
+                            placeholder={def.placeholder ?? ""}
+                            value={String((val(schema.id, key) as number) ?? (def.default as number) ?? "")}
+                            onInput={(e: Event & { target: HTMLInputElement }) => update(schema.id, key, Number(e.target.value))}
+                          />
+                        </Match>
+                        <Match when={def.type === "string"}>
+                          <input
+                            data-component="input"
+                            type="text"
+                            placeholder={def.placeholder ?? ""}
+                            value={(val(schema.id, key) as string) ?? (def.default as string) ?? ""}
+                            onInput={(e: Event & { target: HTMLInputElement }) => update(schema.id, key, e.target.value)}
+                          />
+                        </Match>
+                      </Switch>
+                    </div>
+                  )}
+                </For>
+              </div>
+              <div data-slot="plugin-actions">
+                <button
+                  data-color="primary"
+                  disabled={saving() === schema.id || !dirty(schema.id)}
+                  onClick={() => save(schema.id)}
+                >
+                  {saving() === schema.id ? "Saving…" : "Save"}
+                </button>
+              </div>
+              <Show when={error()}>
+                <div data-slot="form-error">{error()}</div>
+              </Show>
+            </div>
+          )}
+        </For>
+      </div>
+    </section>
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -997,6 +997,7 @@ export namespace Config {
         })
         .optional(),
       plugin: z.string().array().optional(),
+      plugin_settings: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
       snapshot: z.boolean().optional(),
       share: z
         .enum(["manual", "auto", "disabled"])

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import type { Hooks, PluginInput, Plugin as PluginInstance } from "@opencode-ai/plugin"
+import type { Hooks, PluginInput, PluginSettingsSchema, Plugin as PluginInstance } from "@opencode-ai/plugin"
 import { Config } from "../config/config"
 import { Bus } from "../bus"
 import { Log } from "../util/log"
@@ -104,7 +104,7 @@ export namespace Plugin {
   })
 
   export async function trigger<
-    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool">,
+    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool" | "settings">,
     Input = Parameters<Required<Hooks>[Name]>[0],
     Output = Parameters<Required<Hooks>[Name]>[1],
   >(name: Name, input: Input, output: Output): Promise<Output> {
@@ -122,6 +122,15 @@ export namespace Plugin {
 
   export async function list() {
     return state().then((x) => x.hooks)
+  }
+
+  export async function schemas() {
+    const hooks = await state().then((x) => x.hooks)
+    const result: PluginSettingsSchema[] = []
+    for (const hook of hooks) {
+      if (hook.settings) result.push(hook.settings)
+    }
+    return result
   }
 
   export async function init() {

--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -6,6 +6,7 @@ import { Provider } from "../../provider/provider"
 import { mapValues } from "remeda"
 import { errors } from "../error"
 import { Log } from "../../util/log"
+import { Plugin } from "../../plugin"
 import { lazy } from "../../util/lazy"
 
 const log = Log.create({ service: "server" })
@@ -56,6 +57,74 @@ export const ConfigRoutes = lazy(() =>
         const config = c.req.valid("json")
         await Config.update(config)
         return c.json(config)
+      },
+    )
+    .get(
+      "/plugin-settings",
+      describeRoute({
+        summary: "Get plugin settings",
+        description: "Retrieve plugin settings schemas and current values.",
+        operationId: "config.pluginSettings.get",
+        responses: {
+          200: {
+            description: "Plugin settings schemas and values",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    schemas: z.array(z.unknown()),
+                    values: z.record(z.string(), z.record(z.string(), z.unknown())),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const [schemas, config] = await Promise.all([Plugin.schemas(), Config.get()])
+        return c.json({
+          schemas,
+          values: config.plugin_settings ?? {},
+        })
+      },
+    )
+    .patch(
+      "/plugin-settings",
+      describeRoute({
+        summary: "Update plugin settings",
+        description: "Update settings for a specific plugin.",
+        operationId: "config.pluginSettings.update",
+        responses: {
+          200: {
+            description: "Successfully updated plugin settings",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    plugin_settings: z.record(z.string(), z.record(z.string(), z.unknown())),
+                  }),
+                ),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          plugin_id: z.string(),
+          settings: z.record(z.string(), z.unknown()),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        const config = await Config.get()
+        const current = config.plugin_settings ?? {}
+        const updated = { ...current, [body.plugin_id]: body.settings }
+        await Config.update({ plugin_settings: updated })
+        return c.json({ plugin_settings: updated })
       },
     )
     .get(

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,22 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type SettingDefinition = {
+  type: "string" | "number" | "boolean" | "select" | "secret"
+  title: string
+  description?: string
+  default?: unknown
+  required?: boolean
+  placeholder?: string
+  enum?: string[]
+  enumLabels?: string[]
+}
+
+export type PluginSettingsSchema = {
+  id: string
+  title: string
+  properties: Record<string, SettingDefinition>
+}
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -146,6 +162,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
 )
 
 export interface Hooks {
+  settings?: PluginSettingsSchema
   event?: (input: { event: Event }) => Promise<void>
   config?: (input: Config) => Promise<void>
   tool?: {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -16,6 +16,9 @@ import type {
   CommandListResponses,
   Config as Config3,
   ConfigGetResponses,
+  ConfigPluginSettingsGetResponses,
+  ConfigPluginSettingsUpdateErrors,
+  ConfigPluginSettingsUpdateResponses,
   ConfigProvidersResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
@@ -652,6 +655,70 @@ export class Pty extends HeyApiClient {
   }
 }
 
+export class PluginSettings extends HeyApiClient {
+  /**
+   * Get plugin settings
+   *
+   * Retrieve plugin settings schemas and current values.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<ConfigPluginSettingsGetResponses, unknown, ThrowOnError>({
+      url: "/config/plugin-settings",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Update plugin settings
+   *
+   * Update settings for a specific plugin.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      plugin_id?: string
+      settings?: {
+        [key: string]: unknown
+      }
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "plugin_id" },
+            { in: "body", key: "settings" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).patch<
+      ConfigPluginSettingsUpdateResponses,
+      ConfigPluginSettingsUpdateErrors,
+      ThrowOnError
+    >({
+      url: "/config/plugin-settings",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Config2 extends HeyApiClient {
   /**
    * Get configuration
@@ -724,6 +791,11 @@ export class Config2 extends HeyApiClient {
       ...options,
       ...params,
     })
+  }
+
+  private _pluginSettings?: PluginSettings
+  get pluginSettings(): PluginSettings {
+    return (this._pluginSettings ??= new PluginSettings({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1337,6 +1337,11 @@ export type Config = {
     ignore?: Array<string>
   }
   plugin?: Array<string>
+  plugin_settings?: {
+    [key: string]: {
+      [key: string]: unknown
+    }
+  }
   snapshot?: boolean
   /**
    * Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing
@@ -2347,6 +2352,70 @@ export type ConfigUpdateResponses = {
 }
 
 export type ConfigUpdateResponse = ConfigUpdateResponses[keyof ConfigUpdateResponses]
+
+export type ConfigPluginSettingsGetData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/config/plugin-settings"
+}
+
+export type ConfigPluginSettingsGetResponses = {
+  /**
+   * Plugin settings schemas and values
+   */
+  200: {
+    schemas: Array<unknown>
+    values: {
+      [key: string]: {
+        [key: string]: unknown
+      }
+    }
+  }
+}
+
+export type ConfigPluginSettingsGetResponse = ConfigPluginSettingsGetResponses[keyof ConfigPluginSettingsGetResponses]
+
+export type ConfigPluginSettingsUpdateData = {
+  body?: {
+    plugin_id: string
+    settings: {
+      [key: string]: unknown
+    }
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/config/plugin-settings"
+}
+
+export type ConfigPluginSettingsUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ConfigPluginSettingsUpdateError = ConfigPluginSettingsUpdateErrors[keyof ConfigPluginSettingsUpdateErrors]
+
+export type ConfigPluginSettingsUpdateResponses = {
+  /**
+   * Successfully updated plugin settings
+   */
+  200: {
+    plugin_settings: {
+      [key: string]: {
+        [key: string]: unknown
+      }
+    }
+  }
+}
+
+export type ConfigPluginSettingsUpdateResponse =
+  ConfigPluginSettingsUpdateResponses[keyof ConfigPluginSettingsUpdateResponses]
 
 export type ConfigProvidersData = {
   body?: never


### PR DESCRIPTION
## Summary

This PR introduces a **Dynamic Plugin Settings UI** system that allows OpenCode plugins to declaratively define their configuration schemas and have settings forms automatically generated in the web console.

### Problem
Currently, plugins (envsitter, with-context, etc.) have no mechanism to accept user configuration like API keys or custom settings through the UI. Users must manually edit config files to configure plugins.

### Solution
A full-stack implementation spanning the plugin interface, config system, backend API, and web console UI:

## Changes

### 1. Plugin Interface Extension (`packages/plugin/src/index.ts`)
- Added `SettingDefinition` type supporting `string`, `number`, `boolean`, `select`, and `secret` field types
- Added `PluginSettingsSchema` type with `id`, `title`, and `properties` fields
- Added optional `settings` property to `Hooks` interface so plugins can declare their schemas

### 2. Config Schema Extension (`packages/opencode/src/config/config.ts`)
- Added `plugin_settings` field to `Config.Info` Zod schema: `z.record(z.string(), z.record(z.string(), z.unknown())).optional()`
- Enables persistent storage of plugin settings as `{ "plugin-id": { "key": "value" } }`

### 3. Plugin Loader Update (`packages/opencode/src/plugin/index.ts`)
- Added `Plugin.schemas()` function that collects settings schemas from all loaded plugins
- Added `"settings"` to the `Exclude` list in `Plugin.trigger()` type constraint (since settings is data, not a hook function)

### 4. Backend API (`packages/opencode/src/server/routes/config.ts`)
- `GET /config/plugin-settings` — Returns all plugin schemas + current saved values
- `PATCH /config/plugin-settings` — Updates settings for a specific plugin by `plugin_id`

### 5. Web Console UI (`packages/console/app/src/routes/workspace/[id]/settings/`)
- Wrapped existing settings in a **Tabs** component (`@kobalte/core/tabs`) with "General" and "Plugins" tabs
- Created `PluginSettingsSection` component with:
  - Dynamic form generation based on `SettingDefinition` types
  - `secret` type renders as password input (for API keys)
  - `boolean` type renders as toggle switch
  - `select` type renders as dropdown with optional labels
  - `number` type renders as number input
  - `string` type renders as text input
  - Per-plugin save with dirty-state tracking
  - Error handling and loading states
- Added CSS module for plugin settings styling

### 6. SDK Auto-generation
- SDK types and client methods automatically regenerated from OpenAPI spec changes

## Plugin Usage Example

```typescript
import type { Plugin } from "@opencode-ai/plugin"

export const MyPlugin: Plugin = async (ctx) => {
  return {
    settings: {
      id: "my-plugin",
      title: "My Plugin",
      properties: {
        api_key: {
          type: "secret",
          title: "API Key",
          description: "Your API key for the service",
          required: true,
          placeholder: "sk-..."
        },
        enabled: {
          type: "boolean",
          title: "Enable Feature",
          default: true
        },
        mode: {
          type: "select",
          title: "Mode",
          enum: ["fast", "balanced", "thorough"],
          enumLabels: ["Fast", "Balanced", "Thorough"],
          default: "balanced"
        }
      }
    },
    // ... other hooks
  }
}
```

## Testing
- ✅ All 16 packages pass `typecheck`
- ✅ All packages build successfully
- ✅ No pre-existing tests broken

## Screenshots
_Plugin settings tab is rendered dynamically based on loaded plugin schemas. When no plugins define settings, an informational message is shown._