### PR TITLE
fix(lsp): prevent socket deadlock on large files with incremental sync

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -15,6 +15,35 @@ import { Filesystem } from "../util/filesystem"
 
 const DIAGNOSTICS_DEBOUNCE_MS = 150
 
+function diffContentChanges(oldText: string, newText: string) {
+  const oldLines = oldText.split("\n")
+  const newLines = newText.split("\n")
+
+  let first = 0
+  while (first < oldLines.length && first < newLines.length && oldLines[first] === newLines[first]) first++
+
+  if (first === oldLines.length && first === newLines.length) return []
+
+  let oldEnd = oldLines.length - 1
+  let newEnd = newLines.length - 1
+  while (oldEnd > first && newEnd > first && oldLines[oldEnd] === newLines[newEnd]) {
+    oldEnd--
+    newEnd--
+  }
+
+  const replacement = newLines.slice(first, newEnd + 1).join("\n") + (newEnd + 1 < newLines.length ? "\n" : "")
+
+  return [
+    {
+      range: {
+        start: { line: first, character: 0 },
+        end: { line: oldEnd + 1, character: 0 },
+      },
+      text: replacement,
+    },
+  ]
+}
+
 export namespace LSPClient {
   const log = Log.create({ service: "lsp.client" })
 
@@ -133,7 +162,7 @@ export namespace LSPClient {
     }
 
     const files: {
-      [path: string]: number
+      [path: string]: { version: number; content: string }
     } = {}
 
     const result = {
@@ -151,55 +180,37 @@ export namespace LSPClient {
           const extension = path.extname(input.path)
           const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
 
-          const version = files[input.path]
-          if (version !== undefined) {
-            log.info("workspace/didChangeWatchedFiles", input)
-            await connection.sendNotification("workspace/didChangeWatchedFiles", {
-              changes: [
-                {
-                  uri: pathToFileURL(input.path).href,
-                  type: 2, // Changed
-                },
-              ],
+          const file = files[input.path]
+
+          const notify = (method: string, params: unknown) =>
+            connection.sendNotification(method, params).catch((err) => log.error(method, { err }))
+
+          if (file !== undefined) {
+            notify("workspace/didChangeWatchedFiles", {
+              changes: [{ uri: pathToFileURL(input.path).href, type: 2 }],
             })
 
-            const next = version + 1
-            files[input.path] = next
-            log.info("textDocument/didChange", {
-              path: input.path,
-              version: next,
-            })
-            await connection.sendNotification("textDocument/didChange", {
-              textDocument: {
-                uri: pathToFileURL(input.path).href,
-                version: next,
-              },
-              contentChanges: [{ text }],
+            const next = file.version + 1
+            const contentChanges = diffContentChanges(file.content, text)
+            files[input.path] = { version: next, content: text }
+            log.info("textDocument/didChange", { path: input.path, version: next })
+            notify("textDocument/didChange", {
+              textDocument: { uri: pathToFileURL(input.path).href, version: next },
+              contentChanges,
             })
             return
           }
 
-          log.info("workspace/didChangeWatchedFiles", input)
-          await connection.sendNotification("workspace/didChangeWatchedFiles", {
-            changes: [
-              {
-                uri: pathToFileURL(input.path).href,
-                type: 1, // Created
-              },
-            ],
+          notify("workspace/didChangeWatchedFiles", {
+            changes: [{ uri: pathToFileURL(input.path).href, type: 1 }],
           })
 
           log.info("textDocument/didOpen", input)
           diagnostics.delete(input.path)
-          await connection.sendNotification("textDocument/didOpen", {
-            textDocument: {
-              uri: pathToFileURL(input.path).href,
-              languageId,
-              version: 0,
-              text,
-            },
+          notify("textDocument/didOpen", {
+            textDocument: { uri: pathToFileURL(input.path).href, languageId, version: 0, text },
           })
-          files[input.path] = 0
+          files[input.path] = { version: 0, content: text }
           return
         },
       },


### PR DESCRIPTION
### Issue for this PR

Closes #16115

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Patching large Python files (e.g. server_args.py in sglang, ~255KB) causes opencode to hang indefinitely on "Preparing patch...".

textDocument/didOpen and textDocument/didChange both sent the full file content over a Unix domain socket. At 255KB this overflows the ~213KB kernel socket buffer. When pyright is CPU-saturated on its initial project scan it can't drain the socket fast enough, both sides stall waiting on each other. Deadlock.

Two changes:
1. All LSP notifications are now fire-and-forget. Node.js buffers the write internally and streams to pyright as the socket drains, without blocking opencode.
2. didChange sends a line-level incremental diff instead of the full document, so subsequent patches never re-saturate the buffer.

### How did you verify your code works?
Profiled both the official nightlyand this fix simultaneously using ss -xp to observe Unix socket buffer states.                                     
  
Official nightly on server_args.py inside sglang:                             
Recv-Q: 219,461   -> pyright's buffer, not draining
Send-Q: 224,000   -> opencode blocked on write, pyright at 108% CPU.     
                                                                                
This fix under the same conditions: 
Recv-Q: 561    -> draining normally
Send-Q: 0        ->opencode not blocked 
Two back-to-back patches on server_args.py completed without hanging.  

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
