### PR TITLE
fix(ci): use bun.lock in setup-bun cache key

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 


### PR DESCRIPTION
### Issue for this PR

Closes #16289

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- updates `.github/actions/setup-bun/action.yml` to hash `bun.lock` instead of `bun.lockb`
- aligns the cache key with the current Bun lockfile name
- prevents stale cache misses caused by hashing a deprecated lockfile path

### How did you verify your code works?

- confirmed the repository lockfile exists (`bun.lock`)
- verified the setup-bun action now references `hashFiles('**/bun.lock')`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
