### PR TITLE
fix: resolve symlinks in Instance cache to prevent duplicate contexts

### DIFF
--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -114,8 +114,15 @@ export namespace Filesystem {
   }
 
   // We cannot rely on path.resolve() here because git.exe may come from Git Bash, Cygwin, or MSYS2, so we need to translate these paths at the boundary.
+  // Also resolves symlinks so that callers using the result as a cache key
+  // always get the same canonical path for a given physical directory.
   export function resolve(p: string): string {
-    return normalizePath(pathResolve(windowsPath(p)))
+    const resolved = pathResolve(windowsPath(p))
+    try {
+      return normalizePath(realpathSync(resolved))
+    } catch {
+      return normalizePath(resolved)
+    }
   }
 
   export function windowsPath(p: string): string {

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -120,8 +120,9 @@ export namespace Filesystem {
     const resolved = pathResolve(windowsPath(p))
     try {
       return normalizePath(realpathSync(resolved))
-    } catch {
-      return normalizePath(resolved)
+    } catch (e) {
+      if (isEnoent(e)) return normalizePath(resolved)
+      throw e
     }
   }
 

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -502,5 +502,24 @@ describe("filesystem", () => {
       const drive = tmp.path[0].toLowerCase()
       expect(Filesystem.resolve(`/mnt/${drive}`)).toBe(Filesystem.resolve(`${drive.toUpperCase()}:/`))
     })
+
+    test("resolves symlinked directory to canonical path", async () => {
+      if (process.platform === "win32") return
+      await using tmp = await tmpdir()
+      const link = tmp.path + "-symlink"
+      await fs.symlink(tmp.path, link)
+      try {
+        expect(Filesystem.resolve(link)).toBe(Filesystem.resolve(tmp.path))
+      } finally {
+        await fs.unlink(link).catch(() => {})
+      }
+    })
+
+    test("returns unresolved path when target does not exist", async () => {
+      await using tmp = await tmpdir()
+      const nonExistent = path.join(tmp.path, "does-not-exist-" + Date.now())
+      const result = Filesystem.resolve(nonExistent)
+      expect(result).toBe(Filesystem.normalizePath(path.resolve(nonExistent)))
+    })
   })
 })

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -521,5 +521,48 @@ describe("filesystem", () => {
       const result = Filesystem.resolve(nonExistent)
       expect(result).toBe(Filesystem.normalizePath(path.resolve(nonExistent)))
     })
+
+    test("throws ELOOP on symlink cycle", async () => {
+      if (process.platform === "win32") return
+      await using tmp = await tmpdir()
+      const a = path.join(tmp.path, "a")
+      const b = path.join(tmp.path, "b")
+      await fs.symlink(b, a)
+      await fs.symlink(a, b)
+      expect(() => Filesystem.resolve(a)).toThrow()
+    })
+
+    test("throws EACCES on permission-denied symlink target", async () => {
+      if (process.platform === "win32") return
+      if (process.getuid?.() === 0) return // skip when running as root
+      await using tmp = await tmpdir()
+      const dir = path.join(tmp.path, "restricted")
+      await fs.mkdir(dir)
+      const link = path.join(tmp.path, "link")
+      await fs.symlink(dir, link)
+      // Remove all permissions from the target directory's parent entry
+      // realpathSync needs execute permission on each component
+      await fs.chmod(dir, 0o000)
+      try {
+        // Resolving a path *inside* the restricted dir should throw EACCES
+        expect(() => Filesystem.resolve(path.join(link, "child"))).toThrow()
+      } finally {
+        await fs.chmod(dir, 0o755)
+      }
+    })
+
+    test("rethrows non-ENOENT errors", () => {
+      // Verify the contract: only ENOENT is caught, other errors propagate
+      // We test this indirectly via ELOOP above, but also verify ENOTDIR
+      if (process.platform === "win32") return
+      const tmpFile = path.join(process.env.TMPDIR || "/tmp", `oc-test-${Date.now()}`)
+      require("fs").writeFileSync(tmpFile, "not-a-directory")
+      try {
+        // Treating a file as a directory component should throw ENOTDIR
+        expect(() => Filesystem.resolve(path.join(tmpFile, "child"))).toThrow()
+      } finally {
+        require("fs").unlinkSync(tmpFile)
+      }
+    })
   })
 })

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -504,26 +504,22 @@ describe("filesystem", () => {
     })
 
     test("resolves symlinked directory to canonical path", async () => {
-      if (process.platform === "win32") return
       await using tmp = await tmpdir()
-      const link = tmp.path + "-symlink"
-      await fs.symlink(tmp.path, link)
-      try {
-        expect(Filesystem.resolve(link)).toBe(Filesystem.resolve(tmp.path))
-      } finally {
-        await fs.unlink(link).catch(() => {})
-      }
+      const target = path.join(tmp.path, "real")
+      await fs.mkdir(target)
+      const link = path.join(tmp.path, "link")
+      await fs.symlink(target, link)
+      expect(Filesystem.resolve(link)).toBe(Filesystem.resolve(target))
     })
 
     test("returns unresolved path when target does not exist", async () => {
       await using tmp = await tmpdir()
-      const nonExistent = path.join(tmp.path, "does-not-exist-" + Date.now())
-      const result = Filesystem.resolve(nonExistent)
-      expect(result).toBe(Filesystem.normalizePath(path.resolve(nonExistent)))
+      const missing = path.join(tmp.path, "does-not-exist-" + Date.now())
+      const result = Filesystem.resolve(missing)
+      expect(result).toBe(Filesystem.normalizePath(path.resolve(missing)))
     })
 
     test("throws ELOOP on symlink cycle", async () => {
-      if (process.platform === "win32") return
       await using tmp = await tmpdir()
       const a = path.join(tmp.path, "a")
       const b = path.join(tmp.path, "b")
@@ -532,6 +528,7 @@ describe("filesystem", () => {
       expect(() => Filesystem.resolve(a)).toThrow()
     })
 
+    // Windows: chmod(0o000) is a no-op, so EACCES cannot be triggered
     test("throws EACCES on permission-denied symlink target", async () => {
       if (process.platform === "win32") return
       if (process.getuid?.() === 0) return // skip when running as root
@@ -540,29 +537,22 @@ describe("filesystem", () => {
       await fs.mkdir(dir)
       const link = path.join(tmp.path, "link")
       await fs.symlink(dir, link)
-      // Remove all permissions from the target directory's parent entry
-      // realpathSync needs execute permission on each component
       await fs.chmod(dir, 0o000)
       try {
-        // Resolving a path *inside* the restricted dir should throw EACCES
         expect(() => Filesystem.resolve(path.join(link, "child"))).toThrow()
       } finally {
         await fs.chmod(dir, 0o755)
       }
     })
 
-    test("rethrows non-ENOENT errors", () => {
-      // Verify the contract: only ENOENT is caught, other errors propagate
-      // We test this indirectly via ELOOP above, but also verify ENOTDIR
+    // Windows: traversing through a file throws ENOENT (not ENOTDIR),
+    // which resolve() catches as a fallback instead of rethrowing
+    test("rethrows non-ENOENT errors", async () => {
       if (process.platform === "win32") return
-      const tmpFile = path.join(process.env.TMPDIR || "/tmp", `oc-test-${Date.now()}`)
-      require("fs").writeFileSync(tmpFile, "not-a-directory")
-      try {
-        // Treating a file as a directory component should throw ENOTDIR
-        expect(() => Filesystem.resolve(path.join(tmpFile, "child"))).toThrow()
-      } finally {
-        require("fs").unlinkSync(tmpFile)
-      }
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "not-a-directory")
+      await fs.writeFile(file, "x")
+      expect(() => Filesystem.resolve(path.join(file, "child"))).toThrow()
     })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #16647
Fixes #15482
Fixes #16659
Related: #16522, #16641

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Filesystem.resolve()` used `path.resolve()` which normalizes `.`/`..` segments but does **not** resolve symlinks. When opencode runs from a symlinked directory, `Instance.provide()` creates duplicate contexts for the same physical directory because two different path strings produce two separate cache entries.

Because the `Bus` pub/sub system is Instance-scoped (via `Instance.state()`), events published on one Instance (where the LLM session runs) are never received by subscribers on the other Instance (where the SSE endpoint listens). This causes a completely blank TUI after sending prompts.

**Fix:** Move symlink resolution (`realpathSync`) into `Filesystem.resolve()` so all callers benefit — not just `Instance.provide()` and `Instance.reload()`. Falls back to the unresolved path only for `ENOENT` (path doesn't exist yet); all other errors (`EACCES`, `ELOOP`, `ENOTDIR`) are rethrown to avoid silently masking broken paths.

This is complementary to #16641 which canonicalizes at the caller (thread.ts) level.

### How did you verify your code works?

- Reproduced the bug by running opencode from `~/src-office` (a symlink to `~/dtkr4-cnjjf/...`)
- Confirmed blank TUI after sending prompt (events never bridged between instances)
- Applied fix, rebuilt, and verified prompts and responses work correctly
- Added tests for symlink resolution, non-existent path fallback, ELOOP, EACCES, and ENOTDIR
- `bun test test/util/filesystem.test.ts` — 55 tests pass (including 5 new)
- `bun tsc --noEmit` — no type errors

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR