### PR TITLE
docs: add local-memory plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -39,6 +39,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
+| [local-memory](https://github.com/jqlong17/local-memory)                                        | Local memory service - stores memories in local PostgreSQL with vector search, 100% private      |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |


### PR DESCRIPTION
## Issue for this PR

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

## What does this PR do?

Add local-memory plugin to the OpenCode ecosystem plugins list. local-memory is a local memory service that stores memories in local SQLite database with in-memory vector search, providing a 100% private and free alternative to cloud-based memory solutions like Supermemory.

**Major Update - v2.0:**
- **Migrated from PostgreSQL to SQLite** - No Docker required anymore!
- **In-memory cosine similarity** for vector search
- **One-click installation** now truly one-click (no Docker dependency)
- Significantly lighter: SQLite base ~10KB vs PostgreSQL ~50MB
- Bilingual documentation: README (Chinese) + README-en.md (English)

**Features:**
- Local-first: All data stored in local SQLite database
- Semantic search with Ollama (nomic-embed-text model)
- **One-click installation script** - run `./install.sh` to auto-install all dependencies
- MCP integration for OpenCode
- E2E tests included

## How did you verify your code works?

- All 9 E2E tests pass
- Installation script validated (checks bun, ollama, etc.)
- API server tested (health check, save, recall, semantic search)

## Screenshots / recordings

N/A - Documentation only change

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR