### PR TITLE
feat(web): Add login page and session cookie authentication

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -29,6 +29,13 @@ import DirectoryLayout from "@/pages/directory-layout"
 import Layout from "@/pages/layout"
 import { ErrorPage } from "./pages/error"
 
+const Login = lazy(() => import("@/pages/login"))
+const LoginRoute = () => (
+  <Suspense fallback={<Loading />}>
+    <Login />
+  </Suspense>
+)
+
 const Home = lazy(() => import("@/pages/home"))
 const Session = lazy(() => import("@/pages/session"))
 const Loading = () => <div class="size-full" />
@@ -140,6 +147,16 @@ function ServerKey(props: ParentProps) {
   )
 }
 
+function AuthenticatedGate(props: ParentProps) {
+  return (
+    <ServerKey>
+      <GlobalSDKProvider>
+        <GlobalSyncProvider>{props.children}</GlobalSyncProvider>
+      </GlobalSDKProvider>
+    </ServerKey>
+  )
+}
+
 export function AppInterface(props: {
   children?: JSX.Element
   defaultServer: ServerConnection.Key
@@ -147,21 +164,18 @@ export function AppInterface(props: {
 }) {
   return (
     <ServerProvider defaultServer={props.defaultServer} servers={props.servers}>
-      <ServerKey>
-        <GlobalSDKProvider>
-          <GlobalSyncProvider>
-            <Router
-              root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
-            >
-              <Route path="/" component={HomeRoute} />
-              <Route path="/:dir" component={DirectoryLayout}>
-                <Route path="/" component={SessionIndexRoute} />
-                <Route path="/session/:id?" component={SessionRoute} />
-              </Route>
-            </Router>
-          </GlobalSyncProvider>
-        </GlobalSDKProvider>
-      </ServerKey>
+      <Router
+        root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
+      >
+        <Route path="/login" component={LoginRoute} />
+        <Route path="/" component={AuthenticatedGate}>
+          <Route path="/" component={HomeRoute} />
+          <Route path="/:dir" component={DirectoryLayout}>
+            <Route path="/" component={SessionIndexRoute} />
+            <Route path="/session/:id?" component={SessionRoute} />
+          </Route>
+        </Route>
+      </Router>
     </ServerProvider>
   )
 }

--- a/packages/app/src/pages/login.tsx
+++ b/packages/app/src/pages/login.tsx
@@ -1,0 +1,87 @@
+import { createSignal, Show } from "solid-js"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { Button } from "@opencode-ai/ui/button"
+import { Mark } from "@opencode-ai/ui/logo"
+
+export default function LoginPage() {
+  const [username, setUsername] = createSignal("")
+  const [password, setPassword] = createSignal("")
+  const [error, setError] = createSignal("")
+  const [busy, setBusy] = createSignal(false)
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault()
+    if (busy()) return
+    setBusy(true)
+    setError("")
+
+    const res = await fetch("/api/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: username(),
+        password: password(),
+      }),
+    })
+
+    if (!res.ok) {
+      const data = await res.json()
+      setError(data.message || "Failed to log in")
+      setBusy(false)
+      return
+    }
+
+    window.location.href = "/"
+  }
+
+  return (
+    <div class="flex h-screen w-full flex-col items-center justify-center bg-surface-base p-4">
+      <div class="w-full max-w-sm rounded-lg bg-surface-raised-base p-6 shadow-sm">
+        <div class="mb-8 flex flex-col items-center gap-4">
+          <Mark class="h-12 w-12" />
+          <h1 class="text-16-medium text-text-strong">Sign In</h1>
+        </div>
+
+        <Show when={error()}>
+          <div class="mb-4 rounded-md bg-surface-critical-base p-3 text-14-regular text-text-on-critical-base">
+            {error()}
+          </div>
+        </Show>
+
+        <form onSubmit={handleSubmit} class="flex flex-col gap-4">
+          <TextField
+            type="text"
+            label="Username"
+            placeholder="Enter your username"
+            value={username()}
+            onChange={setUsername}
+            disabled={busy()}
+            validationState={error() ? "invalid" : "valid"}
+          />
+
+          <TextField
+            type="password"
+            label="Password"
+            placeholder="Enter your password"
+            value={password()}
+            onChange={setPassword}
+            disabled={busy()}
+            validationState={error() ? "invalid" : "valid"}
+          />
+
+          <Button
+            type="submit"
+            variant="primary"
+            size="large"
+            disabled={busy() || !username() || !password()}
+            class="mt-4 w-full justify-center"
+          >
+            {busy() ? "Signing in..." : "Sign in"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -7,15 +7,29 @@ export function createSdkForServer({
 }: Omit<NonNullable<Parameters<typeof createOpencodeClient>[0]>, "baseUrl"> & {
   server: ServerConnection.HttpBase
 }) {
+  const isSameOrigin = new URL(server.url, window.location.href).origin === window.location.origin
+
   const auth = (() => {
-    if (!server.password) return
+    if (isSameOrigin || !server.password) return
     return {
       Authorization: `Basic ${btoa(`${server.username ?? "opencode"}:${server.password}`)}`,
     }
   })()
 
+  const baseFetch = config.fetch ?? ((req: Request) => fetch(req))
+
+  const wrappedFetch = async (req: Request) => {
+    const response = await baseFetch(req)
+    if (isSameOrigin && response.status === 401 && window.location.pathname !== "/login") {
+      window.location.href = "/login?redirect=" + encodeURIComponent(window.location.pathname + window.location.search)
+    }
+    return response
+  }
+
   return createOpencodeClient({
     ...config,
+    fetch: wrappedFetch as typeof fetch,
+    credentials: isSameOrigin ? "include" : "same-origin",
     headers: { ...config.headers, ...auth },
     baseUrl: server.url,
   })

--- a/packages/opencode/src/server/auth.ts
+++ b/packages/opencode/src/server/auth.ts
@@ -1,0 +1,71 @@
+import { getCookie } from "hono/cookie"
+import type { Context, Next } from "hono"
+
+const encoder = new TextEncoder()
+
+async function sign(payload: string, secret: string) {
+  const key = await crypto.subtle.importKey("raw", encoder.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, [
+    "sign",
+  ])
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload))
+  return `${payload}.${btoa(String.fromCharCode(...new Uint8Array(sig)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")}`
+}
+
+async function verify(token: string, secret: string) {
+  const idx = token.lastIndexOf(".")
+  if (idx === -1) return null
+  const payload = token.slice(0, idx)
+  const expected = await sign(payload, secret)
+  if (expected !== token) return null
+  return payload
+}
+
+async function createSessionCookie(username: string, secret: string) {
+  const payload = JSON.stringify({ sub: username, iat: Math.floor(Date.now() / 1000) })
+  return sign(payload, secret)
+}
+
+async function verifySessionCookie(token: string, secret: string, maxAge = 86400) {
+  const payload = await verify(token, secret)
+  if (!payload) return null
+  const data = JSON.parse(payload) as { sub: string; iat: number }
+  if (Math.floor(Date.now() / 1000) > data.iat + maxAge) return null
+  return data.sub
+}
+
+function dualAuth(username: string, password: string) {
+  return async (c: Context, next: Next) => {
+    if (c.req.method === "OPTIONS") return next()
+
+    const cookie = getCookie(c, "opencode_session")
+    if (cookie) {
+      const secret = password
+      const sub = await verifySessionCookie(cookie, secret)
+      if (sub) {
+        c.set("user", sub)
+        return next()
+      }
+    }
+
+    const auth = c.req.header("Authorization")
+    if (auth && auth.startsWith("Basic ")) {
+      const decoded = atob(auth.slice(6))
+      const colon = decoded.indexOf(":")
+      if (colon !== -1) {
+        const user = decoded.slice(0, colon)
+        const pass = decoded.slice(colon + 1)
+        if (user === username && pass === password) return next()
+      }
+    }
+
+    const accept = c.req.header("Accept") ?? ""
+    if (accept.includes("text/html") && !accept.includes("application/json")) return c.redirect("/login", 302)
+
+    return c.json({ error: "Unauthorized" }, 401)
+  }
+}
+
+export { sign, verify, createSessionCookie, verifySessionCookie, dualAuth }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -6,7 +6,8 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
 import { proxy } from "hono/proxy"
-import { basicAuth } from "hono/basic-auth"
+import { dualAuth, createSessionCookie } from "./auth"
+import { setCookie, deleteCookie } from "hono/cookie"
 import z from "zod"
 import { Provider } from "../provider/provider"
 import { NamedError } from "@opencode-ai/util/error"
@@ -78,13 +79,23 @@ export namespace Server {
           })
         })
         .use((c, next) => {
-          // Allow CORS preflight requests to succeed without auth.
-          // Browser clients sending Authorization headers will preflight with OPTIONS.
           if (c.req.method === "OPTIONS") return next()
           const password = Flag.OPENCODE_SERVER_PASSWORD
           if (!password) return next()
           const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
-          return basicAuth({ username, password })(c, next)
+          const path = new URL(c.req.url).pathname
+          if (
+            path === "/login" ||
+            path === "/api/login" ||
+            path.startsWith("/assets/") ||
+            path.endsWith(".js") ||
+            path.endsWith(".css") ||
+            path.endsWith(".svg") ||
+            path.endsWith(".png") ||
+            path.endsWith(".ico")
+          )
+            return next()
+          return dualAuth(username, password)(c, next)
         })
         .use(async (c, next) => {
           const skipLogging = c.req.path === "/log"
@@ -540,6 +551,25 @@ export namespace Server {
             })
           },
         )
+        .post("/api/login", async (c) => {
+          const password = Flag.OPENCODE_SERVER_PASSWORD
+          if (!password) return c.json({ error: "Auth not configured" }, 400)
+          const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+          const body = await c.req.json()
+          if (body.username !== username || body.password !== password) return c.json({ error: "Invalid credentials" }, 401)
+          const token = await createSessionCookie(body.username, password)
+          setCookie(c, "opencode_session", token, {
+            httpOnly: true,
+            sameSite: "Lax",
+            path: "/",
+            maxAge: 86400,
+          })
+          return c.json({ ok: true })
+        })
+        .post("/api/logout", (c) => {
+          deleteCookie(c, "opencode_session", { path: "/" })
+          return c.json({ ok: true })
+        })
         .all("/*", async (c) => {
           const path = c.req.path
 


### PR DESCRIPTION
## Summary
- Replaced Basic Auth with a proper login page component in the SolidJS web app.
- Added `/api/login` and `/api/logout` endpoints implementing HTTP-Only signed cookies.
- Added a custom dual-auth middleware to accept both cookies (web app) and Basic Auth headers (API/CLI clients) simultaneously.
- SDK Client intercepts 401 Unauthorized responses and natively redirects users to the login page (preventing native browser dialogs).