### PR TITLE
fix(ui): prevent mobile scroll flickering during AI streaming

### DIFF
--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -122,6 +122,14 @@ export function createAutoScroll(options: AutoScrollOptions) {
     stop()
   }
 
+  const handleTouchStart = () => {
+    // On mobile, any touch interaction should stop auto-scroll
+    if (!store.userScrolled) {
+      setStore("userScrolled", true)
+      options.onUserInteracted?.()
+    }
+  }
+
   const handleScroll = () => {
     const el = scroll
     if (!el) return
@@ -232,9 +240,11 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
       updateOverflowAnchor(el)
       el.addEventListener("wheel", handleWheel, { passive: true })
+      el.addEventListener("touchstart", handleTouchStart, { passive: true })
 
       cleanup = () => {
         el.removeEventListener("wheel", handleWheel)
+        el.removeEventListener("touchstart", handleTouchStart)
       }
     },
     contentRef: (el: HTMLElement | undefined) => setStore("contentRef", el),


### PR DESCRIPTION
### Issue for this PR

Closes #16622

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds mobile touch event support to prevent infinite scroll flickering during AI streaming responses.

**Problem:**
When users try to scroll up on mobile devices while AI is generating responses, the page flickers and jumps back to the bottom repeatedly, making it impossible to read previous messages.

**Root Cause:**
Mobile touch events were not being captured - only desktop `wheel` events were handled. This caused the auto-scroll system to not detect when mobile users were manually scrolling.

**Note on v1.2.24:**
The core fix for respecting `userScrolled` state (`if (!force && store.userScrolled) return` at line 87) was already included in v1.2.24's refactored scroll logic. This PR complements that fix by adding mobile touch event detection.

**Changes Made:**
1. Added `handleTouchStart()` function to detect mobile touch interactions:
   - Sets `userScrolled` flag when user touches the screen
   - Triggers `onUserInteracted` callback
   - Prevents auto-scroll from resuming during user interaction

2. Registered `touchstart` event listener for mobile devices:
   - Added event listener with `{ passive: true }` for performance
   - Added cleanup in the cleanup function to prevent memory leaks

**Why This Works:**
- When a user touches the screen on mobile, `handleTouchStart` immediately marks the interaction
- The existing `scrollToBottom()` logic (line 87) checks `userScrolled` and returns early
- This eliminates the conflict between user scrolling and auto-scroll, preventing the flickering
- Desktop behavior remains unchanged (still uses `wheel` events)

**Files Changed:**
- `packages/ui/src/hooks/create-auto-scroll.tsx` (10 lines: 1 function + event listeners)

### How did you verify your code works?

1. Rebased onto v1.2.24 and resolved conflicts
2. Tested on iOS Safari and Android Chrome
3. Started a conversation with AI that generates long responses
4. While AI was streaming, scrolled up to read previous messages
5. Verified that:
   - No flickering occurs on mobile devices
   - Scroll position stays where the user left it
   - Auto-scroll resumes when user scrolls back to the bottom
   - Desktop behavior remains unchanged
   - TypeScript compilation passes

### Screenshots / recordings

_Mobile testing shows smooth scrolling without flickering during AI streaming. The fix has been verified on both iOS and Android devices._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR