### PR TITLE
fix: sdk.responses fallback + codex baseURL correction

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -377,7 +377,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             providerID: "openai",
             api: {
               id: "gpt-5.3-codex",
-              url: "https://chatgpt.com/backend-api/codex",
+              url: "https://api.openai.com/v1",
               npm: "@ai-sdk/openai",
             },
             name: "GPT-5.3 Codex",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -154,6 +154,8 @@ export namespace Provider {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          // Fallback to languageModel if responses is not available (e.g., @ai-sdk/openai-compatible)
+          if (sdk.responses === undefined) return sdk.languageModel(modelID)
           return sdk.responses(modelID)
         },
         options: {},
@@ -183,11 +185,11 @@ export namespace Provider {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          // Fallback to languageModel if responses/chat are not available
           if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
+            return sdk.chat ? sdk.chat(modelID) : sdk.languageModel(modelID)
           }
+          return sdk.responses ? sdk.responses(modelID) : sdk.languageModel(modelID)
         },
         options: {},
       }
@@ -197,11 +199,11 @@ export namespace Provider {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          // Fallback to languageModel if responses/chat are not available
           if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
+            return sdk.chat ? sdk.chat(modelID) : sdk.languageModel(modelID)
           }
+          return sdk.responses ? sdk.responses(modelID) : sdk.languageModel(modelID)
         },
         options: {
           baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,


### PR DESCRIPTION
### Issue for this PR

Closes #16049

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two related bugs when switching between AI models:

**1. SDK responses fallback (provider.ts)**
The `openai`, `azure`, and `azure-cognitive-services` loaders call `sdk.responses(modelID)` unconditionally. But `@ai-sdk/openai-compatible` doesn't have a `.responses()` method - only `.languageModel()`. When switching to a model using that SDK, it crashes with `TypeError: sdk.responses is not a function`.

Fix: Added checks before calling `sdk.responses()`. If undefined, fall back to `sdk.languageModel(modelID)`. This matches what the `github-copilot` loader already does.

**2. Codex baseURL (codex.ts)**
The `gpt-5.3-codex` model had `api.url` set to `https://chatgpt.com/backend-api/codex` which is a ChatGPT internal endpoint, not the OpenAI API. This caused requests to route incorrectly when switching models.

Fix: Changed to `https://api.openai.com/v1`.

### How did you verify your code works?

- Switched between Claude and ChatGPT models - no crash
- Switched from Codex back to Claude - works correctly
- Ran LSP diagnostics on changed files - no errors

### Screenshots / recordings

N/A - not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR