### PR TITLE
fix(tui): fix broken /export toggling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -56,7 +56,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
       setStore("active", order[nextIndex])
       evt.preventDefault()
     }
-    if (evt.name === "space") {
+    if (evt.name === "space" || evt.name === " ") {
       if (store.active === "thinking") setStore("thinking", !store.thinking)
       if (store.active === "toolDetails") setStore("toolDetails", !store.toolDetails)
       if (store.active === "assistantMetadata") setStore("assistantMetadata", !store.assistantMetadata)


### PR DESCRIPTION
### Issue for this PR

Closes #16437

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/export` dialog toggling/selection does not work for terminals that use the kitty keyboard protocol (ex. vscode integrated terminal). This is because the dialog keybinding expects the `"space"` token for toggling while the vscode integreated terminal emits a `" "` token instead. We fixed this by adding `if (evt.name === "space" || evt.name === " ")` to `dialog-export-options`.

### How did you verify your code works?
Tested on iTerm2, kitty, and the vscode integrated terminal and ran 
`bun test test/keybind.test.ts`
`bun run typecheck`
`bun turbo typecheck`

### Screenshots / recordings

### Before fix
https://github.com/user-attachments/assets/6a117316-c212-4e5f-94de-c5b08c9fee33

### After fix
https://github.com/user-attachments/assets/27a28800-33a8-4df9-ad5d-7fdd318d7903


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR