### PR TITLE
fix(opencode): clone part data in Bus event to preserve token values

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -761,7 +761,7 @@ export namespace Session {
         .run()
       Database.effect(() =>
         Bus.publish(MessageV2.Event.PartUpdated, {
-          part,
+          part: structuredClone(part),
         }),
       )
     })

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -4,6 +4,8 @@ import { Session } from "../../src/session"
 import { Bus } from "../../src/bus"
 import { Log } from "../../src/util/log"
 import { Instance } from "../../src/project/instance"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Identifier } from "../../src/id/id"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -68,4 +70,69 @@ describe("session.started event", () => {
       },
     })
   })
+})
+
+describe("step-finish token propagation via Bus event", () => {
+  test("non-zero tokens propagate through PartUpdated event", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const messageID = Identifier.ascending("message")
+        await Session.updateMessage({
+          id: messageID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "user",
+          model: { providerID: "test", modelID: "test" },
+          tools: {},
+          mode: "",
+        } as unknown as MessageV2.Info)
+
+        let received: MessageV2.Part | undefined
+        const unsub = Bus.subscribe(MessageV2.Event.PartUpdated, (event) => {
+          received = event.properties.part
+        })
+
+        const tokens = {
+          total: 1500,
+          input: 500,
+          output: 800,
+          reasoning: 200,
+          cache: { read: 100, write: 50 },
+        }
+
+        const partInput = {
+          id: Identifier.ascending("part"),
+          messageID,
+          sessionID: session.id,
+          type: "step-finish" as const,
+          reason: "stop",
+          cost: 0.005,
+          tokens,
+        }
+
+        await Session.updatePart(partInput)
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        expect(received).toBeDefined()
+        expect(received!.type).toBe("step-finish")
+        const finish = received as MessageV2.StepFinishPart
+        expect(finish.tokens.input).toBe(500)
+        expect(finish.tokens.output).toBe(800)
+        expect(finish.tokens.reasoning).toBe(200)
+        expect(finish.tokens.total).toBe(1500)
+        expect(finish.tokens.cache.read).toBe(100)
+        expect(finish.tokens.cache.write).toBe(50)
+        expect(finish.cost).toBe(0.005)
+        expect(received).not.toBe(partInput)
+
+        unsub()
+        await Session.remove(session.id)
+      },
+    })
+  }, { timeout: 30000 })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15779

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Session.updatePart()` passes the `part` object by reference into `Bus.publish(PartUpdated)` inside a `Database.effect()`. The `fn()` wrapper's Zod `schema.parse()` creates a new object from the input, and the deferred effect closure captures the original reference. If anything mutates that object between queue time and effect execution, JSONL subscribers receive stale data with zeroed token fields — while the TUI is unaffected since it reads from the DB post-persistence.

The bug is timing/provider-dependent: `Database.effect()` fires synchronously after `Database.use()` returns, so in most cases the reference is still valid. It manifests under specific async timing conditions depending on the provider.

The fix wraps the part in `structuredClone(part)` to snapshot the values at queue time, guaranteeing isolation regardless of timing.

### How did you verify your code works?

- `bunx tsc --noEmit` passes
- `bun test test/session/session.test.ts` — 3 pass, 0 fail (includes new regression test with 10 assertions verifying non-zero tokens propagate through the Bus event)
- Regression test also confirms the event part is a clone, not the same object reference
- Verified `bun dev --format json run` produces non-zero tokens in `step_finish` JSONL output

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR