### PR TITLE
fix: update repo name in docs-update conditional

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run opencode
         if: steps.commits.outputs.has_commits == 'true'
-        uses: sst/opencode/github@latest
+        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:


### PR DESCRIPTION
### Issue for this PR

Closes #16045

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the repo conditional in the docs-update workflow causing the workflow to be skipped ever since the `sst -> `anomalyco` github org transfer.

https://github.com/anomalyco/opencode/actions/workflows/docs-update.yml

<img width="942" height="368" alt="image" src="https://github.com/user-attachments/assets/c057a202-1c30-4dd2-b34b-24e0a519ee64" />

### How did you verify your code works?

I confirmed the repo name now matches the string in the conditional.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
