### PR TITLE
docs: add MPM-Coding to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -64,6 +64,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
+| [MPM-Coding](https://github.com/halflifezyf2680/MPM-Coding)                                | Tool-first MCP server for project-anchored AST indexing, symbol search, call-graph impact analysis, and resumable task chains. |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `MPM-Coding` to the **Projects** table on the ecosystem page, linking to the GitHub repo and describing it as a tool-first MCP server (project-anchored AST indexing, symbol search, call-graph impact analysis, resumable task chains).

### How did you verify your code works?

Docs-only change: verified the MDX table row is valid and matches the existing formatting.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
