### PR TITLE
feat(ecosystem): add knowledge-server plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -67,6 +67,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [knowledge-server](https://github.com/MAnders333/knowledge-server)                         | Local semantic knowledge graph that extracts knowledge from session history and injects relevant entries as passive context |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds knowledge-server to the Projects section of the ecosystem page.

knowledge-server is a local server that reads OpenCode session history, extracts durable knowledge entries via LLM, and injects semantically relevant entries as passive context on each new message via the `chat.message` hook.

### How did you verify your code works?

Verified the link is correct and the entry renders properly in the table.

### Screenshots / recordings

_N/A — documentation change only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR