### PR TITLE
fix(core): make JSON-to-SQLite migration truly one-time

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -88,7 +88,7 @@ let cli = yargs(hideBin(process.argv))
       args: process.argv.slice(2),
     })
 
-    const marker = path.join(Global.Path.data, "opencode.db")
+    const marker = path.join(Global.Path.data, "storage", "json-sqlite-migration.done")
     if (!(await Filesystem.exists(marker))) {
       const tty = process.stderr.isTTY
       process.stderr.write("Performing one time database migration, may take a few minutes..." + EOL)
@@ -122,6 +122,7 @@ let cli = yargs(hideBin(process.argv))
           process.stderr.write(`sqlite-migration:done${EOL}`)
         }
       }
+      await Filesystem.write(marker, `${Date.now()}\n`)
       process.stderr.write("Database migration complete." + EOL)
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #16885

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The startup JSON->SQLite migration gate currently checks for `~/.local/share/opencode/opencode.db`. On non-`latest` channels, the active DB can be channel-specific (for example `opencode-local.db`), so that filename check can stay false forever and migration reruns every launch.

This change switches the gate to a dedicated marker file at `~/.local/share/opencode/storage/json-sqlite-migration.done` and writes that marker after a successful migration run. That makes the migration truly one-time regardless of DB filename/channel.

Why this approach instead of checking channel DB names: checking channel DB filenames only fixes the rerun case, but not the skip case where a DB file exists from prior schema migrations even though JSON->SQLite import never completed. A dedicated migration-completion marker tracks the actual event we care about.

### How did you verify your code works?

- Reproduced repeated migration locally before the change (migration banner showed on each startup)
- Applied this patch and validated migration no longer reruns after completion
- Ran typecheck locally using nix-provided bun:
  - `nix shell nixpkgs#bun --command bun install`
  - `nix shell nixpkgs#bun --command bun run --cwd packages/opencode typecheck`

### Screenshots / recordings

Before:
<img width="1656" height="685" alt="image" src="https://github.com/user-attachments/assets/fbfdaa56-ebc8-4b88-aeef-27cb34395f60" />

After:
<img width="1673" height="646" alt="image" src="https://github.com/user-attachments/assets/bd3ac6ce-bf9b-43d3-915c-bacde4c42d61" />


N/A (CLI startup behavior change, no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR