### PR TITLE
fix(opencode): Map bicep file extensions to language ids for custom LSP usage

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -1,6 +1,8 @@
 export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".abap": "abap",
   ".bat": "bat",
+  ".bicep": "bicep",
+  ".bicepparam": "bicep-params",
   ".bib": "bibtex",
   ".bibtex": "bibtex",
   ".clj": "clojure",


### PR DESCRIPTION
### Issue for this PR

Closes #15569

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes missing Bicep diagnostics in custom LSP setups by sending the correct language IDs for Bicep files.
- Adds extension-to-language mappings in packages/opencode/src/lsp/language.ts:
  - .bicep -> bicep
  - .bicepparam -> bicep-params
- Ensures `textDocument/didOpen` uses Bicep language IDs instead of falling back to plaintext, allowing Bicep LSP to publish diagnostics.

### How did you verify your code works?

- Set opencode.json config to 
```
"lsp": {
  "bicep": {
    "extensions": [
      ".bicep",
      ".bicepparam"
    ],
    "command": [
      "dotnet",
      "/Users/pasi/.opencode-lsp/bicep-langserver/Bicep.LangServer.dll"
    ]
  }
},
```

- Built local binary from source:
  - `bun run build --single in packages/opencode`
- Ran diagnostics with the built binary against an invalid .bicep file:
  - `dist/opencode-darwin-arm64/bin/opencode debug lsp diagnostics .development/tmp-bicep-lsp-test.bicep --print-logs --log-level DEBUG`
- Verified diagnostics are now returned (e.g., BCP007) and logs show textDocument/publishDiagnostics for the .bicep file.
```
INFO  2026-03-01T12:27:39 +1ms service=lsp serverIds=SNIPPED..., bicep enabled LSP servers
INFO  2026-03-01T12:27:39 +0ms service=file.watcher init
INFO  2026-03-01T12:27:39 +1ms service=scheduler id=snapshot.cleanup run
INFO  2026-03-01T12:27:39 +0ms service=scheduler id=tool.truncation.cleanup run
INFO  2026-03-01T12:27:39 +0ms service=bus type=command.executed subscribing
INFO  2026-03-01T12:27:39 +1ms service=file.watcher platform=darwin backend=fs-events watcher backend
INFO  2026-03-01T12:27:39 +147ms service=lsp file=.development/tmp-bicep-lsp-test.bicep touching file
INFO  2026-03-01T12:27:39 +2ms service=lsp serverID=bicep spawned lsp server
INFO  2026-03-01T12:27:39 +0ms service=lsp.client serverID=bicep starting client
INFO  2026-03-01T12:27:39 +1ms service=lsp.client serverID=bicep sending initialize
INFO  2026-03-01T12:27:39 +2ms service=vcs branch=main initialized
INFO  2026-03-01T12:27:39 +0ms service=bus type=file.watcher.updated subscribing
INFO  2026-03-01T12:27:39 +240ms service=lsp.client serverID=bicep initialized
INFO  2026-03-01T12:27:39 +0ms service=bus type=lsp.updated publishing
INFO  2026-03-01T12:27:39 +0ms service=lsp.client serverID=bicep path=/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep waiting for diagnostics
INFO  2026-03-01T12:27:39 +0ms service=bus type=lsp.client.diagnostics subscribing
INFO  2026-03-01T12:27:39 +1ms service=lsp.client serverID=bicep path=/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep workspace/didChangeWatchedFiles
INFO  2026-03-01T12:27:39 +0ms service=lsp.client serverID=bicep path=/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep textDocument/didOpen
INFO  2026-03-01T12:27:39 +198ms service=snapshot prune=7.days cleanup
INFO  2026-03-01T12:27:39 +93ms service=lsp.client serverID=bicep path=/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep count=1 textDocument/publishDiagnostics
INFO  2026-03-01T12:27:39 +0ms service=bus type=lsp.client.diagnostics publishing
INFO  2026-03-01T12:27:40 +150ms service=lsp.client serverID=bicep path=/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep got diagnostics
INFO  2026-03-01T12:27:40 +1ms service=bus type=lsp.client.diagnostics unsubscribing
INFO  2026-03-01T12:27:40 +0ms service=bus type=lsp.client.diagnostics unsubscribing
{
  "/Users/pasi/Code/.development/tmp-bicep-lsp-test.bicep": [
    {
      "range": {
        "start": {
          "line": 2,
          "character": 0
        },
        "end": {
          "line": 2,
          "character": 4
        }
      },
      "severity": 1,
      "code": "BCP007",
      "codeDescription": {
        "href": "https://aka.ms/bicep/core-diagnostics#BCP007"
      },
      "source": "bicep",
      "message": "This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration."
    }
  ]
}
```

<img width="1331" height="352" alt="image" src="https://github.com/user-attachments/assets/d205b403-c0b5-4678-afa3-366927a3d11e" />

<img width="1032" height="356" alt="image" src="https://github.com/user-attachments/assets/a4b27817-336e-484d-be6b-e6097a8552b7" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR