### PR TITLE
feat(opencode): send x-opencode-session header for all providers

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -206,10 +206,10 @@ export namespace LLM {
       maxOutputTokens,
       abortSignal: input.abort,
       headers: {
+        "x-opencode-session": input.sessionID,
         ...(input.model.providerID.startsWith("opencode")
           ? {
               "x-opencode-project": Instance.project.id,
-              "x-opencode-session": input.sessionID,
               "x-opencode-request": input.user.id,
               "x-opencode-client": Flag.OPENCODE_CLIENT,
             }


### PR DESCRIPTION
## Why
LiteLLM and other proxy or relay setups use the x-opencode-session header for session affinity routing. Today this header is only sent for opencode providers, so non-opencode providers behind a proxy cannot route consistently.

## What changed
- Send x-opencode-session unconditionally for all providers
- Keep existing opencode-only headers (x-opencode-project, x-opencode-request, x-opencode-client) behind the existing provider check
- Preserve existing User-Agent behavior for non-anthropic providers

## Impact
This enables stable session affinity across proxy setups, including LiteLLM, Ollama relay, and similar gateways, without changing existing provider-specific header behavior.