### PR TITLE
fix(opencode): tmux clipboard cannot copy to system clipboard

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -16,9 +16,7 @@ function writeOsc52(text: string): void {
   if (!process.stdout.isTTY) return
   const base64 = Buffer.from(text).toString("base64")
   const osc52 = `\x1b]52;c;${base64}\x07`
-  const passthrough = process.env["TMUX"] || process.env["STY"]
-  const sequence = passthrough ? `\x1bPtmux;\x1b${osc52}\x1b\\` : osc52
-  process.stdout.write(sequence)
+  process.stdout.write(osc52)
 }
 
 export namespace Clipboard {


### PR DESCRIPTION
### Issue for this PR

Closes #10128
Closes #12082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

modern versions of tmux can correctly handle OSC52 . It DO NOT need escape anymore, tmux can handle it correctly.
#10128 mentioned can config tmux by "set -g allow-passthrough on" for workaround. But with this fix, do not need this workaround.

### How did you verify your code works?

tmux version: tmux 3.6a
terminal: windows terminal, alacritty
tmux config: 
set -g set-clipboard on
set -g set -g allow-passthrough off

select and copy in opencode running in tmux, and try to paste to local system

Before the fix, paste will fail.
After the fix, paste is OK.

### Screenshots / recordings

No recording here.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

