### PR TITLE
fix(provider): forward metadata options to cloudflare-ai-gateway provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -555,22 +555,24 @@ export namespace Provider {
       const { createAiGateway } = await import("ai-gateway-provider")
       const { createUnified } = await import("ai-gateway-provider/providers/unified")
 
-      // Forward AI Gateway options from provider config (metadata, cache settings, etc.)
-      const { metadata, cacheTtl, cacheKey, skipCache, collectLog } = input.options ?? {}
-      // Also support legacy cf-aig-metadata header (JSON string in options.headers)
-      const resolvedMetadata = metadata ?? (
-        input.options?.headers?.["cf-aig-metadata"]
-          ? (() => { try { return JSON.parse(input.options.headers["cf-aig-metadata"]) } catch { return undefined } })()
-          : undefined
-      )
-      const gatewayOptions = { metadata: resolvedMetadata, cacheTtl, cacheKey, skipCache, collectLog }
-      const hasGatewayOptions = Object.values(gatewayOptions).some(v => v !== undefined)
+      const metadata = iife(() => {
+        if (input.options?.metadata) return input.options.metadata
+        try { return JSON.parse(input.options?.headers?.["cf-aig-metadata"]) }
+        catch { return undefined }
+      })
+      const opts = {
+        metadata,
+        cacheTtl: input.options?.cacheTtl,
+        cacheKey: input.options?.cacheKey,
+        skipCache: input.options?.skipCache,
+        collectLog: input.options?.collectLog,
+      }
 
       const aigateway = createAiGateway({
         accountId,
         gateway,
         apiKey: apiToken,
-        ...(hasGatewayOptions ? { options: gatewayOptions } : {}),
+        ...(Object.values(opts).some(v => v !== undefined) ? { options: opts } : {}),
       })
       const unified = createUnified()
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -555,7 +555,23 @@ export namespace Provider {
       const { createAiGateway } = await import("ai-gateway-provider")
       const { createUnified } = await import("ai-gateway-provider/providers/unified")
 
-      const aigateway = createAiGateway({ accountId, gateway, apiKey: apiToken })
+      // Forward AI Gateway options from provider config (metadata, cache settings, etc.)
+      const { metadata, cacheTtl, cacheKey, skipCache, collectLog } = input.options ?? {}
+      // Also support legacy cf-aig-metadata header (JSON string in options.headers)
+      const resolvedMetadata = metadata ?? (
+        input.options?.headers?.["cf-aig-metadata"]
+          ? (() => { try { return JSON.parse(input.options.headers["cf-aig-metadata"]) } catch { return undefined } })()
+          : undefined
+      )
+      const gatewayOptions = { metadata: resolvedMetadata, cacheTtl, cacheKey, skipCache, collectLog }
+      const hasGatewayOptions = Object.values(gatewayOptions).some(v => v !== undefined)
+
+      const aigateway = createAiGateway({
+        accountId,
+        gateway,
+        apiKey: apiToken,
+        ...(hasGatewayOptions ? { options: gatewayOptions } : {}),
+      })
       const unified = createUnified()
 
       return {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2218,3 +2218,64 @@ test("Google Vertex: supports OpenAI compatible models", async () => {
     },
   })
 })
+
+test("cloudflare-ai-gateway loads with env variables", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("CLOUDFLARE_ACCOUNT_ID", "test-account")
+      Env.set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
+      Env.set("CLOUDFLARE_API_TOKEN", "test-token")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["cloudflare-ai-gateway"]).toBeDefined()
+    },
+  })
+})
+
+test("cloudflare-ai-gateway forwards config metadata options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "cloudflare-ai-gateway": {
+              options: {
+                metadata: { invoked_by: "test", project: "opencode" },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("CLOUDFLARE_ACCOUNT_ID", "test-account")
+      Env.set("CLOUDFLARE_GATEWAY_ID", "test-gateway")
+      Env.set("CLOUDFLARE_API_TOKEN", "test-token")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["cloudflare-ai-gateway"]).toBeDefined()
+      expect(providers["cloudflare-ai-gateway"].options.metadata).toEqual({
+        invoked_by: "test",
+        project: "opencode",
+      })
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #15621

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `cloudflare-ai-gateway` custom loader calls `createAiGateway()` without forwarding `options.metadata` from the provider config. This was introduced in PR #12014 when switching to the `ai-gateway-provider` package.

The fix reads `metadata`, `cacheTtl`, `cacheKey`, `skipCache`, and `collectLog` from `input.options` and forwards them to `createAiGateway()` when present. It also supports the legacy `cf-aig-metadata` header (JSON string) as a fallback for existing users who set metadata that way.

The `createAiGateway()` function already accepts `options?: AiGatewayOptions` — we just weren't passing them through.

### How did you verify your code works?

- 2 new tests added to `test/provider/provider.test.ts` — both verify metadata and options forwarding
- Full test suite passes (70/70) via `bun test test/provider/provider.test.ts`
- Typecheck passes via `bun turbo typecheck`
- Verified against [CF AI Gateway metadata docs](https://developers.cloudflare.com/ai-gateway/observability/custom-metadata/)

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR