### PR TITLE
fix(app): support selecting multiple prompt attachments

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -55,6 +55,7 @@ import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
+import { attachFiles } from "./prompt-input/attach-files"
 
 interface PromptInputProps {
   class?: string
@@ -1177,22 +1178,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           onRemove={removeImageAttachment}
           removeLabel={language.t("prompt.attachment.remove")}
         />
-        <div
-          class="relative"
-          onMouseDown={(e) => {
-            const target = e.target
-            if (!(target instanceof HTMLElement)) return
-            if (
-              target.closest(
-                '[data-action="prompt-attach"], [data-action="prompt-submit"], [data-action="prompt-permissions"]',
-              )
-            ) {
-              return
-            }
-            editorRef?.focus()
-          }}
-        >
+        <div class="relative">
           <div class="relative max-h-[240px] overflow-y-auto no-scrollbar" ref={(el) => (scrollRef = el)}>
+            {/* biome-ignore lint/a11y/useSemanticElements: rich text prompt input requires contentEditable */}
             <div
               data-component="prompt-input"
               ref={(el) => {
@@ -1201,8 +1189,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               }}
               role="textbox"
               aria-multiline="true"
+              tabIndex={0}
+              contentEditable
               aria-label={placeholder()}
-              contenteditable="true"
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
               autocorrect={store.mode === "normal" ? "on" : "off"}
               spellcheck={store.mode === "normal"}
@@ -1234,11 +1223,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             <input
               ref={fileInputRef}
               type="file"
+              multiple
               accept={ACCEPTED_FILE_TYPES.join(",")}
               class="hidden"
               onChange={(e) => {
-                const file = e.currentTarget.files?.[0]
-                if (file) addImageAttachment(file)
+                void attachFiles(e.currentTarget.files, addImageAttachment)
                 e.currentTarget.value = ""
               }}
             />

--- a/packages/app/src/components/prompt-input/attach-files.test.ts
+++ b/packages/app/src/components/prompt-input/attach-files.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, mock, test } from "bun:test"
+import { attachFiles } from "./attach-files"
+
+describe("attachFiles", () => {
+  test("adds every selected file in order", async () => {
+    const a = new File(["a"], "a.png", { type: "image/png" })
+    const b = new File(["b"], "b.pdf", { type: "application/pdf" })
+    const add = mock(async (_file: File) => undefined)
+    const list = {
+      0: a,
+      1: b,
+      length: 2,
+      item: (index: number) => [a, b][index] ?? null,
+      [Symbol.iterator]: function* () {
+        yield a
+        yield b
+      },
+    } as FileList
+
+    await attachFiles(list, add)
+
+    expect(add.mock.calls).toHaveLength(2)
+    expect(add.mock.calls[0]?.[0]).toBe(a)
+    expect(add.mock.calls[1]?.[0]).toBe(b)
+  })
+
+  test("ignores empty selections", async () => {
+    const add = mock(async (_file: File) => undefined)
+
+    await attachFiles(null, add)
+
+    expect(add.mock.calls).toHaveLength(0)
+  })
+
+  test("continues after one file add fails", async () => {
+    const a = new File(["a"], "a.png", { type: "image/png" })
+    const b = new File(["b"], "b.pdf", { type: "application/pdf" })
+    const add = mock(async (file: File) => {
+      if (file === a) throw new Error("fail")
+    })
+    const list = {
+      0: a,
+      1: b,
+      length: 2,
+      item: (index: number) => [a, b][index] ?? null,
+      [Symbol.iterator]: function* () {
+        yield a
+        yield b
+      },
+    } as FileList
+
+    await attachFiles(list, add)
+
+    expect(add.mock.calls).toHaveLength(2)
+    expect(add.mock.calls[0]?.[0]).toBe(a)
+    expect(add.mock.calls[1]?.[0]).toBe(b)
+  })
+})

--- a/packages/app/src/components/prompt-input/attach-files.ts
+++ b/packages/app/src/components/prompt-input/attach-files.ts
@@ -1,0 +1,6 @@
+export async function attachFiles(list: FileList | null | undefined, add: (file: File) => Promise<void>) {
+  if (!list?.length) return
+  for (const file of Array.from(list)) {
+    await add(file).catch(() => undefined)
+  }
+}

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -38,22 +38,27 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
   const addImageAttachment = async (file: File) => {
     if (!ACCEPTED_FILE_TYPES.includes(file.type)) return
 
-    const reader = new FileReader()
-    reader.onload = () => {
-      const editor = input.editor()
-      if (!editor) return
-      const dataUrl = reader.result as string
-      const attachment: ImageAttachmentPart = {
-        type: "image",
-        id: uuid(),
-        filename: file.name,
-        mime: file.type,
-        dataUrl,
+    await new Promise<void>((resolve) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const editor = input.editor()
+        if (!editor) return resolve()
+        const dataUrl = reader.result as string
+        const attachment: ImageAttachmentPart = {
+          type: "image",
+          id: uuid(),
+          filename: file.name,
+          mime: file.type,
+          dataUrl,
+        }
+        const cursorPosition = prompt.cursor() ?? getCursorPosition(editor)
+        prompt.set([...prompt.current(), attachment], cursorPosition)
+        resolve()
       }
-      const cursorPosition = prompt.cursor() ?? getCursorPosition(editor)
-      prompt.set([...prompt.current(), attachment], cursorPosition)
-    }
-    reader.readAsDataURL(file)
+      reader.onerror = () => resolve()
+      reader.onabort = () => resolve()
+      reader.readAsDataURL(file)
+    })
   }
 
   const removeImageAttachment = (id: string) => {


### PR DESCRIPTION
### Issue for this PR

Closes #16693

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the prompt attachment picker so it handles all selected files instead of only the first one.

I updated the file input path to process the full `FileList`, added a focused test for the helper, and made attachment processing wait for file reads so multi-file selection is more reliable.

### How did you verify your code works?

- verified in the web app that selecting multiple files from the attachment picker adds all selected files
- ran the focused prompt-input tests
- confirmed desktop uses the same shared app prompt input implementation

### Screenshots / recordings

Web app verification: selecting multiple files from the attachment picker now adds all selected files.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
