### PR TITLE
fix(tui): support middle-click paste from X11 primary selection

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,4 +1,4 @@
-import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, decodePasteBytes } from "@opentui/core"
+import { BoxRenderable, TextareaRenderable, MouseEvent, MouseButton, PasteEvent, decodePasteBytes } from "@opentui/core"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
@@ -1106,7 +1106,15 @@ export function Prompt(props: PromptProps) {
                   input.cursorColor = theme.text
                 }, 0)
               }}
-              onMouseDown={(r: MouseEvent) => r.target?.focus()}
+              onMouseDown={async (r: MouseEvent) => {
+                r.target?.focus()
+                if (r.button !== MouseButton.MIDDLE) return
+                if (props.disabled) return
+                r.preventDefault()
+                const text = await Clipboard.readPrimary()
+                if (!text || !input || input.isDestroyed) return
+                input.insertText(text)
+              }}
               focusedBackgroundColor={theme.backgroundElement}
               cursorColor={theme.text}
               syntaxStyle={syntax()}

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun"
 import { platform, release } from "os"
 import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -110,6 +110,23 @@ export async function read(): Promise<Content | undefined> {
   }
 }
 
+export async function readPrimary(): Promise<string | undefined> {
+  if (platform() !== "linux") return
+  const which = await getWhich()
+  if (process.env["WAYLAND_DISPLAY"] && which("wl-paste")) {
+    const result = await Process.text(["wl-paste", "--primary", "--no-newline"], { nothrow: true })
+    if (result.text) return result.text
+  }
+  if (which("xclip")) {
+    const result = await Process.text(["xclip", "-selection", "primary", "-o"], { nothrow: true })
+    if (result.text) return result.text
+  }
+  if (which("xsel")) {
+    const result = await Process.text(["xsel", "--primary", "--output"], { nothrow: true })
+    if (result.text) return result.text
+  }
+}
+
 const getCopyMethod = lazy(async () => {
   const os = platform()
   const which = await getWhich()

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -1,4 +1,3 @@
-import { $ } from "bun"
 import { platform, release } from "os"
 import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"


### PR DESCRIPTION
### Issue for this PR

Closes #8915 

### Type of change

- [X] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It allows someone on Linux (Xorg, Wayland) to select text in one application and use the middle mouse button to paste into the prompt textbox without have to do ctrl-c + ctrl-v. This is common behaviour on Linux systems.

### How did you verify your code works?

I ran bun dev after making the changes, selected some text in another terminal and pasted it into opencode and it worked. Without the fix, you don't get anything indication that anything at all happened in opencode.

I use Xorg, didn't try Wayland though.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
