### PR TITLE
feat: @-mention for files outside the working directory

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -590,9 +590,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const pinned: AtOption[] = open.map((path) => ({ type: "file", path, display: path, recent: true }))
       if (!query.trim()) return [...agents, ...pinned]
       const paths = await files.searchFilesAndDirectories(query)
+      // Convert absolute home-dir paths to ~/... format so the display matches
+      // what the user typed and client-side fuzzy filtering works correctly.
+      const home = sync.data.path.home
+      const toDisplay = (p: string) => {
+        if (home && (p === home || p.startsWith(home + "/"))) return "~" + p.slice(home.length)
+        return p
+      }
       const fileOptions: AtOption[] = paths
         .filter((path) => !seen.has(path))
-        .map((path) => ({ type: "file", path, display: path }))
+        .map((path) => ({ type: "file", path, display: toDisplay(path) }))
       return [...agents, ...pinned, ...fileOptions]
     },
     key: atKey,

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -118,14 +118,19 @@ export function createPathHelpers(scope: () => string) {
     ) {
       // Slice from original path to preserve native separators
       path = path.slice(root.length)
+      // Strip the separator left over after removing the root prefix.
+      if (path.startsWith("/") || path.startsWith("\\")) {
+        path = path.slice(1)
+      }
     }
+
+    // If the path is still absolute after root stripping, it lives outside the
+    // project subtree. Preserve it as-is so external files keep valid paths.
+    const isAbsolute = path.startsWith("/") || path.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(path)
+    if (isAbsolute) return path
 
     if (path.startsWith("./") || path.startsWith(".\\")) {
       path = path.slice(2)
-    }
-
-    if (path.startsWith("/") || path.startsWith("\\")) {
-      path = path.slice(1)
     }
     return path
   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -1,6 +1,7 @@
 import type { BoxRenderable, TextareaRenderable, KeyEvent, ScrollBoxRenderable } from "@opentui/core"
 import { pathToFileURL } from "bun"
 import fuzzysort from "fuzzysort"
+import os from "os"
 import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
@@ -248,14 +249,22 @@ export function Autocomplete(props: {
         })
 
         const width = props.anchor().width - 4
+        const baseDir = (sync.data.path.directory || process.cwd()).replace(/\/+$/, "")
+        // Convert absolute home-dir paths to ~/... format so the display matches what
+        // the user typed and the secondary fuzzysort pass can find the results.
+        const home = os.homedir()
+        const toDisplay = (p: string) => {
+          if (p === home || p.startsWith(home + "/")) return "~" + p.slice(home.length)
+          return p
+        }
         options.push(
           ...sortedFiles.map((item): AutocompleteOption => {
-            const baseDir = (sync.data.path.directory || process.cwd()).replace(/\/+$/, "")
-            const fullPath = `${baseDir}/${item}`
+            // Use absolute paths from the server as-is; join relative paths with the session directory.
+            const fullPath = item.startsWith("/") ? item.replace(/\/$/, "") || "/" : `${baseDir}/${item}`
             const urlObj = pathToFileURL(fullPath)
-            let filename = item
+            let filename = toDisplay(item)
             if (lineRange && !item.endsWith("/")) {
-              filename = `${item}#${lineRange.startLine}${lineRange.endLine ? `-${lineRange.endLine}` : ""}`
+              filename = `${toDisplay(item)}#${lineRange.startLine}${lineRange.endLine ? `-${lineRange.endLine}` : ""}`
               urlObj.searchParams.set("start", String(lineRange.startLine))
               if (lineRange.endLine !== undefined) {
                 urlObj.searchParams.set("end", String(lineRange.endLine))

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -5,8 +5,10 @@ import { AppFileSystem } from "@/filesystem"
 import { Git } from "@/git"
 import { Effect, Layer, ServiceMap } from "effect"
 import { formatPatch, structuredPatch } from "diff"
+import fs from "fs"
 import fuzzysort from "fuzzysort"
 import ignore from "ignore"
+import os from "os"
 import path from "path"
 import z from "zod"
 import { Global } from "../global"
@@ -15,6 +17,35 @@ import { Filesystem } from "../util/filesystem"
 import { Log } from "../util/log"
 import { Protected } from "./protected"
 import { Ripgrep } from "./ripgrep"
+
+async function searchAbsolute(input: { query: string; limit: number; kind: "file" | "directory" | "all" }) {
+  const { query, limit, kind } = input
+  const trailingSlash = query.endsWith("/") || query.endsWith(path.sep)
+  const dirPath = trailingSlash ? query.replace(/[/\\]+$/, "") || "/" : path.dirname(query)
+  const base = trailingSlash ? "" : path.basename(query)
+
+  let entries: fs.Dirent[]
+  try {
+    entries = await fs.promises.readdir(dirPath, { withFileTypes: true })
+  } catch {
+    return []
+  }
+
+  const filtered = entries.filter((d) => {
+    if (kind === "file") return !d.isDirectory()
+    if (kind === "directory") return d.isDirectory()
+    return true
+  })
+
+  const toFullPath = (d: fs.Dirent) => path.join(dirPath, d.name) + (d.isDirectory() ? "/" : "")
+
+  if (!base) return filtered.map(toFullPath).slice(0, limit)
+
+  const names = filtered.map((d) => d.name)
+  const byName = new Map(filtered.map((d) => [d.name, d]))
+  const sorted = fuzzysort.go(base, names, { limit })
+  return sorted.map((r) => toFullPath(byName.get(r.target)!))
+}
 
 export namespace File {
   export const Info = z
@@ -629,13 +660,20 @@ export namespace File {
         dirs?: boolean
         type?: "file" | "directory"
       }) {
-        yield* ensure()
-        const { cache } = yield* InstanceState.get(state)
-
         const query = input.query.trim()
         const limit = input.limit ?? 100
         const kind = input.type ?? (input.dirs === false ? "file" : "all")
         log.info("search", { query, kind })
+
+        // Expand ~ to the home directory, then delegate to filesystem search for absolute paths.
+        const expanded =
+          query === "~" ? os.homedir() + "/" : query.startsWith("~/") ? os.homedir() + query.slice(1) : query
+        if (path.isAbsolute(expanded)) {
+          return yield* Effect.promise(() => searchAbsolute({ query: expanded, limit, kind }))
+        }
+
+        yield* ensure()
+        const { cache } = yield* InstanceState.get(state)
 
         const preferHidden = query.startsWith(".") || query.includes("/.")
 

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -130,9 +130,9 @@ export namespace Ripgrep {
   const state = lazy(async () => {
     const system = which("rg")
     if (system) {
-      const stat = await fs.stat(system).catch(() => undefined)
-      if (stat?.isFile()) return { filepath: system }
-      log.warn("bun.which returned invalid rg path", { filepath: system })
+      const check = await Process.run([system, "--version"], { nothrow: true })
+      if (check.code === 0) return { filepath: system }
+      log.warn("system rg not executable", { filepath: system })
     }
     const filepath = path.join(Global.Path.bin, "rg" + (process.platform === "win32" ? ".exe" : ""))
 


### PR DESCRIPTION
### Issue for this PR

Closes #16463

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for referencing files outside the working directory via `@`-mention. Previously, typing `~/` or an absolute path after `@` returned no results, as file search was scoped exclusively to the project directory.

The file search backend now handles `~` expansion and absolute paths by listing directory contents directly rather than searching the project tree. Display names are normalized to `~/...` form in both the web app and TUI autocomplete so client-side fuzzy filtering matches what the user typed.

Also fixes a bug in `relativePath` where paths outside the project root had their leading `/` unconditionally stripped, corrupting them (e.g. `/home/user/file.txt` became `home/user/file.txt`).

### How did you verify your code works?

I manually built and tested the feature. See screenshots below.

### Screenshots / recordings

Before, trying to `@`-mention in home dir:
<img width="985" height="315" alt="opencode_mention_home_dir_without_fix" src="https://github.com/user-attachments/assets/560dc684-ce0f-47d1-977d-cd166ccdfc6c" />

After, trying to `@`-mention in home dir:
<img width="982" height="308" alt="opencode_mention_home_dir" src="https://github.com/user-attachments/assets/624f3446-4c4c-42ad-bb45-e8f12fd9ec63" />

After, trying to `@`-mention in root dir:
<img width="968" height="433" alt="opencode_mention_root_dir" src="https://github.com/user-attachments/assets/20a1b9c9-4b60-413d-aa1a-b7e710c691fb" />

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
