### PR TITLE
feat(session): add storage interface for pluggable session backends

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -12,7 +12,7 @@ import { Installation } from "../installation"
 
 import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt } from "../storage/db"
 import type { SQL } from "../storage/db"
-import { SessionTable, MessageTable, PartTable } from "./session.sql"
+import { SessionTable } from "./session.sql"
 import { ProjectTable } from "../project/project.sql"
 import { Storage } from "@/storage/storage"
 import { Log } from "../util/log"
@@ -29,9 +29,11 @@ import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { iife } from "@/util/iife"
+import { SqliteSessionStore } from "./store.sqlite"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
+  const store = SqliteSessionStore
 
   const parentTitlePrefix = "New session - "
   const childTitlePrefix = "Child session - "
@@ -679,17 +681,14 @@ export namespace Session {
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
     const time_created = msg.time.created
     const { id, sessionID, ...data } = msg
-    Database.use((db) => {
-      db.insert(MessageTable)
-        .values({
-          id,
-          session_id: sessionID,
-          time_created,
-          data,
-        })
-        .onConflictDoUpdate({ target: MessageTable.id, set: { data } })
-        .run()
-      Database.effect(() =>
+    store.use((tx) => {
+      tx.message_upsert({
+        id,
+        session_id: sessionID,
+        time_created,
+        data,
+      })
+      store.effect(() =>
         Bus.publish(MessageV2.Event.Updated, {
           info: msg,
         }),
@@ -705,11 +704,9 @@ export namespace Session {
     }),
     async (input) => {
       // CASCADE delete handles parts automatically
-      Database.use((db) => {
-        db.delete(MessageTable)
-          .where(and(eq(MessageTable.id, input.messageID), eq(MessageTable.session_id, input.sessionID)))
-          .run()
-        Database.effect(() =>
+      store.use((tx) => {
+        tx.message_delete(input.sessionID, input.messageID)
+        store.effect(() =>
           Bus.publish(MessageV2.Event.Removed, {
             sessionID: input.sessionID,
             messageID: input.messageID,
@@ -727,11 +724,9 @@ export namespace Session {
       partID: Identifier.schema("part"),
     }),
     async (input) => {
-      Database.use((db) => {
-        db.delete(PartTable)
-          .where(and(eq(PartTable.id, input.partID), eq(PartTable.session_id, input.sessionID)))
-          .run()
-        Database.effect(() =>
+      store.use((tx) => {
+        tx.part_delete(input.sessionID, input.partID)
+        store.effect(() =>
           Bus.publish(MessageV2.Event.PartRemoved, {
             sessionID: input.sessionID,
             messageID: input.messageID,
@@ -748,18 +743,15 @@ export namespace Session {
   export const updatePart = fn(UpdatePartInput, async (part) => {
     const { id, messageID, sessionID, ...data } = part
     const time = Date.now()
-    Database.use((db) => {
-      db.insert(PartTable)
-        .values({
-          id,
-          message_id: messageID,
-          session_id: sessionID,
-          time_created: time,
-          data,
-        })
-        .onConflictDoUpdate({ target: PartTable.id, set: { data } })
-        .run()
-      Database.effect(() =>
+    store.use((tx) => {
+      tx.part_upsert({
+        id,
+        message_id: messageID,
+        session_id: sessionID,
+        time_created: time,
+        data,
+      })
+      store.effect(() =>
         Bus.publish(MessageV2.Event.PartUpdated, {
           part: structuredClone(part),
         }),
@@ -885,4 +877,18 @@ export namespace Session {
   )
 }
 
-export type { SessionStore, SessionStoreTx, SessionRow, MessageRow, PartRow, TodoRow, PermissionRow } from "./store"
+export { SqliteSessionStore } from "./store.sqlite"
+export type {
+  SessionStore,
+  SessionStoreTx,
+  SessionRow,
+  SessionInput,
+  MessageRow,
+  MessageInput,
+  PartRow,
+  PartInput,
+  TodoRow,
+  TodoInput,
+  PermissionRow,
+  PermissionInput,
+} from "./store"

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -681,19 +681,19 @@ export namespace Session {
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
     const time_created = msg.time.created
     const { id, sessionID, ...data } = msg
-    await store.use(async (tx) => {
-      await tx.message_upsert({
+    await store.use((tx) => {
+      return tx.message_upsert({
         id,
         session_id: sessionID,
         time_created,
         data,
       })
-      await store.effect(() =>
-        Bus.publish(MessageV2.Event.Updated, {
-          info: msg,
-        }),
-      )
     })
+    await store.effect(() =>
+      Bus.publish(MessageV2.Event.Updated, {
+        info: msg,
+      }),
+    )
     return msg
   })
 
@@ -704,15 +704,15 @@ export namespace Session {
     }),
     async (input) => {
       // CASCADE delete handles parts automatically
-      await store.use(async (tx) => {
-        await tx.message_delete(input.sessionID, input.messageID)
-        await store.effect(() =>
-          Bus.publish(MessageV2.Event.Removed, {
-            sessionID: input.sessionID,
-            messageID: input.messageID,
-          }),
-        )
+      await store.use((tx) => {
+        return tx.message_delete(input.sessionID, input.messageID)
       })
+      await store.effect(() =>
+        Bus.publish(MessageV2.Event.Removed, {
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+        }),
+      )
       return input.messageID
     },
   )
@@ -724,16 +724,16 @@ export namespace Session {
       partID: Identifier.schema("part"),
     }),
     async (input) => {
-      await store.use(async (tx) => {
-        await tx.part_delete(input.sessionID, input.partID)
-        await store.effect(() =>
-          Bus.publish(MessageV2.Event.PartRemoved, {
-            sessionID: input.sessionID,
-            messageID: input.messageID,
-            partID: input.partID,
-          }),
-        )
+      await store.use((tx) => {
+        return tx.part_delete(input.sessionID, input.partID)
       })
+      await store.effect(() =>
+        Bus.publish(MessageV2.Event.PartRemoved, {
+          sessionID: input.sessionID,
+          messageID: input.messageID,
+          partID: input.partID,
+        }),
+      )
       return input.partID
     },
   )
@@ -743,20 +743,20 @@ export namespace Session {
   export const updatePart = fn(UpdatePartInput, async (part) => {
     const { id, messageID, sessionID, ...data } = part
     const time = Date.now()
-    await store.use(async (tx) => {
-      await tx.part_upsert({
+    await store.use((tx) => {
+      return tx.part_upsert({
         id,
         message_id: messageID,
         session_id: sessionID,
         time_created: time,
         data,
       })
-      await store.effect(() =>
-        Bus.publish(MessageV2.Event.PartUpdated, {
-          part: structuredClone(part),
-        }),
-      )
     })
+    await store.effect(() =>
+      Bus.publish(MessageV2.Event.PartUpdated, {
+        part: structuredClone(part),
+      }),
+    )
     return part
   })
 

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -884,3 +884,5 @@ export namespace Session {
     },
   )
 }
+
+export type { SessionStore, SessionStoreTx, SessionRow, MessageRow, PartRow, TodoRow, PermissionRow } from "./store"

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -681,14 +681,14 @@ export namespace Session {
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
     const time_created = msg.time.created
     const { id, sessionID, ...data } = msg
-    store.use((tx) => {
-      tx.message_upsert({
+    await store.use(async (tx) => {
+      await tx.message_upsert({
         id,
         session_id: sessionID,
         time_created,
         data,
       })
-      store.effect(() =>
+      await store.effect(() =>
         Bus.publish(MessageV2.Event.Updated, {
           info: msg,
         }),
@@ -704,9 +704,9 @@ export namespace Session {
     }),
     async (input) => {
       // CASCADE delete handles parts automatically
-      store.use((tx) => {
-        tx.message_delete(input.sessionID, input.messageID)
-        store.effect(() =>
+      await store.use(async (tx) => {
+        await tx.message_delete(input.sessionID, input.messageID)
+        await store.effect(() =>
           Bus.publish(MessageV2.Event.Removed, {
             sessionID: input.sessionID,
             messageID: input.messageID,
@@ -724,9 +724,9 @@ export namespace Session {
       partID: Identifier.schema("part"),
     }),
     async (input) => {
-      store.use((tx) => {
-        tx.part_delete(input.sessionID, input.partID)
-        store.effect(() =>
+      await store.use(async (tx) => {
+        await tx.part_delete(input.sessionID, input.partID)
+        await store.effect(() =>
           Bus.publish(MessageV2.Event.PartRemoved, {
             sessionID: input.sessionID,
             messageID: input.messageID,
@@ -743,15 +743,15 @@ export namespace Session {
   export const updatePart = fn(UpdatePartInput, async (part) => {
     const { id, messageID, sessionID, ...data } = part
     const time = Date.now()
-    store.use((tx) => {
-      tx.part_upsert({
+    await store.use(async (tx) => {
+      await tx.part_upsert({
         id,
         message_id: messageID,
         session_id: sessionID,
         time_created: time,
         data,
       })
-      store.effect(() =>
+      await store.effect(() =>
         Bus.publish(MessageV2.Event.PartUpdated, {
           part: structuredClone(part),
         }),

--- a/packages/opencode/src/session/store.sqlite.ts
+++ b/packages/opencode/src/session/store.sqlite.ts
@@ -1,0 +1,99 @@
+import { and, Database, desc, eq, gte, inArray, isNull, like, lt, type SQL } from "@/storage/db"
+import { MessageTable, PartTable, PermissionTable, SessionTable, TodoTable } from "./session.sql"
+import type { SessionStore, SessionStoreTx } from "./store"
+
+function tx(db: Database.TxOrDb): SessionStoreTx {
+  return {
+    session_insert(row) {
+      db.insert(SessionTable).values(row).run()
+    },
+    session_get(id) {
+      return db.select().from(SessionTable).where(eq(SessionTable.id, id)).get()
+    },
+    session_update(id, patch) {
+      return db.update(SessionTable).set(patch).where(eq(SessionTable.id, id)).returning().get()
+    },
+    session_list(input) {
+      const conditions: SQL[] = []
+      if (input?.project_id) conditions.push(eq(SessionTable.project_id, input.project_id))
+      if (input?.workspace_id) conditions.push(eq(SessionTable.workspace_id, input.workspace_id))
+      if (input?.directory) conditions.push(eq(SessionTable.directory, input.directory))
+      if (input?.roots) conditions.push(isNull(SessionTable.parent_id))
+      if (input?.start) conditions.push(gte(SessionTable.time_updated, input.start))
+      if (input?.cursor) conditions.push(lt(SessionTable.time_updated, input.cursor))
+      if (input?.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
+      if (input?.archived === false) conditions.push(isNull(SessionTable.time_archived))
+
+      const query =
+        conditions.length > 0 ? db.select().from(SessionTable).where(and(...conditions)) : db.select().from(SessionTable)
+      return query.orderBy(desc(SessionTable.time_updated), desc(SessionTable.id)).limit(input?.limit ?? 100).all()
+    },
+    session_children(project_id, parent_id) {
+      return db
+        .select()
+        .from(SessionTable)
+        .where(and(eq(SessionTable.project_id, project_id), eq(SessionTable.parent_id, parent_id)))
+        .all()
+    },
+    session_delete(id) {
+      db.delete(SessionTable).where(eq(SessionTable.id, id)).run()
+    },
+    message_upsert(row) {
+      db.insert(MessageTable).values(row).onConflictDoUpdate({ target: MessageTable.id, set: { data: row.data } }).run()
+    },
+    message_get(id) {
+      return db.select().from(MessageTable).where(eq(MessageTable.id, id)).get()
+    },
+    message_list(input) {
+      const query = db.select().from(MessageTable).where(eq(MessageTable.session_id, input.session_id))
+      return (input.desc ?? true)
+        ? query.orderBy(desc(MessageTable.time_created)).limit(input.limit).offset(input.offset).all()
+        : query.orderBy(MessageTable.time_created).limit(input.limit).offset(input.offset).all()
+    },
+    message_delete(session_id, id) {
+      db.delete(MessageTable).where(and(eq(MessageTable.id, id), eq(MessageTable.session_id, session_id))).run()
+    },
+    part_upsert(row) {
+      db.insert(PartTable).values(row).onConflictDoUpdate({ target: PartTable.id, set: { data: row.data } }).run()
+    },
+    part_list_by_message(message_id) {
+      return db.select().from(PartTable).where(eq(PartTable.message_id, message_id)).orderBy(PartTable.id).all()
+    },
+    part_list_by_messages(message_ids) {
+      if (message_ids.length === 0) return []
+      return db.select().from(PartTable).where(inArray(PartTable.message_id, message_ids)).orderBy(PartTable.id).all()
+    },
+    part_delete(session_id, id) {
+      db.delete(PartTable).where(and(eq(PartTable.id, id), eq(PartTable.session_id, session_id))).run()
+    },
+    todo_replace(session_id, rows) {
+      db.delete(TodoTable).where(eq(TodoTable.session_id, session_id)).run()
+      if (rows.length === 0) return
+      db.insert(TodoTable).values(rows).run()
+    },
+    todo_list(session_id) {
+      return db.select().from(TodoTable).where(eq(TodoTable.session_id, session_id)).all()
+    },
+    permission_get(project_id) {
+      return db.select().from(PermissionTable).where(eq(PermissionTable.project_id, project_id)).get()
+    },
+    permission_upsert(row) {
+      db.insert(PermissionTable)
+        .values(row)
+        .onConflictDoUpdate({ target: PermissionTable.project_id, set: { data: row.data } })
+        .run()
+    },
+  }
+}
+
+export const SqliteSessionStore: SessionStore = {
+  use(fn) {
+    return Database.use((db) => fn(tx(db)))
+  },
+  transaction(fn) {
+    return Database.transaction((db) => fn(tx(db)))
+  },
+  effect(fn) {
+    return Database.effect(fn)
+  },
+}

--- a/packages/opencode/src/session/store.ts
+++ b/packages/opencode/src/session/store.ts
@@ -1,10 +1,15 @@
 import type { SessionTable, MessageTable, PartTable, TodoTable, PermissionTable } from "./session.sql"
 
 export type SessionRow = typeof SessionTable.$inferSelect
+export type SessionInput = typeof SessionTable.$inferInsert
 export type MessageRow = typeof MessageTable.$inferSelect
+export type MessageInput = typeof MessageTable.$inferInsert
 export type PartRow = typeof PartTable.$inferSelect
+export type PartInput = typeof PartTable.$inferInsert
 export type TodoRow = typeof TodoTable.$inferSelect
+export type TodoInput = typeof TodoTable.$inferInsert
 export type PermissionRow = typeof PermissionTable.$inferSelect
+export type PermissionInput = typeof PermissionTable.$inferInsert
 
 export type SessionPatch = Partial<
   Pick<
@@ -42,36 +47,35 @@ export type MessagePageInput = {
   desc?: boolean
 }
 
-export type SessionStoreEffect = () => void | Promise<void>
-export type SessionStoreValue<T> = T | Promise<T>
+export type SessionStoreEffect = () => unknown
 
 export interface SessionStoreTx {
-  session_insert(row: SessionRow): SessionStoreValue<void>
-  session_get(id: string): SessionStoreValue<SessionRow | undefined>
-  session_update(id: string, patch: SessionPatch): SessionStoreValue<SessionRow | undefined>
-  session_list(input?: SessionListInput): SessionStoreValue<SessionRow[]>
-  session_children(project_id: string, parent_id: string): SessionStoreValue<SessionRow[]>
-  session_delete(id: string): SessionStoreValue<void>
+  session_insert(row: SessionInput): void
+  session_get(id: string): SessionRow | undefined
+  session_update(id: string, patch: SessionPatch): SessionRow | undefined
+  session_list(input?: SessionListInput): SessionRow[]
+  session_children(project_id: string, parent_id: string): SessionRow[]
+  session_delete(id: string): void
 
-  message_upsert(row: MessageRow): SessionStoreValue<void>
-  message_get(id: string): SessionStoreValue<MessageRow | undefined>
-  message_list(input: MessagePageInput): SessionStoreValue<MessageRow[]>
-  message_delete(session_id: string, id: string): SessionStoreValue<void>
+  message_upsert(row: MessageInput): void
+  message_get(id: string): MessageRow | undefined
+  message_list(input: MessagePageInput): MessageRow[]
+  message_delete(session_id: string, id: string): void
 
-  part_upsert(row: PartRow): SessionStoreValue<void>
-  part_list_by_message(message_id: string): SessionStoreValue<PartRow[]>
-  part_list_by_messages(message_ids: string[]): SessionStoreValue<PartRow[]>
-  part_delete(session_id: string, id: string): SessionStoreValue<void>
+  part_upsert(row: PartInput): void
+  part_list_by_message(message_id: string): PartRow[]
+  part_list_by_messages(message_ids: string[]): PartRow[]
+  part_delete(session_id: string, id: string): void
 
-  todo_replace(session_id: string, rows: TodoRow[]): SessionStoreValue<void>
-  todo_list(session_id: string): SessionStoreValue<TodoRow[]>
+  todo_replace(session_id: string, rows: TodoInput[]): void
+  todo_list(session_id: string): TodoRow[]
 
-  permission_get(project_id: string): SessionStoreValue<PermissionRow | undefined>
-  permission_upsert(row: PermissionRow): SessionStoreValue<void>
+  permission_get(project_id: string): PermissionRow | undefined
+  permission_upsert(row: PermissionInput): void
 }
 
 export interface SessionStore {
-  use<T>(fn: (tx: SessionStoreTx) => SessionStoreValue<T>): SessionStoreValue<T>
-  transaction<T>(fn: (tx: SessionStoreTx) => SessionStoreValue<T>): SessionStoreValue<T>
-  effect(fn: SessionStoreEffect): SessionStoreValue<void>
+  use<T>(fn: (tx: SessionStoreTx) => T): T
+  transaction<T>(fn: (tx: SessionStoreTx) => T): T
+  effect(fn: SessionStoreEffect): void
 }

--- a/packages/opencode/src/session/store.ts
+++ b/packages/opencode/src/session/store.ts
@@ -1,0 +1,77 @@
+import type { SessionTable, MessageTable, PartTable, TodoTable, PermissionTable } from "./session.sql"
+
+export type SessionRow = typeof SessionTable.$inferSelect
+export type MessageRow = typeof MessageTable.$inferSelect
+export type PartRow = typeof PartTable.$inferSelect
+export type TodoRow = typeof TodoTable.$inferSelect
+export type PermissionRow = typeof PermissionTable.$inferSelect
+
+export type SessionPatch = Partial<
+  Pick<
+    SessionRow,
+    | "title"
+    | "share_url"
+    | "summary_additions"
+    | "summary_deletions"
+    | "summary_files"
+    | "summary_diffs"
+    | "revert"
+    | "permission"
+    | "time_updated"
+    | "time_archived"
+    | "time_compacting"
+  >
+>
+
+export type SessionListInput = {
+  project_id?: string
+  workspace_id?: string
+  directory?: string
+  roots?: boolean
+  start?: number
+  cursor?: number
+  search?: string
+  limit?: number
+  archived?: boolean
+}
+
+export type MessagePageInput = {
+  session_id: string
+  limit: number
+  offset: number
+  desc?: boolean
+}
+
+export type SessionStoreEffect = () => void | Promise<void>
+export type SessionStoreValue<T> = T | Promise<T>
+
+export interface SessionStoreTx {
+  session_insert(row: SessionRow): SessionStoreValue<void>
+  session_get(id: string): SessionStoreValue<SessionRow | undefined>
+  session_update(id: string, patch: SessionPatch): SessionStoreValue<SessionRow | undefined>
+  session_list(input?: SessionListInput): SessionStoreValue<SessionRow[]>
+  session_children(project_id: string, parent_id: string): SessionStoreValue<SessionRow[]>
+  session_delete(id: string): SessionStoreValue<void>
+
+  message_upsert(row: MessageRow): SessionStoreValue<void>
+  message_get(id: string): SessionStoreValue<MessageRow | undefined>
+  message_list(input: MessagePageInput): SessionStoreValue<MessageRow[]>
+  message_delete(session_id: string, id: string): SessionStoreValue<void>
+
+  part_upsert(row: PartRow): SessionStoreValue<void>
+  part_list_by_message(message_id: string): SessionStoreValue<PartRow[]>
+  part_list_by_messages(message_ids: string[]): SessionStoreValue<PartRow[]>
+  part_delete(session_id: string, id: string): SessionStoreValue<void>
+
+  todo_replace(session_id: string, rows: TodoRow[]): SessionStoreValue<void>
+  todo_list(session_id: string): SessionStoreValue<TodoRow[]>
+
+  permission_get(project_id: string): SessionStoreValue<PermissionRow | undefined>
+  permission_upsert(row: PermissionRow): SessionStoreValue<void>
+}
+
+export interface SessionStore {
+  use<T>(fn: (tx: SessionStoreTx) => SessionStoreValue<T>): SessionStoreValue<T>
+  transaction<T>(fn: (tx: SessionStoreTx) => SessionStoreValue<T>): SessionStoreValue<T>
+  effect(fn: SessionStoreEffect): SessionStoreValue<void>
+}

--- a/packages/opencode/src/session/store.ts
+++ b/packages/opencode/src/session/store.ts
@@ -10,6 +10,7 @@ export type TodoRow = typeof TodoTable.$inferSelect
 export type TodoInput = typeof TodoTable.$inferInsert
 export type PermissionRow = typeof PermissionTable.$inferSelect
 export type PermissionInput = typeof PermissionTable.$inferInsert
+export type Asyncable<T> = T | Promise<T>
 
 export type SessionPatch = Partial<
   Pick<
@@ -47,35 +48,35 @@ export type MessagePageInput = {
   desc?: boolean
 }
 
-export type SessionStoreEffect = () => unknown
+export type SessionStoreEffect = () => Asyncable<unknown>
 
 export interface SessionStoreTx {
-  session_insert(row: SessionInput): void
-  session_get(id: string): SessionRow | undefined
-  session_update(id: string, patch: SessionPatch): SessionRow | undefined
-  session_list(input?: SessionListInput): SessionRow[]
-  session_children(project_id: string, parent_id: string): SessionRow[]
-  session_delete(id: string): void
+  session_insert(row: SessionInput): Asyncable<void>
+  session_get(id: string): Asyncable<SessionRow | undefined>
+  session_update(id: string, patch: SessionPatch): Asyncable<SessionRow | undefined>
+  session_list(input?: SessionListInput): Asyncable<SessionRow[]>
+  session_children(project_id: string, parent_id: string): Asyncable<SessionRow[]>
+  session_delete(id: string): Asyncable<void>
 
-  message_upsert(row: MessageInput): void
-  message_get(id: string): MessageRow | undefined
-  message_list(input: MessagePageInput): MessageRow[]
-  message_delete(session_id: string, id: string): void
+  message_upsert(row: MessageInput): Asyncable<void>
+  message_get(id: string): Asyncable<MessageRow | undefined>
+  message_list(input: MessagePageInput): Asyncable<MessageRow[]>
+  message_delete(session_id: string, id: string): Asyncable<void>
 
-  part_upsert(row: PartInput): void
-  part_list_by_message(message_id: string): PartRow[]
-  part_list_by_messages(message_ids: string[]): PartRow[]
-  part_delete(session_id: string, id: string): void
+  part_upsert(row: PartInput): Asyncable<void>
+  part_list_by_message(message_id: string): Asyncable<PartRow[]>
+  part_list_by_messages(message_ids: string[]): Asyncable<PartRow[]>
+  part_delete(session_id: string, id: string): Asyncable<void>
 
-  todo_replace(session_id: string, rows: TodoInput[]): void
-  todo_list(session_id: string): TodoRow[]
+  todo_replace(session_id: string, rows: TodoInput[]): Asyncable<void>
+  todo_list(session_id: string): Asyncable<TodoRow[]>
 
-  permission_get(project_id: string): PermissionRow | undefined
-  permission_upsert(row: PermissionInput): void
+  permission_get(project_id: string): Asyncable<PermissionRow | undefined>
+  permission_upsert(row: PermissionInput): Asyncable<void>
 }
 
 export interface SessionStore {
-  use<T>(fn: (tx: SessionStoreTx) => T): T
-  transaction<T>(fn: (tx: SessionStoreTx) => T): T
-  effect(fn: SessionStoreEffect): void
+  use<T>(fn: (tx: SessionStoreTx) => Asyncable<T>): Asyncable<T>
+  transaction<T>(fn: (tx: SessionStoreTx) => Asyncable<T>): Asyncable<T>
+  effect(fn: SessionStoreEffect): Asyncable<void>
 }

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -25,9 +25,9 @@ export namespace Todo {
     ),
   }
 
-  export function update(input: { sessionID: string; todos: Info[] }) {
-    store.transaction((tx) => {
-      tx.todo_replace(
+  export async function update(input: { sessionID: string; todos: Info[] }) {
+    await store.transaction(async (tx) => {
+      await tx.todo_replace(
         input.sessionID,
         input.todos.map((todo, position) => ({
           session_id: input.sessionID,
@@ -41,8 +41,8 @@ export namespace Todo {
     Bus.publish(Event.Updated, input)
   }
 
-  export function get(sessionID: string) {
-    const rows = store.use((tx) => tx.todo_list(sessionID))
+  export async function get(sessionID: string) {
+    const rows = await store.use((tx) => tx.todo_list(sessionID))
     rows.sort((a, b) => a.position - b.position)
     return rows.map((row) => ({
       content: row.content,

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,8 +1,9 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import z from "zod"
-import { Database, eq, asc } from "../storage/db"
-import { TodoTable } from "./session.sql"
+import { SqliteSessionStore } from "./store.sqlite"
+
+const store = SqliteSessionStore
 
 export namespace Todo {
   export const Info = z
@@ -25,28 +26,24 @@ export namespace Todo {
   }
 
   export function update(input: { sessionID: string; todos: Info[] }) {
-    Database.transaction((db) => {
-      db.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
-      if (input.todos.length === 0) return
-      db.insert(TodoTable)
-        .values(
-          input.todos.map((todo, position) => ({
-            session_id: input.sessionID,
-            content: todo.content,
-            status: todo.status,
-            priority: todo.priority,
-            position,
-          })),
-        )
-        .run()
+    store.transaction((tx) => {
+      tx.todo_replace(
+        input.sessionID,
+        input.todos.map((todo, position) => ({
+          session_id: input.sessionID,
+          content: todo.content,
+          status: todo.status,
+          priority: todo.priority,
+          position,
+        })),
+      )
     })
     Bus.publish(Event.Updated, input)
   }
 
   export function get(sessionID: string) {
-    const rows = Database.use((db) =>
-      db.select().from(TodoTable).where(eq(TodoTable.session_id, sessionID)).orderBy(asc(TodoTable.position)).all(),
-    )
+    const rows = store.use((tx) => tx.todo_list(sessionID))
+    rows.sort((a, b) => a.position - b.position)
     return rows.map((row) => ({
       content: row.content,
       status: row.status,


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a typed storage contract for session persistence, wraps SQLite behind that contract, and makes the contract async-compatible so non-SQLite providers can be added more easily.

Changes included:
- Added `SessionStore` + `SessionStoreTx` interfaces in `packages/opencode/src/session/store.ts`, with operation groups for sessions/messages/parts/todos/permissions.
- Added schema-derived insert/select types (`SessionInput`, `SessionRow`, etc.).
- Added `Asyncable<T>` return support across the store interface (`use`, `transaction`, `effect`, and tx methods).
- Added `SqliteSessionStore` adapter in `packages/opencode/src/session/store.sqlite.ts` that wraps `Database.use`, `Database.transaction`, and `Database.effect`.
- Routed core write paths through the adapter:
  - `Session.updateMessage`, `Session.removeMessage`, `Session.removePart`, `Session.updatePart`
  - `Todo.update` and `Todo.get` (now async to align with async-capable store)
- Exported store types and sqlite adapter from `packages/opencode/src/session/index.ts`.

This remains incremental: runtime behavior should stay equivalent while introducing a real, async-ready boundary for follow-up backends.

### How did you verify your code works?

- Installed Bun (`1.3.10`) in this environment
- Ran `bun install` at repo root
- Ran `bun run typecheck` in `packages/opencode`
- Pushed branch successfully; pre-push hook ran `bun turbo typecheck` and passed

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR