### PR TITLE
fix(run): exit with non-zero code on session error

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -582,10 +582,7 @@ export const RunCommand = cmd({
       }
       await share(sdk, sessionID)
 
-      loop().catch((e) => {
-        console.error(e)
-        process.exit(1)
-      })
+      const loopDone = loop()
 
       if (args.command) {
         await sdk.session.command({
@@ -606,6 +603,13 @@ export const RunCommand = cmd({
           parts: [...files, { type: "text", text: message }],
         })
       }
+
+      await loopDone.catch((e) => {
+        console.error(e)
+        process.exit(1)
+      })
+
+      if (error) process.exit(1)
     }
 
     if (args.attach) {


### PR DESCRIPTION
## Problem

When `opencode run` encounters a session error (e.g., an invalid model specified via `--model`), the process exits with code 0 instead of 1.

```bash
$ opencode run --model "invalid-model-123" "test" 2>/dev/null; echo "EXIT: $?"
EXIT: 0  # Should be 1
```

## Root Cause

`loop()` was fired with `.catch()` (not awaited), so after `sdk.session.prompt()` returned, `execute()` completed immediately without waiting for the event loop to finish. Even when the loop ran and set the `error` variable from a `session.error` event, `process.exit(1)` was never called because `error` was scoped inside the unawaited promise.

## Fix

- Store the `loop()` promise as `loopDone` instead of calling `.catch()` immediately
- Await `loopDone` after the prompt/command is submitted (the loop terminates naturally when the session reaches idle state)
- Call `process.exit(1)` if the `error` variable was set during the session

This preserves the existing behavior of printing errors to stderr and calling `process.exit(1)` on unexpected loop exceptions.

Fixes #15558