### PR TITLE
fix(tui): honor markdown code block theme token

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -932,9 +932,15 @@ function getSyntaxRules(theme: Theme) {
       },
     },
     {
-      scope: ["markup.raw", "markup.raw.block"],
+      scope: ["markup.raw"],
       style: {
         foreground: theme.markdownCode,
+      },
+    },
+    {
+      scope: ["markup.raw.block", "markup.raw.block.markdown", "markup.fenced_code.block"],
+      style: {
+        foreground: theme.markdownCodeBlock,
       },
     },
     {


### PR DESCRIPTION
### Issue for this PR

Closes #16470

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Issue #16470 reports that fenced markdown code blocks in the TUI were not using the dedicated `markdownCodeBlock` theme token, so light-mode fenced code could fall back to hard-to-read styling.

This PR routes fenced/raw markdown block scopes to `markdownCodeBlock` while keeping inline/raw markdown styling on the existing `markdownCode` token. That keeps fenced code block colors under the intended theme control without changing inline code behavior.

### How did you verify your code works?

I reviewed the touched theme-mapping change in a local checkout and ran `git diff --check` to confirm the patch is clean. I did not run a broader local app test suite in this environment.

### Screenshots / recordings

Not included for this patch.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
