### PR TITLE
docs: add lgrep plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                         |
+| [lgrep](https://github.com/Sharper-Flow/lgrep)                                                      | Semantic code search and symbol intelligence for OpenCode agents                                  |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |


### PR DESCRIPTION
## Summary

Adds [lgrep](https://github.com/Sharper-Flow/lgrep) to the Plugins section of the ecosystem page.

## About the Plugin

OpenCode plugin that gives agents better repo discovery and targeted code retrieval:

- **Semantic code search** for intent-level queries
- **Exact symbol lookup** with file and repo outlines
- **Local-first indexes** backed by tree-sitter and local storage
- **Shared MCP workflow** for multi-agent OpenCode sessions

## Checklist

- [x] Entry added alphabetically in the Plugins table
- [x] Link points to valid GitHub repository
- [x] Description is concise and accurate
