### PR TITLE
fix(app): prevent IME Enter from submitting inline comments

### DIFF
--- a/packages/app/src/pages/layout/inline-editor.test.ts
+++ b/packages/app/src/pages/layout/inline-editor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { createInlineEditorController } from "./inline-editor"
+
+describe("createInlineEditorController editorKeyDown", () => {
+  test("does not submit when Enter confirms IME composition", () => {
+    const controller = createInlineEditorController()
+    controller.openEditor("line-1", "こんにちは")
+
+    let saved: string | undefined
+    let prevented = false
+
+    controller.editorKeyDown(
+      {
+        key: "Enter",
+        isComposing: true,
+        keyCode: 229,
+        preventDefault: () => {
+          prevented = true
+        },
+      } as unknown as KeyboardEvent,
+      (next) => {
+        saved = next
+      },
+    )
+
+    expect(prevented).toBe(false)
+    expect(saved).toBeUndefined()
+    expect(controller.editorOpen("line-1")).toBe(true)
+  })
+
+  test("submits on Enter when not composing", () => {
+    const controller = createInlineEditorController()
+    controller.openEditor("line-1", "  value  ")
+
+    let saved: string | undefined
+    let prevented = false
+
+    controller.editorKeyDown(
+      {
+        key: "Enter",
+        isComposing: false,
+        keyCode: 13,
+        preventDefault: () => {
+          prevented = true
+        },
+      } as unknown as KeyboardEvent,
+      (next) => {
+        saved = next
+      },
+    )
+
+    expect(prevented).toBe(true)
+    expect(saved).toBe("value")
+    expect(controller.editorOpen("line-1")).toBe(false)
+  })
+})

--- a/packages/app/src/pages/layout/inline-editor.tsx
+++ b/packages/app/src/pages/layout/inline-editor.tsx
@@ -28,7 +28,9 @@ export function createInlineEditorController() {
   }
 
   const editorKeyDown = (event: KeyboardEvent, callback: (next: string) => void) => {
-    if (event.key === "Enter") {
+    const isImeConfirm = event.isComposing || event.keyCode === 229
+
+    if (event.key === "Enter" && !isImeConfirm) {
       event.preventDefault()
       saveEditor(callback)
       return


### PR DESCRIPTION
### Issue for this PR

Closes #16360

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes inline comment editor Enter-key handling so IME composition confirmation (CJK input) does not submit the comment.

Changes are intentionally minimal:
- in editorKeyDown, treat Enter as submit only when not composing (event.isComposing / Safari keyCode 229 guard)
- add focused unit tests for both composition Enter (no submit) and normal Enter (submit) behavior

### How did you verify your code works?

- Added unit tests in packages/app/src/pages/layout/inline-editor.test.ts that assert:
  - Enter during composition does not submit
  - Enter outside composition still submits
- Could not execute the Bun test command in this runner because Bun is not installed (bun: command not found).

### Screenshots / recordings

UI behavior change only in keyboard handling; no visual UI changes.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
