### PR TITLE
fix(tui): fix markdown table rendering and dialog dimmer color issues

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1437,6 +1437,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const isStreaming = createMemo(() => !props.message.time.completed)
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1444,7 +1445,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
-              streaming={true}
+              streaming={isStreaming()}
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
             />
@@ -1453,7 +1454,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
             <code
               filetype="markdown"
               drawUnstyledText={false}
-              streaming={true}
+              streaming={isStreaming()}
               syntaxStyle={syntax()}
               content={props.part.text.trim()}
               conceal={ctx.conceal()}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -38,7 +38,7 @@ export function Dialog(
       paddingTop={dimensions().height / 4}
       left={0}
       top={0}
-      backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
+      backgroundColor={new RGBA(theme.background.r, theme.background.g, theme.background.b, 0.6)}
     >
       <box
         onMouseUp={(e) => {


### PR DESCRIPTION
### Issue for this PR

Closes #13855, #13363

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes two TUI rendering bugs:

**Bug #13855 - Markdown table last row missing**

The last row of markdown tables was missing after message streaming completed. The TextPart component passed streaming={true} unconditionally to markdown and code elements, even for completed messages. OpenTUI skips the last table row during streaming (thinking it's incomplete), and doesn't re-render when streaming changes because tokenRaw hasn't changed.

Fixed by deriving streaming state from message.time.completed using createMemo(). Added const isStreaming = createMemo(() => !props.message.time.completed) and changed streaming={true} to streaming={isStreaming()}. This ensures OpenTUI renders all table rows when the message is complete.

**Bug #13363 - Dialog dimmer color on light themes**

Dialog backgrounds were rendering incorrectly on light terminal themes since PR #8467 introduced background transparency. The dimmer rendered against a black buffer rather than the terminal background, breaking contrast.

The dialog dimmer used hardcoded black semi-transparent background RGBA.fromInts(0, 0, 0, 150). Fixed by using the theme's background color with 0.6 opacity: new RGBA(theme.background.r, theme.background.g, theme.background.b, 0.6). This ensures proper contrast on both light and dark terminal themes.

### How did you verify your code works?

Bug #13855:
- Tested with OPENCODE_EXPERIMENTAL_MARKDOWN=true
- Asked AI to output markdown tables with 5+ data rows
- Verified all rows including the last row are displayed correctly
- Tested both markdown and code rendering paths

Bug #13363:
- Tested with light terminal theme
- Set opencode theme to system
- Opened various dialogs like /model and /agent
- Verified dialog dimmer has proper contrast and readability
- Tested with dark theme to ensure no regression

### Screenshots / recordings

_Not applicable - both are TUI rendering fixes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR