### PR TITLE
desktop: remove unnecessary macOS entitlements

### DIFF
--- a/packages/desktop-electron/resources/entitlements.plist
+++ b/packages/desktop-electron/resources/entitlements.plist
@@ -12,19 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.automation.apple-events</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.personal-information.addressbook</key>
-    <true/>
-    <key>com.apple.security.personal-information.calendars</key>
-    <true/>
-    <key>com.apple.security.personal-information.location</key>
-    <true/>
-    <key>com.apple.security.personal-information.photos-library</key>
     <true/>
 </dict>
 </plist>

--- a/packages/desktop/src-tauri/entitlements.plist
+++ b/packages/desktop/src-tauri/entitlements.plist
@@ -12,19 +12,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.automation.apple-events</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.personal-information.addressbook</key>
-    <true/>
-    <key>com.apple.security.personal-information.calendars</key>
-    <true/>
-    <key>com.apple.security.personal-information.location</key>
-    <true/>
-    <key>com.apple.security.personal-information.photos-library</key>
     <true/>
 </dict>
 </plist>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This removes unnecessary macOS entitlements from both desktop shells so the app no longer requests unrelated personal data access. We keep only the code-signing/runtime keys plus `com.apple.security.device.audio-input`. The removed entitlements are Apple Events, camera, contacts, calendars, location, and photos library, and the same entitlement set is now aligned between Tauri and Electron. This works by narrowing the app sandbox capabilities to only what the current app behavior needs.

### How did you verify your code works?

Reviewed `git diff origin/dev...` to confirm both entitlement files only retain required keys and audio input.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
