### PR TITLE
fix(core): log stack trace when schema validation fails

### DIFF
--- a/packages/opencode/src/util/fn.ts
+++ b/packages/opencode/src/util/fn.ts
@@ -2,7 +2,14 @@ import { z } from "zod"
 
 export function fn<T extends z.ZodType, Result>(schema: T, cb: (input: z.infer<T>) => Result) {
   const result = (input: z.infer<T>) => {
-    const parsed = schema.parse(input)
+    let parsed
+    try {
+      parsed = schema.parse(input)
+    } catch (e) {
+      console.trace("schema validation failure stack trace:")
+      throw e
+    }
+
     return cb(parsed)
   }
   result.force = (input: z.infer<T>) => cb(input)


### PR DESCRIPTION
Small improvement for debugging. Previously you only saw the schema failure, now you see where it came from