### PR TITLE
docs: add lgrep plugin to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                         |
+| [lgrep](https://github.com/Sharper-Flow/lgrep)                                                     | Semantic code search and symbol intelligence via MCP                                              |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring

## What does this PR do?

Adds [lgrep](https://github.com/Sharper-Flow/lgrep) to the ecosystem plugins table. lgrep is an MCP server providing semantic code search and symbol intelligence for OpenCode.

## How did you verify?

- Confirmed link resolves to the correct repository
- Description matches repository README
- Row placement follows existing table ordering

## Screenshots

N/A — documentation change only.

## Checklist

- [x] I've read the [contributing guidelines](https://github.com/anomalyco/opencode/blob/main/CONTRIBUTING.md)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/)