### PR TITLE
docs: Add filtering subagents notifications to plugin example

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -225,6 +225,12 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
+        // Filter out notifications from subagents
+        const result = await client.session.get({
+          path: { id: event.properties.sessionID },
+        })
+        if (result.error || result.data.parentID) return
+
         await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
       }
     },


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

I feel that one of the most common (maybe *the* most common) use-cases of plugins is to send a notification when the agent is done and waiting for input. Originally the example of a notification plugin in the docs did exactly this. Nowadays with subagents the same example ends up displaying a notification also whenever a subagent is done but the primary agent is not, meaning it is not waiting for input.

While this might be useful for some people, I feel that a notification only when the primary agent is done would be much more useful, so I think it makes sense to update the docs accordingly.

### How did you verify your code works?

Tested this plugin while running opencode with subagents.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
