### PR TITLE
feat(core): expose workspace adaptor and VCS branch hooks to plugin system

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -82,9 +82,15 @@ function DialogWorkspaceCreate(props: { onSelect: (workspaceID: string) => Promi
   const sdk = useSDK()
   const toast = useToast()
   const [creating, setCreating] = createSignal<string>()
+  const [types, setTypes] = createSignal<{ types: string[]; detected?: string }>({ types: ["worktree"] })
 
   onMount(() => {
     dialog.setSize("medium")
+    void sdk
+      .fetch(`${sdk.url}/experimental/workspace/types`)
+      .then((res) => res.json() as Promise<{ types: string[]; detected?: string }>)
+      .then((data) => setTypes(data))
+      .catch(() => {})
   })
 
   const options = createMemo(() => {
@@ -98,13 +104,12 @@ function DialogWorkspaceCreate(props: { onSelect: (workspaceID: string) => Promi
         },
       ]
     }
-    return [
-      {
-        title: "Worktree",
-        value: "worktree" as const,
-        description: "Create a local git worktree",
-      },
-    ]
+    const info = types()
+    return info.types.map((t) => ({
+      title: t.charAt(0).toUpperCase() + t.slice(1),
+      value: t,
+      description: t === info.detected ? "Detected" : undefined,
+    }))
   })
 
   const createWorkspace = async (type: string) => {

--- a/packages/opencode/src/cli/cmd/tui/component/workspace/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/workspace/dialog-session-list.tsx
@@ -12,6 +12,7 @@ import { useKV } from "../../context/kv"
 import { createDebouncedSignal } from "../../util/signal"
 import { Spinner } from "../spinner"
 import { useToast } from "../../ui/toast"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 
 export function DialogSessionList(props: { workspaceID?: string; localOnly?: boolean } = {}) {
   const dialog = useDialog()
@@ -25,18 +26,27 @@ export function DialogSessionList(props: { workspaceID?: string; localOnly?: boo
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
 
+  const client = props.workspaceID
+    ? createOpencodeClient({
+        baseUrl: sdk.url,
+        fetch: sdk.fetch,
+        directory: sync.data.path.directory || sdk.directory,
+        experimental_workspaceID: props.workspaceID,
+      })
+    : sdk.client
+
   const [listed, listedActions] = createResource(
     () => props.workspaceID,
     async (workspaceID) => {
       if (!workspaceID) return undefined
-      const result = await sdk.client.session.list({ roots: true })
+      const result = await client.session.list({ roots: true })
       return result.data ?? []
     },
   )
 
   const [searchResults] = createResource(search, async (query) => {
     if (!query || props.localOnly) return undefined
-    const result = await sdk.client.session.list({
+    const result = await client.session.list({
       search: query,
       limit: 30,
       ...(props.workspaceID ? { roots: true } : {}),
@@ -111,7 +121,7 @@ export function DialogSessionList(props: { workspaceID?: string; localOnly?: boo
           title: "delete",
           onTrigger: async (option) => {
             if (toDelete() === option.value) {
-              const deleted = await sdk.client.session
+              const deleted = await client.session
                 .delete({
                   sessionID: option.value,
                 })

--- a/packages/opencode/src/control-plane/adaptors/index.ts
+++ b/packages/opencode/src/control-plane/adaptors/index.ts
@@ -1,20 +1,33 @@
 import { lazy } from "@/util/lazy"
 import type { Adaptor } from "../types"
+import type { WorkspaceAdaptor } from "@opencode-ai/plugin"
 
-const ADAPTORS: Record<string, () => Promise<Adaptor>> = {
+const ADAPTORS: Record<string, () => Adaptor | Promise<Adaptor>> = {
   worktree: lazy(async () => (await import("./worktree")).WorktreeAdaptor),
 }
 
-export function getAdaptor(type: string): Promise<Adaptor> {
-  return ADAPTORS[type]()
+export async function getAdaptor(type: string): Promise<Adaptor> {
+  const factory = ADAPTORS[type]
+  if (!factory) throw new Error(`Unknown workspace adaptor type "${type}". Available: ${listTypes().join(", ")}`)
+  return factory()
 }
 
-export function installAdaptor(type: string, adaptor: Adaptor) {
-  // This is experimental: mostly used for testing right now, but we
-  // will likely allow this in the future. Need to figure out the
-  // TypeScript story
+// Accepts both internal Adaptor (branded IDs) and plugin WorkspaceAdaptor
+// (plain strings). The branded types are structurally identical at runtime.
+export function installAdaptor(type: string, adaptor: Adaptor | WorkspaceAdaptor) {
+  ADAPTORS[type] = () => adaptor as Adaptor
+}
 
-  // @ts-expect-error we force the builtin types right now, but we
-  // will implement a way to extend the types for custom adaptors
-  ADAPTORS[type] = () => adaptor
+export function listTypes(): string[] {
+  return Object.keys(ADAPTORS)
+}
+
+export async function detectAdaptor(directory: string) {
+  for (const type of listTypes()) {
+    if (type === "worktree") continue
+    const adaptor = await getAdaptor(type)
+    if (adaptor.detect && (await adaptor.detect(directory))) {
+      return { type, adaptor }
+    }
+  }
 }

--- a/packages/opencode/src/control-plane/types.ts
+++ b/packages/opencode/src/control-plane/types.ts
@@ -10,12 +10,15 @@ export const WorkspaceInfo = z.object({
   directory: z.string().nullable(),
   extra: z.unknown().nullable(),
   projectID: ProjectID.zod,
+  projectDirectory: z.string().optional(),
 })
 export type WorkspaceInfo = z.infer<typeof WorkspaceInfo>
 
 export type Adaptor = {
+  detect?(directory: string): boolean | Promise<boolean>
   configure(input: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
   create(input: WorkspaceInfo, from?: WorkspaceInfo): Promise<void>
   remove(config: WorkspaceInfo): Promise<void>
+  reset?(config: WorkspaceInfo): Promise<void>
   fetch(config: WorkspaceInfo, input: RequestInfo | URL, init?: RequestInit): Promise<Response>
 }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -51,13 +51,20 @@ export namespace Workspace {
     branch: Info.shape.branch,
     projectID: ProjectID.zod,
     extra: Info.shape.extra,
+    projectDirectory: z.string().optional(),
   })
 
   export const create = fn(CreateInput, async (input) => {
     const id = WorkspaceID.ascending(input.id)
     const adaptor = await getAdaptor(input.type)
 
-    const config = await adaptor.configure({ ...input, id, name: null, directory: null })
+    const config = await adaptor.configure({
+      ...input,
+      id,
+      name: null,
+      directory: null,
+      projectDirectory: input.projectDirectory,
+    })
 
     const info: Info = {
       id,
@@ -67,6 +74,7 @@ export namespace Workspace {
       directory: config.directory ?? null,
       extra: config.extra ?? null,
       projectID: input.projectID,
+      projectDirectory: input.projectDirectory,
     }
 
     Database.use((db) => {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -12,6 +12,7 @@ import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-auth"
+import { installAdaptor } from "../control-plane/adaptors"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -41,6 +42,13 @@ export namespace Plugin {
       directory: Instance.directory,
       get serverUrl(): URL {
         return Server.url ?? new URL("http://localhost:4096")
+      },
+      async workspaceFetch(dir, req, init) {
+        const { WorkspaceServer } = await import("../control-plane/workspace-server/server")
+        const url = req instanceof Request || req instanceof URL ? req : new URL(req, "http://opencode.internal")
+        const headers = new Headers(init?.headers ?? (req instanceof Request ? req.headers : undefined))
+        headers.set("x-opencode-directory", dir)
+        return WorkspaceServer.App().fetch(new Request(url, { ...init, headers }))
       },
       $: Bun.$,
     }
@@ -103,6 +111,15 @@ export namespace Plugin {
         })
     }
 
+    for (const hook of hooks) {
+      const adaptors = hook["workspace.adaptor"]
+      if (!adaptors) continue
+      for (const [type, adaptor] of Object.entries(adaptors)) {
+        log.info("installing workspace adaptor", { type })
+        installAdaptor(type, adaptor)
+      }
+    }
+
     return {
       hooks,
       input,
@@ -110,7 +127,7 @@ export namespace Plugin {
   })
 
   export async function trigger<
-    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool">,
+    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool" | "workspace.adaptor">,
     Input = Parameters<Required<Hooks>[Name]>[0],
     Output = Parameters<Required<Hooks>[Name]>[1],
   >(name: Name, input: Input, output: Output): Promise<Output> {

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,11 +1,11 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
-import path from "path"
 import z from "zod"
 import { Log } from "@/util/log"
 import { Instance } from "./instance"
 import { FileWatcher } from "@/file/watcher"
 import { git } from "@/util/git"
+import { Plugin } from "@/plugin"
 
 const log = Log.create({ service: "vcs" })
 
@@ -32,16 +32,22 @@ export namespace Vcs {
     const result = await git(["rev-parse", "--abbrev-ref", "HEAD"], {
       cwd: Instance.worktree,
     })
-    if (result.exitCode !== 0) return
+    if (result.exitCode !== 0) return pluginBranch()
     const text = result.text().trim()
-    if (!text) return
+    if (!text) return pluginBranch()
     return text
+  }
+
+  async function pluginBranch() {
+    const output = { branch: undefined as string | undefined }
+    await Plugin.trigger("vcs.branch", { directory: Instance.worktree, vcs: Instance.project.vcs }, output)
+    return output.branch
   }
 
   const state = Instance.state(
     async () => {
       if (Instance.project.vcs !== "git") {
-        return { branch: async () => undefined, unsubscribe: undefined }
+        return { branch: async () => pluginBranch(), unsubscribe: undefined }
       }
       let current = await currentBranch()
       log.info("initialized", { branch: current })

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -12,6 +12,8 @@ import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { WorkspaceRoutes } from "./workspace"
+import { detectAdaptor } from "../../control-plane/adaptors"
+import { Workspace } from "../../control-plane/workspace"
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
@@ -94,7 +96,8 @@ export const ExperimentalRoutes = lazy(() =>
       "/worktree",
       describeRoute({
         summary: "Create worktree",
-        description: "Create a new git worktree for the current project and run any configured startup scripts.",
+        description:
+          "Create a new git worktree for the current project and run any configured startup scripts. If a plugin adaptor is detected, creates a workspace through that adaptor instead.",
         operationId: "worktree.create",
         responses: {
           200: {
@@ -110,6 +113,17 @@ export const ExperimentalRoutes = lazy(() =>
       }),
       validator("json", Worktree.create.schema),
       async (c) => {
+        const detected = await detectAdaptor(Instance.worktree).catch(() => undefined)
+        if (detected) {
+          const workspace = await Workspace.create({
+            type: detected.type,
+            branch: null,
+            projectID: Instance.project.id,
+            projectDirectory: Instance.worktree,
+            extra: null,
+          })
+          return c.json(workspace)
+        }
         const body = c.req.valid("json")
         const worktree = await Worktree.create(body)
         return c.json(worktree)

--- a/packages/opencode/src/server/routes/workspace.ts
+++ b/packages/opencode/src/server/routes/workspace.ts
@@ -5,9 +5,40 @@ import { Workspace } from "../../control-plane/workspace"
 import { Instance } from "../../project/instance"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { listTypes, detectAdaptor } from "../../control-plane/adaptors"
+
+const TypesResponse = z
+  .object({
+    types: z.array(z.string()),
+    detected: z.string().optional(),
+  })
+  .meta({ ref: "WorkspaceTypes" })
 
 export const WorkspaceRoutes = lazy(() =>
   new Hono()
+    .get(
+      "/types",
+      describeRoute({
+        summary: "List workspace types",
+        description: "List available workspace adaptor types and detect the best match for the current project.",
+        operationId: "experimental.workspace.types",
+        responses: {
+          200: {
+            description: "Available workspace types",
+            content: {
+              "application/json": {
+                schema: resolver(TypesResponse),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const types = listTypes()
+        const result = await detectAdaptor(Instance.worktree).catch(() => undefined)
+        return c.json({ types, detected: result?.type })
+      },
+    )
     .post(
       "/",
       describeRoute({
@@ -30,12 +61,14 @@ export const WorkspaceRoutes = lazy(() =>
         "json",
         Workspace.create.schema.omit({
           projectID: true,
+          projectDirectory: true,
         }),
       ),
       async (c) => {
         const body = c.req.valid("json")
         const workspace = await Workspace.create({
           projectID: Instance.project.id,
+          projectDirectory: Instance.worktree,
           ...body,
         })
         return c.json(workspace)

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,12 +23,41 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type WorkspaceAdaptorInfo = {
+  id: string
+  type: string
+  branch: string | null
+  name: string | null
+  directory: string | null
+  extra: unknown | null
+  projectID: string
+  /**
+   * The root directory of the project this workspace belongs to.
+   * Use this instead of the plugin-load-time `directory` when the
+   * adaptor needs to run commands in the project root (e.g., VCS
+   * operations). This is set at call time and reflects the currently
+   * active project, not the project that was active when the plugin
+   * loaded.
+   */
+  projectDirectory?: string
+}
+
+export type WorkspaceAdaptor = {
+  detect?(directory: string): boolean | Promise<boolean>
+  configure(info: WorkspaceAdaptorInfo): WorkspaceAdaptorInfo | Promise<WorkspaceAdaptorInfo>
+  create(info: WorkspaceAdaptorInfo): Promise<void>
+  remove(info: WorkspaceAdaptorInfo): Promise<void>
+  reset?(info: WorkspaceAdaptorInfo): Promise<void>
+  fetch(info: WorkspaceAdaptorInfo, input: RequestInfo | URL, init?: RequestInit): Promise<Response>
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
   directory: string
   worktree: string
   serverUrl: URL
+  workspaceFetch: (directory: string, input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
   $: BunShell
 }
 
@@ -231,4 +260,35 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Register workspace adaptors. Each key is a workspace type name
+   * (e.g. "jj") and the value implements the adaptor interface.
+   *
+   * ```ts
+   * "workspace.adaptor": {
+   *   jj: {
+   *     detect(dir) { return existsSync(join(dir, ".jj")) },
+   *     configure(info) { ... },
+   *     async create(info) { ... },
+   *     async remove(info) { ... },
+   *     fetch(info, input, init) { ... },
+   *   }
+   * }
+   * ```
+   */
+  "workspace.adaptor"?: {
+    [type: string]: WorkspaceAdaptor
+  }
+  /**
+   * Called to detect the current VCS branch. Plugins can set
+   * `output.branch` to provide branch info for non-git VCS systems
+   * or when git is in a detached HEAD state.
+   *
+   * ```ts
+   * async "vcs.branch"(input, output) {
+   *   output.branch = "my-branch"
+   * }
+   * ```
+   */
+  "vcs.branch"?: (input: { directory: string; vcs?: string }, output: { branch?: string }) => Promise<void>
 }


### PR DESCRIPTION
### Issue for this PR

Loosely related to #5008. The `installAdaptor()` function and `Adaptor` interface already exist internally with a comment saying "we will likely allow this in the future" — this PR implements that by exposing it to the plugin system.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Exposes workspace adaptor registration and VCS branch detection to the plugin system, so plugins can register alternative workspace backends (e.g. jj workspaces) alongside the built-in git worktree adaptor.

I use [jj (jujutsu)](https://github.com/jj-vcs/jj) for version control. jj has its own workspace concept (`jj workspace add/forget`) that's incompatible with git worktrees — `jj git init --colocate` refuses to run inside a git worktree, and running raw git worktree commands behind jj's back corrupts state.

**Changes (all additive, no existing behavior modified):**

1. **`workspace.adaptor` hook** (record-type, same pattern as `tool`): plugins register adaptor implementations keyed by type name. After plugins load, each is registered via the existing `installAdaptor()`.

2. **`detect()` method on adaptors**: plugin adaptors can provide `detect(directory) => boolean`. The `/experimental/worktree` create endpoint now calls `detectAdaptor()` first — if a plugin claims the directory, it creates a workspace through that adaptor instead of the default git worktree path.

3. **`vcs.branch` hook** (pipeline): lets plugins provide branch info for non-git VCS. Also used as fallback when `git rev-parse` fails.

4. **`WorkspaceAdaptor` and `WorkspaceAdaptorInfo` types** exported from `@opencode-ai/plugin`.

5. **`workspaceFetch` helper on `PluginInput`**: proxies requests through the built-in WorkspaceServer so plugin adaptors don't need internal imports.

6. **`GET /experimental/workspace/types` endpoint**: returns available adaptor types and auto-detected adaptor for the current project.

7. **TUI workspace creation dialog**: dynamically fetches available types from the API instead of hardcoding "worktree".

8. **`installAdaptor()` cleanup**: accepts both internal `Adaptor` and plugin `WorkspaceAdaptor` types cleanly, removed `@ts-expect-error`. `getAdaptor()` throws a descriptive error for unknown types instead of crashing.

### How did you verify your code works?

- `bun typecheck` passes clean for both `packages/opencode` and `packages/plugin`
- All changes are additive with no altered code paths for existing behavior
- Built and deployed a [jj workspace plugin](https://git.lyte.dev/lytedev/nix/src/commit/84b0250d212bd6d690a443f6513589894453b154/dotfiles/opencode/plugins/jj-workspace.ts) that exercises both hooks — workspace creation via `jj workspace add` and branch detection via `jj log`

### Screenshots / recordings

_No UI changes beyond the workspace creation dialog showing dynamically fetched types instead of a hardcoded list._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR