### PR TITLE
feat: Switch compaction model from session model

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -443,6 +443,20 @@ function App() {
       },
     },
     {
+      title: "Switch compaction model",
+      value: "compaction_model.list",
+      keybind: "compaction_model_list",
+      category: "Agent",
+      slash: {
+        name: "compaction-models",
+        aliases: ["compaction-model"],
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogModel target="compaction" />)
+      },
+    },
+
+    {
       title: "Switch agent",
       value: "agent.list",
       keybind: "agent_list",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -15,7 +15,7 @@ export function useConnected() {
   )
 }
 
-export function DialogModel(props: { providerID?: string }) {
+export function DialogModel(props: { providerID?: string; target?: "session" | "compaction" }) {
   const local = useLocal()
   const sync = useSync()
   const dialog = useDialog()
@@ -25,13 +25,40 @@ export function DialogModel(props: { providerID?: string }) {
   const connected = useConnected()
   const providers = createDialogProviderOptions()
 
+  const isCompaction = props.target === "compaction"
+
   const showExtra = createMemo(() => connected() && !props.providerID)
+
+  function onModelSelect(model: { providerID: string; modelID: string }) {
+    dialog.clear()
+    if (isCompaction) {
+      local.model.compaction.set(model)
+      return
+    }
+    local.model.set(model, { recent: true })
+  }
 
   const options = createMemo(() => {
     const needle = query().trim()
     const showSections = showExtra() && needle.length === 0
     const favorites = connected() ? local.model.favorite() : []
     const recents = local.model.recent()
+
+    // "Use session model (default)" option only shown in compaction mode
+    const defaultOption = isCompaction
+      ? [
+          {
+            value: { providerID: "", modelID: "" },
+            title: "Use session model (default)",
+            description: "Compaction will use the same model as the session",
+            category: showSections ? "Default" : undefined,
+            onSelect: () => {
+              dialog.clear()
+              local.model.compaction.clear()
+            },
+          },
+        ]
+      : []
 
     function toOptions(items: typeof favorites, category: string) {
       if (!showSections) return []
@@ -49,10 +76,7 @@ export function DialogModel(props: { providerID?: string }) {
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
-            onSelect: () => {
-              dialog.clear()
-              local.model.set({ providerID: provider.id, modelID: model.id }, { recent: true })
-            },
+            onSelect: () => onModelSelect({ providerID: provider.id, modelID: model.id }),
           },
         ]
       })
@@ -87,10 +111,7 @@ export function DialogModel(props: { providerID?: string }) {
             category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
-            onSelect() {
-              dialog.clear()
-              local.model.set({ providerID: provider.id, modelID: model }, { recent: true })
-            },
+            onSelect: () => onModelSelect({ providerID: provider.id, modelID: model }),
           })),
           filter((x) => {
             if (!showSections) return true
@@ -121,19 +142,22 @@ export function DialogModel(props: { providerID?: string }) {
 
     if (needle) {
       return [
+        ...defaultOption,
         ...fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
         ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
       ]
     }
 
-    return [...favoriteOptions, ...recentOptions, ...providerOptions, ...popularProviders]
+    return [...defaultOption, ...favoriteOptions, ...recentOptions, ...providerOptions, ...popularProviders]
   })
 
   const provider = createMemo(() =>
     props.providerID ? sync.data.provider.find((x) => x.id === props.providerID) : null,
   )
 
-  const title = createMemo(() => provider()?.name ?? "Select model")
+  const title = createMemo(() => (isCompaction ? "Select compaction model" : (provider()?.name ?? "Select model")))
+
+  const current = createMemo(() => (isCompaction ? local.model.compaction.current() : local.model.current()))
 
   return (
     <DialogSelect<ReturnType<typeof options>[number]["value"]>
@@ -151,7 +175,10 @@ export function DialogModel(props: { providerID?: string }) {
           title: "Favorite",
           disabled: !connected(),
           onTrigger: (option) => {
-            local.model.toggleFavorite(option.value as { providerID: string; modelID: string })
+            const val = option.value as { providerID: string; modelID: string }
+            if (val.providerID && val.modelID) {
+              local.model.toggleFavorite(val)
+            }
           },
         },
       ]}
@@ -159,7 +186,7 @@ export function DialogModel(props: { providerID?: string }) {
       flat={true}
       skipFilter={true}
       title={title()}
-      current={local.model.current()}
+      current={current()}
     />
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1012,6 +1012,10 @@ export function Prompt(props: PromptProps) {
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
                   </Show>
+                  <Show when={local.model.compaction.current()}>
+                    <text fg={theme.textMuted}>·</text>
+                    <text fg={theme.textMuted}>compact: {local.model.compaction.parsed().model}</text>
+                  </Show>
                 </box>
               </Show>
             </box>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -13,6 +13,7 @@ import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { Filesystem } from "@/util/filesystem"
+import { useKV } from "./kv"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -20,6 +21,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const sdk = useSDK()
     const toast = useToast()
+    const kv = useKV()
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)
@@ -320,6 +322,44 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             save()
           })
         },
+        compaction: iife(() => {
+          const key = "compaction_model"
+          const [get] = kv.signal<{ providerID: string; modelID: string } | undefined>(key, undefined)
+          return {
+            current() {
+              return get() as { providerID: string; modelID: string } | undefined
+            },
+            parsed: createMemo(() => {
+              const value = get() as { providerID: string; modelID: string } | undefined
+              if (!value) {
+                return {
+                  provider: undefined,
+                  model: "Using session model",
+                }
+              }
+              const provider = sync.data.provider.find((x) => x.id === value.providerID)
+              const info = provider?.models[value.modelID]
+              return {
+                provider: provider?.name ?? value.providerID,
+                model: info?.name ?? value.modelID,
+              }
+            }),
+            set(model: { providerID: string; modelID: string }) {
+              if (!isModelValid(model)) {
+                toast.show({
+                  message: `Model ${model.providerID}/${model.modelID} is not valid`,
+                  variant: "warning",
+                  duration: 3000,
+                })
+                return
+              }
+              kv.set(key, { ...model })
+            },
+            clear() {
+              kv.set(key, undefined)
+            },
+          }
+        }),
         variant: {
           current() {
             const m = currentModel()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -430,10 +430,12 @@ export function Session() {
           })
           return
         }
+        const compactionModel = local.model.compaction.current()
         sdk.client.session.summarize({
           sessionID: route.sessionID,
           modelID: selectedModel.modelID,
           providerID: selectedModel.providerID,
+          compactionModel: compactionModel ?? undefined,
         })
         dialog.clear()
       },

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -828,6 +828,7 @@ export namespace Config {
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),
       model_cycle_favorite: z.string().optional().default("none").describe("Next favorite model"),
       model_cycle_favorite_reverse: z.string().optional().default("none").describe("Previous favorite model"),
+      compaction_model_list: z.string().optional().default("none").describe("List available compaction models"),
       command_list: z.string().optional().default("ctrl+p").describe("List available commands"),
       agent_list: z.string().optional().default("<leader>a").describe("List agents"),
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -511,6 +511,12 @@ export const SessionRoutes = lazy(() =>
           providerID: z.string(),
           modelID: z.string(),
           auto: z.boolean().optional().default(false),
+          compactionModel: z
+            .object({
+              providerID: z.string(),
+              modelID: z.string(),
+            })
+            .optional(),
         }),
       ),
       async (c) => {
@@ -535,6 +541,7 @@ export const SessionRoutes = lazy(() =>
             modelID: body.modelID,
           },
           auto: body.auto,
+          compactionModel: body.compactionModel,
         })
         await SessionPrompt.loop({ sessionID })
         return c.json(true)

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -104,12 +104,15 @@ export namespace SessionCompaction {
     sessionID: string
     abort: AbortSignal
     auto: boolean
+    compactionModel?: { providerID: string; modelID: string }
   }) {
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
     const agent = await Agent.get("compaction")
-    const model = agent.model
-      ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
-      : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
+    const model = input.compactionModel
+      ? await Provider.getModel(input.compactionModel.providerID, input.compactionModel.modelID)
+      : agent.model
+        ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
+        : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
     const msg = (await Session.updateMessage({
       id: Identifier.ascending("message"),
       role: "assistant",
@@ -237,6 +240,12 @@ When constructing the summary, try to stick to this template:
         modelID: z.string(),
       }),
       auto: z.boolean(),
+      compactionModel: z
+        .object({
+          providerID: z.string(),
+          modelID: z.string(),
+        })
+        .optional(),
     }),
     async (input) => {
       const msg = await Session.updateMessage({
@@ -255,6 +264,7 @@ When constructing the summary, try to stick to this template:
         sessionID: msg.sessionID,
         type: "compaction",
         auto: input.auto,
+        compactionModel: input.compactionModel,
       })
     },
   )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -196,6 +196,12 @@ export namespace MessageV2 {
   export const CompactionPart = PartBase.extend({
     type: z.literal("compaction"),
     auto: z.boolean(),
+    compactionModel: z
+      .object({
+        providerID: z.string(),
+        modelID: z.string(),
+      })
+      .optional(),
   }).meta({
     ref: "CompactionPart",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -533,6 +533,7 @@ export namespace SessionPrompt {
           abort,
           sessionID,
           auto: task.auto,
+          compactionModel: task.compactionModel,
         })
         if (result === "stop") break
         continue

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1442,6 +1442,10 @@ export class Session2 extends HeyApiClient {
       providerID?: string
       modelID?: string
       auto?: boolean
+      compactionModel?: {
+        providerID: string
+        modelID: string
+      }
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1455,6 +1459,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "providerID" },
             { in: "body", key: "modelID" },
             { in: "body", key: "auto" },
+            { in: "body", key: "compactionModel" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -505,6 +505,10 @@ export type CompactionPart = {
   messageID: string
   type: "compaction"
   auto: boolean
+  compactionModel?: {
+    providerID: string
+    modelID: string
+  }
 }
 
 export type Part =
@@ -1167,6 +1171,10 @@ export type KeybindsConfig = {
    * Previous favorite model
    */
   model_cycle_favorite_reverse?: string
+  /**
+   * List available compaction models
+   */
+  compaction_model_list?: string
   /**
    * List available commands
    */
@@ -3432,6 +3440,10 @@ export type SessionSummarizeData = {
     providerID: string
     modelID: string
     auto?: boolean
+    compactionModel?: {
+      providerID: string
+      modelID: string
+    }
   }
   path: {
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2303,6 +2303,18 @@
                   "auto": {
                     "default": false,
                     "type": "boolean"
+                  },
+                  "compactionModel": {
+                    "type": "object",
+                    "properties": {
+                      "providerID": {
+                        "type": "string"
+                      },
+                      "modelID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["providerID", "modelID"]
                   }
                 },
                 "required": ["providerID", "modelID"]
@@ -7368,6 +7380,18 @@
           },
           "auto": {
             "type": "boolean"
+          },
+          "compactionModel": {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string"
+              },
+              "modelID": {
+                "type": "string"
+              }
+            },
+            "required": ["providerID", "modelID"]
           }
         },
         "required": ["id", "sessionID", "messageID", "type", "auto"]
@@ -8867,6 +8891,11 @@
           },
           "model_cycle_favorite_reverse": {
             "description": "Previous favorite model",
+            "default": "none",
+            "type": "string"
+          },
+          "compaction_model_list": {
+            "description": "List available compaction models",
             "default": "none",
             "type": "string"
           },


### PR DESCRIPTION
### Issue for this PR

Closes #13946
Closes #12135
Related: #14368, #14259, #14233

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a dedicated compaction model selector so users can run one model for chat and a different model for summarization. Run Claude Sonnet or Opus 4.6 for interactive coding while compacting with Zen Big Pickle (free) to eliminate compaction cost entirely, or GPT-5.3 Codex (400k context) for detail-oriented summaries that capture nuance your session model would lose — with headroom to compact sessions that have already exceeded their primary model's context limit.

For best results use this enhanced compaction prompt: https://github.com/anomalyco/opencode/pull/14662

**Why not just use `agent.compaction.model` in config?**

The existing `agent.compaction.model` config option is static — it requires editing `opencode.json` and is fixed for the lifetime of the config. This PR adds runtime switching without touching config files, matching how the primary model switcher works:

- Switch compaction models on the fly without restarting or editing config
- Different sessions can use different compaction models in the same instance
- Browse available models with the same familiar picker UI
- See the active compaction model in the prompt footer at a glance

Both approaches coexist. Model resolution priority: **TUI selection > config file (`agent.compaction.model`) > session model**. When no TUI selection is made, the config-based approach works exactly as before. Nothing is broken.

**Features:**

- Reuses existing provider infrastructure — same providers, API keys, and auth as the primary model picker
- `/compaction-models` slash command and "Switch compaction model" in the command menu
- Model resolution priority: compaction model override > agent config > session model
- Compaction model preference stored via `kv.signal` in `kv.json`, matching how all other TUI settings are persisted
- Prompt footer displays active compaction model when set
- When unset, behavior is identical to upstream

**Changes:**

- `DialogModel` accepts `target="compaction"` prop — no duplicate component
- `SessionCompaction.process()` accepts and resolves the override model
- `CompactionPart` schema extended with optional `compactionModel` field
- `compaction_model_list` keybind added (default: none)
- SDK regenerated via `./script/generate.ts`

### How did you verify your code works?

Tested with Claude Sonnet 4.5 (chat) + GPT-5.3 Codex (compaction). Confirmed correct model at each pipeline stage via `[compaction-model]` log entries. Compaction completed successfully, session resumed on the original model. Also tested auto-compaction with no override set to verify identical upstream behavior. Verified that existing `agent.compaction.model` config continues to work when no TUI override is set.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

![image](https://github.com/user-attachments/assets/8fcb9878-998f-485f-991f-e318f83bf495)
![image](https://github.com/user-attachments/assets/caf43e52-c44b-4ce6-8c13-99e3234d8817)
![image](https://github.com/user-attachments/assets/dbd7d7b4-9ac3-44c6-8820-24c0076d3b31)