### PR TITLE
fix(config): avoid dedup collisions for file:// plugins in node_modules

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1,6 +1,6 @@
 import { Log } from "../util/log"
 import path from "path"
-import { pathToFileURL, fileURLToPath } from "url"
+import { pathToFileURL } from "url"
 import { createRequire } from "module"
 import os from "os"
 import z from "zod"
@@ -473,8 +473,8 @@ export namespace Config {
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
-      const file = fileURLToPath(plugin)
-      const parts = file.split(path.sep)
+      const pathname = decodeURIComponent(new URL(plugin).pathname)
+      const parts = pathname.split("/")
       const nodeModules = parts.lastIndexOf("node_modules")
       if (nodeModules > -1) {
         const name = parts[nodeModules + 1]
@@ -484,7 +484,7 @@ export namespace Config {
         }
         if (name) return name
       }
-      return path.parse(file).name
+      return path.posix.parse(pathname).name
     }
     const lastAt = plugin.lastIndexOf("@")
     if (lastAt > 0) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -473,7 +473,18 @@ export namespace Config {
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
-      return path.parse(new URL(plugin).pathname).name
+      const file = fileURLToPath(plugin)
+      const parts = file.split(path.sep)
+      const nodeModules = parts.lastIndexOf("node_modules")
+      if (nodeModules > -1) {
+        const name = parts[nodeModules + 1]
+        if (name?.startsWith("@")) {
+          const scoped = parts[nodeModules + 2]
+          if (scoped) return `${name}/${scoped}`
+        }
+        if (name) return name
+      }
+      return path.parse(file).name
     }
     const lastAt = plugin.lastIndexOf("@")
     if (lastAt > 0) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1542,6 +1542,14 @@ describe("getPluginName", () => {
     expect(Config.getPluginName("file:///some/path/my-plugin.js")).toBe("my-plugin")
   })
 
+  test("extracts package name from node_modules file:// URL", () => {
+    const basic = pathToFileURL(path.join("/tmp", "project", "node_modules", "foo", "index.js")).href
+    const scoped = pathToFileURL(path.join("/tmp", "project", "node_modules", "@scope", "pkg", "dist", "index.js")).href
+
+    expect(Config.getPluginName(basic)).toBe("foo")
+    expect(Config.getPluginName(scoped)).toBe("@scope/pkg")
+  })
+
   test("extracts name from npm package with version", () => {
     expect(Config.getPluginName("oh-my-opencode@2.4.3")).toBe("oh-my-opencode")
     expect(Config.getPluginName("some-plugin@1.0.0")).toBe("some-plugin")
@@ -1587,6 +1595,17 @@ describe("deduplicatePlugins", () => {
     const result = Config.deduplicatePlugins(plugins)
 
     expect(result).toEqual(["a-plugin@1.0.0", "b-plugin@1.0.0", "c-plugin@1.0.0"])
+  })
+
+  test("keeps multiple npm plugins resolved as file:// URLs", () => {
+    const plugins = [
+      pathToFileURL(path.join("/tmp", "project", "node_modules", "foo", "index.js")).href,
+      pathToFileURL(path.join("/tmp", "project", "node_modules", "bar", "index.js")).href,
+    ]
+
+    const result = Config.deduplicatePlugins(plugins)
+
+    expect(result).toEqual(plugins)
   })
 
   test("local plugin directory overrides global opencode.json plugin", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #15591
Fixes #8759
Fixes #10115
Fixes #11159
Fixes #12285
Fixes #14304

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Config.getPluginName()` previously identified `file://` plugins by filename only (e.g. `index`).
When npm plugins are resolved to `.../node_modules/<pkg>/dist/index.js`, different plugins collapsed to the same identity and only the last plugin survived deduplication.

This PR updates plugin identity extraction to:
- detect `node_modules` file URLs and use package identity (`foo`, `@scope/pkg`), not filename identity
- keep existing filename fallback for non-node_modules local plugins
- handle parsing in a cross-platform way so Windows test runners don't throw on synthetic POSIX-style file URLs

This directly matches the reproduction pattern reported in #10115 (order-dependent "only last plugin" behavior).

### How did you verify your code works?

- `bun test test/config/config.test.ts --test-name-pattern "extracts name from file:// URL|prefers local file over npm package with same name|extracts package name from node_modules file:// URL|keeps multiple npm plugins resolved as file:// URLs"` ✅
- `bun run typecheck` ✅

Also addressed CI feedback:
- Updated PR description to match required template sections (issue-compliance action)
- Fixed Windows CI failures caused by `fileURLToPath()` throwing for POSIX-like file URLs in tests

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR