### PR TITLE
feat(tools): add runtime tool toggles across API, TUI, and web

### DIFF
--- a/packages/app/src/components/dialog-select-tools.tsx
+++ b/packages/app/src/components/dialog-select-tools.tsx
@@ -1,0 +1,75 @@
+import { Component, createMemo, createSignal, Show } from "solid-js"
+import { useSync } from "@/context/sync"
+import { useSDK } from "@/context/sdk"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { List } from "@opencode-ai/ui/list"
+import { Switch } from "@opencode-ai/ui/switch"
+import { useLanguage } from "@/context/language"
+
+export const DialogSelectTools: Component = () => {
+  const sync = useSync()
+  const sdk = useSDK()
+  const language = useLanguage()
+  const [loading, setLoading] = createSignal<string | null>(null)
+
+  const items = createMemo(() =>
+    [...sync.data.tools].sort(
+      (a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name),
+    ),
+  )
+
+  const toggle = async (name: string) => {
+    if (loading()) return
+    setLoading(name)
+    try {
+      const result = await sdk.client.tools.toggle({ name })
+      if (result.data) {
+        sync.set("tools", (prev) => prev.map((t) => (t.name === name ? { ...t, disabled: result.data!.disabled } : t)))
+      }
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const enabledCount = createMemo(() => items().filter((t) => !t.disabled).length)
+  const totalCount = createMemo(() => items().length)
+
+  return (
+    <Dialog
+      title={language.t("dialog.tools.title")}
+      description={language.t("dialog.tools.description", { enabled: enabledCount(), total: totalCount() })}
+    >
+      <List
+        search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
+        emptyMessage={language.t("dialog.tools.empty")}
+        key={(x) => x?.name ?? ""}
+        items={items}
+        filterKeys={["name", "category"]}
+        sortBy={(a, b) => a.name.localeCompare(b.name)}
+        groupBy={(x) => x.category}
+        onSelect={(x) => {
+          if (x) toggle(x.name)
+        }}
+      >
+        {(i) => {
+          const enabled = () => !sync.data.tools.find((t) => t.name === i.name)?.disabled
+          return (
+            <div class="w-full flex items-center justify-between gap-x-3">
+              <div class="flex flex-col gap-0.5 min-w-0">
+                <div class="flex items-center gap-2">
+                  <span class="truncate">{i.name}</span>
+                  <Show when={loading() === i.name}>
+                    <span class="text-11-regular text-text-weak">{language.t("common.loading.ellipsis")}</span>
+                  </Show>
+                </div>
+              </div>
+              <div onClick={(e) => e.stopPropagation()}>
+                <Switch checked={enabled()} disabled={loading() === i.name} onChange={() => toggle(i.name)} />
+              </div>
+            </div>
+          )
+        }}
+      </List>
+    </Dialog>
+  )
+}

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -162,6 +162,7 @@ export async function bootstrapDirectory(input: {
     input.sdk.session.status().then((x) => input.setStore("session_status", x.data!)),
     input.loadSessions(input.directory),
     input.sdk.mcp.status().then((x) => input.setStore("mcp", x.data!)),
+    input.sdk.tools.list().then((x) => input.setStore("tools", x.data ?? [])),
     input.sdk.lsp.status().then((x) => input.setStore("lsp", x.data!)),
     input.sdk.vcs.get().then((x) => {
       const next = x.data ?? input.store.vcs

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -172,6 +172,7 @@ export function createChildStoreManager(input: {
             permission: {},
             question: {},
             mcp: {},
+            tools: [],
             lsp: [],
             vcs: vcsStore.value,
             limit: 5,

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -76,6 +76,7 @@ const baseState = (input: Partial<State> = {}) =>
     permission: {},
     question: {},
     mcp: {},
+    tools: [],
     lsp: [],
     vcs: undefined,
     limit: 10,

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -15,8 +15,11 @@ import type {
   Session,
   SessionStatus,
   Todo,
+  ToolInfo,
   VcsInfo,
 } from "@opencode-ai/sdk/v2/client"
+
+export type { ToolInfo }
 import type { Accessor } from "solid-js"
 import type { SetStoreFunction, Store } from "solid-js/store"
 
@@ -61,6 +64,7 @@ export type State = {
   mcp: {
     [name: string]: McpStatus
   }
+  tools: ToolInfo[]
   lsp: LspStatus[]
   vcs: VcsInfo | undefined
   limit: number

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -63,6 +63,8 @@ export const dict = {
   "command.model.choose.description": "Select a different model",
   "command.mcp.toggle": "Toggle MCPs",
   "command.mcp.toggle.description": "Toggle MCPs",
+  "command.tools.toggle": "Toggle tools",
+  "command.tools.toggle.description": "Toggle tools",
   "command.agent.cycle": "Cycle agent",
   "command.agent.cycle.description": "Switch to the next agent",
   "command.agent.cycle.reverse": "Cycle agent backwards",
@@ -292,6 +294,9 @@ export const dict = {
   "dialog.mcp.title": "MCPs",
   "dialog.mcp.description": "{{enabled}} of {{total}} enabled",
   "dialog.mcp.empty": "No MCPs configured",
+  "dialog.tools.title": "Tools",
+  "dialog.tools.description": "{{enabled}} of {{total}} enabled",
+  "dialog.tools.empty": "No tools available",
 
   "dialog.lsp.empty": "LSPs auto-detected from file types",
   "dialog.plugins.empty": "Plugins configured in opencode.json",

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -14,6 +14,7 @@ import { useTerminal } from "@/context/terminal"
 import { DialogSelectFile } from "@/components/dialog-select-file"
 import { DialogSelectModel } from "@/components/dialog-select-model"
 import { DialogSelectMcp } from "@/components/dialog-select-mcp"
+import { DialogSelectTools } from "@/components/dialog-select-tools"
 import { DialogFork } from "@/components/dialog-fork"
 import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/util/array"
@@ -234,6 +235,13 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       keybind: "mod+;",
       slash: "mcp",
       onSelect: () => dialog.show(() => <DialogSelectMcp />),
+    }),
+    agentCommand({
+      id: "tools.toggle",
+      title: language.t("command.tools.toggle"),
+      description: language.t("command.tools.toggle.description"),
+      slash: "tools",
+      onSelect: () => dialog.show(() => <DialogSelectTools />),
     }),
     agentCommand({
       id: "agent.cycle",

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -14,6 +14,7 @@ import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
+import { DialogTools } from "@tui/component/dialog-tools"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
@@ -468,6 +469,17 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogMcp />)
+      },
+    },
+    {
+      title: "Toggle tools",
+      value: "tools.list",
+      category: "Agent",
+      slash: {
+        name: "tools",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogTools />)
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-tools.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-tools.tsx
@@ -1,0 +1,61 @@
+import { createMemo, createSignal } from "solid-js"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { useTheme } from "../context/theme"
+import { Keybind } from "@/util/keybind"
+import { TextAttributes } from "@opentui/core"
+
+function Status(props: { disabled: boolean; saving: boolean }) {
+  const { theme } = useTheme()
+  if (props.saving) {
+    return <span style={{ fg: theme.textMuted }}>⋯ Saving</span>
+  }
+  if (props.disabled) {
+    return <span style={{ fg: theme.textMuted }}>○ Disabled</span>
+  }
+  return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ Enabled</span>
+}
+
+export function DialogTools() {
+  const sdk = useSDK()
+  const sync = useSync()
+  const [saving, setSaving] = createSignal<string | null>(null)
+
+  async function toggle(option: DialogSelectOption<string>) {
+    if (saving() !== null) return
+    setSaving(option.value)
+    try {
+      const result = await sdk.client.tools.toggle({ name: option.value })
+      if (result.data) {
+        sync.set("tools", (prev) => prev.map((t) => (t.name === option.value ? { ...t, disabled: result.data!.disabled } : t)))
+      }
+    } catch (error) {
+      console.error("Failed to toggle tool:", error)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const options = createMemo(() => {
+    const toolList = [...sync.data.tools].sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name))
+    const savingTool = saving()
+
+    return toolList.map((tool) => ({
+      value: tool.name,
+      title: tool.name,
+      category: tool.category,
+      footer: <Status disabled={tool.disabled} saving={savingTool === tool.name} />,
+    }))
+  })
+
+  const keybinds = createMemo(() => [
+    {
+      keybind: Keybind.parse("space")[0],
+      title: "toggle",
+      onTrigger: toggle,
+    },
+  ])
+
+  return <DialogSelect title="Tools" options={options()} keybind={keybinds()} onSelect={toggle} />
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -13,6 +13,7 @@ import type {
   McpStatus,
   McpResource,
   FormatterStatus,
+  ToolInfo,
   SessionStatus,
   ProviderListResponse,
   ProviderAuthMethod,
@@ -70,6 +71,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       mcp_resource: {
         [key: string]: McpResource
       }
+      tools: ToolInfo[]
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
       path: Path
@@ -95,6 +97,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       message: {},
       part: {},
       lsp: [],
+      tools: [],
       mcp: {},
       mcp_resource: {},
       formatter: [],
@@ -405,6 +408,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
+            sdk.client.tools.list().then((x) => setStore("tools", reconcile(x.data ?? []))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),
             sdk.client.session.status().then((x) => {

--- a/packages/opencode/src/server/routes/tools.ts
+++ b/packages/opencode/src/server/routes/tools.ts
@@ -1,0 +1,93 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { lazy } from "../../util/lazy"
+import { ToolRegistry, ToolInfo } from "../../tool/registry"
+import { MCP } from "../../mcp"
+import { Config } from "../../config/config"
+import { PermissionNext } from "../../permission/next"
+
+export const ToolsRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "List all tools",
+        description: "List all available tools",
+        operationId: "tools.list",
+        responses: {
+          200: {
+            description: "Tool list",
+            content: {
+              "application/json": {
+                schema: resolver(z.array(ToolInfo)),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const [cfg, disabled] = await Promise.all([Config.get(), ToolRegistry.disabled()])
+        const ruleset = PermissionNext.fromConfig(cfg.permission ?? {})
+
+        const builtinIds = (await ToolRegistry.ids()).filter((id) => id !== "invalid")
+
+        const allClients = await MCP.clients()
+        const allStatus = await MCP.status()
+        const mcpCandidates: { key: string; serverName: string }[] = []
+        for (const [serverName, client] of Object.entries(allClients)) {
+          if (allStatus[serverName]?.status !== "connected") continue
+          const result = await client.listTools().catch(() => undefined)
+          if (!result) continue
+          for (const tool of result.tools) {
+            const sanitizedServer = serverName.replace(/[^a-zA-Z0-9_-]/g, "_")
+            const sanitizedTool = tool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
+            mcpCandidates.push({ key: `${sanitizedServer}_${sanitizedTool}`, serverName })
+          }
+        }
+
+        const allNames = [...builtinIds, ...mcpCandidates.map((t) => t.key)]
+        const deniedByPermission = PermissionNext.disabled(allNames, ruleset)
+
+        const builtins = builtinIds
+          .filter((id) => !deniedByPermission.has(id))
+          .map((id) => ({ name: id, category: "builtin", disabled: disabled.has(id) }))
+
+        const mcpTools = mcpCandidates
+          .filter((t) => !deniedByPermission.has(t.key))
+          .map((t) => ({ name: t.key, category: t.serverName, disabled: disabled.has(t.key) }))
+
+        return c.json([...builtins, ...mcpTools])
+      },
+    )
+    .post(
+      "/:name/toggle",
+      describeRoute({
+        summary: "Toggle a tool",
+        description: "Enable or disable a tool",
+        operationId: "tools.toggle",
+        responses: {
+          200: {
+            description: "Updated disabled status",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ disabled: z.boolean() })),
+              },
+            },
+          },
+        },
+      }),
+      validator("param", z.object({ name: z.string() })),
+      async (c) => {
+        const { name } = c.req.valid("param")
+        const disabled = await ToolRegistry.disabled()
+        if (disabled.has(name)) {
+          await ToolRegistry.enable(name)
+          return c.json({ disabled: false })
+        } else {
+          await ToolRegistry.disable(name)
+          return c.json({ disabled: true })
+        }
+      },
+    ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -26,6 +26,7 @@ import { ProjectRoutes } from "./routes/project"
 import { SessionRoutes } from "./routes/session"
 import { PtyRoutes } from "./routes/pty"
 import { McpRoutes } from "./routes/mcp"
+import { ToolsRoutes } from "./routes/tools"
 import { FileRoutes } from "./routes/file"
 import { ConfigRoutes } from "./routes/config"
 import { ExperimentalRoutes } from "./routes/experimental"
@@ -250,6 +251,7 @@ export namespace Server {
         .route("/provider", ProviderRoutes())
         .route("/", FileRoutes())
         .route("/mcp", McpRoutes())
+        .route("/tools", ToolsRoutes())
         .route("/tui", TuiRoutes())
         .post(
           "/instance/dispose",

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -148,7 +148,20 @@ export namespace LLM {
     const maxOutputTokens =
       isCodex || provider.id.includes("github-copilot") ? undefined : ProviderTransform.maxOutputTokens(input.model)
 
-    const tools = await resolveTools(input)
+    const { active: tools, disabled } = await resolveTools(input)
+
+    // System prompts may reference builtin tools by name.
+    // This means that some models may still attempt to call those tools, resulting in an error.
+    // Explicitly telling the model which tools are disabled prevents this.
+    if (disabled.length > 0) {
+      system.push(
+        [
+          "<system-reminder>",
+          `The following tools are currently disabled and must not be called: ${disabled.join(", ")}`,
+          "</system-reminder>",
+        ].join("\n"),
+      )
+    }
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.
@@ -257,7 +270,10 @@ export namespace LLM {
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabledByPermission = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+    const allTools = Object.keys(input.tools)
+    const builtinTools = new Set(await ToolRegistry.ids())
+
+    const disabledByPermission = PermissionNext.disabled(allTools, input.agent.permission)
     const disabledByToggle = await ToolRegistry.disabled()
     const disabledForMessage = new Set(
       Object.keys(input.user.tools ?? {}).filter((k) => input.user.tools?.[k] === false),
@@ -265,11 +281,15 @@ export namespace LLM {
 
     const disabled = new Set([...disabledByPermission, ...disabledByToggle, ...disabledForMessage])
 
-    for (const tool of Object.keys(input.tools)) {
-      if (disabled.has(tool)) delete input.tools[tool]
+    const removed: string[] = []
+    for (const tool of allTools) {
+      if (disabled.has(tool)) {
+        delete input.tools[tool]
+        if (builtinTools.has(tool)) removed.push(tool)
+      }
     }
 
-    return input.tools
+    return { active: input.tools, disabled: removed }
   }
 
   // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -21,6 +21,7 @@ import { Plugin } from "@/plugin"
 import { SystemPrompt } from "./system"
 import { Flag } from "@/flag/flag"
 import { PermissionNext } from "@/permission/next"
+import { ToolRegistry } from "@/tool/registry"
 import { Auth } from "@/auth"
 
 export namespace LLM {
@@ -256,12 +257,18 @@ export namespace LLM {
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+    const disabledByPermission = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+    const disabledByToggle = await ToolRegistry.disabled()
+    const disabledForMessage = new Set(
+      Object.keys(input.user.tools ?? {}).filter((k) => input.user.tools?.[k] === false),
+    )
+
+    const disabled = new Set([...disabledByPermission, ...disabledByToggle, ...disabledForMessage])
+
     for (const tool of Object.keys(input.tools)) {
-      if (input.user.tools?.[tool] === false || disabled.has(tool)) {
-        delete input.tools[tool]
-      }
+      if (disabled.has(tool)) delete input.tools[tool]
     }
+
     return input.tools
   }
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -31,6 +31,14 @@ import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
 
+export const ToolInfo = z
+  .object({
+    name: z.string(),
+    category: z.string(),
+    disabled: z.boolean(),
+  })
+  .meta({ ref: "ToolInfo" })
+
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
 
@@ -58,7 +66,14 @@ export namespace ToolRegistry {
       }
     }
 
-    return { custom }
+    const cfg = await Config.get()
+    const disabled = new Set<string>(
+      Object.entries(cfg.tools ?? {})
+        .filter(([, v]) => v === false)
+        .map(([k]) => k),
+    )
+
+    return { custom, disabled }
   })
 
   function fromPlugin(id: string, def: ToolDefinition): Tool.Info {
@@ -126,6 +141,21 @@ export namespace ToolRegistry {
 
   export async function ids() {
     return all().then((x) => x.map((t) => t.id))
+  }
+
+  export async function disabled() {
+    const s = await state()
+    return new Set(s.disabled)
+  }
+
+  export async function disable(name: string) {
+    const s = await state()
+    s.disabled.add(name)
+  }
+
+  export async function enable(name: string) {
+    const s = await state()
+    s.disabled.delete(name)
   }
 
   export async function tools(

--- a/packages/opencode/test/server/tools-toggle.test.ts
+++ b/packages/opencode/test/server/tools-toggle.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { Log } from "../../src/util/log"
+import { Server } from "../../src/server/server"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("tools routes", () => {
+  test("POST /tools/:name/toggle flips disabled state", async () => {
+    const app = Server.App()
+
+    const firstToggle = await app.request("/tools/bash/toggle", {
+      method: "POST",
+    })
+    expect(firstToggle.status).toBe(200)
+    const firstBody = (await firstToggle.json()) as { disabled: boolean }
+
+    const secondToggle = await app.request("/tools/bash/toggle", {
+      method: "POST",
+    })
+    expect(secondToggle.status).toBe(200)
+    const secondBody = (await secondToggle.json()) as { disabled: boolean }
+    expect(secondBody.disabled).not.toBe(firstBody.disabled)
+
+    const thirdToggle = await app.request("/tools/bash/toggle", {
+      method: "POST",
+    })
+    expect(thirdToggle.status).toBe(200)
+    const thirdBody = (await thirdToggle.json()) as { disabled: boolean }
+    expect(thirdBody.disabled).toBe(firstBody.disabled)
+  })
+
+  test("GET /tools returns builtin tools with disabled state", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        tools: {
+          bash: false,
+        },
+        permission: {
+          bash: "allow",
+        },
+      },
+    })
+
+    const app = Server.App()
+    const response = await app.request(`/tools?directory=${encodeURIComponent(tmp.path)}`)
+    expect(response.status).toBe(200)
+
+    const body = (await response.json()) as Array<{ name: string; category: string; disabled: boolean }>
+    const bash = body.find((tool) => tool.name === "bash")
+    expect(bash).toBeDefined()
+    expect(bash?.category).toBe("builtin")
+    expect(bash?.disabled).toBe(true)
+    expect(body.some((tool) => tool.name === "invalid")).toBe(false)
+  })
+})

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
-import type { ModelMessage } from "ai"
+import { jsonSchema, tool, type ModelMessage } from "ai"
 import { LLM } from "../../src/session/llm"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -11,6 +11,7 @@ import { Filesystem } from "../../src/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
 import type { Agent } from "../../src/agent/agent"
 import type { MessageV2 } from "../../src/session/message-v2"
+import { ToolRegistry } from "../../src/tool/registry"
 
 describe("session.llm.hasToolCalls", () => {
   test("returns false for empty messages array", () => {
@@ -218,6 +219,45 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
     status: 200,
     headers: { "Content-Type": "text/event-stream" },
   })
+}
+
+function createAnthropicTextChunks(modelID: string) {
+  return [
+    {
+      type: "message_start",
+      message: {
+        id: "msg-1",
+        model: modelID,
+        usage: {
+          input_tokens: 3,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+        },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello" },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null, container: null },
+      usage: {
+        input_tokens: 3,
+        output_tokens: 2,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    },
+    { type: "message_stop" },
+  ]
 }
 
 describe("session.llm.stream", () => {
@@ -455,43 +495,7 @@ describe("session.llm.stream", () => {
     const provider = fixture.provider
     const model = fixture.model
 
-    const chunks = [
-      {
-        type: "message_start",
-        message: {
-          id: "msg-1",
-          model: model.id,
-          usage: {
-            input_tokens: 3,
-            cache_creation_input_tokens: null,
-            cache_read_input_tokens: null,
-          },
-        },
-      },
-      {
-        type: "content_block_start",
-        index: 0,
-        content_block: { type: "text", text: "" },
-      },
-      {
-        type: "content_block_delta",
-        index: 0,
-        delta: { type: "text_delta", text: "Hello" },
-      },
-      { type: "content_block_stop", index: 0 },
-      {
-        type: "message_delta",
-        delta: { stop_reason: "end_turn", stop_sequence: null, container: null },
-        usage: {
-          input_tokens: 3,
-          output_tokens: 2,
-          cache_creation_input_tokens: null,
-          cache_read_input_tokens: null,
-        },
-      },
-      { type: "message_stop" },
-    ]
-    const request = waitRequest("/messages", createEventResponse(chunks))
+    const request = waitRequest("/messages", createEventResponse(createAnthropicTextChunks(model.id)))
 
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -558,6 +562,110 @@ describe("session.llm.stream", () => {
         expect(body.max_tokens).toBe(ProviderTransform.maxOutputTokens(resolved))
         expect(body.temperature).toBe(0.4)
         expect(body.top_p).toBe(0.9)
+      },
+    })
+  })
+
+  test("omits disabled builtin tools and adds disabled-tools reminder", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "anthropic"
+    const modelID = "claude-3-5-sonnet-20241022"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest("/messages", createEventResponse(createAnthropicTextChunks(model.id)))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-anthropic-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(providerID, model.id)
+        await ToolRegistry.disable("bash")
+        const sessionID = "session-test-5"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-5",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            bash: tool({
+              description: "Run shell commands",
+              inputSchema: jsonSchema({
+                type: "object",
+                properties: { command: { type: "string" } },
+                required: ["command"],
+                additionalProperties: false,
+              }),
+              execute: async () => ({ ok: true }),
+            }),
+            read: tool({
+              description: "Read files",
+              inputSchema: jsonSchema({
+                type: "object",
+                properties: { filePath: { type: "string" } },
+                required: ["filePath"],
+                additionalProperties: false,
+              }),
+              execute: async () => ({ ok: true }),
+            }),
+          },
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+        const names = ((body.tools ?? []) as Array<{ name: string }>).map((entry) => entry.name)
+
+        expect(capture.url.pathname.endsWith("/messages")).toBe(true)
+        expect(names).toContain("read")
+        expect(names).not.toContain("bash")
+        expect(JSON.stringify(body.system ?? "")).toContain(
+          "The following tools are currently disabled and must not be called: bash",
+        )
       },
     })
   })

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -74,6 +74,64 @@ describe("tool.registry", () => {
     })
   })
 
+  test("disabled() returns empty set by default", async () => {
+    await using tmp = await tmpdir({})
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await ToolRegistry.disabled()
+        expect(result.size).toBe(0)
+      },
+    })
+  })
+
+  test("disable() adds a tool to the disabled set", async () => {
+    await using tmp = await tmpdir({})
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await ToolRegistry.disable("bash")
+        const result = await ToolRegistry.disabled()
+        expect(result.has("bash")).toBe(true)
+      },
+    })
+  })
+
+  test("enable() removes a tool from the disabled set", async () => {
+    await using tmp = await tmpdir({})
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await ToolRegistry.disable("bash")
+        await ToolRegistry.enable("bash")
+        const result = await ToolRegistry.disabled()
+        expect(result.has("bash")).toBe(false)
+      },
+    })
+  })
+
+  test("disabled set is seeded from config on init", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({ tools: { bash: false } }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await ToolRegistry.disabled()
+        expect(result.has("bash")).toBe(true)
+      },
+    })
+  })
+
   test("loads tools with external dependencies without crashing", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -154,6 +154,8 @@ import type {
   ToolIdsResponses,
   ToolListErrors,
   ToolListResponses,
+  ToolsListResponses,
+  ToolsToggleResponses,
   TuiAppendPromptErrors,
   TuiAppendPromptResponses,
   TuiClearPromptResponses,
@@ -3082,6 +3084,70 @@ export class Mcp extends HeyApiClient {
   }
 }
 
+export class Tools extends HeyApiClient {
+  /**
+   * List all tools
+   *
+   * List all available tools
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ToolsListResponses, unknown, ThrowOnError>({
+      url: "/tools",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Toggle a tool
+   *
+   * Enable or disable a tool
+   */
+  public toggle<ThrowOnError extends boolean = false>(
+    parameters: {
+      name: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "name" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ToolsToggleResponses, unknown, ThrowOnError>({
+      url: "/tools/{name}/toggle",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Control extends HeyApiClient {
   /**
    * Get next TUI request
@@ -3946,6 +4012,11 @@ export class OpencodeClient extends HeyApiClient {
   private _mcp?: Mcp
   get mcp(): Mcp {
     return (this._mcp ??= new Mcp({ client: this.client }))
+  }
+
+  private _tools?: Tools
+  get tools(): Tools {
+    return (this._tools ??= new Tools({ client: this.client }))
   }
 
   private _tui?: Tui

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -677,13 +677,6 @@ export type EventQuestionRejected = {
   }
 }
 
-export type EventSessionCompacted = {
-  type: "session.compacted"
-  properties: {
-    sessionID: string
-  }
-}
-
 export type EventFileWatcherUpdated = {
   type: "file.watcher.updated"
   properties: {
@@ -712,6 +705,13 @@ export type EventTodoUpdated = {
   properties: {
     sessionID: string
     todos: Array<Todo>
+  }
+}
+
+export type EventSessionCompacted = {
+  type: "session.compacted"
+  properties: {
+    sessionID: string
   }
 }
 
@@ -978,9 +978,9 @@ export type Event =
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
-  | EventSessionCompacted
   | EventFileWatcherUpdated
   | EventTodoUpdated
+  | EventSessionCompacted
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow
@@ -1843,6 +1843,12 @@ export type McpStatus =
   | McpStatusFailed
   | McpStatusNeedsAuth
   | McpStatusNeedsClientRegistration
+
+export type ToolInfo = {
+  name: string
+  category: string
+  disabled: boolean
+}
 
 export type Path = {
   home: string
@@ -4459,6 +4465,48 @@ export type McpDisconnectResponses = {
 }
 
 export type McpDisconnectResponse = McpDisconnectResponses[keyof McpDisconnectResponses]
+
+export type ToolsListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/tools"
+}
+
+export type ToolsListResponses = {
+  /**
+   * Tool list
+   */
+  200: Array<ToolInfo>
+}
+
+export type ToolsListResponse = ToolsListResponses[keyof ToolsListResponses]
+
+export type ToolsToggleData = {
+  body?: never
+  path: {
+    name: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/tools/{name}/toggle"
+}
+
+export type ToolsToggleResponses = {
+  /**
+   * Updated disabled status
+   */
+  200: {
+    disabled: boolean
+  }
+}
+
+export type ToolsToggleResponse = ToolsToggleResponses[keyof ToolsToggleResponses]
 
 export type TuiAppendPromptData = {
   body?: {

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -106,6 +106,9 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
 
   createEffect(
     on(grouped, () => {
+      // Preserve cursor position if the active item is still in the list (e.g. a property changed in-place)
+      const currentActive = list.active()
+      if (currentActive && flat().some((item) => props.key(item) === currentActive)) return
       reset()
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/15623
Closes https://github.com/anomalyco/opencode/issues/13827
Mitigates https://github.com/anomalyco/opencode/issues/9379


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR introduces first-class tool disable functionality across runtime, API, and UI. This serves a different role from permissions, which are rule-based and order-dependent. Disabling a tool is an explicit state applied independently, and it can be toggled directly in the UI. This is especially useful for MCP servers with many tools, where you may need specific tools intermittently without toggling the whole server.

Core changes:

- Added a dedicated disabled tool state in `ToolRegistry`, separate from permission matching.
- Registered `/tools` slash command in both TUI and web app to open the toggle dialog.
- Added new tools endpoints:
    - `GET /tools` to list available tools (builtin + connected via MCP) with disabled state
    - `POST /tools/:name/toggle` to enable/disable a tool
- Updated runtime tool resolution to apply disabled tool state alongside existing permission/per-message filtering.
- Added a system reminder listing disabled builtin tools to the LLM path, which makes it less likely for the model to call disabled tools when they appear in system instructions. (See https://github.com/anomalyco/opencode/issues/9379)

Notes:
- Top-level `tools` config (pre-existing) seeds disabled state and is enforced independently of permission precedence.
- UI/API toggles update runtime state for the current instance, leaving config untouched.

### How did you verify your code works?

- Manual A/B checks in both TUI and web app:
    - When a tool is disabled, its definition is no longer included, context usage drops, and the model cannot call it.
    - When re-enabled, the definition returns, context usage increases, and tool calls work again.
- Automated coverage for:
    - Registry disabled-state behavior
    - Tools route toggle/list behavior
    - LLM request shaping for disabled tools


### Screenshots / recordings

https://github.com/user-attachments/assets/9b5c71db-f695-4df9-88dc-3e34977b34b9

https://github.com/user-attachments/assets/f0a0b19f-7397-44f1-9770-4540d93a4c9d

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._