### PR TITLE
tweak(ui): add sidebar fade mask under new buttons

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1851,45 +1851,34 @@ export default function Layout(props: ParentProps) {
                   when={workspacesEnabled()}
                   fallback={
                     <>
-                      <div class="shrink-0 py-4 px-3">
-                        <TooltipKeybind
-                          title={language.t("command.session.new")}
-                          keybind={command.keybind("session.new")}
-                          placement="top"
-                        >
-                          <Button
-                            size="large"
-                            icon="plus-small"
-                            class="w-full"
-                            onClick={() => navigateWithSidebarReset(`/${base64Encode(p().worktree)}/session`)}
-                          >
-                            {language.t("command.session.new")}
-                          </Button>
-                        </TooltipKeybind>
-                      </div>
                       <div class="flex-1 min-h-0">
                         <LocalWorkspace
                           ctx={workspaceSidebarCtx}
                           project={p()}
                           sortNow={sortNow}
                           mobile={panelProps.mobile}
+                          header={
+                            <TooltipKeybind
+                              title={language.t("command.session.new")}
+                              keybind={command.keybind("session.new")}
+                              placement="top"
+                            >
+                              <Button
+                                size="large"
+                                icon="plus-small"
+                                class="w-full"
+                                onClick={() => navigateWithSidebarReset(`/${base64Encode(p().worktree)}/session`)}
+                              >
+                                {language.t("command.session.new")}
+                              </Button>
+                            </TooltipKeybind>
+                          }
                         />
                       </div>
                     </>
                   }
                 >
                   <>
-                    <div class="shrink-0 py-4 px-3">
-                      <TooltipKeybind
-                        title={language.t("workspace.new")}
-                        keybind={command.keybind("workspace.new")}
-                        placement="top"
-                      >
-                        <Button size="large" icon="plus-small" class="w-full" onClick={() => createWorkspace(p())}>
-                          {language.t("workspace.new")}
-                        </Button>
-                      </TooltipKeybind>
-                    </div>
                     <div class="relative flex-1 min-h-0">
                       <DragDropProvider
                         onDragStart={handleWorkspaceDragStart}
@@ -1903,21 +1892,41 @@ export default function Layout(props: ParentProps) {
                           ref={(el) => {
                             if (!panelProps.mobile) scrollContainerRef = el
                           }}
-                          class="size-full flex flex-col py-2 gap-4 overflow-y-auto no-scrollbar [overflow-anchor:none]"
+                          class="size-full flex flex-col overflow-y-auto no-scrollbar [overflow-anchor:none]"
                         >
-                          <SortableProvider ids={workspaces()}>
-                            <For each={workspaces()}>
-                              {(directory) => (
-                                <SortableWorkspace
-                                  ctx={workspaceSidebarCtx}
-                                  directory={directory}
-                                  project={p()}
-                                  sortNow={sortNow}
-                                  mobile={panelProps.mobile}
-                                />
-                              )}
-                            </For>
-                          </SortableProvider>
+                          <div class="sticky top-0 z-20 pointer-events-none bg-[linear-gradient(to_bottom,var(--background-stronger)_calc(100%_-_24px),transparent)] pt-4 pb-6 px-3">
+                            <div class="pointer-events-auto">
+                              <TooltipKeybind
+                                title={language.t("workspace.new")}
+                                keybind={command.keybind("workspace.new")}
+                                placement="top"
+                              >
+                                <Button
+                                  size="large"
+                                  icon="plus-small"
+                                  class="w-full"
+                                  onClick={() => createWorkspace(p())}
+                                >
+                                  {language.t("workspace.new")}
+                                </Button>
+                              </TooltipKeybind>
+                            </div>
+                          </div>
+                          <div class="flex flex-col gap-4 py-2">
+                            <SortableProvider ids={workspaces()}>
+                              <For each={workspaces()}>
+                                {(directory) => (
+                                  <SortableWorkspace
+                                    ctx={workspaceSidebarCtx}
+                                    directory={directory}
+                                    project={p()}
+                                    sortNow={sortNow}
+                                    mobile={panelProps.mobile}
+                                  />
+                                )}
+                              </For>
+                            </SortableProvider>
+                          </div>
                         </div>
                         <DragOverlay>
                           <WorkspaceDragOverlay

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -283,7 +283,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   return (
     <div
       data-session-id={props.session.id}
-      class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3
+      class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3 scroll-mt-24
              hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
     >
       <Show

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -467,6 +467,7 @@ export const LocalWorkspace = (props: {
   project: LocalProject
   sortNow: Accessor<number>
   mobile?: boolean
+  header?: JSX.Element
 }): JSX.Element => {
   const globalSync = useGlobalSync()
   const language = useLanguage()
@@ -488,9 +489,14 @@ export const LocalWorkspace = (props: {
   return (
     <div
       ref={(el) => props.ctx.setScrollContainerRef(el, props.mobile)}
-      class="size-full flex flex-col py-2 overflow-y-auto no-scrollbar [overflow-anchor:none]"
+      class="size-full flex flex-col overflow-y-auto no-scrollbar [overflow-anchor:none]"
     >
-      <nav class="flex flex-col gap-1 px-2">
+      <Show when={props.header}>
+        <div class="sticky top-0 z-20 pointer-events-none bg-[linear-gradient(to_bottom,var(--background-stronger)_calc(100%_-_24px),transparent)] pt-4 pb-6 px-3">
+          <div class="pointer-events-auto">{props.header}</div>
+        </div>
+      </Show>
+      <nav class="flex flex-col gap-1 px-2 pb-2" classList={{ "pt-2": !props.header }}>
         <Show when={loading()}>
           <SessionSkeleton />
         </Show>


### PR DESCRIPTION

<img width="698" height="574" alt="image" src="https://github.com/user-attachments/assets/8640609b-a943-4355-a132-8b4247b77000" />


### Issue for this PR


Closes #



### Type of change



- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation



### What does this PR do?



The sidebar workspace/session panel has a sticky "New Session" / "New Workspace" action at the top, but the scrolled content below it didn’t fade out the way the session feed header does.

This change renders those actions inside a `sticky top-0` header that uses the same linear-gradient fade treatment, so the list content scrolls underneath and visually fades behind the button area. To keep the header from blocking scroll interactions, the sticky wrapper is `pointer-events-none` with the button container set back to `pointer-events-auto`.

I also added `scroll-mt-24` to session rows so the existing `scrollIntoView({ block: "nearest" })` behavior doesn’t tuck the focused/selected session under the new sticky header.



### How did you verify your code works?



I wasn’t able to run the app locally in this environment (no `bun` available), so verification here is code review only:

- Confirmed the sidebar header uses the same gradient fade approach as other sticky headers in the app.
- Confirmed scroll behavior remains possible over the masked area via `pointer-events`.



### Screenshots / recordings



_Not available from this environment (no local app dev server)._



### Checklist



- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR