### PR TITLE
fix(storage): sanitize preview channel db filenames

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -27,10 +27,14 @@ export const NotFoundError = NamedError.create(
 const log = Log.create({ service: "db" })
 
 export namespace Database {
+  function file(text: string) {
+    return text.replaceAll("/", "-")
+  }
+
   export const Path = (() => {
     const name =
       Installation.CHANNEL !== "latest" && !Flag.OPENCODE_DISABLE_CHANNEL_DB
-        ? `opencode-${Installation.CHANNEL}.db`
+        ? `opencode-${file(Installation.CHANNEL)}.db`
         : "opencode.db"
     return path.join(Global.Path.data, name)
   })()

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { pathToFileURL } from "url"
+import { tmpdir } from "../fixture/fixture"
+import { Process } from "../../src/util/process"
+
+function bun(script: string) {
+  return [process.execPath, "-e", script]
+}
+
+describe("storage.db", () => {
+  test("opens a preview channel database when the channel contains slashes", async () => {
+    await using tmp = await tmpdir()
+    const url = pathToFileURL(path.join(import.meta.dirname, "../../src/storage/db.ts")).href
+    const env = {
+      XDG_DATA_HOME: path.join(tmp.path, "share"),
+      XDG_CACHE_HOME: path.join(tmp.path, "cache"),
+      XDG_CONFIG_HOME: path.join(tmp.path, "config"),
+      XDG_STATE_HOME: path.join(tmp.path, "state"),
+      OPENCODE_TEST_HOME: path.join(tmp.path, "home"),
+    }
+    const out = await Process.run(
+      bun(`
+        void (async () => {
+          globalThis.OPENCODE_CHANNEL = "foo/bar"
+          globalThis.OPENCODE_VERSION = "0.0.0-foo/bar-202603061921"
+          const { Database } = await import(${JSON.stringify(url)})
+          Database.Client()
+          process.stdout.write(Database.Path)
+          Database.close()
+        })().catch((err) => {
+          console.error(err)
+          process.exit(1)
+        })
+      `),
+      { env },
+    )
+    const want = path.join(env.XDG_DATA_HOME, "opencode", "opencode-foo-bar.db")
+    expect(out.stdout.toString()).toBe(want)
+    expect(await Bun.file(want).exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR
Closes #16396

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
This fixes startup failures for preview builds when the channel contains `/`.
Preview builds use the git branch as the channel. That channel was being used directly in the local SQLite filename, so a channel like `foo/bar` produced `opencode-foo/bar.db`. SQLite treated that as a nested path and startup failed with `unable to open database file`.
This change sanitizes `/` before building the database filename so preview channels still get isolated databases without creating invalid paths.

### How did you verify your code works?
- Added a regression test in `packages/opencode/test/storage/db.test.ts`
- Ran `bun test test/storage/db.test.ts`
- Ran `bun test test/storage/db.test.ts test/storage/json-migration.test.ts`
- Reproduced the failure with a preview channel containing `/` and verified the sanitized path is `opencode-foo-bar.db`

### Screenshots / recordings
N/A

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
