### PR TITLE
test: capture env var prefix permission bypass (#16075)

### DIFF
--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -290,6 +290,35 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  test("strips inline env var prefix from permission pattern", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: 'CI=true git commit -m "test"',
+            description: "Commit with env prefix",
+          },
+          testCtx,
+        )
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+        // TODO: fix #16075 — flip these assertions when the bug is fixed
+        expect(bashReq!.patterns).toContain('CI=true git commit -m "test"')
+        expect(bashReq!.patterns).not.toContain('git commit -m "test"')
+      },
+    })
+  })
+
   test("always pattern has space before wildcard to not include different commands", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Fixes #16075

> Note: This PR does not fix the bug — it only adds a test case capturing the current (buggy) behavior. The fix requires a design decision on how to strip `variable_assignment` AST nodes from `commandText` without losing redirect info. See the issue for options.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a test case that captures the env var prefix permission bypass bug. Commands like `CI=true git commit` produce a permission pattern of `"CI=true git commit -m \"test\""` instead of `"git commit -m \"test\""`, so a rule like `"git *": "ask"` won't match and the command runs without a dialog.

The test currently asserts the buggy behavior with a TODO to flip the assertions once the fix lands.

### How did you verify your code works?

Ran `bun test test/tool/bash.test.ts test/permission/arity.test.ts test/permission/next.test.ts` — 84 pass, 0 fail.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR