### PR TITLE
fix(app): session title turn spinner

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -237,6 +237,42 @@ export function MessageTimeline(props: {
     return sync.data.session_status[id] ?? idle
   })
   const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
+
+  const [slot, setSlot] = createStore({
+    mode: "idle" as "idle" | "work" | "done",
+    fade: false,
+  })
+
+  let f: number | undefined
+  let g: number | undefined
+  const clear = () => {
+    if (f !== undefined) window.clearTimeout(f)
+    if (g !== undefined) window.clearTimeout(g)
+    f = undefined
+    g = undefined
+  }
+
+  onCleanup(clear)
+  createEffect(
+    on(
+      working,
+      (on, prev) => {
+        clear()
+        if (on) {
+          setSlot({ mode: "work", fade: false })
+          return
+        }
+        if (prev) {
+          setSlot({ mode: "done", fade: false })
+          f = window.setTimeout(() => setSlot("fade", true), 200)
+          g = window.setTimeout(() => setSlot({ mode: "idle", fade: false }), 400)
+          return
+        }
+        setSlot({ mode: "idle", fade: false })
+      },
+      { defer: true },
+    ),
+  )
   const activeMessageID = createMemo(() => {
     const parentID = pending()?.parentID
     if (parentID) {
@@ -575,10 +611,29 @@ export function MessageTimeline(props: {
                         aria-label={language.t("common.goBack")}
                       />
                     </Show>
-                    <div class="flex items-center gap-2 min-w-0 grow-1">
-                      <div class="size-4 shrink-0 flex items-center justify-center" aria-hidden="true">
-                        <Show when={working()}>
-                          <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />
+                    <div class="flex items-center min-w-0 grow-1">
+                      <div
+                        class="shrink-0 flex items-center justify-center overflow-hidden transition-[width,margin] duration-200 ease-out"
+                        style={{
+                          width: slot.mode === "idle" ? "0px" : "16px",
+                          "margin-right": slot.mode === "idle" ? "0px" : "8px",
+                        }}
+                        aria-hidden="true"
+                      >
+                        <Show when={slot.mode !== "idle"}>
+                          <div
+                            class="transition-opacity duration-200 ease-out"
+                            classList={{
+                              "opacity-0": slot.mode === "done" && slot.fade,
+                            }}
+                          >
+                            <Show
+                              when={slot.mode === "work"}
+                              fallback={<Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />}
+                            >
+                              <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />
+                            </Show>
+                          </div>
                         </Show>
                       </div>
                       <Show when={titleValue() || title.editing}>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -239,17 +239,15 @@ export function MessageTimeline(props: {
   const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
 
   const [slot, setSlot] = createStore({
-    mode: "idle" as "idle" | "work" | "done",
+    open: false,
+    show: false,
     fade: false,
   })
 
   let f: number | undefined
-  let g: number | undefined
   const clear = () => {
     if (f !== undefined) window.clearTimeout(f)
-    if (g !== undefined) window.clearTimeout(g)
     f = undefined
-    g = undefined
   }
 
   onCleanup(clear)
@@ -259,16 +257,15 @@ export function MessageTimeline(props: {
       (on, prev) => {
         clear()
         if (on) {
-          setSlot({ mode: "work", fade: false })
+          setSlot({ open: true, show: true, fade: false })
           return
         }
         if (prev) {
-          setSlot({ mode: "done", fade: false })
-          f = window.setTimeout(() => setSlot("fade", true), 200)
-          g = window.setTimeout(() => setSlot({ mode: "idle", fade: false }), 400)
+          setSlot({ open: false, show: true, fade: true })
+          f = window.setTimeout(() => setSlot({ show: false, fade: false }), 260)
           return
         }
-        setSlot({ mode: "idle", fade: false })
+        setSlot({ open: false, show: false, fade: false })
       },
       { defer: true },
     ),
@@ -613,26 +610,21 @@ export function MessageTimeline(props: {
                     </Show>
                     <div class="flex items-center min-w-0 grow-1">
                       <div
-                        class="shrink-0 flex items-center justify-center overflow-hidden transition-[width,margin] duration-200 ease-out"
+                        class="shrink-0 flex items-center justify-center overflow-hidden transition-[width,margin] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
                         style={{
-                          width: slot.mode === "idle" ? "0px" : "16px",
-                          "margin-right": slot.mode === "idle" ? "0px" : "8px",
+                          width: slot.open ? "16px" : "0px",
+                          "margin-right": slot.open ? "8px" : "0px",
                         }}
                         aria-hidden="true"
                       >
-                        <Show when={slot.mode !== "idle"}>
+                        <Show when={slot.show}>
                           <div
                             class="transition-opacity duration-200 ease-out"
                             classList={{
-                              "opacity-0": slot.mode === "done" && slot.fade,
+                              "opacity-0": slot.fade,
                             }}
                           >
-                            <Show
-                              when={slot.mode === "work"}
-                              fallback={<Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />}
-                            >
-                              <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />
-                            </Show>
+                            <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />
                           </div>
                         </Show>
                       </div>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -8,6 +8,7 @@ import { IconButton } from "@opencode-ai/ui/icon-button"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { InlineInput } from "@opencode-ai/ui/inline-input"
+import { Spinner } from "@opencode-ai/ui/spinner"
 import { SessionTurn } from "@opencode-ai/ui/session-turn"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import type { AssistantMessage, Message as MessageType, Part, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
@@ -235,6 +236,7 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
+  const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
   const activeMessageID = createMemo(() => {
     const parentID = pending()?.parentID
     if (parentID) {
@@ -573,43 +575,50 @@ export function MessageTimeline(props: {
                         aria-label={language.t("common.goBack")}
                       />
                     </Show>
-                    <Show when={titleValue() || title.editing}>
-                      <Show
-                        when={title.editing}
-                        fallback={
-                          <h1
-                            class="text-14-medium text-text-strong truncate grow-1 min-w-0 pl-2"
-                            onDblClick={openTitleEditor}
-                          >
-                            {titleValue()}
-                          </h1>
-                        }
-                      >
-                        <InlineInput
-                          ref={(el) => {
-                            titleRef = el
-                          }}
-                          value={title.draft}
-                          disabled={title.saving}
-                          class="text-14-medium text-text-strong grow-1 min-w-0 pl-2 rounded-[6px]"
-                          style={{ "--inline-input-shadow": "var(--shadow-xs-border-select)" }}
-                          onInput={(event) => setTitle("draft", event.currentTarget.value)}
-                          onKeyDown={(event) => {
-                            event.stopPropagation()
-                            if (event.key === "Enter") {
-                              event.preventDefault()
-                              void saveTitleEditor()
-                              return
-                            }
-                            if (event.key === "Escape") {
-                              event.preventDefault()
-                              closeTitleEditor()
-                            }
-                          }}
-                          onBlur={closeTitleEditor}
-                        />
+                    <div class="flex items-center gap-2 min-w-0 grow-1 pl-2">
+                      <div class="size-4 shrink-0 flex items-center justify-center" aria-hidden="true">
+                        <Show when={working()}>
+                          <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />
+                        </Show>
+                      </div>
+                      <Show when={titleValue() || title.editing}>
+                        <Show
+                          when={title.editing}
+                          fallback={
+                            <h1
+                              class="text-14-medium text-text-strong truncate grow-1 min-w-0"
+                              onDblClick={openTitleEditor}
+                            >
+                              {titleValue()}
+                            </h1>
+                          }
+                        >
+                          <InlineInput
+                            ref={(el) => {
+                              titleRef = el
+                            }}
+                            value={title.draft}
+                            disabled={title.saving}
+                            class="text-14-medium text-text-strong grow-1 min-w-0 rounded-[6px]"
+                            style={{ "--inline-input-shadow": "var(--shadow-xs-border-select)" }}
+                            onInput={(event) => setTitle("draft", event.currentTarget.value)}
+                            onKeyDown={(event) => {
+                              event.stopPropagation()
+                              if (event.key === "Enter") {
+                                event.preventDefault()
+                                void saveTitleEditor()
+                                return
+                              }
+                              if (event.key === "Escape") {
+                                event.preventDefault()
+                                closeTitleEditor()
+                              }
+                            }}
+                            onBlur={closeTitleEditor}
+                          />
+                        </Show>
                       </Show>
-                    </Show>
+                    </div>
                   </div>
                   <Show when={sessionID()}>
                     {(id) => (

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -575,7 +575,7 @@ export function MessageTimeline(props: {
                         aria-label={language.t("common.goBack")}
                       />
                     </Show>
-                    <div class="flex items-center gap-2 min-w-0 grow-1 pl-2">
+                    <div class="flex items-center gap-2 min-w-0 grow-1">
                       <div class="size-4 shrink-0 flex items-center justify-center" aria-hidden="true">
                         <Show when={working()}>
                           <Spinner class="size-4" style={{ color: "var(--icon-interactive-base)" }} />

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -41,6 +41,7 @@ export function Spinner(props: {
               animation: square.corner
                 ? undefined
                 : `${square.outer ? "pulse-opacity-dim" : "pulse-opacity"} ${square.duration}s ease-in-out infinite`,
+              "animation-fill-mode": square.corner ? undefined : "both",
               "animation-delay": square.corner ? undefined : `${square.delay}s`,
             }}
           />

--- a/packages/ui/src/styles/animations.css
+++ b/packages/ui/src/styles/animations.css
@@ -26,10 +26,10 @@
 @keyframes pulse-opacity-dim {
   0%,
   100% {
-    opacity: 0;
+    opacity: 0.15;
   }
   50% {
-    opacity: 0.2;
+    opacity: 0.35;
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #


https://github.com/user-attachments/assets/3ee076de-c0b3-4fd2-b1c6-b62930de871e



### Type of change


- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation


### What does this PR do?

Adds an inline activity indicator before the session title while a turn is in progress. The slot reserves space so the title does not jump, and then collapses smoothly as the spinner fades out when the turn completes.


### How did you verify your code works?

- `bun run typecheck` (packages/app, packages/ui)
- `bun run test:unit` (packages/app)


### Screenshots / recordings

Not captured yet.


### Checklist


- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR