### PR TITLE
feat: Native Multimodal Context Support (Video/Audio) for Gemini

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -6,7 +6,9 @@ import { uuid } from "@/utils/uuid"
 import { getCursorPosition } from "./editor-dom"
 
 export const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
-export const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
+export const ACCEPTED_VIDEO_TYPES = ["video/mp4", "video/webm", "video/quicktime", "video/mpeg", "video/x-msvideo", "video/x-matroska"]
+export const ACCEPTED_AUDIO_TYPES = ["audio/mpeg", "audio/wav", "audio/ogg", "audio/webm", "audio/m4a", "audio/mp4", "audio/aac", "audio/flac"]
+export const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, ...ACCEPTED_VIDEO_TYPES, ...ACCEPTED_AUDIO_TYPES, "application/pdf"]
 const LARGE_PASTE_CHARS = 8000
 const LARGE_PASTE_BREAKS = 120
 


### PR DESCRIPTION
Closes #10531.

This PR adds native support for Gemini video and audio multimodal context by allowing users to select and attach video and audio file types. 

The OpenCode backend (`ProviderTransform.message`) and the underlying Vercel AI SDK (`@ai-sdk/google`) natively process and attach these as standard file parts. All that was needed was expanding the allowed file types in the frontend UI.

Testing:
- Drag & Drop an .mp4 video into OpenCode. It will render natively using the existing file attachment UI and be parsed natively through the pipeline to the provider.