### PR TITLE
fix: add Bicep and Bicepparam file extension mappings

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -109,6 +109,8 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".zig": "zig",
   ".zon": "zig",
   ".astro": "astro",
+  ".bicep": "bicep",
+  ".bicepparam": "bicepparam",
   ".ml": "ocaml",
   ".mli": "ocaml",
   ".tf": "terraform",

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -110,7 +110,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".zon": "zig",
   ".astro": "astro",
   ".bicep": "bicep",
-  ".bicepparam": "bicepparam",
+  ".bicepparam": "bicep-params",
   ".ml": "ocaml",
   ".mli": "ocaml",
   ".tf": "terraform",


### PR DESCRIPTION
### Issue for this PR

Closes #15569

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes missing Bicep diagnostics in custom LSP setups by sending the correct language IDs for Bicep files.

The official Bicep LSP server defines specific language IDs in its source code (`LanguageConstants.cs`):
- `.bicep` files use language ID: `bicep`
- `.bicepparam` files use language ID: `bicep-params`

Without these mappings, custom configured Bicep LSP falls back to plaintext, causing diagnostics to return `{}` on errors.

This PR adds the correct extension-to-language mappings:
- `.bicep` → `bicep`
- `.bicepparam` → `bicep-params`

Reference: https://github.com/Azure/bicep/blob/main/src/Bicep.Core/LanguageConstants.cs

### How did you verify your code works?

1. Verified the official language IDs by inspecting the Bicep source code:
   - `public const string LanguageId = "bicep";`
   - `public const string ParamsLanguageId = "bicep-params";`

2. Confirmed the mapping follows the existing pattern in `language.ts`:
   - Similar to how `.tfvars` maps to `terraform-vars`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR