### PR TITLE
Fix setup-bun cache key for bun.lock

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 


### PR DESCRIPTION
### Issue for this PR

Closes #16289

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the setup-bun action cache key to hash bun.lock (the current lockfile) instead of bun.lockb, so cache invalidation tracks the correct dependency lockfile.

### How did you verify your code works?

Not run (workflow change only).

### Screenshots / recordings

_Not a UI change._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
