### PR TITLE
fix(config): load project config from worktree root in linked worktrees

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -8,8 +8,35 @@ import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
 
 export namespace ConfigPaths {
+  /**
+   * Returns true if `worktree` is a filesystem ancestor of (or equal to) `directory`.
+   * For linked worktrees, the two paths may be on completely different branches of the
+   * directory tree (e.g., directory = ~/.local/share/opencode/worktree/…,
+   * worktree = ~/code/myproject/), so this check is necessary before relying on
+   * upward filesystem traversal to visit the worktree root.
+   */
+  function isAncestorOrEqual(ancestor: string, descendant: string): boolean {
+    const sep = path.sep
+    return descendant === ancestor || descendant.startsWith(ancestor.endsWith(sep) ? ancestor : ancestor + sep)
+  }
+
   export async function projectFiles(name: string, directory: string, worktree: string) {
     const files: string[] = []
+
+    // When `directory` is a linked worktree on a different filesystem branch than `worktree`
+    // (e.g., ~/.local/share/opencode/worktree/<hash>/<name>/ vs ~/code/myproject/), the
+    // upward traversal from `directory` will never visit `worktree`.  Explicitly check
+    // the worktree root first so those files are loaded at the lowest-priority slot
+    // (project-level base), allowing any config found in `directory`'s own tree to override.
+    if (!isAncestorOrEqual(worktree, directory)) {
+      for (const file of [`${name}.jsonc`, `${name}.json`]) {
+        const worktreeFile = path.join(worktree, file)
+        if (await Filesystem.exists(worktreeFile)) {
+          files.push(worktreeFile)
+        }
+      }
+    }
+
     for (const file of [`${name}.jsonc`, `${name}.json`]) {
       const found = await Filesystem.findUp(file, directory, worktree)
       for (const resolved of found.toReversed()) {
@@ -20,8 +47,21 @@ export namespace ConfigPaths {
   }
 
   export async function directories(directory: string, worktree: string) {
+    // For linked worktrees, `directory` may be on a different filesystem branch than `worktree`.
+    // Filesystem.up() walks upward from `directory` and will never visit `worktree/.opencode`
+    // in that case.  Collect it explicitly and insert it before the per-directory entries so
+    // that the project-level .opencode config is loaded at the correct (lower) priority.
+    const linkedWorktreeOcDir: string[] = []
+    if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG && !isAncestorOrEqual(worktree, directory)) {
+      const worktreeOcDir = path.join(worktree, ".opencode")
+      if (await Filesystem.exists(worktreeOcDir)) {
+        linkedWorktreeOcDir.push(worktreeOcDir)
+      }
+    }
+
     return [
       Global.Path.config,
+      ...linkedWorktreeOcDir,
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? await Array.fromAsync(
             Filesystem.up({

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -8,6 +8,7 @@ import fs from "fs/promises"
 import { pathToFileURL } from "url"
 import { Global } from "../../src/global"
 import { Filesystem } from "../../src/util/filesystem"
+import { ConfigPaths } from "../../src/config/paths"
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR!
@@ -1947,5 +1948,74 @@ describe("OPENCODE_CONFIG_CONTENT token substitution", () => {
         delete process.env["OPENCODE_CONFIG_CONTENT"]
       }
     }
+  })
+})
+
+describe("ConfigPaths linked worktree", () => {
+  test("projectFiles: finds config in worktree root when directory is on a different filesystem branch", async () => {
+    // Simulate a linked worktree scenario:
+    //   worktreeRoot = ~/code/myproject/            (git common dir)
+    //   linkedDir    = ~/.local/share/opencode/worktree/<hash>/<name>/  (linked worktree)
+    // The two paths are on completely different branches of the directory tree.
+    await using worktreeRoot = await tmpdir({
+      init: async (dir) => {
+        // Place opencode.json directly in the worktree root
+        await fs.writeFile(path.join(dir, "opencode.json"), JSON.stringify({ model: "from-worktree-root" }))
+      },
+    })
+    await using linkedDir = await tmpdir()
+
+    // Sanity: linkedDir is NOT under worktreeRoot
+    expect(linkedDir.path.startsWith(worktreeRoot.path + path.sep)).toBe(false)
+
+    const files = await ConfigPaths.projectFiles("opencode", linkedDir.path, worktreeRoot.path)
+
+    // The worktree root's opencode.json should be included
+    expect(files).toContain(path.join(worktreeRoot.path, "opencode.json"))
+  })
+
+  test("directories: finds .opencode dir in worktree root when directory is on a different filesystem branch", async () => {
+    await using worktreeRoot = await tmpdir({
+      init: async (dir) => {
+        // Place .opencode/opencode.json in the worktree root
+        await fs.mkdir(path.join(dir, ".opencode"), { recursive: true })
+        await fs.writeFile(
+          path.join(dir, ".opencode", "opencode.json"),
+          JSON.stringify({ model: "from-dotOpencode" }),
+        )
+      },
+    })
+    await using linkedDir = await tmpdir()
+
+    // Sanity: linkedDir is NOT under worktreeRoot
+    expect(linkedDir.path.startsWith(worktreeRoot.path + path.sep)).toBe(false)
+
+    const dirs = await ConfigPaths.directories(linkedDir.path, worktreeRoot.path)
+
+    // The worktree root's .opencode directory should be included
+    expect(dirs).toContain(path.join(worktreeRoot.path, ".opencode"))
+  })
+
+  test("projectFiles: normal (non-linked) project still works correctly", async () => {
+    // directory IS under worktree — existing behaviour should be unchanged
+    await using worktreeRoot = await tmpdir({
+      init: async (dir) => {
+        await fs.writeFile(path.join(dir, "opencode.json"), JSON.stringify({ model: "root-model" }))
+      },
+    })
+    // Create a subdirectory that IS under worktreeRoot
+    const subDir = path.join(worktreeRoot.path, "subproject")
+    await fs.mkdir(subDir, { recursive: true })
+    await fs.writeFile(path.join(subDir, "opencode.json"), JSON.stringify({ model: "sub-model" }))
+
+    const files = await ConfigPaths.projectFiles("opencode", subDir, worktreeRoot.path)
+
+    // Both root and subproject files should appear; subproject wins (applied last)
+    expect(files).toContain(path.join(worktreeRoot.path, "opencode.json"))
+    expect(files).toContain(path.join(subDir, "opencode.json"))
+    // subproject entry must come after root entry so it takes precedence when merged
+    expect(files.indexOf(path.join(subDir, "opencode.json"))).toBeGreaterThan(
+      files.indexOf(path.join(worktreeRoot.path, "opencode.json")),
+    )
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15911

### Type of change

- [x] Bug fix

### What does this PR do?

When OpenCode creates a sandbox (linked worktree), the working directory ends up at a path like `~/.local/share/opencode/worktree/<hash>/<name>/`, while the main repo root (`Instance.worktree`) is at something like `~/code/myproject/`. These two paths are on completely different branches of the filesystem tree.

`ConfigPaths.projectFiles()` and `ConfigPaths.directories()` both walk upward from `Instance.directory` toward `Instance.worktree`, but since the two paths share no common ancestor below `/`, the traversal never visits the worktree root — so `.opencode/opencode.json` there is silently skipped.

The fix adds an `isAncestorOrEqual()` helper that checks whether the worktree is actually reachable by upward traversal. When it's not, both functions now check the worktree root explicitly (at the lowest-priority slot, so anything in the linked worktree's own directory can still override).

### How did you verify your code works?

Added three tests to `test/config/config.test.ts` covering the new linked-worktree path, as well as a regression test confirming normal (non-linked) projects are unaffected.

### Screenshots / recordings

N/A — config loading, no visual output.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR