### PR TITLE
fix(tui): refresh screen correctly after Ctrl+Z resume

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -3,7 +3,19 @@ import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import {
+  Switch,
+  Match,
+  createEffect,
+  untrack,
+  ErrorBoundary,
+  createSignal,
+  onMount,
+  onCleanup,
+  batch,
+  Show,
+  on,
+} from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
@@ -285,6 +297,41 @@ function App() {
 
   const args = useArgs()
   onMount(() => {
+    const repaint = () => {
+      process.stdout.write("\x1b[2J\x1b[H")
+      renderer.currentRenderBuffer.clear()
+      renderer.requestRender()
+      setTimeout(() => renderer.requestRender(), 16)
+    }
+    const refresh = () => {
+      renderer.resume()
+      process.kill(process.pid, "SIGWINCH")
+      setTimeout(() => process.kill(process.pid, "SIGWINCH"), 120)
+      repaint()
+      setTimeout(repaint, 64)
+      setTimeout(repaint, 160)
+      setTimeout(repaint, 260)
+    }
+    const resize = () => {
+      repaint()
+    }
+    process.on("SIGCONT", refresh)
+    process.on("SIGWINCH", resize)
+    let cols = process.stdout.columns
+    let rows = process.stdout.rows
+    const interval = setInterval(() => {
+      if (process.stdout.columns === cols && process.stdout.rows === rows) return
+      cols = process.stdout.columns
+      rows = process.stdout.rows
+      repaint()
+    }, 120)
+    interval.unref?.()
+    onCleanup(() => {
+      process.off("SIGCONT", refresh)
+      process.off("SIGWINCH", resize)
+      clearInterval(interval)
+    })
+
     batch(() => {
       if (args.agent) local.agent.set(args.agent)
       if (args.model) {
@@ -614,13 +661,13 @@ function App() {
       category: "System",
       hidden: true,
       onSelect: () => {
-        process.once("SIGCONT", () => {
-          renderer.resume()
-        })
-
         renderer.suspend()
-        // pid=0 means send the signal to all processes in the process group
-        process.kill(0, "SIGTSTP")
+        // Give terminal state writes (leaving alt screen/raw mode) a chance to flush
+        // before suspending the whole process group.
+        process.stdout.write("", () => {
+          // pid=0 means send the signal to all processes in the process group
+          process.kill(0, "SIGTSTP")
+        })
       },
     },
     {


### PR DESCRIPTION
### Issue for this PR

Closes #16327

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `opencode` is suspended with `Ctrl+Z`, resized in the shell, and resumed with `fg`, the TUI could return with stale/misaligned characters because resize handling did not reliably run through the renderer's signal path.

This change makes resume explicitly trigger `SIGWINCH` (which `@opentui/core` listens to) and then performs staged repaint passes after resume. In practice this ensures terminal size is reconciled before final draw and removes the broken frame artifacts.

### How did you verify your code works?

- Reproduced locally before fix:
  1. Open TUI
  2. Press `Ctrl+Z`
  3. Resize terminal
  4. `fg`
  5. Observe incomplete redraw / artifacts
- Verified locally after fix with the same steps: screen redraw is complete and stable.
- Push hook also ran workspace typecheck successfully.

### Screenshots / recordings

Not attached (terminal-only behavior). I can add a short recording if needed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR