### PR TITLE
fix(lsp): timeout write to prevent hang when LSP server stdin is full

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -8,6 +8,7 @@ import { LSPServer } from "./server"
 import z from "zod"
 import { Config } from "../config/config"
 import { spawn } from "child_process"
+import { withTimeout } from "../util/timeout"
 import { Instance } from "../project/instance"
 import { Flag } from "@/flag/flag"
 
@@ -274,13 +275,18 @@ export namespace LSP {
     return false
   }
 
+  // Prevent indefinite hang when LSP server stdin is full (e.g. pyright under CPU load).
+  const LSP_WRITE_TIMEOUT_MS = 3_000
+
   export async function touchFile(input: string, waitForDiagnostics?: boolean) {
     log.info("touching file", { file: input })
     const clients = await getClients(input)
     await Promise.all(
       clients.map(async (client) => {
         const wait = waitForDiagnostics ? client.waitForDiagnostics({ path: input }) : Promise.resolve()
-        await client.notify.open({ path: input })
+        await withTimeout(client.notify.open({ path: input }), LSP_WRITE_TIMEOUT_MS).catch((err) => {
+          log.warn("LSP write timed out, skipping notification", { err, file: input })
+        })
         return wait
       }),
     ).catch((err) => {


### PR DESCRIPTION
### Issue for this PR

Closes #16115

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
After a large patch, pyright saturates the CPU and stops reading its stdin. The pipe buffer fills and the next write in LSP.touchFile blocks indefinitely, freezing the UI completely.                                                   

Wraps the write in withTimeout(3s) so we move on if the LSP isn't responsive.  

### How did you verify your code works?
20 iterations of large patch and immediate whitespace follow-up against the exact file that triggered the original hang. Zero freezes, zero timeouts.

### Screenshots / recordings
N/A

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


