### PR TITLE
fix(project): use git common dir for project ID cache to prevent worktree session loss

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -95,27 +95,57 @@ export namespace Project {
       const dotgit = await matches.next().then((x) => x.value)
       await matches.return()
       if (dotgit) {
-        let sandbox = path.dirname(dotgit)
+        const raw = path.dirname(dotgit)
 
         const gitBinary = Bun.which("git")
 
-        // cached id calculation
-        let id = await Filesystem.readText(path.join(dotgit, "opencode"))
-          .then((x) => x.trim())
-          .catch(() => undefined)
-
         if (!gitBinary) {
+          const id = await Filesystem.readText(path.join(dotgit, "opencode"))
+            .then((x) => x.trim())
+            .catch(() => undefined)
           return {
             id: id ?? "global",
-            worktree: sandbox,
-            sandbox: sandbox,
+            worktree: raw,
+            sandbox: raw,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
 
-        // generate id from root commit
+        // Resolve the worktree root and git common dir so the project ID
+        // cache is read from and written to the shared .git directory.  This
+        // ensures all worktrees for the same repo resolve the same project ID.
+        const top = await git(["rev-parse", "--show-toplevel"], {
+          cwd: raw,
+        })
+          .then(async (result) => gitpath(raw, await result.text()))
+          .catch(() => undefined)
+
+        const sandbox = top ?? raw
+
+        const common = await git(["rev-parse", "--git-common-dir"], {
+          cwd: sandbox,
+        })
+          .then(async (result) => {
+            const dir = gitpath(sandbox, await result.text())
+            return dir === sandbox ? undefined : dir
+          })
+          .catch(() => undefined)
+
+        const worktree = common ? path.dirname(common) : sandbox
+
+        // Read cached project ID from the git common dir (shared across
+        // worktrees).  Falls back to dotgit for repos where git-common-dir
+        // resolution failed.
+        const cache = common ? path.join(common, "opencode") : path.join(dotgit, "opencode")
+        let id = await Filesystem.readText(cache)
+          .then((x) => x.trim())
+          .catch(() => undefined)
+
+        // Generate id from root commit.  Use HEAD instead of --all to avoid
+        // orphan branches (gh-pages, stash roots) from changing the sorted
+        // first root commit across restarts.
         if (!id) {
-          const roots = await git(["rev-list", "--max-parents=0", "--all"], {
+          const roots = await git(["rev-list", "--max-parents=0", "HEAD"], {
             cwd: sandbox,
           })
             .then(async (result) =>
@@ -127,63 +157,18 @@ export namespace Project {
             )
             .catch(() => undefined)
 
-          if (!roots) {
-            return {
-              id: "global",
-              worktree: sandbox,
-              sandbox: sandbox,
-              vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-            }
-          }
-
-          id = roots[0]
+          id = roots?.[0]
           if (id) {
-            await Filesystem.write(path.join(dotgit, "opencode"), id).catch(() => undefined)
+            await Filesystem.write(cache, id).catch(() => undefined)
           }
         }
 
         if (!id) {
           return {
             id: "global",
-            worktree: sandbox,
-            sandbox: sandbox,
-            vcs: "git",
-          }
-        }
-
-        const top = await git(["rev-parse", "--show-toplevel"], {
-          cwd: sandbox,
-        })
-          .then(async (result) => gitpath(sandbox, await result.text()))
-          .catch(() => undefined)
-
-        if (!top) {
-          return {
-            id,
+            worktree,
             sandbox,
-            worktree: sandbox,
-            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-          }
-        }
-
-        sandbox = top
-
-        const worktree = await git(["rev-parse", "--git-common-dir"], {
-          cwd: sandbox,
-        })
-          .then(async (result) => {
-            const common = gitpath(sandbox, await result.text())
-            // Avoid going to parent of sandbox when git-common-dir is empty.
-            return common === sandbox ? sandbox : path.dirname(common)
-          })
-          .catch(() => undefined)
-
-        if (!worktree) {
-          return {
-            id,
-            sandbox,
-            worktree: sandbox,
-            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
+            vcs: top ? "git" : Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
 

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -20,6 +20,8 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) {
     await $`git init`.cwd(dirpath).quiet()
+    await $`git config user.email "test@opencode.test"`.cwd(dirpath).quiet()
+    await $`git config user.name "Test"`.cwd(dirpath).quiet()
     await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
   }
   if (options?.config) {

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -22,7 +22,7 @@ mock.module("../../src/util/git", () => ({
       mode === "rev-list-fail" &&
       cmd.includes("git rev-list") &&
       cmd.includes("--max-parents=0") &&
-      cmd.includes("--all")
+      cmd.includes("HEAD")
     ) {
       return Promise.resolve({
         exitCode: 128,
@@ -163,6 +163,32 @@ describe("Project.fromDirectory with worktrees", () => {
       expect(sandbox).toBe(worktreePath)
       expect(project.sandboxes).toContain(worktreePath)
       expect(project.sandboxes).not.toContain(tmp.path)
+    } finally {
+      await $`git worktree remove ${worktreePath}`
+        .cwd(tmp.path)
+        .quiet()
+        .catch(() => {})
+    }
+  })
+
+  test("worktree should share project ID with main repo", async () => {
+    const p = await loadProject()
+    await using tmp = await tmpdir({ git: true })
+
+    const { project: main } = await p.fromDirectory(tmp.path)
+
+    const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt-shared")
+    try {
+      await $`git worktree add ${worktreePath} -b shared-${Date.now()}`.cwd(tmp.path).quiet()
+
+      const { project: wt } = await p.fromDirectory(worktreePath)
+
+      expect(wt.id).toBe(main.id)
+
+      // Cache should live in the common .git dir, not the worktree's .git file
+      const cache = path.join(tmp.path, ".git", "opencode")
+      const exists = await Filesystem.exists(cache)
+      expect(exists).toBe(true)
     } finally {
       await $`git worktree remove ${worktreePath}`
         .cwd(tmp.path)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where sessions become invisible after restarting opencode in a git worktree. The project ID cache was stored in the per-worktree `.git` path, which is a file (not a directory) in worktrees — so reads and writes silently failed. Each restart recomputed the ID via `rev-list --all`, which is unstable for repos with orphan branches (gh-pages, stash roots, subtree merges), producing a different project ID and orphaning all previous sessions.

Changes:
- Resolve `--show-toplevel` and `--git-common-dir` before reading the cache, so the cache is read/written in the shared `.git` directory
- All worktrees for the same repo now resolve the same project ID
- Switch `rev-list` from `--all` to `HEAD` to exclude orphan branches from the root commit set
- Set local git config in test fixture so tests are self-contained

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Issue for this PR

Fixes #12726
Fixes #12103
Fixes #13782
Fixes #5638

## How did you verify your code works?

- `tsgo --noEmit` passes (0 errors)
- `bun test test/project/project.test.ts` — 18 pass, 0 fail
- New test: worktree resolves the same project ID as main repo, cache lives in shared `.git` dir

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR