### PR TITLE
fix(opencode): sort log files before cleanup to avoid deleting newest

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -59,7 +59,7 @@ export namespace Log {
 
   export async function init(options: Options) {
     if (options.level) level = options.level
-    cleanup(Global.Path.log)
+    await cleanup(Global.Path.log)
     if (options.print) return
     logpath = path.join(
       Global.Path.log,
@@ -77,15 +77,15 @@ export namespace Log {
     }
   }
 
-  async function cleanup(dir: string) {
+  export async function cleanup(dir: string) {
     const files = await Glob.scan("????-??-??T??????.log", {
       cwd: dir,
       absolute: true,
       include: "file",
     })
-    if (files.length <= 5) return
+    if (files.length <= 10) return
 
-    const filesToDelete = files.slice(0, -10)
+    const filesToDelete = files.sort().slice(0, -10)
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }
 

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Log } from "../../src/util/log"
+import { Glob } from "../../src/util/glob"
+
+function logname(ts: string) {
+  return `${ts}.log`
+}
+
+async function touch(dir: string, name: string) {
+  await fs.writeFile(path.join(dir, name), "")
+}
+
+describe("log cleanup", () => {
+  test("does nothing when at or below threshold", async () => {
+    await using tmp = await tmpdir()
+    const names = Array.from({ length: 10 }, (_, i) => logname(`2026-01-${String(i + 1).padStart(2, "0")}T000000`))
+    for (const n of names) await touch(tmp.path, n)
+
+    await Log.cleanup(tmp.path)
+
+    expect((await Glob.scan("*.log", { cwd: tmp.path })).sort()).toEqual(names.sort())
+  })
+
+  test("removes oldest files keeping newest 10 (regression: unsorted glob)", async () => {
+    await using tmp = await tmpdir()
+    const names = Array.from({ length: 15 }, (_, i) => logname(`2026-01-${String(i + 1).padStart(2, "0")}T000000`))
+    for (const n of names) await touch(tmp.path, n)
+
+    await Log.cleanup(tmp.path)
+
+    const remaining = (await Glob.scan("*.log", { cwd: tmp.path })).sort()
+    expect(remaining).toEqual(names.sort().slice(5))
+  })
+
+  test("does not delete dev.log", async () => {
+    await using tmp = await tmpdir()
+    for (let i = 1; i <= 12; i++) await touch(tmp.path, logname(`2026-01-${String(i).padStart(2, "0")}T000000`))
+    await touch(tmp.path, "dev.log")
+
+    await Log.cleanup(tmp.path)
+
+    expect(await fs.stat(path.join(tmp.path, "dev.log"))).toBeDefined()
+  })
+
+  test("handles missing log directory gracefully", async () => {
+    await using tmp = await tmpdir()
+    await expect(Log.cleanup(path.join(tmp.path, "does-not-exist"))).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #14731

`cleanup()` in `log.ts` had two bugs that caused it to delete the newest log files instead of the oldest:

1. `Glob.scan` returns files in non-deterministic filesystem order. Without `.sort()`, `slice(0, -10)` could remove the newest files instead of oldest.
2. `cleanup()` was called without `await` in `init()`, racing with new log file creation — the new file could appear in the glob results and get deleted.
3. The guard threshold was `<= 5` but the keep count was 10, making it inconsistent.

**Verified:** ran `bun test test/util/log.test.ts` — 4 pass. Stashed the fix and re-ran — 4 fail (`Log.cleanup is not a function` / wrong files deleted).
