### PR TITLE
fix(context): show post-compaction size immediately after /compact

### DIFF
--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -8,6 +8,7 @@ const assistant = (
   cost: number,
   providerID = "openai",
   modelID = "gpt-4.1",
+  summary?: boolean,
 ) => {
   return {
     id,
@@ -15,6 +16,7 @@ const assistant = (
     providerID,
     modelID,
     cost,
+    summary,
     tokens: {
       input: tokens.input,
       output: tokens.output,
@@ -97,5 +99,61 @@ describe("getSessionContextMetrics", () => {
 
     expect(metrics.totalCost).toBe(0)
     expect(metrics.context).toBeUndefined()
+  })
+
+  test("uses only output tokens when last message is a compaction summary", () => {
+    // A compaction message has a large `input` (the full pre-compaction history
+    // fed to the summarizer) and a small `output` (the resulting summary text).
+    // Displaying input+output would show the pre-compaction size, not the
+    // reduced context the next turn will actually use.
+    const messages = [
+      user("u1"),
+      assistant("a1", { input: 150000, output: 3000, reasoning: 0, read: 0, write: 0 }, 0.5, "openai", "gpt-4.1", true),
+    ]
+    const providers = [
+      {
+        id: "openai",
+        name: "OpenAI",
+        models: { "gpt-4.1": { name: "GPT-4.1", limit: { context: 200000 } } },
+      },
+    ]
+
+    const metrics = getSessionContextMetrics(messages, providers)
+
+    // total should be output-only (3000), not input+output (153000)
+    expect(metrics.context?.total).toBe(3000)
+    expect(metrics.context?.usage).toBe(2)
+  })
+
+  test("uses full token sum when last message is not a compaction summary", () => {
+    const messages = [
+      user("u1"),
+      assistant("a1", { input: 150000, output: 3000, reasoning: 0, read: 0, write: 0 }, 0.5),
+    ]
+    const providers = [
+      {
+        id: "openai",
+        name: "OpenAI",
+        models: { "gpt-4.1": { name: "GPT-4.1", limit: { context: 200000 } } },
+      },
+    ]
+
+    const metrics = getSessionContextMetrics(messages, providers)
+
+    expect(metrics.context?.total).toBe(153000)
+  })
+
+  test("still exposes raw token breakdown fields unchanged after compaction", () => {
+    // The individual input/output/reasoning fields should remain unmodified so
+    // the context breakdown panel can still show the full compaction details.
+    const messages = [
+      user("u1"),
+      assistant("a1", { input: 150000, output: 3000, reasoning: 0, read: 0, write: 0 }, 0.5, "openai", "gpt-4.1", true),
+    ]
+
+    const metrics = getSessionContextMetrics(messages, [])
+
+    expect(metrics.context?.input).toBe(150000)
+    expect(metrics.context?.output).toBe(3000)
   })
 })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -55,7 +55,12 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Metrics =>
   const provider = providers.find((item) => item.id === message.providerID)
   const model = provider?.models[message.modelID]
   const limit = model?.limit.context
-  const total = tokenTotal(message)
+
+  // When the last message is a compaction summary, its `input` tokens reflect
+  // the full pre-compaction history fed to the summarizer -- not what the next
+  // turn will actually see. Use only the summary's `output` tokens so the
+  // context display immediately shows the reduced size after /compact completes.
+  const total = message.summary ? message.tokens.output : tokenTotal(message)
 
   return {
     totalCost,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -51,8 +51,13 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const context = createMemo(() => {
     const last = messages().findLast((x) => x.role === "assistant" && x.tokens.output > 0) as AssistantMessage
     if (!last) return
-    const total =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    // When the last message is a compaction summary, its `input` tokens reflect
+    // the full pre-compaction history that was fed to the summarizer -- not what
+    // the next turn will actually see. Use only the summary's `output` tokens so
+    // the sidebar immediately shows the reduced context after /compact completes.
+    const total = last.summary
+      ? last.tokens.output
+      : last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     const model = sync.data.provider.find((x) => x.id === last.providerID)?.models[last.modelID]
     return {
       tokens: total.toLocaleString(),


### PR DESCRIPTION
### Issue for this PR

Closes #5760

### Type of change

- [x] Bug fix

### What does this PR do?

After `/compact` runs, the sidebar and web context display continue showing
the pre-compaction token count until the next user message is sent. This makes
it appear as if compaction had no effect.

**Root cause:** both displays compute context size from the last assistant
message's tokens as `input + output + reasoning + cache`. For a compaction
summary message, `input` reflects the full pre-compaction history that was fed
to the summarizer — not the context the *next* turn will actually use. `output`
is the summary text (~2-5k tokens). So the display shows ~155k instead of ~5k.

**Fix:** when the last assistant message has `summary: true`, use only its
`output` tokens as the context size estimate. The raw per-field breakdown
(`input`/`output`/`reasoning`/`cache`) is left untouched so the context
breakdown panel still shows full compaction details.

Changed files:
- `packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx` — TUI sidebar context memo
- `packages/app/src/components/session/session-context-metrics.ts` — web/desktop context metrics
- `packages/app/src/components/session/session-context-metrics.test.ts` — three new test cases

### How did you verify your code works?

- Added three tests to the existing `session-context-metrics.test.ts` suite (all 7 pass)
- Full typecheck passes (`bun turbo typecheck`, 13 packages)
- Manually: trigger `/compact` on a session with substantial history, confirm
  the sidebar immediately shows the reduced count (~output tokens of the summary)
  rather than the pre-compaction total

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR