### PR TITLE
fix(opencode): sanitize preview database filenames

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -27,12 +27,14 @@ export const NotFoundError = NamedError.create(
 const log = Log.create({ service: "db" })
 
 export namespace Database {
+  export function file(channel: string) {
+    if (channel === "latest" || Flag.OPENCODE_DISABLE_CHANNEL_DB) return "opencode.db"
+    const safe = channel.replace(/[^a-zA-Z0-9._-]/g, "-")
+    return `opencode-${safe}.db`
+  }
+
   export const Path = (() => {
-    const name =
-      Installation.CHANNEL !== "latest" && !Flag.OPENCODE_DISABLE_CHANNEL_DB
-        ? `opencode-${Installation.CHANNEL}.db`
-        : "opencode.db"
-    return path.join(Global.Path.data, name)
+    return path.join(Global.Path.data, file(Installation.CHANNEL))
   })()
 
   type Schema = typeof schema

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "../../src/storage/db"
+
+describe("Database.file", () => {
+  test("uses the shared database for latest", () => {
+    expect(Database.file("latest")).toBe("opencode.db")
+  })
+
+  test("sanitizes preview channels for filenames", () => {
+    expect(Database.file("fix/windows-modified-files-tracking")).toBe("opencode-fix-windows-modified-files-tracking.db")
+  })
+})


### PR DESCRIPTION
## Summary
- sanitize preview channel names before turning them into database filenames so branch names with `/` stay single-file paths on Windows
- keep latest builds on the shared `opencode.db` filename while preserving per-channel database names for preview builds
- add focused coverage for latest and slash-containing preview channel filenames

## Testing
- `bun test test/storage/db.test.ts`
- `bun run --cwd packages/opencode --conditions=browser src/index.ts --print-logs --log-level DEBUG session list`
- `bun run typecheck`