### PR TITLE
fix(app): guard null entries in terminal store and staging messages

### DIFF
--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -92,6 +92,7 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
   const pickNextTerminalNumber = () => {
     const existingTitleNumbers = new Set(
       store.all.flatMap((pty) => {
+        if (!pty) return []
         const direct = Number.isFinite(pty.titleNumber) && pty.titleNumber > 0 ? pty.titleNumber : undefined
         if (direct !== undefined) return [direct]
         const parsed = numberFromTitle(pty.title)
@@ -136,21 +137,22 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
     meta.migrated = true
 
     setStore("all", (all) => {
-      const next = all.map((pty) => {
+      const safe = all.filter((x) => x != null)
+      const next = safe.map((pty) => {
         const direct = Number.isFinite(pty.titleNumber) && pty.titleNumber > 0 ? pty.titleNumber : undefined
         if (direct !== undefined) return pty
         const parsed = numberFromTitle(pty.title)
         if (parsed === undefined) return pty
         return { ...pty, titleNumber: parsed }
       })
-      if (next.every((pty, index) => pty === all[index])) return all
+      if (safe.length === all.length && next.every((pty, index) => pty === all[index])) return all
       return next
     })
   })
 
   return {
     ready,
-    all: createMemo(() => store.all),
+    all: createMemo(() => store.all.filter((x) => x != null)),
     active: createMemo(() => store.active),
     clear() {
       batch(() => {

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -312,7 +312,7 @@ export function MessageTimeline(props: {
     messages: () => props.renderedUserMessages,
     config: stageCfg,
   })
-  const rendered = createMemo(() => staging.messages().map((message) => message.id))
+  const rendered = createMemo(() => staging.messages().filter((message) => message != null).map((message) => message.id))
 
   return (
     <Show


### PR DESCRIPTION
### Issue for this PR

Closes #16613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The terminal store (`store.all`) can end up with `null` entries after PTY exit events use `produce` + `splice` to remove elements. These nulls get persisted and crash the app on next startup when migration code and downstream `createMemo` calls iterate with `.map()` assuming non-null.

Three fixes:

1. **`terminal.tsx` — `pickNextTerminalNumber`**: added `if (!pty) return []` guard before accessing `pty.titleNumber`
2. **`terminal.tsx` — migration callback**: filter nulls before `.map()`, and fixed the no-op comparison to account for filtered length
3. **`terminal.tsx` — exported `all`**: changed from raw `store.all` to `store.all.filter(x => x != null)` so all consumers get clean data
4. **`message-timeline.tsx`**: filter null entries in `staging.messages()` before `.map((m) => m.id)`

### How did you verify your code works?

- Built and installed the desktop app (`make build && make install`)
- Crash logger confirmed: no more `null is not an object (evaluating 'N.id')` or `g.titleNumber` crashes after fix
- `bun turbo typecheck --filter=@opencode-ai/app --filter=@opencode-ai/desktop` passes

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR