### PR TITLE
docs(tui): note /details command not available

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -95,11 +95,7 @@ Compact the current session. _Alias_: `/summarize`
 
 Toggle tool execution details.
 
-```bash frame="none"
-/details
-```
-
-**Keybind:** `ctrl+x d`
+**Note:** This feature is currently not available as a slash command.
 
 ---
 


### PR DESCRIPTION
Closes #16062

Updates the TUI docs to note that /details is not currently available as a slash command.