### PR TITLE
fix(session): use image part type for images re-injected from tool results

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -705,11 +705,18 @@ export namespace MessageV2 {
                   type: "text" as const,
                   text: "Attached image(s) from tool result:",
                 },
-                ...media.map((attachment) => ({
-                  type: "file" as const,
-                  url: attachment.url,
-                  mediaType: attachment.mime,
-                })),
+                ...media.map((attachment) =>
+                  attachment.mime.startsWith("image/")
+                    ? ({
+                        type: "image" as const,
+                        image: attachment.url,
+                      } as const)
+                    : ({
+                        type: "file" as const,
+                        url: attachment.url,
+                        mediaType: attachment.mime,
+                      } as const),
+                ),
               ],
             })
           }


### PR DESCRIPTION
## Problem

When using vision-capable OpenAI-compatible models (e.g., `qwen3.5-plus` via `@ai-sdk/openai-compatible`), images returned by the `Read` tool are not passed to the model even when image modalities are correctly configured in `opencode.json`.

Reproduction (with image modality configured):
1. Use any OpenAI-compatible provider that supports vision
2. Add `"modalities": { "input": ["text", "image"] }` to the model in `opencode.json`
3. Ask the agent to read an image file
4. The model receives an error or the image is silently dropped

## Root Cause

For providers where `supportsMediaInToolResults = false` (all `@ai-sdk/openai-compatible` providers), images from tool results are extracted and re-injected as a separate user message. This injection always used `type: "file"` for all media types:

```ts
media.map((attachment) => ({
  type: "file" as const,
  url: attachment.url,
  mediaType: attachment.mime,
}))
```

OpenAI-compatible providers convert `type: "image"` parts to `{ type: "image_url", image_url: { url: ... } }` in the request body, which is the standard vision format. However, `type: "file"` parts are not supported by most OpenAI-compatible APIs, causing them to either silently drop the content or throw `AI_UnsupportedFunctionalityError`.

## Fix

Use `type: "image"` with the data URL for image/* MIME types in the re-injected user message. Non-image media (e.g., PDFs) continue to use `type: "file"` unchanged.

```ts
media.map((attachment) =>
  attachment.mime.startsWith("image/")
    ? { type: "image" as const, image: attachment.url }
    : { type: "file" as const, url: attachment.url, mediaType: attachment.mime }
)
```

This allows vision-capable models using `@ai-sdk/openai-compatible` to receive images from tool results when the user has configured image input modalities.

Fixes #15728