### PR TITLE
fix(tui): pass roots:true in session list bootstrap to fix child session dilution

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -350,7 +350,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
-        .list({ start: start })
+        .list({ start: start, roots: true })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session


### PR DESCRIPTION
### Issue for this PR

Closes #16270
Closes #13877

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI session list bootstrap in `sync.tsx` fetches sessions without passing `roots: true`. This means root sessions and child sessions (forks, compaction) are mixed together. `Session.list()` defaults to `LIMIT 100`, and the TUI dialog filters client-side with `.filter(x => x.parentID === undefined)`.

For users who spawn subagents/tasks heavily, child sessions vastly outnumber roots. In my case: top 100 by `time_updated` contains 95 children and only 5 roots. So `/sessions` shows ~5 conversations despite 584 existing in the DB.

Fix: add `roots: true` to the bootstrap call so the server applies `WHERE parent_id IS NULL` before the limit. All 100 slots go to actual conversations.

### How did you verify your code works?

Verified against a production DB with 8,976 sessions (584 root, rest children):

```sql
-- Before (without roots:true): 95 children, 5 roots in top 100
SELECT CASE WHEN parent_id IS NULL THEN 'ROOT' ELSE 'CHILD' END as type, COUNT(*)
FROM (SELECT * FROM session ORDER BY time_updated DESC LIMIT 100) GROUP BY type;

-- After (with roots:true): all 100 are root sessions
SELECT COUNT(*) FROM (SELECT * FROM session WHERE parent_id IS NULL ORDER BY time_updated DESC LIMIT 100);
```

### Screenshots / recordings

N/A — not a UI change, just a query parameter fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
