### PR TITLE
feat: add session.stopping hook for plugins

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -322,7 +322,7 @@ export namespace SessionPrompt {
       ) {
         const hook = await Plugin.trigger("session.stopping", { sessionID }, { stop: true, message: undefined as string | undefined })
         if (!hook.stop && hook.message) {
-          log.info("session.stopping re-entered loop", { sessionID })
+          log.info("session.stopping hook prevented stop", { sessionID })
           await createUserMessage({ sessionID, parts: [{ type: "text", text: hook.message }] })
           continue
         }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -320,10 +320,6 @@ export namespace SessionPrompt {
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
         lastUser.id < lastAssistant.id
       ) {
-        // Fire session.stopping hook — allows plugins to prevent premature stops.
-        // A plugin sets output.stop = false and provides output.message to inject
-        // a follow-up user message and continue the agent loop.
-        // @ts-ignore — session.stopping is not yet in the published Hooks type
         const hook = await Plugin.trigger("session.stopping", { sessionID }, { stop: true, message: undefined as string | undefined })
         if (!hook.stop && hook.message) {
           log.info("session.stopping re-entered loop", { sessionID })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -320,6 +320,16 @@ export namespace SessionPrompt {
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
         lastUser.id < lastAssistant.id
       ) {
+        // Fire session.stopping hook — allows plugins to prevent premature stops.
+        // A plugin sets output.stop = false and provides output.message to inject
+        // a follow-up user message and continue the agent loop.
+        // @ts-ignore — session.stopping is not yet in the published Hooks type
+        const hook = await Plugin.trigger("session.stopping", { sessionID }, { stop: true, message: undefined as string | undefined })
+        if (!hook.stop && hook.message) {
+          log.info("session.stopping re-entered loop", { sessionID })
+          await createUserMessage({ sessionID, parts: [{ type: "text", text: hook.message }] })
+          continue
+        }
         log.info("exiting loop", { sessionID })
         break
       }

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -11,10 +11,10 @@ describe("session.stopping hook", () => {
   test("plugin with session.stopping hook loads and triggers correctly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
-        const plug = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(plug, { recursive: true })
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
         await Bun.write(
-          path.join(plug, "stop-hook.ts"),
+          path.join(pluginDir, "stop-hook.ts"),
           [
             "export default async () => ({",
             '  "session.stopping": async (input, output) => {',
@@ -54,10 +54,10 @@ describe("session.stopping hook", () => {
   test("stop=false without message does not satisfy re-entry condition", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
-        const plug = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(plug, { recursive: true })
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
         await Bun.write(
-          path.join(plug, "no-msg.ts"),
+          path.join(pluginDir, "no-msg.ts"),
           ["export default async () => ({", '  "session.stopping": async (_input, output) => {', "    output.stop = false", "  },", "})"].join("\n"),
         )
       },
@@ -77,10 +77,10 @@ describe("session.stopping hook", () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
-        const plug = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(plug, { recursive: true })
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
         await Bun.write(
-          path.join(plug, "gate.ts"),
+          path.join(pluginDir, "gate.ts"),
           [
             "export default async () => ({",
             '  "session.stopping": async (_input, output) => {',

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for the session.stopping hook.
+ *
+ * Verifies the hook is defined in the Hooks interface and that Plugin.trigger
+ * correctly propagates output mutations from hooks that implement it.
+ */
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Plugin } from "../../src/plugin"
+import type { Hooks } from "@opencode-ai/plugin"
+
+describe("session.stopping hook", () => {
+  test("hook key exists in Hooks interface", () => {
+    // Type-level check: a Hooks object with session.stopping should be valid
+    const hooks: Hooks = {
+      // @ts-ignore — session.stopping is in the local source type
+      "session.stopping": async (_input, output) => {
+        output.stop = false
+        output.message = "continue"
+      },
+    }
+    expect(typeof hooks["session.stopping"]).toBe("function")
+  })
+
+  test("plugin with session.stopping hook loads and triggers correctly", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
+        await Bun.write(
+          path.join(pluginDir, "stop-hook.ts"),
+          [
+            "export default async () => ({",
+            '  "session.stopping": async (input, output) => {',
+            "    output.stop = false",
+            '    output.message = "workflow gate"',
+            "  },",
+            "})",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        // @ts-ignore — session.stopping is not yet in the published type
+        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined })
+        expect(out.stop).toBe(false)
+        expect(out.message).toBe("workflow gate")
+      },
+    })
+  }, 30000)
+
+  test("session continues when stop=true (default, no plugin installed)", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        // @ts-ignore
+        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined })
+        // With no plugin overriding, output is unchanged
+        expect(out.stop).toBe(true)
+        expect(out.message).toBeUndefined()
+      },
+    })
+  }, 30000)
+})

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -74,13 +74,32 @@ describe("session.stopping hook", () => {
     })
   }, 30000)
 
-  test("stop=false without message does not satisfy re-entry condition", () => {
-    // The loop re-enters only when !hook.stop && hook.message.
-    // Verify the guard: stop=false alone is not enough.
-    const stop = false
-    const message = undefined
-    expect(!stop && !!message).toBe(false)
-  })
+  test("plugin returning stop=false but no message does not trigger re-entry", async () => {
+    // The loop guard is: !hook.stop && hook.message
+    // A plugin that sets stop=false but leaves message undefined must not re-enter.
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plug = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plug, { recursive: true })
+        await Bun.write(
+          path.join(plug, "no-msg.ts"),
+          ["export default async () => ({", '  "session.stopping": async (_input, output) => {', "    output.stop = false", "  },", "})"].join("\n"),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        // @ts-ignore — session.stopping is not yet in the published type
+        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
+        expect(out.stop).toBe(false)
+        expect(out.message).toBeUndefined()
+        // Guard: re-entry requires both stop=false AND a message
+        expect(!out.stop && !!out.message).toBe(false)
+      },
+    })
+  }, 30000)
 
   test("hook message is written as a user message part in the session", async () => {
     await using tmp = await tmpdir({

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -1,10 +1,3 @@
-/**
- * Tests for the session.stopping hook.
- *
- * Verifies the hook is defined in the Hooks interface, that Plugin.trigger
- * correctly propagates output mutations, and that the hook message text is
- * correctly written as a user message part in the session when stop=false.
- */
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
@@ -16,10 +9,8 @@ import { SessionPrompt } from "../../src/session/prompt"
 import type { Hooks } from "@opencode-ai/plugin"
 
 describe("session.stopping hook", () => {
-  test("hook key exists in Hooks interface", () => {
-    // Type-level check: a Hooks object with session.stopping should be valid
+  test("hook key is valid in Hooks interface", () => {
     const hooks: Hooks = {
-      // @ts-ignore — session.stopping is in the local source type
       "session.stopping": async (_input, output) => {
         output.stop = false
         output.message = "continue"
@@ -51,7 +42,6 @@ describe("session.stopping hook", () => {
       directory: tmp.path,
       fn: async () => {
         await Plugin.init()
-        // @ts-ignore — session.stopping is not yet in the published type
         const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBe("workflow gate")
@@ -59,24 +49,20 @@ describe("session.stopping hook", () => {
     })
   }, 30000)
 
-  test("session continues when stop=true (default, no plugin installed)", async () => {
+  test("no plugin installed — stop stays true", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
         await Plugin.init()
-        // @ts-ignore — session.stopping is not yet in the published type
         const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
-        // With no plugin overriding, output is unchanged
         expect(out.stop).toBe(true)
         expect(out.message).toBeUndefined()
       },
     })
   }, 30000)
 
-  test("plugin returning stop=false but no message does not trigger re-entry", async () => {
-    // The loop guard is: !hook.stop && hook.message
-    // A plugin that sets stop=false but leaves message undefined must not re-enter.
+  test("stop=false without message does not satisfy re-entry condition", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
         const plug = path.join(dir, ".opencode", "plugin")
@@ -91,17 +77,15 @@ describe("session.stopping hook", () => {
       directory: tmp.path,
       fn: async () => {
         await Plugin.init()
-        // @ts-ignore — session.stopping is not yet in the published type
         const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBeUndefined()
-        // Guard: re-entry requires both stop=false AND a message
         expect(!out.stop && !!out.message).toBe(false)
       },
     })
   }, 30000)
 
-  test("hook message is written as a user message part in the session", async () => {
+  test("hook message is persisted as a user message in the session", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
@@ -127,15 +111,10 @@ describe("session.stopping hook", () => {
         await Plugin.init()
         const session = await Session.create({})
 
-        // Simulate what the loop does when stop=false: fire the hook, then
-        // write the hook message as a new user message via SessionPrompt.prompt
-        // with noReply=true (which is exactly what createUserMessage does).
-        // @ts-ignore — session.stopping is not yet in the published type
         const out = await Plugin.trigger("session.stopping", { sessionID: session.id }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBe("resume from gate")
 
-        // Write the hook message as a user message (mirrors the loop's createUserMessage call)
         const msg = await SessionPrompt.prompt({
           sessionID: session.id,
           noReply: true,

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the session.stopping hook.
  *
- * Verifies the hook is defined in the Hooks interface and that Plugin.trigger
- * correctly propagates output mutations from hooks that implement it.
+ * Verifies the hook is defined in the Hooks interface, that Plugin.trigger
+ * correctly propagates output mutations, and that the hook message text is
+ * correctly written as a user message part in the session when stop=false.
  */
 import { describe, expect, test } from "bun:test"
 import path from "path"
@@ -10,6 +11,8 @@ import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
 import type { Hooks } from "@opencode-ai/plugin"
 
 describe("session.stopping hook", () => {
@@ -67,6 +70,64 @@ describe("session.stopping hook", () => {
         // With no plugin overriding, output is unchanged
         expect(out.stop).toBe(true)
         expect(out.message).toBeUndefined()
+      },
+    })
+  }, 30000)
+
+  test("stop=false without message does not satisfy re-entry condition", () => {
+    // The loop re-enters only when !hook.stop && hook.message.
+    // Verify the guard: stop=false alone is not enough.
+    const stop = false
+    const message = undefined
+    expect(!stop && !!message).toBe(false)
+  })
+
+  test("hook message is written as a user message part in the session", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
+        await Bun.write(
+          path.join(pluginDir, "gate.ts"),
+          [
+            "export default async () => ({",
+            '  "session.stopping": async (_input, output) => {',
+            "    output.stop = false",
+            '    output.message = "resume from gate"',
+            "  },",
+            "})",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+        const session = await Session.create({})
+
+        // Simulate what the loop does when stop=false: fire the hook, then
+        // write the hook message as a new user message via SessionPrompt.prompt
+        // with noReply=true (which is exactly what createUserMessage does).
+        // @ts-ignore
+        const out = await Plugin.trigger("session.stopping", { sessionID: session.id }, { stop: true, message: undefined })
+        expect(out.stop).toBe(false)
+        expect(out.message).toBe("resume from gate")
+
+        // Write the hook message as a user message (mirrors the loop's createUserMessage call)
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [{ type: "text", text: out.message! }],
+        })
+
+        expect(msg.info.role).toBe("user")
+        const text = msg.parts.find((p) => p.type === "text" && !p.synthetic)
+        expect(text?.type === "text" && text.text).toBe("resume from gate")
+
+        await Session.remove(session.id)
       },
     })
   }, 30000)

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -31,10 +31,10 @@ describe("session.stopping hook", () => {
   test("plugin with session.stopping hook loads and triggers correctly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
-        const pluginDir = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(pluginDir, { recursive: true })
+        const plug = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plug, { recursive: true })
         await Bun.write(
-          path.join(pluginDir, "stop-hook.ts"),
+          path.join(plug, "stop-hook.ts"),
           [
             "export default async () => ({",
             '  "session.stopping": async (input, output) => {',
@@ -86,10 +86,10 @@ describe("session.stopping hook", () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
-        const pluginDir = path.join(dir, ".opencode", "plugin")
-        await fs.mkdir(pluginDir, { recursive: true })
+        const plug = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plug, { recursive: true })
         await Bun.write(
-          path.join(pluginDir, "gate.ts"),
+          path.join(plug, "gate.ts"),
           [
             "export default async () => ({",
             '  "session.stopping": async (_input, output) => {',

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -52,7 +52,7 @@ describe("session.stopping hook", () => {
       fn: async () => {
         await Plugin.init()
         // @ts-ignore — session.stopping is not yet in the published type
-        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined })
+        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBe("workflow gate")
       },
@@ -65,8 +65,8 @@ describe("session.stopping hook", () => {
       directory: tmp.path,
       fn: async () => {
         await Plugin.init()
-        // @ts-ignore
-        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined })
+        // @ts-ignore — session.stopping is not yet in the published type
+        const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
         // With no plugin overriding, output is unchanged
         expect(out.stop).toBe(true)
         expect(out.message).toBeUndefined()
@@ -111,8 +111,8 @@ describe("session.stopping hook", () => {
         // Simulate what the loop does when stop=false: fire the hook, then
         // write the hook message as a new user message via SessionPrompt.prompt
         // with noReply=true (which is exactly what createUserMessage does).
-        // @ts-ignore
-        const out = await Plugin.trigger("session.stopping", { sessionID: session.id }, { stop: true, message: undefined })
+        // @ts-ignore — session.stopping is not yet in the published type
+        const out = await Plugin.trigger("session.stopping", { sessionID: session.id }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBe("resume from gate")
 

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -6,19 +6,8 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin"
 import { Session } from "../../src/session"
 import { SessionPrompt } from "../../src/session/prompt"
-import type { Hooks } from "@opencode-ai/plugin"
 
 describe("session.stopping hook", () => {
-  test("hook key is valid in Hooks interface", () => {
-    const hooks: Hooks = {
-      "session.stopping": async (_input, output) => {
-        output.stop = false
-        output.message = "continue"
-      },
-    }
-    expect(typeof hooks["session.stopping"]).toBe("function")
-  })
-
   test("plugin with session.stopping hook loads and triggers correctly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -80,7 +69,6 @@ describe("session.stopping hook", () => {
         const out = await Plugin.trigger("session.stopping", { sessionID: "test-session" }, { stop: true, message: undefined as string | undefined })
         expect(out.stop).toBe(false)
         expect(out.message).toBeUndefined()
-        expect(!out.stop && !!out.message).toBe(false)
       },
     })
   }, 30000)

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -231,4 +231,19 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Called when the agent loop is about to stop (session going idle).
+   * Allows plugins to inject a follow-up message and prevent the session
+   * from becoming idle.
+   *
+   * Set `output.stop = false` and provide `output.message` to inject a
+   * user message and re-enter the agent loop instead of stopping.
+   *
+   * Example use case: a workflow plugin that needs to re-prompt the agent
+   * when the agent tries to stop in the middle of an active workflow phase.
+   */
+  "session.stopping"?: (
+    input: { sessionID: string },
+    output: { stop: boolean; message?: string },
+  ) => Promise<void>
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -232,15 +232,8 @@ export interface Hooks {
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
   /**
-   * Called when the agent loop is about to stop (session going idle).
-   * Allows plugins to inject a follow-up message and prevent the session
-   * from becoming idle.
-   *
-   * Set `output.stop = false` and provide `output.message` to inject a
-   * user message and re-enter the agent loop instead of stopping.
-   *
-   * Example use case: a workflow plugin that needs to re-prompt the agent
-   * when the agent tries to stop in the middle of an active workflow phase.
+   * Called before the agent loop exits. Set `output.stop = false` and
+   * provide `output.message` to inject a user message and continue the loop.
    */
   "session.stopping"?: (
     input: { sessionID: string },


### PR DESCRIPTION
### Issue for this PR

Closes #16626

Related to #12472 (the Stop hook re-activation use case is a subset of what that issue describes).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `session.stopping` hook to the plugin API. It fires before the agent loop breaks, giving plugins a chance to inject a follow-up user message and continue the loop instead of stopping. If no plugin is installed, behaviour is unchanged.

**Known limitation:** if a plugin unconditionally sets `stop=false` on every call, the loop will run indefinitely. There is no built-in re-entry cap. Plugins are responsible for their own termination condition. This is intentional: the correct guard depends entirely on the plugin's use case (a counter, a state flag, a file on disk) and cannot be generalised in core without constraining valid use cases. The same responsibility applies to any plugin that calls `client.session.chat` from `session.idle`.

### How did you verify your code works?

Four tests in `test/plugin/session-stopping.test.ts` — no mocks, real plugin files written to a temp dir and loaded via `Plugin.init()`: plugin mutation propagates through `Plugin.trigger`; no plugin leaves `stop` as `true`; `stop=false` with no message does not satisfy the re-entry condition; hook message is persisted as a real user message via `SessionPrompt.prompt`.

End-to-end against the dev build: created a one-shot plugin that sets `stop=false` on first fire. Ran `opencode run "say exactly the word HELLO and nothing else"`. Session export confirmed 4 messages in order: original user prompt, HELLO, hook-injected user message, second assistant reply. The loop stopped cleanly on the second hook fire because the plugin saw its own marker file and returned without modifying output.

`bun typecheck` clean.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR