### PR TITLE
Fix reasoning-part text color for better visibility

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -281,11 +281,11 @@
     margin-top: 24px;
     font-style: normal;
     font-size: inherit;
-    color: var(--text-weak);
+    color: var(--text-base);
 
     strong,
     b {
-      color: var(--text-weak);
+      color: var(--text-base);
     }
 
     p:has(strong) {


### PR DESCRIPTION
### Issue for this PR

Closes #16035 

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The reasoning and answer text color was invisible, the fix set them back at a visible base color.

### How did you verify your code works?

I verified it by executing it on linux KDE shell.

### Screenshots / recordings

No feature added.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
