### PR TITLE
feat(worktree): expose lifecycle events to plugins via Bus.publish()

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -11,13 +11,32 @@ import { Database, eq } from "../storage/db"
 import { ProjectTable } from "../project/project.sql"
 import { fn } from "../util/fn"
 import { Log } from "../util/log"
+import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
 
 export namespace Worktree {
   const log = Log.create({ service: "worktree" })
 
+  export const Info = z
+    .object({
+      name: z.string(),
+      branch: z.string(),
+      directory: z.string(),
+    })
+    .meta({
+      ref: "Worktree",
+    })
+
+  export type Info = z.infer<typeof Info>
+
   export const Event = {
+    Created: BusEvent.define(
+      "worktree.created",
+      z.object({
+        info: Info,
+      }),
+    ),
     Ready: BusEvent.define(
       "worktree.ready",
       z.object({
@@ -31,19 +50,19 @@ export namespace Worktree {
         message: z.string(),
       }),
     ),
+    Removed: BusEvent.define(
+      "worktree.removed",
+      z.object({
+        directory: z.string(),
+      }),
+    ),
+    Reset: BusEvent.define(
+      "worktree.reset",
+      z.object({
+        directory: z.string(),
+      }),
+    ),
   }
-
-  export const Info = z
-    .object({
-      name: z.string(),
-      branch: z.string(),
-      directory: z.string(),
-    })
-    .meta({
-      ref: "Worktree",
-    })
-
-  export type Info = z.infer<typeof Info>
 
   export const CreateInput = z
     .object({
@@ -354,6 +373,8 @@ export namespace Worktree {
 
     await Project.addSandbox(Instance.project.id, info.directory).catch(() => undefined)
 
+    await Bus.publish(Event.Created, { info })
+
     const projectID = Instance.project.id
     const extra = startCommand?.trim()
 
@@ -514,6 +535,8 @@ export namespace Worktree {
       }
     }
 
+    await Bus.publish(Event.Removed, { directory })
+
     return true
   })
 
@@ -649,6 +672,8 @@ export namespace Worktree {
 
     const projectID = Instance.project.id
     queueStartScripts(worktreePath, { projectID })
+
+    await Bus.publish(Event.Reset, { directory: worktreePath })
 
     return true
   })

--- a/packages/opencode/test/project/worktree-events.test.ts
+++ b/packages/opencode/test/project/worktree-events.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test"
+import { $ } from "bun"
+import path from "path"
+import { Bus } from "../../src/bus"
+import { GlobalBus } from "../../src/bus/global"
+import { Instance } from "../../src/project/instance"
+import { Worktree } from "../../src/worktree"
+import { tmpdir } from "../fixture/fixture"
+
+function collectGlobal() {
+  const events: { directory?: string; payload: any }[] = []
+  const listener = (data: { directory?: string; payload: any }) => {
+    events.push(data)
+  }
+  GlobalBus.on("event", listener)
+  return {
+    events,
+    cleanup: () => GlobalBus.removeListener("event", listener),
+  }
+}
+
+function collectBus() {
+  const events: { type: string; properties: any }[] = []
+  const cleanup = Bus.subscribeAll((event) => {
+    events.push(event)
+  })
+  return { events, cleanup }
+}
+
+describe("Worktree events", () => {
+  test("worktree.created reaches both Bus and GlobalBus", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const global = collectGlobal()
+    try {
+      const info = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const bus = collectBus()
+          try {
+            const result = await Worktree.create(undefined)
+
+            const event = bus.events.find((e) => e.type === "worktree.created")
+            expect(event).toBeDefined()
+            expect(event!.properties.info.name).toBe(result.name)
+            expect(event!.properties.info.branch).toBe(result.branch)
+            expect(event!.properties.info.directory).toBe(result.directory)
+
+            return result
+          } finally {
+            bus.cleanup()
+          }
+        },
+      })
+
+      const event = global.events.find((e) => e.payload.type === "worktree.created")
+      expect(event).toBeDefined()
+      expect(event!.payload.properties.info.directory).toBe(info.directory)
+    } finally {
+      global.cleanup()
+    }
+  })
+
+  test("worktree.removed reaches both Bus and GlobalBus", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const name = `event-remove-${Date.now().toString(36)}`
+    const branch = `opencode/${name}`
+    const dir = path.join(tmp.path, "..", name)
+
+    await $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(tmp.path).quiet()
+    await $`git reset --hard`.cwd(dir).quiet()
+
+    const global = collectGlobal()
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const bus = collectBus()
+          try {
+            await Worktree.remove({ directory: dir })
+
+            const event = bus.events.find((e) => e.type === "worktree.removed")
+            expect(event).toBeDefined()
+            expect(event!.properties.directory).toBeTruthy()
+          } finally {
+            bus.cleanup()
+          }
+        },
+      })
+
+      const event = global.events.find((e) => e.payload.type === "worktree.removed")
+      expect(event).toBeDefined()
+      expect(event!.directory).toBe(tmp.path)
+    } finally {
+      global.cleanup()
+    }
+  })
+
+  test("worktree.reset reaches both Bus and GlobalBus", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const name = `event-reset-${Date.now().toString(36)}`
+    const branch = `opencode/${name}`
+    const dir = path.join(tmp.path, "..", name)
+
+    await $`git worktree add --no-checkout -b ${branch} ${dir}`.cwd(tmp.path).quiet()
+    await $`git reset --hard`.cwd(dir).quiet()
+
+    const global = collectGlobal()
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const bus = collectBus()
+          try {
+            await Worktree.reset({ directory: dir })
+
+            const event = bus.events.find((e) => e.type === "worktree.reset")
+            expect(event).toBeDefined()
+            expect(event!.properties.directory).toBeTruthy()
+          } finally {
+            bus.cleanup()
+          }
+        },
+      })
+
+      const event = global.events.find((e) => e.payload.type === "worktree.reset")
+      expect(event).toBeDefined()
+    } finally {
+      global.cleanup()
+    }
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -889,6 +889,32 @@ export type EventVcsBranchUpdated = {
   }
 }
 
+export type Worktree = {
+  name: string
+  branch: string
+  directory: string
+}
+
+export type EventWorktreeCreated = {
+  type: "worktree.created"
+  properties: {
+    info: Worktree
+  }
+}
+
+export type EventWorktreeRemoved = {
+  type: "worktree.removed"
+  properties: {
+    directory: string
+  }
+}
+
+export type EventWorktreeReset = {
+  type: "worktree.reset"
+  properties: {
+    directory: string
+  }
+}
 export type EventWorkspaceReady = {
   type: "workspace.ready"
   properties: {
@@ -995,14 +1021,17 @@ export type Event =
   | EventSessionDiff
   | EventSessionError
   | EventVcsBranchUpdated
+  | EventWorktreeCreated
+  | EventWorktreeReady
+  | EventWorktreeFailed
+  | EventWorktreeRemoved
+  | EventWorktreeReset
   | EventWorkspaceReady
   | EventWorkspaceFailed
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited
   | EventPtyDeleted
-  | EventWorktreeReady
-  | EventWorktreeFailed
 
 export type GlobalEvent = {
   directory: string
@@ -1639,12 +1668,6 @@ export type Workspace = {
   directory: string | null
   extra: unknown | null
   projectID: string
-}
-
-export type Worktree = {
-  name: string
-  branch: string
-  directory: string
 }
 
 export type WorktreeCreateInput = {


### PR DESCRIPTION
### Issue for this PR

Closes #15680

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds three new worktree lifecycle events (`worktree.created`, `worktree.removed`, `worktree.reset`) emitted via `Bus.publish()` so they reach plugins through the `event` hook. 

### How did you verify your code works?

Added tests that verify each event reaches both `Bus.subscribeAll()` and `GlobalBus`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

I'm happy to address any feedback or adjust the approach if needed