### PR TITLE
fix(web): update oc_locale cookie on language change

### DIFF
--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -63,6 +63,46 @@ const discord = config.social?.find((item) => item.icon === "discord")
   )
 }
 
+<script is:inline>
+  // Update oc_locale cookie when language is changed via the dropdown
+  // to prevent middleware from redirecting back to the previous language on the root path.
+  document.addEventListener("change", (e) => {
+    const target = e.target
+    if (target instanceof HTMLSelectElement && target.closest("starlight-lang-select")) {
+      const newPath = target.value
+      let locale = "en"
+      // Extract locale from path (e.g., /docs/ko/ -> ko)
+      const match = newPath.match(/^\/docs\/([^/]+)/)
+      if (match) {
+        const potentialLocale = match[1]
+        const supportedLocales = [
+          "ar",
+          "bs",
+          "da",
+          "de",
+          "es",
+          "fr",
+          "it",
+          "ja",
+          "ko",
+          "nb",
+          "pl",
+          "pt-br",
+          "ru",
+          "th",
+          "tr",
+          "zh-cn",
+          "zh-tw",
+        ]
+        if (supportedLocales.includes(potentialLocale)) {
+          locale = potentialLocale
+        }
+      }
+      document.cookie = `oc_locale=${locale}; Path=/; Max-Age=31536000; SameSite=Lax`
+    }
+  })
+</script>
+
 <style>
   footer.doc {
     margin-top: 3rem;


### PR DESCRIPTION
### Issue for this PR

Closes #16278

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a bug where the language selection fails to persist when switching back to English from a localized page (e.g., `/docs/ko/`).

**The Problem:**
The [middleware.ts] uses an `oc_locale` cookie to handle redirects at the root path (`/docs/`). When "English" is selected from the footer, Starlight navigates to `/docs/` but doesn't update the cookie. The middleware then sees the old locale (e.g., `ko`) and redirects the user back to the localized page.

**The Fix:**
Added a client-side script to [Footer.astro] that listens for changes in the `LanguageSelect` component. It manually updates the `oc_locale` cookie to the selected language before navigation occurs. This ensures the middleware recognizes the user's manual choice, even when navigating to the root path.

### How did you verify your code works?

1. Started the dev server with `bun dev`.
2. Navigated to `/docs/ko/`.
3. Selected "English" from the footer dropdown.
4. Verified that the page correctly stays at `/docs/` (English) and doesn't redirect back to `/docs/ko/`.
5. Verified that the `oc_locale` cookie is updated to `en` in the browser dev tools.

### Screenshots / recordings
[screen-capture.webm](https://github.com/user-attachments/assets/1aaf4282-68db-439b-b341-dfd23183a7a1)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR