### PR TITLE
feat(agent): add short description for better UI display

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -25,6 +25,7 @@ export namespace Agent {
     .object({
       name: z.string(),
       description: z.string().optional(),
+      shortDescription: z.string().optional(),
       mode: z.enum(["subagent", "primary", "all"]),
       native: z.boolean().optional(),
       hidden: z.boolean().optional(),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -9,10 +9,15 @@ export function DialogAgent() {
 
   const options = createMemo(() =>
     local.agent.list().map((item) => {
+      const displayDesc = item.shortDescription 
+        || (item.description && item.description.length > 100 
+          ? item.description.substring(0, 100) + "..." 
+          : item.description)
+        || ""
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "native" : displayDesc,
       }
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #4825

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds support for short descriptions in agent configurations to improve readability in the `/agents` command dialog.

**Problem:** When users create agents with `opencode agent create`, they often write detailed descriptions explaining agent behavior. These long descriptions make the `/agents` selection dialog unreadable because the full text is displayed, causing horizontal scrolling and poor UX.

**Solution:**
1. Added optional `shortDescription` field to the Agent.Info schema
2. Updated dialog-agent.tsx to display descriptions intelligently:
   - Priority 1: Use `shortDescription` if available
   - Priority 2: Auto-truncate `description` to 100 characters if too long
   - Priority 3: Display full description if already concise

**Why it works:** By separating display text (short) from documentation text (full), we maintain detailed agent descriptions for internal use while showing concise text in the UI. The auto-truncation ensures backward compatibility with existing agents.

### How did you verify your code works?

1. Created new agent with `shortDescription` field - verified it displays correctly
2. Tested existing agents without `shortDescription` - auto-truncation works
3. Tested agents with short descriptions - displays full text without truncation
4. Verified native agents still show "native" label
5. Confirmed backward compatibility - all existing agent configs work unchanged

### Screenshots / recordings

_Not applicable - TUI dialog improvement_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR