### PR TITLE
fix(auth): display schema and provider metadata in auth list

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -13,6 +13,7 @@ import { Instance } from "../../project/instance"
 import type { Hooks } from "@opencode-ai/plugin"
 import { Process } from "../../util/process"
 import { text } from "node:stream/consumers"
+import { Filesystem } from "../../util/filesystem"
 
 type PluginAuth = NonNullable<Hooks["auth"]>
 
@@ -211,6 +212,7 @@ export const AuthListCommand = cmd({
     const homedir = os.homedir()
     const displayPath = authPath.startsWith(homedir) ? authPath.replace(homedir, "~") : authPath
     prompts.intro(`Credentials ${UI.Style.TEXT_DIM}${displayPath}`)
+    const rawAuthData = await Filesystem.readJson<Record<string, any>>(authPath).catch(() => ({}))
     const results = Object.entries(await Auth.all())
     const database = await ModelsDev.get()
 
@@ -220,6 +222,25 @@ export const AuthListCommand = cmd({
     }
 
     prompts.outro(`${results.length} credentials`)
+
+    const metadataFields = ['$schema', 'provider']
+    const hasMetadata = metadataFields.some(key => rawAuthData[key] !== undefined)
+
+    if (hasMetadata) {
+      UI.empty()
+      prompts.intro("Configuration")
+      
+      for (const key of metadataFields) {
+        if (rawAuthData[key] !== undefined) {
+          const value = typeof rawAuthData[key] === 'object' 
+            ? JSON.stringify(rawAuthData[key], null, 2)
+            : String(rawAuthData[key])
+          prompts.log.info(`${key} ${UI.Style.TEXT_DIM}${value}`)
+        }
+      }
+      
+      prompts.outro("metadata fields")
+    }
 
     // Environment variables section
     const activeEnvVars: Array<{ provider: string; envVar: string }> = []


### PR DESCRIPTION
### Issue for this PR

Closes #4533

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the issue where `opencode auth list` displays "undefined" for `$schema` and `provider` fields in the auth.json configuration file.

**Problem:** The `Auth.all()` function only parses authentication credentials (OAuth/Api/WellKnown types) and ignores metadata fields like `$schema` and `provider` that exist in the raw JSON file.

**Solution:** 
1. Read the raw auth.json file using `Filesystem.readJson()` to access all fields
2. Added a new "Configuration" section that displays metadata fields (`$schema` and `provider`)
3. Implemented smart formatting: objects are displayed as JSON, other values as strings

**Why it works:** By reading the raw JSON file separately from the parsed credentials, we can access and display metadata fields that aren't part of the authentication schema.

### How did you verify your code works?

1. Created a test auth.json file with `$schema` and `provider` fields
2. Ran `opencode auth list` and verified metadata displays correctly in the new Configuration section
3. Tested with missing metadata fields - gracefully handles absence
4. Verified existing credentials display still works correctly

### Screenshots / recordings

_Not applicable - CLI output change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR