### PR TITLE
fix(app): align same() helper usage across app and util

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -40,7 +40,7 @@ import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
-import { same } from "@/utils/same"
+import { same } from "@opencode-ai/util/array"
 
 const emptyUserMessages: UserMessage[] = []
 

--- a/packages/util/src/array.ts
+++ b/packages/util/src/array.ts
@@ -1,3 +1,10 @@
+export function same<T>(a: readonly T[] | undefined, b: readonly T[] | undefined) {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.length !== b.length) return false
+  return a.every((x, i) => x === b[i])
+}
+
 export function findLast<T>(
   items: readonly T[],
   predicate: (item: T, index: number, items: readonly T[]) => boolean,


### PR DESCRIPTION
a couple PRs in beta conflict so it doesnt build :(

--- llm yapping:

The naughty combo is:
- #15863 — removed packages/app/src/utils/same.ts and moved usage away from it.
- #16221 — reintroduced import { same } from "@/utils/same" in packages/app/src/pages/session.tsx during apply.
So the immediate offender is #16221, but it only breaks because it collided with state introduced by #15863.  
(#16069 wasn’t the root cause.)