### PR TITLE
fix(tui): fix broken /mcp toggling

### DIFF
--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -23,7 +23,7 @@ export namespace Keybind {
    */
   export function fromParsedKey(key: ParsedKey, leader = false): Info {
     return {
-      name: key.name,
+      name: key.name === " " ? "space" : key.name,
       ctrl: key.ctrl,
       meta: key.meta,
       shift: key.shift,


### PR DESCRIPTION
### Issue for this PR

Closes #16358 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The`/mcp` command uses the space bar to toggle between mcps.
Within certain terminals (ex. VS Code Integrated Terminal), toggling is completely broken because hitting the space bar types a space into the search bar instead of toggling. this PR fixes that. 

### How did you verify your code works?

Tested in iTerm2, Kitty, and VS Code Integrated Terminal. The space key now toggles MCPs instead of entering a space key into the search bar

I verified by running `bun test test/keybind.test.ts` from `packages/opencode` (all tests passed).

### Screenshots / recordings
Before Fix: 

https://github.com/user-attachments/assets/a65845f7-be60-4adb-8ffe-a056132318cb

After Fix: 

https://github.com/user-attachments/assets/354d25df-52ac-473b-86af-04f2698b041a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR