### PR TITLE
fix(app): add english to locale matchers

### DIFF
--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -146,6 +146,7 @@ const DICT: Record<Locale, Dictionary> = {
 }
 
 const localeMatchers: Array<{ locale: Locale; match: (language: string) => boolean }> = [
+  { locale: "en", match: (language) => language.startsWith("en") },
   { locale: "zht", match: (language) => language.startsWith("zh") && language.includes("hant") },
   { locale: "zh", match: (language) => language.startsWith("zh") },
   { locale: "ko", match: (language) => language.startsWith("ko") },
@@ -217,6 +218,7 @@ export const { use: useLanguage, provider: LanguageProvider } = createSimpleCont
     )
 
     const locale = createMemo<Locale>(() => normalizeLocale(store.locale))
+    console.log("locale", locale())
     const intl = createMemo(() => INTL[locale()])
 
     const dict = createMemo<Dictionary>(() => DICT[locale()])

--- a/packages/desktop-electron/src/renderer/i18n/index.ts
+++ b/packages/desktop-electron/src/renderer/i18n/index.ts
@@ -76,6 +76,7 @@ function detectLocale(): Locale {
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
   for (const language of languages) {
     if (!language) continue
+    if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
       if (language.toLowerCase().includes("hant")) return "zht"
       return "zh"

--- a/packages/desktop/src/i18n/index.ts
+++ b/packages/desktop/src/i18n/index.ts
@@ -77,6 +77,7 @@ function detectLocale(): Locale {
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
   for (const language of languages) {
     if (!language) continue
+    if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
       if (language.toLowerCase().includes("hant")) return "zht"
       return "zh"


### PR DESCRIPTION
### Issue for this PR

Closes #9996, #12063, #9998, #12064

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

<!-- Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!** -->

This reimplements #9998 and #12064 to align with [Adam's most recent change](https://github.com/anomalyco/opencode/blame/cb411248bf0898b351ae282a7c0b8b9b6d6fa340/packages/app/src/context/language.tsx#L197-L199). English locale detection in the the web, desktop, and desktop-electron UIs could fall through to a later supported locale (es/fr/etc) even when navigator.languages prefers en*, because en was not explicitly matched.

### How did you verify your code works?

Ran the following for web ui:

#### Start server
1. `bun install`
2. `bun dev serve`

#### Start app
1. `bun run --cwd packages/app dev`

### Screenshots / recordings

<!-- _If this is a UI change, please include a screenshot or recording._ -->

Before:

<img width="1188" height="751" alt="image" src="https://github.com/user-attachments/assets/65c0b238-3f19-4486-a460-222a9af22129" />

After:

<img width="1188" height="751" alt="image" src="https://github.com/user-attachments/assets/11912ad4-e2e2-47c4-8f2f-ff0de12577be" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- _If you do not follow this template your PR will be automatically rejected._-->
