### PR TITLE
feat(tui): add Subagents section to session sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -25,6 +25,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     diff: true,
     todo: true,
     lsp: true,
+    subagents: true,
   })
 
   // Sort MCP servers alphabetically for consistent display order
@@ -62,6 +63,13 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
 
   const directory = useDirectory()
   const kv = useKV()
+
+  const subagents = createMemo(() =>
+    sync.data.session
+      .filter((x) => x.parentID === props.sessionID)
+      .map((x) => x.id)
+      .toSorted((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+  )
 
   const hasProviders = createMemo(() =>
     sync.data.provider.some((x) => x.id !== "opencode" || Object.values(x.models).some((y) => y.cost?.input !== 0)),
@@ -226,6 +234,53 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </box>
                 <Show when={todo().length <= 2 || expanded.todo}>
                   <For each={todo()}>{(todo) => <TodoItem status={todo.status} content={todo.content} />}</For>
+                </Show>
+              </box>
+            </Show>
+            <Show when={subagents().length > 0}>
+              <box>
+                <box
+                  flexDirection="row"
+                  gap={1}
+                  onMouseDown={() => subagents().length > 2 && setExpanded("subagents", !expanded.subagents)}
+                >
+                  <Show when={subagents().length > 2}>
+                    <text fg={theme.text}>{expanded.subagents ? "▼" : "▶"}</text>
+                  </Show>
+                  <text fg={theme.text}>
+                    <b>Subagents</b>
+                    <Show when={!expanded.subagents}>
+                      <span style={{ fg: theme.textMuted }}> ({subagents().length})</span>
+                    </Show>
+                  </text>
+                </box>
+                <Show when={subagents().length <= 2 || expanded.subagents}>
+                  <For each={subagents()}>
+                    {(id) => {
+                      const status = createMemo(() => sync.session.status(id))
+                      const title = createMemo(() => sync.session.get(id)?.title ?? id)
+                      return (
+                        <box flexDirection="row" gap={1}>
+                          <text
+                            flexShrink={0}
+                            style={{
+                              fg: status() === "idle" ? theme.success : theme.warning,
+                            }}
+                          >
+                            •
+                          </text>
+                          <box flexGrow={1}>
+                            <text fg={theme.text} wrapMode="word">
+                              {title()}
+                            </text>
+                            <text fg={theme.textMuted}>
+                              {status() === "idle" ? "idle" : "working"}
+                            </text>
+                          </box>
+                        </box>
+                      )
+                    }}
+                  </For>
                 </Show>
               </box>
             </Show>


### PR DESCRIPTION
Show live status of child sessions spawned by the parent agent in the sidebar, including title, and working/idle state. Section is collapsible when more than 2 subagents are present.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When context is too long, it's becomes hard to keep track of each subagent's status, then I add a component in the sidebar to keep track of each subagent and corresponding task.

### How did you verify your code works?
I build the binary locally and test it by calling some subagents.

### Screenshots / recordings
<img width="2560" height="1306" alt="Snipaste_2026-03-02_23-36-57" src="https://github.com/user-attachments/assets/91437ed5-6596-4e57-bd33-1e6584d4fca6" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
