### PR TITLE
fix: permission config deny rules not working with wildcard ask (#15664)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -212,7 +212,7 @@ export namespace Config {
         }
         perms[tool] = action
       }
-      result.permission = mergeDeep(perms, result.permission ?? {})
+      result.permission = mergeDeep(result.permission ?? {}, perms)
     }
 
     if (!result.username) result.username = os.userInfo().username


### PR DESCRIPTION
### Issue for this PR

Closes #15664

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes issue where tools config deny rules are silently overridden by wildcard ask rule in permission config.

The fix changes the merge order in config.ts. Previously mergeDeep(perms, result.permission) placed tool deny rules BEFORE user config rules. Changed to mergeDeep(result.permission ?? {}, perms) so user config comes first.

### How did you verify your code works?

Analyzed the code and confirmed the merge order issue.

Local tests pass:
test/permission/next.test.ts: 62 pass

### Screenshots / recordings

N/A - This is a backend fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR