### PR TITLE
fix(app): text-shimmer undefined length

### DIFF
--- a/packages/ui/src/components/text-shimmer.tsx
+++ b/packages/ui/src/components/text-shimmer.tsx
@@ -8,6 +8,7 @@ export const TextShimmer = <T extends ValidComponent = "span">(props: {
   active?: boolean
   offset?: number
 }) => {
+  const text = createMemo(() => props.text ?? "")
   const active = createMemo(() => props.active ?? true)
   const offset = createMemo(() => props.offset ?? 0)
   const [run, setRun] = createSignal(active())
@@ -36,17 +37,14 @@ export const TextShimmer = <T extends ValidComponent = "span">(props: {
     clearTimeout(timer)
   })
 
-  const shimmerSize = createMemo(() => {
-    const len = Math.max(props.text.length, 1)
-    return Math.max(300, Math.round(200 + 1400 / len))
-  })
+  const len = createMemo(() => Math.max(text().length, 1))
+  const shimmerSize = createMemo(() => Math.max(300, Math.round(200 + 1400 / len())))
 
   // duration = len × (size - 1) / velocity → uniform perceived sweep speed
   const VELOCITY = 0.01375 // ch per ms, ~10% faster than original 0.0125 baseline
   const shimmerDuration = createMemo(() => {
-    const len = Math.max(props.text.length, 1)
     const s = shimmerSize() / 100
-    return Math.max(1000, Math.min(2500, Math.round((len * (s - 1)) / VELOCITY)))
+    return Math.max(1000, Math.min(2500, Math.round((len() * (s - 1)) / VELOCITY)))
   })
 
   return (
@@ -55,7 +53,7 @@ export const TextShimmer = <T extends ValidComponent = "span">(props: {
       data-component="text-shimmer"
       data-active={active() ? "true" : "false"}
       class={props.class}
-      aria-label={props.text}
+      aria-label={text()}
       style={{
         "--text-shimmer-swap": `${swap}ms`,
         "--text-shimmer-index": `${offset()}`,
@@ -65,10 +63,10 @@ export const TextShimmer = <T extends ValidComponent = "span">(props: {
     >
       <span data-slot="text-shimmer-char">
         <span data-slot="text-shimmer-char-base" aria-hidden="true">
-          {props.text}
+          {text()}
         </span>
         <span data-slot="text-shimmer-char-shimmer" data-run={run() ? "true" : "false"} aria-hidden="true">
-          {props.text}
+          {text()}
         </span>
       </span>
     </Dynamic>


### PR DESCRIPTION
### Issue for this PR

Closes #16473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix below 500 error in desktop, 100% by Codex.app GPT 5.4

```log
TypeError: Cannot read properties of undefined (reading 'length')
    at Object.fn (http://localhost:3000/@fs/Users/guochunzhong/git/oss/opencode/packages/ui/src/components/text-shimmer.tsx:41:37)
    at runComputation (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:734:22)
    at updateComputation (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:717:3)
    at Object.readSignal (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:650:67)
    at get style (http://localhost:3000/@fs/Users/guochunzhong/git/oss/opencode/packages/ui/src/components/text-shimmer.tsx:64:39)
    at assign (http://localhost:3000/node_modules/.vite/deps/chunk-5C2DUIQJ.js?v=a409caaf:759:24)
    at Object.fn (http://localhost:3000/node_modules/.vite/deps/chunk-5C2DUIQJ.js?v=a409caaf:725:28)
    at runComputation (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:734:22)
    at updateComputation (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:717:3)
    at createRenderEffect (http://localhost:3000/node_modules/.vite/deps/chunk-VL2SL2GY.js?v=a409caaf:236:8)
```

### How did you verify your code works?

It works in my machine.([TM](https://worksonmymachine.ai))

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
