### PR TITLE
feat(provider): add data residency header support for OpenAI Enterprise

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -623,6 +623,10 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
       output.headers.originator = "opencode"
       output.headers["User-Agent"] = `opencode/${Installation.VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`
       output.headers.session_id = input.sessionID
+      const residency = input.provider?.options?.enforce_residency
+      if (residency) {
+        output.headers["x-openai-internal-codex-residency"] = residency
+      }
     },
   }
 }


### PR DESCRIPTION
### Issue for this PR

No existing issue — this addresses a gap in OpenAI Enterprise support for non-US regions using Codex OAuth.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the `x-openai-internal-codex-residency` HTTP header to OpenAI Codex provider requests in `packages/opencode/src/plugin/codex.ts`.

**Problem**: OpenAI Enterprise workspaces with US data residency reject Codex API requests from non-US regions with `401 "Workspace is not authorized in this region"`. OpenCode's Codex auth plugin shares the identical OAuth flow, client ID, and endpoint as OpenAI's own Codex CLI — but is missing this one header.

**Fix**: Read `enforce_residency` from provider options and set `x-openai-internal-codex-residency` in the `chat.headers` hook. This mirrors exactly how Codex CLI handles it in [`codex-rs/core/src/default_client.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/default_client.rs). Users configure it via `opencode.json`:

```jsonc
{
  "provider": {
    "openai": {
      "options": {
        "enforce_residency": "us"
      }
    }
  }
}
```

The provider options schema already uses `.catchall(z.any())`, so no schema changes are needed.

### How did you verify your code works?

- Verified the header is added to outgoing requests when `enforce_residency` is set in provider config
- Confirmed the header is NOT added when the option is absent (no impact on non-Enterprise users)
- Cross-referenced with Codex CLI source to ensure header name and value match exactly

### Screenshots / recordings

_N/A — backend-only change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR