### PR TITLE
feat: add built-in Solidity LSP server

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -83,6 +83,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".json.erb": "erb",
   ".rs": "rust",
   ".scss": "scss",
+  ".sol": "solidity",
   ".sass": "sass",
   ".scala": "scala",
   ".shader": "shaderlab",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -2055,4 +2055,22 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const SolidityLS: Info = {
+    id: "solidity",
+    extensions: [".sol"],
+    root: NearestRoot(["foundry.toml", "hardhat.config.ts", "hardhat.config.js", "truffle-config.js", "remappings.txt"]),
+    async spawn(root) {
+      const bin = which("solidity-language-server")
+      if (!bin) {
+        log.info("solidity-language-server not found, install via: cargo install solidity-language-server")
+        return
+      }
+      return {
+        process: spawn(bin, ["--stdio"], {
+          cwd: root,
+        }),
+      }
+    },
+  }
 }


### PR DESCRIPTION
## Summary

Add `solidity-language-server` as a built-in LSP server for `.sol` files.

- **Server**: [`solidity-language-server`](https://github.com/mmsaki/solidity-language-server) — the fastest Solidity language server, optimized for low-latency go-to-definition, references, hover, completions, rename, and 20+ LSP methods
- **Install**: `cargo install solidity-language-server` or pre-built binaries from [releases](https://github.com/mmsaki/solidity-language-server/releases)
- **Transport**: `--stdio`
- **Extension**: `.sol`
- **Root detection**: `foundry.toml`, `hardhat.config.ts`, `hardhat.config.js`, `truffle-config.js`, `remappings.txt`

Follows the same "binary must be in PATH" pattern as rust-analyzer and gopls.

## Changes

- `packages/opencode/src/lsp/server.ts` — add `SolidityLS` server definition
- `packages/opencode/src/lsp/language.ts` — add `.sol` → `"solidity"` extension mapping

## Verification

Tested locally with `.sol` files in a Foundry project. Server starts, diagnostics appear, go-to-definition and references work.