### PR TITLE
fix(tui): avoid stuck QUEUED badges from orphan assistant messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -139,7 +139,11 @@ export function Session() {
   })
 
   const pending = createMemo(() => {
-    return messages().findLast((x) => x.role === "assistant" && !x.time.completed)?.id
+    const lastMessage = messages().at(-1)
+    if (!lastMessage || lastMessage.role !== "assistant") return
+    if (lastMessage.time.completed) return
+    if (lastMessage.error) return
+    return lastMessage.id
   })
 
   const lastAssistant = createMemo(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #16856

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the stuck QUEUED badge when an old orphan assistant message exists in session history.

Before: pending used indLast over all messages for assistant entries missing 	ime.completed. If an older crashed/orphaned assistant message was still incomplete, pending pointed to it forever, so later user messages looked queued even when idle.

After: pending only considers the tail message, and only if it is an assistant message that is still incomplete and has no error.

Why this works: only the tail assistant message can represent current in-flight generation; historical orphan records should not drive live queued state.

### How did you verify your code works?

- Reproduced logic path by inspecting the current queued condition in UserMessage (message.id > pending).
- Verified the new memo returns undefined when the last message is not an active assistant response.
- Confirmed this prevents stale mid-history assistant records from setting global queued status.

### Screenshots / recordings

Not included (small logic-only TUI state fix).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
