### PR TITLE
feat(plugin): add session webview bridge and file write actions

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -12,6 +12,7 @@ import { createEffect, createMemo, For, onCleanup, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 import { useCommand } from "@/context/command"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { usePlatform } from "@/context/platform"
@@ -23,6 +24,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { messageAgentColor } from "@/utils/agent"
 import { decode64 } from "@/utils/base64"
 import { Persist, persisted } from "@/utils/persist"
+import { resolveSessionPluginUI } from "@/utils/plugin-ui"
 import { StatusPopover } from "../status-popover"
 
 const OPEN_APPS = [
@@ -131,6 +133,7 @@ const showRequestError = (language: ReturnType<typeof useLanguage>, err: unknown
 export function SessionHeader() {
   const layout = useLayout()
   const command = useCommand()
+  const globalSDK = useGlobalSDK()
   const server = useServer()
   const platform = usePlatform()
   const language = useLanguage()
@@ -139,6 +142,8 @@ export function SessionHeader() {
   const { params, view } = useSessionLayout()
 
   const projectDirectory = createMemo(() => decode64(params.dir) ?? "")
+  const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
+  const tabs = createMemo(() => layout.tabs(sessionKey))
   const project = createMemo(() => {
     const directory = projectDirectory()
     if (!directory) return
@@ -151,6 +156,8 @@ export function SessionHeader() {
   })
   const hotkey = createMemo(() => command.keybind("file.open"))
   const os = createMemo(() => detectOS(platform))
+  const pluginUI = createMemo(() => resolveSessionPluginUI(sync.data.config, projectDirectory(), globalSDK.url))
+  const webButtons = createMemo(() => pluginUI().buttons)
 
   const [exists, setExists] = createStore<Partial<Record<OpenApp, boolean>>>({
     finder: true,
@@ -260,6 +267,11 @@ export function SessionHeader() {
         })
       })
       .catch((err: unknown) => showRequestError(language, err))
+  }
+
+  const openWebTab = (tab: string) => {
+    view().reviewPanel.open()
+    tabs().open(tab)
   }
 
   const centerMount = createMemo(() => document.getElementById("opencode-titlebar-center"))
@@ -418,6 +430,18 @@ export function SessionHeader() {
                 <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
                   <StatusPopover />
                 </Tooltip>
+                <For each={webButtons()}>
+                  {(button) => (
+                    <Button
+                      variant="ghost"
+                      class="hidden md:flex h-[24px] px-2 rounded-md border border-border-base bg-surface-panel text-text-strong"
+                      onClick={() => openWebTab(button.tab)}
+                      aria-label={`Open ${button.label}`}
+                    >
+                      <span class="text-12-regular">{button.label}</span>
+                    </Button>
+                  )}
+                </For>
                 <TooltipKeybind
                   title={language.t("command.terminal.toggle")}
                   keybind={command.keybind("terminal.toggle")}

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -60,6 +60,12 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     const layout = useLayout()
 
     const scope = createMemo(() => sdk.directory)
+    const encodedDirectory = createMemo(() => {
+      const value = sdk.directory
+      if (!value) return ""
+      const isNonASCII = /[^\x00-\x7F]/.test(value)
+      return isNonASCII ? encodeURIComponent(value) : value
+    })
     const path = createPathHelpers(scope)
     const tabs = layout.tabs(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
 
@@ -200,6 +206,55 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
         () => [],
       )
 
+    const write = async (input: { path: string; content: string }) => {
+      const file = path.normalize(input.path)
+      if (!file) throw new Error("Invalid path")
+
+      const url = new URL("/file/content", sdk.url)
+      url.searchParams.set("path", file)
+
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "x-opencode-directory": encodedDirectory(),
+        },
+        body: JSON.stringify({ content: input.content }),
+      })
+
+      if (!response.ok) {
+        const message = await response.text().catch(() => "")
+        throw new Error(message || `Failed to write ${file}`)
+      }
+
+      const result = (await response.json().catch(() => ({ path: file, hash: "" }))) as {
+        path: string
+        hash: string
+      }
+
+      const next = {
+        type: "text",
+        content: input.content,
+      } as const
+
+      setStore(
+        "file",
+        file,
+        produce((draft) => {
+          draft.path = file
+          draft.name = getFilename(file)
+          draft.loaded = true
+          draft.loading = false
+          draft.error = undefined
+          draft.content = next
+        }),
+      )
+
+      touchFileContent(file, approxBytes(next))
+      evictContent(new Set([file]))
+      return result
+    }
+
     const stop = sdk.event.listen((e) => {
       invalidateFromWatcher(e.details, {
         normalize: path.normalize,
@@ -267,6 +322,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       },
       get,
       load,
+      write,
       scrollTop,
       scrollLeft,
       setScrollTop,

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -30,6 +30,7 @@ import { checksum } from "@opencode-ai/util/encode"
 import { useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
+import { useGlobalSDK } from "@/context/global-sdk"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -58,6 +59,7 @@ import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
 import { Persist, persisted } from "@/utils/persist"
+import { resolveSessionPluginUI } from "@/utils/plugin-ui"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
@@ -313,6 +315,7 @@ function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
 }
 
 export default function Page() {
+  const globalSDK = useGlobalSDK()
   const globalSync = useGlobalSync()
   const layout = useLayout()
   const local = useLocal()
@@ -429,12 +432,16 @@ export default function Page() {
   const reviewCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
   const hasReview = createMemo(() => reviewCount() > 0)
   const reviewTab = createMemo(() => isDesktop())
+  const pluginUI = createMemo(() => resolveSessionPluginUI(sync.data.config, sdk.directory, globalSDK.url))
+  const webTabs = createMemo(() => pluginUI().tabs)
+  const webSet = createMemo(() => new Set(webTabs().map((tab) => tab.tab)))
   const tabState = createSessionTabs({
     tabs,
     pathFromTab: file.pathFromTab,
     normalizeTab,
     review: reviewTab,
     hasReview,
+    isExtraTab: (tab) => webSet().has(tab),
   })
   const contextOpen = tabState.contextOpen
   const openedTabs = tabState.openedTabs
@@ -1865,6 +1872,8 @@ export default function Page() {
           focusReviewDiff={focusReviewDiff}
           reviewSnap={ui.reviewSnap}
           size={size}
+          webTabs={webTabs}
+          directory={sdk.directory}
         />
       </div>
 

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -15,6 +15,7 @@ type TabsInput = {
   normalizeTab: (tab: string) => string
   review?: Accessor<boolean>
   hasReview?: Accessor<boolean>
+  isExtraTab?: (tab: string) => boolean
 }
 
 export const getSessionKey = (dir: string | undefined, id: string | undefined) => `${dir ?? ""}${id ? `/${id}` : ""}`
@@ -22,6 +23,7 @@ export const getSessionKey = (dir: string | undefined, id: string | undefined) =
 export const createSessionTabs = (input: TabsInput) => {
   const review = input.review ?? (() => false)
   const hasReview = input.hasReview ?? (() => false)
+  const isExtra = input.isExtraTab ?? (() => false)
   const contextOpen = createMemo(() => input.tabs().active() === "context" || input.tabs().all().includes("context"))
   const openedTabs = createMemo(
     () => {
@@ -31,6 +33,8 @@ export const createSessionTabs = (input: TabsInput) => {
         .all()
         .flatMap((tab) => {
           if (tab === "context" || tab === "review") return []
+          if (isExtra(tab)) return []
+          if (!input.pathFromTab(tab)) return []
           const value = input.pathFromTab(tab) ? input.normalizeTab(tab) : tab
           if (seen.has(value)) return []
           seen.add(value)
@@ -44,10 +48,16 @@ export const createSessionTabs = (input: TabsInput) => {
     const active = input.tabs().active()
     if (active === "context") return active
     if (active === "review" && review()) return active
+    if (active && isExtra(active)) return active
     if (active && input.pathFromTab(active)) return input.normalizeTab(active)
 
     const first = openedTabs()[0]
     if (first) return first
+    const extra = input
+      .tabs()
+      .all()
+      .find((tab) => isExtra(tab))
+    if (extra) return extra
     if (contextOpen()) return "context"
     if (review() && hasReview()) return "review"
     return "empty"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -24,6 +24,20 @@ import { FileTabContent } from "@/pages/session/file-tabs"
 import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type Sizing } from "@/pages/session/helpers"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import type { PluginWebTab } from "@/utils/plugin-ui"
+import { hashText, inScopes, isAllowedOrigin, normalizeBridgePath } from "@/pages/session/webview-bridge"
+
+type WebviewRequest = {
+  type: "opencode.bridge.request"
+  requestId: string
+  action: "file.read" | "file.write"
+  token: string
+  payload?: {
+    path?: string
+    content?: string
+    expectedHash?: string
+  }
+}
 
 export function SessionSidePanel(props: {
   reviewPanel: () => JSX.Element
@@ -31,6 +45,8 @@ export function SessionSidePanel(props: {
   focusReviewDiff: (path: string) => void
   reviewSnap: boolean
   size: Sizing
+  webTabs: () => PluginWebTab[]
+  directory: string
 }) {
   const layout = useLayout()
   const sync = useSync()
@@ -39,6 +55,164 @@ export function SessionSidePanel(props: {
   const command = useCommand()
   const dialog = useDialog()
   const { params, sessionKey, tabs, view } = useSessionLayout()
+  const frames = new Map<string, HTMLIFrameElement>()
+  const tokens = new Map<string, string>()
+
+  const isRequest = (value: unknown): value is WebviewRequest => {
+    if (!value || typeof value !== "object") return false
+    if (!("type" in value) || value.type !== "opencode.bridge.request") return false
+    if (!("requestId" in value) || typeof value.requestId !== "string") return false
+    if (!("action" in value)) return false
+    if (value.action !== "file.read" && value.action !== "file.write") return false
+    if (!("token" in value) || typeof value.token !== "string") return false
+    return true
+  }
+
+  const tabsByKey = createMemo(() => {
+    const map = new Map<string, PluginWebTab>()
+    for (const tab of props.webTabs()) map.set(tab.tab, tab)
+    return map
+  })
+
+  const webSet = createMemo(() => new Set(props.webTabs().map((tab) => tab.tab)))
+
+  const tokenFor = (tab: string) => {
+    const current = tokens.get(tab)
+    if (current) return current
+    const next = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    tokens.set(tab, next)
+    return next
+  }
+
+  const postResponse = (input: {
+    source: MessageEventSource | null
+    requestId: string
+    ok: boolean
+    payload?: unknown
+    error?: string
+  }) => {
+    const target = input.source
+    if (!target || typeof (target as Window).postMessage !== "function") return
+    ;(target as Window).postMessage(
+      {
+        type: "opencode.bridge.response",
+        requestId: input.requestId,
+        ok: input.ok,
+        payload: input.payload,
+        error: input.error,
+      },
+      "*",
+    )
+  }
+
+  const resolveTabBySource = (source: MessageEventSource | null) => {
+    for (const [tab, frame] of frames.entries()) {
+      if (frame.contentWindow !== source) continue
+      return tab
+    }
+  }
+
+  const postReady = (tab: string) => {
+    const frame = frames.get(tab)
+    const cfg = tabsByKey().get(tab)
+    if (!frame || !cfg || !frame.contentWindow) return
+    frame.contentWindow.postMessage(
+      {
+        type: "opencode.bridge.ready",
+        token: tokenFor(tab),
+      },
+      "*",
+    )
+  }
+
+  createEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (!isRequest(event.data)) return
+      const tab = resolveTabBySource(event.source)
+      if (!tab) return
+      const cfg = tabsByKey().get(tab)
+      if (!cfg) return
+      if (!isAllowedOrigin(event.origin, cfg.origins)) return
+      if (event.data.token !== tokenFor(tab)) return
+
+      const run = async () => {
+        const raw = event.data.payload?.path
+        const path = normalizeBridgePath(props.directory, typeof raw === "string" ? raw : "")
+        if (!path) {
+          postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "Invalid path" })
+          return
+        }
+
+        if (event.data.action === "file.read") {
+          if (!inScopes(path, cfg.permissions.file.read)) {
+            postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "Read blocked" })
+            return
+          }
+          await file.load(path)
+          const state = file.get(path)
+          const content = state?.content
+          if (!content || content.type !== "text") {
+            postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "File unreadable" })
+            return
+          }
+          const hash = await hashText(content.content)
+          postResponse({
+            source: event.source,
+            requestId: event.data.requestId,
+            ok: true,
+            payload: {
+              path,
+              content: content.content,
+              hash,
+            },
+          })
+          return
+        }
+
+        if (!inScopes(path, cfg.permissions.file.write)) {
+          postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "Write blocked" })
+          return
+        }
+
+        const next = event.data.payload?.content
+        if (typeof next !== "string") {
+          postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "Invalid content" })
+          return
+        }
+
+        const expected = event.data.payload?.expectedHash
+        if (expected) {
+          await file.load(path)
+          const state = file.get(path)
+          const current = state?.content
+          if (!current || current.type !== "text") {
+            postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "File unreadable" })
+            return
+          }
+          const hash = await hashText(current.content)
+          if (hash !== expected) {
+            postResponse({ source: event.source, requestId: event.data.requestId, ok: false, error: "Hash mismatch" })
+            return
+          }
+        }
+
+        const wrote = await file.write({ path, content: next })
+        postResponse({ source: event.source, requestId: event.data.requestId, ok: true, payload: wrote })
+      }
+
+      void run().catch((err) => {
+        postResponse({
+          source: event.source,
+          requestId: event.data.requestId,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+    }
+
+    window.addEventListener("message", handler)
+    onCleanup(() => window.removeEventListener("message", handler))
+  })
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
@@ -130,12 +304,23 @@ export function SessionSidePanel(props: {
     setActive: tabs().setActive,
   })
 
+  const openPanelTab = (value: string) => {
+    if (webSet().has(value)) {
+      tabs().open(value)
+      tabs().setActive(value)
+      openReviewPanel()
+      return
+    }
+    openTab(value)
+  }
+
   const tabState = createSessionTabs({
     tabs,
     pathFromTab: file.pathFromTab,
     normalizeTab,
     review: reviewTab,
     hasReview,
+    isExtraTab: (tab) => webSet().has(tab),
   })
   const contextOpen = tabState.contextOpen
   const openedTabs = tabState.openedTabs
@@ -232,7 +417,7 @@ export function SessionSidePanel(props: {
               >
                 <DragDropSensors />
                 <ConstrainDragYAxis />
-                <Tabs value={activeTab()} onChange={openTab}>
+                <Tabs value={activeTab()} onChange={openPanelTab}>
                   <div class="sticky top-0 shrink-0 flex">
                     <Tabs.List
                       ref={(el: HTMLDivElement) => {
@@ -278,6 +463,15 @@ export function SessionSidePanel(props: {
                           </div>
                         </Tabs.Trigger>
                       </Show>
+                      <For each={props.webTabs()}>
+                        {(tab) => (
+                          <Tabs.Trigger value={tab.tab}>
+                            <div class="flex items-center gap-2">
+                              <div>{tab.title}</div>
+                            </div>
+                          </Tabs.Trigger>
+                        )}
+                      </For>
                       <SortableProvider ids={openedTabs()}>
                         <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
                       </SortableProvider>
@@ -332,6 +526,28 @@ export function SessionSidePanel(props: {
                       </Show>
                     </Tabs.Content>
                   </Show>
+
+                  <For each={props.webTabs()}>
+                    {(tab) => (
+                      <Tabs.Content value={tab.tab} class="flex flex-col h-full overflow-hidden contain-strict">
+                        <Show when={activeTab() === tab.tab}>
+                          <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
+                            <iframe
+                              ref={(el) => {
+                                if (el) frames.set(tab.tab, el)
+                                else frames.delete(tab.tab)
+                              }}
+                              src={tab.src}
+                              class="size-full border-0 bg-background-base"
+                              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+                              loading="lazy"
+                              onLoad={() => postReady(tab.tab)}
+                            />
+                          </div>
+                        </Show>
+                      </Tabs.Content>
+                    )}
+                  </For>
 
                   <Show when={activeFileTab()} keyed>
                     {(tab) => <FileTabContent tab={tab} />}

--- a/packages/app/src/pages/session/webview-bridge.test.ts
+++ b/packages/app/src/pages/session/webview-bridge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test"
+import { inScopes, isAllowedOrigin, matchScope, normalizeBridgePath } from "./webview-bridge"
+
+describe("normalizeBridgePath", () => {
+  it("normalizes relative paths", () => {
+    expect(normalizeBridgePath("/repo", "./tasks/T-001.md")).toBe("tasks/T-001.md")
+  })
+
+  it("blocks escaping paths", () => {
+    expect(normalizeBridgePath("/repo", "../etc/passwd")).toBeUndefined()
+  })
+
+  it("accepts absolute path inside workspace", () => {
+    expect(normalizeBridgePath("/repo", "/repo/TASKS.md")).toBe("TASKS.md")
+  })
+})
+
+describe("scope matching", () => {
+  it("matches simple wildcard", () => {
+    expect(matchScope("tasks/T-001.md", "tasks/*.md")).toBe(true)
+  })
+
+  it("matches deep wildcard", () => {
+    expect(matchScope("tasks/epic/T-001.md", "tasks/**/*.md")).toBe(true)
+  })
+
+  it("checks allow list", () => {
+    expect(inScopes("TASKS.md", ["tasks/*.md", "TASKS.md"])).toBe(true)
+    expect(inScopes("README.md", ["tasks/*.md", "TASKS.md"])).toBe(false)
+  })
+})
+
+describe("origin allowlist", () => {
+  it("allows wildcard", () => {
+    expect(isAllowedOrigin("https://any.site", ["*"])).toBe(true)
+  })
+
+  it("allows opaque origin when listed", () => {
+    expect(isAllowedOrigin("null", ["null"])).toBe(true)
+  })
+
+  it("allows localhost any port when rule omits port", () => {
+    expect(isAllowedOrigin("http://localhost:3000", ["http://localhost"])).toBe(true)
+  })
+
+  it("allows listed origin", () => {
+    expect(isAllowedOrigin("http://localhost:3000", ["http://localhost:3000"])).toBe(true)
+  })
+
+  it("rejects non-listed origin", () => {
+    expect(isAllowedOrigin("https://evil.test", ["http://localhost:3000"])).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/webview-bridge.ts
+++ b/packages/app/src/pages/session/webview-bridge.ts
@@ -1,0 +1,94 @@
+const SEPARATOR = /[\\/]+/
+
+const split = (value: string) => value.split(SEPARATOR).filter(Boolean)
+
+const clean = (value: string) => value.trim().replace(/\\/g, "/")
+
+const regexEscape = (value: string) => value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+
+export function normalizeBridgePath(directory: string, value: string): string | undefined {
+  const root = clean(directory).replace(/\/+$/, "")
+  const input = clean(value)
+  if (!root || !input) return
+
+  const isAbs = input.startsWith("/") || /^[A-Za-z]:\//.test(input)
+  const absolute = isAbs ? input : `${root}/${input.replace(/^\.\//, "")}`
+  const parts = [] as string[]
+  for (const piece of split(absolute)) {
+    if (piece === ".") continue
+    if (piece === "..") {
+      parts.pop()
+      continue
+    }
+    parts.push(piece)
+  }
+
+  const normalized = absolute.startsWith("/") ? `/${parts.join("/")}` : parts.join("/")
+
+  if (normalized === root) return ""
+  if (!normalized.startsWith(`${root}/`)) return
+  return normalized.slice(root.length + 1)
+}
+
+export function matchScope(path: string, scope: string): boolean {
+  const target = clean(path).replace(/^\.\//, "")
+  const rule = clean(scope).replace(/^\.\//, "")
+  if (!target || !rule) return false
+  if (rule === "*") return true
+  let pattern = "^"
+  let i = 0
+  while (i < rule.length) {
+    const char = rule[i]
+    const next = rule[i + 1]
+    if (char === "*" && next === "*") {
+      pattern += ".*"
+      i += 2
+      continue
+    }
+    if (char === "*") {
+      pattern += "[^/]*"
+      i += 1
+      continue
+    }
+    pattern += regexEscape(char)
+    i += 1
+  }
+  pattern += "$"
+  return new RegExp(pattern).test(target)
+}
+
+export function inScopes(path: string, scopes: string[]): boolean {
+  if (!scopes.length) return false
+  return scopes.some((scope) => matchScope(path, scope))
+}
+
+export function isAllowedOrigin(origin: string, origins: string[]): boolean {
+  if (origins.includes("*")) return true
+  if (origin === "null") return origins.includes("null")
+  let current: URL
+  try {
+    current = new URL(origin)
+  } catch {
+    return false
+  }
+
+  return origins.some((allowed) => {
+    try {
+      const rule = new URL(allowed)
+      if (rule.protocol !== current.protocol) return false
+      if (rule.hostname !== current.hostname) return false
+      if (rule.port) return rule.port === current.port
+      return true
+    } catch {
+      return false
+    }
+  })
+}
+
+export async function hashText(content: string): Promise<string> {
+  const bytes = new TextEncoder().encode(content)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/packages/app/src/utils/plugin-ui.test.ts
+++ b/packages/app/src/utils/plugin-ui.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test"
+import { resolveSessionPluginUI } from "./plugin-ui"
+
+describe("resolveSessionPluginUI", () => {
+  it("builds web tabs and buttons from config", () => {
+    const input = {
+      ui: {
+        session: {
+          tabs: [
+            {
+              id: "kanban-roadmap",
+              title: "Tasks",
+              src: "http://localhost:3000?tasksFile=TASKS.md",
+              permissions: {
+                file: {
+                  read: ["TASKS.md"],
+                  write: ["TASKS.md"],
+                },
+              },
+            },
+          ],
+          buttons: [
+            {
+              id: "tasks",
+              label: "Tasks",
+              tab: "kanban-roadmap",
+            },
+          ],
+        },
+      },
+    }
+
+    const ui = resolveSessionPluginUI(input, "/repo", "http://127.0.0.1:4096")
+    expect(ui.tabs).toHaveLength(1)
+    expect(ui.tabs[0]?.tab).toBe("web:kanban-roadmap")
+    expect(ui.tabs[0]?.src).toContain("directory=%2Frepo")
+    expect(ui.buttons).toEqual([
+      {
+        id: "tasks",
+        label: "Tasks",
+        tab: "web:kanban-roadmap",
+      },
+    ])
+  })
+
+  it("uses localhost defaults for missing origins", () => {
+    const ui = resolveSessionPluginUI(
+      {
+        ui: {
+          session: {
+            tabs: [{ id: "x", title: "X", src: "http://localhost:3000" }],
+          },
+        },
+      },
+      "/repo",
+      "http://127.0.0.1:4096",
+    )
+
+    expect(ui.tabs[0]?.origins).toContain("http://localhost")
+    expect(ui.tabs[0]?.origins).toContain("http://127.0.0.1")
+  })
+
+  it("uses opaque origin default for app tabs", () => {
+    const ui = resolveSessionPluginUI(
+      {
+        ui: {
+          session: {
+            tabs: [{ id: "kanban-roadmap", title: "Kanban", src: "app://plugin/kanban-roadmap/index.html" }],
+          },
+        },
+      },
+      "/repo",
+      "http://127.0.0.1:4096",
+    )
+
+    expect(ui.tabs[0]?.origins).toEqual(["null"])
+  })
+
+  it("resolves relative src with base url", () => {
+    const ui = resolveSessionPluginUI(
+      {
+        ui: {
+          session: {
+            tabs: [{ id: "kanban-roadmap", title: "Tasks", src: "/global/plugin/kanban-roadmap/index.html" }],
+          },
+        },
+      },
+      "/repo",
+      "http://127.0.0.1:4096",
+    )
+
+    expect(ui.tabs[0]?.src.startsWith("http://127.0.0.1:4096/global/plugin/kanban-roadmap/index.html")).toBe(true)
+  })
+})

--- a/packages/app/src/utils/plugin-ui.ts
+++ b/packages/app/src/utils/plugin-ui.ts
@@ -1,0 +1,143 @@
+const DEFAULT_ORIGINS = ["http://localhost", "http://127.0.0.1", "https://localhost", "https://127.0.0.1"]
+const OPAQUE_ORIGIN = ["null"]
+
+type SessionUI = {
+  tabs?: unknown
+  buttons?: unknown
+}
+
+export type PluginWebTab = {
+  id: string
+  tab: string
+  title: string
+  src: string
+  origins: string[]
+  permissions: {
+    file: {
+      read: string[]
+      write: string[]
+    }
+  }
+}
+
+export type PluginWebButton = {
+  id: string
+  label: string
+  tab: string
+}
+
+const asRecord = (value: unknown) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return
+  return value as Record<string, unknown>
+}
+
+const asList = (value: unknown) => (Array.isArray(value) ? value : [])
+
+const asText = (value: unknown) => {
+  if (typeof value !== "string") return ""
+  return value.trim()
+}
+
+const toList = (value: unknown) => asList(value).map(asText).filter(Boolean)
+
+const normalizeOrigin = (value: string) => {
+  if (!value) return ""
+  if (value === "*") return "*"
+  if (value === "null") return "null"
+  try {
+    const url = new URL(value)
+    if (url.protocol === "app:") return "null"
+    if (url.protocol !== "http:" && url.protocol !== "https:") return ""
+    return url.origin
+  } catch {
+    return ""
+  }
+}
+
+const normalizeOrigins = (value: unknown, fallback: string[]) => {
+  const list = toList(value).map(normalizeOrigin).filter(Boolean)
+  if (list.length) return Array.from(new Set(list))
+  return fallback
+}
+
+const normalizeScopes = (value: unknown) =>
+  toList(value)
+    .map((item) => item.replace(/\\/g, "/").replace(/^\.\//, ""))
+    .filter(Boolean)
+
+const sessionUI = (config: unknown): SessionUI => {
+  const root = asRecord(config)
+  const ui = asRecord(root?.ui)
+  const session = asRecord(ui?.session)
+  return {
+    tabs: session?.tabs,
+    buttons: session?.buttons,
+  }
+}
+
+export function resolveSessionPluginUI(
+  config: unknown,
+  directory: string,
+  baseUrl?: string,
+): {
+  tabs: PluginWebTab[]
+  buttons: PluginWebButton[]
+} {
+  const ui = sessionUI(config)
+
+  const tabs = asList(ui.tabs)
+    .map((item) => {
+      const row = asRecord(item)
+      const id = asText(row?.id)
+      const title = asText(row?.title)
+      const src = asText(row?.src)
+      if (!id || !title || !src) return
+      try {
+        const url = new URL(src, baseUrl)
+        if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "app:") return
+        if (!url.searchParams.has("directory") && directory) {
+          url.searchParams.set("directory", directory)
+        }
+        const fallback = url.protocol === "app:" ? OPAQUE_ORIGIN : DEFAULT_ORIGINS
+        const permissions = asRecord(row?.permissions)
+        const file = asRecord(permissions?.file)
+        return {
+          id,
+          tab: `web:${id}`,
+          title,
+          src: url.toString(),
+          origins: normalizeOrigins(row?.origins, fallback),
+          permissions: {
+            file: {
+              read: normalizeScopes(file?.read),
+              write: normalizeScopes(file?.write),
+            },
+          },
+        } satisfies PluginWebTab
+      } catch {
+        return
+      }
+    })
+    .filter((item): item is PluginWebTab => Boolean(item))
+    .filter((item, index, list) => list.findIndex((row) => row.id === item.id) === index)
+
+  const tabSet = new Set(tabs.map((tab) => tab.id))
+
+  const buttons = asList(ui.buttons)
+    .map((item) => {
+      const row = asRecord(item)
+      const id = asText(row?.id)
+      const label = asText(row?.label)
+      const tab = asText(row?.tab).replace(/^web:/, "")
+      if (!id || !label || !tab || !tabSet.has(tab)) return
+      return {
+        id,
+        label,
+        tab: `web:${tab}`,
+      } satisfies PluginWebButton
+    })
+    .filter((item): item is PluginWebButton => Boolean(item))
+    .filter((item, index, list) => list.findIndex((row) => row.id === item.id) === index)
+
+  return { tabs, buttons }
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -545,6 +545,50 @@ export namespace Config {
   })
   export type Command = z.infer<typeof Command>
 
+  const UIFilePermission = z
+    .object({
+      read: z.array(z.string()).optional(),
+      write: z.array(z.string()).optional(),
+    })
+    .strict()
+
+  const UIPermission = z
+    .object({
+      file: UIFilePermission.optional(),
+    })
+    .strict()
+
+  const UISessionTab = z
+    .object({
+      id: z.string(),
+      title: z.string(),
+      src: z.string(),
+      icon: z.string().optional(),
+      origins: z.array(z.string()).optional(),
+      permissions: UIPermission.optional(),
+    })
+    .strict()
+
+  const UISessionButton = z
+    .object({
+      id: z.string(),
+      label: z.string(),
+      tab: z.string(),
+    })
+    .strict()
+
+  const UI = z
+    .object({
+      session: z
+        .object({
+          tabs: z.array(UISessionTab).optional(),
+          buttons: z.array(UISessionButton).optional(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict()
+
   export const Skills = z.object({
     paths: z.array(z.string()).optional().describe("Additional paths to skill folders"),
     urls: z
@@ -891,6 +935,7 @@ export namespace Config {
         .record(z.string(), Command)
         .optional()
         .describe("Command configuration, see https://opencode.ai/docs/commands"),
+      ui: UI.optional().describe("Plugin-contributed UI configuration for session buttons and web tabs"),
       skills: Skills.optional().describe("Additional skill folder paths"),
       watcher: z
         .object({

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -1,4 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
+import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@/filesystem"
@@ -74,6 +75,16 @@ export namespace File {
       ref: "FileContent",
     })
   export type Content = z.infer<typeof Content>
+
+  export const Mutation = z
+    .object({
+      path: z.string(),
+      hash: z.string(),
+    })
+    .meta({
+      ref: "FileMutation",
+    })
+  export type Mutation = z.infer<typeof Mutation>
 
   export const Event = {
     Edited: BusEvent.define(
@@ -588,6 +599,27 @@ export namespace File {
         return { type: "text" as const, content }
       })
 
+      const write = Effect.fn("File.write")(function* (file: string, content: string) {
+        return yield* Effect.promise(async () => {
+          using _ = log.time("write", { file })
+          const full = path.join(Instance.directory, file)
+          if (!Instance.containsPath(full)) {
+            throw new Error("Access denied: path escapes project directory")
+          }
+
+          await fs.promises.mkdir(path.dirname(full), { recursive: true })
+          await Bun.write(full, content)
+          await Bus.publish(Event.Edited, {
+            file: full,
+          })
+
+          return {
+            path: file,
+            hash: hash(content),
+          }
+        })
+      })
+
       const list = Effect.fn("File.list")(function* (dir?: string) {
         const exclude = [".git", ".DS_Store"]
         let ignored = (_: string) => false
@@ -663,7 +695,7 @@ export namespace File {
       })
 
       log.info("init")
-      return Service.of({ init, status, read, list, search })
+      return Service.of({ init, status, read, write, list, search })
     }),
   )
 
@@ -679,8 +711,16 @@ export namespace File {
     return runPromise((svc) => svc.status())
   }
 
+  export function hash(content: string) {
+    return new Bun.CryptoHasher("sha256").update(content).digest("hex")
+  }
+
   export async function read(file: string): Promise<Content> {
     return runPromise((svc) => svc.read(file))
+  }
+
+  export async function write(file: string, content: string): Promise<Mutation> {
+    return runPromise((svc) => svc.write(file, content))
   }
 
   export async function list(dir?: string) {

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -341,6 +341,7 @@ export namespace File {
     readonly init: () => Effect.Effect<void>
     readonly status: () => Effect.Effect<File.Info[]>
     readonly read: (file: string) => Effect.Effect<File.Content>
+    readonly write: (file: string, content: string) => Effect.Effect<File.Mutation>
     readonly list: (dir?: string) => Effect.Effect<File.Node[]>
     readonly search: (input: {
       query: string

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -172,6 +172,41 @@ export const FileRoutes = lazy(() =>
         return c.json(content)
       },
     )
+    .put(
+      "/file/content",
+      describeRoute({
+        summary: "Write file",
+        description: "Write text content to a specified file.",
+        operationId: "file.write",
+        responses: {
+          200: {
+            description: "Write result",
+            content: {
+              "application/json": {
+                schema: resolver(File.Mutation),
+              },
+            },
+          },
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          path: z.string(),
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          content: z.string(),
+        }),
+      ),
+      async (c) => {
+        const path = c.req.valid("query").path
+        const content = c.req.valid("json").content
+        return c.json(await File.write(path, content))
+      },
+    )
     .get(
       "/file/status",
       describeRoute({

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -8,6 +8,8 @@ import { GlobalBus } from "@/bus/global"
 import { AsyncQueue } from "@/util/queue"
 import { Instance } from "../../project/instance"
 import { Installation } from "@/installation"
+import { Global } from "@/global"
+import path from "path"
 import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
@@ -69,6 +71,32 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
 
 export const GlobalRoutes = lazy(() =>
   new Hono()
+    .get("/plugin/:name/:asset{.+}", async (c) => {
+      const name = c.req.param("name")
+      const asset = c.req.param("asset")
+      const clean = asset.replace(/\\/g, "/").replace(/^\/+/, "")
+      if (!clean || clean.includes("..") || path.isAbsolute(clean)) {
+        return c.text("Invalid asset path", 400)
+      }
+
+      const roots = [path.join(Global.Path.config, "plugins", name), path.join(Global.Path.config, "plugin", name)]
+
+      for (const root of roots) {
+        const full = path.join(root, clean)
+        if (!full.startsWith(root + path.sep)) continue
+        const file = Bun.file(full)
+        if (!(await file.exists().catch(() => false))) continue
+        const type = file.type || "text/plain; charset=utf-8"
+        return new Response(file, {
+          headers: {
+            "content-type": type,
+            "cache-control": "no-store",
+          },
+        })
+      }
+
+      return c.text("Plugin asset not found", 404)
+    })
     .get(
       "/health",
       describeRoute({

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -44,6 +44,7 @@ export namespace Server {
         // Allow CORS preflight requests to succeed without auth.
         // Browser clients sending Authorization headers will preflight with OPTIONS.
         if (c.req.method === "OPTIONS") return next()
+        if (c.req.path.startsWith("/global/plugin/")) return next()
         const password = Flag.OPENCODE_SERVER_PASSWORD
         if (!password) return next()
         const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -36,6 +36,7 @@ import type {
   FilePartSource,
   FileReadResponses,
   FileStatusResponses,
+  FileWriteResponses,
   FindFilesResponses,
   FindSymbolsResponses,
   FindTextResponses,
@@ -2964,6 +2965,45 @@ export class File extends HeyApiClient {
       url: "/file/content",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Write file
+   *
+   * Write text content to a specified file.
+   */
+  public write<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      path: string
+      content?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "path" },
+            { in: "body", key: "content" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<FileWriteResponses, unknown, ThrowOnError>({
+      url: "/file/content",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1432,6 +1432,31 @@ export type Config = {
     }
   }
   /**
+   * Plugin-contributed UI configuration for session buttons and web tabs
+   */
+  ui?: {
+    session?: {
+      tabs?: Array<{
+        id: string
+        title: string
+        src: string
+        icon?: string
+        origins?: Array<string>
+        permissions?: {
+          file?: {
+            read?: Array<string>
+            write?: Array<string>
+          }
+        }
+      }>
+      buttons?: Array<{
+        id: string
+        label: string
+        tab: string
+      }>
+    }
+  }
+  /**
    * Additional skill folder paths
    */
   skills?: {
@@ -1955,6 +1980,11 @@ export type FileContent = {
   }
   encoding?: "base64"
   mimeType?: string
+}
+
+export type FileMutation = {
+  path: string
+  hash: string
 }
 
 export type File = {
@@ -4421,6 +4451,28 @@ export type FileReadResponses = {
 }
 
 export type FileReadResponse = FileReadResponses[keyof FileReadResponses]
+
+export type FileWriteData = {
+  body?: {
+    content: string
+  }
+  path?: never
+  query: {
+    directory?: string
+    workspace?: string
+    path: string
+  }
+  url: "/file/content"
+}
+
+export type FileWriteResponses = {
+  /**
+   * Write result
+   */
+  200: FileMutation
+}
+
+export type FileWriteResponse = FileWriteResponses[keyof FileWriteResponses]
 
 export type FileStatusData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #15747

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR introduces a plugin session webview bridge and related plumbing so plugins can expose session UI and communicate with the host in a request/response flow.

Main changes:
- Adds plugin session UI contributions via `ui.session.tabs` and `ui.session.buttons`
- Adds bridge protocol events (`opencode.bridge.host`, `opencode.bridge.request`, `opencode.bridge.response`)
- Adds base bridge file operations, including `file.write` with optimistic concurrency (`expectedHash`)
- Serves plugin webview assets through global plugin routes
- Allows CORS preflight for global plugin paths
- Updates docs for plugin bridge usage and desktop troubleshooting

Context:
- Related to #11249 because this PR adds plugin bridge file-write capabilities (file.write+expectedHash) that address the same safe plugin-driven write/update concerns, but through a webview bridge path.
- Related to #6330 (this PR is a narrower incremental step)

### How did you verify your code works?

- Ran repository pre-push checks locally (including `bun turbo typecheck`)
- Pre-push hook completed successfully before pushing branch updates

### Screenshots / recordings

Session side-panel / webview integration updates are included in this PR.

_If maintainers want, I can attach a short recording in a follow-up comment._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
