### PR TITLE
Fix subagent MCP tool permissions

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { MCP } from "../mcp"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -69,6 +70,8 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           if (found) return found
         }
 
+        const mcpTools = Object.keys(await MCP.tools())
+
         return await Session.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
@@ -97,6 +100,11 @@ export const TaskTool = Tool.define("task", async (ctx) => {
               action: "allow" as const,
               permission: t,
             })) ?? []),
+            ...mcpTools.map((t) => ({
+              pattern: "*",
+              action: "allow" as const,
+              permission: t,
+            })),
           ],
         })
       })
@@ -124,6 +132,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       ctx.abort.addEventListener("abort", cancel)
       using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
+      const mcpTools = Object.keys(await MCP.tools())
 
       const result = await SessionPrompt.prompt({
         messageID,
@@ -138,6 +147,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           todoread: false,
           ...(hasTaskPermission ? {} : { task: false }),
           ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
+          ...Object.fromEntries(mcpTools.map((t) => [t, false])),
         },
         parts: promptParts,
       })


### PR DESCRIPTION
Fixes #16491. Subagents spawned via Task tool can now execute MCP tools. Previously, MCP tools appeared in the subagent tool registry but permission checks failed because they were not granted in the session permission array. This fix retrieves available MCP tools and adds them to the permission array with allow action, and also includes them in the tools object passed to SessionPrompt.prompt().