### PR TITLE
fix: don't create Java metadata files in project root

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1216,6 +1216,7 @@ export namespace LSPServer {
             "-Dosgi.bundles.defaultStartLevel=4",
             "-Declipse.product=org.eclipse.jdt.ls.core.product",
             "-Dlog.level=ALL",
+            "-Djdt.ls.generatesMetadataFilesAtProjectRoot=false",
             "--add-modules=ALL-SYSTEM",
             "--add-opens java.base/java.util=ALL-UNNAMED",
             "--add-opens java.base/java.lang=ALL-UNNAMED",


### PR DESCRIPTION
### Issue for this PR

Closes #9596

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The language server creates metadata files in the project root, even when the agent is in plan mode. With this setting files are no longer pollute the project's root dir.

Reference: https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/da54ab6744fe87e23a3cd9d915df8e55567f8411/org.eclipse.jdt.ls.filesystem/src/org/eclipse/jdt/ls/core/internal/filesystem/JLSFsUtils.java#L192

### How did you verify your code works?
Started server locally with `-Djdt.ls.generatesMetadataFilesAtProjectRoot=false`

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
