### PR TITLE
fix: warn on unrecognized permission keys in opencode.json

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -599,6 +599,26 @@ export namespace Config {
     return val
   }
 
+  const KNOWN_PERMISSION_KEYS = new Set([
+    "read",
+    "edit",
+    "glob",
+    "grep",
+    "list",
+    "bash",
+    "task",
+    "external_directory",
+    "todowrite",
+    "todoread",
+    "question",
+    "webfetch",
+    "websearch",
+    "codesearch",
+    "lsp",
+    "doom_loop",
+    "skill",
+  ])
+
   const permissionTransform = (x: unknown): Record<string, PermissionRule> => {
     if (typeof x === "string") return { "*": x as PermissionAction }
     const obj = x as { __originalKeys?: string[] } & Record<string, unknown>
@@ -607,6 +627,11 @@ export namespace Config {
     const result: Record<string, PermissionRule> = {}
     for (const key of __originalKeys) {
       if (key in rest) result[key] = rest[key] as PermissionRule
+      if (!KNOWN_PERMISSION_KEYS.has(key)) {
+        const lower = key.toLowerCase()
+        const hint = KNOWN_PERMISSION_KEYS.has(lower) ? ` — did you mean "${lower}"?` : ""
+        log.warn("unrecognized permission key, permission not applied", { key, hint })
+      }
     }
     return result
   }


### PR DESCRIPTION
### Issue for this PR

Closes #15507

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `permission` block in `opencode.json` uses `.catchall(PermissionRule)` which silently accepts unknown keys. Users migrating from Claude Code (which uses PascalCase like `"Bash"`, `"Read"`) get zero signal that their permissions have no effect.

The fix adds a `KNOWN_PERMISSION_KEYS` set and checks each key in the `permissionTransform` function. Unrecognized keys trigger a warning log with a case-insensitive hint (e.g. `"Bash" — did you mean "bash"?`).

The `.catchall()` is preserved so the schema doesn't reject configs outright — the warning is informational.

### How did you verify your code works?

Ran the existing config test suite (`bun test test/config/config.test.ts`) — all previously-passing tests still pass (55/61, 6 pre-existing failures unrelated to permissions).

### Screenshots / recordings

_N/A — log output change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
