### PR TITLE
fix: use user temp dir for Windows CLI startup

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -6,8 +6,12 @@ const path = require("path")
 const os = require("os")
 
 function run(target) {
+  const temp =
+    process.platform === "win32" && process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, "Temp") : undefined
+
   const result = childProcess.spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
+    env: temp ? { ...process.env, TMP: temp, TEMP: temp } : process.env,
   })
   if (result.error) {
     console.error(result.error.message)


### PR DESCRIPTION
## Summary
- set `TMP` and `TEMP` to `%LOCALAPPDATA%\Temp` before spawning the Windows binary from `packages/opencode/bin/opencode`
- avoid OpenTUI DLL load failures on Windows where Bun falls back to bad temp extraction paths like `B:/~BUN/root/...`
- keep the fix scoped to the Windows launcher so generated npm wrappers do not need custom patching

## Verification
- reproduced the local Windows failure with `Failed to initialize OpenTUI render library ... error code 126`
- verified that forcing a user-scoped temp directory lets the TUI boot normally
- upstreamed the same fix into the launcher source used by the published package
