### PR TITLE
fix(build): include migration name in builds OPENCODE_MIGRATIONS var

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -51,7 +51,7 @@ const migrations = await Promise.all(
           Number(match[6]),
         )
       : 0
-    return { sql, timestamp }
+    return { sql, timestamp, name }
   }),
 )
 console.log(`Loaded ${migrations.length} migrations`)


### PR DESCRIPTION
### Issue for this PR

Closes #16381

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes sure the `name` object is passed into the Build MIGRATION var, when used by the current beta release of drizzle as it seems is [required now](https://github.com/drizzle-team/drizzle-orm/pull/5376/changes?mode=single#diff-92021748424774a52af18b041343bee5299789eb8a12b36a92405d6df9fdbbb7R31) and errors out migrations without it.

**Error**
```bash
Failed to run the query 'INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name", "applied_at") values(?, ?, , ?)' Caused by: near ",": syntax error failed 
```

### How did you verify your code works?

Tested running `bun run tauri dev`, which builds opencode to use as the sidecar-cli this time it worked.

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
