### PR TITLE
fix(cli): clarify Anthropic hint to Claude Pro/Max

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -338,7 +338,7 @@ export const AuthLoginCommand = cmd({
                 value: x.id,
                 hint: {
                   opencode: "recommended",
-                  anthropic: "Claude Max or API key",
+                  anthropic: "Claude Pro/Max or API key",
                   openai: "ChatGPT Plus/Pro or API key",
                 }[x.id],
               })),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -36,7 +36,7 @@ export function createDialogProviderOptions() {
         value: provider.id,
         description: {
           opencode: "(Recommended)",
-          anthropic: "(Claude Max or API key)",
+          anthropic: "(Claude Pro/Max or API key)",
           openai: "(ChatGPT Plus/Pro or API key)",
           "opencode-go": "Low cost subscription for everyone",
         }[provider.id],


### PR DESCRIPTION
### Issue for this PR

Closes #15975

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Anthropic provider hint in the CLI currently says `Claude Max or API key`, which is incomplete and can mislead users into thinking only Max is supported.

This PR updates that hint to `Claude Pro/Max or API key` in both CLI entry points:
- `packages/opencode/src/cli/cmd/auth.ts`
- `packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx`

Why this works:
- The auth flow supports Pro/Max and API-key paths.
- Updating the hint makes provider selection copy accurate before method selection.
- This is a copy-only change and does not alter auth behavior.

### How did you verify your code works?

- Verified both updated strings in the changed files.
- Confirmed there are no remaining `Claude Max or API key` matches in `packages/opencode/src`.
- Confirmed the change scope is copy-only (2 lines in 2 files).

### Screenshots / recordings

N/A (CLI text-only copy change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR