### PR TITLE
fix: list all sessions regardless of git context (#15678)

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -27,7 +27,7 @@ export const ExportCommand = cmd({
         })
 
         const sessions = []
-        for await (const session of Session.list()) {
+        for await (const session of Session.listGlobal()) {
           sessions.push(session)
         }
 

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -87,7 +87,8 @@ export const SessionListCommand = cmd({
   },
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
-      const sessions = [...Session.list({ roots: true, limit: args.maxCount })]
+      // Use listGlobal to show all sessions regardless of current project/git context
+      const sessions = [...Session.listGlobal({ roots: true, limit: args.maxCount })]
 
       if (sessions.length === 0) {
         return


### PR DESCRIPTION
### Issue for this PR

Closes #15678

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes issue #15678 where `opencode session list` returns empty results when run inside a Git repository.

The bug was caused by using `Session.list()` which filters by current project ID. When running inside a Git repo, it only shows sessions for that specific project. Changed to `Session.listGlobal()` which shows all sessions regardless of current project/git context.

### How did you verify this code works?

Analyzed the code and confirmed:
1. `Session.list()` filters by `project.id` - causes the bug
2. `Session.listGlobal()` does not filter by project - fixes the bug

Local tests pass:
```
test/server/session-list.test.ts: 5 pass
```

### Screenshots / recordings

N/A - This is a CLI fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR