### PR TITLE
fix(opencode): detect HTML responses in GitHub Copilot 403 errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -40,8 +40,13 @@ export namespace ProviderError {
     return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
   }
 
+  function html(body?: string) {
+    if (!body) return false
+    return /^\s*<!doctype|^\s*<html/i.test(body)
+  }
+
   function error(providerID: string, error: APICallError) {
-    if (providerID.includes("github-copilot") && error.statusCode === 403) {
+    if (providerID.includes("github-copilot") && error.statusCode === 403 && !html(error.responseBody)) {
       return "Please reauthenticate with the copilot provider to ensure your credentials work properly with OpenCode."
     }
 
@@ -79,7 +84,7 @@ export namespace ProviderError {
 
       // If responseBody is HTML (e.g. from a gateway or proxy error page),
       // provide a human-readable message instead of dumping raw markup
-      if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) {
+      if (html(e.responseBody)) {
         if (e.statusCode === 401) {
           return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
         }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -871,6 +871,35 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("maps github-copilot 403 html body to proxy guidance", () => {
+    const error = new APICallError({
+      message: "Forbidden",
+      url: "https://api.githubcopilot.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 403,
+      responseHeaders: { "content-type": "text/html" },
+      responseBody: "<html><body><h1>403 Forbidden</h1></body></html>",
+      isRetryable: false,
+    })
+
+    const result = MessageV2.fromError(error, { providerID: "github-copilot" })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message:
+          "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings.",
+        statusCode: 403,
+        isRetryable: false,
+        responseHeaders: { "content-type": "text/html" },
+        responseBody: "<html><body><h1>403 Forbidden</h1></body></html>",
+        metadata: {
+          url: "https://api.githubcopilot.com/v1/chat/completions",
+        },
+      },
+    })
+  })
+
   test("detects context overflow from APICallError provider messages", () => {
     const cases = [
       "prompt is too long: 213462 tokens > 200000 maximum",


### PR DESCRIPTION
### Issue for this PR

Closes #16901

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GitHub Copilot 403 errors are currently treated as authentication issues in all cases. When using OpenCode behind a corporate proxy (like Zscaler), proxies block requests and return 403 with HTML error pages. The existing HTML detection logic was unreachable because the code returned early with an auth message.

**Changes:**
- Extract HTML detection into reusable `html()` helper function
- Add condition to check response body type before showing auth message
- Non-HTML 403s → show auth message (existing behavior)
- HTML 403s → show proxy/gateway error message (fixed behavior)

This allows users behind proxies to see the correct error message explaining the request was blocked by a gateway/proxy rather than being incorrectly told to re-authenticate.

### How did you verify your code works?

- Added test case for GitHub Copilot 403 with HTML body response
- Test verifies HTML responses show proxy error message
- Existing test for JSON 403 still shows auth message
- All tests pass

### Screenshots / recordings

N/A - Error handling logic change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR