### PR TITLE
feat: add per-provider small_model configuration

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -933,6 +933,12 @@ export namespace Config {
     .extend({
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
+      small_model: z
+        .string()
+        .optional()
+        .describe(
+          "Small model override for this provider. Supports either a model ID (provider-local) or provider/model format.",
+        ),
       models: z
         .record(
           z.string(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1233,6 +1233,12 @@ export namespace Provider {
   export async function getSmallModel(providerID: string) {
     const cfg = await Config.get()
 
+    const ref = cfg.provider?.[providerID]?.small_model
+    if (ref) {
+      const parsed = parseModelRef(providerID, ref)
+      return getModel(parsed.providerID, parsed.modelID)
+    }
+
     if (cfg.small_model) {
       const parsed = parseModel(cfg.small_model)
       return getModel(parsed.providerID, parsed.modelID)
@@ -1338,6 +1344,14 @@ export namespace Provider {
     return {
       providerID: providerID,
       modelID: rest.join("/"),
+    }
+  }
+
+  function parseModelRef(providerID: string, model: string) {
+    if (model.includes("/")) return parseModel(model)
+    return {
+      providerID,
+      modelID: model,
     }
   }
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { Provider } from "@/provider/provider"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -103,10 +104,24 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 
-      const model = agent.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
-      }
+      const { modelID: msgModelID, providerID: msgProviderID } = msg.info
+
+      const model = await iife(async () => {
+        if (agent.model) return agent.model
+        if (agent.name === "explore") {
+          const small = await Provider.getSmallModel(msgProviderID)
+          if (small) {
+            return {
+              modelID: small.id,
+              providerID: small.providerID,
+            }
+          }
+        }
+        return {
+          modelID: msgModelID,
+          providerID: msgProviderID,
+        }
+      })
 
       ctx.metadata({
         title: params.description,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -964,6 +964,67 @@ test("getSmallModel respects config small_model override", async () => {
   })
 })
 
+test("getSmallModel respects provider-specific small_model override", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              small_model: "claude-sonnet-4-20250514",
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const model = await Provider.getSmallModel("anthropic")
+      expect(model).toBeDefined()
+      expect(model?.providerID).toBe("anthropic")
+      expect(model?.id).toBe("claude-sonnet-4-20250514")
+    },
+  })
+})
+
+test("provider-specific small_model takes precedence over global small_model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          small_model: "anthropic/claude-sonnet-4-20250514",
+          provider: {
+            anthropic: {
+              small_model: "claude-sonnet-4-20250514",
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const model = await Provider.getSmallModel("anthropic")
+      expect(model).toBeDefined()
+      expect(model?.providerID).toBe("anthropic")
+      expect(model?.id).toBe("claude-sonnet-4-20250514")
+    },
+  })
+})
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -244,6 +244,20 @@ You can configure the providers and models you want to use in your OpenCode conf
 
 The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
 
+You can also set `provider.<id>.small_model` to override the small model for a specific provider. This is used by subagents like `explore` when the agent model is not explicitly configured.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "opencode/claude-opus-4-6",
+  "provider": {
+    "opencode": {
+      "small_model": "gpt-5-mini"
+    }
+  }
+}
+```
+
 Provider options can include `timeout` and `setCacheKey`:
 
 ```json title="opencode.json"


### PR DESCRIPTION
## Summary
- Adds `small_model` option to the provider-specific configuration
- Updates `Provider.getSmallModel` to prioritize provider-specific `small_model` over the global `small_model`
- Updates `explore` agent to respect the provider-specific small model
- Adds tests to verify correct config precedence
- Updates documentation for the new configuration option

Resolves https://github.com/anomalyco/opencode/issues/16207