### PR TITLE
fix(ui): guard TextShimmer against undefined text prop

### DIFF
--- a/packages/ui/src/components/text-shimmer.tsx
+++ b/packages/ui/src/components/text-shimmer.tsx
@@ -37,14 +37,14 @@ export const TextShimmer = <T extends ValidComponent = "span">(props: {
   })
 
   const shimmerSize = createMemo(() => {
-    const len = Math.max(props.text.length, 1)
+    const len = Math.max(props.text?.length ?? 0, 1)
     return Math.max(300, Math.round(200 + 1400 / len))
   })
 
   // duration = len × (size - 1) / velocity → uniform perceived sweep speed
   const VELOCITY = 0.01375 // ch per ms, ~10% faster than original 0.0125 baseline
   const shimmerDuration = createMemo(() => {
-    const len = Math.max(props.text.length, 1)
+    const len = Math.max(props.text?.length ?? 0, 1)
     const s = shimmerSize() / 100
     return Math.max(1000, Math.min(2500, Math.round((len * (s - 1)) / VELOCITY)))
   })


### PR DESCRIPTION
### Issue for this PR

Closes #16473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `opencode web` opens in the browser, `props.text` is `undefined` during the initial reactive evaluation in `TextShimmer` — before upstream signals (e.g. i18n) resolve. The `shimmerSize` and `shimmerDuration` memos access `props.text.length` without a null guard, throwing a `TypeError`.

Fixed by adding optional chaining with a nullish coalescing fallback:

```diff
- const len = Math.max(props.text.length, 1)
+ const len = Math.max(props.text?.length ?? 0, 1)
```

### How did you verify your code works?

Ran `opencode web`, confirmed the `TypeError` no longer occurs on initial page load.

### Screenshots / recordings

_N/A — runtime error fix, no visual change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR