### PR TITLE
fix: auto-accept should not be enabled for all sessions by default

### DIFF
--- a/packages/app/src/context/permission-auto-respond.test.ts
+++ b/packages/app/src/context/permission-auto-respond.test.ts
@@ -31,13 +31,13 @@ describe("autoRespondsPermission", () => {
     expect(autoRespondsPermission({ root: true }, sessions, permission("child"), "/tmp/project")).toBe(true)
   })
 
-  test("defaults to auto-accept when no lineage override exists", () => {
+  test("ignores auto-accept from sessions without explicit auto-accept", () => {
     const sessions = [session({ id: "root" }), session({ id: "child", parentID: "root" }), session({ id: "other" })]
     const autoAccept = {
       other: true,
     }
 
-    expect(autoRespondsPermission(autoAccept, sessions, permission("child"), "/tmp/project")).toBe(true)
+    expect(autoRespondsPermission(autoAccept, sessions, permission("child"), "/tmp/project")).toBe(false)
   })
 
   test("inherits a parent session's false override", () => {

--- a/packages/app/src/context/permission-auto-respond.ts
+++ b/packages/app/src/context/permission-auto-respond.ts
@@ -37,5 +37,5 @@ export function autoRespondsPermission(
   const value = sessionLineage(session, permission.sessionID)
     .map((id) => accepted(autoAccept, id, directory))
     .find((item): item is boolean => item !== undefined)
-  return value ?? true
+  return value ?? false
 }


### PR DESCRIPTION
### Issue for this PR

Closes #15589

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

*Problem:* Auto-accept is on by default for each new and existing session, until it is explicitly disabled. This is (a) a breaking change compared to the previous behavior, and (b) a serious security risk, as it effectively turns all "ask" permissions into "allow".

*Solution:* Fall back to "false" (= no auto-accept) if there is no autoaccept entry for the session/directory in the local storage.

### How did you verify your code works?

Adapted tests and ran the web app locally. The default behavior is back to asking, and explicitly enabling auto-accept works.

### Screenshots / recordings

–

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
