### PR TITLE
feat(tui): add configurable paste summary thresholds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -962,8 +962,10 @@ export function Prompt(props: PromptProps) {
                 }
 
                 const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
+                const minLines = sync.data.config.experimental?.paste_min_lines ?? 3
+                const minLength = sync.data.config.experimental?.paste_min_length ?? 150
                 if (
-                  (lineCount >= 3 || pastedContent.length > 150) &&
+                  (lineCount >= minLines || pastedContent.length > minLength) &&
                   !sync.data.config.experimental?.disable_paste_summary
                 ) {
                   event.preventDefault()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1166,6 +1166,18 @@ export namespace Config {
             .positive()
             .optional()
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+          paste_min_lines: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Minimum number of lines in pasted content before it is summarized (default: 3)"),
+          paste_min_length: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Minimum character length of pasted content before it is summarized (default: 150)"),
         })
         .optional(),
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1496,6 +1496,14 @@ export type Config = {
      * Timeout in milliseconds for model context protocol (MCP) requests
      */
     mcp_timeout?: number
+    /**
+     * Minimum number of lines in pasted content before it is summarized (default: 3)
+     */
+    paste_min_lines?: number
+    /**
+     * Minimum character length of pasted content before it is summarized (default: 150)
+     */
+    paste_min_length?: number
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #15767

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add `paste_min_lines` and `paste_min_length` to the experimental config section. These let users control when pasted content gets collapsed into `[Pasted ~N lines]` instead of being inserted inline.

The hardcoded thresholds (3 lines / 150 characters) are too aggressive for voice dictation users — dictated text routinely exceeds 150 characters in a single utterance, making it impossible to review and correct transcription errors. The only existing workaround (`disable_paste_summary: true`) removes paste summaries entirely, which is undesirable when pasting large content like stack traces.

Both settings are optional and default to the current values (3 and 150), so existing behaviour is unchanged.

### How did you verify your code works?

Set both values in `opencode.json` and confirmed paste summary triggers at the configured thresholds rather than the defaults.

### Screenshots / recordings

_N/A — no UI changes, only threshold logic._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR