### PR TITLE
fix(opencode): sanitize history and gate options on target model switch

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -20,6 +20,193 @@ function mimeToModality(mime: string): Modality | undefined {
 export namespace ProviderTransform {
   export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
+  function rewrite(
+    options: Record<string, unknown> | undefined,
+    fn: (opts: Record<string, unknown>) => Record<string, unknown>,
+  ) {
+    if (!options) return undefined
+    const next = fn(options)
+    return Object.keys(next).length ? next : undefined
+  }
+
+  function clean(options: Record<string, unknown> | undefined, keep?: "reasoning_content" | "reasoning_details") {
+    return rewrite(options, (opts) => {
+      const next = { ...opts }
+      if (keep !== "reasoning_content") delete next.reasoning_content
+      if (keep !== "reasoning_details") delete next.reasoning_details
+      return next
+    })
+  }
+
+  function scrub(options: Record<string, unknown> | undefined, keep?: "reasoning_content" | "reasoning_details") {
+    return rewrite(options, (opts) =>
+      Object.fromEntries(
+        Object.entries(opts).flatMap(([key, value]) => {
+          if (!value || typeof value !== "object" || Array.isArray(value)) return [[key, value]]
+          const cleaned = clean(value as Record<string, unknown> | undefined, keep)
+          if (!cleaned) return []
+          return [[key, cleaned]]
+        }),
+      ),
+    )
+  }
+
+  function patch(options: Record<string, unknown> | undefined, values: Record<string, unknown>) {
+    return {
+      ...(options ?? {}),
+      openaiCompatible: {
+        ...(typeof options?.openaiCompatible === "object" && options.openaiCompatible ? options.openaiCompatible : {}),
+        ...values,
+      },
+    }
+  }
+
+  function bare<T extends { providerOptions?: unknown }>(msg: T) {
+    const rest = { ...msg }
+    delete rest.providerOptions
+    return rest
+  }
+
+  function mode(model: Provider.Model) {
+    if (model.capabilities.reasoning) {
+      if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
+        return "field"
+      }
+      return "parts"
+    }
+    if (model.providerID === "anthropic" || model.api.npm === "@ai-sdk/anthropic") {
+      return "parts"
+    }
+    return "strip"
+  }
+
+  function sanitize(msgs: ModelMessage[], model: Provider.Model) {
+    const keep =
+      model.capabilities.reasoning && typeof model.capabilities.interleaved === "object"
+        ? model.capabilities.interleaved.field
+        : undefined
+
+    return msgs.flatMap<ModelMessage>((msg) => {
+      if (msg.role === "tool" && !model.capabilities.toolcall) return []
+      if (!Array.isArray(msg.content)) {
+        if (!msg.providerOptions) return [msg]
+        const opts = scrub(msg.providerOptions, keep)
+        return [
+          {
+            ...bare(msg),
+            ...(opts ? { providerOptions: opts } : {}),
+          } as ModelMessage,
+        ]
+      }
+
+      const stripped =
+        !model.capabilities.toolcall &&
+        msg.content.some((part) => part.type === "tool-call" || part.type === "tool-result")
+      const content = model.capabilities.toolcall
+        ? msg.content
+        : msg.content.filter((part) => part.type !== "tool-call" && part.type !== "tool-result")
+      const opts = scrub(msg.providerOptions, keep)
+
+      if (msg.role === "assistant") {
+        const kind = mode(model)
+        const reasoning = content.filter(
+          (part): part is Extract<(typeof content)[number], { type: "reasoning" }> => part.type === "reasoning",
+        )
+        const text = reasoning.map((part) => part.text).join("")
+
+        if (kind === "field" && typeof model.capabilities.interleaved === "object") {
+          const next = content.filter((part) => part.type !== "reasoning")
+          const meta = text
+            ? patch(opts, {
+                [model.capabilities.interleaved.field]: text,
+              })
+            : opts
+          if (next.length > 0) {
+            return [
+              {
+                ...bare(msg),
+                content: next,
+                ...(meta ? { providerOptions: meta } : {}),
+              } as ModelMessage,
+            ]
+          }
+          if (!stripped && !reasoning.length) {
+            return [
+              {
+                ...bare(msg),
+                ...(meta ? { providerOptions: meta } : {}),
+              } as ModelMessage,
+            ]
+          }
+          return [
+            {
+              ...bare(msg),
+              content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+              ...(meta ? { providerOptions: meta } : {}),
+            } as ModelMessage,
+          ]
+        }
+
+        if (kind === "strip") {
+          const next = content.filter((part) => part.type !== "reasoning")
+          if (next.length > 0) {
+            return [
+              {
+                ...bare(msg),
+                content: next,
+                ...(opts ? { providerOptions: opts } : {}),
+              } as ModelMessage,
+            ]
+          }
+          if (!stripped && reasoning.length === 0) {
+            return [
+              {
+                ...bare(msg),
+                ...(opts ? { providerOptions: opts } : {}),
+              } as ModelMessage,
+            ]
+          }
+          return [
+            {
+              ...bare(msg),
+              content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+              ...(opts ? { providerOptions: opts } : {}),
+            } as ModelMessage,
+          ]
+        }
+      }
+
+      // "parts" mode (Anthropic): reasoning parts are kept as-is in content;
+      // the Anthropic SDK handles them natively in the message history.
+      if (content.length > 0) {
+        return [
+          {
+            ...bare(msg),
+            content,
+            ...(opts ? { providerOptions: opts } : {}),
+          } as ModelMessage,
+        ]
+      }
+
+      if (!stripped) {
+        return [
+          {
+            ...bare(msg),
+            ...(opts ? { providerOptions: opts } : {}),
+          } as ModelMessage,
+        ]
+      }
+
+      return [
+        {
+          ...bare(msg),
+          content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+          ...(opts ? { providerOptions: opts } : {}),
+        } as ModelMessage,
+      ]
+    })
+  }
+
   // Maps npm package to the key the AI SDK expects for providerOptions
   function sdkKey(npm: string): string | undefined {
     switch (npm) {
@@ -44,11 +231,7 @@ export namespace ProviderTransform {
     return undefined
   }
 
-  function normalizeMessages(
-    msgs: ModelMessage[],
-    model: Provider.Model,
-    options: Record<string, unknown>,
-  ): ModelMessage[] {
+  function normalizeMessages(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content
     if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {
@@ -133,41 +316,6 @@ export namespace ProviderTransform {
       return result
     }
 
-    if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
-      const field = model.capabilities.interleaved.field
-      return msgs.map((msg) => {
-        if (msg.role === "assistant" && Array.isArray(msg.content)) {
-          const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
-          const reasoningText = reasoningParts.map((part: any) => part.text).join("")
-
-          // Filter out reasoning parts from content
-          const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
-
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
-            return {
-              ...msg,
-              content: filteredContent,
-              providerOptions: {
-                ...msg.providerOptions,
-                openaiCompatible: {
-                  ...(msg.providerOptions as any)?.openaiCompatible,
-                  [field]: reasoningText,
-                },
-              },
-            }
-          }
-
-          return {
-            ...msg,
-            content: filteredContent,
-          }
-        }
-
-        return msg
-      })
-    }
-
     return msgs
   }
 
@@ -249,9 +397,10 @@ export namespace ProviderTransform {
     })
   }
 
-  export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
+  export function message(msgs: ModelMessage[], model: Provider.Model) {
+    msgs = sanitize(msgs, model)
     msgs = unsupportedParts(msgs, model)
-    msgs = normalizeMessages(msgs, model, options)
+    msgs = normalizeMessages(msgs, model)
     if (
       (model.providerID === "anthropic" ||
         model.api.id.includes("anthropic") ||
@@ -790,26 +939,28 @@ export namespace ProviderTransform {
     }
 
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-      if (!input.model.api.id.includes("gpt-5-pro")) {
-        result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
-      }
+      if (input.model.capabilities.reasoning) {
+        if (!input.model.api.id.includes("gpt-5-pro")) {
+          result["reasoningEffort"] = "medium"
+          result["reasoningSummary"] = "auto"
+        }
 
-      // Only set textVerbosity for non-chat gpt-5.x models
-      // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
-      if (
-        input.model.api.id.includes("gpt-5.") &&
-        !input.model.api.id.includes("codex") &&
-        !input.model.api.id.includes("-chat") &&
-        input.model.providerID !== "azure"
-      ) {
-        result["textVerbosity"] = "low"
-      }
+        // Only set textVerbosity for non-chat gpt-5.x models
+        // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
+        if (
+          input.model.api.id.includes("gpt-5.") &&
+          !input.model.api.id.includes("codex") &&
+          !input.model.api.id.includes("-chat") &&
+          input.model.providerID !== "azure"
+        ) {
+          result["textVerbosity"] = "low"
+        }
 
-      if (input.model.providerID.startsWith("opencode")) {
-        result["promptCacheKey"] = input.sessionID
-        result["include"] = ["reasoning.encrypted_content"]
-        result["reasoningSummary"] = "auto"
+        if (input.model.providerID.startsWith("opencode")) {
+          result["promptCacheKey"] = input.sessionID
+          result["include"] = ["reasoning.encrypted_content"]
+          result["reasoningSummary"] = "auto"
+        }
       }
     }
 
@@ -826,7 +977,7 @@ export namespace ProviderTransform {
       }
     }
 
-    return result
+    return compat(input.model, result)
   }
 
   export function smallOptions(model: Provider.Model) {
@@ -836,6 +987,7 @@ export namespace ProviderTransform {
       model.api.npm === "@ai-sdk/github-copilot"
     ) {
       if (model.api.id.includes("gpt-5")) {
+        if (!model.capabilities.reasoning) return { store: false }
         if (model.api.id.includes("5.")) {
           return { store: false, reasoningEffort: "low" }
         }
@@ -844,6 +996,7 @@ export namespace ProviderTransform {
       return { store: false }
     }
     if (model.providerID === "google") {
+      if (!model.capabilities.reasoning) return {}
       // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget
       if (model.api.id.includes("gemini-3")) {
         return { thinkingConfig: { thinkingLevel: "minimal" } }
@@ -854,14 +1007,50 @@ export namespace ProviderTransform {
       if (model.api.id.includes("google")) {
         return { reasoning: { enabled: false } }
       }
+      if (!model.capabilities.reasoning) return {}
       return { reasoningEffort: "minimal" }
     }
 
     if (model.providerID === "venice") {
+      if (!model.capabilities.reasoning) return {}
       return { veniceParameters: { disableThinking: true } }
     }
 
     return {}
+  }
+
+  export function compat(model: Provider.Model, options: Record<string, unknown>) {
+    if (model.capabilities.reasoning) return options
+
+    const result = { ...options }
+    delete result.reasoning
+    delete result.reasoningConfig
+    delete result.reasoningEffort
+    delete result.reasoningSummary
+    delete result.thinking
+    delete result.thinkingConfig
+    delete result.enable_thinking
+    delete result.textVerbosity
+
+    if (Array.isArray(result.include)) {
+      const include = result.include.filter((item) => item !== "reasoning.encrypted_content")
+      result.include = include
+      if (!include.length) delete result.include
+    }
+
+    if (
+      result.chat_template_args &&
+      typeof result.chat_template_args === "object" &&
+      !Array.isArray(result.chat_template_args)
+    ) {
+      const entries = Object.entries(result.chat_template_args as Record<string, unknown>).filter(
+        ([key]) => key !== "enable_thinking",
+      )
+      if (entries.length) result.chat_template_args = Object.fromEntries(entries)
+      if (!entries.length) delete result.chat_template_args
+    }
+
+    return result
   }
 
   // Maps model ID prefix to provider slug used in providerOptions.

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -101,12 +101,7 @@ export namespace LLM {
           sessionID: input.sessionID,
           providerOptions: provider.options,
         })
-    const options: Record<string, any> = pipe(
-      base,
-      mergeDeep(input.model.options),
-      mergeDeep(input.agent.options),
-      mergeDeep(variant),
-    )
+    const options = pipe(base, mergeDeep(input.model.options), mergeDeep(input.agent.options), mergeDeep(variant))
     if (isCodex) {
       options.instructions = SystemPrompt.instructions()
     }
@@ -147,7 +142,8 @@ export namespace LLM {
     const maxOutputTokens =
       isCodex || provider.id.includes("github-copilot") ? undefined : ProviderTransform.maxOutputTokens(input.model)
 
-    const tools = await resolveTools(input)
+    const toolcall = input.model.capabilities.toolcall
+    const tools = toolcall ? await resolveTools(input) : {}
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.
@@ -160,7 +156,7 @@ export namespace LLM {
       input.model.providerID.toLowerCase().includes("litellm") ||
       input.model.api.id.toLowerCase().includes("litellm")
 
-    if (isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
+    if (toolcall && isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
       tools["_noop"] = tool({
         description:
           "Placeholder for LiteLLM/Anthropic proxy compatibility - required when message history contains tool calls but no active tools are needed",
@@ -199,10 +195,14 @@ export namespace LLM {
       temperature: params.temperature,
       topP: params.topP,
       topK: params.topK,
-      providerOptions: ProviderTransform.providerOptions(input.model, params.options),
+      providerOptions: ProviderTransform.providerOptions(
+        input.model,
+        // Re-apply capability filtering after plugin hooks mutate params.options.
+        ProviderTransform.compat(input.model, params.options),
+      ),
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
       tools,
-      toolChoice: input.toolChoice,
+      toolChoice: toolcall ? input.toolChoice : undefined,
       maxOutputTokens,
       abortSignal: input.abort,
       headers: {
@@ -238,7 +238,7 @@ export namespace LLM {
             async transformParams(args) {
               if (args.type === "stream") {
                 // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
+                args.params.prompt = ProviderTransform.message(args.params.prompt, input.model)
               }
               return args.params
             },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import type { ModelMessage } from "ai"
+import type { Provider } from "../../src/provider/provider"
 import { ProviderTransform } from "../../src/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
@@ -722,8 +724,142 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
 })
 
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
+  const deepseek = {
+    id: "deepseek/deepseek-chat",
+    providerID: "deepseek",
+    api: {
+      id: "deepseek-chat",
+      url: "https://api.deepseek.com",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "DeepSeek Chat",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: {
+        field: "reasoning_content",
+      },
+    },
+    cost: {
+      input: 0.001,
+      output: 0.002,
+      cache: { read: 0.0001, write: 0.0002 },
+    },
+    limit: {
+      context: 128000,
+      output: 8192,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2023-04-01",
+  } satisfies Provider.Model
+
+  const openai = {
+    id: "openai/gpt-4",
+    providerID: "openai",
+    api: {
+      id: "gpt-4",
+      url: "https://api.openai.com",
+      npm: "@ai-sdk/openai",
+    },
+    name: "GPT-4",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0.03,
+      output: 0.06,
+      cache: { read: 0.001, write: 0.002 },
+    },
+    limit: {
+      context: 128000,
+      output: 4096,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2023-04-01",
+  } satisfies Provider.Model
+
+  const dax = {
+    id: "dax/mistral-medium-latest",
+    providerID: "dax",
+    api: {
+      id: "mistral-medium-latest",
+      url: "https://dax.example/v1",
+      npm: "@ai-sdk/openai-compatible",
+    },
+    name: "DAX SMART",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: true,
+      toolcall: false,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0.001,
+      output: 0.002,
+      cache: { read: 0.0001, write: 0.0002 },
+    },
+    limit: {
+      context: 128000,
+      output: 4096,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2023-04-01",
+  } satisfies Provider.Model
+
+  const anthropic = {
+    id: "anthropic/claude-opus-4-5",
+    providerID: "anthropic",
+    api: {
+      id: "claude-opus-4-5",
+      url: "https://api.anthropic.com",
+      npm: "@ai-sdk/anthropic",
+    },
+    name: "Claude Opus",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: {
+      input: 0.015,
+      output: 0.075,
+      cache: { read: 0.0015, write: 0.00375 },
+    },
+    limit: {
+      context: 200000,
+      output: 4096,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2024-06-01",
+  } satisfies Provider.Model
+
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
-    const msgs = [
+    const msgs: ModelMessage[] = [
       {
         role: "assistant",
         content: [
@@ -736,46 +872,9 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           },
         ],
       },
-    ] as any[]
+    ]
 
-    const result = ProviderTransform.message(
-      msgs,
-      {
-        id: ModelID.make("deepseek/deepseek-chat"),
-        providerID: ProviderID.make("deepseek"),
-        api: {
-          id: "deepseek-chat",
-          url: "https://api.deepseek.com",
-          npm: "@ai-sdk/openai-compatible",
-        },
-        name: "DeepSeek Chat",
-        capabilities: {
-          temperature: true,
-          reasoning: true,
-          attachment: false,
-          toolcall: true,
-          input: { text: true, audio: false, image: false, video: false, pdf: false },
-          output: { text: true, audio: false, image: false, video: false, pdf: false },
-          interleaved: {
-            field: "reasoning_content",
-          },
-        },
-        cost: {
-          input: 0.001,
-          output: 0.002,
-          cache: { read: 0.0001, write: 0.0002 },
-        },
-        limit: {
-          context: 128000,
-          output: 8192,
-        },
-        status: "active",
-        options: {},
-        headers: {},
-        release_date: "2023-04-01",
-      },
-      {},
-    )
+    const result = ProviderTransform.message(msgs, deepseek)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toEqual([
@@ -789,8 +888,27 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
   })
 
-  test("Non-DeepSeek providers leave reasoning content unchanged", () => {
-    const msgs = [
+  test("field targets keep existing reasoning field metadata", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Answer" }],
+        providerOptions: {
+          copilot: {
+            reasoning_content: "Keep me",
+          },
+        },
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, deepseek)
+
+    expect(result[0].content).toEqual([{ type: "text", text: "Answer" }])
+    expect(result[0].providerOptions?.copilot?.reasoning_content).toBe("Keep me")
+  })
+
+  test("non-interleaved targets strip reasoning parts", () => {
+    const msgs: ModelMessage[] = [
       {
         role: "assistant",
         content: [
@@ -798,50 +916,170 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           { type: "text", text: "Answer" },
         ],
       },
-    ] as any[]
+    ]
 
-    const result = ProviderTransform.message(
-      msgs,
-      {
-        id: ModelID.make("openai/gpt-4"),
-        providerID: ProviderID.make("openai"),
-        api: {
-          id: "gpt-4",
-          url: "https://api.openai.com",
-          npm: "@ai-sdk/openai",
-        },
-        name: "GPT-4",
-        capabilities: {
-          temperature: true,
-          reasoning: false,
-          attachment: true,
-          toolcall: true,
-          input: { text: true, audio: false, image: true, video: false, pdf: false },
-          output: { text: true, audio: false, image: false, video: false, pdf: false },
-          interleaved: false,
-        },
-        cost: {
-          input: 0.03,
-          output: 0.06,
-          cache: { read: 0.001, write: 0.002 },
-        },
-        limit: {
-          context: 128000,
-          output: 4096,
-        },
-        status: "active",
-        options: {},
-        headers: {},
-        release_date: "2023-04-01",
-      },
-      {},
-    )
+    const result = ProviderTransform.message(msgs, openai)
 
-    expect(result[0].content).toEqual([
-      { type: "reasoning", text: "Should not be processed" },
-      { type: "text", text: "Answer" },
-    ])
+    expect(result[0].content).toEqual([{ type: "text", text: "Answer" }])
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+
+  test("replaces tool-only assistant history for targets without tool support", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { command: "echo hello" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: { type: "text", value: "hello" },
+          },
+        ],
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, dax)
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+      },
+    ])
+  })
+
+  test("Anthropic target keeps reasoning parts in content", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "internal thought" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, anthropic)
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "internal thought" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    ])
+  })
+
+  test("non-reasoning target strips reasoning parts from Anthropic history", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "internal thought" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, openai)
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ])
+  })
+
+  test("reasoning-only assistant message gets placeholder on strip target", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "only thoughts" }],
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, openai)
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+      },
+    ])
+  })
+
+  test("reasoning-only assistant message gets placeholder with field target", () => {
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "only thoughts" }],
+      },
+    ]
+
+    const result = ProviderTransform.message(msgs, deepseek)
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[Previous content omitted for model compatibility.]" }],
+        providerOptions: {
+          openaiCompatible: { reasoning_content: "only thoughts" },
+        },
+      },
+    ])
+  })
+})
+
+describe("ProviderTransform.options - capability filtering", () => {
+  test("removes reasoning defaults for models without reasoning support", () => {
+    const model = {
+      id: "openai/gpt-5-proxy",
+      providerID: "openai",
+      api: {
+        id: "gpt-5.2",
+        url: "https://api.openai.com/v1",
+        npm: "@ai-sdk/openai",
+      },
+      name: "GPT Proxy",
+      capabilities: {
+        temperature: true,
+        reasoning: false,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2023-04-01",
+    } satisfies Provider.Model
+
+    const result = ProviderTransform.options({ model, sessionID: "test-session-123", providerOptions: {} })
+
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+    expect(result.enable_thinking).toBeUndefined()
+    expect(result.include).toBeUndefined()
   })
 })
 
@@ -889,7 +1127,7 @@ describe("ProviderTransform.message - empty image handling", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, mockModel, {})
+    const result = ProviderTransform.message(msgs, mockModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(2)
@@ -913,7 +1151,7 @@ describe("ProviderTransform.message - empty image handling", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, mockModel, {})
+    const result = ProviderTransform.message(msgs, mockModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(2)
@@ -935,7 +1173,7 @@ describe("ProviderTransform.message - empty image handling", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, mockModel, {})
+    const result = ProviderTransform.message(msgs, mockModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(3)
@@ -988,7 +1226,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       { role: "user", content: "World" },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(2)
     expect(result[0].content).toBe("Hello")
@@ -1007,7 +1245,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(1)
@@ -1026,7 +1264,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(1)
@@ -1046,7 +1284,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       { role: "user", content: "World" },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(2)
     expect(result[0].content).toBe("Hello")
@@ -1064,7 +1302,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(1)
@@ -1088,7 +1326,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {})
+    const result = ProviderTransform.message(msgs, anthropicModel)
 
     expect(result).toHaveLength(1)
     expect(result[0].content).toHaveLength(2)
@@ -1147,7 +1385,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, openaiModel, {})
+    const result = ProviderTransform.message(msgs, openaiModel)
 
     expect(result).toHaveLength(2)
     expect(result[0].content).toBe("")
@@ -1209,7 +1447,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, openaiModel) as any[]
 
     expect(result).toHaveLength(1)
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("rs_123")
@@ -1248,7 +1486,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, zenModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, zenModel) as any[]
 
     expect(result).toHaveLength(1)
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("rs_123")
@@ -1274,7 +1512,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, openaiModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, openaiModel) as any[]
 
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_123")
     expect(result[0].content[0].providerOptions?.openai?.otherOption).toBe("value")
@@ -1299,7 +1537,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
     ] as any[]
 
     // openai package preserves itemId regardless of store value
-    const result = ProviderTransform.message(msgs, openaiModel, { store: true }) as any[]
+    const result = ProviderTransform.message(msgs, openaiModel) as any[]
 
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_123")
   })
@@ -1332,7 +1570,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
     ] as any[]
 
     // store=false preserves metadata for non-openai packages
-    const result = ProviderTransform.message(msgs, anthropicModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, anthropicModel) as any[]
 
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_123")
   })
@@ -1365,7 +1603,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, opencodeModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, opencodeModel) as any[]
 
     expect(result[0].content[0].providerOptions?.opencode?.itemId).toBe("msg_123")
     expect(result[0].content[0].providerOptions?.opencode?.otherOption).toBe("value")
@@ -1403,7 +1641,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, opencodeModel, { store: false }) as any[]
+    const result = ProviderTransform.message(msgs, opencodeModel) as any[]
 
     expect(result[0].providerOptions?.openai?.itemId).toBe("msg_root")
     expect(result[0].providerOptions?.opencode?.itemId).toBe("msg_opencode")
@@ -1440,7 +1678,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, anthropicModel, {}) as any[]
+    const result = ProviderTransform.message(msgs, anthropicModel) as any[]
 
     expect(result[0].content[0].providerOptions?.openai?.itemId).toBe("msg_123")
   })
@@ -1485,7 +1723,7 @@ describe("ProviderTransform.message - providerOptions key remapping", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {})
+    const result = ProviderTransform.message(msgs, model)
 
     expect(result[0].providerOptions?.azure).toEqual({ someOption: "value" })
     expect(result[0].providerOptions?.openai).toBeUndefined()
@@ -1503,7 +1741,7 @@ describe("ProviderTransform.message - providerOptions key remapping", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {})
+    const result = ProviderTransform.message(msgs, model)
 
     expect(result[0].providerOptions?.copilot).toEqual({ someOption: "value" })
     expect(result[0].providerOptions?.["github-copilot"]).toBeUndefined()
@@ -1521,7 +1759,7 @@ describe("ProviderTransform.message - providerOptions key remapping", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {})
+    const result = ProviderTransform.message(msgs, model)
 
     expect(result[0].providerOptions?.bedrock).toEqual({ someOption: "value" })
     expect(result[0].providerOptions?.["my-bedrock"]).toBeUndefined()
@@ -1551,7 +1789,7 @@ describe("ProviderTransform.message - claude w/bedrock custom inference profile"
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {})
+    const result = ProviderTransform.message(msgs, model)
 
     expect(result[0].providerOptions?.bedrock).toEqual(
       expect.objectContaining({
@@ -1604,7 +1842,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {}) as any[]
+    const result = ProviderTransform.message(msgs, model) as any[]
 
     expect(result[0].content[0].providerOptions).toBeUndefined()
     expect(result[0].providerOptions).toBeUndefined()
@@ -1630,7 +1868,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, model, {}) as any[]
+    const result = ProviderTransform.message(msgs, model) as any[]
 
     expect(result[0].providerOptions).toEqual({
       anthropic: {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -725,8 +725,8 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
 
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   const deepseek = {
-    id: "deepseek/deepseek-chat",
-    providerID: "deepseek",
+    id: ModelID.make("deepseek/deepseek-chat"),
+    providerID: ProviderID.make("deepseek"),
     api: {
       id: "deepseek-chat",
       url: "https://api.deepseek.com",
@@ -760,8 +760,8 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   } satisfies Provider.Model
 
   const openai = {
-    id: "openai/gpt-4",
-    providerID: "openai",
+    id: ModelID.make("openai/gpt-4"),
+    providerID: ProviderID.make("openai"),
     api: {
       id: "gpt-4",
       url: "https://api.openai.com",
@@ -793,8 +793,8 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   } satisfies Provider.Model
 
   const dax = {
-    id: "dax/mistral-medium-latest",
-    providerID: "dax",
+    id: ModelID.make("dax/mistral-medium-latest"),
+    providerID: ProviderID.make("dax"),
     api: {
       id: "mistral-medium-latest",
       url: "https://dax.example/v1",
@@ -826,8 +826,8 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   } satisfies Provider.Model
 
   const anthropic = {
-    id: "anthropic/claude-opus-4-5",
-    providerID: "anthropic",
+    id: ModelID.make("anthropic/claude-opus-4-5"),
+    providerID: ProviderID.make("anthropic"),
     api: {
       id: "claude-opus-4-5",
       url: "https://api.anthropic.com",
@@ -1048,8 +1048,8 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
 describe("ProviderTransform.options - capability filtering", () => {
   test("removes reasoning defaults for models without reasoning support", () => {
     const model = {
-      id: "openai/gpt-5-proxy",
-      providerID: "openai",
+      id: ModelID.make("openai/gpt-5-proxy"),
+      providerID: ProviderID.make("openai"),
       api: {
         id: "gpt-5.2",
         url: "https://api.openai.com/v1",
@@ -1358,7 +1358,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       },
     ] as any[]
 
-    const result = ProviderTransform.message(msgs, bedrockModel, {})
+    const result = ProviderTransform.message(msgs, bedrockModel)
 
     expect(result).toHaveLength(2)
     expect(result[0].content).toBe("Hello")

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -711,8 +711,8 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel("dax", model.id)
-        const sessionID = "session-test-5"
+        const resolved = await Provider.getModel(ProviderID.make("dax"), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-5")
         const agent = {
           name: "test",
           mode: "primary",
@@ -722,12 +722,12 @@ describe("session.llm.stream", () => {
         } satisfies Agent.Info
 
         const user = {
-          id: "user-5",
+          id: MessageID.make("user-5"),
           sessionID,
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID: "dax", modelID: resolved.id },
+          model: { providerID: ProviderID.make("dax"), modelID: resolved.id },
         } satisfies MessageV2.User
 
         const messages = [

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -666,4 +666,112 @@ describe("session.llm.stream", () => {
       },
     })
   })
+
+  test("strips reasoning history and options when target model disables reasoning", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const model = (await loadFixture("mistral", "mistral-medium-latest")).model
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["dax"],
+            provider: {
+              dax: {
+                name: "DAX",
+                npm: "@ai-sdk/openai-compatible",
+                api: `${server.url.origin}/v1`,
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel("dax", model.id)
+        const sessionID = "session-test-5"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.4,
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-5",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: "dax", modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const messages = [
+          {
+            role: "assistant",
+            content: [
+              { type: "reasoning", text: "Private GPT reasoning" },
+              { type: "text", text: "Earlier answer" },
+            ],
+            providerOptions: {
+              openaiCompatible: {
+                reasoning_content: "stale reasoning",
+              },
+            },
+          },
+          {
+            role: "user",
+            content: "Continue",
+          },
+        ] as ModelMessage[]
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages,
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+        expect(JSON.stringify(capture.body.messages).includes("reasoning_content")).toBe(false)
+        expect(JSON.stringify(capture.body.messages).includes("Private GPT reasoning")).toBe(false)
+        expect(JSON.stringify(capture.body.messages).includes("Earlier answer")).toBe(true)
+        expect(JSON.stringify(capture.body).includes("reasoningEffort")).toBe(false)
+        expect(JSON.stringify(capture.body).includes("reasoning_effort")).toBe(false)
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #16154

Also covers the same bug class as closed issue #11571 and overlaps with #11572 and #14783.

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [ ] New feature
- [ ] Documentation

### What does this PR do?

When a session switches to a different target model, it now sanitizes history and request options against that target model's capabilities.

- Strips incompatible reasoning/tool history for targets that do not support those features
- Preserves field-based reasoning metadata for interleaved targets
- Filters unsupported reasoning/thinking options
- Gates tool resolution plus toolChoice on target model toolcall

Added regression tests for GPT reasoning history -> non-reasoning OpenAI-compatible Mistral.

### How did you verify your code works?

Ran from `packages/opencode`:

- `bun test test/provider/transform.test.ts test/session/llm.test.ts`
- `bunx tsc --noEmit`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR