### PR TITLE
feat(opencode): allow parentID when forking sessions

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -235,6 +235,7 @@ export namespace Session {
     z.object({
       sessionID: Identifier.schema("session"),
       messageID: Identifier.schema("message").optional(),
+      parentID: Identifier.schema("session").optional(),
     }),
     async (input) => {
       const original = await get(input.sessionID)
@@ -242,6 +243,7 @@ export namespace Session {
       const title = getForkedTitle(original.title)
       const session = await createNext({
         directory: Instance.directory,
+        parentID: input.parentID,
         title,
       })
       const msgs = await messages({ sessionID: input.sessionID })

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -140,3 +140,23 @@ describe("step-finish token propagation via Bus event", () => {
     { timeout: 30000 },
   )
 })
+
+describe("Session.fork", () => {
+  test("can fork a session with an explicit parent", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const src = await Session.create({ title: "source-session" })
+        const parent = await Session.create({ title: "parent-session" })
+        const child = await Session.fork({ sessionID: src.id, parentID: parent.id })
+
+        expect(child.parentID).toBe(parent.id)
+        expect(child.title).toBe("source-session (fork #1)")
+
+        await Session.remove(child.id)
+        await Session.remove(parent.id)
+        await Session.remove(src.id)
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -2348,6 +2348,7 @@ export type SessionInitResponse = SessionInitResponses[keyof SessionInitResponse
 export type SessionForkData = {
   body?: {
     messageID?: string
+    parentID?: string
   }
   path: {
     id: string

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1579,6 +1579,7 @@ export class Session2 extends HeyApiClient {
       directory?: string
       workspace?: string
       messageID?: string
+      parentID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1591,6 +1592,7 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "body", key: "messageID" },
+            { in: "body", key: "parentID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3043,6 +3043,7 @@ export type SessionInitResponse = SessionInitResponses[keyof SessionInitResponse
 export type SessionForkData = {
   body?: {
     messageID?: string
+    parentID?: string
   }
   path: {
     sessionID: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2421,6 +2421,10 @@
                   "messageID": {
                     "type": "string",
                     "pattern": "^msg.*"
+                  },
+                  "parentID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
                   }
                 }
               }


### PR DESCRIPTION
### Issue for this PR

Closes #16639

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds optional `parentID` support to `session.fork()`.

Before this change, callers could either create a child session with the desired parent, or fork an existing session to reuse transcript context, but not both at the same time.

This update lets `session.fork()` assign the new forked session to an explicit parent. It also updates the OpenAPI/SDK artifacts and adds a focused test for the new behavior.

### How did you verify your code works?

- Ran `bun test test/session/session.test.ts` from `packages/opencode`
- Ran `bun tsc` from `packages/sdk/js`
- Validated the behavior with a small custom task-like tool prototype that forks a session into a child hierarchy while preserving the source transcript

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
