### PR TITLE
fix: normalize gpt-5.4 compaction thresholds

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -60,6 +60,27 @@ export namespace Provider {
     return isGpt5OrLater(modelID) && !modelID.startsWith("gpt-5-mini")
   }
 
+  const NORMALIZED_INPUT_LIMITS = new Set([
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-pro",
+    "openrouter/openai/gpt-5.4-pro",
+  ])
+
+  function normalizeKnownModelLimits(model: Model): Model {
+    const key = `${model.providerID}/${model.id}`
+    if (!NORMALIZED_INPUT_LIMITS.has(key)) return model
+    if (model.limit.context !== 1_050_000 || model.limit.input !== 272_000 || model.limit.output !== 128_000)
+      return model
+
+    return {
+      ...model,
+      limit: {
+        ...model.limit,
+        input: model.limit.context - model.limit.output,
+      },
+    }
+  }
+
   function googleVertexVars(options: Record<string, any>) {
     const project =
       options["project"] ?? Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
@@ -677,7 +698,7 @@ export namespace Provider {
   export type Info = z.infer<typeof Info>
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
-    const m: Model = {
+    const m = normalizeKnownModelLimits({
       id: model.id,
       providerID: provider.id,
       name: model.name,
@@ -736,7 +757,7 @@ export namespace Provider {
       },
       release_date: model.release_date,
       variants: {},
-    }
+    })
 
     m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -4,7 +4,51 @@ import path from "path"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
+import type { ModelsDev } from "../../src/provider/models"
 import { Env } from "../../src/env"
+
+function createModelsDevProvider(providerID: string, modelID: string, input = 272_000): ModelsDev.Provider {
+  return {
+    id: providerID,
+    name: providerID,
+    env: [],
+    api: "https://api.example.com/v1",
+    npm: providerID === "openrouter" ? "@openrouter/ai-sdk-provider" : "@ai-sdk/openai",
+    models: {
+      [modelID]: {
+        id: modelID,
+        name: modelID,
+        release_date: "2026-03-05",
+        attachment: true,
+        reasoning: true,
+        temperature: true,
+        tool_call: true,
+        options: {},
+        limit: {
+          context: 1_050_000,
+          input,
+          output: 128_000,
+        },
+      },
+    },
+  }
+}
+
+for (const [providerID, modelID] of [
+  ["openai", "gpt-5.4"],
+  ["openai", "gpt-5.4-pro"],
+  ["openrouter", "openai/gpt-5.4-pro"],
+] as const) {
+  test(`normalizes ${providerID}/${modelID} input limit to leave room for output`, () => {
+    const provider = Provider.fromModelsDevProvider(createModelsDevProvider(providerID, modelID))
+    expect(provider.models[modelID].limit.input).toBe(922_000)
+  })
+}
+
+test("does not normalize non-target GPT-5.4 metadata", () => {
+  const provider = Provider.fromModelsDevProvider(createModelsDevProvider("opencode", "gpt-5.4-pro"))
+  expect(provider.models["gpt-5.4-pro"].limit.input).toBe(272_000)
+})
 
 test("provider loaded from env variable", async () => {
   await using tmp = await tmpdir({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -101,6 +101,22 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
+  test("uses corrected GPT-5.4-style input caps near the full context window", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 1_050_000, input: 922_000, output: 128_000 })
+
+        const belowThreshold = { input: 880_000, output: 20_000, reasoning: 0, cache: { read: 1_999, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens: belowThreshold, model })).toBe(false)
+
+        const atThreshold = { input: 880_000, output: 20_000, reasoning: 0, cache: { read: 2_000, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens: atThreshold, model })).toBe(true)
+      },
+    })
+  })
+
   test("returns false when output within limit with input caps", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Closes #16333

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GPT-5.4 entries currently come through with a `limit.context` around 1.05M, `limit.input` 272k, and `limit.output` 128k. Because session compaction prefers `limit.input`, OpenCode starts compacting around ~252k usable tokens even though the model appears to support a much larger window.

This change normalizes only the known-bad GPT-5.4 entries during provider model loading. When the imported limits match the bad shape exactly, it rewrites `limit.input` to `context - output`, which gives a usable input cap of 922k and moves compaction closer to the actual long-context window. The generic compaction logic stays unchanged for other models with legitimate asymmetric limits.

It also adds regression coverage for both the provider normalization and the compaction threshold behavior.

### How did you verify your code works?

- Ran:
  - `npx bun test test/provider/provider.test.ts test/session/compaction.test.ts --timeout 30000`
  - `npx bun run typecheck`
- Both passed locally.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
