### PR TITLE
fix(app): open project when navigating directly to a project URL

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -586,6 +586,20 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
+  createEffect(
+    on(
+      () => ({ ready: pageReady(), layoutReady: layoutReady(), dir: currentDir() }),
+      (value) => {
+        if (!value.ready) return
+        if (!value.layoutReady) return
+        if (!value.dir) return
+        const list = layout.projects.list()
+        if (list.find((p) => p.worktree === value.dir || p.sandboxes?.includes(value.dir))) return
+        openProject(value.dir, false)
+      },
+    ),
+  )
+
   const workspaceName = (directory: string, projectId?: string, branch?: string) => {
     const key = workspaceKey(directory)
     const direct = store.workspaceName[key] ?? store.workspaceName[directory]


### PR DESCRIPTION
### Issue for this PR

Closes #16837

### Type of change

- [x] Bug fix

### What does this PR do?

When the app is opened at a project URL directly (e.g. reloading the page, opening a session link in a new tab, or deep-linking), the sidebar panel renders blank. The existing auto-select `createEffect` bails out early when `state.autoselect` is `false` — which is always the case when a `dir` param is already in the URL. This means `layout.projects.open()` is never called, `layout.projects.list()` stays empty, `currentProject()` returns `undefined`, and the sidebar shows nothing.

The fix adds a second `createEffect` that reacts to changes in `pageReady`, `layoutReady`, `currentDir()`, and `layout.projects.list()`. If the current directory is not already in the open projects list (checking both `worktree` and `sandboxes`), it calls `openProject(dir, false)` to register it without navigating.

### How did you verify your code works?

1. Run `opencode web` and navigate to a project to get a project URL (e.g. `http://localhost:4096/<base64-dir>/session`).
2. Open that URL directly in a new tab — sidebar now correctly shows project name, branch, session list and New Session button.
3. Reload the page — sidebar remains populated.
4. Verify the original auto-select flow (opening the app at `/`) still works correctly.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR