### PR TITLE
fix(core): make worktrees read the project id from local workspace

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -88,6 +88,12 @@ export namespace Project {
     }
   }
 
+  function readCachedId(dir: string) {
+    return Filesystem.readText(path.join(dir, "opencode"))
+      .then((x) => x.trim())
+      .catch(() => undefined)
+  }
+
   export async function fromDirectory(directory: string) {
     log.info("fromDirectory", { directory })
 
@@ -101,9 +107,7 @@ export namespace Project {
         const gitBinary = which("git")
 
         // cached id calculation
-        let id = await Filesystem.readText(path.join(dotgit, "opencode"))
-          .then((x) => x.trim())
-          .catch(() => undefined)
+        let id = await readCachedId(dotgit)
 
         if (!gitBinary) {
           return {
@@ -114,13 +118,40 @@ export namespace Project {
           }
         }
 
+        const worktree = await git(["rev-parse", "--git-common-dir"], {
+          cwd: sandbox,
+        })
+          .then(async (result) => {
+            const common = gitpath(sandbox, await result.text())
+            // Avoid going to parent of sandbox when git-common-dir is empty.
+            return common === sandbox ? sandbox : path.dirname(common)
+          })
+          .catch(() => undefined)
+
+        if (!worktree) {
+          return {
+            id: id ?? "global",
+            worktree: sandbox,
+            sandbox: sandbox,
+            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
+          }
+        }
+
+        // In the case of a git worktree, it can't cache the id
+        // because `.git` is not a folder, but it always needs the
+        // same project id as the common dir, so we resolve it now
+        if (id == null) {
+          id = await readCachedId(path.join(worktree, ".git"))
+        }
+
         // generate id from root commit
         if (!id) {
           const roots = await git(["rev-list", "--max-parents=0", "--all"], {
             cwd: sandbox,
           })
             .then(async (result) =>
-              (await result.text())
+              result
+                .text()
                 .split("\n")
                 .filter(Boolean)
                 .map((x) => x.trim())
@@ -161,32 +192,13 @@ export namespace Project {
         if (!top) {
           return {
             id,
-            sandbox,
             worktree: sandbox,
+            sandbox: sandbox,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
 
         sandbox = top
-
-        const worktree = await git(["rev-parse", "--git-common-dir"], {
-          cwd: sandbox,
-        })
-          .then(async (result) => {
-            const common = gitpath(sandbox, await result.text())
-            // Avoid going to parent of sandbox when git-common-dir is empty.
-            return common === sandbox ? sandbox : path.dirname(common)
-          })
-          .catch(() => undefined)
-
-        if (!worktree) {
-          return {
-            id,
-            sandbox,
-            worktree: sandbox,
-            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-          }
-        }
 
         return {
           id,

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -113,7 +113,7 @@ export namespace Project {
           return {
             id: id ?? "global",
             worktree: sandbox,
-            sandbox: sandbox,
+            sandbox,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
@@ -132,7 +132,7 @@ export namespace Project {
           return {
             id: id ?? "global",
             worktree: sandbox,
-            sandbox: sandbox,
+            sandbox,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
@@ -163,7 +163,7 @@ export namespace Project {
             return {
               id: "global",
               worktree: sandbox,
-              sandbox: sandbox,
+              sandbox,
               vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
             }
           }
@@ -178,7 +178,7 @@ export namespace Project {
           return {
             id: "global",
             worktree: sandbox,
-            sandbox: sandbox,
+            sandbox,
             vcs: "git",
           }
         }
@@ -193,7 +193,7 @@ export namespace Project {
           return {
             id,
             worktree: sandbox,
-            sandbox: sandbox,
+            sandbox,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -150,8 +150,7 @@ export namespace Project {
             cwd: sandbox,
           })
             .then(async (result) =>
-              result
-                .text()
+              (await result.text())
                 .split("\n")
                 .filter(Boolean)
                 .map((x) => x.trim())

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -411,7 +411,7 @@ export namespace Worktree {
         await runStartScripts(info.directory, { projectID, extra })
       }
 
-      void start().catch((error) => {
+      return start().catch((error) => {
         log.error("worktree start task failed", { directory: info.directory, error })
       })
     }


### PR DESCRIPTION
Worktrees currently have a problem where the project id generated for them is always new. This registers them in the db as an entirely new project which is wrong: worktrees should be a workspaces that all connect back to the same project.

This is why things don't work as you expect with worktrees currently: when listing sessions for a project you don't get all the sessions across worktrees by default, you only get sessions for the local workspace. This PR will make anything like that work because those routes are scoped by project, and now worktrees will not create new projects. Everything will be related to a single project.

In a git worktree, `.git` exists but it's just a file that points to the internal git registry for that workspace inside the real `.git` directory. We can't cache the id in there. Instead, we need to resolve the worktree and if we still don't have an `id` yet we then try to read the cached id from the main dir where `.git` is a real directory

Note that we use `git rev-list --max-parents=0 --all` to derive the "root" commit. So the way it worked before might have worked in some cases (the cached id file doesn't exist, so it always goes through that path to get the id). If all cases returned the same output and derived the same id, it would have worked. but that's not realiable: `rev-list` that return multiple roots, and these can change over time, so it's really important that we cache it and always reuse whatever we generated first.