### PR TITLE
fix(install): Add `source` command to instructions after install

### DIFF
--- a/install
+++ b/install
@@ -452,6 +452,15 @@ echo -e ""
 echo -e ""
 echo -e "${MUTED}OpenCode includes free models, to start:${NC}"
 echo -e ""
+if [[ -n "${config_file:-}" && ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+case $current_shell in
+    sh) echo -e ". \"$config_file\"  ${MUTED}# Or open a new terminal${NC}" ;;
+    *)  echo -e "source \"$config_file\"  ${MUTED}# Or open a new terminal${NC}" ;;
+esac
+echo -e ""
+echo -e "${MUTED}then:${NC}"
+echo -e ""
+fi
 echo -e "cd <project>  ${MUTED}# Open directory${NC}"
 echo -e "opencode      ${MUTED}# Run command${NC}"
 echo -e ""


### PR DESCRIPTION
### Issue for this PR

Closes #13764

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After installation, if opencode isn't yet in the current shell's PATH, then show an instruction to `source` this config file.

Tried to add this in a way that fits with current design.

Message is only shown if a config file path was found (e.g., if `--no-modify-path` wasn't set).

If the shell is `sh`, instructions use `.` not `source` as `source` is not posix standard and might not be present depending on what impl of `sh` actually is. Chose to use `source` for other shells as it is present in them and I think `source` is more commonly understood.

Note that #13404 already exists trying to fix this, but it has other extraneous functionality and formatting changes and I thought a more targeted change might be appreciated.

### How did you verify your code works?

Tested locally on mac. Tested via docker with the following setups:

| OS / Shell     | Source command shown                          | Config file                     |
|----------------|-----------------------------------------------|---------------------------------|
| Ubuntu / bash  | `source "/root/.bashrc"`                     | `~/.bashrc`                     |
| Alpine / ash   | `. "/root/.profile"`                         | `~/.profile`                    |
| Debian / sh    | `. "/root/.profile"`                         | `~/.profile`                    |
| Ubuntu / zsh   | `source "/root/.zshrc"`                      | `~/.zshrc`                      |
| Ubuntu / fish  | `source "/root/.config/fish/config.fish"`    | `~/.config/fish/config.fish`    |

### Screenshots / recordings

<img width="3234" height="2092" alt="CleanShot 2026-03-07 at 12 53 15@2x" src="https://github.com/user-attachments/assets/f231c37d-641a-4090-9f6f-9b4ebdc4ae87" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
