### PR TITLE
fix(core): a chunk timeout when processing llm stream

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -972,6 +972,14 @@ export namespace Config {
             .describe(
               "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
             ),
+          chunkTimeout: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+            ),
         })
         .catchall(z.any())
         .optional(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -46,6 +46,8 @@ import { GoogleAuth } from "google-auth-library"
 import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 
+const DEFAULT_CHUNK_TIMEOUT = 120_000
+
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
@@ -82,6 +84,54 @@ export namespace Provider {
     return raw.replace(/\$\{([^}]+)\}/g, (match, key) => {
       const val = Env.get(String(key)) ?? vars?.[String(key) as keyof typeof vars]
       return val ?? match
+    })
+  }
+
+  function wrapSSE(res: Response, ms: number, ctl: AbortController) {
+    if (typeof ms !== "number" || ms <= 0) return res
+    if (!res.body) return res
+    if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+
+    const reader = res.body.getReader()
+    const body = new ReadableStream<Uint8Array>({
+      async pull(ctrl) {
+        const part = await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+          const id = setTimeout(() => {
+            const err = new Error("SSE read timed out")
+            ctl.abort(err)
+            void reader.cancel(err)
+            reject(err)
+          }, ms)
+
+          reader.read().then(
+            (part) => {
+              clearTimeout(id)
+              resolve(part)
+            },
+            (err) => {
+              clearTimeout(id)
+              reject(err)
+            },
+          )
+        })
+
+        if (part.done) {
+          ctrl.close()
+          return
+        }
+
+        ctrl.enqueue(part.value)
+      },
+      async cancel(reason) {
+        ctl.abort(reason)
+        await reader.cancel(reason)
+      },
+    })
+
+    return new Response(body, {
+      headers: new Headers(res.headers),
+      status: res.status,
+      statusText: res.statusText,
     })
   }
 
@@ -1091,21 +1141,25 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
+      const chunkTimeout = options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT
+      const timeout = options["timeout"]
+      delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, wrap it with timeout logic
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
+        const chunkAbortCtl =
+          typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
+        const signals: AbortSignal[] = []
 
-        if (options["timeout"] !== undefined && options["timeout"] !== null) {
-          const signals: AbortSignal[] = []
-          if (opts.signal) signals.push(opts.signal)
-          if (options["timeout"] !== false) signals.push(AbortSignal.timeout(options["timeout"]))
+        if (opts.signal) signals.push(opts.signal)
+        if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
+        if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
+          signals.push(AbortSignal.timeout(options["timeout"]))
 
-          const combined = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
-
-          opts.signal = combined
-        }
+        const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
+        if (combined) opts.signal = combined
 
         // Strip openai itemId metadata following what codex does
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:
@@ -1125,11 +1179,14 @@ export namespace Provider {
           }
         }
 
-        return fetchFn(input, {
+        const res = await fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+
+        if (!chunkAbortCtl) return res
+        return wrapSSE(res, chunkTimeout, chunkAbortCtl)
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -95,7 +95,7 @@ export namespace Provider {
     const reader = res.body.getReader()
     const body = new ReadableStream<Uint8Array>({
       async pull(ctrl) {
-        const part = await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+        const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
           const id = setTimeout(() => {
             const err = new Error("SSE read timed out")
             ctl.abort(err)
@@ -1142,15 +1142,13 @@ export namespace Provider {
 
       const customFetch = options["fetch"]
       const chunkTimeout = options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT
-      const timeout = options["timeout"]
       delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, wrap it with timeout logic
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
-        const chunkAbortCtl =
-          typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
+        const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
         const signals: AbortSignal[] = []
 
         if (opts.signal) signals.push(opts.signal)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -260,6 +260,7 @@ test("env variable takes precedence, config merges options", async () => {
             anthropic: {
               options: {
                 timeout: 60000,
+                chunkTimeout: 15000,
               },
             },
           },
@@ -277,6 +278,7 @@ test("env variable takes precedence, config merges options", async () => {
       expect(providers["anthropic"]).toBeDefined()
       // Config options should be merged
       expect(providers["anthropic"].options.timeout).toBe(60000)
+      expect(providers["anthropic"].options.chunkTimeout).toBe(15000)
     },
   })
 })

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -244,7 +244,7 @@ You can configure the providers and models you want to use in your OpenCode conf
 
 The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
 
-Provider options can include `timeout` and `setCacheKey`:
+Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 
 ```json title="opencode.json"
 {
@@ -253,6 +253,7 @@ Provider options can include `timeout` and `setCacheKey`:
     "anthropic": {
       "options": {
         "timeout": 600000,
+        "chunkTimeout": 30000,
         "setCacheKey": true
       }
     }
@@ -261,6 +262,7 @@ Provider options can include `timeout` and `setCacheKey`:
 ```
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
+- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).


### PR DESCRIPTION
It's possible for an SSE stream to stall. We handle some of the cases, but when reading the SSE stream from the provider, we are currently prone to it stalling in the case where the OS freezes network requests (due to going to sleep or other reasons), and the provider closes the request. When the OS unfreezes the network request, the SSE stream will hang because it never receives any notification that the other end has closed it.

(The above may not be 100% correct, I am not super familiar with the specifics of TCP requests when it comes to SSE. It seems to _sometimes_ be able to become aware that the other end has closed it, but I am to reliably reproduce a stalled SSE connection by forcing the OS to freeze network requests, waiting a while, and unfreezing them)

We need to timeout if we don't receive a chunk from the SSE stream after a period of time. It's currently set to 2 minutes which is quite high; this should handle the case of a stalled connection with no impact on normal slow SSE streams. Note that this does NOT timeout the initial fetch to get the SSE stream; that may take a while, but once streaming starts, 2 minutes should be a very high upper bound (I scanned some other projects, some people set it to 30 seconds)

AI SDK has this feature: https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text#timeout. However they added that in v6 and we are on v5; still, it's a pattern for us to handle timeouts ourselves so we can control it.

I originally added this in the processor loop, but I quickly realized we can't do it there. We need to do it much more low-level. The processor loop may wait a while if tools are running, especially for things like subagents. We need to do it directly for every call to `/messages`, which will work because that is a direct start, stream, and finish turn. This PR does that.

It adds a new `chunkTimeout` option in the providers config, so users can customize this.

**Testing**

I manually test this by running complex conversations that invoked long-running tools and subagents. At this low-level, it works to apply a timeout here as each fetch to the provider endpoint starts a stream that will end when the chunks are fully streamed. I added extensive logging and everything looked correct. I also test overriding this config per model.