### PR TITLE
feat(provider): add Blackbox AI as inference provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -588,6 +588,17 @@ export namespace Provider {
         },
       }
     },
+    blackbox: async () => {
+      return {
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
+          },
+        },
+      }
+    },
   }
 
   export const Model = z
@@ -792,6 +803,86 @@ export namespace Provider {
           providerID: "github-copilot-enterprise",
         })),
       }
+    }
+
+    // Add Blackbox AI provider (OpenAI-compatible, not in models.dev)
+    database["blackbox"] = {
+      id: "blackbox",
+      name: "Blackbox AI",
+      source: "custom",
+      env: ["BLACKBOX_API_KEY"],
+      options: {},
+      models: {
+        "blackbox-ai": {
+          id: "blackbox-ai",
+          providerID: "blackbox",
+          name: "Blackbox AI",
+          api: {
+            id: "blackbox-ai",
+            url: "https://api.blackbox.ai/api/chat/completions",
+            npm: "@ai-sdk/openai-compatible",
+          },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 128000, input: 128000, output: 16384 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false },
+          },
+        },
+        "blackbox-pro": {
+          id: "blackbox-pro",
+          providerID: "blackbox",
+          name: "Blackbox Pro",
+          api: {
+            id: "blackbox-pro",
+            url: "https://api.blackbox.ai/api/chat/completions",
+            npm: "@ai-sdk/openai-compatible",
+          },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 200000, input: 200000, output: 16384 },
+          capabilities: {
+            temperature: true,
+            reasoning: true,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false },
+          },
+        },
+        "blackbox-search": {
+          id: "blackbox-search",
+          providerID: "blackbox",
+          name: "Blackbox Search",
+          api: {
+            id: "blackbox-search",
+            url: "https://api.blackbox.ai/api/chat/completions",
+            npm: "@ai-sdk/openai-compatible",
+          },
+          status: "active",
+          headers: {},
+          options: {},
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 32000, input: 32000, output: 8192 },
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: false,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false },
+          },
+        },
+      },
     }
 
     function mergeProvider(providerID: string, provider: Partial<Info>) {


### PR DESCRIPTION
## Summary

- Adds [Blackbox AI](https://www.blackbox.ai/) as a built-in inference provider using its OpenAI-compatible API
- Registers three native models: `blackbox-ai` (128K context), `blackbox-pro` (200K, reasoning), `blackbox-search` (32K, web search)
- Uses `@ai-sdk/openai-compatible` which is already bundled — no new dependencies needed
- Authenticated via `BLACKBOX_API_KEY` environment variable
- Follows the same static-injection pattern used by `github-copilot-enterprise`

Blackbox AI also provides routed access to 300+ models from other providers, which users can add via config.

## Test plan

- [ ] Set `BLACKBOX_API_KEY` and launch opencode
- [ ] Verify `blackbox/blackbox-ai`, `blackbox/blackbox-pro`, `blackbox/blackbox-search` appear in model picker
- [ ] Select `blackbox/blackbox-ai` and send a test message
- [ ] Verify tool calling works with `blackbox-ai` and `blackbox-pro`
- [ ] Verify `blackbox-search` correctly has tool calling disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)