### PR TITLE
docs: add oMLX provider entry

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1338,6 +1338,71 @@ To use Ollama Cloud with OpenCode:
 
 ---
 
+### oMLX
+
+You can configure opencode to use local MLX models on Apple Silicon through [oMLX](https://github.com/jundot/omlx).
+
+:::note
+oMLX requires Apple Silicon (M1/M2/M3/M4) and macOS.
+:::
+
+**Install** via [macOS app](https://github.com/jundot/omlx/releases), Homebrew, or pip:
+
+```sh
+brew tap jundot/omlx https://github.com/jundot/omlx
+brew install omlx
+
+# Or run as a background service
+brew services start omlx
+```
+
+Then start the server pointing at a directory of MLX-format model subdirectories:
+
+```sh
+omlx serve --model-dir ~/models
+```
+
+The server exposes an OpenAI-compatible API at `http://localhost:8000/v1`. Model IDs are the subdirectory names under your model dir.
+
+```json title="opencode.json" "omlx" {5, 6, 8, 10-17}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "omlx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "oMLX (local)",
+      "options": {
+        "baseURL": "http://localhost:8000/v1"
+      },
+      "models": {
+        "Qwen3-Coder-Next-8bit": {
+          "name": "Qwen3-Coder (local)",
+          "limit": {
+            "context": 32768,
+            "output": 8192
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `omlx` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server.
+- `models` is a map of model IDs to their configurations. Model IDs must match the subdirectory names under your `--model-dir`.
+- `limit.context` and `limit.output` let OpenCode track context usage — set these to match your model's actual limits.
+
+:::tip
+oMLX persists KV cache to SSD across requests and server restarts. To enable it: `omlx serve --model-dir ~/models --paged-ssd-cache-dir ~/.omlx/cache`
+:::
+
+---
+
 ### OpenAI
 
 We recommend signing up for [ChatGPT Plus or Pro](https://chatgpt.com/pricing).


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an entry for [oMLX](https://github.com/jundot/omlx) to the providers directory. oMLX is an OpenAI-compatible local inference server for Apple Silicon that uses MLX-format models and runs as a macOS menu bar app. Like Ollama, LM Studio, and llama.cpp, it exposes a `/v1` endpoint so it works as a custom `@ai-sdk/openai-compatible` provider in opencode.

The entry follows the same pattern as the other local provider entries: install instructions, a minimal `opencode.json` config snippet with the correct `baseURL` (`http://localhost:8000/v1`), and a field-by-field explanation. Notable difference from Ollama: model IDs are filesystem directory names under the user's `--model-dir`, so that's called out explicitly. Inserted alphabetically between Ollama Cloud and OpenAI.

### How did you verify your code works?

Documentation-only change — no code modified. Verified the config snippet is correct against oMLX's README (OpenAI-compatible API, default port 8000, model IDs match subdirectory names). Spot-checked that the MDX structure matches adjacent entries.

### Screenshots / recordings

_N/A — docs-only change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR