### PR TITLE
feat(opencode): prioritize text/markdown in webfetch accept header

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -53,7 +53,7 @@ export const WebFetchTool = Tool.define("webfetch", {
         break
       default:
         acceptHeader =
-          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
+          "text/markdown,text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
     }
     const headers = {
       "User-Agent":

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -29,6 +29,130 @@ async function withFetch(
   }
 }
 
+describe("tool.webfetch accept headers", () => {
+  test("markdown format sends text/markdown as highest priority", async () => {
+    let captured: RequestInit | undefined
+    await withFetch(
+      async (_url, init) => {
+        captured = init
+        return new Response("# Hello", { status: 200, headers: { "content-type": "text/markdown" } })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            await webfetch.execute({ url: "https://example.com", format: "markdown" }, ctx)
+            const accept = (captured?.headers as Record<string, string>)?.Accept ?? ""
+            expect(accept).toStartWith("text/markdown")
+          },
+        })
+      },
+    )
+  })
+
+  test("text format sends text/plain as highest priority", async () => {
+    let captured: RequestInit | undefined
+    await withFetch(
+      async (_url, init) => {
+        captured = init
+        return new Response("hello", { status: 200, headers: { "content-type": "text/plain" } })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            await webfetch.execute({ url: "https://example.com", format: "text" }, ctx)
+            const accept = (captured?.headers as Record<string, string>)?.Accept ?? ""
+            expect(accept).toStartWith("text/plain")
+          },
+        })
+      },
+    )
+  })
+
+  test("html format sends text/html as highest priority", async () => {
+    let captured: RequestInit | undefined
+    await withFetch(
+      async (_url, init) => {
+        captured = init
+        return new Response("<p>hi</p>", { status: 200, headers: { "content-type": "text/html" } })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            await webfetch.execute({ url: "https://example.com", format: "html" }, ctx)
+            const accept = (captured?.headers as Record<string, string>)?.Accept ?? ""
+            expect(accept).toStartWith("text/html")
+          },
+        })
+      },
+    )
+  })
+
+  test("default accept header prioritizes text/markdown", async () => {
+    let captured: RequestInit | undefined
+    await withFetch(
+      async (_url, init) => {
+        captured = init
+        return new Response("# Hello", { status: 200, headers: { "content-type": "text/markdown" } })
+      },
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            // format defaults to "markdown" via zod, so we test the explicit markdown path
+            await webfetch.execute({ url: "https://example.com", format: "markdown" }, ctx)
+            const accept = (captured?.headers as Record<string, string>)?.Accept ?? ""
+            expect(accept).toContain("text/markdown")
+            expect(accept.indexOf("text/markdown")).toBeLessThan(accept.indexOf("text/html"))
+          },
+        })
+      },
+    )
+  })
+
+  test("markdown format returns server markdown without conversion", async () => {
+    const md = "# Title\n\nSome **bold** text"
+    await withFetch(
+      async () => new Response(md, { status: 200, headers: { "content-type": "text/markdown; charset=utf-8" } }),
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            const result = await webfetch.execute({ url: "https://example.com/page", format: "markdown" }, ctx)
+            expect(result.output).toBe(md)
+          },
+        })
+      },
+    )
+  })
+
+  test("markdown format converts html response to markdown", async () => {
+    const html = "<h1>Title</h1><p>Hello world</p>"
+    await withFetch(
+      async () => new Response(html, { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }),
+      async () => {
+        await Instance.provide({
+          directory: projectRoot,
+          fn: async () => {
+            const webfetch = await WebFetchTool.init()
+            const result = await webfetch.execute({ url: "https://example.com/page", format: "markdown" }, ctx)
+            expect(result.output).toContain("Title")
+            expect(result.output).toContain("Hello world")
+            expect(result.output).not.toContain("<h1>")
+          },
+        })
+      },
+    )
+  })
+})
+
 describe("tool.webfetch", () => {
   test("returns image responses as file attachments", async () => {
     const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])


### PR DESCRIPTION
### Issue for this PR

Closes #13486

Redo of #15899, which was auto-closed for not following the PR template.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds `text/markdown` as the highest priority in the default Accept header for the webfetch tool. When a server supports content negotiation and can serve markdown directly, this skips the HTML-to-markdown conversion on the client side.

Cloudflare's [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) serves markdown at the edge for any zone with the feature enabled. By requesting `text/markdown` first, opencode gets cleaner output with fewer tokens from sites that support it, and falls back to the existing HTML conversion otherwise.

The change is a single line in the default `Accept` header — `text/markdown` is prepended before `text/html`.

### How did you verify your code works?

Added tests covering accept header behavior for each format option and verifying markdown passthrough vs HTML conversion. Ran the test suite in `packages/opencode`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR