### PR TITLE
fix(tui): handle empty agent list without crashing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -40,7 +40,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const [agentStore, setAgentStore] = createStore<{
         current: string
       }>({
-        current: agents()[0].name,
+        current: agents()[0]?.name ?? "",
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -52,12 +52,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         theme.error,
         theme.info,
       ])
+      createEffect(() => {
+        const list = agents()
+        if (list.length && !list.some((x) => x.name === agentStore.current)) setAgentStore("current", list[0].name)
+      })
       return {
         list() {
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current)!
+          return agents().find((x) => x.name === agentStore.current) ?? agents()[0]
         },
         set(name: string) {
           if (!agents().some((x) => x.name === name))
@@ -69,6 +73,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setAgentStore("current", name)
         },
         move(direction: 1 | -1) {
+          if (!agents().length) return
           batch(() => {
             let next = agents().findIndex((x) => x.name === agentStore.current) + direction
             if (next < 0) next = agents().length - 1
@@ -192,6 +197,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const currentModel = createMemo(() => {
         const a = agent.current()
+        if (!a) return undefined
         return (
           getFirstValidModel(
             () => modelStore.model[a.name],
@@ -240,7 +246,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (next >= recent.length) next = 0
           const val = recent[next]
           if (!val) return
-          setModelStore("model", agent.current().name, { ...val })
+          const a = agent.current()
+          if (!a) return
+          setModelStore("model", a.name, { ...val })
         },
         cycleFavorite(direction: 1 | -1) {
           const favorites = modelStore.favorite.filter((item) => isModelValid(item))
@@ -266,7 +274,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           const next = favorites[index]
           if (!next) return
-          setModelStore("model", agent.current().name, { ...next })
+          const a = agent.current()
+          if (!a) return
+          setModelStore("model", a.name, { ...next })
           const uniq = uniqueBy([next, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
           if (uniq.length > 10) uniq.pop()
           setModelStore(
@@ -285,7 +295,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               })
               return
             }
-            setModelStore("model", agent.current().name, model)
+            setModelStore("model", agent.current()?.name ?? "", model)
             if (options?.recent) {
               const uniq = uniqueBy([model, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
               if (uniq.length > 10) uniq.pop()
@@ -381,6 +391,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     // Automatically update model when agent changes
     createEffect(() => {
       const value = agent.current()
+      if (!value) return
       if (value.model) {
         if (isModelValid(value.model))
           model.set({


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: undefined is not an object (evaluating 'agents()[0].name')` crash in the TUI when the filtered agent list is empty at initialization time
- This occurs when plugins reconfigure agent modes (e.g. demoting all built-in agents to `subagent`) so that no primary/visible agents remain when `LocalProvider` initializes

## Changes

All changes are in `packages/opencode/src/cli/cmd/tui/context/local.tsx`:

1. **Safe initial value**: `agents()[0].name` → `agents()[0]?.name ?? ""` to avoid crash on empty list
2. **Reactive sync**: Added `createEffect` to update `current` when the agent list changes and the current selection becomes invalid
3. **Safe `current()` accessor**: Removed non-null assertion (`!`), falls back to `agents()[0]` (which may be `undefined`)
4. **Guard `move()`**: Early return when agent list is empty
5. **Guard `currentModel` memo**: Return `undefined` when `agent.current()` is `undefined`
6. **Guard `cycle()` / `cycleFavorite()`**: Extract `agent.current()` into a variable, early return if `undefined`
7. **Guard agent-change effect**: Early return when agent value is `undefined`

## Reproduction

1. Install a plugin that reconfigures agent modes (e.g. `oh-my-opencode` with Claude Code user agents in `~/.claude/agents/` that shadow built-in agent names)
2. Start the TUI — crashes immediately at `local.tsx:43`

## Test plan

- [ ] Start TUI with no plugins — agents render normally, no regression
- [ ] Start TUI with a plugin that demotes all agents to `subagent` — TUI starts without crash, shows remaining visible agents
- [ ] Switch agents via keybind — cycling works without errors
- [ ] Change model while agent list is dynamic — no crash on undefined agent