### PR TITLE
docs(providers): document Responses API support for custom providers

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1946,6 +1946,50 @@ The `limit` fields allow OpenCode to understand how much context you have left. 
 
 ---
 
+##### Responses API support
+
+The examples above use `@ai-sdk/openai-compatible`, which connects to the **Chat Completions API** (`/v1/chat/completions`). This works for most models, but some features and models require the **Responses API** (`/v1/responses`):
+
+- **Codex models** like `gpt-5.3-codex` are only available through the Responses API.
+- **Reasoning summaries** (`reasoningSummary`) are exclusive to the Responses API.
+- **Message phases** (`commentary` / `final_answer`) for Codex models require the Responses API.
+
+If your proxy supports the Responses API (e.g. [LiteLLM](https://docs.litellm.ai), [OpenRouter](https://openrouter.ai)), use `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible`:
+
+```json title="opencode.json" {5}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "my-proxy": {
+      "npm": "@ai-sdk/openai",
+      "name": "My Proxy",
+      "options": {
+        "baseURL": "http://localhost:4000/v1"
+      },
+      "models": {
+        "gpt-5.3-codex": {
+          "name": "GPT-5.3 Codex"
+        },
+        "gpt-5-mini": {
+          "name": "GPT-5 Mini"
+        }
+      }
+    }
+  }
+}
+```
+
+| SDK package | API endpoint | Use when |
+| --- | --- | --- |
+| `@ai-sdk/openai-compatible` | `/v1/chat/completions` | Your provider only supports Chat Completions |
+| `@ai-sdk/openai` | `/v1/responses` | Your provider supports the Responses API and you need Codex models, reasoning summaries, or message phases |
+
+:::tip
+When in doubt, try `@ai-sdk/openai` first — it supports the latest OpenAI features. Fall back to `@ai-sdk/openai-compatible` if your provider doesn't support the Responses API.
+:::
+
+---
+
 ## Troubleshooting
 
 If you are having trouble with configuring a provider, check the following:

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1954,7 +1954,7 @@ The examples above use `@ai-sdk/openai-compatible`, which connects to the **Chat
 - **Reasoning summaries** (`reasoningSummary`) are exclusive to the Responses API.
 - **Message phases** (`commentary` / `final_answer`) for Codex models require the Responses API.
 
-If your proxy supports the Responses API (e.g. [LiteLLM](https://docs.litellm.ai), [OpenRouter](https://openrouter.ai)), use `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible`:
+If your server supports the OpenAI Responses API endpoint (`/v1/responses`) (e.g. [LiteLLM](https://docs.litellm.ai), [OpenRouter](https://openrouter.ai)), use `@ai-sdk/openai` instead of `@ai-sdk/openai-compatible`:
 
 ```json title="opencode.json" {5}
 {


### PR DESCRIPTION
### Issue for this PR

Related to #10601, #12579, #15528,
Closes BerriAI/litellm#21998

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Documents when to use `@ai-sdk/openai` vs `@ai-sdk/openai-compatible` for custom providers in the "Custom provider" section of the providers docs.

Currently the docs only show `@ai-sdk/openai-compatible` for custom/proxy providers, which uses the Chat Completions API (`/v1/chat/completions`). Some models and features require the Responses API (`/v1/responses`):

- **Codex models** (`gpt-5.3-codex`) are only available through the Responses API
- **Reasoning summaries** (`reasoningSummary`) are exclusive to the Responses API
- **Message phases** (`commentary` / `final_answer`) require the Responses API

Users can already use `"npm": "@ai-sdk/openai"` with a custom `baseURL` to connect to servers that support the OpenAI Responses API endpoint (e.g. LiteLLM, OpenRouter), but this wasn't documented.

The change adds:
- A "Responses API support" subsection under "Custom provider"
- A config example using `@ai-sdk/openai`
- A comparison table explaining when to use each SDK package
- A tip recommending `@ai-sdk/openai` as the default when supported

### How did you verify your code works?

Tested locally with:
1. OpenCode (`bun run dev`) configured with `"npm": "@ai-sdk/openai"` pointing to a LiteLLM proxy
2. Verified `gpt-5.3-codex` (Responses API-only model) works through the proxy
3. Verified the SDK sends requests to `/v1/responses` in the correct format
4. Verified docs render correctly with `bun run --cwd packages/web dev`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR