### PR TITLE
fix(provider): load Requesty account-approved models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -368,6 +368,57 @@ export namespace Provider {
         },
       }
     },
+    requesty: async (input) => {
+      const apiKey = await (async () => {
+        const envKey = Env.get("REQUESTY_API_KEY")
+        if (envKey) return envKey
+
+        const auth = await Auth.get(input.id)
+        if (auth?.type === "api") return auth.key
+        if (auth?.type === "oauth") return auth.access
+
+        const config = await Config.get()
+        return config.provider?.requesty?.options?.apiKey
+      })()
+
+      if (!apiKey) return { autoload: false }
+
+      const modelIDs = new Set<string>()
+      const defaultBaseURL = Object.values(input.models)[0]?.api.url ?? "https://router.requesty.ai/v1"
+      const baseURL = String(defaultBaseURL).replace(/\/+$/, "")
+
+      try {
+        const response = await fetch(`${baseURL}/models`, {
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        })
+
+        if (response.ok) {
+          const json = (await response.json()) as any
+          const data = Array.isArray(json?.data) ? json.data : []
+          for (const item of data) {
+            if (item && typeof item.id === "string") modelIDs.add(item.id)
+          }
+
+          if (modelIDs.size > 0) {
+            for (const modelID of Object.keys(input.models)) {
+              if (!modelIDs.has(modelID)) {
+                delete input.models[modelID]
+              }
+            }
+          }
+        }
+      } catch (error) {
+        log.debug("failed to fetch requesty models", {
+          error,
+        })
+      }
+
+      return {
+        autoload: false,
+      }
+    },
     vercel: async () => {
       return {
         autoload: false,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { test, expect, mock } from "bun:test"
 import path from "path"
 
 import { tmpdir } from "../fixture/fixture"
@@ -169,6 +169,53 @@ test("model blacklist excludes specific models", async () => {
       expect(models).not.toContain("claude-sonnet-4-20250514")
     },
   })
+})
+
+test("requesty provider filters models to account-approved list", async () => {
+  const originalFetch = globalThis.fetch
+  const mockFetch = mock(async (_url: string | URL | Request) => {
+    return new Response(
+      JSON.stringify({
+        data: [{ id: "openai/gpt-5" }, { id: "openai/gpt-5-mini" }],
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    )
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+
+  globalThis.fetch = mockFetch as unknown as typeof fetch
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("REQUESTY_API_KEY", "requesty-test-key")
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        expect(providers["requesty"]).toBeDefined()
+        const models = Object.keys(providers["requesty"].models)
+        expect(models).toContain("openai/gpt-5")
+        expect(models).toContain("openai/gpt-5-mini")
+        expect(models).not.toContain("openai/gpt-4.1")
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 test("custom model alias via config", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #16344

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Requesty model discovery now uses the account API key to fetch `/models` and filters the provider model map to only IDs returned by Requesty. This keeps the model selector aligned with the models actually approved on the user account.

I also added a focused provider test that mocks the Requesty models response and verifies non-approved models are excluded.

### How did you verify your code works?

- Added `requesty provider filters models to account-approved list` in `packages/opencode/test/provider/provider.test.ts`.
- I could not run Bun tests in this environment because Bun is not installed (`bun: command not found`).

### Screenshots / recordings

_Not a UI layout change; behavior change is covered by test case and issue reproduction path._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
