### PR TITLE
feat(opencode): add GET/POST /tui/active-session endpoint

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -261,6 +261,18 @@ function App() {
     console.log(JSON.stringify(route.data))
   })
 
+  // Report active session to server whenever route changes
+  createEffect(() => {
+    const sessionID = route.data.type === "session" ? route.data.sessionID : null
+    sdk
+      .fetch(sdk.url + "/tui/active-session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionID }),
+      })
+      .catch(() => {})
+  })
+
   // Update terminal window title based on current route and session
   createEffect(() => {
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -96,6 +96,19 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    const raw = props.fetch ?? fetch
+    const wrapped = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const merged = new Headers(props.headers as HeadersInit)
+      if (init?.headers) {
+        const h = new Headers(init.headers as HeadersInit)
+        h.forEach((v, k) => {
+          merged.set(k, v)
+        })
+      }
+      if (props.directory && !merged.has("x-opencode-directory")) merged.set("x-opencode-directory", props.directory)
+      return raw(input as RequestInfo, { ...init, headers: merged })
+    }) as typeof fetch
+
+    return { client: sdk, event: emitter, url: props.url, fetch: wrapped }
   },
 })

--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -8,6 +8,8 @@ import { AsyncQueue } from "../../util/queue"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 
+let activeSessionID: string | undefined
+
 const TuiRequest = z.object({
   path: z.string(),
   body: z.any(),
@@ -372,6 +374,57 @@ export const TuiRoutes = lazy(() =>
         const { sessionID } = c.req.valid("json")
         await Session.get(sessionID)
         await Bus.publish(TuiEvent.SessionSelect, { sessionID })
+        activeSessionID = sessionID
+        return c.json(true)
+      },
+    )
+    .get(
+      "/active-session",
+      describeRoute({
+        summary: "Get active session",
+        description: "Get the session currently being viewed in the TUI.",
+        operationId: "tui.activeSession.get",
+        responses: {
+          200: {
+            description: "Currently active session, or null if on home screen",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info.nullable()),
+              },
+            },
+          },
+          ...errors(404),
+        },
+      }),
+      async (c) => {
+        if (!activeSessionID) return c.json(null)
+        const session = await Session.get(activeSessionID)
+        return c.json(session)
+      },
+    )
+    .post(
+      "/active-session",
+      describeRoute({
+        summary: "Report active session",
+        description: "Report which session the TUI is currently viewing.",
+        operationId: "tui.activeSession.set",
+        responses: {
+          200: {
+            description: "Active session updated",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("json", z.object({ sessionID: z.string().nullable() })),
+      async (c) => {
+        const { sessionID } = c.req.valid("json")
+        if (sessionID !== null) await Session.get(sessionID)
+        activeSessionID = sessionID ?? undefined
         return c.json(true)
       },
     )


### PR DESCRIPTION
### Issue for this PR

Closes #15759

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

There was no way to query which session the TUI is currently viewing. The server had no awareness of the TUI's route state — `POST /tui/select-session` could tell the TUI to navigate, but nothing exposed the current state back.

This adds `GET /tui/active-session` (returns `Session.Info | null`) and `POST /tui/active-session` (receives session reports from TUI).

Server side: a module-level variable in `tui.ts` stores the active sessionID. Updated on both `select-session` calls and TUI reports.

Client side: a `createEffect` in `app.tsx` watches `route.data` and POSTs the current sessionID whenever navigation happens — covers keybinds, dialogs, CLI flags, all paths.

Also exposed `fetch` from the SDK context so the TUI can communicate back to the server in both HTTP and RPC modes.

### How did you verify your code works?

- Built with `bun run --cwd packages/opencode script/build.ts --single` — success
- LSP diagnostics clean on all 3 changed files
- No unrelated changes to `bun.lock` or `package.json`

### Screenshots / recordings

_Not a UI change — API-only addition._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR