### PR TITLE
fix: resolve TUI blank response when launched from symlinked directory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -95,7 +95,7 @@ const startEventStream = (directory: string) => {
   })
 }
 
-startEventStream(process.cwd())
+startEventStream(process.env.PWD ?? process.cwd())
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {


### PR DESCRIPTION
### Issue for this PR

Closes #16528

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI worker starts its SSE event stream using `process.cwd()` (worker.ts:98), which resolves symlinks to the physical path. The main thread uses `process.env.PWD` (thread.ts:114), which preserves the symlink path. Since `Instance` and `Bus` are keyed by directory string, this creates two separate scopes — events from one never reach the other, so the TUI renders blank.

The fix changes worker.ts:98 from `process.cwd()` to `process.env.PWD ?? process.cwd()`, matching the existing pattern in thread.ts. On Windows where PWD is unset, the fallback preserves current behavior.

### How did you verify your code works?

1. Created a symlink to a git repo: `ln -s /real/path/dotfiles ~/dotfiles`
2. Launched `opencode` from `~/dotfiles` — confirmed blank responses (before fix)
3. Applied fix, launched again — responses render correctly
4. Verified real path still works: `cd /real/path/dotfiles && opencode` — works
5. Verified non-git symlinked dirs still work (no regression)
6. All 1221 existing tests pass

### Screenshots / recordings

#### Bug

https://github.com/user-attachments/assets/9a97bf49-68c3-48cf-a6c5-cfd7a2598cdf

#### Fix

https://github.com/user-attachments/assets/aeaa1af6-3204-4b78-9a78-edf9e7752717

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR