### PR TITLE
docs: add local-memory to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -15,40 +15,39 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Plugins
 
-| Name                                                                                               | Description                                                                                       |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
-| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                |
-| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
-| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
-| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
-| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
-| [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
-| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
-| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                             |
-| [opencode-vibeguard](https://github.com/inkdust2021/opencode-vibeguard)                            | Redact secrets/PII into VibeGuard-style placeholders before LLM calls; restore locally            |
-| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                   |
-| [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.           |
-| [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
-| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                |
-| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                         |
-| [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
-| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
-| [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
-| [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
-| [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
-| [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
-| [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
-| [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
-| [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |
-| [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |
-| [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                         |
-| [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                             |
-| [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                 |
-| [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
-| [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
-| [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
-| [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| Name                                                                                                      | Description                                                                                       |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [opencode-daytona](https://github.com/jamesmurdza/daytona/blob/main/guides/typescript/opencode/README.md) | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
+| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                         | Automatically inject Helicone session headers for request grouping                                |
+| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                                   | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
+| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)                    | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
+| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                                   | Use your existing Gemini plan instead of API billing                                              |
+| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                       | Use Antigravity's free models instead of API billing                                              |
+| [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                                | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
+| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)          | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
+| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)         | Optimize token usage by pruning obsolete tool outputs                                             |
+| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                        | Add native websearch support for supported providers with Google grounded style                   |
+| [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                              | Enables AI agents to run background processes in a PTY, send interactive input to them.           |
+| [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
+| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Track OpenCode usage with Wakatime                                                                |
+| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
+| [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
+| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
+| [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |
+| [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | Desktop notifications and sound alerts for permission, completion, and error events               |
+| [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |
+| [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
+| [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Persistent memory across sessions using Supermemory                                               |
+| [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)        | Interactive plan review with visual annotation and private/offline sharing                        |
+| [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                                     | Extend opencode /commands into a powerful orchestration system with granular flow control         |
+| [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                                  | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |
+| [micode](https://github.com/vtemian/micode)                                                               | Structured Brainstorm → Plan → Implement workflow with session continuity                         |
+| [octto](https://github.com/vtemian/octto)                                                                 | Interactive browser UI for AI brainstorming with multi-question forms                             |
+| [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)                     | Claude Code-style background agents with async delegation and context persistence                 |
+| [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
+| [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
+| [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [local-memory](https://github.com/jqlong17/local-memory)                                                  | 100% local memory service - SQLite + Ollama, zero cost, full privacy                              |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Documentation

### What does this PR do?

Add local-memory plugin to the OpenCode ecosystem documentation.

local-memory is a 100% local memory service for OpenCode that stores memories in SQLite database with Ollama embeddings, providing zero-cost and full privacy.

### How did you verify your code works?

Verified the markdown link format matches other ecosystem entries.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR