### PR TITLE
fix: convert import.meta.resolve result to file:// URL for plugins

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1247,7 +1247,9 @@ export namespace Config {
         for (let i = 0; i < data.plugin.length; i++) {
           const plugin = data.plugin[i]
           try {
-            data.plugin[i] = import.meta.resolve!(plugin, options.path)
+            const resolved = import.meta.resolve!(plugin, options.path)
+            // Ensure resolved path is a file:// URL for consistent handling
+            data.plugin[i] = resolved.startsWith("file://") ? resolved : pathToFileURL(resolved).href
           } catch (e) {
             try {
               // import.meta.resolve sometimes fails with newly created node_modules


### PR DESCRIPTION
## Summary

On Windows, `import.meta.resolve()` returns a raw filesystem path instead of a `file://` URL. This causes the plugin name extraction logic to fail, displaying the full raw path in the UI.

## How to Test

1. On Windows, add a plugin in `opencode.json`: `"plugin": ["oh-my-opencode@latest"]`
2. Start OpenCode and check the plugin list in `/status` dialog
3. Before fix: Shows raw path like `C:\Users\Username\` or `E:\opencode\`
4. After fix: Shows correct plugin name `oh-my-opencode @latest`

## Test Plan

- [x] Verified fix resolves the issue on Windows
- [x] Code change is minimal and matches existing `require.resolve()` fallback pattern
- [ ] CI tests pass

Fixes #16559