### PR TITLE
fix(app): preserve question dock state across session switches

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -8,6 +8,8 @@ import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
 
+const cache = new Map<string, { tab: number; answers: QuestionAnswer[]; custom: string[]; customOn: boolean[] }>()
+
 export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit: () => void }> = (props) => {
   const sdk = useSDK()
   const language = useLanguage()
@@ -15,16 +17,18 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const questions = createMemo(() => props.request.questions)
   const total = createMemo(() => questions().length)
 
+  const cached = cache.get(props.request.id)
   const [store, setStore] = createStore({
-    tab: 0,
-    answers: [] as QuestionAnswer[],
-    custom: [] as string[],
-    customOn: [] as boolean[],
+    tab: cached?.tab ?? 0,
+    answers: cached?.answers ?? ([] as QuestionAnswer[]),
+    custom: cached?.custom ?? ([] as string[]),
+    customOn: cached?.customOn ?? ([] as boolean[]),
     editing: false,
     sending: false,
   })
 
   let root: HTMLDivElement | undefined
+  let replied = false
 
   const question = createMemo(() => questions()[store.tab])
   const options = createMemo(() => question()?.options ?? [])
@@ -107,6 +111,16 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     })
   })
 
+  onCleanup(() => {
+    if (replied) return
+    cache.set(props.request.id, {
+      tab: store.tab,
+      answers: store.answers.map((a) => (a ? [...a] : [])),
+      custom: store.custom.map((s) => s ?? ""),
+      customOn: store.customOn.map((b) => b ?? false),
+    })
+  })
+
   const fail = (err: unknown) => {
     const message = err instanceof Error ? err.message : String(err)
     showToast({ title: language.t("common.requestFailed"), description: message })
@@ -119,6 +133,8 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     setStore("sending", true)
     try {
       await sdk.client.question.reply({ requestID: props.request.id, answers })
+      replied = true
+      cache.delete(props.request.id)
     } catch (err) {
       fail(err)
     } finally {
@@ -133,6 +149,8 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     setStore("sending", true)
     try {
       await sdk.client.question.reject({ requestID: props.request.id })
+      replied = true
+      cache.delete(props.request.id)
     } catch (err) {
       fail(err)
     } finally {


### PR DESCRIPTION
### Issue for this PR

Closes #16172

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the question tool presents multiple questions in a batch, switching to another session and back resets the UI to question 1 with all answers lost. This happens because `SessionQuestionDock` is rendered inside `<Show keyed>`, so navigating away unmounts it and navigating back remounts it with fresh local state (`tab: 0`, `answers: []`).

This adds a module-level cache keyed by question request ID that saves in-progress state (`tab`, `answers`, `custom`, `customOn`) on unmount and restores it on remount. The cache is cleared after a successful reply or reject so stale drafts don't linger.

### How did you verify your code works?

- LSP diagnostics clean
- Typecheck + build pass via pre-push hook

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR