### PR TITLE
fix(storybook): restore build by mocking useLocation

### DIFF
--- a/packages/storybook/.storybook/mocks/solid-router.tsx
+++ b/packages/storybook/.storybook/mocks/solid-router.tsx
@@ -11,6 +11,14 @@ export function useNavigate() {
   return () => undefined
 }
 
+export function useLocation() {
+  return {
+    pathname: "/story/session/story-session",
+    search: "",
+    hash: "",
+  }
+}
+
 export function MemoryRouter(props: ParentProps) {
   return props.children
 }


### PR DESCRIPTION
### Issue for this PR

Closes #16471

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes storybook build by adding a `useLocation()` mock.

### How did you verify your code works?

Ran `bun run --cwd packages/storybook build`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

