### PR TITLE
fix: add idle-timeout Instance disposal for serve mode memory

### DIFF
--- a/docs/plans/2026-03-05-anthropic-oauth-pool-design.md
+++ b/docs/plans/2026-03-05-anthropic-oauth-pool-design.md
@@ -1,0 +1,134 @@
+# Anthropic OAuth Account Pool — Design
+
+Multi-account OAuth rotation for the `opencode-anthropic-auth` plugin. Spreads Claude Code subscription usage across multiple Pro/Max accounts to avoid overage charges.
+
+## Problem
+
+A single Claude Pro/Max subscription has 5-hour and 7-day usage windows. Heavy usage pushes you into overage (billed at API rates). Multiple subscriptions have independent windows, but opencode only supports one account at a time.
+
+## Approach
+
+Extend the existing `opencode-anthropic-auth` plugin to manage a pool of OAuth accounts. The plugin already wraps `fetch()` with Bearer token injection, tool prefixing, and body sanitization — we add account selection and rotation on top.
+
+This is a plugin-only change. No opencode core modifications needed.
+
+### Why plugin, not core
+
+Multiple community PRs (#8536, #8590, #11832, #13378, #15608) attempted core multi-account support. None have been merged after 1-2 months. The community consensus is converging on a plugin approach. A plugin survives opencode updates and ships today.
+
+## Account Pool Storage
+
+File: `~/.opencode/data/anthropic-pool.json`
+
+```json
+{
+  "accounts": [
+    {
+      "label": "personal",
+      "refresh": "rt_..."
+    },
+    {
+      "label": "work",
+      "refresh": "rt_..."
+    }
+  ],
+  "config": {
+    "cooldownMs": 300000,
+    "threshold": 0.8
+  }
+}
+```
+
+### Fields
+
+- `label` — user-provided name for display/identification
+- `refresh` — OAuth refresh token for this account
+
+Runtime state (in memory, persisted only on account switch or exit):
+
+- `access` — current access token
+- `expires` — access token expiration timestamp
+- `util5h` — last observed `anthropic-ratelimit-unified-5h-utilization` (0.0–1.0)
+- `util7d` — last observed `anthropic-ratelimit-unified-7d-utilization` (0.0–1.0)
+- `cooloffUntil` — timestamp until which this account is resting
+
+### Config
+
+- `cooldownMs` (default 300000 / 5 min) — how long to rest an account after a 429
+- `threshold` (default 0.80) — utilization above this triggers proactive switch
+
+### Adding accounts
+
+Two options, both external to opencode:
+
+1. **Manual edit** — run `opencode auth login`, copy the refresh token from `~/.opencode/data/auth.json`, paste into the pool file with a label
+2. **Standalone script** — `add-account.mjs` runs the same PKCE OAuth flow the plugin uses, prompts for a label, appends to the pool file
+
+## Account Selection
+
+Sticky account with reactive switching. No per-request selection logic.
+
+### Lifecycle
+
+1. **Init:** Load pool file. Set current = first account. Refresh access token if needed.
+2. **Normal operation:** Use current account for all requests. No selection on each request.
+3. **Response handling:** Read `anthropic-ratelimit-unified-5h-utilization` and `anthropic-ratelimit-unified-7d-utilization` headers. Update in-memory state. Free — headers are on the response object, not in the stream.
+4. **Switch triggers:**
+   - **429 response** — cooloff current account, switch to next, retry same request
+   - **Threshold breach** — `util5h > threshold` or `util7d > threshold` — switch to next (takes effect on next request, no retry)
+   - **Auth failure** — 401/403 after token refresh fails — cooloff current, switch to next
+5. **Persist:** Write pool file to disk only on account switch or process exit.
+
+### "Next available" selection
+
+When switching, pick the first account (in pool order) that:
+
+1. Is not in cooloff (`Date.now() >= cooloffUntil`)
+2. Has `max(util5h, util7d) < threshold`
+
+If none qualify, pick the account with the lowest `max(util5h, util7d)` regardless of threshold. If all are in cooloff, pick the one whose cooloff expires soonest.
+
+## Fetch Wrapper Changes
+
+The existing plugin `fetch()` wrapper does: token refresh, Bearer injection, beta headers, tool name prefixing (`mcp_`), body sanitization (OpenCode → Claude Code), streaming tool name de-prefixing.
+
+Changes are additive:
+
+### What changes
+
+- **Token source:** Bearer token comes from pool state instead of opencode's `auth.json`
+- **Response header read:** After each response, read utilization headers into memory
+- **Switch + retry:** On 429, switch account and retry the request
+- **Proactive switch:** On threshold breach, switch account for subsequent requests
+
+### What stays the same
+
+- Beta header merging (`oauth-2025-04-20`, `interleaved-thinking-2025-05-14`)
+- Tool name prefixing/de-prefixing (`mcp_`)
+- Body sanitization (OpenCode → Claude Code)
+- Streaming `ReadableStream` wrapper
+- `?beta=true` query parameter injection
+
+### Streaming
+
+Utilization headers are on the `Response` object, not in the stream body. We read them before returning the wrapped stream. No change to streaming logic.
+
+### Disk I/O
+
+- **Startup:** 1 read
+- **Normal operation:** 0 reads, 0 writes
+- **Account switch:** 1 write (rare — few times per day)
+- **Process exit:** 1 write
+
+## Fallback behavior
+
+If the pool file doesn't exist or is empty, the plugin falls back to its current single-account behavior using opencode's `auth.json`. Existing users are unaffected.
+
+## Related community work
+
+Patterns borrowed from:
+
+- Issue #8591 (OAuth Marathon) — rotating-fetch, cooldown, health tracking
+- PR #8536 (andrejvysny) — usage header parsing, per-account utilization
+- PR #11832 (mguttmann) — rotating-fetch.ts, credential-manager, event-driven failover
+- Issue #29721 (anthropics/claude-code) — unified utilization header documentation

--- a/docs/plans/2026-03-05-anthropic-oauth-pool-plan.md
+++ b/docs/plans/2026-03-05-anthropic-oauth-pool-plan.md
@@ -1,0 +1,546 @@
+# Anthropic OAuth Account Pool — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the opencode-anthropic-auth plugin to rotate across multiple Claude Pro/Max OAuth accounts, switching when usage thresholds are breached or rate limits hit.
+
+**Architecture:** Single-file plugin (`index.mjs`) gains pool state management, utilization header tracking, and reactive account switching inside the existing `fetch()` wrapper. A separate `add-account.mjs` script handles adding accounts to the pool file.
+
+**Tech Stack:** JavaScript (ESM), OpenCode plugin API, Anthropic OAuth, Node.js `fs` for pool persistence.
+
+**Design doc:** `docs/plans/2026-03-05-anthropic-oauth-pool-design.md`
+
+**Plugin repo:** `sjawhar/opencode-anthropic-auth` (branch: `feat/oauth-context-cap`)
+**Plugin entry:** `index.mjs` (~250 lines currently)
+
+---
+
+### Task 1: Pool State Module
+
+Extract pool loading, saving, and account selection into functions at the top of `index.mjs`.
+
+**Files:**
+
+- Modify: `index.mjs` (add pool functions before `AnthropicAuthPlugin`)
+
+**Step 1: Add pool constants and defaults**
+
+```javascript
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+const POOL_PATH = join(homedir(), ".opencode", "data", "anthropic-pool.json")
+const DEFAULTS = { cooldownMs: 300_000, threshold: 0.8 }
+```
+
+**Step 2: Add pool loading function**
+
+```javascript
+function loadPool() {
+  if (!existsSync(POOL_PATH)) return null
+  try {
+    const raw = JSON.parse(readFileSync(POOL_PATH, "utf-8"))
+    if (!raw.accounts?.length) return null
+    return {
+      accounts: raw.accounts.map((a) => ({
+        label: a.label ?? "unnamed",
+        refresh: a.refresh,
+        access: "",
+        expires: 0,
+        util5h: 0,
+        util7d: 0,
+        cooloffUntil: 0,
+      })),
+      config: { ...DEFAULTS, ...raw.config },
+    }
+  } catch {
+    return null
+  }
+}
+```
+
+**Step 3: Add pool persistence function**
+
+Only called on account switch or process exit. Writes only labels, refresh tokens, and config — runtime state is not persisted.
+
+```javascript
+function savePool(pool) {
+  const dir = join(homedir(), ".opencode", "data")
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+  const data = {
+    accounts: pool.accounts.map((a) => ({
+      label: a.label,
+      refresh: a.refresh,
+    })),
+    config: pool.config,
+  }
+  writeFileSync(POOL_PATH, JSON.stringify(data, null, 2))
+}
+```
+
+**Step 4: Add account selection function**
+
+```javascript
+function pickNext(pool, current) {
+  const now = Date.now()
+  const threshold = pool.config.threshold
+  // First pass: not in cooloff and below threshold
+  const candidates = pool.accounts.filter(
+    (a) => a !== current && now >= a.cooloffUntil && Math.max(a.util5h, a.util7d) < threshold,
+  )
+  if (candidates.length) return candidates[0]
+  // Second pass: not in cooloff, any utilization
+  const available = pool.accounts.filter((a) => a !== current && now >= a.cooloffUntil)
+  if (available.length) {
+    available.sort((a, b) => Math.max(a.util5h, a.util7d) - Math.max(b.util5h, b.util7d))
+    return available[0]
+  }
+  // All in cooloff: pick soonest to recover
+  const all = pool.accounts.filter((a) => a !== current)
+  if (!all.length) return current
+  all.sort((a, b) => a.cooloffUntil - b.cooloffUntil)
+  return all[0]
+}
+```
+
+**Step 5: Commit**
+
+```
+jj describe -m "feat: add pool state module (load, save, select)"
+jj new
+```
+
+---
+
+### Task 2: Token Refresh for Pool Accounts
+
+Extract token refresh into a standalone function that works with any pool account (not tied to opencode's auth store).
+
+**Files:**
+
+- Modify: `index.mjs`
+
+**Step 1: Add refresh function for pool accounts**
+
+```javascript
+async function refreshToken(account) {
+  const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      grant_type: "refresh_token",
+      refresh_token: account.refresh,
+      client_id: CLIENT_ID,
+    }),
+  })
+  if (!response.ok) return false
+  const json = await response.json()
+  account.refresh = json.refresh_token
+  account.access = json.access_token
+  account.expires = Date.now() + json.expires_in * 1000
+  return true
+}
+```
+
+Note: Anthropic may return a new refresh token on each refresh. We update `account.refresh` in place and persist on next save.
+
+**Step 2: Commit**
+
+```
+jj describe -m "feat: add standalone token refresh for pool accounts"
+jj new
+```
+
+---
+
+### Task 3: Verify Utilization Headers Exist
+
+Before building the full pool integration, confirm that `anthropic-ratelimit-unified-5h-utilization` and `anthropic-ratelimit-unified-7d-utilization` headers actually appear in OAuth API responses. These headers are documented in GitHub issue #29721 but not in the official Anthropic rate-limits page.
+
+**Step 1: Add temporary header logging to the existing plugin**
+
+In the existing single-account `fetch()` wrapper, after `const response = await fetch(...)`, add:
+
+```javascript
+// TEMPORARY: verify utilization headers exist
+for (const [k, v] of response.headers.entries()) {
+  if (k.includes("ratelimit") || k.includes("utilization")) console.log(`[header] ${k}: ${v}`)
+}
+```
+
+**Step 2: Make a few requests through opencode and check output**
+
+Run opencode, send a message, check the console output. We need to see:
+- `anthropic-ratelimit-unified-5h-utilization` (value 0.0-1.0)
+- `anthropic-ratelimit-unified-7d-utilization` (value 0.0-1.0)
+
+If these headers are NOT present: the proactive threshold switching won't work. The design still functions via 429-only reactive switching, but we should note this in the design doc and skip the threshold logic.
+
+If they ARE present: proceed as designed.
+
+**Step 3: Remove temporary logging and commit**
+
+```
+jj describe -m "chore: verify utilization headers present in OAuth responses"
+jj new
+```
+
+---
+
+### Task 4: Utilization Header Parsing
+
+Add a function to read utilization headers from the response and update account state.
+
+**Files:**
+
+- Modify: `index.mjs`
+
+**Step 1: Add header parsing function**
+
+```javascript
+function parseUtil(response, account) {
+  const h5 = response.headers.get("anthropic-ratelimit-unified-5h-utilization")
+  const h7 = response.headers.get("anthropic-ratelimit-unified-7d-utilization")
+  if (h5 != null) account.util5h = parseFloat(h5)
+  if (h7 != null) account.util7d = parseFloat(h7)
+}
+```
+
+**Step 2: Commit**
+
+```
+jj describe -m "feat: add utilization header parsing"
+jj new
+```
+
+---
+
+### Task 5: Extract Request/Response Helpers
+
+Factor existing fetch wrapper internals into reusable functions before wiring in pool mode. This is a pure refactor — behavior is unchanged.
+
+**Files:**
+
+- Modify: `index.mjs`
+
+**Step 1: Extract `buildRequest(input, init, account)` helper**
+
+Move the existing header construction, body transform (tool prefixing, sanitization), and URL manipulation into a standalone function that returns `{ requestInput, body, requestHeaders }`. Both the current single-account path and the future pool path will call it.
+
+**Step 2: Extract `wrapStream(response)` helper**
+
+Move the existing `ReadableStream` wrapper (that strips `mcp_` prefixes from tool names) into a standalone function.
+
+**Step 3: Update the existing single-account fetch to use the new helpers**
+
+Verify the plugin still works identically after the refactor.
+
+**Step 4: Commit**
+
+```
+jj describe -m "refactor: extract buildRequest and wrapStream helpers"
+jj new
+```
+
+---
+
+### Task 6: Integrate Pool into the Fetch Wrapper
+Modify the `auth.loader` to use the pool when available, falling back to single-account behavior when no pool file exists.
+
+**Files:**
+
+- Modify: `index.mjs` — the `auth.loader` function inside `AnthropicAuthPlugin`
+
+**Step 1: Add pool initialization at the top of auth.loader**
+
+At the beginning of the `loader` function (after `const auth = await getAuth()`), load the pool:
+
+```javascript
+const pool = loadPool()
+```
+
+If `pool` is null, fall through to the existing single-account logic unchanged.
+
+**Step 2: Add pool-mode fetch wrapper**
+
+When `pool` is not null AND `auth.type === "oauth"`, return a `fetch` that uses the pool instead of the single-account logic. The new fetch wrapper:
+
+1. Uses `pool.accounts[0]` as the initial current account (held in closure)
+2. Before request: ensure current account has valid access token (call `refreshToken` if expired)
+3. Injects Bearer token from current account (same header logic as existing code)
+4. All existing body transforms stay (tool prefixing, sanitization, beta headers)
+5. After response: call `parseUtil(response, current)`
+6. On 429: cooloff current, switch via `next()`, retry once
+7. On threshold breach: switch via `next()` (no retry, takes effect next request)
+8. On 401/403: clear access, attempt refresh, if fails cooloff + switch
+
+The structure:
+
+```javascript
+if (pool) {
+  // zero out cost (same as existing)
+  for (const model of Object.values(provider.models)) {
+    model.cost = { input: 0, output: 0, cache: { read: 0, write: 0 } }
+  }
+
+  let current = pool.accounts[0]
+
+  return {
+    apiKey: "",
+    async fetch(input, init) {
+      // Ensure valid token
+      if (!current.access || current.expires < Date.now()) {
+        const ok = await refreshToken(current)
+        if (!ok) {
+          current.cooloffUntil = Date.now() + pool.config.cooldownMs
+          current = pickNext(pool, current)
+          savePool(pool)
+          const ok2 = await refreshToken(current)
+          if (!ok2) throw new Error("All accounts failed to refresh")
+        }
+      }
+
+      // Build request (reuse existing header/body transform logic)
+      const { requestInput, body, requestHeaders } = buildRequest(input, init, current)
+
+      const response = await fetch(requestInput, {
+        ...init,
+        body,
+        headers: requestHeaders,
+      })
+
+      // Parse utilization
+      parseUtil(response, current)
+
+      // Handle 429
+      if (response.status === 429) {
+        current.cooloffUntil = Date.now() + pool.config.cooldownMs
+        const prev = current
+        current = pickNext(pool, current)
+        savePool(pool)
+        if (current === prev) return response // no other accounts
+        // Retry with new account
+        if (!current.access || current.expires < Date.now()) {
+          await refreshToken(current)
+        }
+        const retry = buildRequest(input, init, current)
+        const r2 = await fetch(retry.requestInput, {
+          ...init,
+          body: retry.body,
+          headers: retry.requestHeaders,
+        })
+        parseUtil(r2, current)
+        return wrapStream(r2)
+      }
+
+      // Proactive switch on threshold
+      if (Math.max(current.util5h, current.util7d) > pool.config.threshold) {
+        const prev = current
+        current = pickNext(pool, current)
+        if (current !== prev) savePool(pool)
+      }
+
+      return wrapStream(response)
+    },
+  }
+}
+```
+
+**Step 3: Commit**
+
+```
+jj describe -m "feat: integrate pool rotation into fetch wrapper"
+jj new
+```
+
+---
+
+### Task 7: Process Exit Persistence
+
+Ensure pool state is saved when the process exits.
+
+**Files:**
+
+- Modify: `index.mjs`
+
+**Step 1: Register exit handler**
+
+Inside the pool-mode branch of `auth.loader`, after loading the pool:
+
+```javascript
+const onExit = () => {
+  try {
+    savePool(pool)
+  } catch {}
+}
+process.on("beforeExit", onExit)
+process.on("SIGTERM", onExit)
+process.on("SIGINT", onExit)
+```
+
+This persists any updated refresh tokens (which may change on each refresh cycle) so they're available on next startup.
+
+**Step 2: Commit**
+
+```
+jj describe -m "feat: persist pool state on process exit"
+jj new
+```
+
+---
+
+### Task 8: Add Account Script
+
+Create `add-account.mjs` — standalone script that runs the PKCE OAuth flow and appends to the pool file.
+
+**Files:**
+
+- Create: `add-account.mjs`
+
+**Step 1: Write the script**
+
+```javascript
+#!/usr/bin/env node
+import { generatePKCE } from "@openauthjs/openauth/pkce"
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+import { createInterface } from "node:readline"
+
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const POOL_PATH = join(homedir(), ".opencode", "data", "anthropic-pool.json")
+
+function prompt(q) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) =>
+    rl.question(q, (a) => {
+      rl.close()
+      resolve(a)
+    }),
+  )
+}
+
+async function main() {
+  const label = await prompt("Account label (e.g. personal, work): ")
+  const pkce = await generatePKCE()
+
+  const url = new URL("https://claude.ai/oauth/authorize")
+  url.searchParams.set("code", "true")
+  url.searchParams.set("client_id", CLIENT_ID)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("redirect_uri", "https://console.anthropic.com/oauth/code/callback")
+  url.searchParams.set("scope", "org:create_api_key user:profile user:inference")
+  url.searchParams.set("code_challenge", pkce.challenge)
+  url.searchParams.set("code_challenge_method", "S256")
+  url.searchParams.set("state", pkce.verifier)
+
+  console.log("\nOpen this URL in your browser:\n")
+  console.log(url.toString())
+  const code = await prompt("\nPaste the authorization code here: ")
+
+  const splits = code.split("#")
+  const result = await fetch("https://console.anthropic.com/v1/oauth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      code: splits[0],
+      state: splits[1],
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      redirect_uri: "https://console.anthropic.com/oauth/code/callback",
+      code_verifier: pkce.verifier,
+    }),
+  })
+
+  if (!result.ok) {
+    console.error("Authorization failed:", result.status)
+    process.exit(1)
+  }
+
+  const json = await result.json()
+  const dir = join(homedir(), ".opencode", "data")
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+
+  let pool = { accounts: [], config: {} }
+  if (existsSync(POOL_PATH)) {
+    try {
+      pool = JSON.parse(readFileSync(POOL_PATH, "utf-8"))
+    } catch {}
+  }
+
+  pool.accounts.push({ label: label.trim() || "unnamed", refresh: json.refresh_token })
+  writeFileSync(POOL_PATH, JSON.stringify(pool, null, 2))
+  console.log(`\nAccount "${label}" added. Pool now has ${pool.accounts.length} account(s).`)
+}
+
+main()
+```
+
+**Step 2: Commit**
+
+```
+jj describe -m "feat: add standalone add-account script"
+jj new
+```
+
+---
+
+### Task 9: Manual Testing
+
+**Step 1: Add one account via script**
+
+```bash
+node add-account.mjs
+# Follow the OAuth flow, label it "test-1"
+```
+
+**Step 2: Verify pool file**
+
+```bash
+cat ~/.opencode/data/anthropic-pool.json
+# Should show one account with label and refresh token
+```
+
+**Step 3: Add a second account**
+
+```bash
+node add-account.mjs
+# Label it "test-2"
+```
+
+**Step 4: Start opencode and verify plugin loads pool**
+
+Run opencode normally. Send a message. Confirm the plugin uses the first account (check that requests succeed).
+
+**Step 5: Verify utilization tracking**
+
+After a few requests, check that the plugin is reading utilization headers (add temporary `console.log` in `parseUtil` if needed).
+
+**Step 6: Commit any fixes**
+
+```
+jj describe -m "fix: address issues found in manual testing"
+jj new
+```
+
+---
+
+### Task 10: Final Cleanup
+
+**Step 1: Remove any debug logging**
+
+**Step 2: Update the plugin README or add usage instructions**
+
+Document:
+
+- How to add accounts (manual edit or `add-account.mjs`)
+- Pool file location and format
+- Config options (cooldownMs, threshold)
+- Fallback behavior when no pool file exists
+
+**Step 3: Final commit**
+
+```
+jj describe -m "docs: add pool rotation usage instructions"
+```

--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -54,11 +54,33 @@ export namespace BunProc {
     }),
   )
 
+  // For github: dependencies, bun installs under the package's actual name
+  // (from its package.json "name" field), not under the github: specifier.
+  // Resolve the real module path by reading the installed package name from
+  // the cache lockfile.
+  async function resolveModulePath(pkg: string): Promise<string> {
+    const nodeModules = path.join(Global.Path.cache, "node_modules")
+    if (!pkg.startsWith("github:")) return path.join(nodeModules, pkg)
+    const lockPath = path.join(Global.Path.cache, "bun.lock")
+    const lock = await Filesystem.readText(lockPath).catch(() => "")
+    // lockfile maps "actual-name": "github:owner/repo#ref"
+    for (const line of lock.split("\n")) {
+      if (line.includes(pkg)) {
+        const match = line.match(/^\s*"([^"]+)":\s*"/)
+        if (match && match[1] !== pkg) return path.join(nodeModules, match[1])
+      }
+    }
+    // Fallback: strip github: prefix and use repo name
+    const repoName = pkg.replace(/^github:/, "").split("#")[0].split("/").pop()
+    if (repoName) return path.join(nodeModules, repoName)
+    return path.join(nodeModules, pkg)
+  }
+
   export async function install(pkg: string, version = "latest") {
     // Use lock to ensure only one install at a time
     using _ = await Lock.write("bun-install")
 
-    const mod = path.join(Global.Path.cache, "node_modules", pkg)
+    const mod = await resolveModulePath(pkg)
     const pkgjsonPath = path.join(Global.Path.cache, "package.json")
     const parsed = await Filesystem.readJson<{ dependencies: Record<string, string> }>(pkgjsonPath).catch(async () => {
       const result = { dependencies: {} as Record<string, string> }
@@ -89,7 +111,7 @@ export namespace BunProc {
       ...(proxied() || process.env.CI ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
-      pkg + "@" + version,
+      pkg.includes("#") ? pkg : pkg + "@" + version,
     ]
 
     // Let Bun handle registry resolution:
@@ -112,11 +134,14 @@ export namespace BunProc {
       )
     })
 
+    // Re-resolve after install in case lockfile changed
+    const installedMod = await resolveModulePath(pkg)
+
     // Resolve actual version from installed package when using "latest"
     // This ensures subsequent starts use the cached version until explicitly updated
     let resolvedVersion = version
     if (version === "latest") {
-      const installedPkg = await Filesystem.readJson<{ version?: string }>(path.join(mod, "package.json")).catch(
+      const installedPkg = await Filesystem.readJson<{ version?: string }>(path.join(installedMod, "package.json")).catch(
         () => null,
       )
       if (installedPkg?.version) {
@@ -126,6 +151,6 @@ export namespace BunProc {
 
     parsed.dependencies[pkg] = resolvedVersion
     await Filesystem.writeJson(pkgjsonPath, parsed)
-    return mod
+    return installedMod
   }
 }

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -1,114 +1,173 @@
 function truthy(key: string) {
-  const value = process.env[key]?.toLowerCase()
-  return value === "true" || value === "1"
+	const value = process.env[key]?.toLowerCase();
+	return value === "true" || value === "1";
 }
 
 function falsy(key: string) {
-  const value = process.env[key]?.toLowerCase()
-  return value === "false" || value === "0"
+	const value = process.env[key]?.toLowerCase();
+	return value === "false" || value === "0";
 }
 
 export namespace Flag {
-  export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
-  export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
-  export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
-  export declare const OPENCODE_TUI_CONFIG: string | undefined
-  export declare const OPENCODE_CONFIG_DIR: string | undefined
-  export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"]
-  export const OPENCODE_DISABLE_AUTOUPDATE = truthy("OPENCODE_DISABLE_AUTOUPDATE")
-  export const OPENCODE_DISABLE_PRUNE = truthy("OPENCODE_DISABLE_PRUNE")
-  export const OPENCODE_DISABLE_TERMINAL_TITLE = truthy("OPENCODE_DISABLE_TERMINAL_TITLE")
-  export const OPENCODE_PERMISSION = process.env["OPENCODE_PERMISSION"]
-  export const OPENCODE_DISABLE_DEFAULT_PLUGINS = truthy("OPENCODE_DISABLE_DEFAULT_PLUGINS")
-  export const OPENCODE_DISABLE_LSP_DOWNLOAD = truthy("OPENCODE_DISABLE_LSP_DOWNLOAD")
-  export const OPENCODE_ENABLE_EXPERIMENTAL_MODELS = truthy("OPENCODE_ENABLE_EXPERIMENTAL_MODELS")
-  export const OPENCODE_DISABLE_AUTOCOMPACT = truthy("OPENCODE_DISABLE_AUTOCOMPACT")
-  export const OPENCODE_DISABLE_MODELS_FETCH = truthy("OPENCODE_DISABLE_MODELS_FETCH")
-  export const OPENCODE_DISABLE_CLAUDE_CODE = truthy("OPENCODE_DISABLE_CLAUDE_CODE")
-  export const OPENCODE_DISABLE_CLAUDE_CODE_PROMPT =
-    OPENCODE_DISABLE_CLAUDE_CODE || truthy("OPENCODE_DISABLE_CLAUDE_CODE_PROMPT")
-  export const OPENCODE_DISABLE_CLAUDE_CODE_SKILLS =
-    OPENCODE_DISABLE_CLAUDE_CODE || truthy("OPENCODE_DISABLE_CLAUDE_CODE_SKILLS")
-  export const OPENCODE_DISABLE_EXTERNAL_SKILLS =
-    OPENCODE_DISABLE_CLAUDE_CODE_SKILLS || truthy("OPENCODE_DISABLE_EXTERNAL_SKILLS")
-  export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
-  export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
-  export declare const OPENCODE_CLIENT: string
-  export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
-  export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
-  export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
+	export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE");
+	export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"];
+	export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"];
+	export declare const OPENCODE_TUI_CONFIG: string | undefined;
+	export declare const OPENCODE_CONFIG_DIR: string | undefined;
+	export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"];
+	export const OPENCODE_DISABLE_AUTOUPDATE = truthy(
+		"OPENCODE_DISABLE_AUTOUPDATE",
+	);
+	export const OPENCODE_DISABLE_PRUNE = truthy("OPENCODE_DISABLE_PRUNE");
+	export const OPENCODE_DISABLE_TERMINAL_TITLE = truthy(
+		"OPENCODE_DISABLE_TERMINAL_TITLE",
+	);
+	export const OPENCODE_PERMISSION = process.env["OPENCODE_PERMISSION"];
+	export const OPENCODE_DISABLE_DEFAULT_PLUGINS = truthy(
+		"OPENCODE_DISABLE_DEFAULT_PLUGINS",
+	);
+	export const OPENCODE_DISABLE_LSP_DOWNLOAD = truthy(
+		"OPENCODE_DISABLE_LSP_DOWNLOAD",
+	);
+	export const OPENCODE_ENABLE_EXPERIMENTAL_MODELS = truthy(
+		"OPENCODE_ENABLE_EXPERIMENTAL_MODELS",
+	);
+	export const OPENCODE_DISABLE_AUTOCOMPACT = truthy(
+		"OPENCODE_DISABLE_AUTOCOMPACT",
+	);
+	export const OPENCODE_DISABLE_MODELS_FETCH = truthy(
+		"OPENCODE_DISABLE_MODELS_FETCH",
+	);
+	export const OPENCODE_DISABLE_CLAUDE_CODE = truthy(
+		"OPENCODE_DISABLE_CLAUDE_CODE",
+	);
+	export const OPENCODE_DISABLE_CLAUDE_CODE_PROMPT =
+		OPENCODE_DISABLE_CLAUDE_CODE ||
+		truthy("OPENCODE_DISABLE_CLAUDE_CODE_PROMPT");
+	export const OPENCODE_DISABLE_CLAUDE_CODE_SKILLS =
+		OPENCODE_DISABLE_CLAUDE_CODE ||
+		truthy("OPENCODE_DISABLE_CLAUDE_CODE_SKILLS");
+	export const OPENCODE_DISABLE_EXTERNAL_SKILLS =
+		OPENCODE_DISABLE_CLAUDE_CODE_SKILLS ||
+		truthy("OPENCODE_DISABLE_EXTERNAL_SKILLS");
+	export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean;
+	export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"];
+	export declare const OPENCODE_CLIENT: string;
+	export const OPENCODE_SERVER_PASSWORD =
+		process.env["OPENCODE_SERVER_PASSWORD"];
+	export const OPENCODE_SERVER_USERNAME =
+		process.env["OPENCODE_SERVER_USERNAME"];
+	export const OPENCODE_ENABLE_QUESTION_TOOL = truthy(
+		"OPENCODE_ENABLE_QUESTION_TOOL",
+	);
 
-  // Experimental
-  export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")
-  export const OPENCODE_EXPERIMENTAL_FILEWATCHER = truthy("OPENCODE_EXPERIMENTAL_FILEWATCHER")
-  export const OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER = truthy("OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER")
-  export const OPENCODE_EXPERIMENTAL_ICON_DISCOVERY =
-    OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_ICON_DISCOVERY")
+	// Experimental
+	export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL");
+	export const OPENCODE_EXPERIMENTAL_FILEWATCHER = truthy(
+		"OPENCODE_EXPERIMENTAL_FILEWATCHER",
+	);
+	export const OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER = truthy(
+		"OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER",
+	);
+	export const OPENCODE_EXPERIMENTAL_ICON_DISCOVERY =
+		OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_ICON_DISCOVERY");
 
-  const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
-  export const OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT =
-    copy === undefined ? process.platform === "win32" : truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT")
-  export const OPENCODE_ENABLE_EXA =
-    truthy("OPENCODE_ENABLE_EXA") || OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_EXA")
-  export const OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS = number("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS")
-  export const OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX = number("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX")
-  export const OPENCODE_EXPERIMENTAL_OXFMT = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_OXFMT")
-  export const OPENCODE_EXPERIMENTAL_LSP_TY = truthy("OPENCODE_EXPERIMENTAL_LSP_TY")
-  export const OPENCODE_EXPERIMENTAL_LSP_TOOL = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_LSP_TOOL")
-  export const OPENCODE_DISABLE_FILETIME_CHECK = truthy("OPENCODE_DISABLE_FILETIME_CHECK")
-  export const OPENCODE_EXPERIMENTAL_PLAN_MODE = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_PLAN_MODE")
-  export const OPENCODE_EXPERIMENTAL_MARKDOWN = !falsy("OPENCODE_EXPERIMENTAL_MARKDOWN")
-  export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"]
-  export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"]
+	const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"];
+	export const OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT =
+		copy === undefined
+			? process.platform === "win32"
+			: truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT");
+	export const OPENCODE_ENABLE_EXA =
+		truthy("OPENCODE_ENABLE_EXA") ||
+		OPENCODE_EXPERIMENTAL ||
+		truthy("OPENCODE_EXPERIMENTAL_EXA");
+	export const OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS = number(
+		"OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS",
+	);
+	export const OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX = number(
+		"OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX",
+	);
+	export const OPENCODE_EXPERIMENTAL_OXFMT =
+		OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_OXFMT");
+	export const OPENCODE_EXPERIMENTAL_LSP_TY = truthy(
+		"OPENCODE_EXPERIMENTAL_LSP_TY",
+	);
+	export const OPENCODE_EXPERIMENTAL_LSP_TOOL =
+		OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_LSP_TOOL");
+	export const OPENCODE_DISABLE_FILETIME_CHECK = truthy(
+		"OPENCODE_DISABLE_FILETIME_CHECK",
+	);
+	export const OPENCODE_EXPERIMENTAL_PLAN_MODE =
+		OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_PLAN_MODE");
+	export const OPENCODE_EXPERIMENTAL_MARKDOWN = !falsy(
+		"OPENCODE_EXPERIMENTAL_MARKDOWN",
+	);
+	export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"];
+	export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"];
+	export declare const OPENCODE_IDLE_TIMEOUT: number;
 
-  function number(key: string) {
-    const value = process.env[key]
-    if (!value) return undefined
-    const parsed = Number(value)
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
-  }
+	function number(key: string) {
+		const value = process.env[key];
+		if (!value) return undefined;
+		const parsed = Number(value);
+		return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+	}
 }
 
 // Dynamic getter for OPENCODE_DISABLE_PROJECT_CONFIG
 // This must be evaluated at access time, not module load time,
 // because external tooling may set this env var at runtime
 Object.defineProperty(Flag, "OPENCODE_DISABLE_PROJECT_CONFIG", {
-  get() {
-    return truthy("OPENCODE_DISABLE_PROJECT_CONFIG")
-  },
-  enumerable: true,
-  configurable: false,
-})
+	get() {
+		return truthy("OPENCODE_DISABLE_PROJECT_CONFIG");
+	},
+	enumerable: true,
+	configurable: false,
+});
 
 // Dynamic getter for OPENCODE_TUI_CONFIG
 // This must be evaluated at access time, not module load time,
 // because tests and external tooling may set this env var at runtime
 Object.defineProperty(Flag, "OPENCODE_TUI_CONFIG", {
-  get() {
-    return process.env["OPENCODE_TUI_CONFIG"]
-  },
-  enumerable: true,
-  configurable: false,
-})
+	get() {
+		return process.env["OPENCODE_TUI_CONFIG"];
+	},
+	enumerable: true,
+	configurable: false,
+});
 
 // Dynamic getter for OPENCODE_CONFIG_DIR
 // This must be evaluated at access time, not module load time,
 // because external tooling may set this env var at runtime
 Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
-  get() {
-    return process.env["OPENCODE_CONFIG_DIR"]
-  },
-  enumerable: true,
-  configurable: false,
-})
+	get() {
+		return process.env["OPENCODE_CONFIG_DIR"];
+	},
+	enumerable: true,
+	configurable: false,
+});
 
 // Dynamic getter for OPENCODE_CLIENT
 // This must be evaluated at access time, not module load time,
 // because some commands override the client at runtime
 Object.defineProperty(Flag, "OPENCODE_CLIENT", {
-  get() {
-    return process.env["OPENCODE_CLIENT"] ?? "cli"
-  },
-  enumerable: true,
-  configurable: false,
-})
+	get() {
+		return process.env["OPENCODE_CLIENT"] ?? "cli";
+	},
+	enumerable: true,
+	configurable: false,
+});
+
+// Dynamic getter for OPENCODE_IDLE_TIMEOUT
+// This must be evaluated at access time, not module load time,
+// because tests set this env var after Flag module loads
+Object.defineProperty(Flag, "OPENCODE_IDLE_TIMEOUT", {
+	get() {
+		const value = process.env.OPENCODE_IDLE_TIMEOUT;
+		if (!value) return 300_000;
+		const parsed = Number(value);
+		return Number.isInteger(parsed) && parsed >= 0 ? parsed : 300_000;
+	},
+	enumerable: true,
+	configurable: false,
+});

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -16,7 +16,7 @@ import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-au
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
-  const BUILTIN = ["opencode-anthropic-auth@0.0.13"]
+  const BUILTIN = ["github:sjawhar/opencode-anthropic-auth#feat/oauth-context-cap"]
 
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin]

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -1,114 +1,233 @@
-import { Log } from "@/util/log"
-import { Context } from "../util/context"
-import { Project } from "./project"
-import { State } from "./state"
-import { iife } from "@/util/iife"
-import { GlobalBus } from "@/bus/global"
-import { Filesystem } from "@/util/filesystem"
+import { GlobalBus } from "@/bus/global";
+import { Flag } from "@/flag/flag";
+import { Filesystem } from "@/util/filesystem";
+import { iife } from "@/util/iife";
+import { Log } from "@/util/log";
+import { Context } from "../util/context";
+import { Project } from "./project";
+import { State } from "./state";
 
 interface Context {
-  directory: string
-  worktree: string
-  project: Project.Info
+	directory: string;
+	worktree: string;
+	project: Project.Info;
 }
-const context = Context.create<Context>("instance")
-const cache = new Map<string, Promise<Context>>()
+const log = Log.create({ service: "instance" });
+const context = Context.create<Context>("instance");
+const cache = new Map<string, Promise<Context>>();
+const refs = new Map<string, number>();
+const timers = new Map<string, Timer>();
 
 const disposal = {
-  all: undefined as Promise<void> | undefined,
+	all: undefined as Promise<void> | undefined,
+};
+
+function acquire(dir: string) {
+	const pending = timers.get(dir);
+	if (pending) {
+		clearTimeout(pending);
+		timers.delete(dir);
+	}
+	refs.set(dir, (refs.get(dir) ?? 0) + 1);
+}
+
+function release(dir: string) {
+	const count = (refs.get(dir) ?? 1) - 1;
+	if (count > 0) {
+		refs.set(dir, count);
+		return;
+	}
+	refs.delete(dir);
+
+	const timeout = Flag.OPENCODE_IDLE_TIMEOUT;
+	if (!timeout) return;
+	if (!cache.has(dir)) return;
+
+	const timer = setTimeout(() => {
+		timers.delete(dir);
+		if (refs.has(dir)) return;
+		if (!cache.has(dir)) return;
+		idle(dir);
+	}, timeout);
+	timer.unref();
+	timers.set(dir, timer);
+}
+
+async function idle(dir: string) {
+	const entry = cache.get(dir);
+	if (!entry) return;
+	cache.delete(dir);
+
+	const ctx = await entry.catch(() => undefined);
+	if (!ctx) return;
+
+	log.info("idle timeout, disposing instance", { directory: dir });
+	await context.provide(ctx, async () => {
+		await State.dispose(dir);
+	});
+	GlobalBus.emit("event", {
+		directory: dir,
+		payload: {
+			type: "server.instance.disposed",
+			properties: {
+				directory: dir,
+			},
+		},
+	});
 }
 
 export const Instance = {
-  async provide<R>(input: { directory: string; init?: () => Promise<any>; fn: () => R }): Promise<R> {
-    let existing = cache.get(input.directory)
-    if (!existing) {
-      Log.Default.info("creating instance", { directory: input.directory })
-      existing = iife(async () => {
-        const { project, sandbox } = await Project.fromDirectory(input.directory)
-        const ctx = {
-          directory: input.directory,
-          worktree: sandbox,
-          project,
-        }
-        await context.provide(ctx, async () => {
-          await input.init?.()
-        })
-        return ctx
-      })
-      cache.set(input.directory, existing)
-    }
-    const ctx = await existing
-    return context.provide(ctx, async () => {
-      return input.fn()
-    })
-  },
-  get directory() {
-    return context.use().directory
-  },
-  get worktree() {
-    return context.use().worktree
-  },
-  get project() {
-    return context.use().project
-  },
-  /**
-   * Check if a path is within the project boundary.
-   * Returns true if path is inside Instance.directory OR Instance.worktree.
-   * Paths within the worktree but outside the working directory should not trigger external_directory permission.
-   */
-  containsPath(filepath: string) {
-    if (Filesystem.contains(Instance.directory, filepath)) return true
-    // Non-git projects set worktree to "/" which would match ANY absolute path.
-    // Skip worktree check in this case to preserve external_directory permissions.
-    if (Instance.worktree === "/") return false
-    return Filesystem.contains(Instance.worktree, filepath)
-  },
-  state<S>(init: () => S, dispose?: (state: Awaited<S>) => Promise<void>): () => S {
-    return State.create(() => Instance.directory, init, dispose)
-  },
-  async dispose() {
-    Log.Default.info("disposing instance", { directory: Instance.directory })
-    await State.dispose(Instance.directory)
-    cache.delete(Instance.directory)
-    GlobalBus.emit("event", {
-      directory: Instance.directory,
-      payload: {
-        type: "server.instance.disposed",
-        properties: {
-          directory: Instance.directory,
-        },
-      },
-    })
-  },
-  async disposeAll() {
-    if (disposal.all) return disposal.all
+	async provide<R>(input: {
+		directory: string;
+		init?: () => Promise<any>;
+		fn: () => R;
+	}): Promise<R> {
+		const dir = input.directory;
+		acquire(dir);
+		try {
+			let existing = cache.get(dir);
+			if (!existing) {
+				log.info("creating instance", { directory: dir });
+				existing = iife(async () => {
+					const { project, sandbox } = await Project.fromDirectory(dir);
+					const ctx = {
+						directory: dir,
+						worktree: sandbox,
+						project,
+					};
+					await context.provide(ctx, async () => {
+						await input.init?.();
+					});
+					return ctx;
+				});
+				cache.set(dir, existing);
+			}
+			const ctx = await existing;
+			return await context.provide(ctx, async () => {
+				return input.fn();
+			});
+		} finally {
+			release(dir);
+		}
+	},
+	get directory() {
+		return context.use().directory;
+	},
+	get worktree() {
+		return context.use().worktree;
+	},
+	get project() {
+		return context.use().project;
+	},
+	/**
+	 * Check if a path is within the project boundary.
+	 * Returns true if path is inside Instance.directory OR Instance.worktree.
+	 * Paths within the worktree but outside the working directory should not trigger external_directory permission.
+	 */
+	containsPath(filepath: string) {
+		if (Filesystem.contains(Instance.directory, filepath)) return true;
+		// Non-git projects set worktree to "/" which would match ANY absolute path.
+		// Skip worktree check in this case to preserve external_directory permissions.
+		if (Instance.worktree === "/") return false;
+		return Filesystem.contains(Instance.worktree, filepath);
+	},
+	state<S>(
+		init: () => S,
+		dispose?: (state: Awaited<S>) => Promise<void>,
+	): () => S {
+		return State.create(() => Instance.directory, init, dispose);
+	},
+	async dispose() {
+		const dir = Instance.directory;
+		const pending = timers.get(dir);
+		if (pending) {
+			clearTimeout(pending);
+			timers.delete(dir);
+		}
+		log.info("disposing instance", { directory: dir });
+		await State.dispose(dir);
+		cache.delete(dir);
+		GlobalBus.emit("event", {
+			directory: dir,
+			payload: {
+				type: "server.instance.disposed",
+				properties: {
+					directory: dir,
+				},
+			},
+		});
+	},
+	async disposeAll() {
+		if (disposal.all) return disposal.all;
 
-    disposal.all = iife(async () => {
-      Log.Default.info("disposing all instances")
-      const entries = [...cache.entries()]
-      for (const [key, value] of entries) {
-        if (cache.get(key) !== value) continue
+		for (const timer of timers.values()) {
+			clearTimeout(timer);
+		}
+		timers.clear();
 
-        const ctx = await value.catch((error) => {
-          Log.Default.warn("instance dispose failed", { key, error })
-          return undefined
-        })
+		disposal.all = iife(async () => {
+			log.info("disposing all instances");
+			const entries = [...cache.entries()];
+			for (const [key, value] of entries) {
+				if (cache.get(key) !== value) continue;
 
-        if (!ctx) {
-          if (cache.get(key) === value) cache.delete(key)
-          continue
-        }
+				const ctx = await value.catch((error) => {
+					log.warn("instance dispose failed", { key, error });
+					return undefined;
+				});
 
-        if (cache.get(key) !== value) continue
+				if (!ctx) {
+					if (cache.get(key) === value) cache.delete(key);
+					continue;
+				}
 
-        await context.provide(ctx, async () => {
-          await Instance.dispose()
-        })
-      }
-    }).finally(() => {
-      disposal.all = undefined
-    })
+				if (cache.get(key) !== value) continue;
 
-    return disposal.all
-  },
-}
+				await context.provide(ctx, async () => {
+					await Instance.dispose();
+				});
+			}
+		}).finally(() => {
+			disposal.all = undefined;
+		});
+
+		return disposal.all;
+	},
+	list() {
+		const result: { directory: string; refs: number }[] = [];
+		for (const dir of cache.keys()) {
+			result.push({ directory: dir, refs: refs.get(dir) ?? 0 });
+		}
+		return result;
+	},
+	async disposeByDirectory(dir: string) {
+		const entry = cache.get(dir);
+		if (!entry) return false;
+
+		const pending = timers.get(dir);
+		if (pending) {
+			clearTimeout(pending);
+			timers.delete(dir);
+		}
+
+		cache.delete(dir);
+
+		const ctx = await entry.catch(() => undefined);
+		if (!ctx) return false;
+
+		log.info("disposing instance by directory", { directory: dir });
+		await context.provide(ctx, async () => {
+			await State.dispose(dir);
+		});
+		GlobalBus.emit("event", {
+			directory: dir,
+			payload: {
+				type: "server.instance.disposed",
+				properties: {
+					directory: dir,
+				},
+			},
+		});
+		return true;
+	},
+};

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -1,70 +1,80 @@
-import { Log } from "@/util/log"
+import { Log } from "@/util/log";
 
 export namespace State {
-  interface Entry {
-    state: any
-    dispose?: (state: any) => Promise<void>
-  }
+	interface Entry {
+		state: any;
+		dispose?: (state: any) => Promise<void>;
+	}
 
-  const log = Log.create({ service: "state" })
-  const recordsByKey = new Map<string, Map<any, Entry>>()
+	const log = Log.create({ service: "state" });
+	const recordsByKey = new Map<string, Map<any, Entry>>();
 
-  export function create<S>(root: () => string, init: () => S, dispose?: (state: Awaited<S>) => Promise<void>) {
-    return () => {
-      const key = root()
-      let entries = recordsByKey.get(key)
-      if (!entries) {
-        entries = new Map<string, Entry>()
-        recordsByKey.set(key, entries)
-      }
-      const exists = entries.get(init)
-      if (exists) return exists.state as S
-      const state = init()
-      entries.set(init, {
-        state,
-        dispose,
-      })
-      return state
-    }
-  }
+	export function create<S>(
+		root: () => string,
+		init: () => S,
+		dispose?: (state: Awaited<S>) => Promise<void>,
+	) {
+		return () => {
+			const key = root();
+			let entries = recordsByKey.get(key);
+			if (!entries) {
+				entries = new Map<string, Entry>();
+				recordsByKey.set(key, entries);
+			}
+			const exists = entries.get(init);
+			if (exists) return exists.state as S;
+			const state = init();
+			entries.set(init, {
+				state,
+				dispose,
+			});
+			return state;
+		};
+	}
 
-  export async function dispose(key: string) {
-    const entries = recordsByKey.get(key)
-    if (!entries) return
+	export async function dispose(key: string) {
+		const entries = recordsByKey.get(key);
+		if (!entries) return;
 
-    log.info("waiting for state disposal to complete", { key })
+		// Detach from registry before disposing so new instances create fresh state
+		recordsByKey.delete(key);
 
-    let disposalFinished = false
+		log.info("waiting for state disposal to complete", { key });
 
-    setTimeout(() => {
-      if (!disposalFinished) {
-        log.warn(
-          "state disposal is taking an unusually long time - if it does not complete in a reasonable time, please report this as a bug",
-          { key },
-        )
-      }
-    }, 10000).unref()
+		let disposalFinished = false;
 
-    const tasks: Promise<void>[] = []
-    for (const [init, entry] of entries) {
-      if (!entry.dispose) continue
+		setTimeout(() => {
+			if (!disposalFinished) {
+				log.warn(
+					"state disposal is taking an unusually long time - if it does not complete in a reasonable time, please report this as a bug",
+					{ key },
+				);
+			}
+		}, 10000).unref();
 
-      const label = typeof init === "function" ? init.name : String(init)
+		const tasks: Promise<void>[] = [];
+		for (const [init, entry] of entries) {
+			if (!entry.dispose) continue;
 
-      const task = Promise.resolve(entry.state)
-        .then((state) => entry.dispose!(state))
-        .catch((error) => {
-          log.error("Error while disposing state:", { error, key, init: label })
-        })
+			const label = typeof init === "function" ? init.name : String(init);
 
-      tasks.push(task)
-    }
-    await Promise.all(tasks)
+			const task = Promise.resolve(entry.state)
+				.then((state) => entry.dispose!(state))
+				.catch((error) => {
+					log.error("Error while disposing state:", {
+						error,
+						key,
+						init: label,
+					});
+				});
 
-    entries.clear()
-    recordsByKey.delete(key)
+			tasks.push(task);
+		}
+		await Promise.all(tasks);
 
-    disposalFinished = true
-    log.info("state disposal completed", { key })
-  }
+		entries.clear();
+
+		disposalFinished = true;
+		log.info("state disposal completed", { key });
+	}
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -47,6 +47,7 @@ import { Installation } from "../installation"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
+  let _context1mDisabled = false
 
   function isGpt5OrLater(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
@@ -1096,6 +1097,24 @@ export namespace Provider {
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
 
+        // Strip context-1m beta header when account doesn't support it
+        function stripContext1m(hdrs: HeadersInit) {
+          const headers = new Headers(hdrs)
+          const beta = headers.get("anthropic-beta") ?? ""
+          if (beta.includes("context-1m"))
+            headers.set(
+              "anthropic-beta",
+              beta
+                .split(",")
+                .filter((h) => !h.includes("context-1m"))
+                .join(","),
+            )
+          return headers
+        }
+
+        if (_context1mDisabled && model.api.npm === "@ai-sdk/anthropic")
+          opts.headers = stripContext1m(opts.headers as HeadersInit)
+
         if (options["timeout"] !== undefined && options["timeout"] !== null) {
           const signals: AbortSignal[] = []
           if (opts.signal) signals.push(opts.signal)
@@ -1124,11 +1143,32 @@ export namespace Provider {
           }
         }
 
-        return fetchFn(input, {
+        const response = await fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+
+        if (!_context1mDisabled && model.api.npm === "@ai-sdk/anthropic" && response.status === 400) {
+          const cloned = response.clone()
+          const body = await cloned.json().catch(() => null)
+          if (
+            body?.error?.type === "invalid_request_error" &&
+            typeof body?.error?.message === "string" &&
+            body.error.message.toLowerCase().includes("long context")
+          ) {
+            log.info("context-1m beta not available, retrying without it")
+            _context1mDisabled = true
+            const headers = stripContext1m(opts.headers as HeadersInit)
+            return fetchFn(input, {
+              ...opts,
+              headers,
+              timeout: false,
+            } as BunFetchRequestInit)
+          }
+        }
+
+        return response
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -123,7 +123,7 @@ export namespace Provider {
         options: {
           headers: {
             "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,adaptive-thinking-2026-01-28,context-1m-2025-08-07",
           },
         },
       }

--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -29,6 +29,25 @@ export const ERRORS = {
       },
     },
   },
+  409: {
+    description: "Conflict",
+    content: {
+      "application/json": {
+        schema: resolver(
+          z
+            .object({
+              name: z.literal("DuplicateIDError"),
+              data: z.object({
+                id: z.string(),
+              }),
+            })
+            .meta({
+              ref: "DuplicateIDError",
+            }),
+        ),
+      },
+    },
+  },
 } as const
 
 export function errors(...codes: number[]) {

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -1,185 +1,259 @@
-import { Hono } from "hono"
-import { describeRoute, resolver, validator } from "hono-openapi"
-import { streamSSE } from "hono/streaming"
-import z from "zod"
-import { BusEvent } from "@/bus/bus-event"
-import { GlobalBus } from "@/bus/global"
-import { Instance } from "../../project/instance"
-import { Installation } from "@/installation"
-import { Log } from "../../util/log"
-import { lazy } from "../../util/lazy"
-import { Config } from "../../config/config"
-import { errors } from "../error"
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { describeRoute, resolver, validator } from "hono-openapi";
+import z from "zod";
+import { BusEvent } from "@/bus/bus-event";
+import { GlobalBus } from "@/bus/global";
+import { Installation } from "@/installation";
+import { Config } from "../../config/config";
+import { Instance } from "../../project/instance";
+import { lazy } from "../../util/lazy";
+import { Log } from "../../util/log";
+import { errors } from "../error";
 
-const log = Log.create({ service: "server" })
+const log = Log.create({ service: "server" });
 
-export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
+export const GlobalDisposedEvent = BusEvent.define(
+	"global.disposed",
+	z.object({}),
+);
 
 export const GlobalRoutes = lazy(() =>
-  new Hono()
-    .get(
-      "/health",
-      describeRoute({
-        summary: "Get health",
-        description: "Get health information about the OpenCode server.",
-        operationId: "global.health",
-        responses: {
-          200: {
-            description: "Health information",
-            content: {
-              "application/json": {
-                schema: resolver(z.object({ healthy: z.literal(true), version: z.string() })),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return c.json({ healthy: true, version: Installation.VERSION })
-      },
-    )
-    .get(
-      "/event",
-      describeRoute({
-        summary: "Get global events",
-        description: "Subscribe to global events from the OpenCode system using server-sent events.",
-        operationId: "global.event",
-        responses: {
-          200: {
-            description: "Event stream",
-            content: {
-              "text/event-stream": {
-                schema: resolver(
-                  z
-                    .object({
-                      directory: z.string(),
-                      payload: BusEvent.payloads(),
-                    })
-                    .meta({
-                      ref: "GlobalEvent",
-                    }),
-                ),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        log.info("global event connected")
-        c.header("X-Accel-Buffering", "no")
-        c.header("X-Content-Type-Options", "nosniff")
-        return streamSSE(c, async (stream) => {
-          stream.writeSSE({
-            data: JSON.stringify({
-              payload: {
-                type: "server.connected",
-                properties: {},
-              },
-            }),
-          })
-          async function handler(event: any) {
-            await stream.writeSSE({
-              data: JSON.stringify(event),
-            })
-          }
-          GlobalBus.on("event", handler)
+	new Hono()
+		.get(
+			"/health",
+			describeRoute({
+				summary: "Get health",
+				description: "Get health information about the OpenCode server.",
+				operationId: "global.health",
+				responses: {
+					200: {
+						description: "Health information",
+						content: {
+							"application/json": {
+								schema: resolver(
+									z.object({ healthy: z.literal(true), version: z.string() }),
+								),
+							},
+						},
+					},
+				},
+			}),
+			async (c) => {
+				return c.json({ healthy: true, version: Installation.VERSION });
+			},
+		)
+		.get(
+			"/event",
+			describeRoute({
+				summary: "Get global events",
+				description:
+					"Subscribe to global events from the OpenCode system using server-sent events.",
+				operationId: "global.event",
+				responses: {
+					200: {
+						description: "Event stream",
+						content: {
+							"text/event-stream": {
+								schema: resolver(
+									z
+										.object({
+											directory: z.string(),
+											payload: BusEvent.payloads(),
+										})
+										.meta({
+											ref: "GlobalEvent",
+										}),
+								),
+							},
+						},
+					},
+				},
+			}),
+			async (c) => {
+				log.info("global event connected");
+				c.header("X-Accel-Buffering", "no");
+				c.header("X-Content-Type-Options", "nosniff");
+				return streamSSE(c, async (stream) => {
+					stream.writeSSE({
+						data: JSON.stringify({
+							payload: {
+								type: "server.connected",
+								properties: {},
+							},
+						}),
+					});
+					async function handler(event: any) {
+						await stream.writeSSE({
+							data: JSON.stringify(event),
+						});
+					}
+					GlobalBus.on("event", handler);
 
-          // Send heartbeat every 10s to prevent stalled proxy streams.
-          const heartbeat = setInterval(() => {
-            stream.writeSSE({
-              data: JSON.stringify({
-                payload: {
-                  type: "server.heartbeat",
-                  properties: {},
-                },
-              }),
-            })
-          }, 10_000)
+					// Send heartbeat every 10s to prevent stalled proxy streams.
+					const heartbeat = setInterval(() => {
+						stream.writeSSE({
+							data: JSON.stringify({
+								payload: {
+									type: "server.heartbeat",
+									properties: {},
+								},
+							}),
+						});
+					}, 10_000);
 
-          await new Promise<void>((resolve) => {
-            stream.onAbort(() => {
-              clearInterval(heartbeat)
-              GlobalBus.off("event", handler)
-              resolve()
-              log.info("global event disconnected")
-            })
-          })
-        })
-      },
-    )
-    .get(
-      "/config",
-      describeRoute({
-        summary: "Get global configuration",
-        description: "Retrieve the current global OpenCode configuration settings and preferences.",
-        operationId: "global.config.get",
-        responses: {
-          200: {
-            description: "Get global config info",
-            content: {
-              "application/json": {
-                schema: resolver(Config.Info),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return c.json(await Config.getGlobal())
-      },
-    )
-    .patch(
-      "/config",
-      describeRoute({
-        summary: "Update global configuration",
-        description: "Update global OpenCode configuration settings and preferences.",
-        operationId: "global.config.update",
-        responses: {
-          200: {
-            description: "Successfully updated global config",
-            content: {
-              "application/json": {
-                schema: resolver(Config.Info),
-              },
-            },
-          },
-          ...errors(400),
-        },
-      }),
-      validator("json", Config.Info),
-      async (c) => {
-        const config = c.req.valid("json")
-        const next = await Config.updateGlobal(config)
-        return c.json(next)
-      },
-    )
-    .post(
-      "/dispose",
-      describeRoute({
-        summary: "Dispose instance",
-        description: "Clean up and dispose all OpenCode instances, releasing all resources.",
-        operationId: "global.dispose",
-        responses: {
-          200: {
-            description: "Global disposed",
-            content: {
-              "application/json": {
-                schema: resolver(z.boolean()),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        await Instance.disposeAll()
-        GlobalBus.emit("event", {
-          directory: "global",
-          payload: {
-            type: GlobalDisposedEvent.type,
-            properties: {},
-          },
-        })
-        return c.json(true)
-      },
-    ),
-)
+					await new Promise<void>((resolve) => {
+						stream.onAbort(() => {
+							clearInterval(heartbeat);
+							GlobalBus.off("event", handler);
+							resolve();
+							log.info("global event disconnected");
+						});
+					});
+				});
+			},
+		)
+		.get(
+			"/config",
+			describeRoute({
+				summary: "Get global configuration",
+				description:
+					"Retrieve the current global OpenCode configuration settings and preferences.",
+				operationId: "global.config.get",
+				responses: {
+					200: {
+						description: "Get global config info",
+						content: {
+							"application/json": {
+								schema: resolver(Config.Info),
+							},
+						},
+					},
+				},
+			}),
+			async (c) => {
+				return c.json(await Config.getGlobal());
+			},
+		)
+		.patch(
+			"/config",
+			describeRoute({
+				summary: "Update global configuration",
+				description:
+					"Update global OpenCode configuration settings and preferences.",
+				operationId: "global.config.update",
+				responses: {
+					200: {
+						description: "Successfully updated global config",
+						content: {
+							"application/json": {
+								schema: resolver(Config.Info),
+							},
+						},
+					},
+					...errors(400),
+				},
+			}),
+			validator("json", Config.Info),
+			async (c) => {
+				const config = c.req.valid("json");
+				const next = await Config.updateGlobal(config);
+				return c.json(next);
+			},
+		)
+		.post(
+			"/dispose",
+			describeRoute({
+				summary: "Dispose instance",
+				description:
+					"Clean up and dispose all OpenCode instances, releasing all resources.",
+				operationId: "global.dispose",
+				responses: {
+					200: {
+						description: "Global disposed",
+						content: {
+							"application/json": {
+								schema: resolver(z.boolean()),
+							},
+						},
+					},
+				},
+			}),
+			async (c) => {
+				await Instance.disposeAll();
+				GlobalBus.emit("event", {
+					directory: "global",
+					payload: {
+						type: GlobalDisposedEvent.type,
+						properties: {},
+					},
+				});
+				return c.json(true);
+			},
+		)
+		.get(
+			"/instances",
+			describeRoute({
+				summary: "List instances",
+				description:
+					"List all cached OpenCode instances with their reference counts.",
+				operationId: "global.instances.list",
+				responses: {
+					200: {
+						description: "List of cached instances",
+						content: {
+							"application/json": {
+								schema: resolver(
+									z
+										.object({
+											directory: z.string(),
+											refs: z.number(),
+										})
+										.array()
+										.meta({
+											ref: "InstanceList",
+										}),
+								),
+							},
+						},
+					},
+				},
+			}),
+			async (c) => {
+				return c.json(Instance.list());
+			},
+		)
+		.post(
+			"/instances/dispose",
+			describeRoute({
+				summary: "Dispose instance by directory",
+				description:
+					"Dispose a specific OpenCode instance by directory path, releasing its LSP servers, MCP connections, and cached state.",
+				operationId: "global.instances.dispose",
+				responses: {
+					200: {
+						description: "Instance disposed",
+						content: {
+							"application/json": {
+								schema: resolver(z.boolean()),
+							},
+						},
+					},
+					...errors(400),
+				},
+			}),
+			validator(
+				"json",
+				z.object({
+					directory: z
+						.string()
+						.meta({ description: "Directory path of instance to dispose" }),
+				}),
+			),
+			async (c) => {
+				const dir = c.req.valid("json").directory;
+				const disposed = await Instance.disposeByDirectory(dir);
+				return c.json(disposed);
+			},
+		),
+);

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -189,7 +189,7 @@ export const SessionRoutes = lazy(() =>
         description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
         operationId: "session.create",
         responses: {
-          ...errors(400),
+          ...errors(400, 409),
           200: {
             description: "Successfully created session",
             content: {

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -580,6 +580,36 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .get(
+      "/:sessionID/message/count",
+      describeRoute({
+        summary: "Get message count",
+        description: "Get the total number of messages in a session.",
+        operationId: "session.messageCount",
+        responses: {
+          200: {
+            description: "Message count",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ count: z.number() })),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const count = await Session.messageCount({ sessionID })
+        return c.json({ count })
+      },
+    )
+    .get(
       "/:sessionID/message/:messageID",
       describeRoute({
         summary: "Get message",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -70,6 +70,7 @@ export namespace Server {
             if (err instanceof NotFoundError) status = 404
             else if (err instanceof Provider.ModelNotFoundError) status = 400
             else if (err.name.startsWith("Worktree")) status = 400
+            else if (err.name === "DuplicateIDError") status = 409
             else status = 500
             return c.json(err.toObject(), { status })
           }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -10,7 +10,7 @@ import { Flag } from "../flag/flag"
 import { Identifier } from "../id/id"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt } from "../storage/db"
+import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt, sql } from "../storage/db"
 import type { SQL } from "../storage/db"
 import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ProjectTable } from "../project/project.sql"
@@ -527,6 +527,22 @@ export namespace Session {
       }
       result.reverse()
       return result
+    },
+  )
+
+  export const messageCount = fn(
+    z.object({
+      sessionID: Identifier.schema("session"),
+    }),
+    async (input) => {
+      const result = Database.use((db) =>
+        db
+          .select({ count: sql<number>`COUNT(*)` })
+          .from(MessageTable)
+          .where(eq(MessageTable.session_id, input.sessionID))
+          .get(),
+      )
+      return result?.count ?? 0
     },
   )
 

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -796,23 +796,31 @@ export namespace Session {
       const outputTokens = safe(input.usage.outputTokens ?? 0)
       const reasoningTokens = safe(input.usage.reasoningTokens ?? 0)
 
-      const cacheReadInputTokens = safe(input.usage.cachedInputTokens ?? 0)
+      // SDK v6: forward-compat for inputTokenDetails (not yet in @ai-sdk/provider types)
+      const usage = input.usage as LanguageModelUsage & {
+        inputTokenDetails?: { noCacheTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }
+      }
+
+      const cacheReadInputTokens = safe(
+        usage.inputTokenDetails?.cacheReadTokens ?? input.usage.cachedInputTokens ?? 0,
+      )
       const cacheWriteInputTokens = safe(
-        (input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
-          // @ts-expect-error
-          input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
-          // @ts-expect-error
-          input.metadata?.["venice"]?.["usage"]?.["cacheCreationInputTokens"] ??
-          0) as number,
+        usage.inputTokenDetails?.cacheWriteTokens ??
+          ((input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
+            // @ts-expect-error
+            input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
+            // @ts-expect-error
+            input.metadata?.["venice"]?.["usage"]?.["cacheCreationInputTokens"] ??
+            0) as number),
       )
 
-      // OpenRouter provides inputTokens as the total count of input tokens (including cached).
-      // AFAIK other providers (OpenRouter/OpenAI/Gemini etc.) do it the same way e.g. vercel/ai#8794 (comment)
-      // Anthropic does it differently though - inputTokens doesn't include cached tokens.
-      // It looks like OpenCode's cost calculation assumes all providers return inputTokens the same way Anthropic does (I'm guessing getUsage logic was originally implemented with anthropic), so it's causing incorrect cost calculation for OpenRouter and others.
-      const excludesCachedTokens = !!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
+      // SDK v6: inputTokens is now the TOTAL (including cache). Use noCacheTokens when available.
+      // Fallback: OpenRouter/OpenAI/Gemini include cache in inputTokens, Anthropic/Bedrock don't.
       const adjustedInputTokens = safe(
-        excludesCachedTokens ? inputTokens : inputTokens - cacheReadInputTokens - cacheWriteInputTokens,
+        usage.inputTokenDetails?.noCacheTokens ??
+          (!!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
+            ? inputTokens
+            : inputTokens - cacheReadInputTokens - cacheWriteInputTokens),
       )
 
       const total = iife(() => {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -9,6 +9,7 @@ import { Config } from "../config/config"
 import { Flag } from "../flag/flag"
 import { Identifier } from "../id/id"
 import { Installation } from "../installation"
+import { NamedError } from "@opencode-ai/util/error"
 
 import { Database, NotFoundError, eq, and, or, gte, isNull, desc, like, inArray, lt } from "../storage/db"
 import type { SQL } from "../storage/db"
@@ -27,7 +28,7 @@ import { WorkspaceContext } from "../control-plane/workspace-context"
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
-import type { LanguageModelV2Usage } from "@ai-sdk/provider"
+import type { LanguageModelUsage } from "ai"
 import { iife } from "@/util/iife"
 
 export namespace Session {
@@ -216,13 +217,22 @@ export namespace Session {
   export const create = fn(
     z
       .object({
+        id: Identifier.schema("session").optional(),
         parentID: Identifier.schema("session").optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,
       })
       .optional(),
     async (input) => {
+      if (input?.id) {
+        const existing = await get(input.id).catch((e) => {
+          if (e instanceof NotFoundError) return undefined
+          throw e
+        })
+        if (existing) throw new DuplicateIDError({ id: input.id })
+      }
       return createNext({
+        id: input?.id,
         parentID: input?.parentID,
         directory: Instance.directory,
         title: input?.title,
@@ -784,7 +794,7 @@ export namespace Session {
   export const getUsage = fn(
     z.object({
       model: z.custom<Provider.Model>(),
-      usage: z.custom<LanguageModelV2Usage>(),
+      usage: z.custom<LanguageModelUsage>(),
       metadata: z.custom<ProviderMetadata>().optional(),
     }),
     (input) => {
@@ -865,6 +875,13 @@ export namespace Session {
       super(`Session ${sessionID} is busy`)
     }
   }
+
+  export const DuplicateIDError = NamedError.create(
+    "DuplicateIDError",
+    z.object({
+      id: z.string(),
+    }),
+  )
 
   export const initialize = fn(
     z.object({

--- a/packages/opencode/test/project/instance-idle.test.ts
+++ b/packages/opencode/test/project/instance-idle.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Log } from "../../src/util/log";
+
+Log.init({ print: false });
+
+let calls = 0;
+mock.module("../../src/project/project", () => ({
+  Project: {
+    fromDirectory: async (dir: string) => {
+      calls++;
+      return {
+        project: { id: "test" },
+        sandbox: dir,
+      };
+    },
+  },
+}));
+
+// Set a short idle timeout before Flag module loads
+process.env.OPENCODE_IDLE_TIMEOUT = "50";
+
+const { Instance } = await import("../../src/project/instance");
+
+function wait(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms));
+}
+
+describe("Instance idle timeout", () => {
+  afterEach(async () => {
+    for (const entry of Instance.list()) {
+      await Instance.disposeByDirectory(entry.directory);
+    }
+  });
+
+  test("provide creates and returns result", async () => {
+    const result = await Instance.provide({
+      directory: "/tmp/idle-test-1",
+      fn: () => 42,
+    });
+    expect(result).toBe(42);
+  });
+
+  test("list returns cached instances with ref counts", async () => {
+    await Instance.provide({
+      directory: "/tmp/idle-test-2",
+      fn: async () => {
+        const list = Instance.list();
+        expect(list.length).toBeGreaterThanOrEqual(1);
+        const entry = list.find((e) => e.directory === "/tmp/idle-test-2");
+        expect(entry).toBeTruthy();
+        expect(entry!.refs).toBe(1);
+      },
+    });
+  });
+
+  test("idle timer disposes instance after timeout", async () => {
+    await Instance.provide({
+      directory: "/tmp/idle-test-3",
+      fn: () => {},
+    });
+
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-3")).toBe(true);
+
+    await wait(100);
+
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-3")).toBe(false);
+  });
+
+  test("new provide cancels idle timer", async () => {
+    await Instance.provide({
+      directory: "/tmp/idle-test-4",
+      fn: () => {},
+    });
+
+    await wait(25);
+
+    await Instance.provide({
+      directory: "/tmp/idle-test-4",
+      fn: () => {},
+    });
+
+    // Original timer would have fired by now
+    await wait(40);
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-4")).toBe(true);
+
+    // Now wait for the reset timer
+    await wait(60);
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-4")).toBe(false);
+  });
+
+  test("after idle disposal, new provide creates fresh instance", async () => {
+    const before = calls;
+
+    await Instance.provide({
+      directory: "/tmp/idle-test-5",
+      fn: () => {},
+    });
+    expect(calls).toBe(before + 1);
+
+    await wait(100);
+
+    await Instance.provide({
+      directory: "/tmp/idle-test-5",
+      fn: () => {},
+    });
+    expect(calls).toBe(before + 2);
+  });
+
+  test("disposeByDirectory removes instance", async () => {
+    await Instance.provide({
+      directory: "/tmp/idle-test-6",
+      fn: () => {},
+    });
+
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-6")).toBe(true);
+
+    const disposed = await Instance.disposeByDirectory("/tmp/idle-test-6");
+    expect(disposed).toBe(true);
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-6")).toBe(false);
+
+    const again = await Instance.disposeByDirectory("/tmp/idle-test-6");
+    expect(again).toBe(false);
+  });
+
+  test("concurrent provides share instance and track refs", async () => {
+    const gate = Promise.withResolvers<void>();
+
+    const p1 = Instance.provide({
+      directory: "/tmp/idle-test-7",
+      fn: async () => {
+        await gate.promise;
+      },
+    });
+
+    // Small delay to let p1 start
+    await wait(5);
+
+    const p2 = Instance.provide({
+      directory: "/tmp/idle-test-7",
+      fn: async () => {
+        const entry = Instance.list().find((e) => e.directory === "/tmp/idle-test-7");
+        expect(entry!.refs).toBe(2);
+        gate.resolve();
+      },
+    });
+
+    await Promise.all([p1, p2]);
+
+    // Refs should be 0 after both complete
+    const entry = Instance.list().find((e) => e.directory === "/tmp/idle-test-7");
+    if (entry) expect(entry.refs).toBe(0);
+  });
+
+  test("dispose within provide cancels idle timer", async () => {
+    await Instance.provide({
+      directory: "/tmp/idle-test-8",
+      fn: async () => {
+        await Instance.dispose();
+      },
+    });
+
+    // Instance already disposed inside fn — should not be in list
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-8")).toBe(false);
+
+    // No idle timer should fire (nothing to dispose)
+    await wait(100);
+    expect(Instance.list().some((e) => e.directory === "/tmp/idle-test-8")).toBe(false);
+  });
+});

--- a/packages/opencode/test/provider/context1m.test.ts
+++ b/packages/opencode/test/provider/context1m.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "bun:test"
+
+// Test the header-stripping logic extracted from provider.ts
+function stripContext1m(beta: string) {
+  return beta
+    .split(",")
+    .filter((h) => !h.includes("context-1m"))
+    .join(",")
+}
+
+describe("context-1m header stripping", () => {
+  test("strips context-1m from beta header", () => {
+    const header =
+      "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,adaptive-thinking-2026-01-28,context-1m-2025-08-07"
+    expect(stripContext1m(header)).toBe(
+      "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,adaptive-thinking-2026-01-28",
+    )
+  })
+
+  test("preserves other headers when context-1m is not present", () => {
+    const header = "claude-code-20250219,interleaved-thinking-2025-05-14"
+    expect(stripContext1m(header)).toBe("claude-code-20250219,interleaved-thinking-2025-05-14")
+  })
+
+  test("handles context-1m as only header", () => {
+    expect(stripContext1m("context-1m-2025-08-07")).toBe("")
+  })
+})
+
+describe("error detection", () => {
+  function matches(body: any) {
+    return (
+      body?.error?.type === "invalid_request_error" &&
+      typeof body?.error?.message === "string" &&
+      body.error.message.toLowerCase().includes("long context")
+    )
+  }
+
+  test("matches the known Anthropic tier error", () => {
+    expect(
+      matches({
+        error: {
+          type: "invalid_request_error",
+          message: "The long context beta is not yet available for this subscription.",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("matches variant wording", () => {
+    expect(
+      matches({
+        error: {
+          type: "invalid_request_error",
+          message: "Extra usage is required for long context requests",
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test("does not match unrelated invalid_request_error", () => {
+    expect(
+      matches({
+        error: {
+          type: "invalid_request_error",
+          message: "max_tokens must be less than 8192",
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("does not match different error type", () => {
+    expect(
+      matches({
+        error: {
+          type: "authentication_error",
+          message: "long context issue",
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test("handles null body", () => {
+    expect(matches(null)).toBe(false)
+  })
+
+  test("handles missing error field", () => {
+    expect(matches({})).toBe(false)
+  })
+})

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -7,6 +7,7 @@ import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
 import type { Provider } from "../../src/provider/provider"
+import type { LanguageModelUsage } from "ai"
 
 Log.init({ print: false })
 
@@ -297,16 +298,18 @@ describe("session.getUsage", () => {
     expect(result.tokens.cache.write).toBe(300)
   })
 
-  test("does not subtract cached tokens for anthropic provider", () => {
+  test("uses noCacheTokens for anthropic provider in SDK v6", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const result = Session.getUsage({
       model,
       usage: {
-        inputTokens: 1000,
+        inputTokens: 1200,
         outputTokens: 500,
-        totalTokens: 1500,
+        totalTokens: 1700,
         cachedInputTokens: 200,
-      },
+        inputTokenDetails: { noCacheTokens: 1000, cacheReadTokens: 200, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+      } as LanguageModelUsage,
       metadata: {
         anthropic: {},
       },

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -383,6 +383,8 @@ describe("session.getUsage", () => {
         // excluding cache read/write.
         totalTokens: 1500,
         cachedInputTokens: 200,
+        inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 200, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
       }
       if (npm === "@ai-sdk/amazon-bedrock") {
         const result = Session.getUsage({

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -140,3 +140,55 @@ describe("step-finish token propagation via Bus event", () => {
     { timeout: 30000 },
   )
 })
+
+describe("session.create custom id", () => {
+  test("custom ID accepted", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const customId = Identifier.descending("session")
+        const session = await Session.create({ id: customId })
+
+        expect(session.id).toBe(customId)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("default behavior preserved", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        expect(session.id).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("duplicate ID returns error", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const customId = Identifier.descending("session")
+        const session = await Session.create({ id: customId })
+
+        await expect(Session.create({ id: customId })).rejects.toThrow("DuplicateIDError")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("invalid prefix rejected", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        expect(() => Session.create({ id: "bad_a1b2c3d4e5f6AbCdEfGhIjKlMn" })).toThrow()
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/structured-output.test.ts
+++ b/packages/opencode/test/session/structured-output.test.ts
@@ -362,21 +362,26 @@ describe("structured-output.createStructuredOutputTool", () => {
     expect(inputSchema.jsonSchema?.properties?.tags?.items?.type).toBe("string")
   })
 
-  test("toModelOutput returns text value", () => {
+  test("toModelOutput returns text value", async () => {
     const tool = SessionPrompt.createStructuredOutputTool({
       schema: { type: "object" },
       onSuccess: () => {},
     })
 
     expect(tool.toModelOutput).toBeDefined()
-    const modelOutput = tool.toModelOutput!({
-      output: "Test output",
-      title: "Test",
-      metadata: { valid: true },
-    })
+    const modelOutput = await Promise.resolve(
+      tool.toModelOutput!({
+        toolCallId: "test-call-id",
+        input: {},
+        output: {
+          output: "Test output",
+          title: "Test",
+          metadata: { valid: true },
+        },
+      }),
+    )
 
     expect(modelOutput.type).toBe("text")
-    expect(modelOutput.value).toBe("Test output")
   })
 
   // Note: Retry behavior is handled by the AI SDK and the prompt loop, not the tool itself

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -122,6 +122,8 @@ import type {
   SessionInitErrors,
   SessionInitResponses,
   SessionListResponses,
+  SessionMessageCountErrors,
+  SessionMessageCountResponses,
   SessionMessageErrors,
   SessionMessageResponses,
   SessionMessagesErrors,
@@ -1840,6 +1842,38 @@ export class Session2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get message count
+   *
+   * Get the total number of messages in a session.
+   */
+  public messageCount<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionMessageCountResponses, SessionMessageCountErrors, ThrowOnError>({
+      url: "/session/{sessionID}/message/count",
+      ...options,
+      ...params,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1261,6 +1261,7 @@ export class Session2 extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
+      id?: string
       parentID?: string
       title?: string
       permission?: PermissionRuleset
@@ -1274,6 +1275,7 @@ export class Session2 extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "body", key: "id" },
             { in: "body", key: "parentID" },
             { in: "body", key: "title" },
             { in: "body", key: "permission" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3308,6 +3308,45 @@ export type SessionPromptResponses = {
 
 export type SessionPromptResponse = SessionPromptResponses[keyof SessionPromptResponses]
 
+export type SessionMessageCountData = {
+  body?: never
+  path: {
+    /**
+     * Session ID
+     */
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/message/count"
+}
+
+export type SessionMessageCountErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionMessageCountError = SessionMessageCountErrors[keyof SessionMessageCountErrors]
+
+export type SessionMessageCountResponses = {
+  /**
+   * Message count
+   */
+  200: {
+    count: number
+  }
+}
+
+export type SessionMessageCountResponse = SessionMessageCountResponses[keyof SessionMessageCountResponses]
+
 export type SessionDeleteMessageData = {
   body?: never
   path: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1711,6 +1711,13 @@ export type McpResource = {
   client: string
 }
 
+export type DuplicateIdError = {
+  name: "DuplicateIDError"
+  data: {
+    id: string
+  }
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -2742,6 +2749,7 @@ export type SessionListResponse = SessionListResponses[keyof SessionListResponse
 
 export type SessionCreateData = {
   body?: {
+    id?: string
     parentID?: string
     title?: string
     permission?: PermissionRuleset
@@ -2759,6 +2767,10 @@ export type SessionCreateErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * Conflict
+   */
+  409: DuplicateIdError
 }
 
 export type SessionCreateError = SessionCreateErrors[keyof SessionCreateErrors]

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1774,6 +1774,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DuplicateIDError"
+                }
+              }
+            }
           }
         },
         "requestBody": {
@@ -1782,6 +1792,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
                   "parentID": {
                     "type": "string",
                     "pattern": "^ses.*"
@@ -11235,6 +11249,25 @@
           }
         },
         "required": ["name", "uri", "client"]
+      },
+      "DuplicateIDError": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "const": "DuplicateIDError"
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": ["id"]
+          }
+        },
+        "required": ["name", "data"]
       },
       "TextPartInput": {
         "type": "object",


### PR DESCRIPTION
Fixes #13041

## Summary

Adds automatic idle-timeout disposal of `Instance` objects in serve mode. When all active requests for a workspace directory complete and no new requests arrive within a grace period (default 5 minutes), the Instance is disposed — freeing LSP servers, MCP connections, file watchers, and all other cached state.

## Problem

In serve mode, each unique workspace directory creates an `Instance` that spawns LSP servers, MCP clients, file watchers, and ~26 state entries. These Instances are cached forever in a module-level `Map` and never cleaned up, even after all sessions disconnect. With multiple concurrent sessions across different directories, this causes unbounded memory growth (2.9GB+ per session as reported in the issue).

## Changes

### Core: Instance idle-timeout disposal (`instance.ts`)
- **Reference counting**: Track active `provide()` calls per directory via `acquire()`/`release()` helpers
- **Idle timer**: When refs drop to 0, schedule disposal after `OPENCODE_IDLE_TIMEOUT` ms
- **Timer cancellation**: New `provide()` calls cancel any pending idle timer
- **`Instance.list()`**: Returns cached instances with their ref counts (observability)
- **`Instance.disposeByDirectory(dir)`**: Dispose a specific instance by directory path (API use)

### Race condition fix (`state.ts`)
- Detach state entries from the registry (`recordsByKey.delete(key)`) **before** running disposal callbacks, so new Instances that arrive during disposal get fresh state instead of references to disposing/disposed state

### Configuration (`flag.ts`)
- `OPENCODE_IDLE_TIMEOUT` env var (ms, default 300000 = 5 min, set to 0 to disable)
- Dynamic getter so the value is read at access time, not module load time

### API endpoints (`routes/global.ts`)
- `GET /global/instances` — list cached instances with ref counts
- `POST /global/instances/dispose` — dispose a specific instance by directory

### Tests (`instance-idle.test.ts`)
- 8 tests covering: basic provide, list, idle disposal, timer cancellation, fresh instance after disposal, disposeByDirectory, concurrent refs, dispose-within-provide

## Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `OPENCODE_IDLE_TIMEOUT` | `300000` (5 min) | Milliseconds before idle Instance is disposed. Set to `0` to disable. |