### PR TITLE
Fix: `opencode run --attach` should pass auth headers from env vars

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -648,7 +648,13 @@ export const RunCommand = cmd({
     }
 
     if (args.attach) {
-      const sdk = createOpencodeClient({ baseUrl: args.attach, directory })
+      // Build auth headers from env vars (same as attach.ts)
+      const password = process.env.OPENCODE_SERVER_PASSWORD
+      const username = process.env.OPENCODE_SERVER_USERNAME ?? "opencode"
+      const headers = password
+        ? { Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}` }
+        : undefined
+      const sdk = createOpencodeClient({ baseUrl: args.attach, directory, headers })
       return await execute(sdk)
     }
 


### PR DESCRIPTION
Fixes #16096

## Description

When using `opencode run --attach=localhost:<port>` with
OPENCODE_SERVER_USERNAME and OPENCODE_SERVER_PASSWORD env vars,
the command failed with "Error: Session not found".

The `run` command did not pass auth headers to `createOpencodeClient`,
while the `attach` TUI command correctly builds Basic auth headers from env vars.

## Changes

Modified `packages/opencode/src/cli/cmd/run.ts` to:
- Read `OPENCODE_SERVER_PASSWORD` and `OPENCODE_SERVER_USERNAME` env vars
- Create Basic auth headers when password is provided
- Pass headers to `createOpencodeClient`

This matches the behavior of the `attach` TUI command in
`packages/opencode/src/cli/cmd/tui/attach.ts`.