### PR TITLE
fix(tui): avoid forced worker termination during shutdown

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -159,12 +159,15 @@ export const TuiThreadCommand = cmd({
         process.off("uncaughtException", error)
         process.off("unhandledRejection", error)
         process.off("SIGUSR2", reload)
-        await withTimeout(client.call("shutdown", undefined), 5000).catch((error) => {
-          Log.Default.warn("worker shutdown failed", {
-            error: error instanceof Error ? error.message : String(error),
+        const done = await withTimeout(client.call("shutdown", undefined), 6500)
+          .then(() => true)
+          .catch((error) => {
+            Log.Default.warn("worker shutdown failed", {
+              error: error instanceof Error ? error.message : String(error),
+            })
+            return false
           })
-        })
-        worker.terminate()
+        if (!done) worker.terminate()
       }
 
       const prompt = await input(args.prompt)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -142,7 +142,12 @@ export const rpc = {
   async shutdown() {
     Log.Default.info("worker shutting down")
     if (eventStream.abort) eventStream.abort.abort()
-    await Instance.disposeAll()
+    await Promise.race([
+      Instance.disposeAll(),
+      new Promise((resolve) => {
+        setTimeout(resolve, 5000)
+      }),
+    ])
     if (server) server.stop(true)
   },
 }

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -8,6 +8,11 @@ const seen = {
   tui: [] as string[],
   inst: [] as string[],
 }
+const state = {
+  timeout: false,
+  shutdown: 0,
+  terminate: 0,
+}
 
 mock.module("../../../src/cli/cmd/tui/app", () => ({
   tui: async (input: { directory: string }) => {
@@ -19,7 +24,13 @@ mock.module("../../../src/cli/cmd/tui/app", () => ({
 mock.module("@/util/rpc", () => ({
   Rpc: {
     client: () => ({
-      call: async () => ({ url: "http://127.0.0.1" }),
+      call: async (name: string) => {
+        if (name === "shutdown") {
+          state.shutdown++
+          return undefined
+        }
+        return { url: "http://127.0.0.1" }
+      },
       on: () => {},
     }),
   },
@@ -51,7 +62,10 @@ mock.module("@/util/log", () => ({
 }))
 
 mock.module("@/util/timeout", () => ({
-  withTimeout: <T>(input: Promise<T>) => input,
+  withTimeout: <T>(input: Promise<T>) => {
+    if (state.timeout) return Promise.reject(new Error("timeout"))
+    return input
+  },
 }))
 
 mock.module("@/cli/network", () => ({
@@ -127,12 +141,19 @@ describe("tui thread", () => {
       onmessage = null
       onmessageerror = null
       postMessage() {}
-      terminate() {}
+      terminate() {
+        state.terminate++
+      }
     } as unknown as typeof Worker
+
+    const timeout = state.timeout
 
     try {
       process.chdir(tmp.path)
       process.env.PWD = link
+      state.timeout = timeout
+      state.shutdown = 0
+      state.terminate = 0
       await expect(call(project)).rejects.toBe(stop)
       expect(seen.inst[0]).toBe(tmp.path)
       expect(seen.tui[0]).toBe(tmp.path)
@@ -153,5 +174,19 @@ describe("tui thread", () => {
 
   test("uses the real cwd after resolving a relative project from PWD", async () => {
     await check(".")
+  })
+
+  test("does not terminate worker after a clean shutdown", async () => {
+    state.timeout = false
+    await check()
+    expect(state.shutdown).toBe(1)
+    expect(state.terminate).toBe(0)
+  })
+
+  test("terminates worker when shutdown times out", async () => {
+    state.timeout = true
+    await check()
+    expect(state.shutdown).toBe(1)
+    expect(state.terminate).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- keep TUI worker shutdown bounded inside the worker instead of always relying on the parent thread to hard-terminate it
- only call `worker.terminate()` as a fallback when the shutdown RPC times out, which avoids interrupting terminal cleanup in tmux
- add regression coverage for both clean shutdown and timed-out shutdown paths

## Why
- issue #16351 reports that opencode becomes unusable in tmux starting in `1.2.17`, with raw mouse SGR sequences being inserted into the prompt and keyboard shortcuts no longer behaving correctly
- `#16565` fixed double cleanup, but the remaining forced worker termination path still appears to leave OpenTUI/tmux terminal cleanup half-applied
- restoring the older bounded worker-side shutdown behavior fixes the tmux regression while still preserving a timeout-based fallback if cleanup wedges

Fixes #16351

## Testing
- `bun test test/cli/tui/thread.test.ts`
- `bun run typecheck`