### PR TITLE
fix(lsp): fallback to workspace oxlint via bun x

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -280,6 +280,28 @@ export namespace LSPServer {
         }
       }
 
+      // If `oxlint` is declared in the workspace but no directly executable binary
+      // was found, try Bun's package runner from the project root. This matches
+      // docs that describe project dependency-based enablement.
+      const packageJSON = path.join(root, "package.json")
+      if (await Filesystem.exists(packageJSON)) {
+        try {
+          const json = JSON.parse(await fs.readFile(packageJSON, "utf8")) as {
+            dependencies?: Record<string, string>
+            devDependencies?: Record<string, string>
+          }
+          if (json.dependencies?.oxlint || json.devDependencies?.oxlint) {
+            return {
+              process: spawn(BunProc.which(), ["x", "oxlint", "--lsp"], {
+                cwd: root,
+              }),
+            }
+          }
+        } catch {
+          // ignore invalid package.json
+        }
+      }
+
       let serverBin = await resolveBin(serverTarget)
       if (!serverBin) {
         const found = which("oxc_language_server")


### PR DESCRIPTION
### Issue for this PR

Closes #16309

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `oxlint` is enabled by project dependency detection but an executable binary is not resolved directly, this adds a fallback to start `oxlint` via `bun x oxlint --lsp` from the workspace root.

This keeps existing resolution order (local binary -> PATH binary -> oxc_language_server) and only inserts a dependency-aware fallback before moving on to `oxc_language_server`.

### How did you verify your code works?

- Verified the fallback is gated on `package.json` containing `oxlint` in `dependencies`/`devDependencies`.
- Attempted to run local type checks, but Bun is not available in this execution environment (`bun: command not found`), so I could not run the repo's Bun-based test/typecheck scripts here.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
