### PR TITLE
fix(app): stale show

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { For, createEffect, createMemo, on, onCleanup, Show, startTransition, Index, type JSX } from "solid-js"
+import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { useNavigate, useParams } from "@solidjs/router"
 import { Button } from "@opencode-ai/ui/button"
@@ -160,7 +160,7 @@ function createTimelineStaging(input: TimelineStageInput) {
           }
           const currentTotal = input.messages().length
           count = Math.min(currentTotal, count + input.config.batch)
-          startTransition(() => setState("count", count))
+          setState("count", count)
           if (count >= currentTotal) {
             setState({ completedSession: sessionKey, activeSession: "" })
             frame = undefined


### PR DESCRIPTION
### Issue for this PR

Closes #16235 #16039

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the error Stale read from show 

The timeline staging loop in `MessageTimeline` used `startTransition` to increment the staged message count during `requestAnimationFrame`, which can cause Solid’s <Show> to read a stale accessor while a transition is in progress

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

1. Open a session with a long history (or load earlier messages so turnStart > 0).
2. Click Load earlier so the timeline starts staging.
3. While staging is happening, do rapid UI actions:
- Scroll up/down quickly while the load is in progress.
- Trigger message arrival (send a new prompt) so new messages append during staging.
- Switch between sessions quickly (sidebar) while the staging banner is visible.


### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
