### PR TITLE
fix(tui): preserve keyboard selection in Windows text areas

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -220,6 +220,25 @@ function App() {
     if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
     if (!renderer.getSelection()) return
 
+    if (Selection.focused(renderer)) {
+      if (evt.ctrl && evt.name === "c") {
+        if (!Selection.copy(renderer, toast)) return
+
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
+
+      if (evt.name === "escape") {
+        renderer.clearSelection()
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
+
+      return
+    }
+
     // Windows Terminal-like behavior:
     // - Ctrl+C copies and dismisses selection
     // - Esc dismisses selection

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -70,6 +70,10 @@ function init() {
   useKeyboard((evt) => {
     if (store.stack.length === 0) return
     if (evt.defaultPrevented) return
+    if (Selection.focused(renderer)) {
+      if ((evt.name === "escape" || (evt.ctrl && evt.name === "c")) && renderer.getSelection()) return
+      return
+    }
     if ((evt.name === "escape" || (evt.ctrl && evt.name === "c")) && renderer.getSelection()) return
     if (evt.name === "escape" || (evt.ctrl && evt.name === "c")) {
       const current = store.stack.at(-1)!

--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -8,9 +8,14 @@ type Toast = {
 type Renderer = {
   getSelection: () => { getSelectedText: () => string } | null
   clearSelection: () => void
+  currentFocusedRenderable?: { hasSelection?: () => boolean } | null
 }
 
 export namespace Selection {
+  export function focused(renderer: Renderer) {
+    return !!renderer.currentFocusedRenderable?.hasSelection?.()
+  }
+
   export function copy(renderer: Renderer, toast: Toast): boolean {
     const text = renderer.getSelection()?.getSelectedText()
     if (!text) return false


### PR DESCRIPTION
### Issue for this PR

Closes #16245

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, keyboard text selection in the prompt was being cleared by the global copy-on-select handler before the textarea could keep extending it. That caused Shift+Arrow selection to get stuck, and Backspace/Delete only removed a single character even when a textarea selection was visible.

This change makes the global selection handler ignore selections owned by the currently focused renderable. For focused textarea selections, normal editing keys are left alone so selection and deletion work normally, while Ctrl+C still copies the selected text and Esc still clears the selection.

### How did you verify your code works?

I tested locally on Windows in the TUI prompt by reproducing the issue cases:

- `Shift+Left` repeatedly expands selection instead of getting stuck on two characters
- `Shift+Home` then `Delete` removes the whole selected line
- `Home` then `Shift+End` then `Backspace` removes the whole selected line
-  Ran `bun run --cwd packages/opencode typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR