### PR TITLE
docs(ecosystem): add opencode-rexd-target plugin listing

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,7 +46,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [octto](https://github.com/vtemian/octto)                                                                 | Interactive browser UI for AI brainstorming with multi-question forms                             |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)                     | Claude Code-style background agents with async delegation and context persistence                 |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
-| [opencode-rexd-target](https://github.com/samiralibabic/opencode-rexd-target)                             | Route OpenCode tools to remote REXD targets over SSH with local fallback, PTY support, and patch/edit routing |
+| [opencode-rexd-target](https://github.com/samiralibabic/opencode-rexd-target)                             | Route OpenCode tools to remote servers running [REXD](https://github.com/samiralibabic/rexd) (Remote Execution Daemon) over SSH with local fallback, PTY support, and patch/edit routing |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,6 +46,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [octto](https://github.com/vtemian/octto)                                                                 | Interactive browser UI for AI brainstorming with multi-question forms                             |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)                     | Claude Code-style background agents with async delegation and context persistence                 |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
+| [opencode-rexd-target](https://github.com/samiralibabic/opencode-rexd-target)                             | Route OpenCode tools to remote REXD targets over SSH with local fallback, PTY support, and patch/edit routing |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
 


### PR DESCRIPTION
### Issue for this PR

N/A (docs listing update)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds `opencode-rexd-target` to the ecosystem plugins table and clarifies that REXD means Remote Execution Daemon with a direct link to the REXD repository.

### How did you verify your code works?

I reviewed the markdown table row in `packages/web/src/content/docs/ecosystem.mdx`, verified the links are valid, and confirmed the docs checks run successfully on the PR.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR