### PR TITLE
fix(tui): ensure input field text is visible in small windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -817,6 +817,7 @@ export function Prompt(props: PromptProps) {
             flexShrink={0}
             backgroundColor={theme.backgroundElement}
             flexGrow={1}
+            minWidth={20}
           >
             <textarea
               placeholder={placeholderText()}


### PR DESCRIPTION
### Issue for this PR

Closes #4332

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the issue where the input field text becomes invisible when the terminal window is resized to a very small width.

**Problem:** The textarea container in the prompt component has no minimum width constraint. When the terminal window becomes very small, the container gets compressed to near-zero width, making the text invisible or unreadable.

**Solution:** Added `minWidth={20}` to the textarea container box element in `/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` (line 820).

**Why it works:** The `minWidth` property ensures the container maintains a minimum readable width even when the terminal window is very small. This prevents the flexbox layout from compressing the input field beyond usability.

### How did you verify your code works?

1. Tested by resizing terminal window to various small sizes
2. Verified text remains visible and readable at minimum width
3. Tested in multiple terminal emulators (iTerm2, Terminal.app, Rider Console)
4. Confirmed normal-sized windows still work correctly
5. Verified no layout issues with other UI elements

### Screenshots / recordings

_Not applicable - terminal behavior fix_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR