### PR TITLE
docs(ecosystem): add opencode-loamlog plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,7 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
-
+| [opencode-loamlog](https://github.com/tongsh6/loamlog/tree/master/plugins/opencode) | Capture every OpenCode session on idle and archive as structured JSON snapshots via the loam daemon |
 ---
 
 ## Projects


### PR DESCRIPTION
### Issue for this PR

N/A — this is a documentation addition only.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-loamlog](https://github.com/tongsh6/loamlog/tree/master/plugins/opencode) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

**opencode-loamlog** is an OpenCode plugin that listens to the `session.idle` event and POSTs the full session payload to a local `loam daemon`. The daemon archives each session as a structured JSON snapshot + Markdown file for later distillation into reusable assets (issue candidates, PRD drafts, knowledge cards, etc.).

Install via `opencode.json`:
```jsonc
{
  "plugins": ["opencode-loamlog"]
}
```

npm: https://www.npmjs.com/package/opencode-loamlog

### How did you verify your code works?

- Confirmed the plugin is published on npm as `opencode-loamlog`
- Verified the table row renders correctly in the MDX format (matches existing rows)

### Screenshots / recordings

_N/A — text-only documentation change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR