### PR TITLE
feat(nix): add bun version check workflow

### DIFF
--- a/.github/workflows/nix-bun-version-check.yml
+++ b/.github/workflows/nix-bun-version-check.yml
@@ -1,0 +1,44 @@
+name: nix-bun-version-check
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "package.json"
+      - "flake.lock"
+      - ".github/workflows/nix-bun-version-check.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Nix
+        uses: nixbuild/nix-quick-install-action@v34
+
+      - name: Check bun version matches nixpkgs
+        run: |
+          set -euo pipefail
+
+          pkg_bun=$(jq -r '.packageManager' package.json | sed 's/bun@//')
+          nix_bun=$(nix eval --inputs-from . --raw nixpkgs#bun.version)
+
+          echo "package.json: bun@${pkg_bun}"
+          echo "nixpkgs:      bun@${nix_bun}"
+
+          if [ "$pkg_bun" != "$nix_bun" ]; then
+            echo "::error::Bun version mismatch: package.json requires ${pkg_bun} but nixpkgs provides ${nix_bun}. Update flake.lock (nix flake update nixpkgs) or align package.json."
+            exit 1
+          fi
+
+          echo "Versions match."


### PR DESCRIPTION
### Issue for this PR

Would have avoided: #12602, #12632, #13300, #13302, #13458, #13828, #15394, #15635, #15648
Supersedes #13496

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Every bun bump since the Jan 18 nix overhaul has broken `nix run github:anomalyco/opencode` — 3 for 3, with 7 tagged releases shipping broken. The problem is widespread enough that the nixpkgs `opencode` package now patches out the bun version check to avoid it. Each fix was a one-line `flake.lock` bump that no CI check was catching, so this adds a lightweight 30-second check to do exactly that.

The check runs `nix eval --inputs-from . --raw nixpkgs#bun.version` and compares it to `package.json`. It only triggers when those two files are touched. Approach suggested by @gigamonster256 on #13496 as a lighter alternative to `nix build`. Complementary to #12175 which catches eval-time errors but not this version mismatch.

### How did you verify your code works?
Tested on a fork: https://github.com/DanConwayDev/opencode/actions/runs/22571065110/job/65379180175
package.json: bun@1.3.10
nixpkgs:      bun@1.3.10
Versions match.
Completed in 39 seconds.

### Screenshots / recordings
N/A

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR