### PR TITLE
fix(mcp): generate OAuth state on-the-fly during initial connection

### DIFF
--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -144,10 +144,15 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async state(): Promise<string> {
     const entry = await McpAuth.get(this.mcpName)
-    if (!entry?.oauthState) {
-      throw new Error(`No OAuth state saved for MCP server: ${this.mcpName}`)
+    if (entry?.oauthState) {
+      return entry.oauthState
     }
-    return entry.oauthState
+    // Generate and persist a new state if none exists (e.g. during initial connection)
+    const generated = Array.from(crypto.getRandomValues(new Uint8Array(32)))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+    await McpAuth.updateOAuthState(this.mcpName, generated)
+    return generated
   }
 
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {


### PR DESCRIPTION
### Issue for this PR

Closes #16247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When connecting to a remote MCP server requiring OAuth, the SDK's auth flow calls `provider.state()` to get the state parameter.
This method was throwing when no state had been pre-generated, causing a non-`UnauthorizedError` that prevented the server from being recognized as needing auth.
The error fell through to the SSE transport fallback, which also failed, resulting in a generic "Non-200 status code" status instead of `needs_auth`.

### How did you verify your code works?

Following the reproduction steps in #16247, you'll see that the TUI properly marks the server as needing authentication, rather than having an SSE transport error:

<img width="1092" height="666" alt="Screenshot of /status in OpenCode TUI" src="https://github.com/user-attachments/assets/bf13fa03-5f01-4f13-aa73-f6a734021b7c" />

### Screenshots / recordings

N/A - not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

