### PR TITLE
fix(web): persist locale cookie on canonical docs pages

### DIFF
--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -77,13 +77,36 @@ function localeFromAcceptLanguage(header: string | null) {
   return locale ?? "root"
 }
 
-export const onRequest = defineMiddleware((ctx, next) => {
+export const onRequest = defineMiddleware(async (ctx, next) => {
   const alias = docsAlias(ctx.url.pathname)
   if (alias) {
     return redirect(ctx.url, alias.path, alias.locale)
   }
 
-  if (ctx.url.pathname !== "/docs" && ctx.url.pathname !== "/docs/") return next()
+  if (ctx.url.pathname !== "/docs" && ctx.url.pathname !== "/docs/") {
+    const response = await next()
+
+    // Detect the locale from the URL path and persist it in the oc_locale cookie so
+    // that the user's language-switcher choice is remembered across navigations.
+    //
+    // Previously the cookie was only written during alias-redirect (e.g. /docs/en/ →
+    // /docs/).  Canonical locale paths like /docs/tr/page and English paths like
+    // /docs/page never wrote the cookie, so returning to /docs/ would re-apply the
+    // browser's Accept-Language header and undo the user's manual selection.
+    const hit = /^\/docs\/([^/]+)(?:\/|$)/.exec(ctx.url.pathname)
+    const urlLocale = (hit ? exactLocale(hit[1] ?? "") : null) ?? "root"
+    const cookieLocale = localeFromCookie(ctx.request.headers.get("cookie"))
+    if (cookieLocale !== urlLocale) {
+      const headers = new Headers(response.headers)
+      headers.append("Set-Cookie", cookie(urlLocale))
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      })
+    }
+    return response
+  }
 
   const locale =
     localeFromCookie(ctx.request.headers.get("cookie")) ??


### PR DESCRIPTION
### Issue for this PR

Closes #15845

### Type of change

- [x] Bug fix

### What does this PR do?

The language switcher on opencode.ai/docs doesn't stick when switching to English (or any locale via the Starlight switcher).

Root cause: the `oc_locale` cookie was only written in one place — inside `docsAlias()`, which triggers on alias URLs like `/docs/en/page` and redirects to the canonical path. The Starlight language switcher generates canonical URLs directly (e.g. `/docs/page` for English, `/docs/tr/page` for Turkish), so the cookie was never written when switching language this way. On the next visit to `/docs/`, the middleware re-read `Accept-Language` from the browser and redirected back to the original locale.

The fix detects the locale from the URL path on every docs page request and appends the `oc_locale` cookie to the response when the current cookie value differs. This makes the language switcher choice sticky without requiring any Starlight or build-time changes.

### How did you verify your code works?

Traced the middleware logic manually:
- `/docs/tr/page` → sets `oc_locale=tr` if cookie differs
- `/docs/page` → infers root/English (no locale prefix → `exactLocale` returns null → "root") → sets `oc_locale=en`
- Subsequent `/docs/` → reads cookie → no redirect ✓
- Already-matching cookie → no Set-Cookie header (no overhead per request) ✓

### Screenshots / recordings

N/A — middleware logic change, no visual output.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR