### PR TITLE
refactor: allow full URL for closing issue

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -229,7 +229,7 @@ jobs:
             if (!isDocsRefactorOrFeat && hasIssueSection) {
               const issueMatch = body.match(/### Issue for this PR\s*\n([\s\S]*?)(?=###|$)/);
               const issueContent = issueMatch ? issueMatch[1].trim() : '';
-              const hasIssueRef = /(closes|fixes|resolves)\s+#\d+/i.test(issueContent) || /#\d+/.test(issueContent);
+              const hasIssueRef = /(closes|fixes|resolves)\s+(#\d+|https:\/\/github\.com\/anomalyco\/opencode\/issues\/\d+)/i.test(issueContent) || /#\d+/.test(issueContent) || /https:\/\/github\.com\/anomalyco\/opencode\/issues\/\d+/.test(issueContent);
               if (!hasIssueRef) {
                 issues.push('No issue referenced. Please add `Closes #<number>` linking to the relevant issue.');
               }


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

the PR bot does not recognize the full URL of an issue being closed (which is rendered the same as if the user simply put #<issue>)

### How did you verify your code works?

looked at regex

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
