### PR TITLE
fix(opencode): reduce memory usage and database bloat in long-running instances

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1043,6 +1043,16 @@ export namespace Config {
           url: z.string().optional().describe("Enterprise URL"),
         })
         .optional(),
+      retention: z
+        .object({
+          days: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("Auto-delete archived sessions older than this many days (default: 90, 0 = disabled)"),
+        })
+        .optional(),
       compaction: z
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -57,7 +57,12 @@ export namespace LSPClient {
         count: params.diagnostics.length,
       })
       const exists = diagnostics.has(filePath)
-      diagnostics.set(filePath, params.diagnostics)
+      if (params.diagnostics.length === 0) {
+        if (!exists) return
+        diagnostics.delete(filePath)
+      } else {
+        diagnostics.set(filePath, params.diagnostics)
+      }
       if (!exists && input.serverID === "typescript") return
       Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
     })

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -131,6 +131,9 @@ export namespace SessionCompaction {
           for (const part of toPrune) {
             if (part.state.status === "completed") {
               part.state.time.compacted = Date.now()
+              part.state.output = "[compacted]"
+              part.state.metadata = {}
+              part.state.attachments = undefined
               yield* session.updatePart(part)
             }
           }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -3,6 +3,7 @@ import os from "os"
 import { spawn } from "child_process"
 import { Tool } from "./tool"
 import path from "path"
+import fs from "fs"
 import DESCRIPTION from "./bash.txt"
 import { Log } from "../util/log"
 import { Instance } from "../project/instance"
@@ -17,6 +18,7 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncate"
+import { Identifier } from "@/id/id"
 import { Plugin } from "@/plugin"
 
 const MAX_METADATA_LENGTH = 30_000
@@ -327,7 +329,10 @@ async function run(
   ctx: Tool.Context,
 ) {
   const proc = launch(input.shell, input.name, input.command, input.cwd, input.env)
-  let output = ""
+  let head = ""
+  let spoolFd: number | undefined
+  let spoolPath: string | undefined
+  let total = 0
 
   ctx.metadata({
     metadata: {
@@ -337,10 +342,28 @@ async function run(
   })
 
   const append = (chunk: Buffer) => {
-    output += chunk.toString()
+    const str = chunk.toString()
+    total += str.length
+    // Keep only enough in memory for the metadata preview and final
+    // truncated output (Truncate.MAX_BYTES = 50 KB).  Everything else
+    // goes straight to a spool file on disk so the full output is
+    // recoverable via grep/read without blowing up the heap.
+    if (head.length < Truncate.MAX_BYTES) {
+      head += str
+    }
+    if (total > Truncate.MAX_BYTES) {
+      if (spoolFd === undefined) {
+        spoolPath = path.join(Truncate.DIR, Identifier.ascending("tool"))
+        fs.mkdirSync(Truncate.DIR, { recursive: true })
+        spoolFd = fs.openSync(spoolPath, "w")
+        // Flush everything accumulated so far
+        fs.writeSync(spoolFd, head)
+      }
+      fs.writeSync(spoolFd, str)
+    }
     ctx.metadata({
       metadata: {
-        output: preview(output),
+        output: preview(head),
         description: input.description,
       },
     })
@@ -394,21 +417,37 @@ async function run(
     })
   })
 
-  const metadata: string[] = []
-  if (expired) metadata.push(`bash tool terminated command after exceeding timeout ${input.timeout} ms`)
-  if (aborted) metadata.push("User aborted the command")
-  if (metadata.length > 0) {
-    output += "\n\n<bash_metadata>\n" + metadata.join("\n") + "\n</bash_metadata>"
+  if (spoolFd !== undefined) fs.closeSync(spoolFd)
+
+  const suffix: string[] = []
+  if (expired) suffix.push(`bash tool terminated command after exceeding timeout ${input.timeout} ms`)
+  if (aborted) suffix.push("User aborted the command")
+  if (suffix.length > 0) {
+    head += "\n\n<bash_metadata>\n" + suffix.join("\n") + "\n</bash_metadata>"
+  }
+
+  const meta = {
+    output: preview(head),
+    exit: proc.exitCode,
+    description: input.description,
+  }
+
+  // If output was spooled to disk, run truncation ourselves and signal
+  // the Tool.define wrapper to skip its own Truncate.output() pass.
+  if (spoolPath) {
+    const snip = head.slice(0, Truncate.MAX_BYTES)
+    const hint = `The tool call succeeded but the output was truncated. Full output saved to: ${spoolPath}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
+    return {
+      title: input.description,
+      metadata: { ...meta, truncated: true as const, outputPath: spoolPath },
+      output: `${snip}\n\n...${total - snip.length} bytes truncated...\n\n${hint}`,
+    }
   }
 
   return {
     title: input.description,
-    metadata: {
-      output: preview(output),
-      exit: proc.exitCode,
-      description: input.description,
-    },
-    output,
+    metadata: meta,
+    output: head,
   }
 }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -173,24 +173,21 @@ const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.0
 const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.3
 
 /**
- * Levenshtein distance algorithm implementation
+ * Levenshtein distance — 2-row O(min(n,m)) memory instead of full O(n×m) matrix.
  */
 function levenshtein(a: string, b: string): number {
-  // Handle empty strings
-  if (a === "" || b === "") {
-    return Math.max(a.length, b.length)
-  }
-  const matrix = Array.from({ length: a.length + 1 }, (_, i) =>
-    Array.from({ length: b.length + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
-  )
-
+  if (a === "" || b === "") return Math.max(a.length, b.length)
+  if (a.length < b.length) [a, b] = [b, a]
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j)
+  let curr = new Array(b.length + 1)
   for (let i = 1; i <= a.length; i++) {
+    curr[0] = i
     for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+      curr[j] = a[i - 1] === b[j - 1] ? prev[j - 1] : 1 + Math.min(prev[j], curr[j - 1], prev[j - 1])
     }
+    ;[prev, curr] = [curr, prev]
   }
-  return matrix[a.length][b.length]
+  return prev[b.length]
 }
 
 export const SimpleReplacer: Replacer = function* (_content, find) {

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -44,10 +44,17 @@ export namespace Rpc {
     }
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
-        const requestId = id++
-        return new Promise((resolve) => {
-          pending.set(requestId, resolve)
-          target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
+        const rid = id++
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            pending.delete(rid)
+            reject(new Error(`RPC timeout: ${String(method)}`))
+          }, 60_000)
+          pending.set(rid, (result) => {
+            clearTimeout(timer)
+            resolve(result)
+          })
+          target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: rid }))
         })
       },
       on<Data>(event: string, handler: (data: Data) => void) {


### PR DESCRIPTION
### Issue for this PR

Closes #16777

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A long-running OpenCode server (2+ days) was consuming 1.76 GB (602 MB RSS + 1.15 GB swap) on an 8 GB system. The database grew to 1.99 GB (274K parts, 1,706 sessions spanning 53 days) with no automatic cleanup. This PR fixes several root causes:

**Database health** (`storage/db.ts`, `project/bootstrap.ts`): Enable incremental auto-vacuum (one-time migration) so disk space is reclaimed on deletes. Add periodic WAL checkpoint (every 5 min) and incremental vacuum (hourly) via Scheduler.

**Bash/shell output spooling** (`tool/bash.ts`, `session/prompt.ts`): Both accumulated ALL stdout/stderr in an unbounded in-memory string. Now output beyond 50 KB streams to a spool file on disk. Only a 50 KB preview stays in memory. Full output is recoverable via the spool file path in metadata.

**Compaction clears dead data** (`session/compaction.ts`): Compacted tool parts kept their full output in SQLite even though `toModelMessages()` skips them. Now clears output/metadata/attachments on compaction.

**Levenshtein optimization** (`tool/edit.ts`): Replace O(n×m) full-matrix with O(min(n,m)) 2-row algorithm. For 10K char strings: ~400 MB → ~40 KB. Identical results.

**Memory leak fixes** (`file/time.ts`, `lsp/client.ts`, `util/rpc.ts`): Clean FileTime per-session state on archive/delete. Delete empty LSP diagnostics map entries. Add 60s timeout to RPC pending calls.

**Session retention** (`session/index.ts`, `config/config.ts`): Auto-delete archived sessions older than `retention.days` (default 90, 0 = disabled). Runs every 6 hours, batched at 100 per run.

### How did you verify your code works?

- Edit tool tests: 27/27 pass
- Compaction tests: 24/24 pass
- Bash tool tests: 16/16 pass (includes new spooling test)
- TypeScript typecheck: clean
- Measured process memory on a live instance to identify the issues

### Screenshots / recordings

_N/A — backend changes only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR