### PR TITLE
fix(shell): blacklist POSIX-only shells for bash tool

### DIFF
--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -34,7 +34,7 @@ export namespace Shell {
       }
     }
   }
-  const BLACKLIST = new Set(["fish", "nu"])
+  const BLACKLIST = new Set(["fish", "nu", "sh", "dash", "ash"])
 
   function fallback() {
     if (process.platform === "win32") {


### PR DESCRIPTION
### Issue for this PR

Closes #3340

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `$SHELL` is a POSIX-only shell (sh, dash, ash), brace expansion in `mkdir -p src/{a,b,c}` doesn't work — creating a literal `src/{a,b,c}` folder instead of three separate directories.

LLMs routinely generate bash-compatible syntax with brace expansion. The `acceptable()` shell selector already blacklists fish and nu, but not POSIX-only shells. This adds sh, dash, and ash to the blacklist so `fallback()` picks bash (or zsh on macOS) instead, which all support brace expansion.

The `fallback()` already has the right priority: bash → sh. This change just ensures the acceptable shell selector doesn't short-circuit to a POSIX-only `$SHELL`.

### How did you verify your code works?

- Verified `sh -c "mkdir -p /tmp/test/{a,b,c}"` creates literal folder vs `bash -c "mkdir -p /tmp/test/{a,b,c}"` creates three
- Checked `fallback()` priority chain: on Linux it tries `Bun.which("bash")` first before falling to `/bin/sh`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
