### PR TITLE
fix: include plugin-injected providers in models command

### DIFF
--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -1,77 +1,74 @@
-import type { Argv } from "yargs"
-import { Instance } from "../../project/instance"
-import { Provider } from "../../provider/provider"
-import { ModelsDev } from "../../provider/models"
-import { cmd } from "./cmd"
-import { UI } from "../ui"
 import { EOL } from "os"
+import type { Argv } from "yargs"
+import { ModelsDev } from "../../provider/models"
+import { Provider } from "../../provider/provider"
+import { bootstrap } from "../bootstrap"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
 
 export const ModelsCommand = cmd({
-  command: "models [provider]",
-  describe: "list all available models",
-  builder: (yargs: Argv) => {
-    return yargs
-      .positional("provider", {
-        describe: "provider ID to filter models by",
-        type: "string",
-        array: false,
-      })
-      .option("verbose", {
-        describe: "use more verbose model output (includes metadata like costs)",
-        type: "boolean",
-      })
-      .option("refresh", {
-        describe: "refresh the models cache from models.dev",
-        type: "boolean",
-      })
-  },
-  handler: async (args) => {
-    if (args.refresh) {
-      await ModelsDev.refresh()
-      UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
-    }
+	command: "models [provider]",
+	describe: "list all available models",
+	builder: (yargs: Argv) => {
+		return yargs
+			.positional("provider", {
+				describe: "provider ID to filter models by",
+				type: "string",
+				array: false,
+			})
+			.option("verbose", {
+				describe: "use more verbose model output (includes metadata like costs)",
+				type: "boolean",
+			})
+			.option("refresh", {
+				describe: "refresh the models cache from models.dev",
+				type: "boolean",
+			})
+	},
+	handler: async (args) => {
+		if (args.refresh) {
+			await ModelsDev.refresh()
+			UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
+		}
 
-    await Instance.provide({
-      directory: process.cwd(),
-      async fn() {
-        const providers = await Provider.list()
+		await bootstrap(process.cwd(), async () => {
+			const providers = await Provider.list()
 
-        function printModels(providerID: string, verbose?: boolean) {
-          const provider = providers[providerID]
-          const sortedModels = Object.entries(provider.models).sort(([a], [b]) => a.localeCompare(b))
-          for (const [modelID, model] of sortedModels) {
-            process.stdout.write(`${providerID}/${modelID}`)
-            process.stdout.write(EOL)
-            if (verbose) {
-              process.stdout.write(JSON.stringify(model, null, 2))
-              process.stdout.write(EOL)
-            }
-          }
-        }
+			function printModels(providerID: string, verbose?: boolean) {
+				const provider = providers[providerID]
+				const sortedModels = Object.entries(provider.models).sort(([a], [b]) => a.localeCompare(b))
+				for (const [modelID, model] of sortedModels) {
+					process.stdout.write(`${providerID}/${modelID}`)
+					process.stdout.write(EOL)
+					if (verbose) {
+						process.stdout.write(JSON.stringify(model, null, 2))
+						process.stdout.write(EOL)
+					}
+				}
+			}
 
-        if (args.provider) {
-          const provider = providers[args.provider]
-          if (!provider) {
-            UI.error(`Provider not found: ${args.provider}`)
-            return
-          }
+			if (args.provider) {
+				const provider = providers[args.provider]
+				if (!provider) {
+					UI.error(`Provider not found: ${args.provider}`)
+					return
+				}
 
-          printModels(args.provider, args.verbose)
-          return
-        }
+				printModels(args.provider, args.verbose)
+				return
+			}
 
-        const providerIDs = Object.keys(providers).sort((a, b) => {
-          const aIsOpencode = a.startsWith("opencode")
-          const bIsOpencode = b.startsWith("opencode")
-          if (aIsOpencode && !bIsOpencode) return -1
-          if (!aIsOpencode && bIsOpencode) return 1
-          return a.localeCompare(b)
-        })
+			const providerIDs = Object.keys(providers).sort((a, b) => {
+				const aIsOpencode = a.startsWith("opencode")
+				const bIsOpencode = b.startsWith("opencode")
+				if (aIsOpencode && !bIsOpencode) return -1
+				if (!aIsOpencode && bIsOpencode) return 1
+				return a.localeCompare(b)
+			})
 
-        for (const providerID of providerIDs) {
-          printModels(providerID, args.verbose)
-        }
-      },
-    })
-  },
+			for (const providerID of providerIDs) {
+				printModels(providerID, args.verbose)
+			}
+		})
+	},
 })

--- a/packages/opencode/test/cli/models.test.ts
+++ b/packages/opencode/test/cli/models.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from "bun:test"
+
+let bootstrapCalls = 0
+let pluginConfigApplied = false
+
+mock.module("../../src/cli/bootstrap", () => ({
+	bootstrap: async (_directory: string, cb: () => Promise<unknown>) => {
+		bootstrapCalls += 1
+		pluginConfigApplied = true
+		return cb()
+	},
+}))
+
+mock.module("../../src/provider/provider", () => ({
+	Provider: {
+		list: async () => {
+			const providers: Record<string, { models: Record<string, unknown> }> = {
+				openai: {
+					models: {
+						"gpt-5": {},
+					},
+				},
+			}
+
+			if (pluginConfigApplied) {
+				providers["cliproxy-test"] = {
+					models: {
+						"proxy-model": {},
+					},
+				}
+			}
+
+			return providers
+		},
+	},
+}))
+
+const { ModelsCommand } = await import("../../src/cli/cmd/models")
+
+describe("models command", () => {
+	test("includes providers added via plugin config hooks", async () => {
+		bootstrapCalls = 0
+		pluginConfigApplied = false
+
+		const output: string[] = []
+		const originalWrite = process.stdout.write.bind(process.stdout)
+		process.stdout.write = ((chunk: string | Uint8Array) => {
+			output.push(typeof chunk === "string" ? chunk : chunk.toString())
+			return true
+		}) as typeof process.stdout.write
+
+		try {
+			await ModelsCommand.handler({
+				refresh: false,
+				verbose: false,
+			} as any)
+		} finally {
+			process.stdout.write = originalWrite as typeof process.stdout.write
+		}
+
+		expect(bootstrapCalls).toBe(1)
+		expect(output.join("")).toContain("cliproxy-test/proxy-model")
+	})
+})


### PR DESCRIPTION
## Summary
- route `opencode models` through the shared CLI bootstrap path so plugin `config` hooks run before provider discovery
- keep command behavior unchanged otherwise while ensuring plugin-added providers (for example `cliproxy-*`) appear in model listings
- add a CLI regression test that fails when bootstrap is skipped and verifies plugin-injected providers are listed