### PR TITLE
feat: add metals LSP for scala

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -2038,6 +2038,24 @@ export namespace LSPServer {
     },
   }
 
+  export const Metals: Info = {
+    id: "metals",
+    extensions: [".scala"],
+    root: NearestRoot(["build.sbt", "build.sc", ".scala-build"]),
+    async spawn(root) {
+      const bin = which("metals")
+      if (!bin) {
+        log.info("metals not found, please install metals first")
+        return
+      }
+      return {
+        process: spawn(bin, {
+          cwd: root,
+        }),
+      }
+    },
+  }
+
   export const JuliaLS: Info = {
     id: "julials",
     extensions: [".jl"],


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds built-in support for Metals, the Scala language server. The implementation follows the same pattern as other simple LSP servers in the codebase that expect the binary to be pre-installed. If the binary is not found, the server is silently skipped.

The server definition specifies `.scala` file extensions and uses `build.sbt`, `build.sc`, and `.scala-build` as project root markers. These cover [sbt](https://www.scala-sbt.org/), [Mill](https://mill-build.org/mill/index.html), and [scala-cli](https://scala-cli.virtuslab.org/) projects respectively.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
By running locally and opening/editing Scala files with opencode. Also tested locally with `opencode debug lsp diagnostics`.

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
