### PR TITLE
feat: add conversation-only revert capability

### DIFF
--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -342,7 +342,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
           setActiveMessage(lastMsg)
           return
         }
-        await sdk.client.session.revert({ sessionID, messageID: nextMessage.id })
+        const mode = info()?.revert?.mode
+        await sdk.client.session.revert({ sessionID, messageID: nextMessage.id, mode })
         const priorMsg = findLast(userMessages(), (x) => x.id < nextMessage.id)
         setActiveMessage(priorMsg)
       },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -21,7 +21,39 @@ export function DialogMessage(props: {
       title="Message Actions"
       options={[
         {
-          title: "Revert",
+          title: "Revert conversation",
+          value: "session.revert",
+          description: "undo messages only",
+          onSelect: (dialog) => {
+            const msg = message()
+            if (!msg) return
+
+            sdk.client.session.revert({
+              sessionID: props.sessionID,
+              messageID: msg.id,
+              mode: "conversation",
+            })
+
+            if (props.setPrompt) {
+              const parts = sync.data.part[msg.id]
+              const promptInfo = parts.reduce(
+                (agg, part) => {
+                  if (part.type === "text") {
+                    if (!part.synthetic) agg.input += part.text
+                  }
+                  if (part.type === "file") agg.parts.push(part)
+                  return agg
+                },
+                { input: "", parts: [] as PromptInfo["parts"] },
+              )
+              props.setPrompt(promptInfo)
+            }
+
+            dialog.clear()
+          },
+        },
+        {
+          title: "Revert conversation and code",
           value: "session.revert",
           description: "undo messages and file changes",
           onSelect: (dialog) => {
@@ -31,6 +63,7 @@ export function DialogMessage(props: {
             sdk.client.session.revert({
               sessionID: props.sessionID,
               messageID: msg.id,
+              mode: "conversation_and_code",
             })
 
             if (props.setPrompt) {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -22,7 +22,7 @@ export function DialogMessage(props: {
       options={[
         {
           title: "Revert conversation",
-          value: "session.revert",
+          value: "session.revert.conversation",
           description: "undo messages only",
           onSelect: (dialog) => {
             const msg = message()
@@ -54,7 +54,7 @@ export function DialogMessage(props: {
         },
         {
           title: "Revert conversation and code",
-          value: "session.revert",
+          value: "session.revert.conversation_and_code",
           description: "undo messages and file changes",
           onSelect: (dialog) => {
             const msg = message()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -16,6 +16,36 @@ export function DialogMessage(props: {
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
   const route = useRoute()
 
+  function revert(mode: "conversation" | "conversation_and_code") {
+    return (dialog: { clear: () => void }) => {
+      const msg = message()
+      if (!msg) return
+
+      sdk.client.session.revert({
+        sessionID: props.sessionID,
+        messageID: msg.id,
+        mode,
+      })
+
+      if (props.setPrompt) {
+        const parts = sync.data.part[msg.id]
+        const promptInfo = parts.reduce(
+          (agg, part) => {
+            if (part.type === "text") {
+              if (!part.synthetic) agg.input += part.text
+            }
+            if (part.type === "file") agg.parts.push(part)
+            return agg
+          },
+          { input: "", parts: [] as PromptInfo["parts"] },
+        )
+        props.setPrompt(promptInfo)
+      }
+
+      dialog.clear()
+    }
+  }
+
   return (
     <DialogSelect
       title="Message Actions"
@@ -24,65 +54,13 @@ export function DialogMessage(props: {
           title: "Revert conversation",
           value: "session.revert.conversation",
           description: "undo messages only",
-          onSelect: (dialog) => {
-            const msg = message()
-            if (!msg) return
-
-            sdk.client.session.revert({
-              sessionID: props.sessionID,
-              messageID: msg.id,
-              mode: "conversation",
-            })
-
-            if (props.setPrompt) {
-              const parts = sync.data.part[msg.id]
-              const promptInfo = parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(part)
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-              props.setPrompt(promptInfo)
-            }
-
-            dialog.clear()
-          },
+          onSelect: revert("conversation"),
         },
         {
           title: "Revert conversation and code",
           value: "session.revert.conversation_and_code",
           description: "undo messages and file changes",
-          onSelect: (dialog) => {
-            const msg = message()
-            if (!msg) return
-
-            sdk.client.session.revert({
-              sessionID: props.sessionID,
-              messageID: msg.id,
-              mode: "conversation_and_code",
-            })
-
-            if (props.setPrompt) {
-              const parts = sync.data.part[msg.id]
-              const promptInfo = parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(part)
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-              props.setPrompt(promptInfo)
-            }
-
-            dialog.clear()
-          },
+          onSelect: revert("conversation_and_code"),
         },
         {
           title: "Copy",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -543,9 +543,11 @@ export function Session() {
           prompt.set({ input: "", parts: [] })
           return
         }
+        const mode = session()?.revert?.mode
         sdk.client.session.revert({
           sessionID: route.sessionID,
           messageID: message.id,
+          mode,
         })
       },
     },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -152,6 +152,7 @@ export namespace Session {
           partID: z.string().optional(),
           snapshot: z.string().optional(),
           diff: z.string().optional(),
+          mode: z.enum(["conversation", "conversation_and_code"]).optional(),
         })
         .optional(),
     })

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -153,6 +153,16 @@ export namespace Session {
           snapshot: z.string().optional(),
           diff: z.string().optional(),
           mode: z.enum(["conversation", "conversation_and_code"]).optional(),
+          points: z
+            .object({
+              messageID: z.string(),
+              partID: z.string().optional(),
+              mode: z.enum(["conversation", "conversation_and_code"]),
+              snapshot: z.string().optional(),
+            })
+            .array()
+            .optional(),
+          index: z.number().optional(),
         })
         .optional(),
     })

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -737,7 +737,7 @@ export namespace MessageV2 {
           .select()
           .from(MessageTable)
           .where(eq(MessageTable.session_id, sessionID))
-          .orderBy(desc(MessageTable.time_created))
+          .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
           .limit(size)
           .offset(offset)
           .all(),

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -29,24 +29,24 @@ export namespace SessionRevert {
     const session = await Session.get(input.sessionID)
 
     const mode = input.mode ?? session.revert?.mode ?? "conversation_and_code"
-    let revert: Session.Info["revert"]
+    let next: Session.Info["revert"]
     const patches: Snapshot.Patch[] = []
     for (const msg of all) {
       if (msg.info.role === "user") lastUser = msg.info
       const remaining = []
       for (const part of msg.parts) {
-        if (revert) {
+        if (next) {
           if (part.type === "patch") {
             patches.push(part)
           }
           continue
         }
 
-        if (!revert) {
+        if (!next) {
           if ((msg.info.id === input.messageID && !input.partID) || part.id === input.partID) {
             // if no useful parts left in message, same as reverting whole message
             const partID = remaining.some((item) => ["text", "tool"].includes(item.type)) ? input.partID : undefined
-            revert = {
+            next = {
               messageID: !partID && lastUser ? lastUser.id : msg.info.id,
               partID,
             }
@@ -56,42 +56,91 @@ export namespace SessionRevert {
       }
     }
 
-    if (revert) {
-      const session = await Session.get(input.sessionID)
-      if (mode === "conversation") {
-        const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
-        const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
-        return Session.setRevert({
+    if (!next) return session
+
+    const range = all.filter((msg) => msg.info.id >= next.messageID)
+    const diffs = await SessionSummary.computeDiff({ messages: range })
+    const summary = {
+      additions: diffs.reduce((sum, x) => sum + x.additions, 0),
+      deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
+      files: diffs.length,
+    }
+
+    const pts = session.revert?.points ?? []
+    const idx = session.revert?.index ?? pts.length - 1
+    const hit = pts.findIndex((item) => item.messageID === next!.messageID && item.partID === next!.partID)
+
+    if (hit >= 0) {
+      const point = pts[hit]
+      if (point?.snapshot) await Snapshot.restore(point.snapshot)
+      if (point?.mode === "conversation_and_code") {
+        await Storage.write(["session_diff", input.sessionID], diffs)
+        Bus.publish(Session.Event.Diff, {
           sessionID: input.sessionID,
-          revert: { ...revert, mode },
-          summary: {
-            additions: diffs.reduce((sum, x) => sum + x.additions, 0),
-            deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
-            files: diffs.length,
-          },
+          diff: diffs,
         })
       }
-      revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
-      await Snapshot.revert(patches)
-      if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
-      const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
-      const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
-      await Storage.write(["session_diff", input.sessionID], diffs)
-      Bus.publish(Session.Event.Diff, {
-        sessionID: input.sessionID,
-        diff: diffs,
-      })
       return Session.setRevert({
         sessionID: input.sessionID,
-        revert: { ...revert, mode },
-        summary: {
-          additions: diffs.reduce((sum, x) => sum + x.additions, 0),
-          deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
-          files: diffs.length,
+        revert: {
+          ...next,
+          snapshot: session.revert?.snapshot,
+          mode: point?.mode ?? mode,
+          points: pts,
+          index: hit,
         },
+        summary,
       })
     }
-    return session
+
+    const root = session.revert?.snapshot ?? (await Snapshot.track())
+    const keep = idx >= 0 ? pts.slice(0, idx + 1) : []
+
+    if (mode === "conversation") {
+      const point = {
+        ...next,
+        mode,
+        snapshot: await Snapshot.track(),
+      }
+      const points = [...keep, point]
+      return Session.setRevert({
+        sessionID: input.sessionID,
+        revert: {
+          ...next,
+          snapshot: root,
+          mode,
+          points,
+          index: points.length - 1,
+        },
+        summary,
+      })
+    }
+
+    await Snapshot.revert(patches)
+    const point = {
+      ...next,
+      mode,
+      snapshot: await Snapshot.track(),
+    }
+    const points = [...keep, point]
+    const revert = {
+      ...next,
+      snapshot: root,
+      mode,
+      points,
+      index: points.length - 1,
+      diff: root ? await Snapshot.diff(root) : undefined,
+    }
+    await Storage.write(["session_diff", input.sessionID], diffs)
+    Bus.publish(Session.Event.Diff, {
+      sessionID: input.sessionID,
+      diff: diffs,
+    })
+    return Session.setRevert({
+      sessionID: input.sessionID,
+      revert,
+      summary,
+    })
   }
 
   export async function unrevert(input: { sessionID: string }) {

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -18,6 +18,7 @@ export namespace SessionRevert {
     sessionID: Identifier.schema("session"),
     messageID: Identifier.schema("message"),
     partID: Identifier.schema("part").optional(),
+    mode: z.enum(["conversation", "conversation_and_code"]).optional(),
   })
   export type RevertInput = z.infer<typeof RevertInput>
 
@@ -27,6 +28,7 @@ export namespace SessionRevert {
     let lastUser: MessageV2.User | undefined
     const session = await Session.get(input.sessionID)
 
+    const mode = input.mode ?? session.revert?.mode ?? "conversation_and_code"
     let revert: Session.Info["revert"]
     const patches: Snapshot.Patch[] = []
     for (const msg of all) {
@@ -56,6 +58,19 @@ export namespace SessionRevert {
 
     if (revert) {
       const session = await Session.get(input.sessionID)
+      if (mode === "conversation") {
+        const rangeMessages = all.filter((msg) => msg.info.id >= revert!.messageID)
+        const diffs = await SessionSummary.computeDiff({ messages: rangeMessages })
+        return Session.setRevert({
+          sessionID: input.sessionID,
+          revert: { ...revert, mode },
+          summary: {
+            additions: diffs.reduce((sum, x) => sum + x.additions, 0),
+            deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),
+            files: diffs.length,
+          },
+        })
+      }
       revert.snapshot = session.revert?.snapshot ?? (await Snapshot.track())
       await Snapshot.revert(patches)
       if (revert.snapshot) revert.diff = await Snapshot.diff(revert.snapshot)
@@ -68,7 +83,7 @@ export namespace SessionRevert {
       })
       return Session.setRevert({
         sessionID: input.sessionID,
-        revert,
+        revert: { ...revert, mode },
         summary: {
           additions: diffs.reduce((sum, x) => sum + x.additions, 0),
           deletions: diffs.reduce((sum, x) => sum + x.deletions, 0),

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -32,6 +32,13 @@ export const SessionTable = sqliteTable(
       snapshot?: string
       diff?: string
       mode?: "conversation" | "conversation_and_code"
+      points?: {
+        messageID: string
+        partID?: string
+        mode: "conversation" | "conversation_and_code"
+        snapshot?: string
+      }[]
+      index?: number
     }>(),
     permission: text({ mode: "json" }).$type<PermissionNext.Ruleset>(),
     ...Timestamps,

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -26,7 +26,13 @@ export const SessionTable = sqliteTable(
     summary_deletions: integer(),
     summary_files: integer(),
     summary_diffs: text({ mode: "json" }).$type<Snapshot.FileDiff[]>(),
-    revert: text({ mode: "json" }).$type<{ messageID: string; partID?: string; snapshot?: string; diff?: string }>(),
+    revert: text({ mode: "json" }).$type<{
+      messageID: string
+      partID?: string
+      snapshot?: string
+      diff?: string
+      mode?: "conversation" | "conversation_and_code"
+    }>(),
     permission: text({ mode: "json" }).$type<PermissionNext.Ruleset>(),
     ...Timestamps,
     time_compacting: integer(),

--- a/packages/opencode/test/session/revert-mode.test.ts
+++ b/packages/opencode/test/session/revert-mode.test.ts
@@ -466,3 +466,163 @@ test("sequential revert keeps prior conversation mode", async () => {
     },
   })
 })
+
+test("redo to prior conversation-only point restores code state", async () => {
+  await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      const sessionID = session.id
+      const file = path.join(tmp.path, "test.txt")
+      await Bun.write(file, "ORIGINAL")
+
+      const user1 = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: user1.id,
+        sessionID,
+        type: "text",
+        text: "first",
+      })
+
+      const ass1: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: user1.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(ass1)
+
+      const hash1 = await Snapshot.track()
+      expect(hash1).toBeTruthy()
+      await Bun.write(file, "STEP1")
+      const patch1 = await Snapshot.patch(hash1!)
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: ass1.id,
+        type: "patch",
+        hash: patch1.hash,
+        files: patch1.files.map((x) => path.relative(tmp.path, x).replaceAll("\\", "/")),
+      })
+
+      const user2 = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: user2.id,
+        sessionID,
+        type: "text",
+        text: "second",
+      })
+
+      const ass2: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: user2.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(ass2)
+
+      const hash2 = await Snapshot.track()
+      expect(hash2).toBeTruthy()
+      await Bun.write(file, "STEP2")
+      const patch2 = await Snapshot.patch(hash2!)
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: ass2.id,
+        type: "patch",
+        hash: patch2.hash,
+        files: patch2.files.map((x) => path.relative(tmp.path, x).replaceAll("\\", "/")),
+      })
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: user2.id,
+        mode: "conversation",
+      })
+      expect(await Bun.file(file).text()).toBe("STEP2")
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: user1.id,
+        mode: "conversation_and_code",
+      })
+      expect(await Bun.file(file).text()).toBe("ORIGINAL")
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: user2.id,
+        mode: "conversation_and_code",
+      })
+
+      expect(await Bun.file(file).text()).toBe("STEP2")
+      expect((await Session.get(sessionID)).revert?.mode).toBe("conversation")
+    },
+  })
+})

--- a/packages/opencode/test/session/revert-mode.test.ts
+++ b/packages/opencode/test/session/revert-mode.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import path from "path"
+import { Session } from "../../src/session"
+import { SessionRevert } from "../../src/session/revert"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Instance } from "../../src/project/instance"
+import { Identifier } from "../../src/id/id"
+import { Snapshot } from "../../src/snapshot"
+import { tmpdir } from "../fixture/fixture"
+
+let cfg: string | undefined
+
+beforeEach(() => {
+  cfg = process.env.OPENCODE_CONFIG_CONTENT
+  process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({ snapshot: true })
+})
+
+afterEach(() => {
+  if (cfg === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = cfg
+})
+
+test("conversation mode reverts messages but keeps files", async () => {
+  await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // Create a session
+      const session = await Session.create({})
+      const sessionID = session.id
+
+      // Create a user message with file modification intent
+      const userMsg = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      // Add text part to user message
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMsg.id,
+        sessionID,
+        type: "text",
+        text: "Modify test.txt",
+      })
+
+      // Create assistant response with patch
+      const assistantMsg: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: userMsg.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(assistantMsg)
+
+      // Create test file
+      const filePath = path.join(tmp.path, "test.txt")
+      const originalContent = "ORIGINAL"
+      await Bun.write(filePath, originalContent)
+
+      // Add patch part to assistant message
+      const patchPart: MessageV2.PatchPart = {
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg.id,
+        type: "patch",
+        hash: "abc123",
+        files: ["test.txt"],
+      }
+      await Session.updatePart(patchPart)
+
+      // Modify file
+      const modifiedContent = "MODIFIED"
+      await Bun.write(filePath, modifiedContent)
+
+      // Verify file is modified
+      expect(await Bun.file(filePath).text()).toBe(modifiedContent)
+
+      // Revert with conversation mode
+      await SessionRevert.revert({
+        sessionID,
+        messageID: assistantMsg.id,
+        mode: "conversation",
+      })
+
+      // Verify file content is unchanged
+      expect(await Bun.file(filePath).text()).toBe(modifiedContent)
+
+      // Verify session.revert.mode is "conversation"
+      const updatedSession = await Session.get(sessionID)
+      expect(updatedSession.revert?.mode).toBe("conversation")
+    },
+  })
+})
+
+test("default revert still reverts conversation and code", async () => {
+  await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      const sessionID = session.id
+
+      const userMsg = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMsg.id,
+        sessionID,
+        type: "text",
+        text: "Modify test.txt",
+      })
+
+      const assistantMsg: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: userMsg.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(assistantMsg)
+
+      const filePath = path.join(tmp.path, "test.txt")
+      const originalContent = "ORIGINAL"
+      await Bun.write(filePath, originalContent)
+
+      const hash = await Snapshot.track()
+      expect(hash).toBeTruthy()
+
+      const modifiedContent = "MODIFIED"
+      await Bun.write(filePath, modifiedContent)
+
+      const patch = await Snapshot.patch(hash!)
+      expect(patch.files.length).toBeGreaterThan(0)
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg.id,
+        type: "patch",
+        hash: patch.hash,
+        files: patch.files.map((x) => path.relative(tmp.path, x).replaceAll("\\", "/")),
+      })
+
+      expect(await Bun.file(filePath).text()).toBe(modifiedContent)
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: userMsg.id,
+      })
+
+      expect(await Bun.file(filePath).text()).toBe(originalContent)
+
+      const updatedSession = await Session.get(sessionID)
+      expect(updatedSession.revert?.mode).toBe("conversation_and_code")
+    },
+  })
+})
+
+test("sequential revert keeps prior conversation mode", async () => {
+  await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      const sessionID = session.id
+
+      const userMsg1 = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMsg1.id,
+        sessionID,
+        type: "text",
+        text: "First message",
+      })
+
+      const assistantMsg1: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: userMsg1.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(assistantMsg1)
+
+      const filePath = path.join(tmp.path, "test.txt")
+      const originalContent = "ORIGINAL"
+      await Bun.write(filePath, originalContent)
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg1.id,
+        type: "text",
+        text: "First response",
+      })
+
+      const userMsg2 = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: Date.now(),
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMsg2.id,
+        sessionID,
+        type: "text",
+        text: "Second message",
+      })
+
+      const assistantMsg2: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: userMsg2.id,
+        time: {
+          created: Date.now(),
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(assistantMsg2)
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg2.id,
+        type: "text",
+        text: "Second response",
+      })
+
+      const snap = await Snapshot.track()
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg2.id,
+        type: "patch",
+        hash: snap ?? "",
+        files: ["test.txt"],
+      })
+
+      const modifiedContent = "MODIFIED"
+      await Bun.write(filePath, modifiedContent)
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: userMsg2.id,
+        mode: "conversation",
+      })
+
+      let updatedSession = await Session.get(sessionID)
+      expect(updatedSession.revert?.mode).toBe("conversation")
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: userMsg1.id,
+      })
+
+      updatedSession = await Session.get(sessionID)
+      expect(updatedSession.revert?.mode).toBe("conversation")
+      expect(await Bun.file(filePath).text()).toBe(modifiedContent)
+    },
+  })
+})

--- a/packages/opencode/test/session/revert-mode.test.ts
+++ b/packages/opencode/test/session/revert-mode.test.ts
@@ -124,6 +124,96 @@ test("conversation mode reverts messages but keeps files", async () => {
   })
 })
 
+test("default revert reverts code when messages share timestamp", async () => {
+  await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      const sessionID = session.id
+      const now = Date.now()
+
+      const userMsg = await Session.updateMessage({
+        id: Identifier.ascending("message"),
+        role: "user",
+        sessionID,
+        agent: "default",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-4",
+        },
+        time: {
+          created: now,
+        },
+      })
+
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMsg.id,
+        sessionID,
+        type: "text",
+        text: "Modify test.txt",
+      })
+
+      const assistantMsg: MessageV2.Assistant = {
+        id: Identifier.ascending("message"),
+        role: "assistant",
+        sessionID,
+        mode: "default",
+        agent: "default",
+        path: {
+          cwd: tmp.path,
+          root: tmp.path,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: "gpt-4",
+        providerID: "openai",
+        parentID: userMsg.id,
+        time: {
+          created: now,
+        },
+        finish: "end_turn",
+      }
+      await Session.updateMessage(assistantMsg)
+
+      const filePath = path.join(tmp.path, "test.txt")
+      await Bun.write(filePath, "ORIGINAL")
+
+      const hash = await Snapshot.track()
+      expect(hash).toBeTruthy()
+
+      await Bun.write(filePath, "MODIFIED")
+
+      const patch = await Snapshot.patch(hash!)
+      expect(patch.files.length).toBeGreaterThan(0)
+      await Session.updatePart({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMsg.id,
+        type: "patch",
+        hash: patch.hash,
+        files: patch.files.map((x) => path.relative(tmp.path, x).replaceAll("\\", "/")),
+      })
+
+      const messages = await Session.messages({ sessionID })
+      expect(messages.map((x) => x.info.id)).toEqual([userMsg.id, assistantMsg.id])
+
+      await SessionRevert.revert({
+        sessionID,
+        messageID: userMsg.id,
+      })
+
+      expect(await Bun.file(filePath).text()).toBe("ORIGINAL")
+    },
+  })
+})
+
 test("default revert still reverts conversation and code", async () => {
   await using tmp = await tmpdir({ git: true, config: { snapshot: true } })
   await Instance.provide({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2122,6 +2122,7 @@ export class Session2 extends HeyApiClient {
       workspace?: string
       messageID?: string
       partID?: string
+      mode?: "conversation" | "conversation_and_code"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2135,6 +2136,7 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "body", key: "messageID" },
             { in: "body", key: "partID" },
+            { in: "body", key: "mode" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -835,6 +835,7 @@ export type Session = {
     partID?: string
     snapshot?: string
     diff?: string
+    mode?: "conversation" | "conversation_and_code"
   }
 }
 
@@ -1699,6 +1700,7 @@ export type GlobalSession = {
     partID?: string
     snapshot?: string
     diff?: string
+    mode?: "conversation" | "conversation_and_code"
   }
   project: ProjectSummary | null
 }
@@ -3660,6 +3662,7 @@ export type SessionRevertData = {
   body?: {
     messageID: string
     partID?: string
+    mode?: "conversation" | "conversation_and_code"
   }
   path: {
     sessionID: string


### PR DESCRIPTION
### Issue for this PR

Closes #7963

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

<img width="588" height="285" alt="image" src="https://github.com/user-attachments/assets/c99df39f-fc61-4354-bd7b-cef49952fbd3" />


I, like probably a few other people, have gotten a bit used to some Claude Code functionality. I appreciate a restore conversation AND NOT code feature. I do love the forking feature, but it's more conveniant than forking a session to me for minor deviations. Therefore, I worked on this PR. Okay, I'll let the AI take over from here :p

Introduces a new `mode` parameter to the revert API that allows users to revert conversation messages without reverting file changes. This provides more flexibility when users want to re-run the LLM's response without losing their manual file edits.

- **New Revert Modes**: Added `mode` parameter to revert API with two options:
  - `\"conversation\"`: Reverts messages only, keeps file changes intact
  - `\"conversation_and_code\"` (default): Reverts both messages and file changes

- **Persistent Mode**: The revert mode persists across sequential reverts, so subsequent reverts maintain the same behavior as the initial revert.

- **UI Updates**:
  - CLI: Split the single \"Revert\" option into \"Revert conversation\" and \"Revert conversation and code\" in the message actions dialog
  - App: Updated keyboard shortcut to pass the current session's revert mode to the revert API

- **Bug Fix**: Added deterministic message ordering by adding secondary sort on `id` to fix flaky revert tests when messages share the same timestamp

### How did you verify your code works?

Added comprehensive tests covering:
- Conversation mode reverts messages but keeps files unchanged
- Default revert still reverts both messages and code
- Sequential reverts maintain the prior conversation mode
- Deterministic message ordering with shared timestamps

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR