### PR TITLE
feat(opencode): add macOS to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         settings:
           - name: linux
             host: blacksmith-4vcpu-ubuntu-2404
+          - name: macos
+            host: macos-latest
           - name: windows
             host: blacksmith-4vcpu-windows-2025
     runs-on: ${{ matrix.settings.host }}
@@ -48,6 +50,9 @@ jobs:
           - name: linux
             host: blacksmith-4vcpu-ubuntu-2404
             playwright: bunx playwright install --with-deps
+          - name: macos
+            host: macos-latest
+            playwright: bunx playwright install
           - name: windows
             host: blacksmith-4vcpu-windows-2025
             playwright: bunx playwright install


### PR DESCRIPTION
### Issue for this PR

Closes #16661
Related: #16647

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `macos-latest` runner to both the `unit` and `e2e` test matrices in `.github/workflows/test.yml`.

The test matrix currently only covers Linux and Windows. The symlink regression in #16647 was macOS-specific — `process.cwd()` preserves symlink paths on macOS but Linux's `getcwd()` returns the canonical path — and would have been caught by a macOS CI runner.

This also improves coverage for case-sensitivity differences (macOS APFS is case-insensitive by default) and other Darwin/Linux POSIX divergences.

Uses `macos-latest`, consistent with the runner label already used in `publish.yml`.

### How did you verify your code works?

- Verified `setup-bun` action already handles macOS (`case` on line 21)
- Confirmed `macos-latest` is the same runner label used in other workflows (`publish.yml`)
- Playwright install uses `bunx playwright install` (no `--with-deps`), matching the Windows pattern

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR