### PR TITLE
fix(build): exit after build to prevent process hang

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -224,3 +224,8 @@ if (Script.release) {
 }
 
 export { binaries }
+
+// Explicitly exit — the `@opencode-ai/script` import runs top-level shell
+// commands that leave handles open, preventing the process from exiting
+// naturally after the build completes.
+process.exit(0)


### PR DESCRIPTION
### Issue for this PR

Closes #16644

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The build script (`packages/opencode/script/build.ts`) hangs indefinitely after `Bun.build` completes. The `@opencode-ai/script` package runs top-level shell commands (e.g., `await $\`git branch --show-current\``) at import time, which leave handles open in the event loop and prevent the process from exiting naturally.

This adds an explicit `process.exit(0)` at the end of the build script so it exits cleanly after the build completes.

### How did you verify your code works?

- Ran `bun run build --single` in `packages/opencode` — confirmed it completes and exits cleanly instead of hanging
- Verified the built binary works correctly

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR