### PR TITLE
fix(provider): guard sdk.responses in azure loaders for non-OpenAI models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -185,9 +185,10 @@ export namespace Provider {
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (options?.["useCompletionUrls"]) {
             return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
           }
+          if (sdk.responses) return sdk.responses(modelID)
+          if (sdk.chat) return sdk.chat(modelID)
+          return sdk.languageModel(modelID)
         },
         options: {},
       }
@@ -199,9 +200,10 @@ export namespace Provider {
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (options?.["useCompletionUrls"]) {
             return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
           }
+          if (sdk.responses) return sdk.responses(modelID)
+          if (sdk.chat) return sdk.chat(modelID)
+          return sdk.languageModel(modelID)
         },
         options: {
           baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,


### PR DESCRIPTION
## Summary

- Fix `TypeError: sdk.responses is not a function` when using non-OpenAI models (e.g. Claude) under the `azure` provider
- Guard `sdk.responses` with existence checks in both `azure` and `azure-cognitive-services` custom loaders, falling back through `sdk.chat` → `sdk.languageModel`

## Root Cause

Azure Claude models in the models.dev catalog specify `npm: "@ai-sdk/anthropic"` with endpoint `https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1`. The `@ai-sdk/anthropic` SDK has `.chat()` but no `.responses()`. The azure custom loaders unconditionally called `sdk.responses(modelID)`, crashing on any model whose SDK isn't `@ai-sdk/azure`.

Fixes #16328