### PR TITLE
docs: add opencode-homeassistant and opencode-terminal-progress to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,6 +49,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-homeassistant](https://github.com/pedropombeiro/opencode-homeassistant)                  | Send agent status to Home Assistant via webhook for smart home automations                         |
+| [opencode-terminal-progress](https://github.com/pedropombeiro/opencode-terminal-progress)          | Show agent progress in terminal tabs (iTerm2, WezTerm, Windows Terminal) via OSC 9;4              |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #16452
Closes #16453

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the opencode-homeassistant and opencode-terminal-progress community plugins to the ecosystem page, including their links and short descriptions.

### How did you verify your code works?

Reviewed the updated ecosystem.mdx entries locally for formatting and correctness (docs-only change). I'm using both plugins in my own setup.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR