### PR TITLE
feat: add keybind viewer dialog and fuzzy search

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -17,6 +17,7 @@ import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
+import { DialogKeybind } from "@tui/component/dialog-keybind"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
@@ -553,6 +554,17 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogHelp />)
+      },
+      category: "System",
+    },
+    {
+      title: "View keybinds",
+      value: "keybinds.list",
+      slash: {
+        name: "keybinds",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogKeybind />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-keybind.tsx
@@ -1,0 +1,49 @@
+import { Config } from "@/config/config"
+import { useKeybind, type KeybindKey } from "@tui/context/keybind"
+import { useDialog } from "@tui/ui/dialog"
+import { DialogSelect } from "@tui/ui/dialog-select"
+import * as fuzzysort from "fuzzysort"
+import { createMemo, createSignal } from "solid-js"
+
+const GROUPS = ["General", "Session", "Messages", "Model & Agent", "Input", "Terminal"] as const
+
+function group(key: string): (typeof GROUPS)[number] {
+  if (key.startsWith("input_") || key.startsWith("history_")) return "Input"
+  if (key.startsWith("session_") || key.startsWith("stash_")) return "Session"
+  if (key.startsWith("messages_")) return "Messages"
+  if (key.startsWith("model_") || key.startsWith("agent_") || key.startsWith("variant_")) return "Model & Agent"
+  if (key.startsWith("terminal_")) return "Terminal"
+  return "General"
+}
+
+function options(print: (key: KeybindKey) => string) {
+  return Object.entries(Config.Keybinds.shape)
+    .filter(([key]) => key !== "leader")
+    .map(([key, schema]) => ({
+      title: schema.description ?? key,
+      value: key,
+      footer: print(key as KeybindKey) || "none",
+      category: group(key),
+    }))
+}
+
+export function DialogKeybind() {
+  const keybind = useKeybind()
+  const dialog = useDialog()
+  const [query, setQuery] = createSignal("")
+  const list = createMemo(() => {
+    const rows = options((k) => keybind.print(k))
+    const q = query().trim()
+    if (!q) return rows
+    return fuzzysort
+      .go(q, rows, {
+        keys: ["title", "footer", "value"],
+        threshold: -10000,
+      })
+      .map((x) => x.obj)
+  })
+
+  return (
+    <DialogSelect title="Keybinds" skipFilter options={list()} onFilter={setQuery} onSelect={() => dialog.clear()} />
+  )
+}

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -46,6 +46,8 @@ import type {
   GlobalDisposeResponses,
   GlobalEventResponses,
   GlobalHealthResponses,
+  GlobalTuiKeybindUpdateErrors,
+  GlobalTuiKeybindUpdateResponses,
   InstanceDisposeResponses,
   LspStatusResponses,
   McpAddErrors,
@@ -265,6 +267,55 @@ export class Config extends HeyApiClient {
   }
 }
 
+export class Keybind extends HeyApiClient {
+  /**
+   * Update global tui keybind
+   *
+   * Update a global keybind in tui.json.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      body?:
+        | {
+            mode: "set"
+            action: string
+            keybind: string
+          }
+        | {
+            mode: "reset"
+            action: string
+          }
+        | {
+            mode: "reset_all"
+          }
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ key: "body", map: "body" }] }])
+    return (options?.client ?? this.client).patch<
+      GlobalTuiKeybindUpdateResponses,
+      GlobalTuiKeybindUpdateErrors,
+      ThrowOnError
+    >({
+      url: "/global/tui/keybind",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Tui extends HeyApiClient {
+  private _keybind?: Keybind
+  get keybind(): Keybind {
+    return (this._keybind ??= new Keybind({ client: this.client }))
+  }
+}
+
 export class Global extends HeyApiClient {
   /**
    * Get health
@@ -305,6 +356,11 @@ export class Global extends HeyApiClient {
   private _config?: Config
   get config(): Config {
     return (this._config ??= new Config({ client: this.client }))
+  }
+
+  private _tui?: Tui
+  get tui(): Tui {
+    return (this._tui ??= new Tui({ client: this.client }))
   }
 }
 
@@ -3150,7 +3206,7 @@ export class Control extends HeyApiClient {
   }
 }
 
-export class Tui extends HeyApiClient {
+export class Tui2 extends HeyApiClient {
   /**
    * Append TUI prompt
    *
@@ -3947,9 +4003,9 @@ export class OpencodeClient extends HeyApiClient {
     return (this._mcp ??= new Mcp({ client: this.client }))
   }
 
-  private _tui?: Tui
-  get tui(): Tui {
-    return (this._tui ??= new Tui({ client: this.client }))
+  private _tui?: Tui2
+  get tui(): Tui2 {
+    return (this._tui ??= new Tui2({ client: this.client }))
   }
 
   private _instance?: Instance

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1979,6 +1979,160 @@ export type GlobalConfigUpdateResponses = {
 
 export type GlobalConfigUpdateResponse = GlobalConfigUpdateResponses[keyof GlobalConfigUpdateResponses]
 
+export type GlobalTuiKeybindUpdateData = {
+  body?:
+    | {
+        mode: "set"
+        action: string
+        keybind: string
+      }
+    | {
+        mode: "reset"
+        action: string
+      }
+    | {
+        mode: "reset_all"
+      }
+  path?: never
+  query?: never
+  url: "/global/tui/keybind"
+}
+
+export type GlobalTuiKeybindUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalTuiKeybindUpdateError = GlobalTuiKeybindUpdateErrors[keyof GlobalTuiKeybindUpdateErrors]
+
+export type GlobalTuiKeybindUpdateResponses = {
+  /**
+   * Successfully updated global tui keybind
+   */
+  200: {
+    $schema?: string
+    theme?: string
+    keybinds?: {
+      leader?: string
+      app_exit?: string
+      editor_open?: string
+      theme_list?: string
+      sidebar_toggle?: string
+      scrollbar_toggle?: string
+      username_toggle?: string
+      status_view?: string
+      session_export?: string
+      session_new?: string
+      session_list?: string
+      session_timeline?: string
+      session_fork?: string
+      session_rename?: string
+      session_delete?: string
+      stash_delete?: string
+      model_provider_list?: string
+      model_favorite_toggle?: string
+      session_share?: string
+      session_unshare?: string
+      session_interrupt?: string
+      session_compact?: string
+      messages_page_up?: string
+      messages_page_down?: string
+      messages_line_up?: string
+      messages_line_down?: string
+      messages_half_page_up?: string
+      messages_half_page_down?: string
+      messages_first?: string
+      messages_last?: string
+      messages_next?: string
+      messages_previous?: string
+      messages_last_user?: string
+      messages_copy?: string
+      messages_undo?: string
+      messages_redo?: string
+      messages_toggle_conceal?: string
+      tool_details?: string
+      model_list?: string
+      model_cycle_recent?: string
+      model_cycle_recent_reverse?: string
+      model_cycle_favorite?: string
+      model_cycle_favorite_reverse?: string
+      command_list?: string
+      agent_list?: string
+      agent_cycle?: string
+      agent_cycle_reverse?: string
+      variant_cycle?: string
+      input_clear?: string
+      input_paste?: string
+      input_submit?: string
+      input_newline?: string
+      input_move_left?: string
+      input_move_right?: string
+      input_move_up?: string
+      input_move_down?: string
+      input_select_left?: string
+      input_select_right?: string
+      input_select_up?: string
+      input_select_down?: string
+      input_line_home?: string
+      input_line_end?: string
+      input_select_line_home?: string
+      input_select_line_end?: string
+      input_visual_line_home?: string
+      input_visual_line_end?: string
+      input_select_visual_line_home?: string
+      input_select_visual_line_end?: string
+      input_buffer_home?: string
+      input_buffer_end?: string
+      input_select_buffer_home?: string
+      input_select_buffer_end?: string
+      input_delete_line?: string
+      input_delete_to_line_end?: string
+      input_delete_to_line_start?: string
+      input_backspace?: string
+      input_delete?: string
+      input_undo?: string
+      input_redo?: string
+      input_word_forward?: string
+      input_word_backward?: string
+      input_select_word_forward?: string
+      input_select_word_backward?: string
+      input_delete_word_forward?: string
+      input_delete_word_backward?: string
+      history_previous?: string
+      history_next?: string
+      session_child_first?: string
+      session_child_cycle?: string
+      session_child_cycle_reverse?: string
+      session_parent?: string
+      terminal_suspend?: string
+      terminal_title_toggle?: string
+      tips_toggle?: string
+      display_thinking?: string
+    }
+    /**
+     * TUI scroll speed
+     */
+    scroll_speed?: number
+    /**
+     * Scroll acceleration settings
+     */
+    scroll_acceleration?: {
+      /**
+       * Enable scroll acceleration
+       */
+      enabled: boolean
+    }
+    /**
+     * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
+     */
+    diff_style?: "auto" | "stacked"
+  }
+}
+
+export type GlobalTuiKeybindUpdateResponse = GlobalTuiKeybindUpdateResponses[keyof GlobalTuiKeybindUpdateResponses]
+
 export type GlobalDisposeData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #16196 

### Type of change

- [x] New feature

### What does this PR do?

 - Adds a `DialogKeybind` component and registers it as a `/keybinds` slash command in the System category.
 - Opens a fuzzy-searchable list of all configured keybinds grouped by category (General, Session, Messages, Model & Agent, Input, Terminal). 
 - You can Search the keybind directly or by its description or name.
 - also regenerated the SDK to pick up the new keybind update endpoint.

### How did you verify your code works?

**Tested:** Ran `bun dev`, and typed `/keybinds` in the prompt input. dialog shows all keybinds with correct grouping and fuzzy filtering works as expected. no lint or type errors

### Screenshots / recordings

https://github.com/user-attachments/assets/af89e81c-2301-4294-86b8-adc1c87138cb


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
