### PR TITLE
fix(codex): handle non-streaming error responses from Codex API

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -487,10 +487,42 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                 ? new URL(CODEX_API_ENDPOINT)
                 : parsed
 
-            return fetch(url, {
+            const response = await fetch(url, {
               ...init,
               headers,
             })
+
+            // Handle non-streaming error responses from the Codex API.
+            // When the API returns an error (e.g. 429 usage_limit_reached),
+            // it responds with application/json instead of text/event-stream.
+            // If we pass this response through to the AI SDK's SSE parser,
+            // it hangs forever waiting for SSE data that never comes.
+            if (!response.ok) {
+              const contentType = response.headers.get("content-type") || ""
+              if (contentType.includes("application/json")) {
+                try {
+                  const body = await response.clone().json()
+                  const errorMsg = body?.error?.message ?? body?.detail ?? JSON.stringify(body)
+                  const errorType = body?.error?.type ?? "unknown"
+                  log.error("codex api error", {
+                    status: response.status,
+                    type: errorType,
+                    message: errorMsg,
+                  })
+                  // Return a synthetic SSE error response so the AI SDK
+                  // can process it cleanly instead of hanging.
+                  throw new Error(
+                    `Codex API error (${response.status}): ${errorType} - ${errorMsg}`,
+                  )
+                } catch (e) {
+                  if (e instanceof Error && e.message.startsWith("Codex API error")) throw e
+                  // If JSON parsing fails, still throw with status
+                  throw new Error(`Codex API error: HTTP ${response.status}`)
+                }
+              }
+            }
+
+            return response
           },
         }
       },


### PR DESCRIPTION
## Summary

When the Codex API returns an error response (e.g. HTTP 429 `usage_limit_reached`), it responds with `application/json` instead of `text/event-stream`. The AI SDK's SSE parser then **hangs indefinitely** waiting for SSE data that never comes, causing the session to freeze with no error reported.

## Root Cause

In `packages/opencode/src/plugin/codex.ts`, the custom `fetch()` handler passes the raw response directly to the AI SDK without checking `response.ok`. When the Codex API returns an error:

```
HTTP/2 429
Content-Type: application/json
{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}
```

The AI SDK's SSE parser receives a JSON body instead of SSE stream data and hangs forever.

## Fix

Added error detection in the Codex plugin's `fetch()` handler (codex.ts ~line 490):

1. After `fetch()`, check `response.ok`
2. If non-OK with `application/json` body, parse the error and `throw` a descriptive error
3. The error propagates through the existing pipeline: `processor.ts catch` → `SessionRetry.retryable()` → `Bus.publish(Session.Event.Error)`

## Impact

- **Before**: Any Codex API error (rate limit, auth, server errors) causes sessions to hang silently forever
- **After**: Errors are properly caught, logged, and reported to the user. Retryable errors go through the existing retry logic.

## Reproduction

1. Call `POST /session/{id}/message` with `model: { providerID: "openai", modelID: "gpt-5.3-codex" }`
2. Account has exhausted Codex usage limits
3. Codex API returns HTTP 429 with JSON error
4. **Expected**: Error is reported to user
5. **Actual (before fix)**: Session hangs indefinitely with 0 parts