### PR TITLE
fix(ci): use `bun.lock` as caching key instead of deprecated `bun.lockb`

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 


### PR DESCRIPTION
### Issue for this PR

Closes #16289

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes caching in the `setup-bun` GH action by replacing deprecated `bun.lockb` with `bun.lock`.

### How did you verify your code works?

PR CI

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
