### PR TITLE
fix(app): fix review expand button overflow on long labels

### DIFF
--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -574,7 +574,7 @@ export const SessionReview = (props: SessionReviewProps) => {
             <Button
               size="small"
               icon="chevron-grabber-vertical"
-              class="w-[106px] justify-start"
+              class="min-w-0 max-w-full justify-start"
               onClick={handleExpandOrCollapseAll}
             >
               <Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #15878

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR updates the Review Panel's "Expand all" button to not overflowing in languages with longer texts

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
WIP

### Screenshots / recordings
Before:
<img width="900" height="48" alt="image" src="https://github.com/user-attachments/assets/da0bbedb-92fb-4314-80f3-ae945a9de181" />


After:
<img width="1278" height="50" alt="image" src="https://github.com/user-attachments/assets/1c0e5b2f-eb70-4da7-b98a-98cdcd22f863" />


_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
