### PR TITLE
feat: Add API endpoint to register/remove projects

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -380,6 +380,18 @@ export namespace Project {
     },
   )
 
+  export const remove = fn(
+    z.object({
+      projectID: z.string(),
+    }),
+    async ({ projectID }) => {
+      const existing = Database.use((db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, projectID)).get())
+      if (!existing) throw new Error(`Project not found: ${projectID}`)
+      Database.use((db) => db.delete(ProjectTable).where(eq(ProjectTable.id, projectID)).run())
+      return true
+    },
+  )
+
   export async function sandboxes(id: string) {
     const row = Database.use((db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
     if (!row) return []

--- a/packages/opencode/src/server/routes/project.ts
+++ b/packages/opencode/src/server/routes/project.ts
@@ -31,6 +31,31 @@ export const ProjectRoutes = lazy(() =>
         return c.json(projects)
       },
     )
+    .post(
+      "/",
+      describeRoute({
+        summary: "Add a project",
+        description: "Register a new project by providing a directory path. The directory will be analyzed and registered as a project.",
+        operationId: "project.add",
+        responses: {
+          200: {
+            description: "Project successfully added",
+            content: {
+              "application/json": {
+                schema: resolver(Project.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("json", z.object({ directory: z.string() })),
+      async (c) => {
+        const { directory } = c.req.valid("json")
+        const { project } = await Project.fromDirectory(directory)
+        return c.json(project)
+      },
+    )
     .get(
       "/current",
       describeRoute({

--- a/packages/opencode/src/server/routes/project.ts
+++ b/packages/opencode/src/server/routes/project.ts
@@ -103,5 +103,30 @@ export const ProjectRoutes = lazy(() =>
         const project = await Project.update({ ...body, projectID })
         return c.json(project)
       },
+    )
+    .delete(
+      "/:projectID",
+      describeRoute({
+        summary: "Delete project",
+        description: "Delete a project by ID.",
+        operationId: "project.delete",
+        responses: {
+          200: {
+            description: "Project deleted",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ projectID: z.string() })),
+      async (c) => {
+        const projectID = c.req.valid("param").projectID
+        await Project.remove({ projectID })
+        return c.json(true)
+      },
     ),
 )

--- a/packages/opencode/test/server/project-routes.test.ts
+++ b/packages/opencode/test/server/project-routes.test.ts
@@ -32,4 +32,34 @@ describe("project routes", () => {
 
     expect(response.status).toBe(400)
   })
+
+  test("DELETE /project/:projectID removes a project", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const app = Server.App()
+    const createResponse = await app.request("/project", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ directory: tmp.path }),
+    })
+    expect(createResponse.status).toBe(200)
+
+    const created = await createResponse.json()
+    const projectID = created.id as string
+    expect(projectID).toBeDefined()
+
+    const deleteResponse = await app.request(`/project/${projectID}`, {
+      method: "DELETE",
+    })
+    expect(deleteResponse.status).toBe(200)
+    expect(await deleteResponse.json()).toBe(true)
+
+    const listResponse = await app.request("/project", {
+      method: "GET",
+    })
+    expect(listResponse.status).toBe(200)
+    const projects = (await listResponse.json()) as Array<{ id: string; worktree: string }>
+    expect(projects.find((p) => p.id === projectID)).toBeUndefined()
+    expect(projects.find((p) => p.worktree === tmp.path)).toBeUndefined()
+  })
 })

--- a/packages/opencode/test/server/project-routes.test.ts
+++ b/packages/opencode/test/server/project-routes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { Log } from "../../src/util/log"
+import { Server } from "../../src/server/server"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("project routes", () => {
+  test("POST /project registers a project from directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const app = Server.App()
+    const response = await app.request("/project", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ directory: tmp.path }),
+    })
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.worktree).toBe(tmp.path)
+    expect(body.id).toBeDefined()
+  })
+
+  test("POST /project returns 400 for invalid payload", async () => {
+    const app = Server.App()
+    const response = await app.request("/project", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(400)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds project lifecycle endpoints so integrations can manage projects programmatically:

- `POST /project` to register a project from a directory path
- `DELETE /project/:projectID` to remove a project by ID

Before this change, API users could list/update projects but could not add or remove them. The new routes reuse existing project internals:

- add uses `Project.fromDirectory()`
- delete uses `Project.remove()` (new helper), which removes the project row by ID and returns success

This keeps behavior aligned with OpenCode's project model while making bot/integration workflows possible.

### How did you verify your code works?

- Added route test coverage in `packages/opencode/test/server/project-routes.test.ts`:
  - success case for `POST /project`
  - validation failure case for `POST /project` (400)
  - success case for `DELETE /project/:projectID`, including verification that the deleted project no longer appears in `GET /project`
- Ran locally:
  - `bun test --timeout 30000 test/server/project-routes.test.ts` (from `packages/opencode`)
- Manual API verification on local patched server:
  - `POST /project` returns project JSON for real directories
  - `DELETE /project/:projectID` returns `true` and the project no longer appears in `GET /project`

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR