### PR TITLE
docs(go): clarify usage limits are included with subscription, not extra charges

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -73,7 +73,7 @@ The list of models may change as we test and add new ones.
 
 ## Usage limits
 
-OpenCode Go includes the following limits:
+OpenCode Go includes the following rate limits to ensure fair access for all subscribers. These are **included** with your $10/month subscription and are not additional charges:
 
 - **5 hour limit** — $12 of usage
 - **Weekly limit** — $30 of usage


### PR DESCRIPTION
### Issue for this PR

Closes #15872

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The Go pricing page (/docs/go/) listed usage limits ($12/5h, $30/week, $60/month) right after stating the subscription costs $10/month. This caused confusion: users assumed their monthly usage cap was $10 (the subscription price), not realising the limits listed are the included allowances.

One-line fix: change the lead-in sentence to explicitly state these are rate limits **included** with the subscription and are not additional charges.

### How did you verify your code works?

Docs-only change — no runtime behavior affected. The sentence change directly resolves the confusion described in the issue.

### Screenshots / recordings

_No UI changes; text-only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR