### PR TITLE
fix(tui): canonicalize cwd after chdir

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -110,19 +110,20 @@ export const TuiThreadCommand = cmd({
         return
       }
 
-      // Use PWD when resolving relative --project paths, but default to the
-      // real cwd so the TUI thread and worker share the same directory key.
+      // Resolve relative --project paths from PWD, then use the real cwd after
+      // chdir so the thread and worker share the same directory key.
       const root = Filesystem.resolve(process.env.PWD ?? process.cwd())
-      const cwd = args.project
+      const next = args.project
         ? Filesystem.resolve(path.isAbsolute(args.project) ? args.project : path.join(root, args.project))
         : Filesystem.resolve(process.cwd())
       const file = await target()
       try {
-        process.chdir(cwd)
+        process.chdir(next)
       } catch {
-        UI.error("Failed to change directory to " + cwd)
+        UI.error("Failed to change directory to " + next)
         return
       }
+      const cwd = Filesystem.resolve(process.cwd())
 
       const worker = new Worker(file, {
         env: Object.fromEntries(

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -110,11 +110,12 @@ export const TuiThreadCommand = cmd({
         return
       }
 
-      // Resolve relative paths against PWD to preserve behavior when using --cwd flag
+      // Use PWD when resolving relative --project paths, but default to the
+      // real cwd so the TUI thread and worker share the same directory key.
       const root = Filesystem.resolve(process.env.PWD ?? process.cwd())
       const cwd = args.project
         ? Filesystem.resolve(path.isAbsolute(args.project) ? args.project : path.join(root, args.project))
-        : root
+        : Filesystem.resolve(process.cwd())
       const file = await target()
       try {
         process.chdir(cwd)

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -84,7 +84,29 @@ mock.module("@/project/instance", () => ({
 }))
 
 describe("tui thread", () => {
-  test("uses the real cwd when PWD points at a symlink", async () => {
+  async function call(project?: string) {
+    const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
+    const args: Parameters<NonNullable<typeof TuiThreadCommand.handler>>[0] = {
+      _: [],
+      $0: "opencode",
+      project,
+      prompt: "hi",
+      model: undefined,
+      agent: undefined,
+      session: undefined,
+      continue: false,
+      fork: false,
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      mdnsDomain: "opencode.local",
+      cors: [],
+    }
+    return TuiThreadCommand.handler(args)
+  }
+
+  async function check(project?: string) {
     await using tmp = await tmpdir({ git: true })
     const cwd = process.cwd()
     const pwd = process.env.PWD
@@ -92,7 +114,6 @@ describe("tui thread", () => {
     const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
     const link = path.join(path.dirname(tmp.path), path.basename(tmp.path) + "-link")
     const type = process.platform === "win32" ? "junction" : "dir"
-
     seen.tui.length = 0
     seen.inst.length = 0
     await fs.symlink(tmp.path, link, type)
@@ -101,26 +122,18 @@ describe("tui thread", () => {
       configurable: true,
       value: true,
     })
-    globalThis.Worker = class {
-      onerror?: (error: unknown) => void
+    globalThis.Worker = class extends EventTarget {
+      onerror = null
+      onmessage = null
+      onmessageerror = null
+      postMessage() {}
       terminate() {}
-    } as typeof Worker
+    } as unknown as typeof Worker
 
     try {
       process.chdir(tmp.path)
       process.env.PWD = link
-      const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
-      await expect(
-        TuiThreadCommand.handler({
-          project: undefined,
-          prompt: "hi",
-          model: undefined,
-          agent: undefined,
-          session: undefined,
-          continue: false,
-          fork: false,
-        }),
-      ).rejects.toBe(stop)
+      await expect(call(project)).rejects.toBe(stop)
       expect(seen.inst[0]).toBe(tmp.path)
       expect(seen.tui[0]).toBe(tmp.path)
     } finally {
@@ -132,5 +145,13 @@ describe("tui thread", () => {
       globalThis.Worker = worker
       await fs.rm(link, { recursive: true, force: true }).catch(() => undefined)
     }
+  }
+
+  test("uses the real cwd when PWD points at a symlink", async () => {
+    await check()
+  })
+
+  test("uses the real cwd after resolving a relative project from PWD", async () => {
+    await check(".")
   })
 })

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, mock, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../../fixture/fixture"
+
+const stop = new Error("stop")
+const seen = {
+  tui: [] as string[],
+  inst: [] as string[],
+}
+
+mock.module("../../../src/cli/cmd/tui/app", () => ({
+  tui: async (input: { directory: string }) => {
+    seen.tui.push(input.directory)
+    throw stop
+  },
+}))
+
+mock.module("@/util/rpc", () => ({
+  Rpc: {
+    client: () => ({
+      call: async () => ({ url: "http://127.0.0.1" }),
+      on: () => {},
+    }),
+  },
+}))
+
+mock.module("@/cli/ui", () => ({
+  UI: {
+    error: () => {},
+  },
+}))
+
+mock.module("@/util/log", () => ({
+  Log: {
+    init: async () => {},
+    create: () => ({
+      error: () => {},
+      info: () => {},
+      warn: () => {},
+      debug: () => {},
+      time: () => ({ stop: () => {} }),
+    }),
+    Default: {
+      error: () => {},
+      info: () => {},
+      warn: () => {},
+      debug: () => {},
+    },
+  },
+}))
+
+mock.module("@/util/timeout", () => ({
+  withTimeout: <T>(input: Promise<T>) => input,
+}))
+
+mock.module("@/cli/network", () => ({
+  withNetworkOptions: <T>(input: T) => input,
+  resolveNetworkOptions: async () => ({
+    mdns: false,
+    port: 0,
+    hostname: "127.0.0.1",
+  }),
+}))
+
+mock.module("../../../src/cli/cmd/tui/win32", () => ({
+  win32DisableProcessedInput: () => {},
+  win32InstallCtrlCGuard: () => undefined,
+}))
+
+mock.module("@/config/tui", () => ({
+  TuiConfig: {
+    get: () => ({}),
+  },
+}))
+
+mock.module("@/project/instance", () => ({
+  Instance: {
+    provide: async (input: { directory: string; fn: () => Promise<unknown> | unknown }) => {
+      seen.inst.push(input.directory)
+      return input.fn()
+    },
+  },
+}))
+
+describe("tui thread", () => {
+  test("uses the real cwd when PWD points at a symlink", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const cwd = process.cwd()
+    const pwd = process.env.PWD
+    const worker = globalThis.Worker
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+    const link = path.join(path.dirname(tmp.path), path.basename(tmp.path) + "-link")
+    const type = process.platform === "win32" ? "junction" : "dir"
+
+    seen.tui.length = 0
+    seen.inst.length = 0
+    await fs.symlink(tmp.path, link, type)
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+    globalThis.Worker = class {
+      onerror?: (error: unknown) => void
+      terminate() {}
+    } as typeof Worker
+
+    try {
+      process.chdir(tmp.path)
+      process.env.PWD = link
+      const { TuiThreadCommand } = await import("../../../src/cli/cmd/tui/thread")
+      await expect(
+        TuiThreadCommand.handler({
+          project: undefined,
+          prompt: "hi",
+          model: undefined,
+          agent: undefined,
+          session: undefined,
+          continue: false,
+          fork: false,
+        }),
+      ).rejects.toBe(stop)
+      expect(seen.inst[0]).toBe(tmp.path)
+      expect(seen.tui[0]).toBe(tmp.path)
+    } finally {
+      process.chdir(cwd)
+      if (pwd === undefined) delete process.env.PWD
+      else process.env.PWD = pwd
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+      globalThis.Worker = worker
+      await fs.rm(link, { recursive: true, force: true }).catch(() => undefined)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #16522
Fixes https://github.com/anomalyco/opencode/issues/16528
Fixes https://github.com/anomalyco/opencode/issues/16596



Use the same canonical cwd for the TUI thread and worker, including relative --project paths resolved from PWD.

---

Before 1.2.21
- thread/TUI used: real dir /tmp/opencode-test-abc
- worker used: real dir /tmp/opencode-test-abc
- aligned: yes

In broken 1.2.21
- thread/TUI used: symlink dir /tmp/opencode-test-abc-link
- worker used: real dir /tmp/opencode-test-abc
- aligned: no

After this fix
- thread/TUI uses: real dir /tmp/opencode-test-abc
- worker uses: real dir /tmp/opencode-test-abc
- aligned: yes

For relative --project from a symlinked PWD
- it first resolves relative to the symlink-aware PWD
- then after chdir, it canonicalizes with process.cwd()
- final directory identity is again the real dir