### PR TITLE
docs: Add OpenCode-IMean to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -76,3 +76,5 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+
+| [OpenCode-IMean](https://github.com/vc999999999/OpenCode-IMean) | Local-first workflow plugin for OpenCode that externalizes task state, enforces phase transitions, and reduces drift in large-context models |


### PR DESCRIPTION
### Issue for this PR
Documentation: add OpenCode-IMean plugin entry to the ecosystem page.

Closes # (no linked issue)

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds OpenCode-IMean to `packages/web/src/content/docs/ecosystem.mdx` so it shows up in the ecosystem list.

### How did you verify your code works?
N/A - documentation change only.

### Screenshots / recordings
N/A

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR