### PR TITLE
fix(web): ensure language switcher sets cookie to persist user choice

### DIFF
--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import config from "virtual:starlight/user-config"
-import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro"
+import LanguageSelect from "./LanguageSelect.astro"
 import { Icon } from "@astrojs/starlight/components"
 
 const { lang, editUrl, lastUpdated, entry } = Astro.locals.starlightRoute

--- a/packages/web/src/components/LanguageSelect.astro
+++ b/packages/web/src/components/LanguageSelect.astro
@@ -1,0 +1,17 @@
+---
+import Default from "@astrojs/starlight/components/LanguageSelect.astro"
+---
+
+<Default />
+
+<script>
+  const select = document.querySelector("starlight-lang-select select") as HTMLSelectElement | null
+  if (select) {
+    select.addEventListener("change", (e) => {
+      const target = e.currentTarget as HTMLSelectElement
+      const path = target.value
+      const locale = path === "/docs/" ? "en" : path.match(/\/docs\/([^/]+)/)?.[1] || "en"
+      document.cookie = `oc_locale=${encodeURIComponent(locale)}; Path=/; Max-Age=31536000; SameSite=Lax`
+    })
+  }
+</script>

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -85,10 +85,14 @@ export const onRequest = defineMiddleware((ctx, next) => {
 
   if (ctx.url.pathname !== "/docs" && ctx.url.pathname !== "/docs/") return next()
 
-  const locale =
-    localeFromCookie(ctx.request.headers.get("cookie")) ??
-    localeFromAcceptLanguage(ctx.request.headers.get("accept-language"))
-  if (!locale || locale === "root") return next()
+  const cookieLocale = localeFromCookie(ctx.request.headers.get("cookie"))
+  if (cookieLocale !== null) {
+    if (cookieLocale === "root") return next()
+    return redirect(ctx.url, `/docs/${cookieLocale}/`)
+  }
 
-  return redirect(ctx.url, `/docs/${locale}/`)
+  const acceptLanguageLocale = localeFromAcceptLanguage(ctx.request.headers.get("accept-language"))
+  if (!acceptLanguageLocale || acceptLanguageLocale === "root") return next()
+
+  return redirect(ctx.url, `/docs/${acceptLanguageLocale}/`)
 })


### PR DESCRIPTION
## Problem

Non-English users cannot switch to English in the documentation site. When they click "English" in the language switcher, they are immediately redirected back to their browser's language (Chinese, Japanese, etc.).

Related issues: #14997, #15194, #13442

## Possible Root Cause

From what I can observe:

1. Starlight's default `LanguageSelect` component changes the URL but doesn't set the `oc_locale` cookie
2. English uses `/docs/` (not `/docs/en/`), so it doesn't trigger the `docsAlias` function that sets cookies for other languages
3. The middleware checks for the cookie, doesn't find one, falls back to `Accept-Language` header, and redirects back
4. Other languages seem to work because paths like `/docs/zh-cn/` trigger `docsAlias` and set the cookie

## Why This Might Be Hard to Reproduce Locally

The behavior appears different between Astro's dev server and production (Cloudflare). The dev server seems to merge cookies from multiple sources, which might mask this issue during local testing.

## Proposed Solution

- Created a custom `LanguageSelect.astro` wrapper that sets the `oc_locale` cookie when language changes
- Updated `Footer.astro` to use this custom component
- Clarified cookie priority in `middleware.ts`

## Testing

I wasn't able to reproduce the issue in the local dev environment, but based on the code analysis and user reports, this should address the problem in production.

---

**Note:** This was identified and implemented with AI assistance. I'm not deeply familiar with the codebase, so I may have misunderstood something. Very happy to receive feedback, make changes, or provide more details if needed.