### PR TITLE
refactor(opencode): compress 4 duplication patterns into shared helpers

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { Global } from "../global"
 import z from "zod"
-import { Filesystem } from "../util/filesystem"
+import { JsonStore } from "../util/json-store"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -35,34 +35,28 @@ export namespace Auth {
   export const Info = z.discriminatedUnion("type", [Oauth, Api, WellKnown]).meta({ ref: "Auth" })
   export type Info = z.infer<typeof Info>
 
-  const filepath = path.join(Global.Path.data, "auth.json")
+  const store = JsonStore.create<Info>({
+    path: () => path.join(Global.Path.data, "auth.json"),
+    mode: 0o600,
+    validate: (raw) => {
+      const parsed = Info.safeParse(raw)
+      return parsed.success ? parsed.data : undefined
+    },
+  })
 
   export async function get(providerID: string) {
-    const auth = await all()
-    return auth[providerID]
+    return store.get(providerID)
   }
 
   export async function all(): Promise<Record<string, Info>> {
-    const data = await Filesystem.readJson<Record<string, unknown>>(filepath).catch(() => ({}))
-    return Object.entries(data).reduce(
-      (acc, [key, value]) => {
-        const parsed = Info.safeParse(value)
-        if (!parsed.success) return acc
-        acc[key] = parsed.data
-        return acc
-      },
-      {} as Record<string, Info>,
-    )
+    return store.all()
   }
 
   export async function set(key: string, info: Info) {
-    const data = await all()
-    await Filesystem.writeJson(filepath, { ...data, [key]: info }, 0o600)
+    return store.set(key, info)
   }
 
   export async function remove(key: string) {
-    const data = await all()
-    delete data[key]
-    await Filesystem.writeJson(filepath, data, 0o600)
+    return store.remove(key)
   }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -334,117 +334,92 @@ export namespace Config {
     return ext.length ? file.slice(0, -ext.length) : file
   }
 
-  async function loadCommand(dir: string) {
-    const result: Record<string, Command> = {}
-    for (const item of await Glob.scan("{command,commands}/**/*.md", {
-      cwd: dir,
-      absolute: true,
-      dot: true,
-      symlink: true,
-    })) {
-      const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-          ? err.data.message
-          : `Failed to parse command ${item}`
-        const { Session } = await import("@/session")
-        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-        log.error("failed to load command", { command: item, err })
-        return undefined
-      })
-      if (!md) continue
+  async function loadMarkdownEntities<T>(options: {
+    dirs: string[]
+    glob: string
+    schema: z.ZodType<T>
+    contentField: "template" | "prompt"
+    getName: (file: string) => string
+    onError: "throw" | "skip"
+    kind: "command" | "agent" | "mode"
+    postProcess?: (parsed: T) => T
+  }) {
+    const result: Record<string, T> = {}
+    for (const dir of options.dirs) {
+      for (const item of await Glob.scan(options.glob, {
+        cwd: dir,
+        absolute: true,
+        dot: true,
+        symlink: true,
+      })) {
+        const md = await ConfigMarkdown.parse(item).catch(async (err) => {
+          const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+            ? err.data.message
+            : `Failed to parse ${options.kind} ${item}`
+          const { Session } = await import("@/session")
+          Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+          log.error(`failed to load ${options.kind}`, { [options.kind]: item, err })
+          return undefined
+        })
+        if (!md) continue
 
-      const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
-      const file = rel(item, patterns) ?? path.basename(item)
-      const name = trim(file)
-
-      const config = {
-        name,
-        ...md.data,
-        template: md.content.trim(),
+        const config: { name: string } & Record<string, unknown> = {
+          name: options.getName(item),
+          ...md.data,
+          [options.contentField]: md.content.trim(),
+        }
+        const parsed = options.schema.safeParse(config)
+        if (parsed.success) {
+          result[config.name] = options.postProcess ? options.postProcess(parsed.data) : parsed.data
+          continue
+        }
+        if (options.onError === "skip") continue
+        throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
       }
-      const parsed = Command.safeParse(config)
-      if (parsed.success) {
-        result[config.name] = parsed.data
-        continue
-      }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
     }
     return result
+  }
+
+  async function loadCommand(dir: string) {
+    const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
+    return loadMarkdownEntities({
+      dirs: [dir],
+      glob: "{command,commands}/**/*.md",
+      schema: Command,
+      contentField: "template",
+      getName: (file) => trim(rel(file, patterns) ?? path.basename(file)),
+      onError: "throw",
+      kind: "command",
+    })
   }
 
   async function loadAgent(dir: string) {
-    const result: Record<string, Agent> = {}
-
-    for (const item of await Glob.scan("{agent,agents}/**/*.md", {
-      cwd: dir,
-      absolute: true,
-      dot: true,
-      symlink: true,
-    })) {
-      const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-          ? err.data.message
-          : `Failed to parse agent ${item}`
-        const { Session } = await import("@/session")
-        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-        log.error("failed to load agent", { agent: item, err })
-        return undefined
-      })
-      if (!md) continue
-
-      const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-      const file = rel(item, patterns) ?? path.basename(item)
-      const agentName = trim(file)
-
-      const config = {
-        name: agentName,
-        ...md.data,
-        prompt: md.content.trim(),
-      }
-      const parsed = Agent.safeParse(config)
-      if (parsed.success) {
-        result[config.name] = parsed.data
-        continue
-      }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
-    }
-    return result
+    const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
+    return loadMarkdownEntities({
+      dirs: [dir],
+      glob: "{agent,agents}/**/*.md",
+      schema: Agent,
+      contentField: "prompt",
+      getName: (file) => trim(rel(file, patterns) ?? path.basename(file)),
+      onError: "throw",
+      kind: "agent",
+    })
   }
 
   async function loadMode(dir: string) {
-    const result: Record<string, Agent> = {}
-    for (const item of await Glob.scan("{mode,modes}/*.md", {
-      cwd: dir,
-      absolute: true,
-      dot: true,
-      symlink: true,
-    })) {
-      const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-          ? err.data.message
-          : `Failed to parse mode ${item}`
-        const { Session } = await import("@/session")
-        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-        log.error("failed to load mode", { mode: item, err })
-        return undefined
-      })
-      if (!md) continue
-
-      const config = {
-        name: path.basename(item, ".md"),
-        ...md.data,
-        prompt: md.content.trim(),
-      }
-      const parsed = Agent.safeParse(config)
-      if (parsed.success) {
-        result[config.name] = {
-          ...parsed.data,
-          mode: "primary" as const,
-        }
-        continue
-      }
-    }
-    return result
+    return loadMarkdownEntities({
+      dirs: [dir],
+      glob: "{mode,modes}/*.md",
+      schema: Agent,
+      contentField: "prompt",
+      getName: (file) => path.basename(file, ".md"),
+      onError: "skip",
+      kind: "mode",
+      postProcess: (parsed) => ({
+        ...parsed,
+        mode: "primary" as const,
+      }),
+    })
   }
 
   async function loadPlugin(dir: string) {

--- a/packages/opencode/src/control-plane/workspace-server/routes.ts
+++ b/packages/opencode/src/control-plane/workspace-server/routes.ts
@@ -1,6 +1,7 @@
 import { GlobalBus } from "../../bus/global"
 import { Hono } from "hono"
 import { streamSSE } from "hono/streaming"
+import { withHeartbeat } from "../../server/sse"
 
 export function WorkspaceServerRoutes() {
   return new Hono().get("/event", async (c) => {
@@ -17,17 +18,13 @@ export function WorkspaceServerRoutes() {
       }
       GlobalBus.on("event", handler)
       await send({ type: "server.connected", properties: {} })
-      const heartbeat = setInterval(() => {
-        void send({ type: "server.heartbeat", properties: {} })
-      }, 10_000)
-
-      await new Promise<void>((resolve) => {
-        stream.onAbort(() => {
-          clearInterval(heartbeat)
+      await withHeartbeat(
+        stream,
+        () => send({ type: "server.heartbeat", properties: {} }),
+        () => {
           GlobalBus.off("event", handler)
-          resolve()
-        })
-      })
+        },
+      )
     })
   })
 }

--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import z from "zod"
 import { Global } from "../global"
-import { Filesystem } from "../util/filesystem"
+import { JsonStore } from "../util/json-store"
 
 export namespace McpAuth {
   export const Tokens = z.object({
@@ -29,11 +29,13 @@ export namespace McpAuth {
   })
   export type Entry = z.infer<typeof Entry>
 
-  const filepath = path.join(Global.Path.data, "mcp-auth.json")
+  const store = JsonStore.create<Entry>({
+    path: () => path.join(Global.Path.data, "mcp-auth.json"),
+    mode: 0o600,
+  })
 
   export async function get(mcpName: string): Promise<Entry | undefined> {
-    const data = await all()
-    return data[mcpName]
+    return store.get(mcpName)
   }
 
   /**
@@ -54,22 +56,19 @@ export namespace McpAuth {
   }
 
   export async function all(): Promise<Record<string, Entry>> {
-    return Filesystem.readJson<Record<string, Entry>>(filepath).catch(() => ({}))
+    return store.all()
   }
 
   export async function set(mcpName: string, entry: Entry, serverUrl?: string): Promise<void> {
-    const data = await all()
     // Always update serverUrl if provided
     if (serverUrl) {
       entry.serverUrl = serverUrl
     }
-    await Filesystem.writeJson(filepath, { ...data, [mcpName]: entry }, 0o600)
+    return store.set(mcpName, entry)
   }
 
   export async function remove(mcpName: string): Promise<void> {
-    const data = await all()
-    delete data[mcpName]
-    await Filesystem.writeJson(filepath, data, 0o600)
+    return store.remove(mcpName)
   }
 
   export async function updateTokens(mcpName: string, tokens: Tokens, serverUrl?: string): Promise<void> {

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -10,6 +10,7 @@ import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
+import { withHeartbeat } from "../sse"
 
 const log = Log.create({ service: "server" })
 
@@ -84,26 +85,21 @@ export const GlobalRoutes = lazy(() =>
           }
           GlobalBus.on("event", handler)
 
-          // Send heartbeat every 10s to prevent stalled proxy streams.
-          const heartbeat = setInterval(() => {
-            stream.writeSSE({
+          await withHeartbeat(
+            stream,
+            () => stream.writeSSE({
               data: JSON.stringify({
                 payload: {
                   type: "server.heartbeat",
                   properties: {},
                 },
               }),
-            })
-          }, 10_000)
-
-          await new Promise<void>((resolve) => {
-            stream.onAbort(() => {
-              clearInterval(heartbeat)
+            }),
+            () => {
               GlobalBus.off("event", handler)
-              resolve()
               log.info("global event disconnected")
-            })
-          })
+            },
+          )
         })
       },
     )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -41,6 +41,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
+import { withHeartbeat } from "./sse"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -535,24 +536,19 @@ export namespace Server {
                 }
               })
 
-              // Send heartbeat every 10s to prevent stalled proxy streams.
-              const heartbeat = setInterval(() => {
-                stream.writeSSE({
+              await withHeartbeat(
+                stream,
+                () => stream.writeSSE({
                   data: JSON.stringify({
                     type: "server.heartbeat",
                     properties: {},
                   }),
-                })
-              }, 10_000)
-
-              await new Promise<void>((resolve) => {
-                stream.onAbort(() => {
-                  clearInterval(heartbeat)
+                }),
+                () => {
                   unsub()
-                  resolve()
                   log.info("event disconnected")
-                })
-              })
+                },
+              )
             })
           },
         )

--- a/packages/opencode/src/server/sse.ts
+++ b/packages/opencode/src/server/sse.ts
@@ -1,0 +1,20 @@
+import type { SSEStreamingApi } from "hono/streaming"
+
+export function withHeartbeat(
+  stream: SSEStreamingApi,
+  sendHeartbeat: () => void | Promise<void>,
+  onAbort?: () => void,
+  options?: { interval?: number },
+): Promise<void> {
+  const interval = options?.interval ?? 10_000
+
+  const heartbeat = setInterval(() => void Promise.resolve(sendHeartbeat()).catch(() => {}), interval)
+
+  return new Promise<void>((resolve) => {
+    stream.onAbort(() => {
+      clearInterval(heartbeat)
+      onAbort?.()
+      resolve()
+    })
+  })
+}

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -273,19 +273,19 @@ export namespace Session {
     },
   )
 
-  export const touch = fn(Identifier.schema("session"), async (sessionID) => {
-    const now = Date.now()
-    Database.use((db) => {
-      const row = db
-        .update(SessionTable)
-        .set({ time_updated: now })
-        .where(eq(SessionTable.id, sessionID))
-        .returning()
-        .get()
-      if (!row) throw new NotFoundError({ message: `Session not found: ${sessionID}` })
+  function patch(id: string, set: Partial<typeof SessionTable.$inferInsert>) {
+    return Database.use((db) => {
+      const row = db.update(SessionTable).set(set).where(eq(SessionTable.id, id)).returning().get()
+      if (!row) throw new NotFoundError({ message: `Session not found: ${id}` })
       const info = fromRow(row)
       Database.effect(() => Bus.publish(Event.Updated, { info }))
+      return info
     })
+  }
+
+  export const touch = fn(Identifier.schema("session"), async (sessionID) => {
+    const now = Date.now()
+    return patch(sessionID, { time_updated: now })
   })
 
   export async function createNext(input: {
@@ -377,18 +377,7 @@ export namespace Session {
       title: z.string(),
     }),
     async (input) => {
-      return Database.use((db) => {
-        const row = db
-          .update(SessionTable)
-          .set({ title: input.title })
-          .where(eq(SessionTable.id, input.sessionID))
-          .returning()
-          .get()
-        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-        const info = fromRow(row)
-        Database.effect(() => Bus.publish(Event.Updated, { info }))
-        return info
-      })
+      return patch(input.sessionID, { title: input.title })
     },
   )
 
@@ -398,18 +387,7 @@ export namespace Session {
       time: z.number().optional(),
     }),
     async (input) => {
-      return Database.use((db) => {
-        const row = db
-          .update(SessionTable)
-          .set({ time_archived: input.time })
-          .where(eq(SessionTable.id, input.sessionID))
-          .returning()
-          .get()
-        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-        const info = fromRow(row)
-        Database.effect(() => Bus.publish(Event.Updated, { info }))
-        return info
-      })
+      return patch(input.sessionID, { time_archived: input.time })
     },
   )
 
@@ -419,18 +397,7 @@ export namespace Session {
       permission: PermissionNext.Ruleset,
     }),
     async (input) => {
-      return Database.use((db) => {
-        const row = db
-          .update(SessionTable)
-          .set({ permission: input.permission, time_updated: Date.now() })
-          .where(eq(SessionTable.id, input.sessionID))
-          .returning()
-          .get()
-        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-        const info = fromRow(row)
-        Database.effect(() => Bus.publish(Event.Updated, { info }))
-        return info
-      })
+      return patch(input.sessionID, { permission: input.permission, time_updated: Date.now() })
     },
   )
 
@@ -441,42 +408,20 @@ export namespace Session {
       summary: Info.shape.summary,
     }),
     async (input) => {
-      return Database.use((db) => {
-        const row = db
-          .update(SessionTable)
-          .set({
-            revert: input.revert ?? null,
-            summary_additions: input.summary?.additions,
-            summary_deletions: input.summary?.deletions,
-            summary_files: input.summary?.files,
-            time_updated: Date.now(),
-          })
-          .where(eq(SessionTable.id, input.sessionID))
-          .returning()
-          .get()
-        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-        const info = fromRow(row)
-        Database.effect(() => Bus.publish(Event.Updated, { info }))
-        return info
+      return patch(input.sessionID, {
+        revert: input.revert ?? null,
+        summary_additions: input.summary?.additions,
+        summary_deletions: input.summary?.deletions,
+        summary_files: input.summary?.files,
+        time_updated: Date.now(),
       })
     },
   )
 
   export const clearRevert = fn(Identifier.schema("session"), async (sessionID) => {
-    return Database.use((db) => {
-      const row = db
-        .update(SessionTable)
-        .set({
-          revert: null,
-          time_updated: Date.now(),
-        })
-        .where(eq(SessionTable.id, sessionID))
-        .returning()
-        .get()
-      if (!row) throw new NotFoundError({ message: `Session not found: ${sessionID}` })
-      const info = fromRow(row)
-      Database.effect(() => Bus.publish(Event.Updated, { info }))
-      return info
+    return patch(sessionID, {
+      revert: null,
+      time_updated: Date.now(),
     })
   })
 
@@ -486,22 +431,11 @@ export namespace Session {
       summary: Info.shape.summary,
     }),
     async (input) => {
-      return Database.use((db) => {
-        const row = db
-          .update(SessionTable)
-          .set({
-            summary_additions: input.summary?.additions,
-            summary_deletions: input.summary?.deletions,
-            summary_files: input.summary?.files,
-            time_updated: Date.now(),
-          })
-          .where(eq(SessionTable.id, input.sessionID))
-          .returning()
-          .get()
-        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-        const info = fromRow(row)
-        Database.effect(() => Bus.publish(Event.Updated, { info }))
-        return info
+      return patch(input.sessionID, {
+        summary_additions: input.summary?.additions,
+        summary_deletions: input.summary?.deletions,
+        summary_files: input.summary?.files,
+        time_updated: Date.now(),
       })
     },
   )

--- a/packages/opencode/src/util/json-store.ts
+++ b/packages/opencode/src/util/json-store.ts
@@ -1,0 +1,43 @@
+import { Filesystem } from "./filesystem"
+
+export namespace JsonStore {
+  export function create<T>(options: {
+    path: () => string
+    mode?: number
+    validate?: (raw: unknown) => T | undefined
+  }) {
+    const { path: getPath, mode = 0o600, validate } = options
+
+    return {
+      async all(): Promise<Record<string, T>> {
+        const data = await Filesystem.readJson<Record<string, unknown>>(getPath()).catch(() => ({}))
+        if (!validate) return data as Record<string, T>
+        return Object.entries(data).reduce(
+          (acc, [key, value]) => {
+            const parsed = validate(value)
+            if (parsed === undefined) return acc
+            acc[key] = parsed
+            return acc
+          },
+          {} as Record<string, T>,
+        )
+      },
+
+      async get(key: string): Promise<T | undefined> {
+        const map = await this.all()
+        return map[key]
+      },
+
+      async set(key: string, value: T): Promise<void> {
+        const data = await this.all()
+        await Filesystem.writeJson(getPath(), { ...data, [key]: value }, mode)
+      },
+
+      async remove(key: string): Promise<void> {
+        const data = await this.all()
+        delete data[key]
+        await Filesystem.writeJson(getPath(), data, mode)
+      },
+    }
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #15674

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extracts 4 repeated code patterns in `packages/opencode/src/` into shared helpers:

1. **Session update boilerplate** → private `patch()` helper in `session/index.ts` replaces 6 copy-pasted read-patch-write-publish cycles (-66 lines)
2. **Markdown entity loading** → generic `loadMarkdownEntities<T>()` in `config/config.ts` unifies `loadCommand`/`loadAgent`/`loadMode` (-25 lines)
3. **JSON file CRUD** → `JsonStore` namespace in new `util/json-store.ts` used by `auth/index.ts` and `mcp/auth.ts`
4. **SSE heartbeat setup** → `withHeartbeat()` in new `server/sse.ts` used by `server.ts` and workspace-server `routes.ts`

Net result: 211 insertions, 257 deletions across 9 files. No public API or behavioral changes.

### How did you verify your code works?

Ran the full test suite from `packages/opencode/`:

```
bun test --timeout 30000
# 1176 pass, 3 fail
```

The 3 failures are pre-existing in `test/server/session-select.test.ts` (same on `dev` branch).

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR