### PR TITLE
feat: support full GitHub issue URLs in PR compliance check

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -229,7 +229,7 @@ jobs:
             if (!isDocsRefactorOrFeat && hasIssueSection) {
               const issueMatch = body.match(/### Issue for this PR\s*\n([\s\S]*?)(?=###|$)/);
               const issueContent = issueMatch ? issueMatch[1].trim() : '';
-              const hasIssueRef = /(closes|fixes|resolves)\s+#\d+/i.test(issueContent) || /#\d+/.test(issueContent);
+              const hasIssueRef = /(closes|fixes|resolves)\s+(#\d+|https:\/\/github\.com\/[^\s]+\/issues\/\d+)/i.test(issueContent) || /#\d+/.test(issueContent) || /https:\/\/github\.com\/[^\s]+\/issues\/\d+/.test(issueContent);
               if (!hasIssueRef) {
                 issues.push('No issue referenced. Please add `Closes #<number>` linking to the relevant issue.');
               }


### PR DESCRIPTION
### Issue for this PR

Closes #15550

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `check-compliance` job in `pr-standards.yml` only matches issue references like `Closes #1234`. GitHub also supports full issue URLs like `Closes https://github.com/anomalyco/opencode/issues/1234` for auto-closing, but the regex didn't catch that format.

This updates the regex to also accept full GitHub issue URLs.

### How did you verify your code works?

Verified the regex matches both formats: `Closes #1234` and `Closes https://github.com/anomalyco/opencode/issues/1234`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR