### PR TITLE
fix(tui): handle error when creating a session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -539,12 +539,25 @@ export function Prompt(props: PromptProps) {
       promptModelWarning()
       return
     }
-    const sessionID = props.sessionID
-      ? props.sessionID
-      : await (async () => {
-          const sessionID = await sdk.client.session.create({}).then((x) => x.data!.id)
-          return sessionID
-        })()
+
+    let sessionID = props.sessionID
+    if (sessionID == null) {
+      const res = await sdk.client.session.create({})
+
+      if (res.error) {
+        console.log("Creating a session failed:", res.error)
+
+        toast.show({
+          message: "Creating a session failed. Open console for more details.",
+          variant: "error",
+        })
+
+        return
+      }
+
+      sessionID = res.data.id
+    }
+
     const messageID = Identifier.ascending("message")
     let inputText = store.prompt.input
 


### PR DESCRIPTION
Improves the experience when something is wrong in the backend and sessions can't be created:

<img width="2082" height="1368" alt="Screenshot 2026-03-09 at 10 58 29 AM" src="https://github.com/user-attachments/assets/67837ee2-2e74-4dd6-8780-05a89fa0aeed" />

Previously it would silently fail, and pressing enter would just do nothing