### PR TITLE
feat(opencode): add GPT-5.4 fast mode to opencode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2962,7 +2962,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,5 +1,17 @@
 import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg } from "@opentui/core"
-import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
+import {
+  createEffect,
+  createMemo,
+  type JSX,
+  onMount,
+  createSignal,
+  onCleanup,
+  on,
+  Show,
+  Switch,
+  Match,
+  For,
+} from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
 import { Filesystem } from "@/util/filesystem"
@@ -164,6 +176,10 @@ export function Prompt(props: PromptProps) {
         local.agent.set(msg.agent)
         if (msg.model) local.model.set(msg.model)
         if (msg.variant) local.model.variant.set(msg.variant)
+        const activeControls = new Set([...(msg.controls ?? []), ...(msg.fast ? ["fast"] : [])])
+        for (const control of local.model.control.list()) {
+          local.model.control.set(control.id, activeControls.has(control.id))
+        }
       }
     }
   })
@@ -239,6 +255,24 @@ export function Prompt(props: PromptProps) {
             })
             setStore("interrupt", 0)
           }
+          dialog.clear()
+        },
+      },
+      {
+        title: local.model.control.enabled("fast") ? "Disable fast mode" : "Enable fast mode",
+        value: "prompt.fast.toggle",
+        category: "Agent",
+        enabled: local.model.control.supported("fast"),
+        slash: {
+          name: "fast",
+        },
+        onSelect: (dialog) => {
+          if (!local.model.control.toggle("fast")) return
+          toast.show({
+            variant: "info",
+            message: local.model.control.enabled("fast") ? "Fast mode enabled" : "Fast mode disabled",
+            duration: 2000,
+          })
           dialog.clear()
         },
       },
@@ -539,6 +573,17 @@ export function Prompt(props: PromptProps) {
       promptModelWarning()
       return
     }
+    if (store.mode === "normal" && trimmed.split(/\s+/, 1)[0] === "/fast") {
+      if (local.model.control.toggle("fast")) {
+        toast.show({
+          variant: "info",
+          message: local.model.control.enabled("fast") ? "Fast mode enabled" : "Fast mode disabled",
+          duration: 2000,
+        })
+      }
+      clearPrompt()
+      return
+    }
     const sessionID = props.sessionID
       ? props.sessionID
       : await (async () => {
@@ -570,6 +615,8 @@ export function Prompt(props: PromptProps) {
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()
+    const controls = local.model.control.current()
+    const fast = controls.includes("fast")
 
     if (store.mode === "shell") {
       sdk.client.session.shell({
@@ -605,6 +652,8 @@ export function Prompt(props: PromptProps) {
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,
         variant,
+        controls,
+        fast,
         parts: nonTextParts
           .filter((x) => x.type === "file")
           .map((x) => ({
@@ -621,6 +670,8 @@ export function Prompt(props: PromptProps) {
           agent: local.agent.current().name,
           model: selectedModel,
           variant,
+          controls,
+          fast,
           parts: [
             {
               id: Identifier.ascending("part"),
@@ -639,12 +690,7 @@ export function Prompt(props: PromptProps) {
       ...store.prompt,
       mode: currentMode,
     })
-    input.extmarks.clear()
-    setStore("prompt", {
-      input: "",
-      parts: [],
-    })
-    setStore("extmarkToPartIndex", new Map())
+    clearPrompt()
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent
@@ -655,6 +701,14 @@ export function Prompt(props: PromptProps) {
           sessionID,
         })
       }, 50)
+  }
+  function clearPrompt() {
+    input.extmarks.clear()
+    setStore("prompt", {
+      input: "",
+      parts: [],
+    })
+    setStore("extmarkToPartIndex", new Map())
     input.clear()
   }
   const exit = useExit()
@@ -748,6 +802,7 @@ export function Prompt(props: PromptProps) {
     const current = local.model.variant.current()
     return !!current
   })
+  const activeControls = createMemo(() => local.model.control.active())
 
   const placeholderText = createMemo(() => {
     if (props.sessionID) return undefined
@@ -1012,6 +1067,16 @@ export function Prompt(props: PromptProps) {
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
                   </Show>
+                  <For each={activeControls()}>
+                    {(control) => (
+                      <>
+                        <text fg={theme.textMuted}>·</text>
+                        <text>
+                          <span style={{ fg: theme.warning, bold: true }}>{control.label}</span>
+                        </text>
+                      </>
+                    )}
+                  </For>
                 </box>
               </Show>
             </box>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -112,12 +112,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           modelID: string
         }[]
         variant: Record<string, string | undefined>
+        controls: Record<string, string[] | undefined>
       }>({
         ready: false,
         model: {},
         recent: [],
         favorite: [],
         variant: {},
+        controls: {},
       })
 
       const filePath = path.join(Global.Path.state, "model.json")
@@ -135,6 +137,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           recent: modelStore.recent,
           favorite: modelStore.favorite,
           variant: modelStore.variant,
+          controls: modelStore.controls,
         })
       }
 
@@ -143,6 +146,21 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (Array.isArray(x.recent)) setModelStore("recent", x.recent)
           if (Array.isArray(x.favorite)) setModelStore("favorite", x.favorite)
           if (typeof x.variant === "object" && x.variant !== null) setModelStore("variant", x.variant)
+          const controls: Record<string, string[]> = {}
+          if (typeof x.controls === "object" && x.controls !== null) {
+            for (const [key, value] of Object.entries(x.controls)) {
+              if (!Array.isArray(value)) continue
+              const ids = [...new Set(value.filter((item): item is string => typeof item === "string"))]
+              if (ids.length > 0) controls[key] = ids
+            }
+          }
+          if (typeof x.fast === "object" && x.fast !== null) {
+            for (const [key, value] of Object.entries(x.fast)) {
+              if (!value) continue
+              controls[key] = [...new Set([...(controls[key] ?? []), "fast"])]
+            }
+          }
+          if (Object.keys(controls).length > 0) setModelStore("controls", controls)
         })
         .catch(() => {})
         .finally(() => {
@@ -200,6 +218,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           ) ?? undefined
         )
       })
+
+      function modelKey(model: { providerID: string; modelID: string }) {
+        return `${model.providerID}/${model.modelID}`
+      }
+
+      function currentModelInfo() {
+        const value = currentModel()
+        if (!value) return
+        const provider = sync.data.provider.find((x) => x.id === value.providerID)
+        return provider?.models[value.modelID]
+      }
 
       return {
         current: currentModel,
@@ -324,22 +353,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           current() {
             const m = currentModel()
             if (!m) return undefined
-            const key = `${m.providerID}/${m.modelID}`
-            return modelStore.variant[key]
+            return modelStore.variant[modelKey(m)]
           },
           list() {
-            const m = currentModel()
-            if (!m) return []
-            const provider = sync.data.provider.find((x) => x.id === m.providerID)
-            const info = provider?.models[m.modelID]
+            const info = currentModelInfo()
             if (!info?.variants) return []
             return Object.keys(info.variants)
           },
           set(value: string | undefined) {
             const m = currentModel()
             if (!m) return
-            const key = `${m.providerID}/${m.modelID}`
-            setModelStore("variant", key, value)
+            setModelStore("variant", modelKey(m), value)
             save()
           },
           cycle() {
@@ -356,6 +380,58 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               return
             }
             this.set(variants[index + 1])
+          },
+        },
+        control: {
+          current() {
+            const m = currentModel()
+            if (!m) return []
+            return modelStore.controls[modelKey(m)] ?? []
+          },
+          list() {
+            const info = currentModelInfo()
+            if (!info?.controls) return []
+            return Object.entries(info.controls).map(([id, control]) => ({
+              id,
+              label: control.label ?? id,
+            }))
+          },
+          active() {
+            const ids = this.current()
+            const info = currentModelInfo()
+            return ids.flatMap((id) => {
+              const control = info?.controls?.[id]
+              if (!control) return []
+              return [{ id, label: control.label ?? id }]
+            })
+          },
+          enabled(id: string) {
+            return this.current().includes(id)
+          },
+          supported(id: string) {
+            return this.list().some((control) => control.id === id)
+          },
+          set(id: string, value: boolean | undefined) {
+            const m = currentModel()
+            if (!m) return false
+            const info = currentModelInfo()
+            if (value && !info?.controls?.[id]) {
+              toast.show({
+                message: `${id} is not supported for ${m.providerID}/${m.modelID}`,
+                variant: "warning",
+                duration: 3000,
+              })
+              return false
+            }
+            const next = new Set(this.current())
+            if (value) next.add(id)
+            else next.delete(id)
+            setModelStore("controls", modelKey(m), next.size > 0 ? [...next] : undefined)
+            save()
+            return true
+          },
+          toggle(id: string) {
+            return this.set(id, !this.enabled(id))
           },
         },
       }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -948,6 +948,15 @@ export namespace Config {
               )
               .optional()
               .describe("Variant-specific configuration"),
+            controls: z
+              .record(
+                z.string(),
+                ModelsDev.Control.extend({
+                  disabled: z.boolean().optional().describe("Disable this control for the model"),
+                }),
+              )
+              .optional()
+              .describe("Control-specific configuration"),
           }),
         )
         .optional(),

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -15,6 +15,13 @@ export namespace ModelsDev {
   const log = Log.create({ service: "models.dev" })
   const filepath = path.join(Global.Path.cache, "models.json")
 
+  export const Control = z
+    .object({
+      label: z.string().optional(),
+      options: z.record(z.string(), z.any()).optional(),
+    })
+    .catchall(z.any())
+
   export const Model = z.object({
     id: z.string(),
     name: z.string(),
@@ -67,6 +74,7 @@ export namespace ModelsDev {
     headers: z.record(z.string(), z.string()).optional(),
     provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
     variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+    controls: z.record(z.string(), Control).optional(),
   })
   export type Model = z.infer<typeof Model>
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -612,6 +612,11 @@ export namespace Provider {
     },
   }
 
+  export const Control = ModelsDev.Control.meta({
+    ref: "ModelControl",
+  })
+  export type Control = z.infer<typeof Control>
+
   export const Model = z
     .object({
       id: z.string(),
@@ -677,6 +682,7 @@ export namespace Provider {
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),
       variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+      controls: z.record(z.string(), Control).optional(),
     })
     .meta({
       ref: "Model",
@@ -758,9 +764,11 @@ export namespace Provider {
       },
       release_date: model.release_date,
       variants: {},
+      controls: {},
     }
 
     m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
+    m.controls = mapValues(mergeDeep(ProviderTransform.controls(m), model.controls ?? {}), (v) => v)
 
     return m
   }
@@ -901,10 +909,16 @@ export namespace Provider {
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
           variants: {},
+          controls: {},
         }
         const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
         parsedModel.variants = mapValues(
           pickBy(merged, (v) => !v.disabled),
+          (v) => omit(v, ["disabled"]),
+        )
+        const mergedControls = mergeDeep(ProviderTransform.controls(parsedModel), model.controls ?? {})
+        parsedModel.controls = mapValues(
+          pickBy(mergedControls, (v) => !v.disabled),
           (v) => omit(v, ["disabled"]),
         )
         parsed.models[modelID] = parsedModel
@@ -1028,12 +1042,22 @@ export namespace Provider {
           delete provider.models[modelID]
 
         model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
+        model.controls = mapValues(ProviderTransform.controls(model), (v) => v)
 
         // Filter out disabled variants from config
         const configVariants = configProvider?.models?.[modelID]?.variants
         if (configVariants && model.variants) {
           const merged = mergeDeep(model.variants, configVariants)
           model.variants = mapValues(
+            pickBy(merged, (v) => !v.disabled),
+            (v) => omit(v, ["disabled"]),
+          )
+        }
+
+        const configControls = configProvider?.models?.[modelID]?.controls
+        if (configControls && model.controls) {
+          const merged = mergeDeep(model.controls, configControls)
+          model.controls = mapValues(
             pickBy(merged, (v) => !v.disabled),
             (v) => omit(v, ["disabled"]),
           )

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -30,6 +30,7 @@ import type { OpenAIResponsesIncludeOptions, OpenAIResponsesIncludeValue } from 
 import { prepareResponsesTools } from "./openai-responses-prepare-tools"
 import type { OpenAIResponsesModelId } from "./openai-responses-settings"
 import { localShellInputSchema } from "./tool/local-shell"
+import { ProviderTransform } from "@/provider/transform"
 
 const webSearchCallItem = z.object({
   type: z.literal("web_search_call"),
@@ -1633,16 +1634,8 @@ type ResponsesModelConfig = {
 }
 
 function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
-  const supportsFlexProcessing =
-    modelId.startsWith("o3") ||
-    modelId.startsWith("o4-mini") ||
-    (modelId.startsWith("gpt-5") && !modelId.startsWith("gpt-5-chat"))
-  const supportsPriorityProcessing =
-    modelId.startsWith("gpt-4") ||
-    modelId.startsWith("gpt-5-mini") ||
-    (modelId.startsWith("gpt-5") && !modelId.startsWith("gpt-5-nano") && !modelId.startsWith("gpt-5-chat")) ||
-    modelId.startsWith("o3") ||
-    modelId.startsWith("o4-mini")
+  const supportsFlexProcessing = ProviderTransform.supportsOpenAIFlexProcessing(modelId)
+  const supportsPriorityProcessing = ProviderTransform.supportsOpenAIPriorityProcessing(modelId)
   const defaults = {
     requiredAutoTruncation: false,
     systemMessageMode: "system" as const,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -329,6 +329,45 @@ export namespace ProviderTransform {
   const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
   const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
+  export function supportsOpenAIFlexProcessing(modelID: string) {
+    const id = modelID.toLowerCase()
+    return id.startsWith("o3") || id.startsWith("o4-mini") || (id.startsWith("gpt-5") && !id.startsWith("gpt-5-chat"))
+  }
+
+  export function supportsOpenAIPriorityProcessing(modelID: string) {
+    const id = modelID.toLowerCase()
+    return (
+      id.startsWith("gpt-4") ||
+      id.startsWith("gpt-5-mini") ||
+      (id.startsWith("gpt-5") && !id.startsWith("gpt-5-nano") && !id.startsWith("gpt-5-chat")) ||
+      id.startsWith("o3") ||
+      id.startsWith("o4-mini")
+    )
+  }
+
+  export function controls(model: Provider.Model): Record<string, Provider.Control> {
+    const id = (model.api.id ?? model.id).toLowerCase()
+    if (model.providerID === "openai" && supportsOpenAIPriorityProcessing(id)) {
+      return {
+        fast: {
+          label: "fast",
+          options: {
+            serviceTier: "priority",
+          },
+        },
+      }
+    }
+    return {}
+  }
+
+  export function controlOptions(model: Provider.Model, controls: string[]) {
+    return controls.reduce<Record<string, any>>((acc, controlID) => {
+      const control = model.controls?.[controlID]
+      if (!control?.options) return acc
+      return mergeDeep(acc, control.options)
+    }, {})
+  }
+
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities.reasoning) return {}
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -140,6 +140,8 @@ export namespace SessionCompaction {
       mode: "compaction",
       agent: "compaction",
       variant: userMessage.variant,
+      controls: MessageV2.controlIDs(userMessage),
+      fast: MessageV2.hasControl(userMessage, "fast") ? true : undefined,
       summary: true,
       path: {
         cwd: Instance.directory,
@@ -246,6 +248,8 @@ When constructing the summary, try to stick to this template:
           tools: original.tools,
           system: original.system,
           variant: original.variant,
+          controls: MessageV2.controlIDs(original),
+          fast: MessageV2.hasControl(original, "fast") ? true : undefined,
         })
         for (const part of replay.parts) {
           if (part.type === "compaction") continue
@@ -268,6 +272,8 @@ When constructing the summary, try to stick to this template:
           time: { created: Date.now() },
           agent: userMessage.agent,
           model: userMessage.model,
+          controls: MessageV2.controlIDs(userMessage),
+          fast: MessageV2.hasControl(userMessage, "fast") ? true : undefined,
         })
         const text =
           (input.overflow

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -11,12 +11,12 @@ import {
   tool,
   jsonSchema,
 } from "ai"
-import { mergeDeep, pipe } from "remeda"
+import { mergeDeep } from "remeda"
 import { ProviderTransform } from "@/provider/transform"
 import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
 import type { Agent } from "@/agent/agent"
-import type { MessageV2 } from "./message-v2"
+import { MessageV2 } from "./message-v2"
 import { Plugin } from "@/plugin"
 import { SystemPrompt } from "./system"
 import { Flag } from "@/flag/flag"
@@ -101,11 +101,12 @@ export namespace LLM {
           sessionID: input.sessionID,
           providerOptions: provider.options,
         })
-    const options: Record<string, any> = pipe(
-      base,
-      mergeDeep(input.model.options),
-      mergeDeep(input.agent.options),
-      mergeDeep(variant),
+    const options: Record<string, any> = mergeDeep(base, input.model.options) as Record<string, any>
+    Object.assign(options, mergeDeep(options, input.agent.options))
+    Object.assign(options, mergeDeep(options, variant))
+    Object.assign(
+      options,
+      mergeDeep(options, ProviderTransform.controlOptions(input.model, MessageV2.controlIDs(input.user))),
     )
     if (isCodex) {
       options.instructions = SystemPrompt.instructions()

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -368,6 +368,8 @@ export namespace MessageV2 {
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
+    controls: z.array(z.string()).optional(),
+    fast: z.boolean().optional(),
   }).meta({
     ref: "UserMessage",
   })
@@ -436,6 +438,8 @@ export namespace MessageV2 {
     }),
     structured: z.any().optional(),
     variant: z.string().optional(),
+    controls: z.array(z.string()).optional(),
+    fast: z.boolean().optional(),
     finish: z.string().optional(),
   }).meta({
     ref: "AssistantMessage",
@@ -446,6 +450,16 @@ export namespace MessageV2 {
     ref: "Message",
   })
   export type Info = z.infer<typeof Info>
+
+  export function controlIDs(message: { controls?: string[]; fast?: boolean } | undefined) {
+    const result = new Set(message?.controls ?? [])
+    if (message?.fast) result.add("fast")
+    return [...result]
+  }
+
+  export function hasControl(message: { controls?: string[]; fast?: boolean } | undefined, controlID: string) {
+    return controlIDs(message).includes(controlID)
+  }
 
   export const Event = {
     Updated: BusEvent.define(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -108,6 +108,8 @@ export namespace SessionPrompt {
     format: MessageV2.Format.optional(),
     system: z.string().optional(),
     variant: z.string().optional(),
+    controls: z.array(z.string()).optional(),
+    fast: z.boolean().optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -360,6 +362,8 @@ export namespace SessionPrompt {
           mode: task.agent,
           agent: task.agent,
           variant: lastUser.variant,
+          controls: MessageV2.controlIDs(lastUser),
+          fast: MessageV2.hasControl(lastUser, "fast") ? true : undefined,
           path: {
             cwd: Instance.directory,
             root: Instance.worktree,
@@ -572,6 +576,8 @@ export namespace SessionPrompt {
           mode: agent.name,
           agent: agent.name,
           variant: lastUser.variant,
+          controls: MessageV2.controlIDs(lastUser),
+          fast: MessageV2.hasControl(lastUser, "fast") ? true : undefined,
           path: {
             cwd: Instance.directory,
             root: Instance.worktree,
@@ -962,6 +968,7 @@ export namespace SessionPrompt {
         ? await Provider.getModel(model.providerID, model.modelID).catch(() => undefined)
         : undefined
     const variant = input.variant ?? (agent.variant && full?.variants?.[agent.variant] ? agent.variant : undefined)
+    const controls = MessageV2.controlIDs(input)
 
     const info: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
@@ -976,6 +983,8 @@ export namespace SessionPrompt {
       system: input.system,
       format: input.format,
       variant,
+      controls: controls.length > 0 ? controls : undefined,
+      fast: controls.includes("fast") ? true : undefined,
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
 
@@ -1302,6 +1311,8 @@ export namespace SessionPrompt {
         model: input.model,
         messageID: input.messageID,
         variant: input.variant,
+        controls: controls.length > 0 ? controls : undefined,
+        fast: controls.includes("fast") ? true : input.fast,
       },
       {
         message: info,
@@ -1718,6 +1729,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     arguments: z.string(),
     command: z.string(),
     variant: z.string().optional(),
+    controls: z.array(z.string()).optional(),
+    fast: z.boolean().optional(),
     parts: z
       .array(
         z.discriminatedUnion("type", [
@@ -1875,6 +1888,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agent: userAgent,
       parts,
       variant: input.variant,
+      controls: input.controls,
+      fast: input.fast,
     })) as MessageV2.WithParts
 
     Bus.publish(Command.Event.Executed, {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -443,6 +443,121 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("sends priority service tier when fast mode is enabled", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("openai", "gpt-5.2")
+    const model = source.model
+
+    const responseChunks = [
+      {
+        type: "response.created",
+        response: {
+          id: "resp-fast",
+          created_at: Math.floor(Date.now() / 1000),
+          model: model.id,
+          service_tier: "priority",
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-fast",
+        delta: "Hello",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: "priority",
+        },
+      },
+    ]
+    const request = waitRequest("/responses", createEventResponse(responseChunks, true))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["openai"],
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel("openai", model.id)
+        const sessionID = "session-fast"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.2,
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-fast",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: "openai", modelID: resolved.id },
+          variant: "high",
+          controls: ["fast"],
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+
+        expect(body.service_tier).toBe("priority")
+        expect((body.reasoning as { effort?: string } | undefined)?.effort).toBe("high")
+      },
+    })
+  })
+
   test("sends messages API payload for Anthropic models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -209,3 +209,37 @@ describe("session.prompt agent variant", () => {
     }
   })
 })
+
+describe("session.prompt fast mode", () => {
+  test("normalizes fast mode into user message controls", async () => {
+    const prev = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = "test-openai-key"
+
+    try {
+      await using tmp = await tmpdir({ git: true })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+
+          const message = await SessionPrompt.prompt({
+            sessionID: session.id,
+            model: { providerID: "openai", modelID: "gpt-5.2" },
+            noReply: true,
+            fast: true,
+            parts: [{ type: "text", text: "hello" }],
+          })
+          if (message.info.role !== "user") throw new Error("expected user message")
+          expect(message.info.controls).toEqual(["fast"])
+          expect(message.info.fast).toBe(true)
+
+          await Session.remove(session.id)
+        },
+      })
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_API_KEY
+      else process.env.OPENAI_API_KEY = prev
+    }
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -162,6 +162,8 @@ export interface Hooks {
       model?: { providerID: string; modelID: string }
       messageID?: string
       variant?: string
+      controls?: string[]
+      fast?: boolean
     },
     output: { message: UserMessage; parts: Part[] },
   ) => Promise<void>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1837,6 +1837,8 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      controls?: Array<string>
+      fast?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -1857,6 +1859,8 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
+            { in: "body", key: "controls" },
+            { in: "body", key: "fast" },
             { in: "body", key: "parts" },
           ],
         },
@@ -1969,6 +1973,8 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
+      controls?: Array<string>
+      fast?: boolean
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
@@ -1989,6 +1995,8 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "format" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
+            { in: "body", key: "controls" },
+            { in: "body", key: "fast" },
             { in: "body", key: "parts" },
           ],
         },
@@ -2022,6 +2030,8 @@ export class Session2 extends HeyApiClient {
       arguments?: string
       command?: string
       variant?: string
+      controls?: Array<string>
+      fast?: boolean
       parts?: Array<{
         id?: string
         type: "file"
@@ -2047,6 +2057,8 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "arguments" },
             { in: "body", key: "command" },
             { in: "body", key: "variant" },
+            { in: "body", key: "controls" },
+            { in: "body", key: "fast" },
             { in: "body", key: "parts" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -138,6 +138,8 @@ export type UserMessage = {
     [key: string]: boolean
   }
   variant?: string
+  controls?: Array<string>
+  fast?: boolean
 }
 
 export type ProviderAuthError = {
@@ -240,6 +242,8 @@ export type AssistantMessage = {
   }
   structured?: unknown
   variant?: string
+  controls?: Array<string>
+  fast?: boolean
   finish?: string
 }
 
@@ -1206,6 +1210,29 @@ export type ProviderConfig = {
           [key: string]: unknown | boolean | undefined
         }
       }
+      /**
+       * Control-specific configuration
+       */
+      controls?: {
+        [key: string]: {
+          label?: string
+          options?: {
+            [key: string]: unknown
+          }
+          /**
+           * Disable this control for the model
+           */
+          disabled?: boolean
+          [key: string]:
+            | unknown
+            | string
+            | {
+                [key: string]: unknown
+              }
+            | boolean
+            | undefined
+        }
+      }
     }
   }
   whitelist?: Array<string>
@@ -1536,6 +1563,20 @@ export type NotFoundError = {
   }
 }
 
+export type ModelControl = {
+  label?: string
+  options?: {
+    [key: string]: unknown
+  }
+  [key: string]:
+    | unknown
+    | string
+    | {
+        [key: string]: unknown
+      }
+    | undefined
+}
+
 export type Model = {
   id: string
   providerID: string
@@ -1604,6 +1645,9 @@ export type Model = {
     [key: string]: {
       [key: string]: unknown
     }
+  }
+  controls?: {
+    [key: string]: ModelControl
   }
 }
 
@@ -3287,6 +3331,8 @@ export type SessionPromptData = {
     format?: OutputFormat
     system?: string
     variant?: string
+    controls?: Array<string>
+    fast?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -3520,6 +3566,8 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
+    controls?: Array<string>
+    fast?: boolean
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
   }
   path: {
@@ -3565,6 +3613,8 @@ export type SessionCommandData = {
     arguments: string
     command: string
     variant?: string
+    controls?: Array<string>
+    fast?: boolean
     parts?: Array<{
       id?: string
       type: "file"
@@ -3984,6 +4034,21 @@ export type ProviderListResponses = {
           variants?: {
             [key: string]: {
               [key: string]: unknown
+            }
+          }
+          controls?: {
+            [key: string]: {
+              label?: string
+              options?: {
+                [key: string]: unknown
+              }
+              [key: string]:
+                | unknown
+                | string
+                | {
+                    [key: string]: unknown
+                  }
+                | undefined
             }
           }
         }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3005,6 +3005,15 @@
                   "variant": {
                     "type": "string"
                   },
+                  "controls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "fast": {
+                    "type": "boolean"
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3489,6 +3498,15 @@
                   "variant": {
                     "type": "string"
                   },
+                  "controls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "fast": {
+                    "type": "boolean"
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3620,6 +3638,15 @@
                   },
                   "variant": {
                     "type": "string"
+                  },
+                  "controls": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "fast": {
+                    "type": "boolean"
                   },
                   "parts": {
                     "type": "array",
@@ -4569,6 +4596,28 @@
                                     "type": "object",
                                     "propertyNames": {
                                       "type": "string"
+                                    },
+                                    "additionalProperties": {}
+                                  }
+                                },
+                                "controls": {
+                                  "type": "object",
+                                  "propertyNames": {
+                                    "type": "string"
+                                  },
+                                  "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "options": {
+                                        "type": "object",
+                                        "propertyNames": {
+                                          "type": "string"
+                                        },
+                                        "additionalProperties": {}
+                                      }
                                     },
                                     "additionalProperties": {}
                                   }
@@ -7259,6 +7308,15 @@
           },
           "variant": {
             "type": "string"
+          },
+          "controls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "fast": {
+            "type": "boolean"
           }
         },
         "required": ["id", "sessionID", "role", "time", "agent", "model"]
@@ -7543,6 +7601,15 @@
           "structured": {},
           "variant": {
             "type": "string"
+          },
+          "controls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "fast": {
+            "type": "boolean"
           },
           "finish": {
             "type": "string"
@@ -10060,6 +10127,33 @@
                     },
                     "additionalProperties": {}
                   }
+                },
+                "controls": {
+                  "description": "Control-specific configuration",
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {}
+                      },
+                      "disabled": {
+                        "description": "Disable this control for the model",
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": {}
+                  }
                 }
               }
             }
@@ -10744,6 +10838,22 @@
         },
         "required": ["name", "data"]
       },
+      "ModelControl": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "options": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          }
+        },
+        "additionalProperties": {}
+      },
       "Model": {
         "type": "object",
         "properties": {
@@ -10948,6 +11058,15 @@
                 "type": "string"
               },
               "additionalProperties": {}
+            }
+          },
+          "controls": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ModelControl"
             }
           }
         },


### PR DESCRIPTION
### Issue for this PR

Closes #16499

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds GPT-5.4 fast mode (`/fast`) to opencode.

- `/fast` toggles fast mode
- the prompt status line shows `fast` when enabled
- supported models send the fast-mode request option

Internally, fast mode is represented as model-level `controls` instead of ad hoc handling. This keeps support checks, UI state, and request behavior in sync, and gives future fast-capable models a consistent integration path.

### How did you verify your code works?

- ran `./script/generate.ts`
- ran `bun typecheck`
- ran the tests affected by this change, including the updated `packages/opencode` prompt/session coverage and package-level test runs for the touched areas
- manually verified `/fast` toggles the status-line indicator

### Screenshots / recordings

https://github.com/user-attachments/assets/6848540f-a716-4f51-a2fe-d658bcbcc1fb

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
