### PR TITLE
fix(opencode): avoid TTY corruption from double cleanup

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -208,7 +208,6 @@ export const TuiThreadCommand = cmd({
             prompt,
             fork: args.fork,
           },
-          onExit: stop,
         })
       } finally {
         await stop()


### PR DESCRIPTION
### Issue for this PR

Closes #16564

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When using `--continue` multiple times and exiting with CTRL+C, the terminal enters an inconsistent state where mouse movements produce escape sequences (e.g. `^[[<35;9734M`). This affects terminal emulators like MinTTY (Git Bash) and PuTTY on Windows.

The root cause was a double cleanup introduced in commit 3ebebe0a: the `tui()` call had both `onExit: stop` as a callback *and* a `finally { await stop() }` block outside it. On CTRL+C, `stop()` was called twice, corrupting the TTY state and leaving mouse tracking active.

Fix: Either set `onExit: undefined` or remote it (I've done so) so the exit callback no longer calls `stop()` on its own. The `finally` block remains as the single cleanup point, ensuring `stop()` is called exactly once — both on normal exit and on errors.

### How did you verify your code works?

Tested manually with multiple `--continue` runs and CTRL+C exits:
- Single run exits cleanly
- Multiple sequential runs produce no stray mouse escape sequences
- Terminal remains in a consistent state after exit
- Verified on MinTTY, PuTTY, and Linux terminals

### Screenshots / recordings

<img width="1159" height="297" alt="image" src="https://github.com/user-attachments/assets/1462c2c2-461d-4269-bce8-17f0ff13056d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR