### PR TITLE
fix(provider): await models.dev refresh before computing provider state

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -103,6 +103,8 @@ export namespace ModelsDev {
     return result as Record<string, Provider>
   }
 
+  let refreshing: Promise<void> | undefined
+
   export async function refresh() {
     const result = await fetch(`${url()}/api.json`, {
       headers: {
@@ -119,10 +121,19 @@ export namespace ModelsDev {
       ModelsDev.Data.reset()
     }
   }
+
+  export function startRefresh() {
+    refreshing = refresh()
+    return refreshing
+  }
+
+  export async function ensureFresh() {
+    if (refreshing) await refreshing.catch(() => {})
+  }
 }
 
 if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
-  ModelsDev.refresh()
+  ModelsDev.startRefresh()
   setInterval(
     async () => {
       await ModelsDev.refresh()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -757,6 +757,7 @@ export namespace Provider {
   const state = Instance.state(async () => {
     using _ = log.time("state")
     const config = await Config.get()
+    await ModelsDev.ensureFresh()
     const modelsDev = await ModelsDev.get()
     const database = mapValues(modelsDev, fromModelsDevProvider)
 


### PR DESCRIPTION
### Issue for this PR

Closes #8587

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ModelsDev.refresh()` fires at module load (fire-and-forget) but `Provider.state()` can resolve from the bundled snapshot before the refresh completes. When a model exists in live models.dev but not in the snapshot, `getModel()` throws `ProviderModelNotFoundError`.

This fix tracks the initial refresh promise via `startRefresh()` and awaits it in `Provider.state()` initialization through `ensureFresh()`. If the refresh fails or was never started (e.g. `OPENCODE_DISABLE_MODELS_FETCH`), the await is a no-op and falls through to the snapshot as before.

### How did you verify your code works?

- Traced the race: `Data()` resolves from snapshot → `state()` computes → `refresh()` completes and resets `Data` too late
- Confirmed `remeda.mergeDeep` preserves shared references (nested objects not in the merge source keep the same ref), so `Data.reset()` after `state()` has resolved doesn't help
- Ran provider and tool tests — no regressions (pre-existing bash permission failures unrelated)

### Screenshots / recordings

N/A — backend fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
