### PR TITLE
fix(ui): update/sync diff summary when git status changed

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -17,6 +17,8 @@ import { git } from "@/util/git"
 
 const SUBSCRIBE_TIMEOUT_MS = 10_000
 
+const GIT_STATUS_CHANGE_DEBOUNCE = 200
+
 declare const OPENCODE_LIBC: string | undefined
 
 export namespace FileWatcher {
@@ -30,6 +32,7 @@ export namespace FileWatcher {
         event: z.union([z.literal("add"), z.literal("change"), z.literal("unlink")]),
       }),
     ),
+    GitStatusChanged: BusEvent.define("git.status.changed", z.object({ directory: z.string() })),
   }
 
   const watcher = lazy((): typeof import("@parcel/watcher") | undefined => {
@@ -101,6 +104,32 @@ export namespace FileWatcher {
           })
           const sub = await withTimeout(pending, SUBSCRIBE_TIMEOUT_MS).catch((err) => {
             log.error("failed to subscribe to vcsDir", { error: err })
+            pending.then((s) => s.unsubscribe()).catch(() => {})
+            return undefined
+          })
+          if (sub) subs.push(sub)
+        }
+      }
+
+      if (Instance.project.vcs === "git") {
+        const result = await git(["rev-parse", "--absolute-git-dir"], {
+          cwd: Instance.directory,
+        })
+        if (result.exitCode === 0 && result.text().trim()) {
+          const gitDir = result.text().trim()
+          const directory = path.dirname(gitDir)
+          let debounceTimer: ReturnType<typeof setTimeout> | undefined
+          const handleGitStatusChange: ParcelWatcher.SubscribeCallback = (err) => {
+            if (err) return
+            if (debounceTimer) clearTimeout(debounceTimer)
+            debounceTimer = setTimeout(() => {
+              Bus.publish(Event.GitStatusChanged, { directory: directory })
+            }, GIT_STATUS_CHANGE_DEBOUNCE)
+          }
+          const pending = w.subscribe(gitDir, handleGitStatusChange, { ignore: [], backend })
+          const sub = await withTimeout(pending, SUBSCRIBE_TIMEOUT_MS).catch((err) => {
+            log.error("failed to subscribe to .git change", { error: err, cwd: Instance.directory })
+            if (debounceTimer) clearTimeout(debounceTimer)
             pending.then((s) => s.unsubscribe()).catch(() => {})
             return undefined
           })

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -6,6 +6,9 @@ import { Log } from "@/util/log"
 import { Instance } from "./instance"
 import { FileWatcher } from "@/file/watcher"
 import { git } from "@/util/git"
+import { Session } from "@/session"
+import { Storage } from "@/storage/storage"
+import { Snapshot } from "@/snapshot"
 
 const log = Log.create({ service: "vcs" })
 
@@ -41,7 +44,11 @@ export namespace Vcs {
   const state = Instance.state(
     async () => {
       if (Instance.project.vcs !== "git") {
-        return { branch: async () => undefined, unsubscribe: undefined }
+        return {
+          branch: async () => undefined,
+          unsubscribe: undefined,
+          unsubscribeGitStatus: undefined,
+        }
       }
       let current = await currentBranch()
       log.info("initialized", { branch: current })
@@ -56,13 +63,43 @@ export namespace Vcs {
         }
       })
 
+      const unsubscribeGitStatus = Bus.subscribe(FileWatcher.Event.GitStatusChanged, async (evt) => {
+        const directory = evt.properties.directory
+        log.info("git status change", { directory: directory })
+
+        const changedFiles = await Snapshot.diffFull("HEAD", "", path.join(directory, ".git"))
+        const sessions = [...Session.list({ directory: directory })]
+        for (const s of sessions) {
+          try {
+            await Storage.write(["session_diff", s.id], changedFiles)
+            await Session.setSummary({
+              sessionID: s.id,
+              summary: {
+                additions: changedFiles.reduce((sum, f) => sum + f.additions, 0),
+                deletions: changedFiles.reduce((sum, f) => sum + f.deletions, 0),
+                files: changedFiles.length,
+              },
+            })
+            Bus.publish(Session.Event.Diff, { sessionID: s.id, diff: changedFiles })
+          } catch (e) {
+            log.error("failed to handle git status change", { 
+              error: e,
+              sessionID: s.id,
+              directory: directory,
+            })
+          }
+        }
+      })
+
       return {
         branch: async () => current,
         unsubscribe,
+        unsubscribeGitStatus,
       }
     },
     async (state) => {
       state.unsubscribe?.()
+      state.unsubscribeGitStatus?.()
     },
   )
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -16,7 +16,7 @@ export namespace Snapshot {
   const prune = "7.days"
 
   function args(git: string, cmd: string[]) {
-    return ["--git-dir", git, "--work-tree", Instance.worktree, ...cmd]
+    return ["--git-dir", git, "--work-tree", Instance.worktree, ...cmd.filter(Boolean)]
   }
 
   export function init() {
@@ -265,8 +265,10 @@ export namespace Snapshot {
       ref: "FileDiff",
     })
   export type FileDiff = z.infer<typeof FileDiff>
-  export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
-    const git = gitdir()
+  export async function diffFull(from: string, to: string, git?: string): Promise<FileDiff[]> {
+    if (! git) {
+      git = gitdir()
+    }
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 


### PR DESCRIPTION
### Issue for this PR

Closes #11856
Closes #10920

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Update/Sync  ui `Modified Files` when git status changed outside opencode.

1. Add new event `GitStatusChanged`, fired when `.git` changed. This happend when use git command outside opencode (git add/git commit/git reset...)
2. Subscribe event `GitStatusChanged` then update diff summary.

### How did you verify your code works?
1. start opencode in cli.
2. using `git add/reset` make some changes.
3. verify `Modified Files` ui change.

### Screenshots / recordings

![a](https://github.com/user-attachments/assets/7b55e67b-cfb6-4fad-bc84-cf87d6909ac6)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR