### PR TITLE
fix(app): auto-enable project workspaces when worktree is uploaded

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1262,7 +1262,7 @@ export default function Layout(props: ParentProps) {
       }
     }
 
-    if (project && project.vcs !== "git") return
+    if (project && project.vcs && project.vcs !== "git") return
 
     void globalSDK.client.project
       .current({ directory })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1238,7 +1238,50 @@ export default function Layout(props: ParentProps) {
     navigateWithSidebarReset(`/${base64Encode(session.directory)}/session/${session.id}`)
   }
 
+  function autoEnableWorkspacesIfSandbox(directory: string) {
+    const dir = workspaceKey(directory)
+    const project = layout
+      .projects
+      .list()
+      .find(
+        (item) =>
+          workspaceKey(item.worktree) === dir || item.sandboxes?.some((entry) => workspaceKey(entry) === dir),
+      )
+
+    if (project?.vcs === "git") {
+      const root = workspaceKey(project.worktree)
+      const isSandbox = project.sandboxes?.some((item) => workspaceKey(item) === dir)
+      if (root === dir) return
+      if (isSandbox) {
+        const enabled = layout.sidebar.workspaces(project.worktree)()
+        if (!enabled) {
+          layout.sidebar.setWorkspaces(project.worktree, true)
+          return
+        }
+        return
+      }
+    }
+
+    if (project && project.vcs !== "git") return
+
+    void globalSDK.client.project
+      .current({ directory })
+      .then((x) => x.data)
+      .then((item) => {
+        if (!item) return
+        if (item.vcs !== "git") return
+        const root = workspaceKey(item.worktree)
+        const isSandbox = item.sandboxes?.some((entry) => workspaceKey(entry) === dir)
+        if (root === dir) return
+        if (!isSandbox) return
+        if (layout.sidebar.workspaces(item.worktree)()) return
+        layout.sidebar.setWorkspaces(item.worktree, true)
+      })
+      .catch(() => undefined)
+  }
+
   function openProject(directory: string, navigate = true) {
+    autoEnableWorkspacesIfSandbox(directory)
     layout.projects.open(directory)
     if (navigate) navigateToProject(directory)
   }


### PR DESCRIPTION
### Issue for this PR

Closes #16474

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Selecting a Git worktree directory via the "Open Project" button loads the repository root and branch instead of the uploaded worktree when workspace view is disabled for that project. New projects default to workspaces disabled, and Git worktree directories are represented as project sandboxes that only appear when workspaces are enabled. This PR auto-enables the project's workspaces when the uploaded directory matches a sandbox (Git worktree), so the selected worktree is not hidden.

### How did you verify your code works?
Tested on desktop app and web app, including testing by uploading multiple worktrees at once, symlinked worktrees, deeplinks, etc.

### Screenshots / recordings
Before Fix: 
(branch should of changed to the worktree branch and ui should of showed new worktree)

https://github.com/user-attachments/assets/7ae9d0ec-def3-4a3e-b328-dea8d2b9f09e 

After Fix: 


https://github.com/user-attachments/assets/27d99180-1db7-4116-9bf1-704370de4bff


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR