### PR TITLE
fix(app): resize layout viewport when mobile keyboard appears

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -2,7 +2,7 @@
 <html lang="en" style="background-color: var(--background-base)">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <title>OpenCode</title>
     <link rel="icon" type="image/png" href="/favicon-96x96-v3.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />


### PR DESCRIPTION
### Issue for this PR

Closes #15842

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The viewport meta tag defaults to `interactive-widget=resizes-visual`, which means the virtual keyboard overlays the visual viewport without resizing the layout viewport. Since the root element uses `h-dvh` and `dvh` tracks the layout viewport, the full flex layout stays at its original height behind the keyboard — pushing the composer (`shrink-0` at the bottom of a `flex-col`) under it.

Adding `interactive-widget=resizes-content` tells the browser to resize the layout viewport (and thus the ICB) when the keyboard appears. `dvh` then shrinks to the space above the keyboard, the message timeline (`flex-1`) absorbs the reduction, and the composer stays visible.

Desktop is unaffected (no virtual keyboard = no viewport change). Browser support: Chrome 108+, Safari 15+, Edge 108+.

### How did you verify your code works?

Tested on iOS Safari and Chrome Android — the composer stays visible above the keyboard after the change.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR