### PR TITLE
fix(project): use cwd instead of "/" when .git is not found

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -198,8 +198,8 @@ export namespace Project {
 
       return {
         id: "global",
-        worktree: "/",
-        sandbox: "/",
+        worktree: directory,
+        sandbox: directory,
         vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
       }
     })


### PR DESCRIPTION
When no .git directory exists in the directory tree, the project worktree and sandbox were hardcoded to "/", causing the web UI to show the root filesystem as the working directory. Now falls back to the actual working directory instead.

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When running opencode in a directory without a `.git` folder, `Project.fromDirectory()` traverses up the directory tree looking for `.git`. If none is found, the fallback sets `worktree` and `sandbox` to `"/"` (root filesystem).

This causes the web UI to display `/` as the working directory, which is incorrect. The fix changes the fallback to use the original `directory` parameter (the actual CWD) instead of `"/"`.

Changed file: `packages/opencode/src/project/project.ts` line 199-204

```diff
- worktree: "/",
- sandbox: "/",
+ worktree: directory,
+ sandbox: directory,
```

### How did you verify your code works?

Ran opencode in a directory without `.git` and confirmed the web UI shows the correct CWD instead of `/`.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
