### PR TITLE
feat(config): add support for config.d fragments

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -33,6 +33,7 @@ import { ConfigParse } from "./parse"
 import { ConfigPaths } from "./paths"
 import { ConfigPlugin } from "./plugin"
 import { ConfigVariable } from "./variable"
+import { Glob } from "@opencode-ai/shared/util/glob"
 import { Npm } from "@opencode-ai/core/npm"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 
@@ -243,6 +244,19 @@ export const layer = Layer.effect(
       return yield* loadConfig(text, { path: filepath }, env)
     })
 
+    const loadConfigDir = Effect.fnUntraced(function* (dir: string) {
+      const cfg = path.join(dir, "config.d")
+      if (!existsSync(cfg)) return [] as string[]
+      return (
+        yield* Effect.promise(() =>
+          Glob.scan("*.{json,jsonc}", {
+            cwd: cfg,
+            absolute: true,
+          }),
+        )
+      ).sort()
+    })
+
     const loadGlobal = Effect.fnUntraced(function* (env?: Record<string, string>) {
       let result: Info = {}
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
@@ -396,6 +410,9 @@ export const layer = Layer.effect(
 
         const global = Object.keys(authEnv).length ? yield* loadGlobal(authEnv) : yield* getGlobal()
         yield* merge(Global.Path.config, global, "global")
+        for (const file of yield* loadConfigDir(Global.Path.config)) {
+          yield* merge(file, yield* loadFile(file, authEnv), "global")
+        }
 
         if (Flag.OPENCODE_CONFIG) {
           yield* merge(Flag.OPENCODE_CONFIG, yield* loadFile(Flag.OPENCODE_CONFIG, authEnv))
@@ -426,6 +443,12 @@ export const layer = Layer.effect(
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)
               yield* merge(source, yield* loadFile(source, authEnv))
+              result.agent ??= {}
+              result.mode ??= {}
+              result.plugin ??= []
+            }
+            for (const file of yield* loadConfigDir(dir)) {
+              yield* merge(file, yield* loadFile(file, authEnv))
               result.agent ??= {}
               result.mode ??= {}
               result.plugin ??= []

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -33,8 +33,8 @@ import { ConfigParse } from "./parse"
 import { ConfigPaths } from "./paths"
 import { ConfigPlugin } from "./plugin"
 import { ConfigVariable } from "./variable"
-import { Glob } from "@opencode-ai/shared/util/glob"
 import { Npm } from "@opencode-ai/core/npm"
+import { Glob } from "@opencode-ai/core/util/glob"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 
 // Custom merge function that concatenates array fields instead of replacing them

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -166,6 +166,9 @@ async function writeConfig(dir: string, config: object, name = "opencode.json") 
 const writeConfigEffect = (dir: string, config: object, name = "opencode.json") =>
   FSUtil.use.writeWithDirs(path.join(dir, name), JSON.stringify(config))
 
+const writeFragmentEffect = (dir: string, name: string, config: object | string) =>
+  FSUtil.use.writeWithDirs(path.join(dir, "config.d", name), typeof config === "string" ? config : JSON.stringify(config))
+
 const withInstanceDir = <A, E, R>(dir: string, effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
     Effect.provideService(TestInstance, { directory: dir }),
@@ -536,6 +539,142 @@ it.instance("preserves env variables when adding $schema to config", () =>
       expect(content).toContain("$schema")
     }),
   ),
+)
+
+it.effect("loads global config.d fragments after main config", () =>
+  withGlobalConfig({ config: { model: "test/base", username: "base-user" } }, ({ dir }) =>
+    Effect.gen(function* () {
+      yield* writeFragmentEffect(dir, "10-user.jsonc", {
+        username: "fragment-user",
+        permission: {
+          bash: {
+            "git status *": "allow",
+          },
+        },
+      })
+      const project = yield* tmpdirScoped()
+      const config = yield* withInstanceDir(project, Config.use.get())
+
+      expect(config.model).toBe("test/base")
+      expect(config.username).toBe("fragment-user")
+      expect(config.permission?.bash).toEqual({
+        "git status *": "allow",
+      })
+    }),
+  ),
+)
+
+it.effect("loads .opencode config.d fragments in alphabetical order", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const cfg = path.join(dir, ".opencode")
+    yield* writeConfigEffect(
+      cfg,
+      {
+        $schema: "https://opencode.ai/config.json",
+        username: "main-user",
+        permission: {
+          bash: {
+            "git status *": "allow",
+            "git diff *": "allow",
+            "npm test *": "ask",
+            "docker inspect *": "deny",
+          },
+        },
+        plugin: ["main-plugin"],
+        instructions: ["main.md"],
+      },
+      "opencode.json",
+    )
+    yield* writeFragmentEffect(cfg, "10-base.jsonc", {
+      permission: {
+        bash: {
+          "pytest *": "allow",
+        },
+      },
+      plugin: ["base-plugin"],
+      instructions: ["base.md"],
+    })
+    yield* writeFragmentEffect(cfg, "20-override.json", {
+      username: "fragment-user",
+      permission: {
+        bash: {
+          "npm test *": "allow",
+          "docker inspect *": "ask",
+        },
+      },
+      plugin: ["extra-plugin"],
+      instructions: ["extra.md"],
+    })
+
+    const config = yield* withInstanceDir(dir, Config.use.get())
+    expect(config.username).toBe("fragment-user")
+    expect(config.permission?.bash).toEqual({
+      "git status *": "allow",
+      "git diff *": "allow",
+      "npm test *": "allow",
+      "docker inspect *": "ask",
+      "pytest *": "allow",
+    })
+    expect(config.plugin?.some((item) => item.includes("main-plugin"))).toBe(true)
+    expect(config.plugin?.some((item) => item.includes("base-plugin"))).toBe(true)
+    expect(config.plugin?.some((item) => item.includes("extra-plugin"))).toBe(true)
+    expect(config.instructions).toEqual(["main.md", "base.md", "extra.md"])
+  }),
+)
+
+it.effect("supports env and file substitutions in config.d fragments", () =>
+  withProcessEnv(
+    "TEST_CONFIG_D_VAR",
+    "test-user",
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const cfg = path.join(dir, ".opencode")
+      yield* FSUtil.use.writeWithDirs(path.join(cfg, "config.d", "secret.txt"), "test/model")
+      yield* writeFragmentEffect(
+        cfg,
+        "10-subst.jsonc",
+        `{
+          "$schema": "https://opencode.ai/config.json",
+          "username": "{env:TEST_CONFIG_D_VAR}",
+          "model": "{file:secret.txt}"
+        }`,
+      )
+
+      const config = yield* withInstanceDir(dir, Config.use.get())
+      expect(config.username).toBe("test-user")
+      expect(config.model).toBe("test/model")
+    }),
+  ),
+)
+
+it.effect("throws for invalid config.d fragments", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    yield* writeFragmentEffect(path.join(dir, ".opencode"), "10-bad.json", "{ invalid json }")
+
+    const exit = yield* withInstanceDir(dir, Config.use.get().pipe(Effect.exit))
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)
+
+it.effect("loads config.d fragments from OPENCODE_CONFIG_DIR", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const custom = yield* tmpdirScoped()
+    yield* writeFragmentEffect(custom, "10-user.json", {
+      username: "custom-user",
+    })
+
+    yield* withProcessEnv(
+      "OPENCODE_CONFIG_DIR",
+      custom,
+      Effect.gen(function* () {
+        const config = yield* withInstanceDir(dir, Config.use.get())
+        expect(config.username).toBe("custom-user")
+      }),
+    )
+  }),
 )
 
 it.instance("handles file inclusion substitution", () =>
@@ -1839,6 +1978,22 @@ describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
         const config = yield* Config.use.get()
         expect(config).toBeDefined()
         expect(config.username).toBeDefined()
+      }),
+    ),
+  )
+
+  it.instance("skips project config.d fragments when flag is set", () =>
+    withProcessEnv(
+      "OPENCODE_DISABLE_PROJECT_CONFIG",
+      "true",
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* writeFragmentEffect(path.join(test.directory, ".opencode"), "10-user.json", {
+          username: "project-user",
+        })
+
+        const config = yield* Config.use.get()
+        expect(config.username).not.toBe("project-user")
       }),
     ),
   )

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -45,12 +45,13 @@ Config sources are loaded in this order (later sources override earlier ones):
 
 1. **Remote config** (from `.well-known/opencode`) - organizational defaults
 2. **Global config** (`~/.config/opencode/opencode.json`) - user preferences
-3. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
-4. **Project config** (`opencode.json` in project) - project-specific settings
-5. **`.opencode` directories** - agents, commands, plugins
-6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
-7. **Managed config files** (`/Library/Application Support/opencode/` on macOS) - admin-controlled
-8. **macOS managed preferences** (`.mobileconfig` via MDM) - highest priority, not user-overridable
+3. **Global config fragments** (`~/.config/opencode/config.d/*.json[c]`) - user preference overrides
+4. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
+5. **Project config** (`opencode.json` in project) - project-specific settings
+6. **`.opencode` directories** - agents, commands, plugins, config fragments
+7. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
+8. **Managed config files** (`/Library/Application Support/opencode/` on macOS) - admin-controlled
+9. **macOS managed preferences** (`.mobileconfig` via MDM) - highest priority, not user-overridable
 
 This means project configs can override global defaults, and global configs can override remote organizational defaults. Managed settings override everything.
 
@@ -148,6 +149,45 @@ opencode run "Hello world"
 ```
 
 The custom directory is loaded after the global config and `.opencode` directories, so it **can override** their settings.
+
+---
+
+### Config fragments
+
+You can split config into multiple files by creating a `config.d/` directory next to the main config file.
+
+```bash title="Directory structure"
+~/.config/opencode/
+|-- opencode.jsonc
+`-- config.d/
+    |-- 10-permissions.jsonc
+    `-- 20-overrides.json
+```
+
+Fragments are loaded alphabetically after the main config file in the same directory.
+
+- `~/.config/opencode/config.d/` extends your global config
+- `.opencode/config.d/` extends project-local `.opencode/opencode.json{,c}`
+- `OPENCODE_CONFIG_DIR/config.d/` extends a custom config directory
+
+Fragment files use the normal config schema. Later files override earlier ones for conflicting keys, while `plugin` and `instructions` continue to merge.
+
+```jsonc title=".opencode/config.d/10-permissions.jsonc"
+{
+  "permission": {
+    "bash": {
+      "git status *": "allow",
+      "git diff *": "allow"
+    },
+    "external_directory": {
+      "*": "ask",
+      "~/trusted/*": "allow"
+    }
+  }
+}
+```
+
+Fragment files also support `{env:VAR}` and `{file:path}` substitutions.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #9062
and closes the duplicate, but dangling Pull Request [#9061](https://github.com/anomalyco/opencode/pull/9061)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds support for loading config fragments from `config.d/*.json` and `config.d/*.jsonc`.

Fragments load after the main config file in the same directory and keep the existing merge behavior:
- later fragment files override earlier ones for conflicting keys
- objects still deep-merge
- `plugin` and `instructions` still concat/dedupe

This works for:
- `~/.config/opencode/config.d/`
- `.opencode/config.d/`
- `OPENCODE_CONFIG_DIR/config.d/`

The PR also adds tests for fragment ordering, permission merging, substitutions, invalid fragments, and config flag behavior, plus docs for the new loading order.

### How did you verify your code works?

- Ran `mise x bun@1.3.10 -- bun run typecheck` in `packages/opencode`
- Ran `GIT_AUTHOR_NAME=OpenCode GIT_AUTHOR_EMAIL=opencode@example.com GIT_COMMITTER_NAME=OpenCode GIT_COMMITTER_EMAIL=opencode@example.com mise x bun@1.3.10 -- bun test test/config/config.test.ts` in `packages/opencode`
- The config test file passed for this change; there was one unrelated timeout flake on `installs dependencies in writable OPENCODE_CONFIG_DIR`

### Screenshots / recordings

_Not applicable - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR