### PR TITLE
fix(tui): limit rendering of Modified Files list to prevent slowdown

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useSync } from "@tui/context/sync"
-import { createMemo, For, Show, Switch, Match } from "solid-js"
+import { createMemo, createSignal, For, Show, Switch, Match } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
@@ -25,6 +25,12 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     diff: true,
     todo: true,
     lsp: true,
+  })
+  const DIFF_PAGE_SIZE = 50
+  const [diffLimit, setDiffLimit] = createSignal(DIFF_PAGE_SIZE)
+  const visibleDiff = createMemo(() => {
+    const list = diff()
+    return list.slice(0, diffLimit())
   })
 
   // Sort MCP servers alphabetically for consistent display order
@@ -240,11 +246,11 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                     <text fg={theme.text}>{expanded.diff ? "▼" : "▶"}</text>
                   </Show>
                   <text fg={theme.text}>
-                    <b>Modified Files</b>
+                    <b>Modified Files ({diff().length})</b>
                   </text>
                 </box>
                 <Show when={diff().length <= 2 || expanded.diff}>
-                  <For each={diff() || []}>
+                  <For each={visibleDiff()}>
                     {(item) => {
                       return (
                         <box flexDirection="row" gap={1} justifyContent="space-between">
@@ -263,6 +269,14 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                       )
                     }}
                   </For>
+                  <Show when={diff().length > diffLimit()}>
+                    <text
+                      fg={theme.textMuted}
+                      onMouseDown={() => setDiffLimit(Math.min(diffLimit() + DIFF_PAGE_SIZE, diff().length))}
+                    >
+                      Show more ({diffLimit()} of {diff().length})
+                    </text>
+                  </Show>
                 </Show>
               </box>
             </Show>


### PR DESCRIPTION
### Issue for this PR
Closes #16600

### Type of change
- [x] Bug fix

### What does this PR do?
The Modified Files sidebar renders every entry in the diff list with no upper bound. When thousands of files become visible (e.g. after .gitignore is removed and target/ becomes tracked), the TUI becomes severely sluggish and scrolling produces gibberish escape sequences in the input field.

Fix: cap the rendered entries to 50 at a time using a visibleDiff memo, and add a "Show more" control that loads the next 50 on click. The header now shows the total file count so users can see the scale at a glance.

The root cause is the unbounded `<For each={diff()}>` loop in sidebar.tsx which tries to render every entry on every reactive update.

### How did you verify your code works?
Reproduced the issue by asking the agent to generate 20,000 files in a test repo.
Before the fix: sidebar rendered all entries, TUI lagged heavily and showed rendering artifacts while scrolling.
After the fix: sidebar shows first 50 entries, "Show more" loads the next 50, TUI stays fully responsive at 20,000+ files.

### Screenshots / recordings
<!-- attached -->

https://github.com/user-attachments/assets/64136723-52db-409c-9f64-581317cb3a52

<img width="1508" height="863" alt="Screenshot 2026-03-08 at 7 28 39 PM" src="https://github.com/user-attachments/assets/1356d7f6-8cda-4c79-8e63-5589760a4752" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR