### PR TITLE
fix(project): use working directory instead of / as fallback for non-git projects

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -197,8 +197,8 @@ export namespace Project {
 
       return {
         id: "global",
-        worktree: "/",
-        sandbox: "/",
+        worktree: directory,
+        sandbox: directory,
         vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
       }
     })


### PR DESCRIPTION
## Issue for this PR

Closes #15719

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

`Project.fromDirectory()` has a fallback when no `.git` is found: it hardcodes `worktree` and `sandbox` to `"/"`. This means the recent projects list shows `/` for any non-git directory.

The fix replaces `"/"` with the `directory` argument already available in scope, so the project path reflects the actual working directory.

## How did you verify your code works?

Started opencode in a non-git directory (`/home/agent/projects`). Before the fix, recent projects showed `/`. After the fix, it correctly shows `/home/agent/projects`.

## Screenshots / recordings

N/A — no UI change, only the displayed path value changes.

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR