### PR TITLE
fix(nix): overlay bun 1.3.10 and include TEAM_MEMBERS in fileset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,47 @@
         "aarch64-darwin"
         "x86_64-darwin"
       ];
-      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
       rev = self.shortRev or self.dirtyShortRev or "dirty";
+      # TODO: remove once nixpkgs-unstable has bun >= 1.3.10
+      bunOverlay = final: prev: {
+        bun = prev.bun.overrideAttrs (old: rec {
+          version = "1.3.10";
+          passthru = old.passthru // {
+            sources = {
+              "aarch64-darwin" = final.fetchurl {
+                url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-aarch64.zip";
+                hash = "sha256-ggNOh8nZtDmOphmu4u7V0qaMgVfppq4tEFLYTVM8zY0=";
+              };
+              "aarch64-linux" = final.fetchurl {
+                url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-aarch64.zip";
+                hash = "sha256-+l7LJcr6jo9ch6D4M3GdRt0K8KhseDfYBlMSEtVWNtM=";
+              };
+              "x86_64-darwin" = final.fetchurl {
+                url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-darwin-x64-baseline.zip";
+                hash = "sha256-+WhsTk52DbTN53oPH60F5VJki5ycv6T3/Jp+wmufMmc=";
+              };
+              "x86_64-linux" = final.fetchurl {
+                url = "https://github.com/oven-sh/bun/releases/download/bun-v${version}/bun-linux-x64.zip";
+                hash = "sha256-9XvAGH45Yj3nFro6OJ/aVIay175xMamAulTce3M9Lgg=";
+              };
+            };
+          };
+          src =
+            passthru.sources.${final.stdenvNoCC.hostPlatform.system}
+              or (throw "Unsupported system: ${final.stdenvNoCC.hostPlatform.system}");
+        });
+      };
+      forEachSystem =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              overlays = [ bunOverlay ];
+            }
+          )
+        );
     in
     {
       devShells = forEachSystem (pkgs: {
@@ -34,13 +73,17 @@
         default =
           final: _prev:
           let
-            node_modules = final.callPackage ./nix/node_modules.nix {
+            pkgs = import nixpkgs {
+              inherit (final) system;
+              overlays = [ bunOverlay ];
+            };
+            node_modules = pkgs.callPackage ./nix/node_modules.nix {
               inherit rev;
             };
-            opencode = final.callPackage ./nix/opencode.nix {
+            opencode = pkgs.callPackage ./nix/opencode.nix {
               inherit node_modules;
             };
-            desktop = final.callPackage ./nix/desktop.nix {
+            desktop = pkgs.callPackage ./nix/desktop.nix {
               inherit opencode;
             };
           in

--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -31,6 +31,7 @@ stdenvNoCC.mkDerivation {
         ../package.json
         ../patches
         ../install # required by desktop build (cli.rs include_str!)
+        ../.github/TEAM_MEMBERS # required by packages/script at build time
       ]
     );
   };


### PR DESCRIPTION
## Summary
- Overlay bun to 1.3.10 in `flake.nix` since nixpkgs-unstable still ships 1.3.9, which fails the `^1.3.10` version check in `packages/script/src/index.ts`
- Include `.github/TEAM_MEMBERS` in the nix source fileset (`nix/node_modules.nix`) since `packages/script/src/index.ts` reads it at build time

Fixes #15394, fixes #15400, fixes #15635