### PR TITLE
fix(copilot): treat synthetic user messages as agent for x-initiator billing

### DIFF
--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -17,6 +17,25 @@ function getUrls(domain: string) {
   }
 }
 
+/**
+ * Returns true if the last message in the conversation is a "synthetic" user
+ * message produced by the agent (e.g. tool results, image attachments) rather
+ * than one typed by the human.  Synthetic messages should be billed as agent
+ * traffic even though their `role` is `"user"`.
+ */
+export function isSyntheticUserMessage(msg: any): boolean {
+  if (!msg || msg.role !== "user") return false
+  if (!Array.isArray(msg.content)) return false
+  return msg.content.every(
+    (part: any) =>
+      part?.type === "tool_result" ||
+      part?.type === "attachment" ||
+      part?.type === "input_image" ||
+      part?.type === "image_url" ||
+      part?.type === "image"
+  )
+}
+
 export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
   const sdk = input.client
   return {
@@ -65,6 +84,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             if (info.type !== "oauth") return fetch(request, init)
 
             const url = request instanceof URL ? request.href : request.toString()
+
             const { isVision, isAgent } = iife(() => {
               try {
                 const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body
@@ -77,7 +97,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                       (msg: any) =>
                         Array.isArray(msg.content) && msg.content.some((part: any) => part.type === "image_url"),
                     ),
-                    isAgent: last?.role !== "user",
+                    isAgent: last?.role !== "user" || isSyntheticUserMessage(last),
                   }
                 }
 
@@ -89,15 +109,13 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                       (item: any) =>
                         Array.isArray(item?.content) && item.content.some((part: any) => part.type === "input_image"),
                     ),
-                    isAgent: last?.role !== "user",
+                    isAgent: last?.role !== "user" || isSyntheticUserMessage(last),
                   }
                 }
 
                 // Messages API
                 if (body?.messages) {
                   const last = body.messages[body.messages.length - 1]
-                  const hasNonToolCalls =
-                    Array.isArray(last?.content) && last.content.some((part: any) => part?.type !== "tool_result")
                   return {
                     isVision: body.messages.some(
                       (item: any) =>
@@ -111,7 +129,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                               part.content.some((nested: any) => nested?.type === "image")),
                         ),
                     ),
-                    isAgent: !(last?.role === "user" && hasNonToolCalls),
+                    isAgent: last?.role !== "user" || isSyntheticUserMessage(last),
                   }
                 }
               } catch {}

--- a/packages/opencode/test/provider/copilot/x-initiator.test.ts
+++ b/packages/opencode/test/provider/copilot/x-initiator.test.ts
@@ -1,0 +1,117 @@
+import { isSyntheticUserMessage } from "@/plugin/copilot"
+import { describe, test, expect } from "bun:test"
+
+describe("isSyntheticUserMessage", () => {
+  describe("returns false for non-user messages", () => {
+    test("assistant message", () => {
+      expect(isSyntheticUserMessage({ role: "assistant", content: "hello" })).toBe(false)
+    })
+
+    test("system message", () => {
+      expect(isSyntheticUserMessage({ role: "system", content: "you are..." })).toBe(false)
+    })
+
+    test("null / undefined", () => {
+      expect(isSyntheticUserMessage(null)).toBe(false)
+      expect(isSyntheticUserMessage(undefined)).toBe(false)
+    })
+  })
+
+  describe("returns false for genuine human user messages", () => {
+    test("plain string content", () => {
+      expect(isSyntheticUserMessage({ role: "user", content: "Hello!" })).toBe(false)
+    })
+
+    test("array with a text part", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [{ type: "text", text: "Hello!" }],
+        }),
+      ).toBe(false)
+    })
+
+    test("array mixing text and tool_result", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [
+            { type: "text", text: "Please also check this result:" },
+            { type: "tool_result", tool_use_id: "abc", content: "done" },
+          ],
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe("returns true for synthetic agent-produced user messages", () => {
+    test("only tool_result parts (Completions / Messages API pattern)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "result A" },
+            { type: "tool_result", tool_use_id: "t2", content: "result B" },
+          ],
+        }),
+      ).toBe(true)
+    })
+
+    test("only image_url parts (Completions API vision attachment)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: "data:image/png;base64,abc" } }],
+        }),
+      ).toBe(true)
+    })
+
+    test("only input_image parts (Responses API vision attachment)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [{ type: "input_image", image_url: "data:image/png;base64,abc" }],
+        }),
+      ).toBe(true)
+    })
+
+    test("only image parts (Messages API vision attachment)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } }],
+        }),
+      ).toBe(true)
+    })
+
+    test("only attachment parts", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [{ type: "attachment", data: "..." }],
+        }),
+      ).toBe(true)
+    })
+
+    test("mixed tool_result and image (compaction scenario)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "done" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+          ],
+        }),
+      ).toBe(true)
+    })
+
+    test("empty content array is treated as synthetic (no human text)", () => {
+      expect(
+        isSyntheticUserMessage({
+          role: "user",
+          content: [],
+        }),
+      ).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #15824

> Originally reported upstream at sst/opencode#8030.

### Type of change

- [x] Bug fix

### What does this PR do?

When GitHub Copilot receives a request, it uses the `x-initiator` header to decide whether to bill the request against the user's premium quota (`user`) or the agent budget (`agent`). opencode sets this header based on the `role` of the last message in the request body.

The problem: **tool results, image attachments, and other agent-produced content** travel as messages with `role: "user"` in all three API flavours (Completions, Responses, Anthropic Messages). The Completions and Responses API paths only checked `last?.role !== "user"`, so every agentic turn containing tool results was mis-classified as user-initiated and incorrectly billed against the user's Copilot premium quota.

The Anthropic Messages API path had a partial fix (`hasNonToolCalls`), but it was inconsistent with the other two paths and only covered `tool_result` parts.

**Fix:** introduce a shared `isSyntheticUserMessage()` helper that returns `true` when every content part of a `role: "user"` message is an agent-produced type (`tool_result`, `attachment`, `input_image`, `image_url`, `image`). Apply it consistently across all three API paths.

### How did you verify your code works?

Added 13 unit tests in `packages/opencode/test/provider/copilot/x-initiator.test.ts` covering genuine human messages (→ `false`) and all synthetic agent-produced message shapes (→ `true`).

```
bun test test/provider/copilot/
42 pass, 0 fail
```

### Screenshots / recordings

_N/A — logic-only change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR