### PR TITLE
feat(web): Add login page and session cookie authentication

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -1,167 +1,200 @@
-import "@/index.css"
-import { File } from "@opencode-ai/ui/file"
-import { I18nProvider } from "@opencode-ai/ui/context"
-import { DialogProvider } from "@opencode-ai/ui/context/dialog"
-import { FileComponentProvider } from "@opencode-ai/ui/context/file"
-import { MarkedProvider } from "@opencode-ai/ui/context/marked"
-import { Font } from "@opencode-ai/ui/font"
-import { ThemeProvider } from "@opencode-ai/ui/theme"
-import { MetaProvider } from "@solidjs/meta"
-import { Navigate, Route, Router } from "@solidjs/router"
-import { ErrorBoundary, type JSX, lazy, type ParentProps, Show, Suspense } from "solid-js"
-import { CommandProvider } from "@/context/command"
-import { CommentsProvider } from "@/context/comments"
-import { FileProvider } from "@/context/file"
-import { GlobalSDKProvider } from "@/context/global-sdk"
-import { GlobalSyncProvider } from "@/context/global-sync"
-import { HighlightsProvider } from "@/context/highlights"
-import { LanguageProvider, useLanguage } from "@/context/language"
-import { LayoutProvider } from "@/context/layout"
-import { ModelsProvider } from "@/context/models"
-import { NotificationProvider } from "@/context/notification"
-import { PermissionProvider } from "@/context/permission"
-import { usePlatform } from "@/context/platform"
-import { PromptProvider } from "@/context/prompt"
-import { type ServerConnection, ServerProvider, useServer } from "@/context/server"
-import { SettingsProvider } from "@/context/settings"
-import { TerminalProvider } from "@/context/terminal"
-import DirectoryLayout from "@/pages/directory-layout"
-import Layout from "@/pages/layout"
-import { ErrorPage } from "./pages/error"
+import "@/index.css";
+import { I18nProvider } from "@opencode-ai/ui/context";
+import { DialogProvider } from "@opencode-ai/ui/context/dialog";
+import { FileComponentProvider } from "@opencode-ai/ui/context/file";
+import { MarkedProvider } from "@opencode-ai/ui/context/marked";
+import { File } from "@opencode-ai/ui/file";
+import { Font } from "@opencode-ai/ui/font";
+import { ThemeProvider } from "@opencode-ai/ui/theme";
+import { MetaProvider } from "@solidjs/meta";
+import { Navigate, Route, Router } from "@solidjs/router";
+import {
+	ErrorBoundary,
+	type JSX,
+	lazy,
+	type ParentProps,
+	Show,
+	Suspense,
+} from "solid-js";
+import { CommandProvider } from "@/context/command";
+import { CommentsProvider } from "@/context/comments";
+import { FileProvider } from "@/context/file";
+import { GlobalSDKProvider } from "@/context/global-sdk";
+import { GlobalSyncProvider } from "@/context/global-sync";
+import { HighlightsProvider } from "@/context/highlights";
+import { LanguageProvider, useLanguage } from "@/context/language";
+import { LayoutProvider } from "@/context/layout";
+import { ModelsProvider } from "@/context/models";
+import { NotificationProvider } from "@/context/notification";
+import { PermissionProvider } from "@/context/permission";
+import { usePlatform } from "@/context/platform";
+import { PromptProvider } from "@/context/prompt";
+import {
+	type ServerConnection,
+	ServerProvider,
+	useServer,
+} from "@/context/server";
+import { SettingsProvider } from "@/context/settings";
+import { TerminalProvider } from "@/context/terminal";
+import DirectoryLayout from "@/pages/directory-layout";
+import Layout from "@/pages/layout";
+import { ErrorPage } from "./pages/error";
 
-const Home = lazy(() => import("@/pages/home"))
-const Session = lazy(() => import("@/pages/session"))
-const Loading = () => <div class="size-full" />
+const LoginRoute = lazy(() => import("@/pages/login"));
+const Home = lazy(() => import("@/pages/home"));
+const Session = lazy(() => import("@/pages/session"));
+const Loading = () => <div class="size-full" />;
+
+const LoginRouteWrapper = () => (
+	<Suspense fallback={<Loading />}>
+		<LoginRoute />
+	</Suspense>
+);
 
 const HomeRoute = () => (
-  <Suspense fallback={<Loading />}>
-    <Home />
-  </Suspense>
-)
+	<Suspense fallback={<Loading />}>
+		<Home />
+	</Suspense>
+);
 
 const SessionRoute = () => (
-  <SessionProviders>
-    <Suspense fallback={<Loading />}>
-      <Session />
-    </Suspense>
-  </SessionProviders>
-)
+	<SessionProviders>
+		<Suspense fallback={<Loading />}>
+			<Session />
+		</Suspense>
+	</SessionProviders>
+);
 
-const SessionIndexRoute = () => <Navigate href="session" />
+const SessionIndexRoute = () => <Navigate href="session" />;
 
 function UiI18nBridge(props: ParentProps) {
-  const language = useLanguage()
-  return <I18nProvider value={{ locale: language.locale, t: language.t }}>{props.children}</I18nProvider>
+	const language = useLanguage();
+	return (
+		<I18nProvider value={{ locale: language.locale, t: language.t }}>
+			{props.children}
+		</I18nProvider>
+	);
 }
 
 declare global {
-  interface Window {
-    __OPENCODE__?: {
-      updaterEnabled?: boolean
-      deepLinks?: string[]
-      wsl?: boolean
-    }
-  }
+	interface Window {
+		__OPENCODE__?: {
+			updaterEnabled?: boolean;
+			deepLinks?: string[];
+			wsl?: boolean;
+		};
+	}
 }
 
 function MarkedProviderWithNativeParser(props: ParentProps) {
-  const platform = usePlatform()
-  return <MarkedProvider nativeParser={platform.parseMarkdown}>{props.children}</MarkedProvider>
+	const platform = usePlatform();
+	return (
+		<MarkedProvider nativeParser={platform.parseMarkdown}>
+			{props.children}
+		</MarkedProvider>
+	);
 }
 
 function AppShellProviders(props: ParentProps) {
-  return (
-    <SettingsProvider>
-      <PermissionProvider>
-        <LayoutProvider>
-          <NotificationProvider>
-            <ModelsProvider>
-              <CommandProvider>
-                <HighlightsProvider>
-                  <Layout>{props.children}</Layout>
-                </HighlightsProvider>
-              </CommandProvider>
-            </ModelsProvider>
-          </NotificationProvider>
-        </LayoutProvider>
-      </PermissionProvider>
-    </SettingsProvider>
-  )
+	return (
+		<SettingsProvider>
+			<PermissionProvider>
+				<LayoutProvider>
+					<NotificationProvider>
+						<ModelsProvider>
+							<CommandProvider>
+								<HighlightsProvider>
+									<Layout>{props.children}</Layout>
+								</HighlightsProvider>
+							</CommandProvider>
+						</ModelsProvider>
+					</NotificationProvider>
+				</LayoutProvider>
+			</PermissionProvider>
+		</SettingsProvider>
+	);
 }
 
 function SessionProviders(props: ParentProps) {
-  return (
-    <TerminalProvider>
-      <FileProvider>
-        <PromptProvider>
-          <CommentsProvider>{props.children}</CommentsProvider>
-        </PromptProvider>
-      </FileProvider>
-    </TerminalProvider>
-  )
+	return (
+		<TerminalProvider>
+			<FileProvider>
+				<PromptProvider>
+					<CommentsProvider>{props.children}</CommentsProvider>
+				</PromptProvider>
+			</FileProvider>
+		</TerminalProvider>
+	);
 }
 
 function RouterRoot(props: ParentProps<{ appChildren?: JSX.Element }>) {
-  return (
-    <AppShellProviders>
-      {props.appChildren}
-      {props.children}
-    </AppShellProviders>
-  )
+	return (
+		<AppShellProviders>
+			{props.appChildren}
+			{props.children}
+		</AppShellProviders>
+	);
 }
 
 export function AppBaseProviders(props: ParentProps) {
-  return (
-    <MetaProvider>
-      <Font />
-      <ThemeProvider>
-        <LanguageProvider>
-          <UiI18nBridge>
-            <ErrorBoundary fallback={(error) => <ErrorPage error={error} />}>
-              <DialogProvider>
-                <MarkedProviderWithNativeParser>
-                  <FileComponentProvider component={File}>{props.children}</FileComponentProvider>
-                </MarkedProviderWithNativeParser>
-              </DialogProvider>
-            </ErrorBoundary>
-          </UiI18nBridge>
-        </LanguageProvider>
-      </ThemeProvider>
-    </MetaProvider>
-  )
+	return (
+		<MetaProvider>
+			<Font />
+			<ThemeProvider>
+				<LanguageProvider>
+					<UiI18nBridge>
+						<ErrorBoundary fallback={(error) => <ErrorPage error={error} />}>
+							<DialogProvider>
+								<MarkedProviderWithNativeParser>
+									<FileComponentProvider component={File}>
+										{props.children}
+									</FileComponentProvider>
+								</MarkedProviderWithNativeParser>
+							</DialogProvider>
+						</ErrorBoundary>
+					</UiI18nBridge>
+				</LanguageProvider>
+			</ThemeProvider>
+		</MetaProvider>
+	);
 }
 
 function ServerKey(props: ParentProps) {
-  const server = useServer()
-  return (
-    <Show when={server.key} keyed>
-      {props.children}
-    </Show>
-  )
+	const server = useServer();
+	return (
+		<Show when={server.key} keyed>
+			{props.children}
+		</Show>
+	);
 }
 
 export function AppInterface(props: {
-  children?: JSX.Element
-  defaultServer: ServerConnection.Key
-  servers?: Array<ServerConnection.Any>
+	children?: JSX.Element;
+	defaultServer: ServerConnection.Key;
+	servers?: Array<ServerConnection.Any>;
 }) {
-  return (
-    <ServerProvider defaultServer={props.defaultServer} servers={props.servers}>
-      <ServerKey>
-        <GlobalSDKProvider>
-          <GlobalSyncProvider>
-            <Router
-              root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
-            >
-              <Route path="/" component={HomeRoute} />
-              <Route path="/:dir" component={DirectoryLayout}>
-                <Route path="/" component={SessionIndexRoute} />
-                <Route path="/session/:id?" component={SessionRoute} />
-              </Route>
-            </Router>
-          </GlobalSyncProvider>
-        </GlobalSDKProvider>
-      </ServerKey>
-    </ServerProvider>
-  )
+	return (
+		<ServerProvider defaultServer={props.defaultServer} servers={props.servers}>
+			<ServerKey>
+				<GlobalSDKProvider>
+					<GlobalSyncProvider>
+						<Router
+							root={(routerProps) => (
+								<RouterRoot appChildren={props.children}>
+									{routerProps.children}
+								</RouterRoot>
+							)}
+						>
+							<Route path="/login" component={LoginRouteWrapper} />
+							<Route path="/" component={HomeRoute} />
+							<Route path="/:dir" component={DirectoryLayout}>
+								<Route path="/" component={SessionIndexRoute} />
+								<Route path="/session/:id?" component={SessionRoute} />
+							</Route>
+						</Router>
+					</GlobalSyncProvider>
+				</GlobalSDKProvider>
+			</ServerKey>
+		</ServerProvider>
+	);
 }

--- a/packages/app/src/pages/login.tsx
+++ b/packages/app/src/pages/login.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@opencode-ai/ui/button";
+import { Mark } from "@opencode-ai/ui/logo";
+import { TextField } from "@opencode-ai/ui/text-field";
+import { createSignal, Show } from "solid-js";
+
+export default function LoginPage() {
+	const [username, setUsername] = createSignal("");
+	const [password, setPassword] = createSignal("");
+	const [error, setError] = createSignal("");
+	const [busy, setBusy] = createSignal(false);
+
+	const handleSubmit = async (e: Event) => {
+		e.preventDefault();
+		if (busy()) return;
+		setBusy(true);
+		setError("");
+
+		const res = await fetch("/api/login", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				username: username(),
+				password: password(),
+			}),
+		});
+
+		if (!res.ok) {
+			const data = await res.json();
+			setError(data.message || "Failed to log in");
+			setBusy(false);
+			return;
+		}
+
+		window.location.href = "/";
+	};
+
+	return (
+		<div class="flex h-screen w-full flex-col items-center justify-center bg-surface-base p-4">
+			<div class="w-full max-w-sm rounded-lg bg-surface-raised-base p-6 shadow-sm">
+				<div class="mb-8 flex flex-col items-center gap-4">
+					<Mark class="h-12 w-12" />
+					<h1 class="text-16-medium text-text-strong">Sign In</h1>
+				</div>
+
+				<Show when={error()}>
+					<div class="mb-4 rounded-md bg-surface-critical-base p-3 text-14-regular text-text-on-critical-base">
+						{error()}
+					</div>
+				</Show>
+
+				<form onSubmit={handleSubmit} class="flex flex-col gap-4">
+					<TextField
+						type="text"
+						label="Username"
+						placeholder="Enter your username"
+						value={username()}
+						onChange={setUsername}
+						disabled={busy()}
+						validationState={error() ? "invalid" : "valid"}
+					/>
+
+					<TextField
+						type="password"
+						label="Password"
+						placeholder="Enter your password"
+						value={password()}
+						onChange={setPassword}
+						disabled={busy()}
+						validationState={error() ? "invalid" : "valid"}
+					/>
+
+					<Button
+						type="submit"
+						variant="primary"
+						size="large"
+						disabled={busy() || !username() || !password()}
+						class="mt-4 w-full justify-center"
+					>
+						{busy() ? "Signing in..." : "Sign in"}
+					</Button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -1,22 +1,27 @@
-import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
-import type { ServerConnection } from "@/context/server"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { ServerConnection } from "@/context/server";
 
 export function createSdkForServer({
-  server,
-  ...config
-}: Omit<NonNullable<Parameters<typeof createOpencodeClient>[0]>, "baseUrl"> & {
-  server: ServerConnection.HttpBase
+	server,
+	...config
+}: Omit<
+	Omit<NonNullable<Parameters<typeof createOpencodeClient>[0]>, "baseUrl"> & {
+		server: ServerConnection.HttpBase;
+	},
+	"baseUrl"
+> & {
+	server: ServerConnection.HttpBase;
 }) {
-  const auth = (() => {
-    if (!server.password) return
-    return {
-      Authorization: `Basic ${btoa(`${server.username ?? "opencode"}:${server.password}`)}`,
-    }
-  })()
+	const auth = (() => {
+		if (!server.password) return;
+		return {
+			Authorization: `Basic ${btoa(`${server.username ?? "opencode"}:${server.password}`)}`,
+		};
+	})();
 
-  return createOpencodeClient({
-    ...config,
-    headers: { ...config.headers, ...auth },
-    baseUrl: server.url,
-  })
+	return createOpencodeClient({
+		...config,
+		headers: { ...config.headers, ...auth },
+		baseUrl: server.url,
+	});
 }

--- a/packages/opencode/src/server/auth.ts
+++ b/packages/opencode/src/server/auth.ts
@@ -1,0 +1,83 @@
+import type { Context, Next } from "hono";
+import { getCookie } from "hono/cookie";
+
+const encoder = new TextEncoder();
+
+async function sign(payload: string, secret: string) {
+	const key = await crypto.subtle.importKey(
+		"raw",
+		encoder.encode(secret),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+	return `${payload}.${btoa(String.fromCharCode(...new Uint8Array(sig)))
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "")}`;
+}
+
+async function verify(token: string, secret: string) {
+	const idx = token.lastIndexOf(".");
+	if (idx === -1) return null;
+	const payload = token.slice(0, idx);
+	const expected = await sign(payload, secret);
+	if (expected !== token) return null;
+	return payload;
+}
+
+async function createSessionCookie(username: string, secret: string) {
+	const payload = JSON.stringify({
+		sub: username,
+		iat: Math.floor(Date.now() / 1000),
+	});
+	return sign(payload, secret);
+}
+
+async function verifySessionCookie(
+	token: string,
+	secret: string,
+	maxAge = 86400,
+) {
+	const payload = await verify(token, secret);
+	if (!payload) return null;
+	const data = JSON.parse(payload) as { sub: string; iat: number };
+	if (Math.floor(Date.now() / 1000) > data.iat + maxAge) return null;
+	return data.sub;
+}
+
+function dualAuth(username: string, password: string) {
+	return async (c: Context, next: Next) => {
+		if (c.req.method === "OPTIONS") return next();
+
+		const cookie = getCookie(c, "opencode_session");
+		if (cookie) {
+			const secret = password;
+			const sub = await verifySessionCookie(cookie, secret);
+			if (sub) {
+				c.set("user", sub);
+				return next();
+			}
+		}
+
+		const auth = c.req.header("Authorization");
+		if (auth?.startsWith("Basic ")) {
+			const decoded = atob(auth.slice(6));
+			const colon = decoded.indexOf(":");
+			if (colon !== -1) {
+				const user = decoded.slice(0, colon);
+				const pass = decoded.slice(colon + 1);
+				if (user === username && pass === password) return next();
+			}
+		}
+
+		const accept = c.req.header("Accept") ?? "";
+		if (accept.includes("text/html") && !accept.includes("application/json"))
+			return c.redirect("/login", 302);
+
+		return c.json({ error: "Unauthorized" }, 401);
+	};
+}
+
+export { sign, verify, createSessionCookie, verifySessionCookie, dualAuth };

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,639 +1,693 @@
-import { BusEvent } from "@/bus/bus-event"
-import { Bus } from "@/bus"
-import { Log } from "../util/log"
-import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
-import { Hono } from "hono"
-import { cors } from "hono/cors"
-import { streamSSE } from "hono/streaming"
-import { proxy } from "hono/proxy"
-import { basicAuth } from "hono/basic-auth"
-import z from "zod"
-import { Provider } from "../provider/provider"
-import { NamedError } from "@opencode-ai/util/error"
-import { LSP } from "../lsp"
-import { Format } from "../format"
-import { TuiRoutes } from "./routes/tui"
-import { Instance } from "../project/instance"
-import { Vcs } from "../project/vcs"
-import { Agent } from "../agent/agent"
-import { Skill } from "../skill/skill"
-import { Auth } from "../auth"
-import { Flag } from "../flag/flag"
-import { Command } from "../command"
-import { Global } from "../global"
-import { WorkspaceContext } from "../control-plane/workspace-context"
-import { ProjectRoutes } from "./routes/project"
-import { SessionRoutes } from "./routes/session"
-import { PtyRoutes } from "./routes/pty"
-import { McpRoutes } from "./routes/mcp"
-import { FileRoutes } from "./routes/file"
-import { ConfigRoutes } from "./routes/config"
-import { ExperimentalRoutes } from "./routes/experimental"
-import { ProviderRoutes } from "./routes/provider"
-import { lazy } from "../util/lazy"
-import { InstanceBootstrap } from "../project/bootstrap"
-import { NotFoundError } from "../storage/db"
-import type { ContentfulStatusCode } from "hono/utils/http-status"
-import { websocket } from "hono/bun"
-import { HTTPException } from "hono/http-exception"
-import { errors } from "./error"
-import { QuestionRoutes } from "./routes/question"
-import { PermissionRoutes } from "./routes/permission"
-import { GlobalRoutes } from "./routes/global"
-import { MDNS } from "./mdns"
+import { NamedError } from "@opencode-ai/util/error";
+import { Hono } from "hono";
+import { websocket } from "hono/bun";
+import { deleteCookie, setCookie } from "hono/cookie";
+import { cors } from "hono/cors";
+import { HTTPException } from "hono/http-exception";
+import { proxy } from "hono/proxy";
+import { streamSSE } from "hono/streaming";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import {
+	describeRoute,
+	generateSpecs,
+	openAPIRouteHandler,
+	resolver,
+	validator,
+} from "hono-openapi";
 
-// @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
-globalThis.AI_SDK_LOG_WARNINGS = false
+import z from "zod";
+import { Bus } from "@/bus";
+import { BusEvent } from "@/bus/bus-event";
+import { Agent } from "../agent/agent";
+import { Auth } from "../auth";
+import { Command } from "../command";
+import { WorkspaceContext } from "../control-plane/workspace-context";
+import { Flag } from "../flag/flag";
+import { Format } from "../format";
+import { Global } from "../global";
+import { LSP } from "../lsp";
+import { InstanceBootstrap } from "../project/bootstrap";
+import { Instance } from "../project/instance";
+import { Vcs } from "../project/vcs";
+import { Provider } from "../provider/provider";
+import { Skill } from "../skill/skill";
+import { NotFoundError } from "../storage/db";
+import { lazy } from "../util/lazy";
+import { Log } from "../util/log";
+import { createSessionCookie, dualAuth } from "./auth";
+import { errors } from "./error";
+import { MDNS } from "./mdns";
+import { ConfigRoutes } from "./routes/config";
+import { ExperimentalRoutes } from "./routes/experimental";
+import { FileRoutes } from "./routes/file";
+import { GlobalRoutes } from "./routes/global";
+import { McpRoutes } from "./routes/mcp";
+import { PermissionRoutes } from "./routes/permission";
+import { ProjectRoutes } from "./routes/project";
+import { ProviderRoutes } from "./routes/provider";
+import { PtyRoutes } from "./routes/pty";
+import { QuestionRoutes } from "./routes/question";
+import { SessionRoutes } from "./routes/session";
+import { TuiRoutes } from "./routes/tui";
+
+globalThis.AI_SDK_LOG_WARNINGS = false;
 
 export namespace Server {
-  const log = Log.create({ service: "server" })
+	const log = Log.create({ service: "server" });
 
-  let _url: URL | undefined
-  let _corsWhitelist: string[] = []
+	let _url: URL | undefined;
+	let _corsWhitelist: string[] = [];
 
-  export function url(): URL {
-    return _url ?? new URL("http://localhost:4096")
-  }
+	export function url(): URL {
+		return _url ?? new URL("http://localhost:4096");
+	}
 
-  const app = new Hono()
-  export const App: () => Hono = lazy(
-    () =>
-      // TODO: Break server.ts into smaller route files to fix type inference
-      app
-        .onError((err, c) => {
-          log.error("failed", {
-            error: err,
-          })
-          if (err instanceof NamedError) {
-            let status: ContentfulStatusCode
-            if (err instanceof NotFoundError) status = 404
-            else if (err instanceof Provider.ModelNotFoundError) status = 400
-            else if (err.name.startsWith("Worktree")) status = 400
-            else status = 500
-            return c.json(err.toObject(), { status })
-          }
-          if (err instanceof HTTPException) return err.getResponse()
-          const message = err instanceof Error && err.stack ? err.stack : err.toString()
-          return c.json(new NamedError.Unknown({ message }).toObject(), {
-            status: 500,
-          })
-        })
-        .use((c, next) => {
-          // Allow CORS preflight requests to succeed without auth.
-          // Browser clients sending Authorization headers will preflight with OPTIONS.
-          if (c.req.method === "OPTIONS") return next()
-          const password = Flag.OPENCODE_SERVER_PASSWORD
-          if (!password) return next()
-          const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
-          return basicAuth({ username, password })(c, next)
-        })
-        .use(async (c, next) => {
-          const skipLogging = c.req.path === "/log"
-          if (!skipLogging) {
-            log.info("request", {
-              method: c.req.method,
-              path: c.req.path,
-            })
-          }
-          const timer = log.time("request", {
-            method: c.req.method,
-            path: c.req.path,
-          })
-          await next()
-          if (!skipLogging) {
-            timer.stop()
-          }
-        })
-        .use(
-          cors({
-            origin(input) {
-              if (!input) return
+	const app = new Hono();
+	export const App: () => Hono = lazy(
+		() =>
+			// TODO: Break server.ts into smaller route files to fix type inference
+			app
+				.onError((err, c) => {
+					log.error("failed", {
+						error: err,
+					});
+					if (err instanceof NamedError) {
+						let status: ContentfulStatusCode;
+						if (err instanceof NotFoundError) status = 404;
+						else if (err instanceof Provider.ModelNotFoundError) status = 400;
+						else if (err.name.startsWith("Worktree")) status = 400;
+						else status = 500;
+						return c.json(err.toObject(), { status });
+					}
+					if (err instanceof HTTPException) return err.getResponse();
+					const message =
+						err instanceof Error && err.stack ? err.stack : err.toString();
+					return c.json(new NamedError.Unknown({ message }).toObject(), {
+						status: 500,
+					});
+				})
+				.use((c, next) => {
+					// Allow CORS preflight requests to succeed without auth.
+					// Browser clients sending Authorization headers will preflight with OPTIONS.
+					if (c.req.method === "OPTIONS") return next();
+					const password = Flag.OPENCODE_SERVER_PASSWORD;
+					if (!password) return next();
+					const path = new URL(c.req.url).pathname;
+					const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode";
+					if (
+						path === "/login" ||
+						path === "/api/login" ||
+						path.startsWith("/assets/") ||
+						path.endsWith(".js") ||
+						path.endsWith(".css") ||
+						path.endsWith(".svg") ||
+						path.endsWith(".png") ||
+						path.endsWith(".ico")
+					)
+						return next();
+					return dualAuth(username, password)(c, next);
+				})
+				.use(async (c, next) => {
+					const skipLogging = c.req.path === "/log";
+					if (!skipLogging) {
+						log.info("request", {
+							method: c.req.method,
+							path: c.req.path,
+						});
+					}
+					const timer = log.time("request", {
+						method: c.req.method,
+						path: c.req.path,
+					});
+					await next();
+					if (!skipLogging) {
+						timer.stop();
+					}
+				})
+				.use(
+					cors({
+						origin(input) {
+							if (!input) return;
 
-              if (input.startsWith("http://localhost:")) return input
-              if (input.startsWith("http://127.0.0.1:")) return input
-              if (
-                input === "tauri://localhost" ||
-                input === "http://tauri.localhost" ||
-                input === "https://tauri.localhost"
-              )
-                return input
+							if (input.startsWith("http://localhost:")) return input;
+							if (input.startsWith("http://127.0.0.1:")) return input;
+							if (
+								input === "tauri://localhost" ||
+								input === "http://tauri.localhost" ||
+								input === "https://tauri.localhost"
+							)
+								return input;
 
-              // *.opencode.ai (https only, adjust if needed)
-              if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
-                return input
-              }
-              if (_corsWhitelist.includes(input)) {
-                return input
-              }
+							// *.opencode.ai (https only, adjust if needed)
+							if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
+								return input;
+							}
+							if (_corsWhitelist.includes(input)) {
+								return input;
+							}
 
-              return
-            },
-          }),
-        )
-        .route("/global", GlobalRoutes())
-        .put(
-          "/auth/:providerID",
-          describeRoute({
-            summary: "Set auth credentials",
-            description: "Set authentication credentials",
-            operationId: "auth.set",
-            responses: {
-              200: {
-                description: "Successfully set authentication credentials",
-                content: {
-                  "application/json": {
-                    schema: resolver(z.boolean()),
-                  },
-                },
-              },
-              ...errors(400),
-            },
-          }),
-          validator(
-            "param",
-            z.object({
-              providerID: z.string(),
-            }),
-          ),
-          validator("json", Auth.Info),
-          async (c) => {
-            const providerID = c.req.valid("param").providerID
-            const info = c.req.valid("json")
-            await Auth.set(providerID, info)
-            return c.json(true)
-          },
-        )
-        .delete(
-          "/auth/:providerID",
-          describeRoute({
-            summary: "Remove auth credentials",
-            description: "Remove authentication credentials",
-            operationId: "auth.remove",
-            responses: {
-              200: {
-                description: "Successfully removed authentication credentials",
-                content: {
-                  "application/json": {
-                    schema: resolver(z.boolean()),
-                  },
-                },
-              },
-              ...errors(400),
-            },
-          }),
-          validator(
-            "param",
-            z.object({
-              providerID: z.string(),
-            }),
-          ),
-          async (c) => {
-            const providerID = c.req.valid("param").providerID
-            await Auth.remove(providerID)
-            return c.json(true)
-          },
-        )
-        .use(async (c, next) => {
-          if (c.req.path === "/log") return next()
-          const workspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")
-          const raw = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
-          const directory = (() => {
-            try {
-              return decodeURIComponent(raw)
-            } catch {
-              return raw
-            }
-          })()
+							return;
+						},
+					}),
+				)
+				.route("/global", GlobalRoutes())
+				.put(
+					"/auth/:providerID",
+					describeRoute({
+						summary: "Set auth credentials",
+						description: "Set authentication credentials",
+						operationId: "auth.set",
+						responses: {
+							200: {
+								description: "Successfully set authentication credentials",
+								content: {
+									"application/json": {
+										schema: resolver(z.boolean()),
+									},
+								},
+							},
+							...errors(400),
+						},
+					}),
+					validator(
+						"param",
+						z.object({
+							providerID: z.string(),
+						}),
+					),
+					validator("json", Auth.Info),
+					async (c) => {
+						const providerID = c.req.valid("param").providerID;
+						const info = c.req.valid("json");
+						await Auth.set(providerID, info);
+						return c.json(true);
+					},
+				)
+				.delete(
+					"/auth/:providerID",
+					describeRoute({
+						summary: "Remove auth credentials",
+						description: "Remove authentication credentials",
+						operationId: "auth.remove",
+						responses: {
+							200: {
+								description: "Successfully removed authentication credentials",
+								content: {
+									"application/json": {
+										schema: resolver(z.boolean()),
+									},
+								},
+							},
+							...errors(400),
+						},
+					}),
+					validator(
+						"param",
+						z.object({
+							providerID: z.string(),
+						}),
+					),
+					async (c) => {
+						const providerID = c.req.valid("param").providerID;
+						await Auth.remove(providerID);
+						return c.json(true);
+					},
+				)
+				.use(async (c, next) => {
+					if (c.req.path === "/log") return next();
+					const workspaceID =
+						c.req.query("workspace") || c.req.header("x-opencode-workspace");
+					const raw =
+						c.req.query("directory") ||
+						c.req.header("x-opencode-directory") ||
+						process.cwd();
+					const directory = (() => {
+						try {
+							return decodeURIComponent(raw);
+						} catch {
+							return raw;
+						}
+					})();
 
-          return WorkspaceContext.provide({
-            workspaceID,
-            async fn() {
-              return Instance.provide({
-                directory,
-                init: InstanceBootstrap,
-                async fn() {
-                  return next()
-                },
-              })
-            },
-          })
-        })
-        .get(
-          "/doc",
-          openAPIRouteHandler(app, {
-            documentation: {
-              info: {
-                title: "opencode",
-                version: "0.0.3",
-                description: "opencode api",
-              },
-              openapi: "3.1.1",
-            },
-          }),
-        )
-        .use(
-          validator(
-            "query",
-            z.object({
-              directory: z.string().optional(),
-              workspace: z.string().optional(),
-            }),
-          ),
-        )
-        .route("/project", ProjectRoutes())
-        .route("/pty", PtyRoutes())
-        .route("/config", ConfigRoutes())
-        .route("/experimental", ExperimentalRoutes())
-        .route("/session", SessionRoutes())
-        .route("/permission", PermissionRoutes())
-        .route("/question", QuestionRoutes())
-        .route("/provider", ProviderRoutes())
-        .route("/", FileRoutes())
-        .route("/mcp", McpRoutes())
-        .route("/tui", TuiRoutes())
-        .post(
-          "/instance/dispose",
-          describeRoute({
-            summary: "Dispose instance",
-            description: "Clean up and dispose the current OpenCode instance, releasing all resources.",
-            operationId: "instance.dispose",
-            responses: {
-              200: {
-                description: "Instance disposed",
-                content: {
-                  "application/json": {
-                    schema: resolver(z.boolean()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            await Instance.dispose()
-            return c.json(true)
-          },
-        )
-        .get(
-          "/path",
-          describeRoute({
-            summary: "Get paths",
-            description:
-              "Retrieve the current working directory and related path information for the OpenCode instance.",
-            operationId: "path.get",
-            responses: {
-              200: {
-                description: "Path",
-                content: {
-                  "application/json": {
-                    schema: resolver(
-                      z
-                        .object({
-                          home: z.string(),
-                          state: z.string(),
-                          config: z.string(),
-                          worktree: z.string(),
-                          directory: z.string(),
-                        })
-                        .meta({
-                          ref: "Path",
-                        }),
-                    ),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            return c.json({
-              home: Global.Path.home,
-              state: Global.Path.state,
-              config: Global.Path.config,
-              worktree: Instance.worktree,
-              directory: Instance.directory,
-            })
-          },
-        )
-        .get(
-          "/vcs",
-          describeRoute({
-            summary: "Get VCS info",
-            description:
-              "Retrieve version control system (VCS) information for the current project, such as git branch.",
-            operationId: "vcs.get",
-            responses: {
-              200: {
-                description: "VCS info",
-                content: {
-                  "application/json": {
-                    schema: resolver(Vcs.Info),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            const branch = await Vcs.branch()
-            return c.json({
-              branch,
-            })
-          },
-        )
-        .get(
-          "/command",
-          describeRoute({
-            summary: "List commands",
-            description: "Get a list of all available commands in the OpenCode system.",
-            operationId: "command.list",
-            responses: {
-              200: {
-                description: "List of commands",
-                content: {
-                  "application/json": {
-                    schema: resolver(Command.Info.array()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            const commands = await Command.list()
-            return c.json(commands)
-          },
-        )
-        .post(
-          "/log",
-          describeRoute({
-            summary: "Write log",
-            description: "Write a log entry to the server logs with specified level and metadata.",
-            operationId: "app.log",
-            responses: {
-              200: {
-                description: "Log entry written successfully",
-                content: {
-                  "application/json": {
-                    schema: resolver(z.boolean()),
-                  },
-                },
-              },
-              ...errors(400),
-            },
-          }),
-          validator(
-            "json",
-            z.object({
-              service: z.string().meta({ description: "Service name for the log entry" }),
-              level: z.enum(["debug", "info", "error", "warn"]).meta({ description: "Log level" }),
-              message: z.string().meta({ description: "Log message" }),
-              extra: z
-                .record(z.string(), z.any())
-                .optional()
-                .meta({ description: "Additional metadata for the log entry" }),
-            }),
-          ),
-          async (c) => {
-            const { service, level, message, extra } = c.req.valid("json")
-            const logger = Log.create({ service })
+					return WorkspaceContext.provide({
+						workspaceID,
+						async fn() {
+							return Instance.provide({
+								directory,
+								init: InstanceBootstrap,
+								async fn() {
+									return next();
+								},
+							});
+						},
+					});
+				})
+				.get(
+					"/doc",
+					openAPIRouteHandler(app, {
+						documentation: {
+							info: {
+								title: "opencode",
+								version: "0.0.3",
+								description: "opencode api",
+							},
+							openapi: "3.1.1",
+						},
+					}),
+				)
+				.use(
+					validator(
+						"query",
+						z.object({
+							directory: z.string().optional(),
+							workspace: z.string().optional(),
+						}),
+					),
+				)
+				.route("/project", ProjectRoutes())
+				.route("/pty", PtyRoutes())
+				.route("/config", ConfigRoutes())
+				.route("/experimental", ExperimentalRoutes())
+				.route("/session", SessionRoutes())
+				.route("/permission", PermissionRoutes())
+				.route("/question", QuestionRoutes())
+				.route("/provider", ProviderRoutes())
+				.route("/", FileRoutes())
+				.route("/mcp", McpRoutes())
+				.route("/tui", TuiRoutes())
+				.post(
+					"/instance/dispose",
+					describeRoute({
+						summary: "Dispose instance",
+						description:
+							"Clean up and dispose the current OpenCode instance, releasing all resources.",
+						operationId: "instance.dispose",
+						responses: {
+							200: {
+								description: "Instance disposed",
+								content: {
+									"application/json": {
+										schema: resolver(z.boolean()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						await Instance.dispose();
+						return c.json(true);
+					},
+				)
+				.get(
+					"/path",
+					describeRoute({
+						summary: "Get paths",
+						description:
+							"Retrieve the current working directory and related path information for the OpenCode instance.",
+						operationId: "path.get",
+						responses: {
+							200: {
+								description: "Path",
+								content: {
+									"application/json": {
+										schema: resolver(
+											z
+												.object({
+													home: z.string(),
+													state: z.string(),
+													config: z.string(),
+													worktree: z.string(),
+													directory: z.string(),
+												})
+												.meta({
+													ref: "Path",
+												}),
+										),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						return c.json({
+							home: Global.Path.home,
+							state: Global.Path.state,
+							config: Global.Path.config,
+							worktree: Instance.worktree,
+							directory: Instance.directory,
+						});
+					},
+				)
+				.get(
+					"/vcs",
+					describeRoute({
+						summary: "Get VCS info",
+						description:
+							"Retrieve version control system (VCS) information for the current project, such as git branch.",
+						operationId: "vcs.get",
+						responses: {
+							200: {
+								description: "VCS info",
+								content: {
+									"application/json": {
+										schema: resolver(Vcs.Info),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						const branch = await Vcs.branch();
+						return c.json({
+							branch,
+						});
+					},
+				)
+				.get(
+					"/command",
+					describeRoute({
+						summary: "List commands",
+						description:
+							"Get a list of all available commands in the OpenCode system.",
+						operationId: "command.list",
+						responses: {
+							200: {
+								description: "List of commands",
+								content: {
+									"application/json": {
+										schema: resolver(Command.Info.array()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						const commands = await Command.list();
+						return c.json(commands);
+					},
+				)
+				.post(
+					"/log",
+					describeRoute({
+						summary: "Write log",
+						description:
+							"Write a log entry to the server logs with specified level and metadata.",
+						operationId: "app.log",
+						responses: {
+							200: {
+								description: "Log entry written successfully",
+								content: {
+									"application/json": {
+										schema: resolver(z.boolean()),
+									},
+								},
+							},
+							...errors(400),
+						},
+					}),
+					validator(
+						"json",
+						z.object({
+							service: z
+								.string()
+								.meta({ description: "Service name for the log entry" }),
+							level: z
+								.enum(["debug", "info", "error", "warn"])
+								.meta({ description: "Log level" }),
+							message: z.string().meta({ description: "Log message" }),
+							extra: z
+								.record(z.string(), z.any())
+								.optional()
+								.meta({ description: "Additional metadata for the log entry" }),
+						}),
+					),
+					async (c) => {
+						const { service, level, message, extra } = c.req.valid("json");
+						const logger = Log.create({ service });
 
-            switch (level) {
-              case "debug":
-                logger.debug(message, extra)
-                break
-              case "info":
-                logger.info(message, extra)
-                break
-              case "error":
-                logger.error(message, extra)
-                break
-              case "warn":
-                logger.warn(message, extra)
-                break
-            }
+						switch (level) {
+							case "debug":
+								logger.debug(message, extra);
+								break;
+							case "info":
+								logger.info(message, extra);
+								break;
+							case "error":
+								logger.error(message, extra);
+								break;
+							case "warn":
+								logger.warn(message, extra);
+								break;
+						}
 
-            return c.json(true)
-          },
-        )
-        .get(
-          "/agent",
-          describeRoute({
-            summary: "List agents",
-            description: "Get a list of all available AI agents in the OpenCode system.",
-            operationId: "app.agents",
-            responses: {
-              200: {
-                description: "List of agents",
-                content: {
-                  "application/json": {
-                    schema: resolver(Agent.Info.array()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            const modes = await Agent.list()
-            return c.json(modes)
-          },
-        )
-        .get(
-          "/skill",
-          describeRoute({
-            summary: "List skills",
-            description: "Get a list of all available skills in the OpenCode system.",
-            operationId: "app.skills",
-            responses: {
-              200: {
-                description: "List of skills",
-                content: {
-                  "application/json": {
-                    schema: resolver(Skill.Info.array()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            const skills = await Skill.all()
-            return c.json(skills)
-          },
-        )
-        .get(
-          "/lsp",
-          describeRoute({
-            summary: "Get LSP status",
-            description: "Get LSP server status",
-            operationId: "lsp.status",
-            responses: {
-              200: {
-                description: "LSP server status",
-                content: {
-                  "application/json": {
-                    schema: resolver(LSP.Status.array()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            return c.json(await LSP.status())
-          },
-        )
-        .get(
-          "/formatter",
-          describeRoute({
-            summary: "Get formatter status",
-            description: "Get formatter status",
-            operationId: "formatter.status",
-            responses: {
-              200: {
-                description: "Formatter status",
-                content: {
-                  "application/json": {
-                    schema: resolver(Format.Status.array()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            return c.json(await Format.status())
-          },
-        )
-        .get(
-          "/event",
-          describeRoute({
-            summary: "Subscribe to events",
-            description: "Get events",
-            operationId: "event.subscribe",
-            responses: {
-              200: {
-                description: "Event stream",
-                content: {
-                  "text/event-stream": {
-                    schema: resolver(BusEvent.payloads()),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            log.info("event connected")
-            c.header("X-Accel-Buffering", "no")
-            c.header("X-Content-Type-Options", "nosniff")
-            return streamSSE(c, async (stream) => {
-              stream.writeSSE({
-                data: JSON.stringify({
-                  type: "server.connected",
-                  properties: {},
-                }),
-              })
-              const unsub = Bus.subscribeAll(async (event) => {
-                await stream.writeSSE({
-                  data: JSON.stringify(event),
-                })
-                if (event.type === Bus.InstanceDisposed.type) {
-                  stream.close()
-                }
-              })
+						return c.json(true);
+					},
+				)
+				.get(
+					"/agent",
+					describeRoute({
+						summary: "List agents",
+						description:
+							"Get a list of all available AI agents in the OpenCode system.",
+						operationId: "app.agents",
+						responses: {
+							200: {
+								description: "List of agents",
+								content: {
+									"application/json": {
+										schema: resolver(Agent.Info.array()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						const modes = await Agent.list();
+						return c.json(modes);
+					},
+				)
+				.get(
+					"/skill",
+					describeRoute({
+						summary: "List skills",
+						description:
+							"Get a list of all available skills in the OpenCode system.",
+						operationId: "app.skills",
+						responses: {
+							200: {
+								description: "List of skills",
+								content: {
+									"application/json": {
+										schema: resolver(Skill.Info.array()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						const skills = await Skill.all();
+						return c.json(skills);
+					},
+				)
+				.get(
+					"/lsp",
+					describeRoute({
+						summary: "Get LSP status",
+						description: "Get LSP server status",
+						operationId: "lsp.status",
+						responses: {
+							200: {
+								description: "LSP server status",
+								content: {
+									"application/json": {
+										schema: resolver(LSP.Status.array()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						return c.json(await LSP.status());
+					},
+				)
+				.get(
+					"/formatter",
+					describeRoute({
+						summary: "Get formatter status",
+						description: "Get formatter status",
+						operationId: "formatter.status",
+						responses: {
+							200: {
+								description: "Formatter status",
+								content: {
+									"application/json": {
+										schema: resolver(Format.Status.array()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						return c.json(await Format.status());
+					},
+				)
+				.get(
+					"/event",
+					describeRoute({
+						summary: "Subscribe to events",
+						description: "Get events",
+						operationId: "event.subscribe",
+						responses: {
+							200: {
+								description: "Event stream",
+								content: {
+									"text/event-stream": {
+										schema: resolver(BusEvent.payloads()),
+									},
+								},
+							},
+						},
+					}),
+					async (c) => {
+						log.info("event connected");
+						c.header("X-Accel-Buffering", "no");
+						c.header("X-Content-Type-Options", "nosniff");
+						return streamSSE(c, async (stream) => {
+							stream.writeSSE({
+								data: JSON.stringify({
+									type: "server.connected",
+									properties: {},
+								}),
+							});
+							const unsub = Bus.subscribeAll(async (event) => {
+								await stream.writeSSE({
+									data: JSON.stringify(event),
+								});
+								if (event.type === Bus.InstanceDisposed.type) {
+									stream.close();
+								}
+							});
 
-              // Send heartbeat every 10s to prevent stalled proxy streams.
-              const heartbeat = setInterval(() => {
-                stream.writeSSE({
-                  data: JSON.stringify({
-                    type: "server.heartbeat",
-                    properties: {},
-                  }),
-                })
-              }, 10_000)
+							// Send heartbeat every 10s to prevent stalled proxy streams.
+							const heartbeat = setInterval(() => {
+								stream.writeSSE({
+									data: JSON.stringify({
+										type: "server.heartbeat",
+										properties: {},
+									}),
+								});
+							}, 10_000);
 
-              await new Promise<void>((resolve) => {
-                stream.onAbort(() => {
-                  clearInterval(heartbeat)
-                  unsub()
-                  resolve()
-                  log.info("event disconnected")
-                })
-              })
-            })
-          },
-        )
-        .all("/*", async (c) => {
-          const path = c.req.path
+							await new Promise<void>((resolve) => {
+								stream.onAbort(() => {
+									clearInterval(heartbeat);
+									unsub();
+									resolve();
+									log.info("event disconnected");
+								});
+							});
+						});
+					},
+				)
+				.post("/api/login", async (c) => {
+					const password = Flag.OPENCODE_SERVER_PASSWORD;
+					if (!password) return c.json({ error: "Auth not configured" }, 400);
+					const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode";
+					const body = await c.req.json();
+					if (body.username !== username || body.password !== password)
+						return c.json({ error: "Invalid credentials" }, 401);
+					const token = await createSessionCookie(body.username, password);
+					setCookie(c, "opencode_session", token, {
+						httpOnly: true,
+						sameSite: "Lax",
+						path: "/",
+						maxAge: 86400,
+					});
+					return c.json({ ok: true });
+				})
+				.post("/api/logout", (c) => {
+					deleteCookie(c, "opencode_session", { path: "/" });
+					return c.json({ ok: true });
+				})
+				.all("/*", async (c) => {
+					const path = c.req.path;
 
-          const response = await proxy(`https://app.opencode.ai${path}`, {
-            ...c.req,
-            headers: {
-              ...c.req.raw.headers,
-              host: "app.opencode.ai",
-            },
-          })
-          response.headers.set(
-            "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-          )
-          return response
-        }) as unknown as Hono,
-  )
+					const response = await proxy(`https://app.opencode.ai${path}`, {
+						...c.req,
+						headers: {
+							...c.req.raw.headers,
+							host: "app.opencode.ai",
+						},
+					});
+					response.headers.set(
+						"Content-Security-Policy",
+						"default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
+					);
+					return response;
+				}) as unknown as Hono,
+	);
 
-  export async function openapi() {
-    // Cast to break excessive type recursion from long route chains
-    const result = await generateSpecs(App() as Hono, {
-      documentation: {
-        info: {
-          title: "opencode",
-          version: "1.0.0",
-          description: "opencode api",
-        },
-        openapi: "3.1.1",
-      },
-    })
-    return result
-  }
+	export async function openapi() {
+		// Cast to break excessive type recursion from long route chains
+		const result = await generateSpecs(App() as Hono, {
+			documentation: {
+				info: {
+					title: "opencode",
+					version: "1.0.0",
+					description: "opencode api",
+				},
+				openapi: "3.1.1",
+			},
+		});
+		return result;
+	}
 
-  export function listen(opts: {
-    port: number
-    hostname: string
-    mdns?: boolean
-    mdnsDomain?: string
-    cors?: string[]
-  }) {
-    _corsWhitelist = opts.cors ?? []
+	export function listen(opts: {
+		port: number;
+		hostname: string;
+		mdns?: boolean;
+		mdnsDomain?: string;
+		cors?: string[];
+	}) {
+		_corsWhitelist = opts.cors ?? [];
 
-    const args = {
-      hostname: opts.hostname,
-      idleTimeout: 0,
-      fetch: App().fetch,
-      websocket: websocket,
-    } as const
-    const tryServe = (port: number) => {
-      try {
-        return Bun.serve({ ...args, port })
-      } catch {
-        return undefined
-      }
-    }
-    const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
-    if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
+		const args = {
+			hostname: opts.hostname,
+			idleTimeout: 0,
+			fetch: App().fetch,
+			websocket: websocket,
+		} as const;
+		const tryServe = (port: number) => {
+			try {
+				return Bun.serve({ ...args, port });
+			} catch {
+				return undefined;
+			}
+		};
+		const server =
+			opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port);
+		if (!server) throw new Error(`Failed to start server on port ${opts.port}`);
 
-    _url = server.url
+		_url = server.url;
 
-    const shouldPublishMDNS =
-      opts.mdns &&
-      server.port &&
-      opts.hostname !== "127.0.0.1" &&
-      opts.hostname !== "localhost" &&
-      opts.hostname !== "::1"
-    if (shouldPublishMDNS) {
-      MDNS.publish(server.port!, opts.mdnsDomain)
-    } else if (opts.mdns) {
-      log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
-    }
+		const shouldPublishMDNS =
+			opts.mdns &&
+			server.port &&
+			opts.hostname !== "127.0.0.1" &&
+			opts.hostname !== "localhost" &&
+			opts.hostname !== "::1";
+		if (shouldPublishMDNS) {
+			MDNS.publish(server.port!, opts.mdnsDomain);
+		} else if (opts.mdns) {
+			log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish");
+		}
 
-    const originalStop = server.stop.bind(server)
-    server.stop = async (closeActiveConnections?: boolean) => {
-      if (shouldPublishMDNS) MDNS.unpublish()
-      return originalStop(closeActiveConnections)
-    }
+		const originalStop = server.stop.bind(server);
+		server.stop = async (closeActiveConnections?: boolean) => {
+			if (shouldPublishMDNS) MDNS.unpublish();
+			return originalStop(closeActiveConnections);
+		};
 
-    return server
-  }
+		return server;
+	}
 }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It replaces the browser's native Basic Auth dialog with a proper login page for the web UI. 
The current implementation using `hono/basic-auth` causes the browser to show a native popup on 401s with `WWW-Authenticate`, and page reloads lose form state. 

This PR:
1. Adds a custom dual-auth middleware that accepts both cookies (for the web app) and Basic Auth headers (for CLI/API clients).
2. Adds `/api/login` and `/api/logout` endpoints that set HTTP-Only signed cookies using `OPENCODE_SERVER_PASSWORD`.
3. Adds a new `/login` route and page component using existing UI elements.
4. Wraps the SDK client fetch to intercept 401 responses and redirect to the login page without triggering the native browser dialog.

### How did you verify your code works?

Tested locally by:
- Verifying unauthenticated API calls return 401 without the `WWW-Authenticate` header.
- Verifying unauthenticated browser requests redirect to `/login`.
- Logging in via the new UI to ensure the session cookie is set correctly.
- Verifying Basic Auth still works for CLI/API clients.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
