### PR TITLE
ui: rely on task part href instead of onClick handler

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1494,27 +1494,6 @@ ToolRegistry.register({
       return `${path.slice(0, idx)}/session/${sessionId}`
     })
 
-    const handleLinkClick = (e: MouseEvent) => {
-      const sessionId = childSessionId()
-      const url = href()
-      if (!sessionId || !url) return
-
-      e.stopPropagation()
-
-      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
-
-      const nav = data.navigateToSession
-      if (!nav || typeof window === "undefined") return
-
-      e.preventDefault()
-      const before = window.location.pathname + window.location.search + window.location.hash
-      nav(sessionId)
-      setTimeout(() => {
-        const after = window.location.pathname + window.location.search + window.location.hash
-        if (after === before) window.location.assign(url)
-      }, 50)
-    }
-
     const titleContent = () => <TextShimmer text={title()} active={running()} />
 
     const trigger = () => (
@@ -1531,7 +1510,7 @@ ToolRegistry.register({
                     data-slot="basic-tool-tool-subtitle"
                     class="clickable subagent-link"
                     href={url()}
-                    onClick={handleLinkClick}
+                    onClick={(e) => e.stopPropagation()}
                   >
                     {description()}
                   </a>


### PR DESCRIPTION
1. Navigation like this should go through solid router, rather than assigning to `window.location` (Electron uses `MemoryRouter`)
2. We already have the href in the component, `navigateToSession` seems unnecessary