### PR TITLE
fix(ci): provide app token before publish prepare step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,6 +176,13 @@ jobs:
           workspaces: packages/desktop/src-tauri
           shared-key: ${{ matrix.settings.target }}
 
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+
       - name: Prepare
         run: |
           cd packages/desktop
@@ -204,13 +211,6 @@ jobs:
       - name: Show tauri-cli version
         if: contains(matrix.settings.host, 'ubuntu')
         run: cargo tauri --version
-
-      - name: Setup git committer
-        id: committer
-        uses: ./.github/actions/setup-git-committer
-        with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - name: Build and upload artifacts
         uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a


### PR DESCRIPTION
### Issue for this PR

Closes #16427

### Type of change

- [x] Bug fix

### What does this PR do?

Currently `steps.committer.outputs.token` is used in the `Prepare` step before it's outputted by `Setup git committer`. This results in an empty token.

This PR fixes this by putting `Setup git committer` before `Prepare`.

### How did you verify your code works?

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR