### PR TITLE
fix(patch): replace naive index-based diff with proper diff algorithm

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import * as path from "path"
 import * as fs from "fs/promises"
 import { readFileSync } from "fs"
+import { createTwoFilesPatch } from "diff"
 import { Log } from "../util/log"
 
 export namespace Patch {
@@ -335,7 +336,7 @@ export namespace Patch {
     const newContent = newLines.join("\n")
 
     // Generate unified diff
-    const unifiedDiff = generateUnifiedDiff(originalContent, newContent)
+    const unifiedDiff = generateUnifiedDiff(filePath, originalContent, newContent)
 
     return {
       unified_diff: unifiedDiff,
@@ -487,31 +488,9 @@ export namespace Patch {
     return normalized
   }
 
-  function generateUnifiedDiff(oldContent: string, newContent: string): string {
-    const oldLines = oldContent.split("\n")
-    const newLines = newContent.split("\n")
-
-    // Simple diff generation - in a real implementation you'd use a proper diff algorithm
-    let diff = "@@ -1 +1 @@\n"
-
-    // Find changes (simplified approach)
-    const maxLen = Math.max(oldLines.length, newLines.length)
-    let hasChanges = false
-
-    for (let i = 0; i < maxLen; i++) {
-      const oldLine = oldLines[i] || ""
-      const newLine = newLines[i] || ""
-
-      if (oldLine !== newLine) {
-        if (oldLine) diff += `-${oldLine}\n`
-        if (newLine) diff += `+${newLine}\n`
-        hasChanges = true
-      } else if (oldLine) {
-        diff += ` ${oldLine}\n`
-      }
-    }
-
-    return hasChanges ? diff : ""
+  function generateUnifiedDiff(filePath: string, oldContent: string, newContent: string): string {
+    if (oldContent === newContent) return ""
+    return createTwoFilesPatch(filePath, filePath, oldContent, newContent)
   }
 
   // Apply hunks to filesystem


### PR DESCRIPTION
## Summary

- Replace the naive `generateUnifiedDiff()` implementation in `packages/opencode/src/patch/index.ts` with `createTwoFilesPatch()` from the `diff` npm package
- The old implementation compared lines by index position (`oldLines[i]` vs `newLines[i]`), which misaligned on any insertion or deletion, producing incorrect and bloated diffs — especially severe for JSON files
- The `diff` package is already a dependency and `createTwoFilesPatch` is already used correctly in `tool/edit.ts`, `tool/write.ts`, and `tool/apply_patch.ts`

## What changed

The `generateUnifiedDiff()` function was a ~25 line naive implementation with a TODO-like comment acknowledging it was a placeholder (`"Simple diff generation - in a real implementation you'd use a proper diff algorithm"`). It has been replaced with a 3-line function that delegates to `createTwoFilesPatch()`, which uses a proper Myers diff algorithm with correct hunk splitting and context windows.

## Testing

- All 20 patch tests pass (`bun test test/patch/patch.test.ts`)
- All 26 apply_patch tests pass (`bun test test/tool/apply_patch.test.ts`)
- All 17 edit tool tests pass (`bun test test/tool/edit.test.ts`)
- Typecheck passes with zero errors (`tsgo --noEmit`)

Closes #15584