### PR TITLE
fix: resolve Claude 4.6 assistant prefill compatibility issues

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -319,7 +319,7 @@ export namespace SessionPrompt {
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
+        lastAssistant.parentID === lastUser.id
       ) {
         log.info("exiting loop", { sessionID })
         break
@@ -667,7 +667,7 @@ export namespace SessionPrompt {
           ...(isLastStep
             ? [
                 {
-                  role: "assistant" as const,
+                  role: "user" as const,
                   content: MAX_STEPS,
                 },
               ]


### PR DESCRIPTION
## Summary

Fixes #13768 - Resolves the "This model does not support assistant message prefill" error that occurs with Claude Opus 4.6 and Sonnet 4.6 models across all providers (Anthropic, GitHub Copilot, OpenRouter, etc.).

This PR addresses two distinct root causes with targeted, surgical fixes:

### 1. Max Steps Message Role (`prompt.ts:670`)

**Problem**: When the maximum step limit is reached, opencode appends an assistant message containing `MAX_STEPS` instructions. Claude 4.6 rejects any conversation ending with an assistant message.

**Fix**: Changed the role from `assistant` to `user` for the MAX_STEPS instruction.
- ✅ Maintains instruction delivery to the model
- ✅ Compatible with Claude 4.6's requirements
- ✅ No behavioral changes to the agent

### 2. Agentic Loop Exit Condition (`prompt.ts:322`)

**Problem**: The loop exit condition used timestamp-based ID comparison (`lastUser.id < lastAssistant.id`) to determine if the assistant had responded to the user. When client clocks run ahead of server clocks, this comparison fails, causing the loop to create an extra assistant message that becomes the final message in the array.

**Fix**: Replaced ID comparison with explicit parent-child relationship check (`lastAssistant.parentID === lastUser.id`).
- ✅ Clock-skew resistant
- ✅ Uses existing `parentID` field that tracks which user message an assistant is responding to
- ✅ More semantically correct

## Changes

- `packages/opencode/src/session/prompt.ts` (2 lines changed)

## Testing

- ✅ All existing session tests pass (110 pass, 4 skip, 0 fail)
- ✅ Prompt-specific tests verified (4 pass)
- ✅ No new test coverage needed as these are targeted fixes to existing logic

## Context

Previous PR #14772 attempted to fix this with a safety net approach (`stripTrailingAssistant()`) but was correctly identified as hiding the real bugs rather than fixing them. This PR implements proper root-cause fixes instead.

Credit to @nguquen for identifying the clock-skew issue in [this comment](https://github.com/anomalyco/opencode/issues/13768#issuecomment-4028254576).