### PR TITLE
fix(project): use working directory instead of / as fallback for non-git projects

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -197,8 +197,8 @@ export namespace Project {
 
       return {
         id: "global",
-        worktree: "/",
-        sandbox: "/",
+        worktree: directory,
+        sandbox: directory,
         vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
       }
     })


### PR DESCRIPTION
### Issue for this PR

Closes #14445 
Closes #15719

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `Project.fromDirectory()` cannot find a `.git` directory, it falls back to hardcoded `"/"` for the `worktree` and `sandbox` fields. This causes the recent projects list to display `/` for any non-git directory, which is confusing and incorrect.

This fix replaces the hardcoded `"/"` with the `directory` argument that is already available in scope, so the project path correctly reflects the actual working directory.

### How did you verify your code works?

Started opencode in a non-git directory (`/home/agent/projects`). Before the fix, recent projects showed `/`. After the fix, it correctly shows `/home/agent/projects`.

### Screenshots / recordings

N/A — no UI change, only the displayed path value changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR