### PR TITLE
fix(core): handle SIGHUP and kill process

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -46,6 +46,11 @@ process.on("uncaughtException", (e) => {
   })
 })
 
+// Ensure the process exits on terminal hangup (eg. closing the terminal tab).
+// Without this, long-running commands like `serve` block on a never-resolving
+// promise and survive as orphaned processes.
+process.on("SIGHUP", () => process.exit())
+
 let cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")


### PR DESCRIPTION
opencode doesn't always cleanly exist: one example is when it's running and you just close a tab. In this case opencode hangs around forever (see [thread](https://x.com/AthorNZ/status/2029003632566575248)). This should fix it.

I didn't record a video, but I reproduced the hanging process. After applying this PR, the process is killed after closing the tab (it takes a few seconds)