### PR TITLE
fix(ci): skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   close-stale-prs:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   close-non-compliant:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     steps:
       - name: Close non-compliant issues and PRs after 2 hours

--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   daily-recap:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   pr-recap:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   stale:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Scheduled workflows (cron-triggered) run on forks, wasting CI minutes and generating noisy email notifications for fork owners. This adds a `if: github.repository == 'anomalyco/opencode'` guard to 6 scheduled workflows that were missing it:

- `beta.yml` (hourly)
- `close-stale-prs.yml` (daily)
- `compliance-close.yml` (every 30 min)
- `daily-issues-recap.yml` (daily)
- `daily-pr-recap.yml` (daily)
- `stale-issues.yml` (daily)

Also fixes `docs-update.yml` which had an incorrect repo reference (`sst/opencode` → `anomalyco/opencode`). `stats.yml` already had the correct guard.

### How did you verify your code works?

Verified the YAML syntax is correct and the `if` condition is placed at the job level. This is the standard GitHub Actions pattern to prevent scheduled workflows from running on forks.

### Screenshots / recordings

_N/A - CI config change only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR