### PR TITLE
fix(acp): backfill missing text chunks from part updates

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -144,8 +144,9 @@ export class Agent implements ACPAgent {
   private eventAbort = new AbortController()
   private eventStarted = false
   private bashSnapshots = new Map<string, string>()
-  private toolStarts = new Set<string>()
-  private permissionQueues = new Map<string, Promise<void>>()
+    private toolStarts = new Set<string>()
+    private textSnapshots = new Map<string, string>()
+    private permissionQueues = new Map<string, Promise<void>>()
   private permissionOptions: PermissionOption[] = [
     { optionId: "once", kind: "allow_once", name: "Allow once" },
     { optionId: "always", kind: "allow_always", name: "Always allow" },
@@ -455,15 +456,21 @@ export class Agent implements ACPAgent {
           }
         }
 
-        // ACP clients already know the prompt they just submitted, so replaying
-        // live user parts duplicates the message. We still replay user history in
-        // loadSession() and forkSession() via processMessage().
-        if (part.type !== "text" && part.type !== "file") return
+          if (part.type === "text" && part.ignored !== true) {
+            const delta = this.textDelta(part.id, part.text)
+            if (delta) await this.sendTextChunk(sessionId, "agent_message_chunk", delta)
+            return
+          }
 
-        return
-      }
+          if (part.type === "reasoning") {
+            const delta = this.textDelta(part.id, part.text)
+            if (delta) await this.sendTextChunk(sessionId, "agent_thought_chunk", delta)
+            return
+          }
+          return
+        }
 
-      case "message.part.delta": {
+        case "message.part.delta": {
         const props = event.properties
         const session = this.sessionManager.tryGet(props.sessionID)
         if (!session) return
@@ -490,43 +497,17 @@ export class Agent implements ACPAgent {
         if (!part) return
 
         if (part.type === "text" && props.field === "text" && part.ignored !== true) {
-          await this.connection
-            .sessionUpdate({
-              sessionId,
-              update: {
-                sessionUpdate: "agent_message_chunk",
-                messageId: props.messageID,
-                content: {
-                  type: "text",
-                  text: props.delta,
-                },
-              },
-            })
-            .catch((error) => {
-              log.error("failed to send text delta to ACP", { error })
-            })
+            this.textSnapshots.set(part.id, (this.textSnapshots.get(part.id) ?? "") + props.delta)
+            await this.sendTextChunk(sessionId, "agent_message_chunk", props.delta)
+            return
+          }
+
+          if (part.type === "reasoning" && props.field === "text") {
+            this.textSnapshots.set(part.id, (this.textSnapshots.get(part.id) ?? "") + props.delta)
+            await this.sendTextChunk(sessionId, "agent_thought_chunk", props.delta)
+          }
           return
         }
-
-        if (part.type === "reasoning" && props.field === "text") {
-          await this.connection
-            .sessionUpdate({
-              sessionId,
-              update: {
-                sessionUpdate: "agent_thought_chunk",
-                messageId: props.messageID,
-                content: {
-                  type: "text",
-                  text: props.delta,
-                },
-              },
-            })
-            .catch((error) => {
-              log.error("failed to send reasoning delta to ACP", { error })
-            })
-        }
-        return
-      }
     }
   }
 
@@ -1110,6 +1091,30 @@ export class Agent implements ACPAgent {
     const output = part.state.metadata["output"]
     if (typeof output !== "string") return
     return output
+  }
+
+  private textDelta(id: string, next: string) {
+    const prev = this.textSnapshots.get(id) ?? ""
+    this.textSnapshots.set(id, next)
+    if (!next) return ""
+    if (next.startsWith(prev)) return next.slice(prev.length)
+    return next
+  }
+
+  private async sendTextChunk(
+    sessionId: string,
+    update: "agent_message_chunk" | "agent_thought_chunk",
+    text: string,
+  ) {
+    await this.connection
+      .sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: update,
+          content: { type: "text", text },
+        },
+      })
+      .catch((error) => log.error(`failed to send ${update} to ACP`, { error }))
   }
 
   private async toolStart(sessionId: string, part: ToolPart) {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { ACP } from "../../src/acp/agent"
 import type { AgentSideConnection } from "@agentclientprotocol/sdk"
 import type { Event, EventMessagePartUpdated, ToolStatePending, ToolStateRunning } from "@opencode-ai/sdk/v2"
-import { Instance } from "../../src/project/instance"
+import { Instance } from "@/project/instance.ts"
 import { tmpdir } from "../fixture/fixture"
 
 type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
@@ -138,7 +138,6 @@ function createFakeAgent() {
       if (update?.sessionUpdate === "agent_message_chunk") {
         const content = update.content
         if (content?.type !== "text") return
-        if (typeof content.text !== "string") return
         chunks.set(params.sessionId, (chunks.get(params.sessionId) ?? "") + content.text)
       }
     },
@@ -382,6 +381,276 @@ describe("acp.agent event subscription", () => {
         for (const part of tokenB) expect(a).not.toContain(part)
         for (const part of tokenA) expect(b).not.toContain(part)
 
+        stop()
+      },
+    })
+  })
+
+  test("emits text chunks from message.part.updated when delta events are absent", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, chunks, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "part_1",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "text",
+                text: "hello",
+              },
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "part_1",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "text",
+                text: "hello world",
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(chunks.get(sessionId)).toBe("hello world")
+        stop()
+      },
+    })
+  })
+
+  test("emits reasoning chunks from message.part.updated when delta events are absent", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const thoughtChunks = new Map<string, string>()
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        const originalSessionUpdate = sessionUpdates.push.bind(sessionUpdates)
+        const connection = (agent as any).connection
+        connection.sessionUpdate = async (params: SessionUpdateParams) => {
+          if (params.update?.sessionUpdate === "agent_thought_chunk") {
+            const content = params.update.content
+            if (content?.type === "text") {
+              thoughtChunks.set(params.sessionId, (thoughtChunks.get(params.sessionId) ?? "") + content.text)
+            }
+          }
+          return originalSessionUpdate(params)
+        }
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "reasoning_1",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "reasoning",
+                text: "thinking...",
+                time: { start: Date.now() },
+              },
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "reasoning_1",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "reasoning",
+                text: "thinking... deeply",
+                time: { start: Date.now() },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(thoughtChunks.get(sessionId)).toBe("thinking... deeply")
+        stop()
+      },
+    })
+  })
+
+  test("does not duplicate chunks when message.part.delta is followed by message.part.updated", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, chunks, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.delta",
+            properties: {
+              sessionID: sessionId,
+              messageID: "msg_1",
+              partID: "msg_1_part",
+              field: "text",
+              delta: "hello",
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "msg_1_part",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "text",
+                text: "hello",
+              },
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "msg_1_part",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "text",
+                text: "hello world",
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(chunks.get(sessionId)).toBe("hello world")
+        stop()
+      },
+    })
+  })
+
+  test("does not duplicate reasoning chunks when delta is followed by updated", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const thoughtChunks = new Map<string, string>()
+        const { agent, controller, stop, sdk } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        sdk.session.message = async (params?: any) => ({
+          data: {
+            info: { role: "assistant" },
+            parts: [
+              {
+                id: params?.messageID ? `${params.messageID}_part` : "part_1",
+                type: "reasoning",
+                text: "",
+                time: { start: Date.now() },
+              },
+            ],
+          },
+        })
+
+        const connection = (agent as any).connection
+        connection.sessionUpdate = async (params: SessionUpdateParams) => {
+          if (params.update?.sessionUpdate === "agent_thought_chunk") {
+            const content = params.update.content
+            if (content?.type === "text") {
+              thoughtChunks.set(params.sessionId, (thoughtChunks.get(params.sessionId) ?? "") + content.text)
+            }
+          }
+        }
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.delta",
+            properties: {
+              sessionID: sessionId,
+              messageID: "msg_1",
+              partID: "msg_1_part",
+              field: "text",
+              delta: "thinking",
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "msg_1_part",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "reasoning",
+                text: "thinking",
+                time: { start: Date.now() },
+              },
+            },
+          },
+        } as any)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "msg_1_part",
+                sessionID: sessionId,
+                messageID: "msg_1",
+                type: "reasoning",
+                text: "thinking deeply",
+                time: { start: Date.now() },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(thoughtChunks.get(sessionId)).toBe("thinking deeply")
         stop()
       },
     })


### PR DESCRIPTION
### Issue for this PR

Closes #15613

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Some ACP clients/plugins (e.g. JetBrains/GLM plugin) can miss or delay `message.part.delta` delivery, causing assistant output to appear truncated until a later refresh. 
- The agent needs to emit any missing assistant/reasoning chunks when only `message.part.updated` arrives so ACP clients receive output incrementally.

This PR therefore contains:

- Added `textSnapshots: Map<string,string>` to `packages/opencode/src/acp/agent.ts` to track the last-seen text for each part id. 
- Handle `message.part.updated` for `text` and `reasoning` parts by computing the missing delta via `textDelta(id, next)` and emitting an `agent_message_chunk` or `agent_thought_chunk` containing only the new text. 
- Update `message.part.delta` handling to keep `textSnapshots` in sync (store full part text) so delta and updated events don’t cause duplicate emission. 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a489825cbc832fa36211a657d48b50)

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I have added unit tests

### Screenshots / recordings

<img width="649" height="564" alt="image" src="https://github.com/user-attachments/assets/bd4c27dd-4e7e-4db8-9214-efe0cd59a797" />

### Checklist

- [X] I have tested my changes locally 
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
