### PR TITLE
fix: kill orphaned MCP child processes and expose OPENCODE_PID on shu…

### DIFF
--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -145,6 +145,7 @@ try {
     Object.assign(process.env, serverEnv)
     process.env.AGENT = "1"
     process.env.OPENCODE = "1"
+    process.env.OPENCODE_PID = String(process.pid)
 
     const log = await import("../../opencode/src/util/log")
     const install = await import("../../opencode/src/installation")

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -76,6 +76,7 @@ let cli = yargs(hideBin(process.argv))
 
     process.env.AGENT = "1"
     process.env.OPENCODE = "1"
+    process.env.OPENCODE_PID = String(process.pid)
 
     Log.Default.info("opencode", {
       version: Installation.VERSION,


### PR DESCRIPTION
### Issue for this PR

Closes #6633
Related: #7261, #14237, #6279, #15117

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode exits, MCP servers that spawn child processes (e.g. chrome-devtools-mcp spawning Chrome) leave those grandchild processes orphaned. The MCP SDK's `StdioClientTransport.close()` only signals the direct child — it has no way to reach processes further down the tree. These orphans accumulate across sessions and cause a 3-5 second shutdown delay because the SDK times out waiting on a server that is blocked waiting on its own children.

Additionally, concurrent opencode sessions sharing the same MCP server config clash on shared state. With chrome-devtools-mcp for example, each new session tries to take over the same browser instance, killing the previous session's MCP service in the process.

Before calling `client.close()`, we now walk the full descendant tree of each local MCP server transport using `pgrep -P` and SIGTERM every descendant. With its children already gone, the MCP server exits immediately and the SDK close completes without hitting its timeout. Skipped on Windows where `pgrep` is not available.

Also sets `OPENCODE_PID` in `process.env` at startup alongside the existing `OPENCODE=1`. MCP server configs can reference `{env:OPENCODE_PID}` to keep each session's MCP services fully independent — each session gets its own isolated browser instance and they no longer interfere with each other.

Example config:

```json
"chrome-devtools": {
  "type": "local",
  "command": [
    "npx", "-y", "chrome-devtools-mcp@latest",
    "--userDataDir={env:HOME}/.cache/chrome-devtools-mcp/{env:OPENCODE_PID}"
  ]
}
```

**Changes:**

- `mcp/index.ts`: `descendants()` walks the process tree via `pgrep -P` BFS; dispose handler SIGTERMs all descendants before SDK close
- `index.ts`, `e2e-local.ts`: set `process.env.OPENCODE_PID = String(process.pid)`

### How did you verify your code works?

Started opencode with chrome-devtools-mcp configured with `--userDataDir={env:HOME}/.cache/chrome-devtools-mcp/{env:OPENCODE_PID}`. Confirmed Chrome launched. Exited opencode — exit was immediate (previously 3-5 seconds). `pgrep -fa chrome-devtools-mcp` returned nothing. Ran two concurrent sessions and confirmed each used an isolated profile directory with no SingletonLock conflicts.

### Screenshots / recordings

_N/A — terminal process, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR