### PR TITLE
Add opencode-chat-channel to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -49,6 +49,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 捆绑式多代理编排套件——16 个组件，一次安装                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 的零摩擦 git worktree 管理                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | 使用 Sentry AI Monitoring 追踪和调试您的 AI 代理                       |
+| [opencode-chat-channel](https://github.com/coneycode/opencode-chat-channel)                    | 支持opencode接入第三方渠道的对话软件，如飞书                       |
 
 ---
 


### PR DESCRIPTION
## add a plugin to ecosystem documentation

#### Issue for this PR
- add a plugin named  opencode-chat-channel to ecosystem documentation; the plugin could connect instant messaging bots like feishu/lark;

#### Type of change
- Documentation

#### What does this PR do?
- just add a plugin named opencode-chat-channel to docs;

#### How did you verify your code works?
- no code added;

#### Screenshots / recordings
- none;