### PR TITLE
fix: work around Bun/Windows UV_FS_O_FILEMAP incompatibility in tar

### DIFF
--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -1,3 +1,14 @@
+// Workaround: Bun on Windows does not support the UV_FS_O_FILEMAP flag that
+// the `tar` package uses for files < 512KB (fs.open returns EINVAL).
+// tar silently swallows the error and skips writing files, leaving only empty
+// directories. Setting __FAKE_PLATFORM__ makes tar fall back to the plain 'w'
+// flag. See tar's get-write-flag.js.
+// Must be set before @npmcli/arborist is imported since tar caches the flag
+// at module evaluation time — so we use a dynamic import() below.
+if (process.platform === "win32") {
+  process.env.__FAKE_PLATFORM__ = "linux"
+}
+
 import semver from "semver"
 import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
@@ -6,7 +17,6 @@ import { Lock } from "../util/lock"
 import { Log } from "../util/log"
 import path from "path"
 import { readdir } from "fs/promises"
-import { Arborist } from "@npmcli/arborist"
 
 export namespace Npm {
   const log = Log.create({ service: "npm" })
@@ -50,6 +60,7 @@ export namespace Npm {
     const hash = pkg
     const dir = directory(hash)
 
+    const { Arborist } = await import("@npmcli/arborist")
     const arborist = new Arborist({
       path: dir,
       binLinks: true,
@@ -84,14 +95,14 @@ export namespace Npm {
 
   export async function install(dir: string) {
     log.info("installing dependencies", { dir })
+    const { Arborist } = await import("@npmcli/arborist")
     const arb = new Arborist({
       path: dir,
       binLinks: true,
       progress: false,
       savePrefix: "",
     })
-    const result = await arb.reify()
-    console.log(result)
+    await arb.reify()
   }
 
   export async function which(pkg: string) {


### PR DESCRIPTION
## Summary

Fixes the Windows-only test failure in `tool.registry > loads tools with external dependencies without crashing`.

## Root Cause

`tar@7` uses `UV_FS_O_FILEMAP` (a libuv/Windows memory-mapped I/O flag) for `fs.open()` on all files < 512KB on Windows (`get-write-flag.js`). **Bun does not support this flag** — `fs.open()` returns `EINVAL`. tar's error handler (`[ONERROR]` in `unpack.js`) treats this as a non-fatal warning and silently skips the file. The result: `Arborist.reify()` reports success, but `node_modules` contains only empty directory structures — no actual files.

## Evidence (step-by-step isolation)

| Step | Test | Node | Bun |
|------|------|------|-----|
| 1 | `fs.openSync(path, UV_FS_O_FILEMAP \| O_TRUNC \| O_CREAT \| O_WRONLY)` | works | **EINVAL** |
| 2 | `tar.x()` with `onwarn` | 0 warnings | **202 EINVAL warnings** |
| 3 | `__FAKE_PLATFORM__=linux` before `require('tar')` then `tar.x()` | - | 0 warnings, all files |
| 4 | Same env var before `require('arborist')` then `arb.reify()` | - | all files extracted |
| 5 | ESM: env var then `import { Arborist }` (static) | - | still broken (hoisted) |
| 6 | env var then `await import("@npmcli/arborist")` (dynamic) | - | works |

## Fix

- Set `process.env.__FAKE_PLATFORM__ = "linux"` at module top level on Windows — makes tar use plain `'w'` flag instead of `UV_FS_O_FILEMAP`
- Change static `import { Arborist }` to dynamic `await import()` — ensures the env var is set before tar evaluates its cached flag at module load time
- Remove stray `console.log(result)` from `Npm.install()`