### PR TITLE
feat(tui): open existing local files via file:// links

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1464,13 +1464,6 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     <Show when={raw()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
-          <Match when={linked()}>
-            <text fg={theme.text}>
-              <For each={segments()}>
-                {(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}
-              </For>
-            </text>
-          </Match>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
@@ -1479,6 +1472,13 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               conceal={ctx.conceal()}
               renderNode={renderNode}
             />
+          </Match>
+          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN && linked()}>
+            <text fg={theme.text}>
+              <For each={segments()}>
+                {(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}
+              </For>
+            </text>
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1435,6 +1435,20 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     return localLink(raw(), cwd)
   })
   const linked = createMemo(() => content().includes("](file://"))
+  const segments = createMemo(() => {
+    const value = content()
+    const matches = value.matchAll(/\[([^\]]+)\]\((file:\/\/[^\s)]+)\)/g)
+    let offset = 0
+    const output: ({ href: string; label: string } | string)[] = []
+    for (const match of matches) {
+      const index = match.index ?? 0
+      if (index > offset) output.push(value.slice(offset, index))
+      output.push({ href: match[2], label: match[1].replace(/^`(.*)`$/, "$1") })
+      offset = index + match[0].length
+    }
+    if (offset < value.length) output.push(value.slice(offset))
+    return output
+  })
   const renderNode = (token: any, context: any) => {
     if (token.type !== "link") return
     if (typeof token.href !== "string") return
@@ -1451,13 +1465,11 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={linked()}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={content()}
-              conceal={ctx.conceal()}
-              renderNode={renderNode}
-            />
+            <text fg={theme.text}>
+              <For each={segments()}>
+                {(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}
+              </For>
+            </text>
           </Match>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1429,10 +1429,12 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const raw = createMemo(() => props.part.text.trim())
   const content = createMemo(() => {
     const cwd = ctx.sync.data.path.directory || process.cwd()
-    return localLink(props.part.text.trim(), cwd)
+    return localLink(raw(), cwd)
   })
+  const linked = createMemo(() => content().includes("](file://"))
   const renderNode = (token: any, context: any) => {
     if (token.type !== "link") return
     if (typeof token.href !== "string") return
@@ -1445,9 +1447,18 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     return node
   }
   return (
-    <Show when={props.part.text.trim()}>
+    <Show when={raw()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
+          <Match when={linked()}>
+            <markdown
+              syntaxStyle={syntax()}
+              streaming={true}
+              content={content()}
+              conceal={ctx.conceal()}
+              renderNode={renderNode}
+            />
+          </Match>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -80,6 +80,7 @@ import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
+import { localLink } from "../../util/local-link"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1426,17 +1427,16 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const content = createMemo(() => {
+    const cwd = ctx.sync.data.path.directory || process.cwd()
+    return localLink(props.part.text.trim(), cwd)
+  })
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-            />
+            <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code
@@ -1444,7 +1444,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={content()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1441,19 +1441,23 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN && linked()}>
-            <FileLinks content={content()} fg={theme.text} />
-          </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
-              syntaxStyle={syntax()}
-              content={content()}
-              conceal={ctx.conceal()}
-              fg={theme.text}
-            />
+            <Show
+              when={linked()}
+              fallback={
+                <code
+                  filetype="markdown"
+                  drawUnstyledText={false}
+                  streaming={true}
+                  syntaxStyle={syntax()}
+                  content={content()}
+                  conceal={ctx.conceal()}
+                  fg={theme.text}
+                />
+              }
+            >
+              <FileLinks content={content()} />
+            </Show>
           </Match>
         </Switch>
       </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -22,12 +22,10 @@ import {
   BoxRenderable,
   ScrollBoxRenderable,
   addDefaultParsers,
-  StyledText,
   MacOSScrollAccel,
   type ScrollAcceleration,
   TextAttributes,
   RGBA,
-  link as textLink,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
@@ -1449,29 +1447,12 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     if (offset < value.length) output.push(value.slice(offset))
     return output
   })
-  const renderNode = (token: any, context: any) => {
-    if (token.type !== "link") return
-    if (typeof token.href !== "string") return
-    if (!token.href.startsWith("file://")) return
-    const node = context.defaultRender()
-    if (!node) return
-    if (!("content" in node)) return node
-    const label = typeof token.text === "string" && token.text ? token.text : token.href
-    node.content = new StyledText([textLink(token.href)(label)])
-    return node
-  }
   return (
     <Show when={raw()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={content()}
-              conceal={ctx.conceal()}
-              renderNode={renderNode}
-            />
+            <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN && linked()}>
             <text fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -81,6 +81,7 @@ import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { localLink } from "../../util/local-link"
+import { FileLinks } from "../../ui/file-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1455,11 +1456,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
             <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN && linked()}>
-            <text fg={theme.text}>
-              <For each={segments()}>
-                {(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}
-              </For>
-            </text>
+            <FileLinks parts={segments()} fg={theme.text} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1434,20 +1434,6 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     return localLink(raw(), cwd)
   })
   const linked = createMemo(() => content().includes("](file://"))
-  const segments = createMemo(() => {
-    const value = content()
-    const matches = value.matchAll(/\[([^\]]+)\]\((file:\/\/[^\s)]+)\)/g)
-    let offset = 0
-    const output: ({ href: string; label: string } | string)[] = []
-    for (const match of matches) {
-      const index = match.index ?? 0
-      if (index > offset) output.push(value.slice(offset, index))
-      output.push({ href: match[2], label: match[1].replace(/^`(.*)`$/, "$1") })
-      offset = index + match[0].length
-    }
-    if (offset < value.length) output.push(value.slice(offset))
-    return output
-  })
   return (
     <Show when={raw()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1456,7 +1442,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
             <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN && linked()}>
-            <FileLinks parts={segments()} fg={theme.text} />
+            <FileLinks content={content()} fg={theme.text} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -22,10 +22,12 @@ import {
   BoxRenderable,
   ScrollBoxRenderable,
   addDefaultParsers,
+  StyledText,
   MacOSScrollAccel,
   type ScrollAcceleration,
   TextAttributes,
   RGBA,
+  link as textLink,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
@@ -1431,12 +1433,29 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
     const cwd = ctx.sync.data.path.directory || process.cwd()
     return localLink(props.part.text.trim(), cwd)
   })
+  const renderNode = (token: any, context: any) => {
+    if (token.type !== "link") return
+    if (typeof token.href !== "string") return
+    if (!token.href.startsWith("file://")) return
+    const node = context.defaultRender()
+    if (!node) return
+    if (!("content" in node)) return node
+    const label = typeof token.text === "string" && token.text ? token.text : token.href
+    node.content = new StyledText([textLink(token.href)(label)])
+    return node
+  }
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
+            <markdown
+              syntaxStyle={syntax()}
+              streaming={true}
+              content={content()}
+              conceal={ctx.conceal()}
+              renderNode={renderNode}
+            />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code

--- a/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
@@ -1,10 +1,24 @@
-import { For } from "solid-js"
+import { For, createMemo } from "solid-js"
 import type { RGBA } from "@opentui/core"
 
-export function FileLinks(props: { parts: ({ href: string; label: string } | string)[]; fg: RGBA }) {
+export function FileLinks(props: { content: string; fg: RGBA }) {
+  const parts = createMemo(() => {
+    const matches = props.content.matchAll(/\[([^\]]+)\]\((file:\/\/[^\s)]+)\)/g)
+    let offset = 0
+    const output: ({ href: string; label: string } | string)[] = []
+    for (const match of matches) {
+      const index = match.index ?? 0
+      if (index > offset) output.push(props.content.slice(offset, index))
+      output.push({ href: match[2], label: match[1].replace(/^`(.*)`$/, "$1") })
+      offset = index + match[0].length
+    }
+    if (offset < props.content.length) output.push(props.content.slice(offset))
+    return output
+  })
+
   return (
     <text fg={props.fg}>
-      <For each={props.parts}>{(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}</For>
+      <For each={parts()}>{(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}</For>
     </text>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
@@ -1,7 +1,8 @@
 import { For, createMemo } from "solid-js"
-import type { RGBA } from "@opentui/core"
+import { useTheme } from "@tui/context/theme"
 
-export function FileLinks(props: { content: string; fg: RGBA }) {
+export function FileLinks(props: { content: string }) {
+  const { theme } = useTheme()
   const parts = createMemo(() => {
     const matches = props.content.matchAll(/\[([^\]]+)\]\((file:\/\/[^\s)]+)\)/g)
     let offset = 0
@@ -17,7 +18,7 @@ export function FileLinks(props: { content: string; fg: RGBA }) {
   })
 
   return (
-    <text fg={props.fg}>
+    <text fg={theme.text}>
       <For each={parts()}>{(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}</For>
     </text>
   )

--- a/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/file-links.tsx
@@ -1,0 +1,10 @@
+import { For } from "solid-js"
+import type { RGBA } from "@opentui/core"
+
+export function FileLinks(props: { parts: ({ href: string; label: string } | string)[]; fg: RGBA }) {
+  return (
+    <text fg={props.fg}>
+      <For each={props.parts}>{(part) => (typeof part === "string" ? part : <a href={part.href}>{part.label}</a>)}</For>
+    </text>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/util/local-link.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/local-link.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath, pathToFileURL } from "bun"
+import path from "path"
+import { Filesystem } from "@/util/filesystem"
+import { Global } from "@/global"
+
+const CODE = /`([^`\n]+)`/g
+
+export function localLink(input: string, cwd: string) {
+  return input.replace(CODE, (match, raw: string, index: number, source: string) => {
+    if (index > 0 && source[index - 1] === "[" && source.slice(index + match.length).startsWith("](")) return match
+    const value = file(raw, cwd)
+    if (!value) return match
+    return `[\`${raw}\`](${value})`
+  })
+}
+
+function file(raw: string, cwd: string) {
+  const target = resolve(raw.trim(), cwd)
+  if (!target) return
+  if (!Filesystem.stat(target)) return
+  return pathToFileURL(target).href
+}
+
+function resolve(raw: string, cwd: string) {
+  if (!raw) return
+  if (raw.startsWith("http://") || raw.startsWith("https://") || raw.startsWith("data:")) return
+  if (raw.startsWith("file://")) {
+    try {
+      return fileURLToPath(raw)
+    } catch {
+      return
+    }
+  }
+  if (raw.startsWith("~/")) return path.join(Global.Path.home, raw.slice(2))
+  if (path.isAbsolute(raw)) return raw
+  if (!raw.includes("/") && !raw.startsWith("./") && !raw.startsWith("../")) return
+  return path.resolve(cwd, raw)
+}

--- a/packages/opencode/src/cli/cmd/tui/util/local-link.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/local-link.ts
@@ -6,9 +6,18 @@ import { Global } from "@/global"
 const CODE = /`([^`\n]+)`/g
 const CONCEALED = /(^|\s)([^\s()]+)\s+\((file:\/\/[^\s)]+)\)/g
 
+/**
+ * Converts local file-like text into markdown links for strict click-to-open behavior.
+ *
+ * - Rewrites inline code spans such as `foo/bar.csv` to [`foo/bar.csv`](file:///...)
+ *   only when the path resolves to an existing local file or directory.
+ * - Rewrites concealed output such as `foo/ (file:///abs/foo)` to `[foo/](file:///abs/foo)`
+ *   only when the file URL resolves to an existing local target.
+ * - Skips code spans that are already inside a markdown link label.
+ */
 export function localLink(input: string, cwd: string) {
   const text = input.replace(CODE, (match, raw: string, index: number, source: string) => {
-    if (index > 0 && source[index - 1] === "[" && source.slice(index + match.length).startsWith("](")) return match
+    if (inside(source, index, match.length)) return match
     const value = file(raw, cwd)
     if (!value) return match
     return `[\`${raw}\`](${value})`
@@ -21,6 +30,15 @@ export function localLink(input: string, cwd: string) {
     if (!pathlike(label.trim())) return match
     return `${space}[${label.trim()}](${href})`
   })
+}
+
+function inside(source: string, start: number, len: number) {
+  const open = source.lastIndexOf("[", start)
+  if (open === -1) return false
+  if (source.slice(open, start).includes("]")) return false
+  const close = source.indexOf("](", start + len)
+  if (close === -1) return false
+  return true
 }
 
 function file(raw: string, cwd: string) {

--- a/packages/opencode/src/cli/cmd/tui/util/local-link.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/local-link.ts
@@ -42,13 +42,17 @@ function resolve(raw: string, cwd: string) {
   }
   if (raw.startsWith("~/")) return path.join(Global.Path.home, raw.slice(2))
   if (path.isAbsolute(raw)) return raw
-  if (!raw.includes("/") && !raw.startsWith("./") && !raw.startsWith("../")) return
   return path.resolve(cwd, raw)
 }
 
 function pathlike(raw: string) {
   if (!raw) return false
   return (
-    raw.startsWith("/") || raw.startsWith("./") || raw.startsWith("../") || raw.startsWith("~/") || raw.includes("/")
+    raw.startsWith("/") ||
+    raw.startsWith("./") ||
+    raw.startsWith("../") ||
+    raw.startsWith("~/") ||
+    raw.includes("/") ||
+    /^[A-Za-z0-9._-]+$/.test(raw)
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/util/local-link.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/local-link.ts
@@ -4,13 +4,22 @@ import { Filesystem } from "@/util/filesystem"
 import { Global } from "@/global"
 
 const CODE = /`([^`\n]+)`/g
+const CONCEALED = /(^|\s)([^\s()]+)\s+\((file:\/\/[^\s)]+)\)/g
 
 export function localLink(input: string, cwd: string) {
-  return input.replace(CODE, (match, raw: string, index: number, source: string) => {
+  const text = input.replace(CODE, (match, raw: string, index: number, source: string) => {
     if (index > 0 && source[index - 1] === "[" && source.slice(index + match.length).startsWith("](")) return match
     const value = file(raw, cwd)
     if (!value) return match
     return `[\`${raw}\`](${value})`
+  })
+  return text.replace(CONCEALED, (match, space: string, label: string, href: string) => {
+    if (label.startsWith("[") && label.endsWith("]")) return match
+    const target = resolve(href, cwd)
+    if (!target) return match
+    if (!Filesystem.stat(target)) return match
+    if (!pathlike(label.trim())) return match
+    return `${space}[${label.trim()}](${href})`
   })
 }
 
@@ -35,4 +44,11 @@ function resolve(raw: string, cwd: string) {
   if (path.isAbsolute(raw)) return raw
   if (!raw.includes("/") && !raw.startsWith("./") && !raw.startsWith("../")) return
   return path.resolve(cwd, raw)
+}
+
+function pathlike(raw: string) {
+  if (!raw) return false
+  return (
+    raw.startsWith("/") || raw.startsWith("./") || raw.startsWith("../") || raw.startsWith("~/") || raw.includes("/")
+  )
 }

--- a/packages/opencode/src/cli/cmd/tui/util/local-link.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/local-link.ts
@@ -70,7 +70,9 @@ function pathlike(raw: string) {
     raw.startsWith("./") ||
     raw.startsWith("../") ||
     raw.startsWith("~/") ||
+    /^[A-Za-z]:[\\/]/.test(raw) ||
     raw.includes("/") ||
+    raw.includes("\\") ||
     /^[A-Za-z0-9._-]+$/.test(raw)
   )
 }

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../../fixture/fixture"
+import { localLink } from "../../../src/cli/cmd/tui/util/local-link"
+
+describe("localLink", () => {
+  test("links existing relative file paths in code spans", async () => {
+    await using tmp = await tmpdir()
+    const target = path.join(tmp.path, "plan_a/data/live_jobs_all.csv")
+    await Bun.write(target, "id\n1\n")
+
+    const result = localLink("Use `plan_a/data/live_jobs_all.csv`.", tmp.path)
+
+    expect(result).toContain("[`plan_a/data/live_jobs_all.csv`](file://")
+    expect(result).toContain("live_jobs_all.csv)")
+  })
+
+  test("does not link missing paths", async () => {
+    await using tmp = await tmpdir()
+    const result = localLink("Use `plan_a/data/live_jobs_all.csv`.", tmp.path)
+    expect(result).toBe("Use `plan_a/data/live_jobs_all.csv`.")
+  })
+
+  test("does not relink existing markdown links", async () => {
+    await using tmp = await tmpdir()
+    const target = path.join(tmp.path, "plan_a/data/live_jobs_all.csv")
+    await Bun.write(target, "id\n1\n")
+    const source = "Use [`plan_a/data/live_jobs_all.csv`](file:///tmp/live_jobs_all.csv)."
+    const result = localLink(source, tmp.path)
+    expect(result).toBe(source)
+  })
+})

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -29,4 +29,13 @@ describe("localLink", () => {
     const result = localLink(source, tmp.path)
     expect(result).toBe(source)
   })
+
+  test("converts concealed file URL format to markdown link", async () => {
+    await using tmp = await tmpdir()
+    const target = path.join(tmp.path, ".agents")
+    await Bun.write(target, "")
+
+    const result = localLink(`Path .agents/ (file://${target})`, tmp.path)
+    expect(result).toBe(`Path [.agents/](file://${target})`)
+  })
 })

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -78,4 +78,12 @@ describe("localLink", () => {
     const result = localLink(`- package-lock.json (file://${file})`, root)
     expect(result).toBe(`- [package-lock.json](file://${file})`)
   })
+
+  test("converts concealed file URL format with windows-style labels", async () => {
+    await using tmp = await tmpdir()
+    const root = tmp.path
+    const input = `Here: C:\\Users\\runneradmin\\repo (file://${root})`
+    const result = localLink(input, root)
+    expect(result).toBe(`Here: [C:\\Users\\runneradmin\\repo](file://${root})`)
+  })
 })

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -38,4 +38,15 @@ describe("localLink", () => {
     const result = localLink(`Path .agents/ (file://${target})`, tmp.path)
     expect(result).toBe(`Path [.agents/](file://${target})`)
   })
+
+  test("converts concealed file URL format in multiline lists", async () => {
+    await using tmp = await tmpdir()
+    const root = tmp.path
+    const dir = path.join(root, ".agents")
+    await Bun.write(dir, "")
+    const input = `Here are files in ${root} (file://${root}):\n- .agents/ (file://${dir})\n- README.md`
+    const result = localLink(input, root)
+    expect(result).toContain(`[${root}](file://${root})`)
+    expect(result).toContain(`- [.agents/](file://${dir})`)
+  })
 })

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -41,6 +41,15 @@ describe("localLink", () => {
     expect(result).toBe(source)
   })
 
+  test("does not relink code spans inside markdown link labels", async () => {
+    await using tmp = await tmpdir()
+    const target = path.join(tmp.path, "foo/bar")
+    await Bun.write(target, "")
+    const source = "Use [open `foo/bar`](https://example.com)."
+    const result = localLink(source, tmp.path)
+    expect(result).toBe(source)
+  })
+
   test("converts concealed file URL format to markdown link", async () => {
     await using tmp = await tmpdir()
     const target = path.join(tmp.path, ".agents")

--- a/packages/opencode/test/cli/tui/local-link.test.ts
+++ b/packages/opencode/test/cli/tui/local-link.test.ts
@@ -15,6 +15,17 @@ describe("localLink", () => {
     expect(result).toContain("live_jobs_all.csv)")
   })
 
+  test("links existing bare filenames in code spans", async () => {
+    await using tmp = await tmpdir()
+    const target = path.join(tmp.path, "package-lock.json")
+    await Bun.write(target, "{}\n")
+
+    const result = localLink("Use `package-lock.json`.", tmp.path)
+
+    expect(result).toContain("[`package-lock.json`](file://")
+    expect(result).toContain("package-lock.json)")
+  })
+
   test("does not link missing paths", async () => {
     await using tmp = await tmpdir()
     const result = localLink("Use `plan_a/data/live_jobs_all.csv`.", tmp.path)
@@ -48,5 +59,14 @@ describe("localLink", () => {
     const result = localLink(input, root)
     expect(result).toContain(`[${root}](file://${root})`)
     expect(result).toContain(`- [.agents/](file://${dir})`)
+  })
+
+  test("converts concealed file URL format for bare filenames", async () => {
+    await using tmp = await tmpdir()
+    const root = tmp.path
+    const file = path.join(root, "package-lock.json")
+    await Bun.write(file, "{}\n")
+    const result = localLink(`- package-lock.json (file://${file})`, root)
+    expect(result).toBe(`- [package-lock.json](file://${file})`)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15811

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- convert assistant inline code spans that look like local paths into markdown links targeting `file://` URLs
- only link paths that resolve to existing files/directories are converted to avoid false positives
- add `FileText` component to render those markdown links 

### How did you verify your code works?

Tested clicking on local files on MacOS while pressing CMD key. App associated with the file type is opened. 

### Screenshots / recordings

https://github.com/user-attachments/assets/1b4428f1-8b51-4f78-9c00-51bb569da89b

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
