### PR TITLE
fix(app): restore wider centered session max-width

### DIFF
--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -140,7 +140,7 @@ export function SessionComposerRegion(props: {
       <div
         classList={{
           "w-full px-3 pointer-events-auto": true,
-          "md:max-w-[500px] md:mx-auto 2xl:max-w-[700px]": props.centered,
+          "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
         }}
       >
         <Show when={props.state.questionRequest()} keyed>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -418,7 +418,7 @@ export function MessageTimeline(props: {
               style={{ "padding-top": "var(--session-title-height)" }}
               classList={{
                 "w-full": true,
-                "md:max-w-[500px] md:mx-auto 2xl:max-w-[700px]": props.centered,
+                "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
                 "mt-0.5": props.centered,
                 "mt-0": !props.centered,
               }}
@@ -473,7 +473,7 @@ export function MessageTimeline(props: {
                       }}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
-                        "md:max-w-[500px] 2xl:max-w-[700px]": props.centered,
+                        "md:max-w-200 2xl:max-w-[1000px]": props.centered,
                       }}
                     >
                       <Show when={commentCount() > 0}>

--- a/packages/app/src/pages/session/session-timeline-header.tsx
+++ b/packages/app/src/pages/session/session-timeline-header.tsx
@@ -404,7 +404,7 @@ export function SessionTimelineHeader(props: {
             "w-full": true,
             "pb-10": true,
             "px-4 md:px-5": true,
-            "md:max-w-[500px] md:mx-auto 2xl:max-w-[700px]": props.centered,
+            "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
           }}
         >
           <div class="pointer-events-auto h-12 w-full flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary
- restore the wider centered-session max-width values used before the recent timeline width regression
- apply the same width rollback to the session header, timeline, and composer so the layout stays aligned

## Testing
- git diff --check

Fixes #16516