### PR TITLE
feat(app): add git changes viewer with inline diff to Changes tab

### DIFF
--- a/packages/app/src/components/git-changes.tsx
+++ b/packages/app/src/components/git-changes.tsx
@@ -16,7 +16,7 @@ type VcsStatus = {
   untracked: FileStatus[]
 }
 
-function createFetchJSON(directory: string) {
+function createFetchJSON(directory: string, authHeaders: Record<string, string>) {
   const encodedDirectory = encodeURIComponent(directory)
   return async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
     const res = await fetch(url, {
@@ -24,6 +24,7 @@ function createFetchJSON(directory: string) {
       headers: {
         "Content-Type": "application/json",
         "x-opencode-directory": encodedDirectory,
+        ...authHeaders,
         ...init?.headers,
       },
     })
@@ -55,7 +56,7 @@ function statusColor(icon: string): string {
 
 export function GitChangesPanel() {
   const sdk = useSDK()
-  const fetchJSON = createFetchJSON(sdk.directory)
+  const fetchJSON = createFetchJSON(sdk.directory, sdk.authHeaders)
 
   const [status, setStatus] = createSignal<VcsStatus>({ staged: [], unstaged: [], untracked: [] })
   const [commitMessage, setCommitMessage] = createSignal("")
@@ -311,7 +312,7 @@ function FileSection(props: {
 
 export function GitChangesBadge() {
   const sdk = useSDK()
-  const fetchJSON = createFetchJSON(sdk.directory)
+  const fetchJSON = createFetchJSON(sdk.directory, sdk.authHeaders)
   const [count, setCount] = createSignal(0)
 
   async function refresh() {

--- a/packages/app/src/components/git-changes.tsx
+++ b/packages/app/src/components/git-changes.tsx
@@ -1,8 +1,16 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
-import { createStore } from "solid-js/store"
-import { Button } from "@opencode-ai/ui/button"
-import { Icon } from "@opencode-ai/ui/icon"
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { useSDK } from "@/context/sdk"
+
+const GIT_DIFF_PREFIX = "gitdiff://"
+
+export function gitDiffTab(path: string) {
+  return `${GIT_DIFF_PREFIX}${path}`
+}
+
+export function pathFromGitDiffTab(tab: string) {
+  if (!tab.startsWith(GIT_DIFF_PREFIX)) return undefined
+  return tab.slice(GIT_DIFF_PREFIX.length)
+}
 
 type FileStatus = {
   path: string
@@ -16,22 +24,7 @@ type VcsStatus = {
   untracked: FileStatus[]
 }
 
-function createFetchJSON(directory: string, authHeaders: Record<string, string>) {
-  const encodedDirectory = encodeURIComponent(directory)
-  return async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
-    const res = await fetch(url, {
-      ...init,
-      headers: {
-        "Content-Type": "application/json",
-        "x-opencode-directory": encodedDirectory,
-        ...authHeaders,
-        ...init?.headers,
-      },
-    })
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-    return res.json()
-  }
-}
+type Kind = "add" | "del" | "mix"
 
 function statusIcon(index: string, working: string): string {
   if (index === "?" && working === "?") return "?"
@@ -41,303 +34,74 @@ function statusIcon(index: string, working: string): string {
   return "M"
 }
 
-function statusColor(icon: string): string {
-  switch (icon) {
-    case "A":
-      return "text-icon-success-base"
-    case "D":
-      return "text-icon-danger-base"
-    case "?":
-      return "text-text-weak"
-    default:
-      return "text-icon-warning-base"
-  }
-}
-
-export function GitChangesPanel() {
+export function createGitStatus() {
   const sdk = useSDK()
-  const fetchJSON = createFetchJSON(sdk.directory, sdk.authHeaders)
-
+  const encodedDirectory = encodeURIComponent(sdk.directory)
   const [status, setStatus] = createSignal<VcsStatus>({ staged: [], unstaged: [], untracked: [] })
-  const [commitMessage, setCommitMessage] = createSignal("")
-  const [loading, setLoading] = createSignal(false)
-  const [sections, setSections] = createStore({ staged: true, unstaged: true, untracked: true })
 
-  const base = () => sdk.url
-
-  async function refresh() {
-    try {
-      const data = await fetchJSON<VcsStatus>(`${base()}/vcs/status`)
-      setStatus(data)
-    } catch {
-      // silently fail if endpoint not available yet
-    }
+  async function fetchJSON<T>(url: string): Promise<T> {
+    const res = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-opencode-directory": encodedDirectory,
+        ...sdk.authHeaders,
+      },
+    })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json()
   }
-
-  createEffect(() => {
-    refresh()
-    const unsub = sdk.event.on("vcs.status.updated" as any, () => refresh())
-    onCleanup(unsub)
-  })
-
-  // Poll as fallback since SSE event type may not be registered yet
-  const interval = setInterval(refresh, 5000)
-  onCleanup(() => clearInterval(interval))
-
-  const totalChanges = createMemo(
-    () => status().staged.length + status().unstaged.length + status().untracked.length,
-  )
-
-  async function stageFiles(files: string[]) {
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/stage`, {
-        method: "POST",
-        body: JSON.stringify({ files }),
-      })
-      await refresh()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function unstageFiles(files: string[]) {
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/unstage`, {
-        method: "POST",
-        body: JSON.stringify({ files }),
-      })
-      await refresh()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function doCommit() {
-    const msg = commitMessage().trim()
-    if (!msg || status().staged.length === 0) return
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/commit`, {
-        method: "POST",
-        body: JSON.stringify({ message: msg }),
-      })
-      setCommitMessage("")
-      await refresh()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function doPush(force?: boolean) {
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/push`, {
-        method: "POST",
-        body: JSON.stringify({ force: force ?? false }),
-      })
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function doStash() {
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/stash`, {
-        method: "POST",
-        body: JSON.stringify({}),
-      })
-      await refresh()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function doStashPop() {
-    setLoading(true)
-    try {
-      await fetchJSON(`${base()}/vcs/stash/pop`, { method: "POST" })
-      await refresh()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  return (
-    <div class="flex flex-col h-full overflow-hidden">
-      {/* Commit section */}
-      <div class="p-2 border-b border-border-base flex flex-col gap-1.5">
-        <input
-          type="text"
-          class="w-full px-2 py-1 text-13-regular bg-surface-base border border-border-base rounded-md
-                 placeholder:text-text-weak focus:outline-none focus:ring-1 focus:ring-border-focus"
-          placeholder="Commit message"
-          value={commitMessage()}
-          onInput={(e) => setCommitMessage(e.currentTarget.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault()
-              doCommit()
-            }
-          }}
-        />
-        <div class="flex gap-1">
-          <Button
-            variant="ghost"
-            class="flex-1 h-6 text-12-regular"
-            disabled={loading() || !commitMessage().trim() || status().staged.length === 0}
-            onClick={doCommit}
-          >
-            Commit
-          </Button>
-          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={() => doPush()}>
-            Push
-          </Button>
-          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={doStash}>
-            Stash
-          </Button>
-          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={doStashPop}>
-            Pop
-          </Button>
-        </div>
-      </div>
-
-      {/* File sections */}
-      <div class="flex-1 overflow-y-auto">
-        <Show when={totalChanges() === 0}>
-          <div class="p-4 text-13-regular text-text-weak text-center">No changes</div>
-        </Show>
-
-        <FileSection
-          title="Staged"
-          files={status().staged}
-          open={sections.staged}
-          onToggle={() => setSections("staged", !sections.staged)}
-          action="unstage"
-          onAction={(file) => unstageFiles([file.path])}
-          onActionAll={() => unstageFiles(status().staged.map((f) => f.path))}
-          loading={loading()}
-        />
-
-        <FileSection
-          title="Unstaged"
-          files={status().unstaged}
-          open={sections.unstaged}
-          onToggle={() => setSections("unstaged", !sections.unstaged)}
-          action="stage"
-          onAction={(file) => stageFiles([file.path])}
-          onActionAll={() => stageFiles(status().unstaged.map((f) => f.path))}
-          loading={loading()}
-        />
-
-        <FileSection
-          title="Untracked"
-          files={status().untracked}
-          open={sections.untracked}
-          onToggle={() => setSections("untracked", !sections.untracked)}
-          action="stage"
-          onAction={(file) => stageFiles([file.path])}
-          onActionAll={() => stageFiles(status().untracked.map((f) => f.path))}
-          loading={loading()}
-        />
-      </div>
-    </div>
-  )
-}
-
-function FileSection(props: {
-  title: string
-  files: FileStatus[]
-  open: boolean
-  onToggle: () => void
-  action: "stage" | "unstage"
-  onAction: (file: FileStatus) => void
-  onActionAll: () => void
-  loading: boolean
-}) {
-  return (
-    <Show when={props.files.length > 0}>
-      <div class="border-b border-border-base last:border-b-0">
-        <div
-          class="w-full flex items-center justify-between px-2 py-1 text-12-medium text-text-weak
-                 hover:bg-surface-base-hover cursor-pointer"
-          onClick={props.onToggle}
-        >
-          <div class="flex items-center gap-1">
-            <Icon name={props.open ? "chevron-down" : "chevron-right"} size="small" />
-            <span>
-              {props.title} ({props.files.length})
-            </span>
-          </div>
-          <button
-            class="text-11-regular text-text-weak hover:text-text-base px-1"
-            onClick={(e) => {
-              e.stopPropagation()
-              props.onActionAll()
-            }}
-            disabled={props.loading}
-          >
-            {props.action === "stage" ? "Stage All" : "Unstage All"}
-          </button>
-        </div>
-        <Show when={props.open}>
-          <For each={props.files}>
-            {(file) => {
-              const icon = () => statusIcon(file.index, file.working)
-              return (
-                <div class="group flex items-center gap-1 px-2 py-0.5 hover:bg-surface-base-hover text-13-regular">
-                  <span class={`shrink-0 w-3 text-center text-12-medium ${statusColor(icon())}`}>{icon()}</span>
-                  <span class="truncate flex-1 text-text-base" title={file.path}>
-                    {file.path}
-                  </span>
-                  <button
-                    class="opacity-0 group-hover:opacity-100 text-11-regular text-text-weak
-                           hover:text-text-base px-1 shrink-0"
-                    onClick={() => props.onAction(file)}
-                    disabled={props.loading}
-                  >
-                    {props.action === "stage" ? "+" : "-"}
-                  </button>
-                </div>
-              )
-            }}
-          </For>
-        </Show>
-      </div>
-    </Show>
-  )
-}
-
-export function GitChangesBadge() {
-  const sdk = useSDK()
-  const fetchJSON = createFetchJSON(sdk.directory, sdk.authHeaders)
-  const [count, setCount] = createSignal(0)
 
   async function refresh() {
     try {
       const data = await fetchJSON<VcsStatus>(`${sdk.url}/vcs/status`)
-      setCount(data.staged.length + data.unstaged.length + data.untracked.length)
+      setStatus(data)
     } catch {
-      setCount(0)
+      // silently fail
     }
   }
 
   createEffect(() => {
     refresh()
     const unsub = sdk.event.on("vcs.status.updated" as any, () => refresh())
-    onCleanup(unsub)
+    const interval = setInterval(refresh, 5000)
+    onCleanup(() => {
+      unsub()
+      clearInterval(interval)
+    })
   })
 
-  const interval = setInterval(refresh, 10000)
-  onCleanup(() => clearInterval(interval))
+  const allFiles = createMemo(() => {
+    const files: FileStatus[] = [...status().staged, ...status().unstaged, ...status().untracked]
+    const seen = new Map<string, FileStatus>()
+    for (const f of files) if (!seen.has(f.path)) seen.set(f.path, f)
+    return [...seen.values()]
+  })
 
-  return (
-    <Show when={count() > 0}>
-      <span class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-surface-warning-base text-11-medium text-text-base">
-        {count()}
-      </span>
-    </Show>
-  )
+  const gitFiles = createMemo(() => allFiles().map((f) => f.path))
+
+  const gitKinds = createMemo(() => {
+    const merge = (a: Kind | undefined, b: Kind) => {
+      if (!a) return b
+      if (a === b) return a
+      return "mix" as const
+    }
+
+    const out = new Map<string, Kind>()
+    for (const f of allFiles()) {
+      const icon = statusIcon(f.index, f.working)
+      const kind: Kind = icon === "A" || icon === "?" ? "add" : icon === "D" ? "del" : "mix"
+      out.set(f.path, kind)
+
+      const parts = f.path.split("/")
+      for (const [idx] of parts.slice(0, -1).entries()) {
+        const dir = parts.slice(0, idx + 1).join("/")
+        if (dir) out.set(dir, merge(out.get(dir), kind))
+      }
+    }
+    return out
+  })
+
+  const count = createMemo(() => gitFiles().length)
+
+  return { gitFiles, gitKinds, count }
 }

--- a/packages/app/src/components/git-changes.tsx
+++ b/packages/app/src/components/git-changes.tsx
@@ -260,9 +260,9 @@ function FileSection(props: {
   return (
     <Show when={props.files.length > 0}>
       <div class="border-b border-border-base last:border-b-0">
-        <button
+        <div
           class="w-full flex items-center justify-between px-2 py-1 text-12-medium text-text-weak
-                 hover:bg-surface-base-hover"
+                 hover:bg-surface-base-hover cursor-pointer"
           onClick={props.onToggle}
         >
           <div class="flex items-center gap-1">
@@ -281,7 +281,7 @@ function FileSection(props: {
           >
             {props.action === "stage" ? "Stage All" : "Unstage All"}
           </button>
-        </button>
+        </div>
         <Show when={props.open}>
           <For each={props.files}>
             {(file) => {

--- a/packages/app/src/components/git-changes.tsx
+++ b/packages/app/src/components/git-changes.tsx
@@ -16,13 +16,20 @@ type VcsStatus = {
   untracked: FileStatus[]
 }
 
-async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
-  })
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-  return res.json()
+function createFetchJSON(directory: string) {
+  const encodedDirectory = encodeURIComponent(directory)
+  return async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(url, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        "x-opencode-directory": encodedDirectory,
+        ...init?.headers,
+      },
+    })
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json()
+  }
 }
 
 function statusIcon(index: string, working: string): string {
@@ -48,6 +55,7 @@ function statusColor(icon: string): string {
 
 export function GitChangesPanel() {
   const sdk = useSDK()
+  const fetchJSON = createFetchJSON(sdk.directory)
 
   const [status, setStatus] = createSignal<VcsStatus>({ staged: [], unstaged: [], untracked: [] })
   const [commitMessage, setCommitMessage] = createSignal("")
@@ -303,6 +311,7 @@ function FileSection(props: {
 
 export function GitChangesBadge() {
   const sdk = useSDK()
+  const fetchJSON = createFetchJSON(sdk.directory)
   const [count, setCount] = createSignal(0)
 
   async function refresh() {

--- a/packages/app/src/components/git-changes.tsx
+++ b/packages/app/src/components/git-changes.tsx
@@ -1,0 +1,333 @@
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { createStore } from "solid-js/store"
+import { Button } from "@opencode-ai/ui/button"
+import { Icon } from "@opencode-ai/ui/icon"
+import { useSDK } from "@/context/sdk"
+
+type FileStatus = {
+  path: string
+  index: string
+  working: string
+}
+
+type VcsStatus = {
+  staged: FileStatus[]
+  unstaged: FileStatus[]
+  untracked: FileStatus[]
+}
+
+async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init?.headers },
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+function statusIcon(index: string, working: string): string {
+  if (index === "?" && working === "?") return "?"
+  if (index === "A" || working === "A") return "A"
+  if (index === "D" || working === "D") return "D"
+  if (index === "R" || working === "R") return "R"
+  return "M"
+}
+
+function statusColor(icon: string): string {
+  switch (icon) {
+    case "A":
+      return "text-icon-success-base"
+    case "D":
+      return "text-icon-danger-base"
+    case "?":
+      return "text-text-weak"
+    default:
+      return "text-icon-warning-base"
+  }
+}
+
+export function GitChangesPanel() {
+  const sdk = useSDK()
+
+  const [status, setStatus] = createSignal<VcsStatus>({ staged: [], unstaged: [], untracked: [] })
+  const [commitMessage, setCommitMessage] = createSignal("")
+  const [loading, setLoading] = createSignal(false)
+  const [sections, setSections] = createStore({ staged: true, unstaged: true, untracked: true })
+
+  const base = () => sdk.url
+
+  async function refresh() {
+    try {
+      const data = await fetchJSON<VcsStatus>(`${base()}/vcs/status`)
+      setStatus(data)
+    } catch {
+      // silently fail if endpoint not available yet
+    }
+  }
+
+  createEffect(() => {
+    refresh()
+    const unsub = sdk.event.on("vcs.status.updated" as any, () => refresh())
+    onCleanup(unsub)
+  })
+
+  // Poll as fallback since SSE event type may not be registered yet
+  const interval = setInterval(refresh, 5000)
+  onCleanup(() => clearInterval(interval))
+
+  const totalChanges = createMemo(
+    () => status().staged.length + status().unstaged.length + status().untracked.length,
+  )
+
+  async function stageFiles(files: string[]) {
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/stage`, {
+        method: "POST",
+        body: JSON.stringify({ files }),
+      })
+      await refresh()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function unstageFiles(files: string[]) {
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/unstage`, {
+        method: "POST",
+        body: JSON.stringify({ files }),
+      })
+      await refresh()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function doCommit() {
+    const msg = commitMessage().trim()
+    if (!msg || status().staged.length === 0) return
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/commit`, {
+        method: "POST",
+        body: JSON.stringify({ message: msg }),
+      })
+      setCommitMessage("")
+      await refresh()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function doPush(force?: boolean) {
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/push`, {
+        method: "POST",
+        body: JSON.stringify({ force: force ?? false }),
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function doStash() {
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/stash`, {
+        method: "POST",
+        body: JSON.stringify({}),
+      })
+      await refresh()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function doStashPop() {
+    setLoading(true)
+    try {
+      await fetchJSON(`${base()}/vcs/stash/pop`, { method: "POST" })
+      await refresh()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div class="flex flex-col h-full overflow-hidden">
+      {/* Commit section */}
+      <div class="p-2 border-b border-border-base flex flex-col gap-1.5">
+        <input
+          type="text"
+          class="w-full px-2 py-1 text-13-regular bg-surface-base border border-border-base rounded-md
+                 placeholder:text-text-weak focus:outline-none focus:ring-1 focus:ring-border-focus"
+          placeholder="Commit message"
+          value={commitMessage()}
+          onInput={(e) => setCommitMessage(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault()
+              doCommit()
+            }
+          }}
+        />
+        <div class="flex gap-1">
+          <Button
+            variant="ghost"
+            class="flex-1 h-6 text-12-regular"
+            disabled={loading() || !commitMessage().trim() || status().staged.length === 0}
+            onClick={doCommit}
+          >
+            Commit
+          </Button>
+          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={() => doPush()}>
+            Push
+          </Button>
+          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={doStash}>
+            Stash
+          </Button>
+          <Button variant="ghost" class="h-6 text-12-regular" disabled={loading()} onClick={doStashPop}>
+            Pop
+          </Button>
+        </div>
+      </div>
+
+      {/* File sections */}
+      <div class="flex-1 overflow-y-auto">
+        <Show when={totalChanges() === 0}>
+          <div class="p-4 text-13-regular text-text-weak text-center">No changes</div>
+        </Show>
+
+        <FileSection
+          title="Staged"
+          files={status().staged}
+          open={sections.staged}
+          onToggle={() => setSections("staged", !sections.staged)}
+          action="unstage"
+          onAction={(file) => unstageFiles([file.path])}
+          onActionAll={() => unstageFiles(status().staged.map((f) => f.path))}
+          loading={loading()}
+        />
+
+        <FileSection
+          title="Unstaged"
+          files={status().unstaged}
+          open={sections.unstaged}
+          onToggle={() => setSections("unstaged", !sections.unstaged)}
+          action="stage"
+          onAction={(file) => stageFiles([file.path])}
+          onActionAll={() => stageFiles(status().unstaged.map((f) => f.path))}
+          loading={loading()}
+        />
+
+        <FileSection
+          title="Untracked"
+          files={status().untracked}
+          open={sections.untracked}
+          onToggle={() => setSections("untracked", !sections.untracked)}
+          action="stage"
+          onAction={(file) => stageFiles([file.path])}
+          onActionAll={() => stageFiles(status().untracked.map((f) => f.path))}
+          loading={loading()}
+        />
+      </div>
+    </div>
+  )
+}
+
+function FileSection(props: {
+  title: string
+  files: FileStatus[]
+  open: boolean
+  onToggle: () => void
+  action: "stage" | "unstage"
+  onAction: (file: FileStatus) => void
+  onActionAll: () => void
+  loading: boolean
+}) {
+  return (
+    <Show when={props.files.length > 0}>
+      <div class="border-b border-border-base last:border-b-0">
+        <button
+          class="w-full flex items-center justify-between px-2 py-1 text-12-medium text-text-weak
+                 hover:bg-surface-base-hover"
+          onClick={props.onToggle}
+        >
+          <div class="flex items-center gap-1">
+            <Icon name={props.open ? "chevron-down" : "chevron-right"} size="small" />
+            <span>
+              {props.title} ({props.files.length})
+            </span>
+          </div>
+          <button
+            class="text-11-regular text-text-weak hover:text-text-base px-1"
+            onClick={(e) => {
+              e.stopPropagation()
+              props.onActionAll()
+            }}
+            disabled={props.loading}
+          >
+            {props.action === "stage" ? "Stage All" : "Unstage All"}
+          </button>
+        </button>
+        <Show when={props.open}>
+          <For each={props.files}>
+            {(file) => {
+              const icon = () => statusIcon(file.index, file.working)
+              return (
+                <div class="group flex items-center gap-1 px-2 py-0.5 hover:bg-surface-base-hover text-13-regular">
+                  <span class={`shrink-0 w-3 text-center text-12-medium ${statusColor(icon())}`}>{icon()}</span>
+                  <span class="truncate flex-1 text-text-base" title={file.path}>
+                    {file.path}
+                  </span>
+                  <button
+                    class="opacity-0 group-hover:opacity-100 text-11-regular text-text-weak
+                           hover:text-text-base px-1 shrink-0"
+                    onClick={() => props.onAction(file)}
+                    disabled={props.loading}
+                  >
+                    {props.action === "stage" ? "+" : "-"}
+                  </button>
+                </div>
+              )
+            }}
+          </For>
+        </Show>
+      </div>
+    </Show>
+  )
+}
+
+export function GitChangesBadge() {
+  const sdk = useSDK()
+  const [count, setCount] = createSignal(0)
+
+  async function refresh() {
+    try {
+      const data = await fetchJSON<VcsStatus>(`${sdk.url}/vcs/status`)
+      setCount(data.staged.length + data.unstaged.length + data.untracked.length)
+    } catch {
+      setCount(0)
+    }
+  }
+
+  createEffect(() => {
+    refresh()
+    const unsub = sdk.event.on("vcs.status.updated" as any, () => refresh())
+    onCleanup(unsub)
+  })
+
+  const interval = setInterval(refresh, 10000)
+  onCleanup(() => clearInterval(interval))
+
+  return (
+    <Show when={count() > 0}>
+      <span class="inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-surface-warning-base text-11-medium text-text-base">
+        {count()}
+      </span>
+    </Show>
+  )
+}

--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -9,6 +9,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useCommand } from "@/context/command"
+import { pathFromGitDiffTab } from "@/components/git-changes"
 
 export function FileVisual(props: { path: string; active?: boolean }): JSX.Element {
   return (
@@ -32,7 +33,7 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
   const language = useLanguage()
   const command = useCommand()
   const sortable = createSortable(props.tab)
-  const path = createMemo(() => file.pathFromTab(props.tab))
+  const path = createMemo(() => file.pathFromTab(props.tab) ?? pathFromGitDiffTab(props.tab))
   const content = createMemo(() => {
     const value = path()
     if (!value) return

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -159,7 +159,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const fileTree = value.fileTree
       const migratedFileTree = (() => {
         if (!isRecord(fileTree)) return fileTree
-        if (fileTree.tab === "changes" || fileTree.tab === "all") return fileTree
+        if (fileTree.tab === "changes" || fileTree.tab === "all" || fileTree.tab === "git") return fileTree
 
         const width = typeof fileTree.width === "number" ? fileTree.width : DEFAULT_PANEL_WIDTH
         return {
@@ -245,7 +245,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         fileTree: {
           opened: true,
           width: DEFAULT_PANEL_WIDTH,
-          tab: "changes" as "changes" | "all",
+          tab: "changes" as "changes" | "all" | "git",
         },
         session: {
           width: DEFAULT_SESSION_WIDTH,
@@ -630,7 +630,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         opened: createMemo(() => store.fileTree?.opened ?? true),
         width: createMemo(() => store.fileTree?.width ?? DEFAULT_PANEL_WIDTH),
         tab: createMemo(() => store.fileTree?.tab ?? "changes"),
-        setTab(tab: "changes" | "all") {
+        setTab(tab: "changes" | "all" | "git") {
           if (!store.fileTree) {
             setStore("fileTree", { opened: true, width: DEFAULT_PANEL_WIDTH, tab })
             return

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -159,7 +159,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const fileTree = value.fileTree
       const migratedFileTree = (() => {
         if (!isRecord(fileTree)) return fileTree
-        if (fileTree.tab === "changes" || fileTree.tab === "all" || fileTree.tab === "git") return fileTree
+        if (fileTree.tab === "changes" || fileTree.tab === "all") return fileTree
+        if (fileTree.tab === "git") return { ...fileTree, tab: "changes" }
 
         const width = typeof fileTree.width === "number" ? fileTree.width : DEFAULT_PANEL_WIDTH
         return {
@@ -245,7 +246,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         fileTree: {
           opened: true,
           width: DEFAULT_PANEL_WIDTH,
-          tab: "changes" as "changes" | "all" | "git",
+          tab: "changes" as "changes" | "all",
         },
         session: {
           width: DEFAULT_SESSION_WIDTH,
@@ -630,7 +631,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         opened: createMemo(() => store.fileTree?.opened ?? true),
         width: createMemo(() => store.fileTree?.width ?? DEFAULT_PANEL_WIDTH),
         tab: createMemo(() => store.fileTree?.tab ?? "changes"),
-        setTab(tab: "changes" | "all" | "git") {
+        setTab(tab: "changes" | "all") {
           if (!store.fileTree) {
             setStore("fileTree", { opened: true, width: DEFAULT_PANEL_WIDTH, tab })
             return

--- a/packages/app/src/context/sdk.tsx
+++ b/packages/app/src/context/sdk.tsx
@@ -3,6 +3,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { type Accessor, createEffect, createMemo, onCleanup } from "solid-js"
 import { useGlobalSDK } from "./global-sdk"
+import { useServer } from "./server"
 
 type SDKEventMap = {
   [key in Event["type"]]: Extract<Event, { type: key }>
@@ -12,6 +13,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
   init: (props: { directory: Accessor<string> }) => {
     const globalSDK = useGlobalSDK()
+    const server = useServer()
 
     const directory = createMemo(props.directory)
     const client = createMemo(() =>
@@ -40,6 +42,13 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       event: emitter,
       get url() {
         return globalSDK.url
+      },
+      get authHeaders(): Record<string, string> {
+        const conn = server.current
+        if (!conn?.http.password) return {}
+        return {
+          Authorization: `Basic ${btoa(`${conn.http.username ?? "opencode"}:${conn.http.password}`)}`,
+        }
       },
       createClient(opts: Parameters<typeof globalSDK.createClient>[0]) {
         return globalSDK.createClient(opts)

--- a/packages/app/src/pages/session/git-diff-tab.tsx
+++ b/packages/app/src/pages/session/git-diff-tab.tsx
@@ -1,0 +1,102 @@
+import { Match, Switch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { Tabs } from "@opencode-ai/ui/tabs"
+import { ScrollView } from "@opencode-ai/ui/scroll-view"
+import { useFileComponent } from "@opencode-ai/ui/context/file"
+import { useSDK } from "@/context/sdk"
+import { useLanguage } from "@/context/language"
+import { pathFromGitDiffTab } from "@/components/git-changes"
+
+export function GitDiffTabContent(props: { tab: string }) {
+  const sdk = useSDK()
+  const language = useLanguage()
+  const fileComponent = useFileComponent()
+
+  const path = createMemo(() => pathFromGitDiffTab(props.tab))
+
+  const [before, setBefore] = createSignal<string | undefined>(undefined)
+  const [after, setAfter] = createSignal<string | undefined>(undefined)
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal<string | undefined>(undefined)
+
+  const encodedDirectory = encodeURIComponent(sdk.directory)
+
+  async function fetchShow(filePath: string): Promise<string> {
+    const res = await fetch(`${sdk.url}/vcs/show?file=${encodeURIComponent(filePath)}`, {
+      headers: {
+        "Content-Type": "application/json",
+        "x-opencode-directory": encodedDirectory,
+        ...sdk.authHeaders,
+      },
+    })
+    if (!res.ok) return ""
+    const data = await res.json()
+    return data.content ?? ""
+  }
+
+  createEffect(() => {
+    const p = path()
+    if (!p) return
+
+    setLoading(true)
+    setError(undefined)
+
+    const aborted = { current: false }
+    onCleanup(() => {
+      aborted.current = true
+    })
+
+    Promise.all([
+      fetchShow(p),
+      sdk.client.file
+        .read({ path: p })
+        .then((r) => r.data?.content ?? "")
+        .catch(() => ""),
+    ])
+      .then(([headContent, currentContent]) => {
+        if (aborted.current) return
+        setBefore(headContent)
+        setAfter(currentContent)
+        setLoading(false)
+      })
+      .catch((err) => {
+        if (aborted.current) return
+        setError(String(err))
+        setLoading(false)
+      })
+  })
+
+  return (
+    <Tabs.Content value={props.tab} class="mt-3 relative h-full">
+      <ScrollView class="h-full">
+        <Switch>
+          <Match when={loading()}>
+            <div class="px-6 py-4 text-text-weak">{language.t("common.loading")}...</div>
+          </Match>
+          <Match when={error()}>
+            {(err) => <div class="px-6 py-4 text-text-weak">{err()}</div>}
+          </Match>
+          <Match when={before() !== undefined && after() !== undefined}>
+            <div class="relative overflow-hidden pb-40">
+              <Dynamic
+                component={fileComponent}
+                mode="diff"
+                diffStyle="unified"
+                before={{
+                  name: path() ?? "",
+                  contents: before()!,
+                }}
+                after={{
+                  name: path() ?? "",
+                  contents: after()!,
+                }}
+                overflow="scroll"
+                class="select-text"
+              />
+            </div>
+          </Match>
+        </Switch>
+      </ScrollView>
+    </Tabs.Content>
+  )
+}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -3,6 +3,7 @@ import { createStore } from "solid-js/store"
 import { createMediaQuery } from "@solid-primitives/media"
 import { useParams } from "@solidjs/router"
 import { Tabs } from "@opencode-ai/ui/tabs"
+import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
@@ -13,7 +14,7 @@ import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 import FileTree from "@/components/file-tree"
-import { GitChangesPanel } from "@/components/git-changes"
+import { createGitStatus, gitDiffTab, pathFromGitDiffTab } from "@/components/git-changes"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { DialogSelectFile } from "@/components/dialog-select-file"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
@@ -24,6 +25,7 @@ import { useLayout } from "@/context/layout"
 import { useSync } from "@/context/sync"
 import { createFileTabListSync } from "@/pages/session/file-tab-scroll"
 import { FileTabContent } from "@/pages/session/file-tabs"
+import { GitDiffTabContent } from "@/pages/session/git-diff-tab"
 import { createOpenSessionFileTab, getTabReorderIndex } from "@/pages/session/helpers"
 import { StickyAddButton } from "@/pages/session/review-tab"
 import { setSessionHandoff } from "@/pages/session/handoff"
@@ -88,6 +90,8 @@ export function SessionSidePanel(props: {
     return out
   })
 
+  const git = createGitStatus()
+
   const normalizeTab = (tab: string) => {
     if (!tab.startsWith("file://")) return tab
     return file.tab(tab)
@@ -97,7 +101,7 @@ export function SessionSidePanel(props: {
     if (!view().reviewPanel.opened()) view().reviewPanel.open()
   }
 
-  const openTab = createOpenSessionFileTab({
+  const openFileTab = createOpenSessionFileTab({
     normalizeTab,
     openTab: tabs().open,
     pathFromTab: file.pathFromTab,
@@ -105,6 +109,16 @@ export function SessionSidePanel(props: {
     openReviewPanel,
     setActive: tabs().setActive,
   })
+
+  const openTab = (value: string) => {
+    if (pathFromGitDiffTab(value)) {
+      tabs().open(value)
+      tabs().setActive(value)
+      openReviewPanel()
+      return
+    }
+    openFileTab(value)
+  }
 
   const contextOpen = createMemo(() => tabs().active() === "context" || tabs().all().includes("context"))
   const openedTabs = createMemo(() =>
@@ -118,6 +132,7 @@ export function SessionSidePanel(props: {
     if (active === "context") return "context"
     if (active === "review" && reviewTab()) return "review"
     if (active && file.pathFromTab(active)) return normalizeTab(active)
+    if (active && pathFromGitDiffTab(active)) return active
 
     const first = openedTabs()[0]
     if (first) return first
@@ -135,7 +150,7 @@ export function SessionSidePanel(props: {
   const fileTreeTab = () => layout.fileTree.tab()
 
   const setFileTreeTabValue = (value: string) => {
-    if (value !== "changes" && value !== "all" && value !== "git") return
+    if (value !== "changes" && value !== "all") return
     layout.fileTree.setTab(value)
   }
 
@@ -147,6 +162,8 @@ export function SessionSidePanel(props: {
   const [store, setStore] = createStore({
     activeDraggable: undefined as string | undefined,
     fileTreeScrolled: false,
+    sessionOpen: true,
+    gitOpen: true,
   })
 
   let changesEl: HTMLDivElement | undefined
@@ -323,13 +340,22 @@ export function SessionSidePanel(props: {
                 </Show>
 
                 <Show when={activeFileTab()} keyed>
-                  {(tab) => <FileTabContent tab={tab} />}
+                  {(tab) => (
+                    <Switch>
+                      <Match when={pathFromGitDiffTab(tab)}>
+                        <GitDiffTabContent tab={tab} />
+                      </Match>
+                      <Match when={true}>
+                        <FileTabContent tab={tab} />
+                      </Match>
+                    </Switch>
+                  )}
                 </Show>
               </Tabs>
               <DragOverlay>
                 <Show when={store.activeDraggable} keyed>
                   {(tab) => {
-                    const path = createMemo(() => file.pathFromTab(tab))
+                    const path = createMemo(() => file.pathFromTab(tab) ?? pathFromGitDiffTab(tab))
                     return (
                       <div data-component="tabs-drag-preview">
                         <Show when={path()} keyed>
@@ -365,9 +391,6 @@ export function SessionSidePanel(props: {
                   <Tabs.Trigger value="all" class="flex-1" classes={{ button: "w-full" }}>
                     {language.t("session.files.all")}
                   </Tabs.Trigger>
-                  <Tabs.Trigger value="git" class="flex-1" classes={{ button: "w-full" }}>
-                    Git
-                  </Tabs.Trigger>
                 </Tabs.List>
                 <Tabs.Content
                   value="changes"
@@ -375,33 +398,69 @@ export function SessionSidePanel(props: {
                   onScroll={(e: UIEvent & { currentTarget: HTMLDivElement }) => syncFileTreeScrolled(e.currentTarget)}
                   class="bg-background-stronger px-3 py-0"
                 >
-                  <Switch>
-                    <Match when={hasReview()}>
-                      <Show
-                        when={diffsReady()}
-                        fallback={
-                          <div class="px-2 py-2 text-12-regular text-text-weak">
-                            {language.t("common.loading")}
-                            {language.t("common.loading.ellipsis")}
-                          </div>
-                        }
-                      >
-                        <FileTree
-                          path=""
-                          allowed={diffFiles()}
-                          kinds={kinds()}
-                          draggable={false}
-                          active={props.activeDiff}
-                          onFileClick={(node) => props.focusReviewDiff(node.path)}
-                        />
-                      </Show>
-                    </Match>
-                    <Match when={true}>
+                  <Show
+                    when={hasReview() || git.count() > 0}
+                    fallback={
                       <div class="mt-8 text-center text-12-regular text-text-weak">
                         {language.t("session.review.noChanges")}
                       </div>
-                    </Match>
-                  </Switch>
+                    }
+                  >
+                    <Show when={hasReview()}>
+                      <div class="mt-1">
+                        <button
+                          class="w-full flex items-center gap-1 px-1 py-1 hover:bg-surface-base-hover rounded-md cursor-pointer"
+                          onClick={() => setStore("sessionOpen", (v) => !v)}
+                        >
+                          <Icon name={store.sessionOpen ? "chevron-down" : "chevron-right"} size="small" class="text-icon-base shrink-0" />
+                          <span class="text-11-medium uppercase tracking-wider text-text-weak">Session</span>
+                          <span class="text-11-regular text-text-weak">{reviewCount()}</span>
+                        </button>
+                      </div>
+                      <Show when={store.sessionOpen}>
+                        <Show
+                          when={diffsReady()}
+                          fallback={
+                            <div class="px-2 py-2 text-12-regular text-text-weak">
+                              {language.t("common.loading")}
+                              {language.t("common.loading.ellipsis")}
+                            </div>
+                          }
+                        >
+                          <FileTree
+                            path=""
+                            allowed={diffFiles()}
+                            kinds={kinds()}
+                            draggable={false}
+                            active={props.activeDiff}
+                            onFileClick={(node) => props.focusReviewDiff(node.path)}
+                          />
+                        </Show>
+                      </Show>
+                    </Show>
+
+                    <Show when={git.count() > 0}>
+                      <div classList={{ "border-t border-border-base mt-1 pt-1": hasReview() }}>
+                        <button
+                          class="w-full flex items-center gap-1 px-1 py-1 hover:bg-surface-base-hover rounded-md cursor-pointer"
+                          onClick={() => setStore("gitOpen", (v) => !v)}
+                        >
+                          <Icon name={store.gitOpen ? "chevron-down" : "chevron-right"} size="small" class="text-icon-base shrink-0" />
+                          <span class="text-11-medium uppercase tracking-wider text-text-weak">Git</span>
+                          <span class="text-11-regular text-text-weak">{git.count()}</span>
+                        </button>
+                      </div>
+                      <Show when={store.gitOpen}>
+                        <FileTree
+                          path=""
+                          allowed={git.gitFiles()}
+                          kinds={git.gitKinds()}
+                          draggable={false}
+                          onFileClick={(node) => openTab(gitDiffTab(node.path))}
+                        />
+                      </Show>
+                    </Show>
+                  </Show>
                 </Tabs.Content>
                 <Tabs.Content
                   value="all"
@@ -415,9 +474,6 @@ export function SessionSidePanel(props: {
                     kinds={kinds()}
                     onFileClick={(node) => openTab(file.tab(node.path))}
                   />
-                </Tabs.Content>
-                <Tabs.Content value="git" class="bg-background-stronger h-full">
-                  <GitChangesPanel />
                 </Tabs.Content>
               </Tabs>
             </div>

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -13,6 +13,7 @@ import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 import FileTree from "@/components/file-tree"
+import { GitChangesPanel } from "@/components/git-changes"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { DialogSelectFile } from "@/components/dialog-select-file"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
@@ -134,7 +135,7 @@ export function SessionSidePanel(props: {
   const fileTreeTab = () => layout.fileTree.tab()
 
   const setFileTreeTabValue = (value: string) => {
-    if (value !== "changes" && value !== "all") return
+    if (value !== "changes" && value !== "all" && value !== "git") return
     layout.fileTree.setTab(value)
   }
 
@@ -364,6 +365,9 @@ export function SessionSidePanel(props: {
                   <Tabs.Trigger value="all" class="flex-1" classes={{ button: "w-full" }}>
                     {language.t("session.files.all")}
                   </Tabs.Trigger>
+                  <Tabs.Trigger value="git" class="flex-1" classes={{ button: "w-full" }}>
+                    Git
+                  </Tabs.Trigger>
                 </Tabs.List>
                 <Tabs.Content
                   value="changes"
@@ -411,6 +415,9 @@ export function SessionSidePanel(props: {
                     kinds={kinds()}
                     onFileClick={(node) => openTab(file.tab(node.path))}
                   />
+                </Tabs.Content>
+                <Tabs.Content value="git" class="bg-background-stronger h-full">
+                  <GitChangesPanel />
                 </Tabs.Content>
               </Tabs>
             </div>

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -205,4 +205,13 @@ export namespace Vcs {
     }
     return $`git diff`.quiet().nothrow().cwd(Instance.worktree).text()
   }
+
+  export async function show(file: string): Promise<string> {
+    return $`git show ${"HEAD:" + file}`
+      .quiet()
+      .nothrow()
+      .cwd(Instance.worktree)
+      .text()
+      .catch(() => "")
+  }
 }

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -17,6 +17,10 @@ export namespace Vcs {
         branch: z.string().optional(),
       }),
     ),
+    StatusUpdated: BusEvent.define(
+      "vcs.status.updated",
+      z.object({}),
+    ),
   }
 
   export const Info = z
@@ -27,6 +31,48 @@ export namespace Vcs {
       ref: "VcsInfo",
     })
   export type Info = z.infer<typeof Info>
+
+  export const FileStatus = z
+    .object({
+      path: z.string(),
+      index: z.string(),
+      working: z.string(),
+    })
+    .meta({
+      ref: "VcsFileStatus",
+    })
+  export type FileStatus = z.infer<typeof FileStatus>
+
+  export const Status = z
+    .object({
+      staged: FileStatus.array(),
+      unstaged: FileStatus.array(),
+      untracked: FileStatus.array(),
+    })
+    .meta({
+      ref: "VcsStatus",
+    })
+  export type Status = z.infer<typeof Status>
+
+  export const CommitInput = z
+    .object({
+      message: z.string(),
+      files: z.string().array().optional(),
+    })
+    .meta({
+      ref: "VcsCommitInput",
+    })
+  export type CommitInput = z.infer<typeof CommitInput>
+
+  export const CommitResult = z
+    .object({
+      hash: z.string(),
+      message: z.string(),
+    })
+    .meta({
+      ref: "VcsCommitResult",
+    })
+  export type CommitResult = z.infer<typeof CommitResult>
 
   async function currentBranch() {
     return $`git rev-parse --abbrev-ref HEAD`
@@ -72,5 +118,91 @@ export namespace Vcs {
 
   export async function branch() {
     return await state().then((s) => s.branch())
+  }
+
+  export async function status(): Promise<Status> {
+    const output = await $`git status --porcelain=v1`
+      .quiet()
+      .nothrow()
+      .cwd(Instance.worktree)
+      .text()
+      .catch(() => "")
+
+    const staged: FileStatus[] = []
+    const unstaged: FileStatus[] = []
+    const untracked: FileStatus[] = []
+
+    for (const line of output.split("\n")) {
+      if (!line) continue
+      const index = line[0] ?? " "
+      const working = line[1] ?? " "
+      const filePath = line.slice(3)
+
+      if (index === "?" && working === "?") {
+        untracked.push({ path: filePath, index, working })
+        continue
+      }
+      if (index !== " " && index !== "?") {
+        staged.push({ path: filePath, index, working })
+      }
+      if (working !== " " && working !== "?") {
+        unstaged.push({ path: filePath, index, working })
+      }
+    }
+
+    return { staged, unstaged, untracked }
+  }
+
+  export async function stage(files: string[]) {
+    await $`git add -- ${files}`.quiet().cwd(Instance.worktree)
+    Bus.publish(Event.StatusUpdated, {})
+  }
+
+  export async function unstage(files: string[]) {
+    await $`git reset HEAD -- ${files}`.quiet().nothrow().cwd(Instance.worktree)
+    Bus.publish(Event.StatusUpdated, {})
+  }
+
+  export async function commit(input: CommitInput): Promise<CommitResult> {
+    if (input.files?.length) {
+      await $`git add -- ${input.files}`.quiet().cwd(Instance.worktree)
+    }
+    await $`git commit -m ${input.message}`.quiet().cwd(Instance.worktree)
+    const hash = await $`git rev-parse --short HEAD`
+      .quiet()
+      .cwd(Instance.worktree)
+      .text()
+      .then((x) => x.trim())
+    Bus.publish(Event.StatusUpdated, {})
+    return { hash, message: input.message }
+  }
+
+  export async function stash(message?: string) {
+    if (message) {
+      await $`git stash push -m ${message}`.quiet().cwd(Instance.worktree)
+    } else {
+      await $`git stash push`.quiet().cwd(Instance.worktree)
+    }
+    Bus.publish(Event.StatusUpdated, {})
+  }
+
+  export async function stashPop() {
+    await $`git stash pop`.quiet().cwd(Instance.worktree)
+    Bus.publish(Event.StatusUpdated, {})
+  }
+
+  export async function push(force?: boolean) {
+    if (force) {
+      await $`git push --force-with-lease`.quiet().cwd(Instance.worktree)
+    } else {
+      await $`git push`.quiet().cwd(Instance.worktree)
+    }
+  }
+
+  export async function diff(file?: string): Promise<string> {
+    if (file) {
+      return $`git diff -- ${file}`.quiet().nothrow().cwd(Instance.worktree).text()
+    }
+    return $`git diff`.quiet().nothrow().cwd(Instance.worktree).text()
   }
 }

--- a/packages/opencode/src/server/routes/vcs.ts
+++ b/packages/opencode/src/server/routes/vcs.ts
@@ -1,0 +1,222 @@
+import { Hono } from "hono"
+import { describeRoute, validator, resolver } from "hono-openapi"
+import z from "zod"
+import { Vcs } from "../../project/vcs"
+import { errors } from "../error"
+import { lazy } from "../../util/lazy"
+
+export const VcsRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "Get VCS info",
+        description:
+          "Retrieve version control system (VCS) information for the current project, such as git branch.",
+        operationId: "vcs.get",
+        responses: {
+          200: {
+            description: "VCS info",
+            content: {
+              "application/json": {
+                schema: resolver(Vcs.Info),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const branch = await Vcs.branch()
+        return c.json({ branch })
+      },
+    )
+    .get(
+      "/status",
+      describeRoute({
+        summary: "Get VCS status",
+        description: "Get the current git working tree status including staged, unstaged, and untracked files.",
+        operationId: "vcs.status",
+        responses: {
+          200: {
+            description: "VCS status",
+            content: {
+              "application/json": {
+                schema: resolver(Vcs.Status),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await Vcs.status())
+      },
+    )
+    .post(
+      "/stage",
+      describeRoute({
+        summary: "Stage files",
+        description: "Stage files for commit (git add).",
+        operationId: "vcs.stage",
+        responses: {
+          200: {
+            description: "Files staged",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", z.object({ files: z.string().array() })),
+      async (c) => {
+        const { files } = c.req.valid("json")
+        await Vcs.stage(files)
+        return c.json(true)
+      },
+    )
+    .post(
+      "/unstage",
+      describeRoute({
+        summary: "Unstage files",
+        description: "Unstage files from the index (git reset HEAD).",
+        operationId: "vcs.unstage",
+        responses: {
+          200: {
+            description: "Files unstaged",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", z.object({ files: z.string().array() })),
+      async (c) => {
+        const { files } = c.req.valid("json")
+        await Vcs.unstage(files)
+        return c.json(true)
+      },
+    )
+    .post(
+      "/commit",
+      describeRoute({
+        summary: "Commit changes",
+        description: "Create a git commit with the given message.",
+        operationId: "vcs.commit",
+        responses: {
+          200: {
+            description: "Commit created",
+            content: {
+              "application/json": {
+                schema: resolver(Vcs.CommitResult),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", Vcs.CommitInput),
+      async (c) => {
+        const input = c.req.valid("json")
+        return c.json(await Vcs.commit(input))
+      },
+    )
+    .post(
+      "/stash",
+      describeRoute({
+        summary: "Stash changes",
+        description: "Stash current working tree changes.",
+        operationId: "vcs.stash",
+        responses: {
+          200: {
+            description: "Changes stashed",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ message: z.string().optional() })),
+      async (c) => {
+        const { message } = c.req.valid("json")
+        await Vcs.stash(message)
+        return c.json(true)
+      },
+    )
+    .post(
+      "/stash/pop",
+      describeRoute({
+        summary: "Pop stash",
+        description: "Apply and remove the most recent stash entry.",
+        operationId: "vcs.stash.pop",
+        responses: {
+          200: {
+            description: "Stash popped",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        await Vcs.stashPop()
+        return c.json(true)
+      },
+    )
+    .post(
+      "/push",
+      describeRoute({
+        summary: "Push commits",
+        description: "Push local commits to the remote repository.",
+        operationId: "vcs.push",
+        responses: {
+          200: {
+            description: "Pushed",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ force: z.boolean().optional() })),
+      async (c) => {
+        const { force } = c.req.valid("json")
+        await Vcs.push(force)
+        return c.json(true)
+      },
+    )
+    .get(
+      "/diff",
+      describeRoute({
+        summary: "Get diff",
+        description: "Get git diff output, optionally for a specific file.",
+        operationId: "vcs.diff",
+        responses: {
+          200: {
+            description: "Diff output",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ diff: z.string() })),
+              },
+            },
+          },
+        },
+      }),
+      validator("query", z.object({ file: z.string().optional() })),
+      async (c) => {
+        const { file } = c.req.valid("query")
+        const diff = await Vcs.diff(file)
+        return c.json({ diff })
+      },
+    ),
+)

--- a/packages/opencode/src/server/routes/vcs.ts
+++ b/packages/opencode/src/server/routes/vcs.ts
@@ -218,5 +218,30 @@ export const VcsRoutes = lazy(() =>
         const diff = await Vcs.diff(file)
         return c.json({ diff })
       },
+    )
+    .get(
+      "/show",
+      describeRoute({
+        summary: "Get file at HEAD",
+        description: "Get the content of a file at the HEAD commit.",
+        operationId: "vcs.show",
+        responses: {
+          200: {
+            description: "File content at HEAD",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ content: z.string() })),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("query", z.object({ file: z.string() })),
+      async (c) => {
+        const { file } = c.req.valid("query")
+        const content = await Vcs.show(file)
+        return c.json({ content })
+      },
     ),
 )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -41,6 +41,7 @@ import { errors } from "./error"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
+import { VcsRoutes } from "./routes/vcs"
 import { MDNS } from "./mdns"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
@@ -253,6 +254,7 @@ export namespace Server {
         .route("/", FileRoutes())
         .route("/mcp", McpRoutes())
         .route("/tui", TuiRoutes())
+        .route("/vcs", VcsRoutes())
         .post(
           "/instance/dispose",
           describeRoute({
@@ -312,31 +314,6 @@ export namespace Server {
               config: Global.Path.config,
               worktree: Instance.worktree,
               directory: Instance.directory,
-            })
-          },
-        )
-        .get(
-          "/vcs",
-          describeRoute({
-            summary: "Get VCS info",
-            description:
-              "Retrieve version control system (VCS) information for the current project, such as git branch.",
-            operationId: "vcs.get",
-            responses: {
-              200: {
-                description: "VCS info",
-                content: {
-                  "application/json": {
-                    schema: resolver(Vcs.Info),
-                  },
-                },
-              },
-            },
-          }),
-          async (c) => {
-            const branch = await Vcs.branch()
-            return c.json({
-              branch,
             })
           },
         )


### PR DESCRIPTION
## Summary

- Adds a **Git section** to the existing Changes tab in the desktop/web app, showing working tree changes as a FileTree with status colors (added/deleted/modified)
- Clicking a changed file opens a **unified diff view** (HEAD vs working tree) in a new editor tab
- Both Session and Git sections are **collapsible** with independent toggle state
- Tab badge count shows only session changes (not git changes)

Closes #15886
Relates to #5562

## What changed

**New files:**
- `packages/app/src/pages/session/git-diff-tab.tsx` - Diff viewer component (fetches HEAD content via `/vcs/show` + current content via SDK)
- `packages/opencode/src/server/routes/vcs.ts` - Extracted VCS routes + new `/vcs/show` endpoint

**Modified files:**
- `packages/app/src/components/git-changes.tsx` - Replaced operations panel with `createGitStatus()` reactive primitive + `gitDiffTab`/`pathFromGitDiffTab` helpers
- `packages/app/src/pages/session/session-side-panel.tsx` - Integrated Git section into Changes tab with collapsible UI
- `packages/app/src/components/session/session-sortable-tab.tsx` - Support `gitdiff://` tab prefix for file name/icon display
- `packages/app/src/context/layout.tsx` - Migrated `"git"` tab value to `"changes"`, narrowed type
- `packages/opencode/src/project/vcs.ts` - Added `Vcs.show(file)` for retrieving file at HEAD
- `packages/opencode/src/server/server.ts` - Extracted VCS routes to dedicated file

## Test plan

- [ ] Open desktop/web app on a repo with uncommitted changes
- [ ] Switch to Changes tab in the side panel
- [ ] Verify "Git" section shows changed files with correct status colors (green for added, red for deleted, orange for modified)
- [ ] Click a file to open unified diff view in editor tab
- [ ] Verify "Session" and "Git" sections are independently collapsible
- [ ] Verify tab badge shows only session change count
- [ ] Verify clean repo shows "No changes" in Git section

## Recording

https://github.com/user-attachments/assets/c84581d6-a231-45b3-9e38-e4a68c96c816


