### PR TITLE
feat(permission): extract inner commands from wrappers for permission matching

### DIFF
--- a/packages/opencode/src/permission/arity.ts
+++ b/packages/opencode/src/permission/arity.ts
@@ -32,22 +32,31 @@ This dictionary is used to identify the "human-understandable command" from an i
     env: 1, // env
     export: 1, // export PATH=/usr/bin
     grep: 1, // grep pattern file.txt
+    ionice: 1, // ionice -c 2 command
     kill: 1, // kill 1234
     killall: 1, // killall process
     ln: 1, // ln -s source target
     ls: 1, // ls -la
     mkdir: 1, // mkdir new-dir
     mv: 1, // mv old.txt new.txt
+    nice: 1, // nice -n 5 command
+    nohup: 1, // nohup command args
     ps: 1, // ps aux
     pwd: 1, // pwd
     rm: 1, // rm file.txt
     rmdir: 1, // rmdir empty-dir
     sleep: 1, // sleep 5
     source: 1, // source ~/.bashrc
+    stdbuf: 1, // stdbuf -oL command
+    sudo: 1, // sudo command
     tail: 1, // tail -f log.txt
+    time: 1, // time command
+    timeout: 1, // timeout 5 command
     touch: 1, // touch file.txt
     unset: 1, // unset VAR
+    watch: 1, // watch -n 1 command
     which: 1, // which node
+    xargs: 1, // xargs -I{} command
     aws: 3, // aws s3 ls
     az: 3, // az storage blob list
     bazel: 2, // bazel build

--- a/packages/opencode/src/permission/wrapper.ts
+++ b/packages/opencode/src/permission/wrapper.ts
@@ -1,0 +1,102 @@
+interface WrapperConfig {
+  readonly flagsWithArgs: string
+  readonly positionalArgs: number
+  readonly skipAssignments?: boolean
+}
+
+const WRAPPERS: Record<string, WrapperConfig> = {
+  env: { flagsWithArgs: "u", positionalArgs: 0, skipAssignments: true },
+  ionice: { flagsWithArgs: "cnp", positionalArgs: 0 },
+  nice: { flagsWithArgs: "n", positionalArgs: 0 },
+  nohup: { flagsWithArgs: "", positionalArgs: 0 },
+  stdbuf: { flagsWithArgs: "ioe", positionalArgs: 0 },
+  sudo: { flagsWithArgs: "ugCDhprtU", positionalArgs: 0 },
+  time: { flagsWithArgs: "", positionalArgs: 0 },
+  timeout: { flagsWithArgs: "ks", positionalArgs: 1 },
+  watch: { flagsWithArgs: "n", positionalArgs: 0 },
+  xargs: { flagsWithArgs: "ILnPsEd", positionalArgs: 0 },
+}
+
+function skip(
+  tokens: ReadonlyArray<string>,
+  index: number,
+  config: WrapperConfig,
+): number {
+  const token = tokens[index]
+  if (token === "--") return -(index + 1)
+
+  if (config.skipAssignments && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token))
+    return index + 1
+
+  if (token.startsWith("--")) {
+    if (token.includes("=")) return index + 1
+    if (config.flagsWithArgs.length > 0) return index + 2
+    return index + 1
+  }
+
+  if (token.startsWith("-") && token.length > 1) {
+    const flag = token[1]
+    if (config.flagsWithArgs.includes(flag)) {
+      if (token.length > 2) return index + 1
+      return index + 2
+    }
+    return index + 1
+  }
+
+  return 0
+}
+
+function extractFind(tokens: ReadonlyArray<string>): string[][] {
+  const results: string[][] = []
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] !== "-exec" && tokens[i] !== "-execdir") continue
+    const inner: string[] = []
+    for (let j = i + 1; j < tokens.length; j++) {
+      const t = tokens[j]
+      if (t === ";" || t === "\\;" || t === "+") {
+        i = j
+        break
+      }
+      if (t !== "{}") inner.push(t)
+    }
+    if (inner.length > 0) results.push(inner)
+  }
+  return results
+}
+
+export namespace BashWrapper {
+  export function extract(tokens: ReadonlyArray<string>): string[][] {
+    if (tokens.length === 0) return []
+    const cmd = tokens[0]
+
+    if (cmd === "find") return extractFind(tokens)
+
+    const config = WRAPPERS[cmd]
+    if (!config) return []
+
+    let i = 1
+    let positionalRemaining = config.positionalArgs
+    while (i < tokens.length) {
+      const result = skip(tokens, i, config)
+      if (result < 0) {
+        const inner = tokens.slice(-result)
+        if (inner.length === 0) return []
+        const nested = extract(inner)
+        return nested.length > 0 ? nested : [Array.from(inner)]
+      }
+      if (result > 0) {
+        i = result
+        continue
+      }
+      if (positionalRemaining > 0) {
+        positionalRemaining--
+        i++
+        continue
+      }
+      const inner = tokens.slice(i)
+      const nested = extract(inner)
+      return nested.length > 0 ? nested : [Array.from(inner)]
+    }
+    return []
+  }
+}

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -15,6 +15,7 @@ import { Flag } from "@/flag/flag.ts"
 import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
+import { BashWrapper } from "@/permission/wrapper"
 import { Truncate } from "./truncation"
 import { Plugin } from "@/plugin"
 
@@ -138,6 +139,12 @@ export const BashTool = Tool.define("bash", async () => {
         if (command.length && command[0] !== "cd") {
           patterns.add(commandText)
           always.add(BashArity.prefix(command).join(" ") + " *")
+          for (const inner of BashWrapper.extract(command)) {
+            if (inner.length > 0 && inner[0] !== "cd") {
+              patterns.add(inner.join(" "))
+              always.add(BashArity.prefix(inner).join(" ") + " *")
+            }
+          }
         }
       }
 

--- a/packages/opencode/test/permission/wrapper.test.ts
+++ b/packages/opencode/test/permission/wrapper.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test"
+import { BashWrapper } from "../../src/permission/wrapper"
+
+describe("BashWrapper.extract", () => {
+  describe("each wrapper type", () => {
+    test("nohup", () => {
+      expect(BashWrapper.extract(["nohup", "git", "push"])).toEqual([["git", "push"]])
+    })
+
+    test("time", () => {
+      expect(BashWrapper.extract(["time", "make", "build"])).toEqual([["make", "build"]])
+    })
+
+    test("timeout", () => {
+      expect(BashWrapper.extract(["timeout", "5", "curl", "http://example.com"])).toEqual([
+        ["curl", "http://example.com"],
+      ])
+    })
+
+    test("nice", () => {
+      expect(BashWrapper.extract(["nice", "-n", "5", "make"])).toEqual([["make"]])
+    })
+
+    test("ionice", () => {
+      expect(BashWrapper.extract(["ionice", "-c", "2", "-n", "7", "dd", "if=/dev/zero"])).toEqual([
+        ["dd", "if=/dev/zero"],
+      ])
+    })
+
+    test("stdbuf", () => {
+      expect(BashWrapper.extract(["stdbuf", "-oL", "tail", "-f", "log.txt"])).toEqual([["tail", "-f", "log.txt"]])
+    })
+
+    test("watch", () => {
+      expect(BashWrapper.extract(["watch", "-n", "1", "kubectl", "get", "pods"])).toEqual([
+        ["kubectl", "get", "pods"],
+      ])
+    })
+
+    test("sudo", () => {
+      expect(BashWrapper.extract(["sudo", "rm", "-rf", "/"])).toEqual([["rm", "-rf", "/"]])
+    })
+
+    test("sudo with flags", () => {
+      expect(BashWrapper.extract(["sudo", "-u", "root", "systemctl", "restart", "nginx"])).toEqual([
+        ["systemctl", "restart", "nginx"],
+      ])
+    })
+
+    test("env", () => {
+      expect(BashWrapper.extract(["env", "node", "server.js"])).toEqual([["node", "server.js"]])
+    })
+
+    test("xargs", () => {
+      expect(BashWrapper.extract(["xargs", "-I{}", "gh", "api", "-X", "DELETE"])).toEqual([
+        ["gh", "api", "-X", "DELETE"],
+      ])
+    })
+
+    test("xargs with split flag and arg", () => {
+      expect(BashWrapper.extract(["xargs", "-I", "{}", "rm"])).toEqual([["rm"]])
+    })
+  })
+
+  describe("flag handling", () => {
+    test("combined flag+arg", () => {
+      expect(BashWrapper.extract(["xargs", "-I{}", "echo"])).toEqual([["echo"]])
+    })
+
+    test("split flag and arg", () => {
+      expect(BashWrapper.extract(["xargs", "-I", "{}", "echo"])).toEqual([["echo"]])
+    })
+
+    test("boolean flag", () => {
+      expect(BashWrapper.extract(["sudo", "-n", "ls"])).toEqual([["ls"]])
+    })
+
+    test("long flag with =", () => {
+      expect(BashWrapper.extract(["timeout", "--signal=KILL", "5", "sleep", "10"])).toEqual([["sleep", "10"]])
+    })
+
+    test("-- terminator", () => {
+      expect(BashWrapper.extract(["sudo", "--", "rm", "-rf", "/tmp/x"])).toEqual([["rm", "-rf", "/tmp/x"]])
+    })
+  })
+
+  describe("env specifics", () => {
+    test("VAR=val skipping", () => {
+      expect(BashWrapper.extract(["env", "FOO=bar", "BAZ=qux", "node", "app.js"])).toEqual([["node", "app.js"]])
+    })
+
+    test("mixed flags and assignments", () => {
+      expect(BashWrapper.extract(["env", "-u", "HOME", "PATH=/usr/bin", "sh", "-c", "echo"])).toEqual([
+        ["sh", "-c", "echo"],
+      ])
+    })
+  })
+
+  describe("timeout positional", () => {
+    test("duration arg skipped before inner command", () => {
+      expect(BashWrapper.extract(["timeout", "30s", "npm", "test"])).toEqual([["npm", "test"]])
+    })
+
+    test("with flags and duration", () => {
+      expect(BashWrapper.extract(["timeout", "--signal=KILL", "10", "make"])).toEqual([["make"]])
+    })
+  })
+
+  describe("find -exec", () => {
+    test("single -exec", () => {
+      expect(BashWrapper.extract(["find", ".", "-name", "*.log", "-exec", "rm", "{}", ";"])).toEqual([["rm"]])
+    })
+
+    test("-execdir", () => {
+      expect(BashWrapper.extract(["find", "/tmp", "-execdir", "chmod", "644", "{}", ";"])).toEqual([["chmod", "644"]])
+    })
+
+    test("multiple -exec clauses", () => {
+      expect(
+        BashWrapper.extract([
+          "find",
+          ".",
+          "-exec",
+          "echo",
+          "{}",
+          ";",
+          "-exec",
+          "rm",
+          "{}",
+          "+",
+        ]),
+      ).toEqual([["echo"], ["rm"]])
+    })
+
+    test("escaped terminator", () => {
+      expect(BashWrapper.extract(["find", ".", "-exec", "cat", "{}", "\\;"])).toEqual([["cat"]])
+    })
+  })
+
+  describe("nested wrappers", () => {
+    test("timeout + sudo", () => {
+      expect(BashWrapper.extract(["timeout", "5", "sudo", "gh", "api"])).toEqual([["gh", "api"]])
+    })
+
+    test("nohup + nice + make", () => {
+      expect(BashWrapper.extract(["nohup", "nice", "-n", "10", "make", "build"])).toEqual([["make", "build"]])
+    })
+
+    test("sudo + env + node", () => {
+      expect(BashWrapper.extract(["sudo", "env", "NODE_ENV=prod", "node", "app.js"])).toEqual([["node", "app.js"]])
+    })
+  })
+
+  describe("non-wrappers", () => {
+    test("regular command returns empty", () => {
+      expect(BashWrapper.extract(["git", "checkout", "main"])).toEqual([])
+    })
+
+    test("unknown command returns empty", () => {
+      expect(BashWrapper.extract(["myapp", "--verbose"])).toEqual([])
+    })
+  })
+
+  describe("edge cases", () => {
+    test("empty tokens", () => {
+      expect(BashWrapper.extract([])).toEqual([])
+    })
+
+    test("wrapper with no args", () => {
+      expect(BashWrapper.extract(["nohup"])).toEqual([])
+    })
+
+    test("wrapper with only flags", () => {
+      expect(BashWrapper.extract(["sudo", "-n"])).toEqual([])
+    })
+
+    test("timeout with only duration", () => {
+      expect(BashWrapper.extract(["timeout", "5"])).toEqual([])
+    })
+  })
+})

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -290,6 +290,90 @@ describe("tool.bash permissions", () => {
     })
   })
 
+  test("xargs inner command appears in permission request", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "xargs -I{} gh api -X DELETE repos/foo",
+            description: "Delete repos via xargs",
+          },
+          testCtx,
+        )
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+        expect(bashReq!.patterns).toContain("gh api -X DELETE repos/foo")
+        expect(bashReq!.always.some((p) => p.startsWith("gh api"))).toBe(true)
+      },
+    })
+  })
+
+  test("nested wrappers produce inner command in patterns and always", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "timeout 5 sudo rm -rf /tmp/x",
+            description: "Remove with nested wrappers",
+          },
+          testCtx,
+        )
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+        expect(bashReq!.patterns).toContain("rm -rf /tmp/x")
+        expect(bashReq!.always.some((p) => p.startsWith("rm "))).toBe(true)
+      },
+    })
+  })
+
+  test("simple wrapper produces inner command alongside wrapper command", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "nohup git log --oneline",
+            description: "Git log with nohup",
+          },
+          testCtx,
+        )
+        const bashReq = requests.find((r) => r.permission === "bash")
+        expect(bashReq).toBeDefined()
+        expect(bashReq!.patterns).toContain("nohup git log --oneline")
+        expect(bashReq!.patterns).toContain("git log --oneline")
+      },
+    })
+  })
+
   test("always pattern has space before wildcard to not include different commands", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -86,6 +86,28 @@ You can use `~` or `$HOME` at the start of a pattern to reference your home dire
 - `$HOME/projects/*` -> `/Users/username/projects/*`
 - `~` -> `/Users/username`
 
+### Command Wrappers
+
+OpenCode automatically extracts inner commands from common wrapper commands for permission matching. When a command is wrapped in `timeout`, `time`, `nice`, `nohup`, `ionice`, `stdbuf`, `watch`, `sudo`, `env`, `xargs`, or `find -exec`, both the wrapper and the inner command are checked against your permission rules.
+
+For example, with this config:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "allow",
+      "rm *": "deny"
+    }
+  }
+}
+```
+
+Running `sudo rm -rf /` is correctly denied because OpenCode extracts `rm -rf /` from the wrapper and matches it against `"rm *": "deny"`. Without wrapper extraction, only `sudo` would be matched, which would hit `"*": "allow"` and bypass the deny rule.
+
+Nested wrappers are also handled — `timeout 5 sudo gh api` extracts `gh api` from both layers.
+
 ### External Directories
 
 Use `external_directory` to allow tool calls that touch paths outside the working directory where OpenCode was started. This applies to any tool that takes a path as input (for example `read`, `edit`, `list`, `glob`, `grep`, and many `bash` commands).
@@ -233,5 +255,5 @@ Only analyze code and suggest changes.
 ```
 
 :::tip
-Use pattern matching for commands with arguments. `"grep *"` allows `grep pattern file.txt`, while `"grep"` alone would block it. Commands like `git status` work for default behavior but require explicit permission (like `"git status *"`) when arguments are passed.
+Use pattern matching for commands with arguments. `"grep *"` allows `grep pattern file.txt`, while `"grep"` alone would block it. Commands like `git status` work for default behavior but require explicit permission (like `"git status *"`) when arguments are passed. Rules also apply when commands are run through wrappers — `"git *": "allow"` works even when git is run via `timeout 5 git status`.
 :::


### PR DESCRIPTION
### Issue for this PR

Closes #9516

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

When commands are wrapped in `xargs`, `timeout`, `sudo`, etc., the permission system only sees the wrapper command. A rule like `"rm *": "deny"` is bypassed when the command is `sudo rm -rf /` because the system matches against `sudo`, not `rm`.

This adds a `BashWrapper` module that extracts inner commands from known wrapper commands. Both the wrapper and inner command(s) get checked against permission rules. The change is purely additive — existing behavior is unchanged, inner commands are additionally checked.

Supported wrappers: `timeout`, `time`, `nice`, `nohup`, `ionice`, `stdbuf`, `watch`, `sudo`, `env`, `xargs`, `find -exec/-execdir`. Nested wrappers are handled recursively (e.g. `timeout 5 sudo gh api` extracts `gh api`).

### How did you verify your code works?

- 34 unit tests for the extraction logic (`test/permission/wrapper.test.ts`)
- 3 integration tests with tree-sitter parsing (`test/tool/bash.test.ts`)
- Existing arity and bash tests continue to pass
- Full test suite passes, typecheck passes

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR