### PR TITLE
feat(config): add disabled_plugins support for per-project plugin filtering

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -66,6 +66,9 @@ export namespace Config {
     if (target.plugin && source.plugin) {
       merged.plugin = Array.from(new Set([...target.plugin, ...source.plugin]))
     }
+    if (target.disabled_plugins && source.disabled_plugins) {
+      merged.disabled_plugins = Array.from(new Set([...target.disabled_plugins, ...source.disabled_plugins]))
+    }
     if (target.instructions && source.instructions) {
       merged.instructions = Array.from(new Set([...target.instructions, ...source.instructions]))
     }
@@ -232,6 +235,11 @@ export namespace Config {
     }
 
     result.plugin = deduplicatePlugins(result.plugin ?? [])
+
+    const disabled = result.disabled_plugins ?? []
+    if (disabled.length) {
+      result.plugin = result.plugin.filter((p) => !disabled.includes(getPluginName(p)))
+    }
 
     return {
       config: result,
@@ -1016,6 +1024,10 @@ export namespace Config {
           "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
         ),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
+      disabled_plugins: z
+        .array(z.string())
+        .optional()
+        .describe("Disable plugins by name. Matches against the canonical plugin name (e.g. 'oh-my-opencode')"),
       enabled_providers: z
         .array(z.string())
         .optional()

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1994,3 +1994,107 @@ describe("OPENCODE_CONFIG_CONTENT token substitution", () => {
     }
   })
 })
+
+describe("disabled_plugins", () => {
+  test("filters out disabled plugins by name", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await writeConfig(dir, {
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["my-plugin@1.0.0", "other-plugin@2.0.0"],
+          disabled_plugins: ["my-plugin"],
+        })
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        expect(plugins.some((p) => p.includes("my-plugin"))).toBe(false)
+        expect(plugins.some((p) => p.includes("other-plugin"))).toBe(true)
+      },
+    })
+  })
+
+  test("project disabled_plugins overrides global plugin", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const projectDir = path.join(dir, "project")
+        const opencodeDir = path.join(projectDir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        await writeConfig(dir, {
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["global-plugin@1.0.0", "keep-plugin@1.0.0"],
+        })
+
+        await writeConfig(opencodeDir, {
+          $schema: "https://opencode.ai/config.json",
+          disabled_plugins: ["global-plugin"],
+        })
+      },
+    })
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: async () => {
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        expect(plugins.some((p) => p.includes("global-plugin"))).toBe(false)
+        expect(plugins.some((p) => p.includes("keep-plugin"))).toBe(true)
+      },
+    })
+  })
+
+  test("disabled_plugins matches scoped packages", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await writeConfig(dir, {
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["@scope/my-plugin@1.0.0", "plain-plugin@1.0.0"],
+          disabled_plugins: ["@scope/my-plugin"],
+        })
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        expect(plugins.some((p) => p.includes("@scope/my-plugin"))).toBe(false)
+        expect(plugins.some((p) => p.includes("plain-plugin"))).toBe(true)
+      },
+    })
+  })
+
+  test("disabled_plugins merges across config levels", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const projectDir = path.join(dir, "project")
+        const opencodeDir = path.join(projectDir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        await writeConfig(dir, {
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["plugin-a@1.0.0", "plugin-b@1.0.0", "plugin-c@1.0.0"],
+          disabled_plugins: ["plugin-a"],
+        })
+
+        await writeConfig(opencodeDir, {
+          $schema: "https://opencode.ai/config.json",
+          disabled_plugins: ["plugin-b"],
+        })
+      },
+    })
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: async () => {
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        expect(plugins.some((p) => p.includes("plugin-a"))).toBe(false)
+        expect(plugins.some((p) => p.includes("plugin-b"))).toBe(false)
+        expect(plugins.some((p) => p.includes("plugin-c"))).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

N/A (new feature, no existing issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `disabled_plugins` config field that lets users disable specific plugins by name per-project. Follows the same pattern as the existing `disabled_providers` — accepts an array of canonical plugin names matched via `getPluginName()` (supports `npm-pkg@version`, `@scope/pkg@version`, `file://` URLs). The field merges across config levels through `mergeConfigConcatArrays`, so both global and project-level disabling work together.

Example usage in `opencode.json`:

```json
{
  "disabled_plugins": ["oh-my-opencode"]
}
```

Changes:

- `packages/opencode/src/config/config.ts`: Added `disabled_plugins` to `mergeConfigConcatArrays`, added the field to `Info` schema, added filtering logic after `deduplicatePlugins()`.
- `packages/opencode/test/config/config.test.ts`: Added 4 test cases covering basic filtering, project-level override, scoped package matching, and cross-level merging.

### How did you verify your code works?

Ran the 4 new test cases in `packages/opencode/test/config/config.test.ts` — all pass. Also manually verified by adding `disabled_plugins` to a local `opencode.json` and confirming the specified plugin was excluded from the loaded plugin list.

### Screenshots / recordings

_N/A (no UI changes)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
