### PR TITLE
perf(opencode): improve config loading, add LSP binary caching, and RPC timeout

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -159,10 +159,15 @@ export namespace Config {
         }),
       )
 
-      result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
-      result.agent = mergeDeep(result.agent, await loadAgent(dir))
-      result.agent = mergeDeep(result.agent, await loadMode(dir))
-      result.plugin.push(...(await loadPlugin(dir)))
+      const [cmd, agent, mode, plugin] = await Promise.all([
+        loadCommand(dir),
+        loadAgent(dir),
+        loadMode(dir),
+        loadPlugin(dir),
+      ])
+      result.command = mergeDeep(result.command ?? {}, cmd)
+      result.agent = mergeDeep(mergeDeep(result.agent, agent), mode)
+      result.plugin.push(...plugin)
     }
 
     // Inline config content overrides all non-managed config sources.

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -21,6 +21,15 @@ export namespace LSPServer {
       .then(() => true)
       .catch(() => false)
 
+  const whichCache: Record<string, string | null> = {}
+  const cachedWhich = (name: string, options?: { PATH?: string }) => {
+    const key = `${options?.PATH ?? ""}:${name}`
+    if (!(key in whichCache)) {
+      whichCache[key] = Bun.which(name, options) ?? null
+    }
+    return whichCache[key]
+  }
+
   export interface Handle {
     process: ChildProcessWithoutNullStreams
     initialization?: Record<string, any>
@@ -75,7 +84,7 @@ export namespace LSPServer {
     },
     extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
     async spawn(root) {
-      const deno = Bun.which("deno")
+      const deno = cachedWhich("deno")
       if (!deno) {
         log.info("deno not found, please install deno first")
         return
@@ -122,7 +131,7 @@ export namespace LSPServer {
     extensions: [".vue"],
     root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
     async spawn(root) {
-      let binary = Bun.which("vue-language-server")
+      let binary = cachedWhich("vue-language-server")
       const args: string[] = []
       if (!binary) {
         const js = path.join(
@@ -260,7 +269,7 @@ export namespace LSPServer {
 
       let lintBin = await resolveBin(lintTarget)
       if (!lintBin) {
-        const found = Bun.which("oxlint")
+        const found = cachedWhich("oxlint")
         if (found) lintBin = found
       }
 
@@ -281,7 +290,7 @@ export namespace LSPServer {
 
       let serverBin = await resolveBin(serverTarget)
       if (!serverBin) {
-        const found = Bun.which("oxc_language_server")
+        const found = cachedWhich("oxc_language_server")
         if (found) serverBin = found
       }
       if (serverBin) {
@@ -332,7 +341,7 @@ export namespace LSPServer {
       let bin: string | undefined
       if (await Filesystem.exists(localBin)) bin = localBin
       if (!bin) {
-        const found = Bun.which("biome")
+        const found = cachedWhich("biome")
         if (found) bin = found
       }
 
@@ -368,11 +377,11 @@ export namespace LSPServer {
     },
     extensions: [".go"],
     async spawn(root) {
-      let bin = Bun.which("gopls", {
+      let bin = cachedWhich("gopls", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
       if (!bin) {
-        if (!Bun.which("go")) return
+        if (!cachedWhich("go")) return
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
 
         log.info("installing gopls")
@@ -405,12 +414,12 @@ export namespace LSPServer {
     root: NearestRoot(["Gemfile"]),
     extensions: [".rb", ".rake", ".gemspec", ".ru"],
     async spawn(root) {
-      let bin = Bun.which("rubocop", {
+      let bin = cachedWhich("rubocop", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
       if (!bin) {
-        const ruby = Bun.which("ruby")
-        const gem = Bun.which("gem")
+        const ruby = cachedWhich("ruby")
+        const gem = cachedWhich("gem")
         if (!ruby || !gem) {
           log.info("Ruby not found, please install Ruby first")
           return
@@ -457,7 +466,7 @@ export namespace LSPServer {
         return undefined
       }
 
-      let binary = Bun.which("ty")
+      let binary = cachedWhich("ty")
 
       const initialization: Record<string, string> = {}
 
@@ -509,7 +518,7 @@ export namespace LSPServer {
     extensions: [".py", ".pyi"],
     root: NearestRoot(["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", "pyrightconfig.json"]),
     async spawn(root) {
-      let binary = Bun.which("pyright-langserver")
+      let binary = cachedWhich("pyright-langserver")
       const args = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "pyright", "dist", "pyright-langserver.js")
@@ -563,7 +572,7 @@ export namespace LSPServer {
     extensions: [".ex", ".exs"],
     root: NearestRoot(["mix.exs", "mix.lock"]),
     async spawn(root) {
-      let binary = Bun.which("elixir-ls")
+      let binary = cachedWhich("elixir-ls")
       if (!binary) {
         const elixirLsPath = path.join(Global.Path.bin, "elixir-ls")
         binary = path.join(
@@ -574,7 +583,7 @@ export namespace LSPServer {
         )
 
         if (!(await Filesystem.exists(binary))) {
-          const elixir = Bun.which("elixir")
+          const elixir = cachedWhich("elixir")
           if (!elixir) {
             log.error("elixir is required to run elixir-ls")
             return
@@ -625,12 +634,12 @@ export namespace LSPServer {
     extensions: [".zig", ".zon"],
     root: NearestRoot(["build.zig"]),
     async spawn(root) {
-      let bin = Bun.which("zls", {
+      let bin = cachedWhich("zls", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
 
       if (!bin) {
-        const zig = Bun.which("zig")
+        const zig = cachedWhich("zig")
         if (!zig) {
           log.error("Zig is required to use zls. Please install Zig first.")
           return
@@ -737,11 +746,11 @@ export namespace LSPServer {
     root: NearestRoot([".slnx", ".sln", ".csproj", "global.json"]),
     extensions: [".cs"],
     async spawn(root) {
-      let bin = Bun.which("csharp-ls", {
+      let bin = cachedWhich("csharp-ls", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
       if (!bin) {
-        if (!Bun.which("dotnet")) {
+        if (!cachedWhich("dotnet")) {
           log.error(".NET SDK is required to install csharp-ls")
           return
         }
@@ -776,11 +785,11 @@ export namespace LSPServer {
     root: NearestRoot([".slnx", ".sln", ".fsproj", "global.json"]),
     extensions: [".fs", ".fsi", ".fsx", ".fsscript"],
     async spawn(root) {
-      let bin = Bun.which("fsautocomplete", {
+      let bin = cachedWhich("fsautocomplete", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
       if (!bin) {
-        if (!Bun.which("dotnet")) {
+        if (!cachedWhich("dotnet")) {
           log.error(".NET SDK is required to install fsautocomplete")
           return
         }
@@ -817,7 +826,7 @@ export namespace LSPServer {
     async spawn(root) {
       // Check if sourcekit-lsp is available in the PATH
       // This is installed with the Swift toolchain
-      const sourcekit = Bun.which("sourcekit-lsp")
+      const sourcekit = cachedWhich("sourcekit-lsp")
       if (sourcekit) {
         return {
           process: spawn(sourcekit, {
@@ -828,7 +837,7 @@ export namespace LSPServer {
 
       // If sourcekit-lsp not found, check if xcrun is available
       // This is specific to macOS where sourcekit-lsp is typically installed with Xcode
-      if (!Bun.which("xcrun")) return
+      if (!cachedWhich("xcrun")) return
 
       const lspLoc = await $`xcrun --find sourcekit-lsp`.quiet().nothrow()
 
@@ -877,7 +886,7 @@ export namespace LSPServer {
     },
     extensions: [".rs"],
     async spawn(root) {
-      const bin = Bun.which("rust-analyzer")
+      const bin = cachedWhich("rust-analyzer")
       if (!bin) {
         log.info("rust-analyzer not found in path, please install it")
         return
@@ -896,7 +905,7 @@ export namespace LSPServer {
     extensions: [".c", ".cpp", ".cc", ".cxx", ".c++", ".h", ".hpp", ".hh", ".hxx", ".h++"],
     async spawn(root) {
       const args = ["--background-index", "--clang-tidy"]
-      const fromPath = Bun.which("clangd")
+      const fromPath = cachedWhich("clangd")
       if (fromPath) {
         return {
           process: spawn(fromPath, args, {
@@ -1041,7 +1050,7 @@ export namespace LSPServer {
     extensions: [".svelte"],
     root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
     async spawn(root) {
-      let binary = Bun.which("svelteserver")
+      let binary = cachedWhich("svelteserver")
       const args: string[] = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "svelte-language-server", "bin", "server.js")
@@ -1088,7 +1097,7 @@ export namespace LSPServer {
       }
       const tsdk = path.dirname(tsserver)
 
-      let binary = Bun.which("astro-ls")
+      let binary = cachedWhich("astro-ls")
       const args: string[] = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "@astrojs", "language-server", "bin", "nodeServer.js")
@@ -1132,7 +1141,7 @@ export namespace LSPServer {
     root: NearestRoot(["pom.xml", "build.gradle", "build.gradle.kts", ".project", ".classpath"]),
     extensions: [".java"],
     async spawn(root) {
-      const java = Bun.which("java")
+      const java = cachedWhich("java")
       if (!java) {
         log.error("Java 21 or newer is required to run the JDTLS. Please install it first.")
         return
@@ -1324,7 +1333,7 @@ export namespace LSPServer {
     extensions: [".yaml", ".yml"],
     root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
     async spawn(root) {
-      let binary = Bun.which("yaml-language-server")
+      let binary = cachedWhich("yaml-language-server")
       const args: string[] = []
       if (!binary) {
         const js = path.join(
@@ -1380,7 +1389,7 @@ export namespace LSPServer {
     ]),
     extensions: [".lua"],
     async spawn(root) {
-      let bin = Bun.which("lua-language-server", {
+      let bin = cachedWhich("lua-language-server", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
 
@@ -1512,7 +1521,7 @@ export namespace LSPServer {
     extensions: [".php"],
     root: NearestRoot(["composer.json", "composer.lock", ".php-version"]),
     async spawn(root) {
-      let binary = Bun.which("intelephense")
+      let binary = cachedWhich("intelephense")
       const args: string[] = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "intelephense", "lib", "intelephense.js")
@@ -1556,7 +1565,7 @@ export namespace LSPServer {
     extensions: [".prisma"],
     root: NearestRoot(["schema.prisma", "prisma/schema.prisma", "prisma"], ["package.json"]),
     async spawn(root) {
-      const prisma = Bun.which("prisma")
+      const prisma = cachedWhich("prisma")
       if (!prisma) {
         log.info("prisma not found, please install prisma")
         return
@@ -1574,7 +1583,7 @@ export namespace LSPServer {
     extensions: [".dart"],
     root: NearestRoot(["pubspec.yaml", "analysis_options.yaml"]),
     async spawn(root) {
-      const dart = Bun.which("dart")
+      const dart = cachedWhich("dart")
       if (!dart) {
         log.info("dart not found, please install dart first")
         return
@@ -1592,7 +1601,7 @@ export namespace LSPServer {
     extensions: [".ml", ".mli"],
     root: NearestRoot(["dune-project", "dune-workspace", ".merlin", "opam"]),
     async spawn(root) {
-      const bin = Bun.which("ocamllsp")
+      const bin = cachedWhich("ocamllsp")
       if (!bin) {
         log.info("ocamllsp not found, please install ocaml-lsp-server")
         return
@@ -1609,7 +1618,7 @@ export namespace LSPServer {
     extensions: [".sh", ".bash", ".zsh", ".ksh"],
     root: async () => Instance.directory,
     async spawn(root) {
-      let binary = Bun.which("bash-language-server")
+      let binary = cachedWhich("bash-language-server")
       const args: string[] = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "bash-language-server", "out", "cli.js")
@@ -1648,7 +1657,7 @@ export namespace LSPServer {
     extensions: [".tf", ".tfvars"],
     root: NearestRoot([".terraform.lock.hcl", "terraform.tfstate", "*.tf"]),
     async spawn(root) {
-      let bin = Bun.which("terraform-ls", {
+      let bin = cachedWhich("terraform-ls", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
 
@@ -1731,7 +1740,7 @@ export namespace LSPServer {
     extensions: [".tex", ".bib"],
     root: NearestRoot([".latexmkrc", "latexmkrc", ".texlabroot", "texlabroot"]),
     async spawn(root) {
-      let bin = Bun.which("texlab", {
+      let bin = cachedWhich("texlab", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
 
@@ -1821,7 +1830,7 @@ export namespace LSPServer {
     extensions: [".dockerfile", "Dockerfile"],
     root: async () => Instance.directory,
     async spawn(root) {
-      let binary = Bun.which("docker-langserver")
+      let binary = cachedWhich("docker-langserver")
       const args: string[] = []
       if (!binary) {
         const js = path.join(Global.Path.bin, "node_modules", "dockerfile-language-server-nodejs", "lib", "server.js")
@@ -1860,7 +1869,7 @@ export namespace LSPServer {
     extensions: [".gleam"],
     root: NearestRoot(["gleam.toml"]),
     async spawn(root) {
-      const gleam = Bun.which("gleam")
+      const gleam = cachedWhich("gleam")
       if (!gleam) {
         log.info("gleam not found, please install gleam first")
         return
@@ -1878,9 +1887,9 @@ export namespace LSPServer {
     extensions: [".clj", ".cljs", ".cljc", ".edn"],
     root: NearestRoot(["deps.edn", "project.clj", "shadow-cljs.edn", "bb.edn", "build.boot"]),
     async spawn(root) {
-      let bin = Bun.which("clojure-lsp")
+      let bin = cachedWhich("clojure-lsp")
       if (!bin && process.platform === "win32") {
-        bin = Bun.which("clojure-lsp.exe")
+        bin = cachedWhich("clojure-lsp.exe")
       }
       if (!bin) {
         log.info("clojure-lsp not found, please install clojure-lsp first")
@@ -1909,7 +1918,7 @@ export namespace LSPServer {
       return Instance.directory
     },
     async spawn(root) {
-      const nixd = Bun.which("nixd")
+      const nixd = cachedWhich("nixd")
       if (!nixd) {
         log.info("nixd not found, please install nixd first")
         return
@@ -1930,7 +1939,7 @@ export namespace LSPServer {
     extensions: [".typ", ".typc"],
     root: NearestRoot(["typst.toml"]),
     async spawn(root) {
-      let bin = Bun.which("tinymist", {
+      let bin = cachedWhich("tinymist", {
         PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
       })
 
@@ -2024,7 +2033,7 @@ export namespace LSPServer {
     extensions: [".hs", ".lhs"],
     root: NearestRoot(["stack.yaml", "cabal.project", "hie.yaml", "*.cabal"]),
     async spawn(root) {
-      const bin = Bun.which("haskell-language-server-wrapper")
+      const bin = cachedWhich("haskell-language-server-wrapper")
       if (!bin) {
         log.info("haskell-language-server-wrapper not found, please install haskell-language-server")
         return
@@ -2042,7 +2051,7 @@ export namespace LSPServer {
     extensions: [".jl"],
     root: NearestRoot(["Project.toml", "Manifest.toml", "*.jl"]),
     async spawn(root) {
-      const julia = Bun.which("julia")
+      const julia = cachedWhich("julia")
       if (!julia) {
         log.info("julia not found, please install julia first (https://julialang.org/downloads/)")
         return

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -57,11 +57,11 @@ export const Instance = {
    * Paths within the worktree but outside the working directory should not trigger external_directory permission.
    */
   containsPath(filepath: string) {
-    if (Filesystem.contains(Instance.directory, filepath)) return true
+    if (Filesystem.containsSafe(Instance.directory, filepath)) return true
     // Non-git projects set worktree to "/" which would match ANY absolute path.
     // Skip worktree check in this case to preserve external_directory permissions.
     if (Instance.worktree === "/") return false
-    return Filesystem.contains(Instance.worktree, filepath)
+    return Filesystem.containsSafe(Instance.worktree, filepath)
   },
   state<S>(init: () => S, dispose?: (state: Awaited<S>) => Promise<void>): () => S {
     return State.create(() => Instance.directory, init, dispose)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -105,7 +105,7 @@ export namespace Provider {
     "@ai-sdk/perplexity": createPerplexity,
     "@ai-sdk/vercel": createVercel,
     "@gitlab/gitlab-ai-provider": createGitLab,
-    // @ts-ignore (TODO: kill this code so we dont have to maintain it)
+    // @ts-ignore Legacy: GitHub Copilot provider type mismatch - needed for copilot plugin integration
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
   }
 
@@ -1064,7 +1064,14 @@ export namespace Provider {
           ...model.headers,
         }
 
-      const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
+      const cacheableOptions = {
+        baseURL: options["baseURL"],
+        apiKey: options["apiKey"],
+        headers: options["headers"],
+        includeUsage: options["includeUsage"],
+        timeout: options["timeout"],
+      }
+      const key = Bun.hash.xxHash32(model.providerID + model.api.npm + JSON.stringify(cacheableOptions))
       const existing = s.sdk.get(key)
       if (existing) return existing
 
@@ -1090,16 +1097,19 @@ export namespace Provider {
         // Message, Reasoning, FunctionCall, LocalShellCall, CustomToolCall, WebSearchCall
         // IDs are only re-attached for Azure with store=true
         if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {
-          const body = JSON.parse(opts.body as string)
           const isAzure = model.providerID.includes("azure")
-          const keepIds = isAzure && body.store === true
-          if (!keepIds && Array.isArray(body.input)) {
-            for (const item of body.input) {
-              if ("id" in item) {
-                delete item.id
+          if (!isAzure) {
+            const body = JSON.parse(opts.body as string)
+            if (Array.isArray(body.input)) {
+              let modified = false
+              for (const item of body.input) {
+                if ("id" in item) {
+                  delete item.id
+                  modified = true
+                }
               }
+              if (modified) opts.body = JSON.stringify(body)
             }
-            opts.body = JSON.stringify(body)
           }
         }
 

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -135,6 +135,15 @@ export namespace Filesystem {
     return !relative(parent, child).startsWith("..")
   }
 
+  export function containsSafe(parent: string, child: string) {
+    try {
+      const realChild = realpathSync(child)
+      return contains(parent, realChild)
+    } catch {
+      return contains(parent, child)
+    }
+  }
+
   export async function findUp(target: string, start: string, stop?: string) {
     let current = start
     const result = []

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -17,19 +17,26 @@ export namespace Rpc {
     postMessage(JSON.stringify({ type: "rpc.event", event, data }))
   }
 
-  export function client<T extends Definition>(target: {
-    postMessage: (data: string) => void | null
-    onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
-  }) {
-    const pending = new Map<number, (result: any) => void>()
+  const DEFAULT_TIMEOUT = 30_000
+
+  export function client<T extends Definition>(
+    target: {
+      postMessage: (data: string) => void | null
+      onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
+    },
+    options?: { timeout?: number },
+  ) {
+    const timeout = options?.timeout ?? DEFAULT_TIMEOUT
+    const pending = new Map<number, { resolve: (result: any) => void; timer: ReturnType<typeof setTimeout> }>()
     const listeners = new Map<string, Set<(data: any) => void>>()
     let id = 0
     target.onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.result") {
-        const resolve = pending.get(parsed.id)
-        if (resolve) {
-          resolve(parsed.result)
+        const entry = pending.get(parsed.id)
+        if (entry) {
+          clearTimeout(entry.timer)
+          entry.resolve(parsed.result)
           pending.delete(parsed.id)
         }
       }
@@ -46,7 +53,11 @@ export namespace Rpc {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
         const requestId = id++
         return new Promise((resolve) => {
-          pending.set(requestId, resolve)
+          const timer = setTimeout(() => {
+            pending.delete(requestId)
+            resolve(undefined as any)
+          }, timeout)
+          pending.set(requestId, { resolve, timer })
           target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
         })
       },


### PR DESCRIPTION
## Summary

Closes #15708

### Changes

### config/config.ts
- Load command, agent, mode, and plugin configs in parallel using `Promise.all`

### lsp/server.ts
- Add `cachedWhich` function to cache results of `Bun.which` lookups
- Replace all `Bun.which` calls with `cachedWhich` for LSP server spawning

### project/instance.ts
- Use `containsSafe` instead of `contains` to handle symlinks properly

### provider/provider.ts
- Optimize SDK cache key generation to only include cacheable options
- Fix Azure-specific logic to skip certain processing for non-Azure providers

### util/filesystem.ts
- Add `containsSafe` function that handles symlinks by using `realpathSync`

### util/rpc.ts
- Add timeout support to RPC client with default of 30 seconds