### PR TITLE
feat: configurable provider endpoints

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -9,7 +9,7 @@ import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { showToast } from "@opencode-ai/ui/toast"
-import { createMemo, Match, onCleanup, onMount, Switch } from "solid-js"
+import { createMemo, Match, onCleanup, onMount, Show, Switch } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { Link } from "@/components/link"
 import { useLanguage } from "@/context/language"
@@ -238,8 +238,10 @@ export function DialogConnectProvider(props: { provider: string }) {
   }
 
   function ApiAuthView() {
+    const api = createMemo(() => provider().api)
     const [formStore, setFormStore] = createStore({
-      value: "",
+      url: api() ?? "",
+      apiKey: "",
       error: undefined as string | undefined,
     })
 
@@ -249,6 +251,7 @@ export function DialogConnectProvider(props: { provider: string }) {
       const form = e.currentTarget as HTMLFormElement
       const formData = new FormData(form)
       const apiKey = formData.get("apiKey") as string
+      const url = formData.get("url") as string
 
       if (!apiKey?.trim()) {
         setFormStore("error", language.t("provider.connect.apiKey.required"))
@@ -261,6 +264,7 @@ export function DialogConnectProvider(props: { provider: string }) {
         auth: {
           type: "api",
           key: apiKey,
+          url: api() ? url?.trim() || undefined : undefined,
         },
       })
       await complete()
@@ -289,14 +293,24 @@ export function DialogConnectProvider(props: { provider: string }) {
           </Match>
         </Switch>
         <form onSubmit={handleSubmit} class="flex flex-col items-start gap-4">
+          <Show when={api()}>
+            <TextField
+              type="text"
+              label="API URL"
+              placeholder={api()}
+              name="url"
+              value={formStore.url}
+              onChange={(v) => setFormStore("url", v)}
+            />
+          </Show>
           <TextField
-            autofocus
-            type="text"
+            autofocus={!api()}
+            type="password"
             label={language.t("provider.connect.apiKey.label", { provider: provider().name })}
             placeholder={language.t("provider.connect.apiKey.placeholder")}
             name="apiKey"
-            value={formStore.value}
-            onChange={(v) => setFormStore("value", v)}
+            value={formStore.apiKey}
+            onChange={(v) => setFormStore("apiKey", v)}
             validationState={formStore.error ? "invalid" : undefined}
             error={formStore.error}
           />

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -21,6 +21,7 @@ export namespace Auth {
     .object({
       type: z.literal("api"),
       key: z.string(),
+      url: z.string().optional(),
     })
     .meta({ ref: "ApiAuth" })
 

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -62,9 +62,11 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
         if (prompts.isCancel(value)) throw new UI.CancelledError()
         inputs[prompt.key] = value
       } else {
-        const value = await prompts.text({
+        const secret = /token|key|secret|password/i.test(prompt.key)
+        const fn = secret ? prompts.password : prompts.text
+        const value = await fn({
           message: prompt.message,
-          placeholder: prompt.placeholder,
+          placeholder: secret ? undefined : prompt.placeholder,
           validate: prompt.validate ? (v) => prompt.validate!(v ?? "") : undefined,
         })
         if (prompts.isCancel(value)) throw new UI.CancelledError()
@@ -444,15 +446,25 @@ export const AuthLoginCommand = cmd({
           )
         }
 
+        const info = providers[provider]
+        let url: string | undefined
+        if (info?.api) {
+          const input = await prompts.text({
+            message: "API URL",
+            placeholder: info.api,
+            defaultValue: info.api,
+          })
+          if (prompts.isCancel(input)) throw new UI.CancelledError()
+          url = input || info.api
+        }
+
         const key = await prompts.password({
           message: "Enter your API key",
           validate: (x) => (x && x.length > 0 ? undefined : "Required"),
         })
         if (prompts.isCancel(key)) throw new UI.CancelledError()
-        await Auth.set(provider, {
-          type: "api",
-          key,
-        })
+
+        await Auth.set(provider, { type: "api", key, url })
 
         prompts.outro("Done")
       },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -211,36 +211,66 @@ function ApiMethod(props: ApiMethodProps) {
   const sync = useSync()
   const { theme } = useTheme()
 
+  const provider = createMemo(() => sync.data.provider_next.all.find((p) => p.id === props.providerID))
+  const api = createMemo(() => provider()?.api)
+  const [url, setUrl] = createSignal("")
+
+  onMount(() => {
+    setUrl(api() || "")
+  })
+
+  const description = createMemo(() => {
+    return (
+      {
+        opencode: (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API key.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
+            </text>
+          </box>
+        ),
+        "opencode-go": (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
+              with generous usage limits.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable OpenCode Go
+            </text>
+          </box>
+        ),
+      }[props.providerID] ?? undefined
+    )
+  })
+
+  if (api()) {
+    return (
+      <DialogPrompt
+        title={props.title}
+        placeholder={api()!}
+        value={url()}
+        description={
+          <box gap={1}>
+            <text fg={theme.textMuted}>API URL (press enter to use default)</text>
+          </box>
+        }
+        onConfirm={(input) => {
+          setUrl(input || api()!)
+          dialog.replace(() => <ApiKeyPrompt providerID={props.providerID} title={props.title} url={input || api()!} />)
+        }}
+      />
+    )
+  }
+
   return (
     <DialogPrompt
       title={props.title}
       placeholder="API key"
-      description={
-        {
-          opencode: (
-            <box gap={1}>
-              <text fg={theme.textMuted}>
-                OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API
-                key.
-              </text>
-              <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
-              </text>
-            </box>
-          ),
-          "opencode-go": (
-            <box gap={1}>
-              <text fg={theme.textMuted}>
-                OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
-                with generous usage limits.
-              </text>
-              <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable OpenCode Go
-              </text>
-            </box>
-          ),
-        }[props.providerID] ?? undefined
-      }
+      description={description()}
       onConfirm={async (value) => {
         if (!value) return
         await sdk.client.auth.set({
@@ -248,6 +278,73 @@ function ApiMethod(props: ApiMethodProps) {
           auth: {
             type: "api",
             key: value,
+          },
+        })
+        await sdk.client.instance.dispose()
+        await sync.bootstrap()
+        dialog.replace(() => <DialogModel providerID={props.providerID} />)
+      }}
+    />
+  )
+}
+
+interface ApiKeyPromptProps {
+  providerID: string
+  title: string
+  url: string
+}
+
+function ApiKeyPrompt(props: ApiKeyPromptProps) {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const sync = useSync()
+  const { theme } = useTheme()
+
+  const description = createMemo(() => {
+    return (
+      {
+        opencode: (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API key.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
+            </text>
+          </box>
+        ),
+        "opencode-go": (
+          <box gap={1}>
+            <text fg={theme.textMuted}>
+              OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
+              with generous usage limits.
+            </text>
+            <text fg={theme.text}>
+              Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> and enable OpenCode Go
+            </text>
+          </box>
+        ),
+      }[props.providerID] ?? (
+        <box gap={1}>
+          <text fg={theme.textMuted}>Enter your API key</text>
+        </box>
+      )
+    )
+  })
+
+  return (
+    <DialogPrompt
+      title={props.title}
+      placeholder="API key"
+      description={description()}
+      onConfirm={async (value) => {
+        if (!value) return
+        await sdk.client.auth.set({
+          providerID: props.providerID,
+          auth: {
+            type: "api",
+            key: value,
+            url: props.url,
           },
         })
         await sdk.client.instance.dispose()

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -121,11 +121,13 @@ export namespace ProviderAuth {
     z.object({
       providerID: z.string(),
       key: z.string(),
+      url: z.string().optional(),
     }),
     async (input) => {
       await Auth.set(input.providerID, {
         type: "api",
         key: input.key,
+        url: input.url,
       })
     },
   )

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -112,6 +112,7 @@ export namespace Provider {
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
   type CustomLoader = (provider: Info) => Promise<{
     autoload: boolean
+    api?: string
     getModel?: CustomModelLoader
     options?: Record<string, any>
   }>
@@ -465,9 +466,9 @@ export namespace Provider {
       }
     },
     gitlab: async (input) => {
-      const instanceUrl = Env.get("GITLAB_INSTANCE_URL") || "https://gitlab.com"
-
       const auth = await Auth.get(input.id)
+      const url = (auth?.type === "api" && auth.url) || Env.get("GITLAB_INSTANCE_URL") || "https://gitlab.com"
+
       const apiKey = await (async () => {
         if (auth?.type === "oauth") return auth.access
         if (auth?.type === "api") return auth.key
@@ -484,8 +485,9 @@ export namespace Provider {
 
       return {
         autoload: !!apiKey,
+        api: url,
         options: {
-          instanceUrl,
+          instanceUrl: url,
           apiKey,
           aiGatewayHeaders,
           featureFlags: {
@@ -686,6 +688,7 @@ export namespace Provider {
     .object({
       id: z.string(),
       name: z.string(),
+      api: z.string().optional(),
       source: z.enum(["env", "config", "custom", "api"]),
       env: z.string().array(),
       key: z.string().optional(),
@@ -764,11 +767,16 @@ export namespace Provider {
     return m
   }
 
+  const DEFAULT_API: Record<string, string> = {
+    gitlab: "https://gitlab.com",
+  }
+
   export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
     return {
       id: provider.id,
       source: "custom",
       name: provider.name,
+      api: provider.api ?? DEFAULT_API[provider.id],
       env: provider.env ?? [],
       options: {},
       models: mapValues(provider.models, (model) => fromModelsDevModel(provider, model)),
@@ -993,6 +1001,7 @@ export namespace Provider {
         if (result.getModel) modelLoaders[providerID] = result.getModel
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
+        if (result.api) patch.api = result.api
         mergeProvider(providerID, patch)
       }
     }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -708,7 +708,7 @@ export namespace Provider {
       family: model.family,
       api: {
         id: model.id,
-        url: model.provider?.api ?? provider.api!,
+        url: model.provider?.api ?? provider.api ?? "",
         npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
       },
       status: model.status ?? "active",
@@ -767,16 +767,12 @@ export namespace Provider {
     return m
   }
 
-  const DEFAULT_API: Record<string, string> = {
-    gitlab: "https://gitlab.com",
-  }
-
   export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
     return {
       id: provider.id,
       source: "custom",
       name: provider.name,
-      api: provider.api ?? DEFAULT_API[provider.id],
+      api: provider.api,
       env: provider.env ?? [],
       options: {},
       models: mapValues(provider.models, (model) => fromModelsDevModel(provider, model)),
@@ -1003,6 +999,15 @@ export namespace Provider {
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         if (result.api) patch.api = result.api
         mergeProvider(providerID, patch)
+      }
+    }
+
+    // backfill model api urls that were empty at database construction time
+    // because the provider-level url was only resolved by custom loaders above
+    for (const provider of Object.values(providers)) {
+      if (!provider.api) continue
+      for (const model of Object.values(provider.models)) {
+        if (!model.api.url) model.api.url = provider.api
       }
     }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1519,6 +1519,7 @@ export type OAuth = {
 export type ApiAuth = {
   type: "api"
   key: string
+  url?: string
 }
 
 export type WellKnownAuth = {
@@ -1610,6 +1611,7 @@ export type Model = {
 export type Provider = {
   id: string
   name: string
+  api?: string
   source: "env" | "config" | "custom" | "api"
   env: Array<string>
   key?: string


### PR DESCRIPTION
### Issue for this PR

Closes #16155

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It provides the possibility to configure the URL endpoints for all providers.
This enables the use of other endpoints for providers e.g. when the provider has multiple hosting options.
This is the case for e.g. GitLab Duo where many companies and private people have their own instance, but the current approach requires one to know that one has to set an environment variable every time.

The cleanest approach is to allow every provider endpoint to be configurable which might also closes some other issues that may be open.

### How did you verify your code works?

A lot of manual testing... Not sure how to do this otherwise

### Screenshots / recordings

<img width="841" height="312" alt="image" src="https://github.com/user-attachments/assets/d17244f6-f412-4f3a-8b52-ff5e22392b05" />
<img width="885" height="574" alt="image" src="https://github.com/user-attachments/assets/8c999929-ab44-4507-8e84-2cd9ad51d5c7" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
