### PR TITLE
fix(tui): use WinRT clipboard API on Windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -126,7 +126,7 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
+      console.log("clipboard: using windows runtime")
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Process.spawn(
@@ -135,7 +135,7 @@ export namespace Clipboard {
             "-NonInteractive",
             "-NoProfile",
             "-Command",
-            "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())",
+            "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; $null = [Windows.ApplicationModel.DataTransfer.DataPackage, Windows.ApplicationModel.DataTransfer, ContentType=WindowsRuntime]; $null = [Windows.ApplicationModel.DataTransfer.Clipboard, Windows.ApplicationModel.DataTransfer, ContentType=WindowsRuntime]; $pkg = New-Object Windows.ApplicationModel.DataTransfer.DataPackage; $pkg.SetText([Console]::In.ReadToEnd()); [Windows.ApplicationModel.DataTransfer.Clipboard]::SetContent($pkg); [Windows.ApplicationModel.DataTransfer.Clipboard]::Flush()",
           ],
           {
             stdin: "pipe",


### PR DESCRIPTION
## Summary
- replace the Windows TUI clipboard write path with the WinRT `Windows.ApplicationModel.DataTransfer.Clipboard` API
- flush the clipboard after setting content so copied text is more likely to appear in Windows clipboard history (`Win+V`)
- keep stdin piping in place so copied text still avoids PowerShell interpolation issues