### PR TITLE
fix(app): auto-enable workspaces when opening sandbox

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -57,6 +57,7 @@ import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
 import { useLanguage, type Locale } from "@/context/language"
 import {
+  autoWorkspaces,
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
@@ -543,6 +544,21 @@ export default function Layout(props: ParentProps) {
     if (!root) return
 
     return projects.find((p) => p.worktree === root)
+  })
+
+  createEffect(() => {
+    const project = currentProject()
+    if (!project) return
+    if (project.vcs !== "git") return
+    if (
+      !autoWorkspaces({
+        dir: currentDir(),
+        project,
+      })
+    ) {
+      return
+    }
+    layout.sidebar.setWorkspaces(project.worktree, true)
   })
 
   createEffect(

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -100,3 +100,13 @@ export const effectiveWorkspaceOrder = (local: string, dirs: string[], persisted
 }
 
 export const syncWorkspaceOrder = effectiveWorkspaceOrder
+
+export const autoWorkspaces = (input: {
+  dir?: string
+  project?: { worktree: string; sandboxes?: string[] }
+}) => {
+  if (!input.dir) return false
+  if (!input.project?.sandboxes?.length) return false
+  const dir = workspaceKey(input.dir)
+  return input.project.sandboxes.some((item) => workspaceKey(item) === dir)
+}


### PR DESCRIPTION
## Summary
- auto-enable workspace mode when the active directory belongs to project sandboxes
- keep behavior scoped to git projects and current project context
- exclude test-file changes in this PR

## Why
Opening a linked worktree could look broken because workspace mode stayed off and only the primary workspace remained visible.