### PR TITLE
fix(opencode): support responses wire mode for openai-compatible gpt-5

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1067,6 +1067,8 @@ export namespace Provider {
       const s = await state()
       const provider = s.providers[model.providerID]
       const options = { ...provider.options }
+      const wire = options["wireApi"] ?? options["wire_api"]
+      const openaiCompatResponses = model.api.npm === "@ai-sdk/openai-compatible" && wire === "responses"
 
       if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
         delete options.fetch
@@ -1110,7 +1112,7 @@ export namespace Provider {
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:
         // Message, Reasoning, FunctionCall, LocalShellCall, CustomToolCall, WebSearchCall
         // IDs are only re-attached for Azure with store=true
-        if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {
+        if ((model.api.npm === "@ai-sdk/openai" || openaiCompatResponses) && opts.body && opts.method === "POST") {
           const body = JSON.parse(opts.body as string)
           const isAzure = model.providerID.includes("azure")
           const keepIds = isAzure && body.store === true
@@ -1129,6 +1131,18 @@ export namespace Provider {
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+      }
+
+      if (openaiCompatResponses) {
+        log.info("using openai responses for openai-compatible provider", {
+          providerID: model.providerID,
+        })
+        const loaded = createOpenAI({
+          name: model.providerID,
+          ...options,
+        })
+        s.sdk.set(key, loaded)
+        return loaded as SDK
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]
@@ -1195,10 +1209,14 @@ export namespace Provider {
 
     const provider = s.providers[model.providerID]
     const sdk = await getSDK(model)
+    const wire = provider.options?.["wireApi"] ?? provider.options?.["wire_api"]
+    const openaiCompatResponses = model.api.npm === "@ai-sdk/openai-compatible" && wire === "responses"
 
     try {
       const language = s.modelLoaders[model.providerID]
         ? await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
+        : openaiCompatResponses && (sdk as any).responses
+          ? (sdk as any).responses(model.api.id)
         : sdk.languageModel(model.api.id)
       s.models.set(key, language)
       return language

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -684,12 +684,15 @@ export namespace ProviderTransform {
     providerOptions?: Record<string, any>
   }): Record<string, any> {
     const result: Record<string, any> = {}
+    const wire = input.providerOptions?.["wireApi"] ?? input.providerOptions?.["wire_api"]
+    const openaiCompatResponses = input.model.api.npm === "@ai-sdk/openai-compatible" && wire === "responses"
 
     // openai and providers using openai package should set store to false by default.
     if (
       input.model.providerID === "openai" ||
       input.model.api.npm === "@ai-sdk/openai" ||
-      input.model.api.npm === "@ai-sdk/github-copilot"
+      input.model.api.npm === "@ai-sdk/github-copilot" ||
+      openaiCompatResponses
     ) {
       result["store"] = false
     }
@@ -759,7 +762,7 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        if (input.model.api.npm !== "@ai-sdk/openai-compatible") {
+        if (input.model.api.npm !== "@ai-sdk/openai-compatible" || openaiCompatResponses) {
           result["reasoningSummary"] = "auto"
         }
       }
@@ -839,7 +842,7 @@ export namespace ProviderTransform {
     amazon: "bedrock",
   }
 
-  export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
+  export function providerOptions(model: Provider.Model, options: { [x: string]: any }, provider?: Provider.Info) {
     if (model.api.npm === "@ai-sdk/gateway") {
       // Gateway providerOptions are split across two namespaces:
       // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
@@ -870,7 +873,11 @@ export namespace ProviderTransform {
       return result
     }
 
-    const key = sdkKey(model.api.npm) ?? model.providerID
+    const wire = provider?.options?.["wireApi"] ?? provider?.options?.["wire_api"]
+    const key =
+      model.api.npm === "@ai-sdk/openai-compatible" && wire === "responses"
+        ? "openai"
+        : sdkKey(model.api.npm) ?? model.providerID
     return { [key]: options }
   }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -759,7 +759,9 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
+        if (input.model.api.npm !== "@ai-sdk/openai-compatible") {
+          result["reasoningSummary"] = "auto"
+        }
       }
 
       // Only set textVerbosity for non-chat gpt-5.x models

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -199,7 +199,7 @@ export namespace LLM {
       temperature: params.temperature,
       topP: params.topP,
       topK: params.topK,
-      providerOptions: ProviderTransform.providerOptions(input.model, params.options),
+      providerOptions: ProviderTransform.providerOptions(input.model, params.options, provider),
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
       tools,
       toolChoice: input.toolChoice,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -211,6 +211,18 @@ describe("ProviderTransform.options - gpt-5 reasoning defaults", () => {
     expect(result.reasoningSummary).toBeUndefined()
   })
 
+  test("openai-compatible gpt-5 with responses wire sets reasoningSummary", () => {
+    const model = createModel("@ai-sdk/openai-compatible")
+    const result = ProviderTransform.options({
+      model,
+      sessionID,
+      providerOptions: { wireApi: "responses" },
+    })
+    expect(result.store).toBe(false)
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+  })
+
   test("openai gpt-5 still sets reasoningSummary", () => {
     const model = createModel("@ai-sdk/openai")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
@@ -413,6 +425,36 @@ describe("ProviderTransform.providerOptions", () => {
 
     expect(ProviderTransform.providerOptions(model, { reasoningFormat: "parsed" })).toEqual({
       groq: { reasoningFormat: "parsed" },
+    })
+  })
+
+  test("routes openai-compatible responses wire options under openai key", () => {
+    const model = createModel({
+      providerID: "packycode-k1",
+      api: {
+        id: "gpt-5-codex",
+        url: "https://api.packycode.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.providerOptions(
+      model,
+      { reasoningEffort: "high", reasoningSummary: "auto" },
+      {
+        id: "packycode-k1",
+        name: "PackyCode",
+        npm: "@ai-sdk/openai-compatible",
+        env: [],
+        options: { wireApi: "responses" },
+        models: {},
+      } as any,
+    )
+
+    expect(result).toEqual({
+      openai: {
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+      },
     })
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -175,6 +175,50 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   })
 })
 
+describe("ProviderTransform.options - gpt-5 reasoning defaults", () => {
+  const sessionID = "test-session-123"
+
+  const createModel = (npm: string) =>
+    ({
+      id: "test/gpt-5-codex",
+      providerID: "test",
+      api: {
+        id: "gpt-5-codex",
+        url: "https://api.test.com",
+        npm,
+      },
+      name: "gpt-5-codex",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("openai-compatible gpt-5 does not set reasoningSummary", () => {
+    const model = createModel("@ai-sdk/openai-compatible")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBeUndefined()
+  })
+
+  test("openai gpt-5 still sets reasoningSummary", () => {
+    const model = createModel("@ai-sdk/openai")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+  })
+})
+
 describe("ProviderTransform.options - gateway", () => {
   const sessionID = "test-session-123"
 


### PR DESCRIPTION
### Issue for this PR

Closes #16154

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Fixes gpt-5 + `@ai-sdk/openai-compatible` default behavior that sent incompatible `reasoningSummary` on chat-style requests.
- Adds optional `wireApi: \"responses\"` (or `wire_api`) for openai-compatible providers.
- In responses mode, routes provider options under `openai` and uses responses model loading so reasoning options map correctly.

### How did you verify your code works?

- Added/updated tests in `packages/opencode/test/provider/transform.test.ts` for:
  - default openai-compatible mode omitting `reasoningSummary`
  - responses wire mode preserving `reasoningSummary`
  - provider options routing to `openai` key in responses mode
- CI validates typecheck/unit/e2e matrix on the PR.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR