### PR TITLE
fix: strip contentEncoding and contentMediaType from Gemini schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -944,6 +944,10 @@ export namespace ProviderTransform {
           delete result.required
         }
 
+        // Remove JSON Schema keywords unsupported by Gemini function calling
+        delete result.contentEncoding
+        delete result.contentMediaType
+
         return result
       }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -620,6 +620,59 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
   })
 })
 
+describe("ProviderTransform.schema - gemini contentEncoding removal", () => {
+  const geminiModel = {
+    providerID: "google",
+    api: {
+      id: "gemini-3-pro",
+    },
+  } as any
+
+  test("strips contentEncoding and contentMediaType from schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        data: {
+          type: "string",
+          contentEncoding: "base64",
+          contentMediaType: "image/png",
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.properties.data.contentEncoding).toBeUndefined()
+    expect(result.properties.data.contentMediaType).toBeUndefined()
+    expect(result.properties.data.type).toBe("string")
+  })
+
+  test("strips contentEncoding from nested array items", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        files: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              content: {
+                type: "string",
+                contentEncoding: "base64",
+              },
+            },
+          },
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.properties.files.items.properties.content.contentEncoding).toBeUndefined()
+    expect(result.properties.files.items.properties.content.type).toBe("string")
+  })
+})
+
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [


### PR DESCRIPTION
### Issue for this PR

Closes #15408

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Gemini function calling API rejects schemas containing `contentEncoding` and `contentMediaType` — valid JSON Schema keywords that Gemini does not support. The existing `sanitizeGemini` function (introduced in #3140) strips `properties`/`required` from non-object types but missed these two keywords.

MCP servers like `chrome-devtools-mcp` use `contentEncoding: "base64"` in tool schemas (e.g. `take_screenshot`, `upload_file`), causing 400 errors when used with Gemini models.

The fix adds two `delete` calls to the existing sanitizer to strip `contentEncoding` and `contentMediaType` from all schema nodes before sending to Gemini.

### How did you verify your code works?

Added two test cases in `transform.test.ts` covering direct and nested array scenarios. All 105 existing tests continue to pass.

### Screenshots / recordings

_N/A — server-side schema change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR