### PR TITLE
fix: preserve model metadata when overriding id in config

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -842,7 +842,7 @@ export namespace Provider {
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-        const existingModel = parsed.models[model.id ?? modelID]
+        const existingModel = parsed.models[modelID] ?? parsed.models[model.id ?? modelID]
         const name = iife(() => {
           if (model.name) return model.name
           if (model.id && model.id !== modelID) return modelID

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2279,3 +2279,40 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
     },
   })
 })
+
+test("model id override inherits cost and limits from models.dev", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "amazon-bedrock": {
+              models: {
+                "deepseek.v3-v1:0": {
+                  id: "deepseek.v3-correct-id",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("AWS_ACCESS_KEY_ID", "test-key")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers["amazon-bedrock"]?.models["deepseek.v3-v1:0"]
+      expect(model).toBeDefined()
+      expect(model!.api.id).toBe("deepseek.v3-correct-id")
+      // cost and limits must be inherited from models.dev, not zeroed out
+      expect(model!.cost.input).toBe(0.58)
+      expect(model!.limit.context).toBe(163840)
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14361

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes an issue where model metadata (like `cost` and `limits`) was not being preserved when a user overrides a model's `id` in their configuration.

**Problem**: When a user overrides a model's `id` in config (e.g., renaming `deepseek.v3-v1:0` to `deepseek.v3-correct-id`), the system was not correctly finding the original model to inherit metadata from.

**Solution**: Updated model lookup logic to check for both the config key and the model's `id` property, ensuring metadata inheritance works correctly.

**Changes**:
- Updated provider logic to handle ID overrides properly
- Added comprehensive test for Amazon Bedrock models to verify cost and limits are preserved after ID override

### How did you verify your code works?

- Manual testing with various provider configurations
- Added unit test covering the specific case
- Verified no breaking changes were introduced

### Screenshots / recordings

_Not applicable - this is a backend fix_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
