### PR TITLE
fix(tools): prevent searching root directory in grep and glob tools

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -31,6 +31,13 @@ export const GlobTool = Tool.define("glob", {
 
     let search = params.path ?? Instance.directory
     search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
+
+    // Prevent searching root directory
+    const parsed = path.parse(search)
+    if (search === parsed.root) {
+      throw new Error(`Searching root directory is not allowed: ${search}`)
+    }
+
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 
     const limit = 100

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -37,6 +37,13 @@ export const GrepTool = Tool.define("grep", {
 
     let searchPath = params.path ?? Instance.directory
     searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
+
+    // Prevent searching root directory
+    const parsed = path.parse(searchPath)
+    if (searchPath === parsed.root) {
+      throw new Error(`Searching root directory is not allowed: ${searchPath}`)
+    }
+
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation behind them. -->

Adds validation to prevent the `grep` and `glob` tools from searching the root directory (`/`), which can cause performance issues and scan unintended system files.

## Related Issue(s)

<!-- Link to the related issue(s). Use \"Fixes #XXX\" or \"Closes #XXX\" if it resolves the issue. -->

Fixes #12051
Related to #14445
Related to #8754 (complementary - this PR specifically targets root directory while #8754 handles general sandboxing)

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

<!-- List the specific changes made in this PR. -->

- Added validation in `grep.ts` to throw an error when attempting to search the root directory
- Added validation in `glob.ts` to throw an error when attempting to search the root directory

## Testing

<!-- Describe the tests you ran and how to reproduce them. -->

- [x] Verified that `grep pattern=\"test\" path=\"/\"` throws: `\"Searching root directory is not allowed: /\"`
- [x] Verified that `glob pattern=\"**/*.ts\" path=\"/\"` throws: `\"Searching root directory is not allowed: /\"`
- [x] Verified that normal project directory searches still work correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Context

Searching the root directory (`/`) can:
- Scan system directories like `/System`, `/Volumes`, etc. on macOS
- Cause significant performance issues
- Return irrelevant results

This PR complements #8754 which adds general sandboxing - while #8754 restricts searches to the project directory using `Filesystem.contains()`, this PR specifically hard-blocks root directory searches which is a common edge case that should never be allowed.