### PR TITLE
fix(db): guard against invalid migration entries at startup

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -40,7 +40,8 @@ export namespace Database {
 
   type Client = SQLiteBunDatabase<Schema>
 
-  type Journal = { sql: string; timestamp: number; name: string }[]
+  type MigrationEntry = { sql: string; timestamp: number; name: string }
+  type Journal = MigrationEntry[]
 
   const state = {
     sqlite: undefined as BunDatabase | undefined,
@@ -79,6 +80,23 @@ export namespace Database {
     return sql.sort((a, b) => a.timestamp - b.timestamp)
   }
 
+  function validMigrationEntries(entries: Journal): Journal {
+    const valid = entries.filter(
+      (entry) =>
+        typeof entry.sql === "string" &&
+        entry.sql.trim().length > 0 &&
+        typeof entry.name === "string" &&
+        entry.name.trim().length > 0,
+    )
+
+    const skipped = entries.length - valid.length
+    if (skipped > 0) {
+      log.warn("skipping invalid migration entries", { skipped, total: entries.length })
+    }
+
+    return valid
+  }
+
   export const Client = lazy(() => {
     log.info("opening database", { path: Path })
 
@@ -95,10 +113,11 @@ export namespace Database {
     const db = drizzle({ client: sqlite, schema })
 
     // Apply schema migrations
-    const entries =
+    const rawEntries =
       typeof OPENCODE_MIGRATIONS !== "undefined"
         ? OPENCODE_MIGRATIONS
         : migrations(path.join(import.meta.dirname, "../../migration"))
+    const entries = validMigrationEntries(rawEntries)
     if (entries.length > 0) {
       log.info("applying migrations", {
         count: entries.length,


### PR DESCRIPTION
### Issue for this PR

Closes #16381

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The startup failure in #16381 shows Drizzle trying to run:

`INSERT INTO "__drizzle_migrations" ("hash", "created_at", "name", "applied_at") values(?, ?, , ?)`

That malformed SQL is consistent with a migration entry whose `name` is empty/invalid. This patch adds a small guard in `Database.Client` to validate migration entries before calling `migrate(...)`:

- require non-empty `name`
- require non-empty `sql`
- log a warning with skipped/total counts when any invalid entries are filtered out

This keeps startup resilient when bundled/dev migration arrays contain malformed entries, instead of crashing during migration bookkeeping.

### How did you verify your code works?

- I validated this fix path against the failing SQL in #16381: the only missing SQL value is migration `name`, and this change prevents empty/invalid migration names from reaching Drizzle migrate.
- I could not run Bun-based tests/build locally in this environment because `bun` is unavailable (`bun: command not found`).

### Screenshots / recordings

_Not a UI change._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
