### PR TITLE
fix: preserve plugin tool metadata in completed state

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -68,17 +68,28 @@ export namespace ToolRegistry {
         parameters: z.object(def.args),
         description: def.description,
         execute: async (args, ctx) => {
-          const pluginCtx = {
+          let title = ""
+          let metadata: Record<string, unknown> = {}
+          const pluginCtx: PluginToolContext = {
             ...ctx,
+            metadata: (input) => {
+              if (input.title !== undefined) title = input.title
+              if (input.metadata) metadata = { ...metadata, ...input.metadata }
+              ctx.metadata(input)
+            },
             directory: Instance.directory,
             worktree: Instance.worktree,
-          } as unknown as PluginToolContext
-          const result = await def.execute(args as any, pluginCtx)
+          }
+          const result = await def.execute(args, pluginCtx)
           const out = await Truncate.output(result, {}, initCtx?.agent)
           return {
-            title: "",
+            title,
             output: out.truncated ? out.content : result,
-            metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+            metadata: {
+              ...metadata,
+              truncated: out.truncated,
+              ...(out.truncated && { outputPath: out.outputPath }),
+            },
           }
         },
       }),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -68,6 +68,7 @@ export namespace ToolRegistry {
         parameters: z.object(def.args),
         description: def.description,
         execute: async (args, ctx) => {
+          const parsed = z.object(def.args).parse(args)
           let title = ""
           let metadata: Record<string, unknown> = {}
           const pluginCtx: PluginToolContext = {
@@ -80,7 +81,7 @@ export namespace ToolRegistry {
             directory: Instance.directory,
             worktree: Instance.worktree,
           }
-          const result = await def.execute(args, pluginCtx)
+          const result = await def.execute(parsed, pluginCtx)
           const out = await Truncate.output(result, {}, initCtx?.agent)
           return {
             title,

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -4,6 +4,17 @@ import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
+import type { Tool } from "../../src/tool/tool"
+
+const ctx: Tool.Context = {
+  sessionID: "test-session",
+  messageID: "test-message",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
 
 describe("tool.registry", () => {
   test("loads tools from .opencode/tool (singular)", async () => {
@@ -117,6 +128,191 @@ describe("tool.registry", () => {
         const ids = await ToolRegistry.ids()
         expect(ids).toContain("cowsay")
       },
+    })
+  })
+
+  describe("plugin metadata in completed tool result", () => {
+    test("preserves title and metadata set via ctx.metadata", async () => {
+      // given
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const opencodeDir = path.join(dir, ".opencode")
+          await fs.mkdir(opencodeDir, { recursive: true })
+
+          const toolsDir = path.join(opencodeDir, "tools")
+          await fs.mkdir(toolsDir, { recursive: true })
+
+          await Bun.write(
+            path.join(toolsDir, "metadata.ts"),
+            [
+              "export default {",
+              "  description: 'metadata tool',",
+              "  args: {},",
+              "  execute: async (_args, ctx) => {",
+              "    ctx.metadata({ title: 'test', metadata: { sessionId: 'ses_123' } })",
+              "    return 'ok'",
+              "  },",
+              "}",
+              "",
+            ].join("\n"),
+          )
+        },
+      })
+
+      // when
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tools = await ToolRegistry.tools({ providerID: "openai", modelID: "gpt-5" })
+          const tool = tools.find((item) => item.id === "metadata")
+          expect(tool).toBeDefined()
+          if (!tool) throw new Error("metadata tool not found")
+          const result = await tool.execute({}, ctx)
+
+          // then
+          expect(result.title).toBe("test")
+          expect(result.metadata.sessionId).toBe("ses_123")
+          expect(result.metadata.truncated).toBeFalse()
+        },
+      })
+    })
+
+    test("keeps latest title and merges metadata across multiple ctx.metadata calls", async () => {
+      // given
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const opencodeDir = path.join(dir, ".opencode")
+          await fs.mkdir(opencodeDir, { recursive: true })
+
+          const toolsDir = path.join(opencodeDir, "tools")
+          await fs.mkdir(toolsDir, { recursive: true })
+
+          await Bun.write(
+            path.join(toolsDir, "metadata.ts"),
+            [
+              "export default {",
+              "  description: 'metadata tool',",
+              "  args: {},",
+              "  execute: async (_args, ctx) => {",
+              "    ctx.metadata({ title: 'first', metadata: { sessionId: 'ses_123', step: 'one' } })",
+              "    ctx.metadata({ title: 'second', metadata: { durationMs: 42 } })",
+              "    return 'ok'",
+              "  },",
+              "}",
+              "",
+            ].join("\n"),
+          )
+        },
+      })
+
+      // when
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tools = await ToolRegistry.tools({ providerID: "openai", modelID: "gpt-5" })
+          const tool = tools.find((item) => item.id === "metadata")
+          expect(tool).toBeDefined()
+          if (!tool) throw new Error("metadata tool not found")
+          const result = await tool.execute({}, ctx)
+
+          // then
+          expect(result.title).toBe("second")
+          expect(result.metadata.sessionId).toBe("ses_123")
+          expect(result.metadata.step).toBe("one")
+          expect(result.metadata.durationMs).toBe(42)
+          expect(result.metadata.truncated).toBeFalse()
+        },
+      })
+    })
+
+    test("keeps backward-compatible defaults when ctx.metadata is never called", async () => {
+      // given
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const opencodeDir = path.join(dir, ".opencode")
+          await fs.mkdir(opencodeDir, { recursive: true })
+
+          const toolsDir = path.join(opencodeDir, "tools")
+          await fs.mkdir(toolsDir, { recursive: true })
+
+          await Bun.write(
+            path.join(toolsDir, "metadata.ts"),
+            [
+              "export default {",
+              "  description: 'metadata tool',",
+              "  args: {},",
+              "  execute: async () => {",
+              "    return 'ok'",
+              "  },",
+              "}",
+              "",
+            ].join("\n"),
+          )
+        },
+      })
+
+      // when
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tools = await ToolRegistry.tools({ providerID: "openai", modelID: "gpt-5" })
+          const tool = tools.find((item) => item.id === "metadata")
+          expect(tool).toBeDefined()
+          if (!tool) throw new Error("metadata tool not found")
+          const result = await tool.execute({}, ctx)
+
+          // then
+          expect(result.title).toBe("")
+          expect(result.metadata.truncated).toBeFalse()
+          expect(result.metadata.outputPath).toBeUndefined()
+        },
+      })
+    })
+
+    test("always includes truncation metadata with plugin metadata", async () => {
+      // given
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const opencodeDir = path.join(dir, ".opencode")
+          await fs.mkdir(opencodeDir, { recursive: true })
+
+          const toolsDir = path.join(opencodeDir, "tools")
+          await fs.mkdir(toolsDir, { recursive: true })
+
+          await Bun.write(
+            path.join(toolsDir, "metadata.ts"),
+            [
+              "export default {",
+              "  description: 'metadata tool',",
+              "  args: {},",
+              "  execute: async (_args, ctx) => {",
+              "    ctx.metadata({ title: 'test', metadata: { sessionId: 'ses_123' } })",
+              "    return 'x'.repeat(60 * 1024)",
+              "  },",
+              "}",
+              "",
+            ].join("\n"),
+          )
+        },
+      })
+
+      // when
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tools = await ToolRegistry.tools({ providerID: "openai", modelID: "gpt-5" })
+          const tool = tools.find((item) => item.id === "metadata")
+          expect(tool).toBeDefined()
+          if (!tool) throw new Error("metadata tool not found")
+          const result = await tool.execute({}, ctx)
+
+          // then
+          expect(result.title).toBe("test")
+          expect(result.metadata.sessionId).toBe("ses_123")
+          expect(result.metadata.truncated).toBeTrue()
+          expect(result.metadata.outputPath).toBeString()
+        },
+      })
     })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #12527

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`fromPlugin()` in `tool/registry.ts` wraps plugin-defined tools into the native `Tool.Info` format. The wrapper calls the plugin's `execute()` (which returns a plain string) and then builds the structured return `{ title, metadata, output }`.

The bug: it always returned `title: ""` and `metadata: { truncated }`, ignoring any values the plugin set via `ctx.metadata()` during execution. Those values update `ToolStateRunning` correctly (the callback is forwarded via spread), but on completion the hardcoded return overwrites them. This means fields like `sessionId` are lost in `ToolStateCompleted`, which breaks the TUI Task component — it reads `metadata.sessionId` to sync subagent sessions and display toolcall count/duration.

The fix intercepts `ctx.metadata()` inside `fromPlugin()` to capture the latest `title` and accumulate `metadata` across calls, while still forwarding each call to the original callback for running-state updates. The captured values are then merged with truncation metadata in the return. Plugins that never call `ctx.metadata()` get the same behavior as before (`title: ""`, truncation-only metadata).

### How did you verify your code works?

Added 4 tests in `packages/opencode/test/tool/registry.test.ts`:
1. Single `ctx.metadata()` call → title and metadata preserved in result
2. Multiple calls → last title wins, metadata merged
3. No `ctx.metadata()` call → backward-compatible defaults
4. Truncation metadata always present regardless of plugin metadata

All tests pass. Full suite: `bun test --timeout 30000` from `packages/opencode` — 1191 pass, 0 fail. Typecheck clean.

### Screenshots / recordings

N/A — internal metadata plumbing, no UI change on its own.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR