### PR TITLE
feat(tui): add theme_mode config to override terminal color detection

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -282,9 +282,16 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   init: (props: { mode: "dark" | "light" }) => {
     const config = useTuiConfig()
     const kv = useKV()
+
+    function configMode(): "dark" | "light" | undefined {
+      const override = config.theme_mode
+      if (override === "light" || override === "dark") return override
+      return undefined
+    }
+
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
-      mode: kv.get("theme_mode", props.mode),
+      mode: configMode() ?? kv.get("theme_mode", props.mode),
       active: (config.theme ?? kv.get("theme", "opencode")) as string,
       ready: false,
     })
@@ -292,6 +299,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     createEffect(() => {
       const theme = config.theme
       if (theme) setStore("active", theme)
+    })
+
+    createEffect(() => {
+      const override = configMode()
+      if (override) setStore("mode", override)
     })
 
     function init() {

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -28,6 +28,12 @@ export const TuiInfo = z
   .object({
     $schema: z.string().optional(),
     theme: z.string().optional(),
+    theme_mode: z
+      .enum(["light", "dark", "system"])
+      .optional()
+      .describe(
+        "Override the detected terminal color scheme. Set to 'light' or 'dark' to force a mode, or 'system' to auto-detect from terminal.",
+      ),
     keybinds: KeybindOverride.optional(),
   })
   .extend(TuiOptions.shape)


### PR DESCRIPTION
### Issue for this PR

Closes #4464

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `theme_mode` config option to `tui.json` that lets users override terminal color scheme detection. Zellij (and some other terminals) misreport the system theme, causing opencode to always render in dark mode.

Users can now set `"theme_mode": "light"` in their `tui.json` to force light mode. Valid values are `"light"`, `"dark"`, or `"system"` (default, auto-detect).

Two files changed:
- `config/tui-schema.ts` — added `theme_mode` enum field to `TuiInfo`
- `tui/context/theme.tsx` — `configMode()` helper reads the override; applied at init and reactively via `createEffect`

### How did you verify your code works?

Reviewed the existing theme init flow: `getTerminalBackgroundColor()` returns the detected mode, `ThemeProvider` receives it as props, and the store initializes from it. The `configMode()` override takes priority over both terminal detection and the persisted KV value when set to `light` or `dark`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
