### PR TITLE
fix(win32): preserve PATH aliases in TUI worker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -121,10 +121,17 @@ export const TuiThreadCommand = cmd({
         return
       }
 
+      const env = Object.fromEntries(
+        Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+      )
+      const p = env.PATH ?? env.Path
+      if (p) {
+        env.PATH = p
+        env.Path = p
+      }
+
       const worker = new Worker(file, {
-        env: Object.fromEntries(
-          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-        ),
+        env,
       })
       worker.onerror = (e) => {
         Log.Default.error(e)

--- a/packages/opencode/src/util/which.ts
+++ b/packages/opencode/src/util/which.ts
@@ -3,8 +3,8 @@ import whichPkg from "which"
 export function which(cmd: string, env?: NodeJS.ProcessEnv) {
   const result = whichPkg.sync(cmd, {
     nothrow: true,
-    path: env?.PATH,
-    pathExt: env?.PATHEXT,
+    path: env?.PATH ?? env?.Path ?? process.env.PATH ?? process.env.Path,
+    pathExt: env?.PATHEXT ?? process.env.PATHEXT,
   })
   return typeof result === "string" ? result : null
 }

--- a/packages/opencode/test/util/which.test.ts
+++ b/packages/opencode/test/util/which.test.ts
@@ -22,6 +22,13 @@ function env(PATH: string): NodeJS.ProcessEnv {
   }
 }
 
+function winenv(Path: string): NodeJS.ProcessEnv {
+  return {
+    Path,
+    PATHEXT: process.env["PATHEXT"],
+  }
+}
+
 function same(a: string | null, b: string) {
   if (process.platform === "win32") {
     expect(a?.toLowerCase()).toBe(b.toLowerCase())
@@ -78,5 +85,16 @@ describe("util.which", () => {
     await fs.writeFile(file, "@echo off\r\n")
 
     expect(which("pathext", { PATH: bin, PATHEXT: ".CMD" })).toBe(file)
+  })
+
+  test("uses Path on windows", async () => {
+    if (process.platform !== "win32") return
+
+    await using tmp = await tmpdir()
+    const bin = path.join(tmp.path, "bin")
+    await fs.mkdir(bin)
+    const file = await cmd(bin, "tool")
+
+    same(which("tool", winenv(bin)), file)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #16391

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, the TUI worker could inherit `Path` without `PATH`. After `74effa8ee`, `which("git")` started relying on `PATH`, so the worker could fail to detect Git, skip snapshots, and break `Modified Files` and `/undo`.

This PR keeps both `PATH` and `Path` in the worker env, makes `util.which()` fall back to `Path`, and adds a Windows regression test for `Path`-only envs.

Note: this PR description and code were generated by GPT 5.4 and then reviewed and verified locally.

### How did you verify your code works?

- Reproduced the regression locally on Windows before the fix.
- Confirmed the patched build restores the original behavior in the original repro.
- Ran `bun test test/util/which.test.ts`
- Ran `bun run script/build.ts --single --skip-install`
- Ran `dist/opencode-windows-x64/bin/opencode.exe --version`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR