### PR TITLE
feat: add config reload command to restart MCP servers without restart

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -7,7 +7,7 @@ import { Installation } from "@/installation"
 import { Global } from "@/global"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
-import { SyncProvider } from "@tui/context/sync"
+import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel } from "@tui/component/dialog-model"
 import { DialogStatus } from "@tui/component/dialog-status"
@@ -171,7 +171,9 @@ function App() {
   const local = useLocal()
   const kv = useKV()
   const command = useCommandDialog()
-  const { event } = useSDK()
+  const sdk = useSDK()
+  const { event } = sdk
+  const sync = useSync()
   const toast = useToast()
   const { theme, mode, setMode } = useTheme()
   const exit = useExit()
@@ -290,6 +292,59 @@ function App() {
         dialog.replace(() => <DialogHelp />)
       },
       category: "System",
+    },
+    {
+      title: "Reload config (opencode.json)",
+      value: "config.reload",
+      category: "System",
+      onSelect: async () => {
+        dialog.clear()
+        toast.show({
+          variant: "info",
+          message: "Reloading config...",
+          duration: 2000,
+        })
+        try {
+          // Call the reload endpoint directly since SDK may not have it yet
+          const baseUrl = sdk.baseUrl
+          const directory = encodeURIComponent(process.cwd())
+          const response = await fetch(`${baseUrl}/config/reload?directory=${directory}`, {
+            method: "POST",
+          })
+          const result = await response.json()
+          
+          if (result.success) {
+            // Refresh sync data after config reload
+            const [providers, agents, config, mcpStatus] = await Promise.all([
+              sdk.client.config.providers(),
+              sdk.client.app.agents(),
+              sdk.client.config.get(),
+              sdk.client.mcp.status(),
+            ])
+            sync.set("provider", providers.data!.providers)
+            sync.set("agent", agents.data ?? [])
+            sync.set("config", config.data!)
+            sync.set("mcp", mcpStatus.data!)
+            toast.show({
+              variant: "success",
+              message: result.message || "Config reloaded successfully",
+              duration: 3000,
+            })
+          } else {
+            toast.show({
+              variant: "error",
+              message: result.message || "Failed to reload config",
+              duration: 5000,
+            })
+          }
+        } catch (error) {
+          toast.show({
+            variant: "error",
+            message: `Reload failed: ${error instanceof Error ? error.message : String(error)}`,
+            duration: 5000,
+          })
+        }
+      },
     },
     {
       title: "Exit the app",

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -32,6 +32,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       abort.abort()
     })
 
-    return { client: sdk, event: emitter }
+    return { client: sdk, event: emitter, baseUrl: props.url }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -22,6 +22,7 @@ export const TuiEvent = {
           "prompt.clear",
           "prompt.submit",
           "agent.cycle",
+          "config.reload",
         ]),
         z.string(),
       ]),
@@ -34,6 +35,13 @@ export const TuiEvent = {
       message: z.string(),
       variant: z.enum(["info", "success", "warning", "error"]),
       duration: z.number().default(5000).optional().describe("Duration in milliseconds"),
+    }),
+  ),
+  ConfigReloaded: Bus.event(
+    "tui.config.reloaded",
+    z.object({
+      success: z.boolean(),
+      message: z.string().optional(),
     }),
   ),
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -192,6 +192,52 @@ export namespace Server {
           return c.json(config)
         },
       )
+      .post(
+        "/config/reload",
+        describeRoute({
+          description: "Reload config from disk (including MCP servers)",
+          operationId: "config.reload",
+          responses: {
+            200: {
+              description: "Config reloaded successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      success: z.boolean(),
+                      message: z.string().optional(),
+                      config: Config.Info.optional(),
+                    }).meta({ ref: "ConfigReloadResult" })
+                  ),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        async (c) => {
+          try {
+            // Dispose current instance state (clears config cache, MCP connections, etc.)
+            await Instance.dispose()
+            // Re-fetch config (will re-read opencode.json and restart MCP servers)
+            const config = await Config.get()
+            // Trigger MCP reconnection by accessing MCP status
+            const mcpStatus = await MCP.status()
+            log.info("config reloaded", { mcpServers: Object.keys(mcpStatus).length })
+            return c.json({
+              success: true,
+              message: `Config reloaded. ${Object.keys(mcpStatus).length} MCP server(s) configured.`,
+              config,
+            })
+          } catch (error) {
+            log.error("config reload failed", { error })
+            return c.json({
+              success: false,
+              message: error instanceof Error ? error.message : String(error),
+            })
+          }
+        },
+      )
       .get(
         "/experimental/tool/ids",
         describeRoute({


### PR DESCRIPTION

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Add POST /config/reload server endpoint that disposes cached state and re-reads opencode.json
- Add 'Reload config (opencode.json)' command to TUI command palette (Ctrl+P)
- Expose baseUrl from SDK context for direct API calls
- Add config.reload command type and ConfigReloaded event

This allows users to modify opencode.json (e.g., add/change MCP servers) and reload the configuration without restarting opencode entirely.


### How did you verify your code works?
made a local project opencode.json file, and started the TUI, modified the opencode.json, ran the config.reload command, then the effect of the file change was observed.

### Screenshots / recordings

_If this is a UI change, please include a screenshot 
or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
