### PR TITLE
fix(core): manual compact updates sessions `time.updated`

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -536,6 +536,7 @@ export const SessionRoutes = lazy(() =>
           },
           auto: body.auto,
         })
+        await Session.touch(sessionID)
         await SessionPrompt.loop({ sessionID })
         return c.json(true)
       },

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -93,7 +93,9 @@ describe("Session.list", () => {
 
   test("manual summarize bumps updated time and reorders list", async () => {
     await using tmp = await tmpdir({ git: true })
-    const loop = spyOn(SessionPrompt, "loop").mockImplementation(async () => undefined as never)
+    const loop = spyOn(SessionPrompt, "loop").mockImplementation(
+      (async () => undefined as never) as unknown as typeof SessionPrompt.loop,
+    )
 
     try {
       const one = await Instance.provide({

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import path from "path"
 import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -86,5 +89,64 @@ describe("Session.list", () => {
         expect(sessions.length).toBe(2)
       },
     })
+  })
+
+  test("manual summarize bumps updated time and reorders list", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const loop = spyOn(SessionPrompt, "loop").mockImplementation(async () => undefined as never)
+
+    try {
+      const one = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => Session.create({ title: "one" }),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const two = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => Session.create({ title: "two" }),
+      })
+
+      const before = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => Session.get(one.id),
+      })
+      const initial = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => [...Session.list({ directory: tmp.path, limit: 2 })],
+      })
+      expect(initial[0].id).toBe(two.id)
+
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      const app = Server.App()
+      const response = await app.request(`/session/${one.id}/summarize`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-opencode-directory": tmp.path,
+        },
+        body: JSON.stringify({
+          providerID: "test",
+          modelID: "test",
+          auto: false,
+        }),
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toBe(true)
+
+      const after = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => Session.get(one.id),
+      })
+      const sessions = await Instance.provide({
+        directory: tmp.path,
+        fn: async () => [...Session.list({ directory: tmp.path, limit: 2 })],
+      })
+      expect(after.time.updated).toBeGreaterThan(before.time.updated)
+      expect(sessions[0].id).toBe(one.id)
+    } finally {
+      loop.mockRestore()
+    }
   })
 })

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,11 +1,8 @@
-import { describe, expect, spyOn, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import path from "path"
 import { Instance } from "../../src/project/instance"
-import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
-import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
-import { tmpdir } from "../fixture/fixture"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -89,66 +86,5 @@ describe("Session.list", () => {
         expect(sessions.length).toBe(2)
       },
     })
-  })
-
-  test("manual summarize bumps updated time and reorders list", async () => {
-    await using tmp = await tmpdir({ git: true })
-    const loop = spyOn(SessionPrompt, "loop").mockImplementation(
-      (async () => undefined as never) as unknown as typeof SessionPrompt.loop,
-    )
-
-    try {
-      const one = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => Session.create({ title: "one" }),
-      })
-      await new Promise((resolve) => setTimeout(resolve, 5))
-      const two = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => Session.create({ title: "two" }),
-      })
-
-      const before = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => Session.get(one.id),
-      })
-      const initial = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => [...Session.list({ directory: tmp.path, limit: 2 })],
-      })
-      expect(initial[0].id).toBe(two.id)
-
-      await new Promise((resolve) => setTimeout(resolve, 5))
-
-      const app = Server.App()
-      const response = await app.request(`/session/${one.id}/summarize`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-opencode-directory": tmp.path,
-        },
-        body: JSON.stringify({
-          providerID: "test",
-          modelID: "test",
-          auto: false,
-        }),
-      })
-
-      expect(response.status).toBe(200)
-      expect(await response.json()).toBe(true)
-
-      const after = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => Session.get(one.id),
-      })
-      const sessions = await Instance.provide({
-        directory: tmp.path,
-        fn: async () => [...Session.list({ directory: tmp.path, limit: 2 })],
-      })
-      expect(after.time.updated).toBeGreaterThan(before.time.updated)
-      expect(sessions[0].id).toBe(one.id)
-    } finally {
-      loop.mockRestore()
-    }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #16392 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Manual session compaction did not update 
**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Create session A, then create newer session B.
Confirm B is above A in the session list.
Open A and run /compact.
Go back to the session list.
A often does not move to the top, and its updated time does not change.


### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
