### PR TITLE
fix(mcp): show auth-required status for streamable HTTP 401

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -396,8 +396,13 @@ export namespace MCP {
         } catch (error) {
           lastError = error instanceof Error ? error : new Error(String(error))
 
+          const msg = lastError.message.toLowerCase()
+          const looksLikeAuthFailure =
+            error instanceof UnauthorizedError ||
+            (name === "StreamableHTTP" && !oauthDisabled && (msg.includes("401") || msg.includes("unauthorized")))
+
           // Handle OAuth-specific errors
-          if (error instanceof UnauthorizedError) {
+          if (looksLikeAuthFailure) {
             log.info("mcp server requires authentication", { key, transport: name })
 
             // Check if this is a "needs registration" error


### PR DESCRIPTION
### Issue for this PR

Closes #16247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a remote MCP server supports Streamable HTTP but requires OAuth, the streamable transport can fail with a plain 401/Unauthorized error that is not typed as `UnauthorizedError`. We were then falling through to the SSE transport, and `/status` ended up showing an SSE error (for example 405), which hides the real action needed.

This change treats Streamable HTTP connection errors containing `401` / `unauthorized` as auth-required (when OAuth is enabled), sets MCP status to `needs_auth`, and avoids trying SSE after that.

### How did you verify your code works?

- Code-path validation by tracing `MCP.create()` transport fallback logic in `packages/opencode/src/mcp/index.ts`.
- Verified that auth-style Streamable HTTP failures now enter the same `needs_auth` status path used for `UnauthorizedError`, including preserving `opencode mcp auth <name>` guidance.

Note: I could not run the Bun test suite in this environment because `bun` is not installed (`bun: command not found`).

### Screenshots / recordings

N/A

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
