### PR TITLE
feat(tui): add all-project toggle in session list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -23,12 +23,28 @@ export function DialogSessionList() {
 
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
+  const [all, setAll] = createSignal(false)
 
-  const [searchResults] = createResource(search, async (query) => {
-    if (!query) return undefined
-    const result = await sdk.client.session.list({ search: query, limit: 30 })
-    return result.data ?? []
-  })
+  const [searchResults] = createResource(
+    () => ({ query: search(), all: all() }),
+    async (input) => {
+      if (!input.query && !input.all) return undefined
+      if (input.all) {
+        const result = await sdk.client.experimental.session.list({
+          roots: true,
+          search: input.query || undefined,
+          limit: 500,
+        })
+        return result.data ?? []
+      }
+      const result = await sdk.client.session.list({
+        roots: true,
+        search: input.query || undefined,
+        limit: 30,
+      })
+      return result.data ?? []
+    },
+  )
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
 
@@ -40,6 +56,9 @@ export function DialogSessionList() {
       .filter((x) => x.parentID === undefined)
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .map((x) => {
+        const worktree = all()
+          ? ((x as { project?: { worktree?: string } | null }).project?.worktree ?? x.directory)
+          : undefined
         const date = new Date(x.time.updated)
         let category = date.toDateString()
         if (category === today) {
@@ -53,6 +72,7 @@ export function DialogSessionList() {
           bg: isDeleting ? theme.error : undefined,
           value: x.id,
           category,
+          description: worktree,
           footer: Locale.time(x.time.updated),
           gutter: isWorking ? <Spinner /> : undefined,
         }
@@ -65,7 +85,7 @@ export function DialogSessionList() {
 
   return (
     <DialogSelect
-      title="Sessions"
+      title={all() ? "Sessions (all projects)" : "Sessions"}
       options={options()}
       skipFilter={true}
       current={currentSessionID()}
@@ -81,6 +101,14 @@ export function DialogSessionList() {
         dialog.clear()
       }}
       keybind={[
+        {
+          keybind: keybind.all.session_list_all?.[0],
+          title: all() ? "project only" : "all projects",
+          onTrigger: async () => {
+            setToDelete(undefined)
+            setAll((value) => !value)
+          },
+        },
         {
           keybind: keybind.all.session_delete?.[0],
           title: "delete",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -764,6 +764,7 @@ export namespace Config {
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),
       session_list: z.string().optional().default("<leader>l").describe("List all sessions"),
+      session_list_all: z.string().optional().default("ctrl+o").describe("Toggle all projects in session list"),
       session_timeline: z.string().optional().default("<leader>g").describe("Show session timeline"),
       session_fork: z.string().optional().default("none").describe("Fork session from message"),
       session_rename: z.string().optional().default("ctrl+r").describe("Rename session"),


### PR DESCRIPTION
### Issue for this PR

Closes #8541

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a quick toggle in the `/session` dialog so you can switch between current-project sessions and all-project sessions without leaving the dialog. The new keybind is `session_list_all` (default `ctrl+o`). In all-project mode, each row shows the source worktree/directory so it is clear which project a session belongs to.

### How did you verify your code works?

- Ran `bun run typecheck` in `packages/opencode`
- Ran `bun test keybind.test.ts test/config` in `packages/opencode`
- Manually tested in TUI: `/session` -> `ctrl+o` toggles all projects on/off and updates list/title as expected

### Screenshots / recordings

![Image 1](https://github.com/user-attachments/assets/8d180d8e-a001-42d0-8cb8-f260af13031f)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR