### PR TITLE
docs: add OpenGUI to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -63,6 +63,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
+| [OpenGUI](https://git.idunara.com/emmanuel/OpenGUI)                                         | Electron and React desktop GUI for OpenCode with multi-project sessions and MCP management |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |


### PR DESCRIPTION
Closes #16015\n\n## Summary\n- add OpenGUI to the Ecosystem Projects table\n- include the OpenGUI repository link and concise project description