### PR TITLE
fix(app): guard session-header current() against undefined when options is empty

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -303,7 +303,12 @@ export function SessionHeader() {
   })
 
   const canOpen = createMemo(() => platform.platform === "desktop" && !!platform.openPath && server.isLocal())
-  const current = createMemo(() => options().find((o) => o.id === prefs.app) ?? options()[0])
+  const current = createMemo(
+    () =>
+      options().find((o) => o.id === prefs.app) ??
+      options()[0] ??
+      ({ id: "finder", label: fileManager().label, icon: fileManager().icon } as const),
+  )
   const opening = createMemo(() => openRequest.app !== undefined)
 
   const selectApp = (app: OpenApp) => {


### PR DESCRIPTION
### Issue for this PR

Closes #16459
Closes #16467

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session-header.tsx` has a `current` memo that can return `undefined`:

```typescript
const current = createMemo(() => options().find((o) => o.id === prefs.app) ?? options()[0])
```

`options()` is temporarily empty during two scenarios:
1. **Startup** — before `platform.checkAppExists` resolves for each installed app
2. **Project switching** — race condition between cleanup and re-render

When `options()` is empty, `options()[0]` is `undefined`, so `current()` is `undefined`. The component then accesses `current().id`, `current().label`, and `current().icon` without a null check, throwing `TypeError: Cannot read properties of undefined (reading 'id')` and crashing the entire UI with the "Something went wrong" screen.

The fix adds a third fallback using `fileManager()` (which is always defined) so `current()` is never `undefined`:

```typescript
const current = createMemo(
  () =>
    options().find((o) => o.id === prefs.app) ??
    options()[0] ??
    ({ id: "finder", label: fileManager().label, icon: fileManager().icon } as const),
)
```

This is the same pattern as PR #16475 / #16476 which fix the structurally identical crash in `TextShimmer` (issue #16473).

### How did you verify your code works?

- Traced the crash stack trace from #16459 to `session-header.tsx` line 306
- Confirmed `options()` can be empty during startup and project switching by reading the `createEffect` that populates `exists` asynchronously (lines 269–290)
- LSP diagnostics show no type errors after the change
- The fallback object matches the shape of `fileManager()` return value, so all downstream `.id`, `.label`, `.icon` accesses remain valid

### Screenshots / recordings

No visual change — this only prevents a crash, the UI behavior when `options()` is non-empty is identical.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR