### PR TITLE
fix(opencode): write tool causes client to hang indefinitely when creating new files

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -71,6 +71,15 @@ export const WriteTool = Tool.define("write", {
       output += `\n\nLSP errors detected in other files:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
     }
 
+    // Send metadata update to signal tool completion (fixes issue #15675)
+    ctx.metadata({
+      metadata: {
+        diagnostics,
+        filepath,
+        exists: exists,
+      },
+    })
+
     return {
       title: path.relative(Instance.worktree, filepath),
       metadata: {

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -5,16 +5,19 @@ import { WriteTool } from "../../src/tool/write"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
-const ctx = {
+const createCtx = (metadataSpy: (args?: any) => void = () => {}) => ({
   sessionID: "test-write-session",
   messageID: "",
   callID: "",
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: metadataSpy,
   ask: async () => {},
-}
+})
+
+// Default context for tests that don't need to spy on metadata
+const ctx = createCtx()
 
 describe("tool.write", () => {
   describe("new file creation", () => {
@@ -31,7 +34,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "Hello, World!",
             },
-            ctx,
+            createCtx(),
           )
 
           expect(result.output).toContain("Wrote file successfully")
@@ -39,6 +42,42 @@ describe("tool.write", () => {
 
           const content = await fs.readFile(filepath, "utf-8")
           expect(content).toBe("Hello, World!")
+        },
+      })
+    })
+
+    test("calls ctx.metadata to signal tool completion (issue #15675)", async () => {
+      await using tmp = await tmpdir()
+      const filepath = path.join(tmp.path, "newfile.txt")
+      let metadataCalled = false
+      let metadataArgs: any = null
+
+      const ctx = createCtx((args: any) => {
+        metadataCalled = true
+        metadataArgs = args
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const write = await WriteTool.init()
+          const result = await write.execute(
+            {
+              filePath: filepath,
+              content: "Hello, World!",
+            },
+            ctx,
+          )
+
+          expect(metadataCalled).toBe(true)
+          expect(metadataArgs).toHaveProperty("metadata")
+          expect(metadataArgs.metadata).toHaveProperty("filepath", filepath)
+          expect(metadataArgs.metadata).toHaveProperty("exists", false)
+          // Verify metadata contains expected fields (truncated is auto-added by Tool.define)
+          expect(result.metadata).toMatchObject({
+            filepath,
+            exists: false,
+          })
         },
       })
     })
@@ -56,7 +95,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "nested content",
             },
-            ctx,
+            createCtx(),
           )
 
           const content = await fs.readFile(filepath, "utf-8")
@@ -77,7 +116,7 @@ describe("tool.write", () => {
               filePath: "relative.txt",
               content: "relative content",
             },
-            ctx,
+            createCtx(),
           )
 
           const content = await fs.readFile(path.join(tmp.path, "relative.txt"), "utf-8")
@@ -106,7 +145,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "new content",
             },
-            ctx,
+            createCtx(),
           )
 
           expect(result.output).toContain("Wrote file successfully")
@@ -135,7 +174,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "new",
             },
-            ctx,
+            createCtx(),
           )
 
           // Diff should be in metadata
@@ -160,7 +199,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: JSON.stringify({ secret: "data" }),
             },
-            ctx,
+            createCtx(),
           )
 
           // On Unix systems, check permissions
@@ -188,7 +227,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: JSON.stringify(data, null, 2),
             },
-            ctx,
+            createCtx(),
           )
 
           const content = await fs.readFile(filepath, "utf-8")
@@ -211,7 +250,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content,
             },
-            ctx,
+            createCtx(),
           )
 
           const buf = await fs.readFile(filepath)
@@ -233,7 +272,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "",
             },
-            ctx,
+            createCtx(),
           )
 
           const content = await fs.readFile(filepath, "utf-8")
@@ -259,7 +298,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: lines,
             },
-            ctx,
+            createCtx(),
           )
 
           const content = await fs.readFile(filepath, "utf-8")
@@ -282,7 +321,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content,
             },
-            ctx,
+            createCtx(),
           )
 
           const buf = await fs.readFile(filepath)
@@ -314,7 +353,7 @@ describe("tool.write", () => {
                 filePath: readonlyPath,
                 content: "new content",
               },
-              ctx,
+              createCtx(),
             ),
           ).rejects.toThrow()
         },
@@ -337,7 +376,7 @@ describe("tool.write", () => {
               filePath: filepath,
               content: "export const Button = () => {}",
             },
-            ctx,
+            createCtx(),
           )
 
           expect(result.title).toEndWith(path.join("src", "components", "Button.tsx"))


### PR DESCRIPTION

Fix: `write` tool causes client to hang indefinitely when creating new files

The write tool was missing ctx.metadata() call that signals tool completion to the client. This caused clients (like IntelliJ with ACP) to hang indefinitely when creating new files.

- Added ctx.metadata() call in write.ts
- Added test to verify metadata is called

Fixes #15675

### Issue for this PR

Closes #15675

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem:** When using the `write` tool to create a new file via the ACP protocol, the client hangs indefinitely showing a "waiting" indicator. The file is successfully created on disk, but the client never receives a completion signal.

**Root Cause:** The `write` tool implementation was missing the `ctx.metadata()` call that signals tool completion to the client. Looking at the codebase, `edit.ts` and `bash.ts` both correctly call `ctx.metadata()` before returning their results, which is why those tools work properly.

**Fix:** Added `ctx.metadata()` call in `write.ts` immediately before returning the result. This signals to the client that the tool execution has completed successfully.

**Changes:**
- `packages/opencode/src/tool/write.ts`: Added `ctx.metadata()` call with diagnostics, filepath, and exists metadata
- `packages/opencode/test/tool/write.test.ts`: Added test case to verify `ctx.metadata()` is called during write operations

### How did you verify your code works?

Ran the existing test suite for the write tool:

```
$ bun test test/tool/write.test.ts

✓ tool.write > new file creation > writes content to new file
✓ tool.write > new file creation > calls ctx.metadata to signal tool completion (issue #15675)
... (12 more tests)

 14 pass
 0 fail
```

All 14 tests pass, including the new test that specifically verifies `ctx.metadata()` is called.

Also verified TypeScript compilation passes.

### Screenshots / recordings

_N/A - This is a backend/protocol fix, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
