### PR TITLE
docs(ecosystem): add opencode-huge-agents to Plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -48,6 +48,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-huge-agents](https://github.com/yurirxmos/opencode-huge-agents)                          | Plugin with three agents: refactor (review-first), ask (read-only), and exec (risk-aware orchestration) |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 
 ---


### PR DESCRIPTION
## Summary
- add `opencode-huge-agents` to the OpenCode ecosystem Plugins table
- include repository link and a concise description of the plugin agents