### PR TITLE
fix(question): implement recovery for pending questions when app starts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -111,6 +111,26 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const fullSyncedSessions = new Set<string>()
     let syncedWorkspace = project.workspace.current()
 
+    async function syncQuestions(workspace: string) {
+      const response = await sdk.client.question.list({ workspace })
+      const grouped: Record<string, QuestionRequest[]> = {}
+      for (const q of response.data ?? []) {
+        if (!grouped[q.sessionID]) grouped[q.sessionID] = []
+        grouped[q.sessionID].push(q)
+      }
+      setStore(
+        "question",
+        produce((draft) => {
+          for (const key of Object.keys(draft)) {
+            if (!grouped[key]) delete draft[key]
+          }
+          for (const [id, qs] of Object.entries(grouped)) {
+            draft[id] = qs.toSorted((a, b) => a.id.localeCompare(b.id))
+          }
+        }),
+      )
+    }
+
     event.subscribe((event) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -355,7 +375,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     async function bootstrap(input: { fatal?: boolean } = {}) {
       const fatal = input.fatal ?? true
-      const workspace = project.workspace.current()
+      const workspace = project.workspace.current() ?? ""
       if (workspace !== syncedWorkspace) {
         fullSyncedSessions.clear()
         syncedWorkspace = workspace
@@ -437,6 +457,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            syncQuestions(workspace),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")
@@ -497,7 +518,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           return last.time.completed ? "idle" : "working"
         },
         async sync(sessionID: string) {
-          if (fullSyncedSessions.has(sessionID)) return
+          const workspace = project.workspace.current() ?? ""
+          if (fullSyncedSessions.has(sessionID)) {
+            await syncQuestions(workspace)
+            return
+          }
           const [session, messages, todo, diff] = await Promise.all([
             sdk.client.session.get({ sessionID }, { throwOnError: true }),
             sdk.client.session.messages({ sessionID, limit: 100 }),
@@ -518,6 +543,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             }),
           )
           fullSyncedSessions.add(sessionID)
+          await syncQuestions(workspace)
         },
       },
       bootstrap,

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -2,7 +2,10 @@ import { Deferred, Effect, Layer, Schema, Context } from "effect"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect"
-import { SessionID, MessageID } from "@/session/schema"
+import { SessionID, MessageID, PartID } from "@/session/schema"
+import { PartTable, SessionTable } from "@/session/session.sql"
+import { Database, eq } from "@/storage"
+import type { MessageV2 } from "@/session/message-v2"
 import { zod } from "@/util/effect-zod"
 import { Log } from "@/util"
 import { withStatics } from "@/util/schema"
@@ -107,12 +110,20 @@ export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("Que
 
 interface PendingEntry {
   info: Request
-  deferred: Deferred.Deferred<ReadonlyArray<Answer>, RejectedError>
+  deferred?: Deferred.Deferred<ReadonlyArray<Answer>, RejectedError>
+  part?: PartID
 }
 
 interface State {
   pending: Map<QuestionID, PendingEntry>
 }
+
+type RunningQuestionPart = MessageV2.ToolPart & {
+  tool: "question"
+  state: MessageV2.ToolStateRunning
+}
+
+type RunningQuestionData = Omit<RunningQuestionPart, "id" | "sessionID" | "messageID">
 
 // Service
 
@@ -142,7 +153,8 @@ export const layer = Layer.effect(
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
             for (const item of state.pending.values()) {
-              yield* Deferred.fail(item.deferred, new RejectedError())
+              if (item.info.tool) continue
+              if (item.deferred) yield* Deferred.fail(item.deferred, new RejectedError())
             }
             state.pending.clear()
           }),
@@ -151,6 +163,71 @@ export const layer = Layer.effect(
         return state
       }),
     )
+
+    function isRunning(part: MessageV2.Part): part is RunningQuestionPart
+    function isRunning(part: typeof PartTable.$inferSelect.data): part is RunningQuestionData
+    function isRunning(part: unknown): boolean {
+      if (!part || typeof part !== "object") return false
+      if (!("type" in part) || part.type !== "tool") return false
+      if (!("tool" in part) || part.tool !== "question") return false
+      if (!("state" in part) || !part.state || typeof part.state !== "object") return false
+      return "status" in part.state && part.state.status === "running"
+    }
+
+    function updatePart(
+      id: PartID,
+      build: (part: RunningQuestionData) => MessageV2.ToolStateCompleted | MessageV2.ToolStateError,
+    ) {
+      const row = Database.use((db) => db.select().from(PartTable).where(eq(PartTable.id, id)).get())
+      if (!row || !isRunning(row.data)) return
+      const part = row.data
+      const data = { ...part, state: build(part) }
+      Database.use((db) =>
+        db
+          .update(PartTable)
+          .set({ data, time_updated: Date.now() })
+          .where(eq(PartTable.id, id))
+          .run(),
+      )
+    }
+
+    const recover = Effect.fn("Question.recover")(function* () {
+      const pending = (yield* InstanceState.get(state)).pending
+      const directory = yield* InstanceState.directory
+
+      const rows = Database.use((db) =>
+        db
+          .select({ part: PartTable })
+          .from(PartTable)
+          .innerJoin(SessionTable, eq(PartTable.session_id, SessionTable.id))
+          .where(eq(SessionTable.directory, directory))
+          .orderBy(PartTable.id)
+          .all(),
+      )
+
+      const seen = new Set<string>()
+      for (const entry of pending.values()) {
+        if (entry.info.tool) seen.add(`${entry.info.tool.messageID}:${entry.info.tool.callID}`)
+      }
+
+      for (const row of rows) {
+        const data = row.part.data
+        if (!isRunning(data)) continue
+
+        const key = `${row.part.message_id}:${data.callID}`
+        if (seen.has(key)) continue
+        seen.add(key)
+
+        const id = QuestionID.ascending()
+        const info = Schema.decodeUnknownSync(Request)({
+          id,
+          sessionID: row.part.session_id,
+          questions: data.state.input.questions,
+          tool: { messageID: row.part.message_id, callID: data.callID },
+        })
+        pending.set(id, { info, part: row.part.id })
+      }
+    })
 
     const ask = Effect.fn("Question.ask")(function* (input: {
       sessionID: SessionID
@@ -196,7 +273,19 @@ export const layer = Layer.effect(
         requestID: existing.info.id,
         answers: input.answers.map((a) => [...a]),
       })
-      yield* Deferred.succeed(existing.deferred, input.answers)
+
+      if (existing.part) {
+        updatePart(existing.part, (part) => ({
+          status: "completed",
+          input: part.state.input,
+          output: `User answered: ${input.answers.map((x) => x.join(", ")).join(" | ")}`,
+          title: `Asked ${part.state.input.questions.length} question${part.state.input.questions.length === 1 ? "" : "s"}`,
+          metadata: { answers: input.answers },
+          time: { start: part.state.time.start, end: Date.now() },
+        }))
+      }
+
+      if (existing.deferred) yield* Deferred.succeed(existing.deferred, input.answers)
     })
 
     const reject = Effect.fn("Question.reject")(function* (requestID: QuestionID) {
@@ -212,10 +301,21 @@ export const layer = Layer.effect(
         sessionID: existing.info.sessionID,
         requestID: existing.info.id,
       })
-      yield* Deferred.fail(existing.deferred, new RejectedError())
+
+      if (existing.part) {
+        updatePart(existing.part, (part) => ({
+          status: "error",
+          input: part.state.input,
+          error: "The user dismissed this question",
+          time: { start: part.state.time.start, end: Date.now() },
+        }))
+      }
+
+      if (existing.deferred) yield* Deferred.fail(existing.deferred, new RejectedError())
     })
 
     const list = Effect.fn("Question.list")(function* () {
+      yield* recover()
       const pending = (yield* InstanceState.get(state)).pending
       return Array.from(pending.values(), (x) => x.info)
     })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -197,6 +197,11 @@ export const layer: Layer.Layer<
       const failToolCall = Effect.fn("SessionProcessor.failToolCall")(function* (toolCallID: string, error: unknown) {
         const match = yield* readToolCall(toolCallID)
         if (!match || match.part.state.status !== "running") return false
+        if (
+          match.part.tool === "question" &&
+          (aborted || (error instanceof DOMException && error.name === "AbortError"))
+        )
+          return false
         yield* session.updatePart({
           ...match.part,
           state: {
@@ -288,19 +293,21 @@ export const layer: Layer.Layer<
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
             }
-            yield* updateToolCall(value.toolCallId, (match) => ({
-              ...match,
-              tool: value.toolName,
-              state: {
-                ...match.state,
-                status: "running",
-                input: value.input,
-                time: { start: Date.now() },
-              },
-              metadata: match.metadata?.providerExecuted
-                ? { ...value.providerMetadata, providerExecuted: true }
-                : value.providerMetadata,
-            }))
+            yield* Effect.uninterruptible(
+              updateToolCall(value.toolCallId, (match) => ({
+                ...match,
+                tool: value.toolName,
+                state: {
+                  ...match.state,
+                  status: "running",
+                  input: value.input,
+                  time: { start: Date.now() },
+                },
+                metadata: match.metadata?.providerExecuted
+                  ? { ...value.providerMetadata, providerExecuted: true }
+                  : value.providerMetadata,
+              })),
+            )
 
             const parts = MessageV2.parts(ctx.assistantMessage.id)
             const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
@@ -502,6 +509,7 @@ export const layer: Layer.Layer<
           const match = yield* readToolCall(toolCallID)
           if (!match) continue
           const part = match.part
+          if (part.tool === "question" && part.state.status === "running") continue
           const end = Date.now()
           const metadata = "metadata" in part.state && isRecord(part.state.metadata) ? part.state.metadata : {}
           yield* session.updatePart({

--- a/packages/opencode/test/question/recover.test.ts
+++ b/packages/opencode/test/question/recover.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, expect, test } from "bun:test"
+import { Question } from "../../src/question"
+import { Instance } from "../../src/project/instance"
+import { Database, eq } from "../../src/storage"
+import { MessageTable, PartTable, SessionTable } from "../../src/session/session.sql"
+import { tmpdir } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { AppRuntime } from "../../src/effect/app-runtime"
+
+const list = () => AppRuntime.runPromise(Question.Service.use((svc) => svc.list()))
+const reply = (input: { requestID: Question.Request["id"]; answers: ReadonlyArray<Question.Answer> }) =>
+  AppRuntime.runPromise(Question.Service.use((svc) => svc.reply(input)))
+const reject = (requestID: Question.Request["id"]) =>
+  AppRuntime.runPromise(Question.Service.use((svc) => svc.reject(requestID)))
+
+afterEach(async () => {
+  await resetDatabase()
+})
+
+function seed(input: { sessionID: SessionID; dir: string }) {
+  const now = Date.now()
+  const messageID = MessageID.ascending()
+
+  Database.use((db) => {
+    db.insert(SessionTable)
+      .values({
+        id: input.sessionID,
+        project_id: Instance.project.id,
+        slug: "test",
+        directory: input.dir,
+        title: "test session",
+        version: "2",
+        time_created: now,
+        time_updated: now,
+      })
+      .run()
+
+    db.insert(MessageTable)
+      .values({
+        id: messageID,
+        session_id: input.sessionID,
+        time_created: now,
+        time_updated: now,
+        data: {
+          role: "assistant" as const,
+          time: { created: now },
+          parentID: "msg_fake",
+          modelID: "test-model",
+          providerID: "test-provider",
+          mode: "default",
+          agent: "coder",
+          path: { cwd: input.dir, root: input.dir },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        } as typeof MessageTable.$inferInsert.data,
+      })
+      .run()
+  })
+
+  return messageID
+}
+
+function add(input: { sessionID: SessionID; messageID: MessageID }) {
+  const partID = PartID.ascending()
+  const now = Date.now()
+  const questions = [
+    {
+      question: "Pick something?",
+      header: "Choice",
+      options: [
+        { label: "A", description: "Option A" },
+        { label: "B", description: "Option B" },
+      ],
+    },
+  ]
+
+  Database.use((db) => {
+    db.insert(PartTable)
+      .values({
+        id: partID,
+        message_id: input.messageID,
+        session_id: input.sessionID,
+        time_created: now,
+        time_updated: now,
+        data: {
+          type: "tool",
+          callID: `call_${partID}`,
+          tool: "question",
+          state: {
+            status: "running" as const,
+            input: { questions },
+            time: { start: now },
+          },
+        } as typeof PartTable.$inferInsert.data,
+      })
+      .run()
+  })
+
+  return partID
+}
+
+test("recover - lists running question parts", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const sessionID = SessionID.descending()
+      const messageID = seed({ sessionID, dir: tmp.path })
+      add({ sessionID, messageID })
+
+      const pending = await list()
+      expect(pending.length).toBe(1)
+    },
+  })
+})
+
+test("recover - reply updates DB part to completed", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const sessionID = SessionID.descending()
+      const messageID = seed({ sessionID, dir: tmp.path })
+      const partID = add({ sessionID, messageID })
+
+      const pending = await list()
+      expect(pending.length).toBe(1)
+
+      await reply({
+        requestID: pending[0].id,
+        answers: [["A"]],
+      })
+
+      const row = Database.use((db) => db.select().from(PartTable).where(eq(PartTable.id, partID)).get())
+      const data = row!.data as MessageV2.ToolPart
+      expect(data.state.status).toBe("completed")
+      if (data.state.status === "completed") {
+        expect(data.state.output).toContain("A")
+        expect(data.state.metadata.answers).toEqual([["A"]])
+      }
+
+      expect((await list()).length).toBe(0)
+    },
+  })
+})
+
+test("recover - reject updates DB part to error", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const sessionID = SessionID.descending()
+      const messageID = seed({ sessionID, dir: tmp.path })
+      const partID = add({ sessionID, messageID })
+
+      const pending = await list()
+      expect(pending.length).toBe(1)
+
+      await reject(pending[0].id)
+
+      const row = Database.use((db) => db.select().from(PartTable).where(eq(PartTable.id, partID)).get())
+      const data = row!.data as MessageV2.ToolPart
+      expect(data.state.status).toBe("error")
+      if (data.state.status === "error") {
+        expect(data.state.error).toBe("The user dismissed this question")
+      }
+
+      expect((await list()).length).toBe(0)
+    },
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -15,6 +15,7 @@ import { Permission } from "../../src/permission"
 import { Plugin } from "../../src/plugin"
 import { Provider as ProviderSvc } from "../../src/provider"
 import { Env } from "../../src/env"
+import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Question } from "../../src/question"
 import { Todo } from "../../src/session/todo"
@@ -808,6 +809,66 @@ it.live(
           expect(taskMsg.info.finish).toBeDefined()
         }),
       { git: true, config: cfg },
+    ),
+  30_000,
+)
+
+it.live(
+  "question tool part stays recoverable after session is interrupted",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ dir, llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const question = yield* Question.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "Pinned",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })
+
+        yield* llm.tool("question", {
+          questions: [
+            {
+              question: "Pick one",
+              header: "Choice",
+              options: [{ label: "A", description: "Option A" }],
+            },
+          ],
+        })
+
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+
+        const pending = yield* Effect.gen(function* () {
+          for (let i = 0; i < 500; i++) {
+            const pending = yield* question.list()
+            if (pending.length > 0) return pending
+            yield* Effect.sleep("10 millis")
+          }
+          throw new Error("timed out waiting for question")
+        })
+
+        yield* prompt.cancel(chat.id)
+
+        const exit = yield* Fiber.await(fiber)
+        yield* Effect.promise(() => Instance.reload({ directory: dir }))
+        const recovered = yield* question.list()
+        const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+        const assistant = msgs.findLast((item) => item.info.role === "assistant" && item.info.agent === "build")
+        const tool = assistant?.parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+
+        expect(Exit.isSuccess(exit)).toBe(true)
+        expect(pending).toHaveLength(1)
+        expect(tool?.state.status).toBe("running")
+        expect(recovered).toHaveLength(1)
+      }),
+      { git: true, config: providerCfg },
     ),
   30_000,
 )


### PR DESCRIPTION
### Issue for this PR

Closes #15172

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the terminal is closed while waiting for a `question` tool answer, the question was lost on restart (red "Tool execution aborted" error).

Two fixes:

1. **Race condition** (`processor.ts`): `Effect.uninterruptible(updateToolCall(...))` ensures the question part reaches `"running"` state before any interrupt can fire. Added `failToolCall` guard to skip abort-caused errors for question tools, and a cleanup guard to skip writing "Tool execution aborted" for running question parts.

2. **Missing recovery** (`question/index.ts`, `sync.tsx`): `recover()` scans the DB for `"running"` question parts and repopulates the pending map on `list()`. `syncQuestions()` is now called on every `session.sync()` so the question prompt re-appears when navigating back to the session.

### How did you verify your code works?

Manual: prompt model -> question tool called -> close terminal -> reopen -> `/session` -> question prompt re-appears.

Added `test/question/recover.test.ts` (DB-level recovery) and a test in `test/session/prompt.test.ts` (end-to-end interrupted recovery).

### How did you verify your code works?

Manual testing with running `bun run dev -s <my-sessionid>` to check it loads the question correctly.
Added a couple of test checking that `recover()` function works correctly.

### Screenshots / recordings

_N/A — no UI changes, behavior change only (recovered questions now appear in existing UI)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR