### PR TITLE
fix(server): remove unnecessary stream() wrapper from prompt_async endpoint

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -790,13 +790,10 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
-        })
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        SessionPrompt.prompt({ ...body, sessionID })
+        return c.body(null, 204)
       },
     )
     .post(


### PR DESCRIPTION
## Summary

The `prompt_async` endpoint wraps a fire-and-forget `SessionPrompt.prompt()` call in Hono's `stream()` helper. This opens a streaming HTTP response that never writes any data before closing, causing reverse proxies (Cloudflare, nginx, etc.) with idle/first-byte timeouts to return **524 timeout errors** — even though the prompt was successfully accepted by the server.

## Problem

```
Browser → Cloudflare CDN (100s first-byte timeout) → cloudflared → nginx → opencode server
```

When a user sends a message via the web UI:

1. Frontend calls `POST /:sessionID/prompt_async`
2. Server opens a streaming response via `stream(c, async () => { ... })`
3. Inside the stream callback, `SessionPrompt.prompt()` is called fire-and-forget (no `await`, no `stream.write()`)
4. The stream stays open momentarily without writing any bytes
5. Cloudflare's 100-second first-byte timeout (non-configurable on Free/Pro plans) triggers a **524 A Timeout Occurred** error
6. Frontend receives the error and shows "Send failed", reverting the input — but the prompt was already accepted server-side

This creates a confusing UX where messages appear to fail but actually succeed.

**Cloudflare error log from production:**
```
ERR Request failed error="stream canceled by remote with error code 0"
    dest=https://dev.feishu.com.de/session/ses_.../command
ERR Request failed error="Incoming request ended abruptly: context canceled"
    dest=https://dev.feishu.com.de/session/ses_.../command
```

## Fix

Replace the `stream()` wrapper with a direct `c.body(null, 204)` response. Since `prompt_async` is designed to return immediately (fire-and-forget), it doesn't need streaming — an atomic 204 No Content response completes in milliseconds and is not susceptible to proxy timeout issues.

**Before:**
```typescript
async (c) => {
  c.status(204)
  c.header("Content-Type", "application/json")
  return stream(c, async () => {
    const sessionID = c.req.valid("param").sessionID
    const body = c.req.valid("json")
    SessionPrompt.prompt({ ...body, sessionID })
  })
},
```

**After:**
```typescript
async (c) => {
  const sessionID = c.req.valid("param").sessionID
  const body = c.req.valid("json")
  SessionPrompt.prompt({ ...body, sessionID })
  return c.body(null, 204)
},
```

## Impact

- **No behavioral change** — `prompt_async` is fire-and-forget by design; the streaming wrapper served no purpose
- **Fixes 524 errors** for all users behind Cloudflare, nginx, or any reverse proxy with first-byte timeouts
- **Eliminates false "Send failed" errors** in the web UI when used behind CDN/proxy
- The synchronous `prompt` endpoint (which legitimately uses `stream()` to write response data) is unaffected