### PR TITLE
fix(ui): update/sync diff summary when git status changed

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -30,6 +30,7 @@ export namespace FileWatcher {
         event: z.union([z.literal("add"), z.literal("change"), z.literal("unlink")]),
       }),
     ),
+    GitStatusChanged: BusEvent.define("git.status.changed", z.object({})),
   }
 
   const watcher = lazy((): typeof import("@parcel/watcher") | undefined => {
@@ -102,6 +103,33 @@ export namespace FileWatcher {
           const sub = await withTimeout(pending, SUBSCRIBE_TIMEOUT_MS).catch((err) => {
             log.error("failed to subscribe to vcsDir", { error: err })
             pending.then((s) => s.unsubscribe()).catch(() => {})
+            return undefined
+          })
+          if (sub) subs.push(sub)
+        }
+      }
+
+      if (Instance.project.vcs === "git") {
+        const result = await git(["rev-parse", "--git-dir"], {
+          cwd: Instance.directory,
+        })
+        if (result.exitCode === 0 && result.text().trim()) {
+          const gitDir= result.text().trim()
+          const handleGitStatusChange: ParcelWatcher.SubscribeCallback = (err, evts) => {
+            if (err) {
+              return
+            }
+            for (const evt of evts) {
+              if (evt.path.endsWith("index") || evt.path.endsWith("HEAD")) {
+                Bus.publish(Event.GitStatusChanged, {})
+                break
+              }
+            }
+          }
+          const pending = w.subscribe(gitDir, handleGitStatusChange, { ignore: [], backend })
+          const sub = await withTimeout(pending, SUBSCRIBE_TIMEOUT_MS).catch(err => {
+            log.error("failed to subscribe to .git/index .git/HEAD", { error: err })
+            pending.then(s => s.unsubscribe()).catch(() => {})
             return undefined
           })
           if (sub) subs.push(sub)

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,11 +1,13 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
-import path from "path"
 import z from "zod"
 import { Log } from "@/util/log"
 import { Instance } from "./instance"
 import { FileWatcher } from "@/file/watcher"
 import { git } from "@/util/git"
+import { Session } from "@/session"
+import { Storage } from "@/storage/storage"
+import { Snapshot } from "@/snapshot"
 
 const log = Log.create({ service: "vcs" })
 
@@ -41,7 +43,11 @@ export namespace Vcs {
   const state = Instance.state(
     async () => {
       if (Instance.project.vcs !== "git") {
-        return { branch: async () => undefined, unsubscribe: undefined }
+        return {
+          branch: async () => undefined,
+          unsubscribe: undefined,
+          unsubscribeGitStatus: undefined,
+        }
       }
       let current = await currentBranch()
       log.info("initialized", { branch: current })
@@ -56,13 +62,45 @@ export namespace Vcs {
         }
       })
 
+      const unsubscribeGitStatus = Bus.subscribe(FileWatcher.Event.GitStatusChanged, async () => {
+        try {
+          const result = await git(["rev-parse", "--git-dir"], {
+            cwd: Instance.directory,
+          })
+          if (result.exitCode !== 0) return
+          const gitDir= result.text().trim()
+          if (!gitDir) return
+
+          log.info("git status changed")
+
+          const changedFiles = await Snapshot.diffFull("", "", gitDir)
+          const sessions = [...Session.list({ directory: Instance.directory })]
+          for (const s of sessions) {
+            await Storage.write(["session_diff", s.id], changedFiles)
+            await Session.setSummary({
+              sessionID: s.id,
+              summary: {
+                additions: changedFiles.reduce((sum, f) => sum + f.additions, 0),
+                deletions: changedFiles.reduce((sum, f) => sum + f.deletions, 0),
+                files: changedFiles.length,
+              },
+            })
+            Bus.publish(Session.Event.Diff, { sessionID: s.id, diff: changedFiles })
+          }
+        } catch (e) {
+          log.error("failed to handle git status change", { error: e })
+        }
+      })
+
       return {
         branch: async () => current,
         unsubscribe,
+        unsubscribeGitStatus,
       }
     },
     async (state) => {
       state.unsubscribe?.()
+      state.unsubscribeGitStatus?.()
     },
   )
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -265,8 +265,10 @@ export namespace Snapshot {
       ref: "FileDiff",
     })
   export type FileDiff = z.infer<typeof FileDiff>
-  export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
-    const git = gitdir()
+  export async function diffFull(from: string, to: string, git?: string): Promise<FileDiff[]> {
+    if (! git) {
+      git = gitdir()
+    }
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 


### PR DESCRIPTION
### Issue for this PR

Closes #11856
Closes #10920
Closes #11802

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Change Modified Files when git status changed outside.

1. Add new event `GitStatusChanged`, fired when `.git/index`, `.git/HEAD` changed. This happend when use git command outside opencode (git add/git commit/git reset...)
2. Subscribe event `GitStatusChanged` then update diff summary, sync to session summary.

### How did you verify your code works?
1. start opencode in cli.
2. using `git add/commit` make some changes.
3. verify `Modified Files` part change.

### Screenshots / recordings

![a](https://github.com/user-attachments/assets/1c492d03-8221-4924-9e04-2e7bde47b91f)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR