### PR TITLE
fix(ui): prevent unwanted key events during composition in LineCommentEditor

### DIFF
--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -240,6 +240,7 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
           }}
           on:keydown={(e) => {
             const event = e as KeyboardEvent
+            if (event.isComposing || event.keyCode === 229) return
             event.stopPropagation()
             if (e.key === "Escape") {
               event.preventDefault()


### PR DESCRIPTION
### Issue for this PR

Closes #16360

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `LineCommentEditor`, the `keydown` handler was missing an IME composition guard. Pressing Enter to confirm a CJK candidate (Japanese, Chinese, Korean) would trigger `submit()` instead of just committing the character. Added the standard `isComposing || keyCode === 229` early return to skip handler logic during composition.

### How did you verify your code works?

Tested in Safari and Chrome using Japanese IME — Enter now confirms the candidate without submitting the comment.

### Screenshots / recordings

#### After fix

https://github.com/user-attachments/assets/d793de24-2325-42c4-ad82-00ef57c6dfd4

#### Before fix

https://github.com/user-attachments/assets/b91eaa65-fcfd-434d-8cf3-fedd2b5ed315


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR