### PR TITLE
feat(ecosystem): add opencode-qwen-auth to plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,6 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
+| [opencode-qwen-auth](https://github.com/bad-noodles/opencode-qwen-auth)                            | Authenticate with Qwen via OAuth and use the generous Qwen Code free tier                        |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Adds [opencode-qwen-auth](https://github.com/bad-noodles/opencode-qwen-auth) to the ecosystem plugins list.

This plugin authenticates with Qwen via OAuth, letting users use the generous Qwen Code free tier directly from OpenCode — no setup beyond a free account at qwen.ai.

### How did you verify your code works?

### Screenshots / recordings

<img width="549" height="220" alt="Screenshot 2026-03-07 at 18 36 54" src="https://github.com/user-attachments/assets/0f4c9b2d-af41-414f-bb4d-28efeb523b5b" />
<img width="344" height="242" alt="Screenshot 2026-03-07 at 18 37 13" src="https://github.com/user-attachments/assets/d7cef990-14e8-4695-a45c-984497a77fb0" />
<img width="669" height="373" alt="Screenshot 2026-03-07 at 18 37 51" src="https://github.com/user-attachments/assets/8eedab02-a40f-4312-b04e-df611c928acc" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._