### PR TITLE
fix: add idle-timeout Instance disposal for serve mode memory

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -78,8 +78,6 @@ export const AttachCommand = cmd({
           sessionID: args.session,
           fork: args.fork,
         },
-        directory,
-        headers,
       })
     } finally {
       unguard?.()

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -169,11 +169,6 @@ export const TuiThreadCommand = cmd({
       }
 
       const prompt = await input(args.prompt)
-      const config = await Instance.provide({
-        directory: cwd,
-        fn: () => TuiConfig.get(),
-      })
-
       const network = await resolveNetworkOptions(args)
       const external =
         process.argv.includes("--port") ||
@@ -183,46 +178,53 @@ export const TuiThreadCommand = cmd({
         network.port !== 0 ||
         network.hostname !== "127.0.0.1"
 
-      const transport = external
-        ? {
-            url: (await client.call("server", network)).url,
-            fetch: undefined,
-            events: undefined,
-          }
-        : {
-            url: "http://opencode.internal",
-            fetch: createWorkerFetch(client),
-            events: createEventSource(client),
-          }
+      await Instance.provide({
+        directory: cwd,
+        fn: async () => {
+          const config = await TuiConfig.get()
 
-      setTimeout(() => {
-        client.call("checkUpgrade", { directory: cwd }).catch(() => {})
-      }, 1000).unref?.()
+          const transport = external
+            ? {
+                url: (await client.call("server", network)).url,
+                fetch: undefined,
+                events: undefined,
+              }
+            : {
+                url: "http://opencode.internal",
+                fetch: createWorkerFetch(client),
+                events: createEventSource(client),
+              }
 
-      try {
-        await tui({
-          url: transport.url,
-          async onSnapshot() {
-            const tui = writeHeapSnapshot("tui.heapsnapshot")
-            const server = await client.call("snapshot", undefined)
-            return [tui, server]
-          },
-          config,
-          directory: cwd,
-          fetch: transport.fetch,
-          events: transport.events,
-          args: {
-            continue: args.continue,
-            sessionID: args.session,
-            agent: args.agent,
-            model: args.model,
-            prompt,
-            fork: args.fork,
-          },
-        })
-      } finally {
-        await stop()
-      }
+          setTimeout(() => {
+            client.call("checkUpgrade", { directory: cwd }).catch(() => {})
+          }, 1000).unref?.()
+
+          try {
+            await tui({
+              url: transport.url,
+              async onSnapshot() {
+                const tui = writeHeapSnapshot("tui.heapsnapshot")
+                const server = await client.call("snapshot", undefined)
+                return [tui, server]
+              },
+              config,
+              directory: cwd,
+              fetch: transport.fetch,
+              events: transport.events,
+              args: {
+                continue: args.continue,
+                sessionID: args.session,
+                agent: args.agent,
+                model: args.model,
+                prompt,
+                fork: args.fork,
+              },
+            })
+          } finally {
+            await stop()
+          }
+        },
+      })
     } finally {
       unguard?.()
     }


### PR DESCRIPTION
### Issue for this PR

Fixes #13041

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In serve mode, each unique workspace directory creates an `Instance` that spawns LSP servers, MCP clients, file watchers, and ~26 state entries. These are cached forever and never cleaned up, even after all sessions disconnect — causing unbounded memory growth (2.9GB+ per session as reported in #13041).

This PR adds automatic idle-timeout disposal:

**Instance idle-timeout disposal** (`instance.ts`):
- Reference counting via `acquire()`/`release()` tracks active `provide()` calls per directory
- When refs drop to 0, schedules disposal after `OPENCODE_IDLE_TIMEOUT` ms (default 5 min)
- New `provide()` calls cancel any pending idle timer
- `Instance.list()` returns cached instances with ref counts for observability
- `Instance.disposeByDirectory(dir)` for API-driven disposal

**Race condition fix** (`state.ts`):
- Detaches state entries from the registry before running disposal callbacks, so new Instances arriving during disposal get fresh state instead of references to disposing/disposed state

**Configuration** (`flag.ts`):
- `OPENCODE_IDLE_TIMEOUT` env var (ms, default 300000 = 5 min, set to 0 to disable)
- Dynamic getter so the value is read at access time, not module load time

**API endpoints** (`routes/global.ts`):
- `GET /global/instances` — list cached instances with ref counts
- `POST /global/instances/dispose` — dispose a specific instance by directory

**Tests** (`instance-idle.test.ts`):
- 8 tests covering: basic provide, list, idle disposal, timer cancellation, fresh instance after disposal, disposeByDirectory, concurrent refs, dispose-within-provide

### How did you verify your code works?

- `bun run typecheck` passes
- 8 new unit tests all pass
- Manual testing in serve mode: instances dispose after 5 min idle, re-create on next request, memory is reclaimed

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR