### PR TITLE
docs: add nerve-agent to ecosystem agents list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -76,3 +76,4 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+| [nerve-agent](https://github.com/NerveNetwork/nerve-agent)        | Nerve blockchain payment skills and MCP server — receive, pay, swap, and multi-chain PayBox collection for AI Agents |


### PR DESCRIPTION
## Summary

- Adds [NerveNetwork/nerve-agent](https://github.com/NerveNetwork/nerve-agent) to the **Agents** section of the ecosystem page

## What is nerve-agent?

A Nerve blockchain payment framework for AI Agents, providing:

- **OpenCode Agent Skills** (`.opencode/skills/`) — two SKILL.md skills auto-loaded by OpenCode:
  - `nerve-agent-payment` — create Nerve addresses, check balances, pay, swap via NerveSwap
  - `paybox-payment` — multi-chain payment collection (ETH, BSC, Polygon, TRON → USDT on Nerve via PayBox)
- **Nerve RPC MCP server** — read-only Nerve blockchain query tools for AI Agents (publishable via `npx nerve-rpc-mcp`)
- **Payment framework docs** — receiver flow, payer flow, PayBox integration guide

Skills follow the OpenCode SKILL.md spec with `name`, `description`, `license`, `compatibility: opencode`, and `metadata` frontmatter.

## Links

- Repo: https://github.com/NerveNetwork/nerve-agent
- Skills: `.opencode/skills/nerve-agent-payment/` and `.opencode/skills/paybox-payment/`
- Nerve: https://nerve.network