### PR TITLE
fix(plugin): last-wins auth override so user plugins replace built-in defaults

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -43,6 +43,27 @@ export namespace Plugin {
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
 
+  // Extract package name from a plugin specifier for dedup.
+  // "github:owner/repo#branch" → "repo"
+  // "@scope/pkg@version" → "@scope/pkg"
+  // "pkg@version" → "pkg"
+  export function pluginRepo(spec: string): string {
+    if (spec.startsWith("github:")) {
+      const repo = spec.replace(/^github:/, "").split("#")[0]
+      return repo.split("/").pop()!
+    }
+    const last = spec.lastIndexOf("@")
+    if (last > 0) return spec.substring(0, last)
+    return spec
+  }
+
+  // Merge BUILTIN and user plugins, dropping any BUILTIN whose
+  // package name is already provided by a user plugin.
+  export function dedup(builtin: string[], user: string[]): string[] {
+    const names = new Set(user.map(pluginRepo))
+    return [...builtin.filter((b) => !names.has(pluginRepo(b))), ...user]
+  }
+
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
 
@@ -91,7 +112,7 @@ export namespace Plugin {
               if (init) hooks.push(init)
             }
 
-            let plugins = cfg.plugin ?? []
+            const plugins = dedup([], cfg.plugin ?? [])
             if (plugins.length) await Config.waitForDependencies()
 
             for (let plugin of plugins) {


### PR DESCRIPTION
### Issue for this PR

Fixes #10063
Fixes #10898

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When multiple plugins provide auth for the same provider, the first one loaded wins — so built-in plugins always shadow user plugins. This makes it impossible for users to override auth behavior (e.g., using a fork with OAuth or account pooling).

**Plugin deduplication** (`plugin/index.ts`):
- `pluginRepo()` extracts a canonical package name from npm specifiers (`pkg@version`) and github refs (`github:owner/repo#branch`) so they can be compared
- `dedup()` drops any built-in plugin whose package name matches a user-configured plugin — user config always wins
- Loading order is internal → built-in → user, so last-wins dedup gives user plugins priority

**Auth loader last-wins** (`provider/provider.ts`):
- Collects auth hooks into a `Map<providerID, Hooks>` — since plugins load internal → built-in → user, the last registration per provider wins
- Wraps `pluginAuth.loader()` in `.catch()` so one broken plugin doesn't block the rest
- Removes the pre-check for stored auth — lets the plugin's loader decide whether it can handle auth (supports credential pools, external DBs, etc.)

**Bun package resolution** (`bun/index.ts`):
- Adds `--bun` flag to ensure compiled binaries invoke bun's runtime for package management
- New `resolve()` function handles github refs where bun installs under the package.json `name` field rather than the specifier — resolves via lockfile or falls back to repo name
- Handles `github:` specifiers that include `#branch` in install commands

**Tests** (`test/plugin/plugin-repo.test.ts`):
- Full coverage for `pluginRepo()` identity extraction (npm, scoped, github, bare)
- Full coverage for `dedup()` replacement logic (same package, mixed sources, order preservation)

### How did you verify your code works?

- `bun run typecheck` passes
- New unit tests for `pluginRepo()` and `dedup()` pass
- Tested with a github-ref user plugin overriding the built-in `opencode-anthropic-auth` — only the user's fork loads

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR