### PR TITLE
fix(desktop): enable dmabuf renderer by default on linux tauri

### DIFF
--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -19,24 +19,39 @@ fn configure_display_backend() -> Option<String> {
     let prefer_wayland = opencode_lib::linux_display::read_wayland().unwrap_or(false);
     let decision = select_backend(&session, prefer_wayland)?;
 
+    let disable_dmabuf = matches!(
+        env::var("OC_DISABLE_DMABUF_RENDERER")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1" | "true" | "yes" | "on")
+    );
+
     match decision.backend {
         Backend::X11 => {
             set_env_if_absent("WINIT_UNIX_BACKEND", "x11");
             set_env_if_absent("GDK_BACKEND", "x11");
-            set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
         Backend::Wayland => {
             set_env_if_absent("WINIT_UNIX_BACKEND", "wayland");
             set_env_if_absent("GDK_BACKEND", "wayland");
-            set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
         Backend::Auto => {
             set_env_if_absent("GDK_BACKEND", "wayland,x11");
-            set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
     }
 
-    Some(decision.note)
+    if disable_dmabuf {
+        set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        return Some(format!(
+            "{} DMA-BUF renderer disabled due to OC_DISABLE_DMABUF_RENDERER=1.",
+            decision.note
+        ));
+    }
+
+    Some(format!("{} DMA-BUF renderer enabled by default.", decision.note))
 }
 
 fn main() {


### PR DESCRIPTION
 ### Issue for this PR

  Closes #15511

  ### Type of change

  - [x] Bug fix

  ### What does this PR do?

  Removes the unconditional Linux startup setting of `WEBKIT_DISABLE_DMABUF_RENDERER=1` in Tauri.

  - DMA-BUF renderer is now enabled by default.
  - Added `OC_DISABLE_DMABUF_RENDERER=1` as an opt-out fallback for users who need it.

Makes Linux Desktop UI snappier 

  ### How did you verify your code works?

  - Ran `bun run tauri:dev` and verified the UI/scrolling feels noticeably more responsive.
  - Ran `bun run tauri build` successfully.

  ### Screenshots / recordings

  https://github.com/user-attachments/assets/5c59c089-9bd4-4927-932c-3cc9666b0383

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR