### PR TITLE
feat(tui): add syntaxKeywordType theme token for type keywords

### DIFF
--- a/packages/console/app/public/theme.json
+++ b/packages/console/app/public/theme.json
@@ -80,6 +80,7 @@
         "markdownCodeBlock": { "$ref": "#/definitions/colorValue" },
         "syntaxComment": { "$ref": "#/definitions/colorValue" },
         "syntaxKeyword": { "$ref": "#/definitions/colorValue" },
+        "syntaxKeywordType": { "$ref": "#/definitions/colorValue" },
         "syntaxFunction": { "$ref": "#/definitions/colorValue" },
         "syntaxVariable": { "$ref": "#/definitions/colorValue" },
         "syntaxString": { "$ref": "#/definitions/colorValue" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -89,6 +89,7 @@ type ThemeColors = {
   markdownCodeBlock: RGBA
   syntaxComment: RGBA
   syntaxKeyword: RGBA
+  syntaxKeywordType: RGBA
   syntaxFunction: RGBA
   syntaxVariable: RGBA
   syntaxString: RGBA
@@ -131,9 +132,10 @@ type ColorValue = HexColor | RefName | Variant | RGBA
 type ThemeJson = {
   $schema?: string
   defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
+  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu" | "syntaxKeywordType"> & {
     selectedListItemText?: ColorValue
     backgroundMenu?: ColorValue
+    syntaxKeywordType?: ColorValue
     thinkingOpacity?: number
   }
 }
@@ -199,7 +201,7 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
 
   const resolved = Object.fromEntries(
     Object.entries(theme.theme)
-      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
+      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "syntaxKeywordType" && key !== "thinkingOpacity")
       .map(([key, value]) => {
         return [key, resolveColor(value as ColorValue)]
       }),
@@ -220,6 +222,13 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
     resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
   } else {
     resolved.backgroundMenu = resolved.backgroundElement
+  }
+
+  // Handle syntaxKeywordType - optional with fallback to syntaxKeyword
+  if (theme.theme.syntaxKeywordType !== undefined) {
+    resolved.syntaxKeywordType = resolveColor(theme.theme.syntaxKeywordType)
+  } else {
+    resolved.syntaxKeywordType = resolved.syntaxKeyword
   }
 
   // Handle thinkingOpacity - optional with default of 0.6
@@ -725,7 +734,7 @@ function getSyntaxRules(theme: Theme) {
     {
       scope: ["keyword.type"],
       style: {
-        foreground: theme.syntaxType,
+        foreground: theme.syntaxKeywordType,
         bold: true,
         italic: true,
       },

--- a/packages/web/public/theme.json
+++ b/packages/web/public/theme.json
@@ -81,6 +81,7 @@
         "markdownCodeBlock": { "$ref": "#/definitions/colorValue" },
         "syntaxComment": { "$ref": "#/definitions/colorValue" },
         "syntaxKeyword": { "$ref": "#/definitions/colorValue" },
+        "syntaxKeywordType": { "$ref": "#/definitions/colorValue" },
         "syntaxFunction": { "$ref": "#/definitions/colorValue" },
         "syntaxVariable": { "$ref": "#/definitions/colorValue" },
         "syntaxString": { "$ref": "#/definitions/colorValue" },


### PR DESCRIPTION
### Issue for this PR
Closes #15705

### Type of change
- [x] New feature

### What does this PR do?
Adds the ability to set different colors for syntax type keywords and type names in themes.

As in
```go
type Name struct {}
```

### How did you verify your code works?
Built the binary locally from the branch and tested with a custom theme.

### Screenshots / recordings

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR