### PR TITLE
feat(opencode): add configurable terminal title format

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -264,6 +264,7 @@ function App() {
   // Update terminal window title based on current route and session
   createEffect(() => {
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return
+    const format = sync.data.config.terminal_title
 
     if (route.data.type === "home") {
       renderer.setTerminalTitle("OpenCode")
@@ -278,8 +279,21 @@ function App() {
       }
 
       // Truncate title to 40 chars max
-      const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
-      renderer.setTerminalTitle(`OC | ${title}`)
+      const name = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
+
+      if (!format) {
+        renderer.setTerminalTitle(`OC | ${name}`)
+        return
+      }
+
+      const status = sync.session.status(route.data.sessionID) === "idle" ? "IDLE" : "BUSY"
+      const model = local.model.current()
+      const title = format
+        .replace(/%n/g, name)
+        .replace(/%s/g, status)
+        .replace(/%m/g, model ? `${model.providerID}/${model.modelID}` : "")
+        .replace(/%a/g, local.agent.current().name)
+      renderer.setTerminalTitle(title)
     }
   })
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1127,6 +1127,12 @@ export namespace Config {
           },
         ),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      terminal_title: z
+        .string()
+        .optional()
+        .describe(
+          "Terminal title format. Placeholders: %n (session name), %s (BUSY/IDLE status), %m (model), %a (agent). Example: '[%s] OC | %n'",
+        ),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1449,6 +1449,10 @@ export type Config = {
    * Additional instruction files or patterns to include
    */
   instructions?: Array<string>
+  /**
+   * Terminal title format. Placeholders: %n (session name), %s (BUSY/IDLE status), %m (model), %a (agent). Example: '[%s] OC | %n'
+   */
+  terminal_title?: string
   layout?: LayoutConfig
   permission?: PermissionConfig
   tools?: {


### PR DESCRIPTION
### Issue for this PR

Closes #4539

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `terminal_title` config field that lets users customize the terminal/tmux pane title with template placeholders:

- `%n` — session name
- `%s` — status (BUSY/IDLE)
- `%m` — current model (provider/model)
- `%a` — current agent

Example config:

```json
{
  "terminal_title": "[%s] OC | %n"
}
```

Without this config, behavior is unchanged — the title stays `OC | <session name>` as before.

### How did you verify your code works?

- Ran `bun dev .` with `terminal_title` set in `~/.config/opencode/opencode.json`, confirmed title updates reactively when session transitions between BUSY and IDLE
- Verified default behavior (no config) is unchanged
- `bun run typecheck` passes on `packages/opencode`
- `bun test` passes on `packages/opencode` (1 pre-existing unrelated failure in `tool.write` permissions test)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR