### PR TITLE
feat(tui): add onClick handler to InlineTool and Task components

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1625,11 +1625,14 @@ function InlineTool(props: {
   spinner?: boolean
   children: JSX.Element
   part: ToolPart
+  onClick?: () => void
 }) {
   const [margin, setMargin] = createSignal(0)
   const { theme } = useTheme()
   const ctx = use()
   const sync = useSync()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
 
   const permission = createMemo(() => {
     const callID = sync.data.permission[ctx.sessionID]?.at(0)?.tool?.callID
@@ -1639,6 +1642,7 @@ function InlineTool(props: {
 
   const fg = createMemo(() => {
     if (permission()) return theme.warning
+    if (hover() && props.onClick) return theme.text
     if (props.complete) return theme.textMuted
     return theme.text
   })
@@ -1656,6 +1660,12 @@ function InlineTool(props: {
     <box
       marginTop={margin()}
       paddingLeft={3}
+      onMouseOver={() => props.onClick && setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={() => {
+        if (renderer.getSelection()?.getSelectedText()) return
+        props.onClick?.()
+      }}
       renderBefore={function () {
         const el = this as BoxRenderable
         const parent = el.parent
@@ -1999,6 +2009,11 @@ function Task(props: ToolProps<typeof TaskTool>) {
       complete={props.input.description}
       pending="Delegating..."
       part={props.part}
+      onClick={() => {
+        if (props.metadata.sessionId) {
+          navigate({ type: "session", sessionID: props.metadata.sessionId })
+        }
+      }}
     >
       {content()}
     </InlineTool>


### PR DESCRIPTION
## Summary
- Add `onClick` prop to `InlineTool` component with hover state management
- Implement subtle hover effect by changing text color instead of background
- Add onClick handler to `Task` component to navigate to child session
- Prevent click when text is selected to avoid accidental navigation

## Changes
- Added `onClick?: () => void` prop to `InlineTool`
- Added hover state with `createSignal` and mouse event handlers
- Modified `fg` memo to change text color on hover when clickable
- Added onClick to `Task` that navigates to `props.metadata.sessionId` if available
- Added selection check before triggering onClick to prevent accidental clicks

## Testing
- Typecheck passes
- Hover effect works correctly (text color change)
- Clicking on Task navigates to child session
- Clicking with text selected does not trigger navigation