### PR TITLE
fix: canonicalize interactive temp directories

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,3 @@
-../../ui/src/custom-elements.d.ts
+import "../../ui/src/custom-elements"
+
+export {}

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,3 @@
-../../ui/src/custom-elements.d.ts
+import "../../ui/src/custom-elements"
+
+export {}

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -5,6 +5,7 @@ import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
 import { existsSync } from "fs"
+import { Dir } from "./directory"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -53,8 +54,7 @@ export const AttachCommand = cmd({
       const directory = (() => {
         if (!args.dir) return undefined
         try {
-          process.chdir(args.dir)
-          return process.cwd()
+          return Dir.enter(args.dir)
         } catch {
           // If the directory doesn't exist locally (remote attach), pass it through.
           return args.dir

--- a/packages/opencode/src/cli/cmd/tui/directory.ts
+++ b/packages/opencode/src/cli/cmd/tui/directory.ts
@@ -1,0 +1,17 @@
+import path from "path"
+import { Filesystem } from "@/util/filesystem"
+
+export const Dir = {
+  root() {
+    return Filesystem.resolve(process.env.PWD ?? process.cwd())
+  },
+  project(input?: string) {
+    const root = Dir.root()
+    const next = input ? Filesystem.resolve(path.isAbsolute(input) ? input : path.join(root, input)) : root
+    return Dir.enter(next)
+  },
+  enter(input: string) {
+    process.chdir(input)
+    return process.cwd()
+  },
+}

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -2,7 +2,6 @@ import { cmd } from "@/cli/cmd/cmd"
 import { tui } from "./app"
 import { Rpc } from "@/util/rpc"
 import { type rpc } from "./worker"
-import path from "path"
 import { fileURLToPath } from "url"
 import { UI } from "@/cli/ui"
 import { Log } from "@/util/log"
@@ -14,6 +13,7 @@ import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
+import { Dir } from "./directory"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -110,18 +110,16 @@ export const TuiThreadCommand = cmd({
         return
       }
 
-      // Resolve relative paths against PWD to preserve behavior when using --cwd flag
-      const root = Filesystem.resolve(process.env.PWD ?? process.cwd())
-      const cwd = args.project
-        ? Filesystem.resolve(path.isAbsolute(args.project) ? args.project : path.join(root, args.project))
-        : root
+      const cwd = (() => {
+        try {
+          return Dir.project(args.project)
+        } catch {
+          UI.error("Failed to change directory to " + (args.project ?? Dir.root()))
+          return
+        }
+      })()
+      if (!cwd) return
       const file = await target()
-      try {
-        process.chdir(cwd)
-      } catch {
-        UI.error("Failed to change directory to " + cwd)
-        return
-      }
 
       const worker = new Worker(file, {
         env: Object.fromEntries(

--- a/packages/opencode/test/cli/tui/directory.test.ts
+++ b/packages/opencode/test/cli/tui/directory.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Dir } from "../../../src/cli/cmd/tui/directory"
+import { tmpdir } from "../../fixture/fixture"
+
+const cwd = process.cwd()
+const pwd = process.env.PWD
+
+afterEach(() => {
+  process.chdir(cwd)
+  if (pwd === undefined) delete process.env.PWD
+  else process.env.PWD = pwd
+})
+
+describe("tui directory", () => {
+  test("canonicalizes macOS temp PWD aliases", async () => {
+    if (process.platform !== "darwin") return
+    await using tmp = await tmpdir()
+    if (!tmp.path.startsWith("/private/var/")) return
+    const alias = tmp.path.replace("/private/var/", "/var/")
+
+    process.env.PWD = alias
+
+    expect(Dir.project()).toBe(tmp.path)
+    expect(process.cwd()).toBe(tmp.path)
+  })
+
+  test("canonicalizes explicit macOS temp directories", async () => {
+    if (process.platform !== "darwin") return
+    await using tmp = await tmpdir()
+    if (!tmp.path.startsWith("/private/var/")) return
+    const alias = tmp.path.replace("/private/var/", "/var/")
+
+    expect(Dir.enter(alias)).toBe(tmp.path)
+    expect(process.cwd()).toBe(tmp.path)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #16607

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Interactive `opencode` could hang in macOS temp directories because the TUI startup path preserved `PWD` as `/var/...` while Bun canonicalized the actual cwd to `/private/var/...`. That split requests and event streaming across two directory identities, so prompts could be submitted without ever showing thinking or returning a reply.

This change canonicalizes the interactive working directory before startup and reuses the same handling in local attach mode. I also added a regression test for the `/var` vs `/private/var` temp-dir alias case.

Note: this PR also includes a small fix to `custom-elements.d.ts` imports in `packages/app` and `packages/enterprise` because the repo's required pre-push typecheck was already failing on those files.

### How did you verify your code works?

- Ran `bun test test/cli/tui/directory.test.ts` in `packages/opencode`
- Ran `bun test test/util/filesystem.test.ts` in `packages/opencode`
- Ran `bun typecheck` from the repo root
- Reproduced the path alias behavior locally and confirmed Bun resolves temp dirs from `/var/...` to `/private/var/...`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR