### PR TITLE
test: make process cwd check cross-platform

### DIFF
--- a/packages/opencode/test/util/process.test.ts
+++ b/packages/opencode/test/util/process.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Process } from "../../src/util/process"
+import { tmpdir } from "../fixture/fixture"
 
 function node(script: string) {
   return [process.execPath, "-e", script]
@@ -58,10 +59,11 @@ describe("util.process", () => {
   }, 3000)
 
   test("uses cwd when spawning commands", async () => {
+    await using tmp = await tmpdir()
     const out = await Process.run(node("process.stdout.write(process.cwd())"), {
-      cwd: "/tmp",
+      cwd: tmp.path,
     })
-    expect(out.stdout.toString()).toBe("/tmp")
+    expect(out.stdout.toString()).toBe(tmp.path)
   })
 
   test("merges environment overrides", async () => {


### PR DESCRIPTION
## Summary
- replace the hardcoded `/tmp` cwd assertion in `packages/opencode/test/util/process.test.ts` with a real temp directory from the shared fixture
- keep `Process.run(..., { cwd })` coverage while making the test valid on windows and unix runners

## Verification
- `bun test test/util/process.test.ts`