### PR TITLE
docs(lsp): correct Intelephense premium key filename to licence.txt

### DIFF
--- a/packages/web/src/content/docs/ar/lsp.mdx
+++ b/packages/web/src/content/docs/ar/lsp.mdx
@@ -182,7 +182,7 @@ description: يتكامل OpenCode مع خوادم LSP لديك.
 
 يوفر PHP Intelephense ميزات مدفوعة عبر مفتاح ترخيص. يمكنك تزويده بمفتاح الترخيص عبر وضع (فقط) المفتاح داخل ملف نصي في:
 
-- على macOS/Linux: `$HOME/intelephense/license.txt`
-- على Windows: `%USERPROFILE%/intelephense/license.txt`
+- على macOS/Linux: `$HOME/intelephense/licence.txt`
+- على Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 يجب أن يحتوي الملف على مفتاح الترخيص فقط دون أي محتوى إضافي.

--- a/packages/web/src/content/docs/bs/lsp.mdx
+++ b/packages/web/src/content/docs/bs/lsp.mdx
@@ -180,6 +180,6 @@ Možete dodati prilagođene LSP servere navodeći ekstenzije naredbe i datoteke:
 
 PHP Intelephense nudi vrhunske funkcije putem licencnog ključa. Možete dati licencni ključ postavljanjem (samo) ključa u tekstualnu datoteku na:
 
-- Na macOS/Linuxu: `$HOME/intelephense/license.txt`
-- Na Windowsima: `%USERPROFILE%/intelephense/license.txt`
+- Na macOS/Linuxu: `$HOME/intelephense/licence.txt`
+- Na Windowsima: `%USERPROFILE%/intelephense/licence.txt`
   Datoteka treba da sadrži samo licencni ključ bez dodatnog sadržaja.

--- a/packages/web/src/content/docs/da/lsp.mdx
+++ b/packages/web/src/content/docs/da/lsp.mdx
@@ -183,7 +183,7 @@ Du kan tilføje brugerdefinerede LSP-servere ved at angive kommandoen og filtype
 
 PHP Intelephense tilbyder premium funktioner gennem en licensnøgle. Du kan angive en licensnøgle ved at placere (kun) nøglen i en tekstfil på:
 
-- På macOS/Linux: `$HOME/intelephense/license.txt`
-- På Windows: `%USERPROFILE%/intelephense/license.txt`
+- På macOS/Linux: `$HOME/intelephense/licence.txt`
+- På Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Filen bør kun indeholde licensnøglen uden yderligere indhold.

--- a/packages/web/src/content/docs/de/lsp.mdx
+++ b/packages/web/src/content/docs/de/lsp.mdx
@@ -182,7 +182,7 @@ Sie können einen benutzerdefinierten LSP-Server hinzufügen, indem Sie den Befe
 
 PHP Intelepense bietet Premium-Funktionen über einen Lizenzschlüssel. Sie können einen Lizenzschlüssel bereitstellen, indem Sie (nur) den Schlüssel in eine Textdatei einfügen unter:
 
-- Auf macOS/Linux: `$HOME/intelephense/license.txt`
-- Unter Windows: `%USERPROFILE%/intelephense/license.txt`
+- Auf macOS/Linux: `$HOME/intelephense/licence.txt`
+- Unter Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Die Datei sollte nur den Lizenzschlüssel ohne zusätzlichen Inhalt enthalten.

--- a/packages/web/src/content/docs/es/lsp.mdx
+++ b/packages/web/src/content/docs/es/lsp.mdx
@@ -183,7 +183,7 @@ Puede agregar servidores LSP personalizados especificando el comando y las exten
 
 PHP Intelephense ofrece funciones premium a través de una clave de licencia. Puede proporcionar una clave de licencia colocando (únicamente) la clave en un archivo de texto en:
 
-- En macOS/Linux: `$HOME/intelephense/license.txt`
-- En Windows: `%USERPROFILE%/intelephense/license.txt`
+- En macOS/Linux: `$HOME/intelephense/licence.txt`
+- En Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 El archivo debe contener sólo la clave de licencia sin contenido adicional.

--- a/packages/web/src/content/docs/fr/lsp.mdx
+++ b/packages/web/src/content/docs/fr/lsp.mdx
@@ -183,7 +183,7 @@ Vous pouvez ajouter des serveurs LSP personnalisés en spécifiant les extension
 
 PHP Intelephense offre des fonctionnalités premium via une clé de licence. Vous pouvez fournir une clé de licence en plaçant (uniquement) la clé dans un fichier texte à l'adresse :
 
-- macOS/Linux : `$HOME/intelephense/license.txt`
-- Windows : `%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux : `$HOME/intelephense/licence.txt`
+- Windows : `%USERPROFILE%/intelephense/licence.txt`
 
 Le fichier doit contenir uniquement la clé de licence sans contenu supplémentaire.

--- a/packages/web/src/content/docs/it/lsp.mdx
+++ b/packages/web/src/content/docs/it/lsp.mdx
@@ -183,7 +183,7 @@ Puoi aggiungere server LSP personalizzati specificando il comando e le estension
 
 PHP Intelephense offre funzionalita premium tramite una chiave di licenza. Puoi fornire la chiave inserendo (solo) la chiave in un file di testo in:
 
-- Su macOS/Linux: `$HOME/intelephense/license.txt`
-- Su Windows: `%USERPROFILE%/intelephense/license.txt`
+- Su macOS/Linux: `$HOME/intelephense/licence.txt`
+- Su Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Il file deve contenere solo la chiave di licenza, senza contenuti aggiuntivi.

--- a/packages/web/src/content/docs/ja/lsp.mdx
+++ b/packages/web/src/content/docs/ja/lsp.mdx
@@ -183,7 +183,7 @@ LSP サーバーの起動時に `env` プロパティを使用して環境変数
 
 PHP Intelephense は、ライセンスキーを通じてプレミアム機能を提供します。ライセンスキーを指定するには、次の場所にあるテキストファイルにキー (のみ) を配置します。
 
-- macOS/Linux の場合: `$HOME/intelephense/license.txt`
-- Windows の場合: `%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux の場合: `$HOME/intelephense/licence.txt`
+- Windows の場合: `%USERPROFILE%/intelephense/licence.txt`
 
 ファイルにはライセンスキーのみが含まれており、追加のコンテンツは含まれていません。

--- a/packages/web/src/content/docs/ko/lsp.mdx
+++ b/packages/web/src/content/docs/ko/lsp.mdx
@@ -183,7 +183,7 @@ OpenCode config의 `lsp` 섹션에서 LSP 서버를 사용자 정의할 수 있�
 
 PHP Intelephense는 라이선스 키를 통해 프리미엄 기능을 제공합니다. 텍스트 파일에 키만 저장해 라이선스 키를 제공할 수 있습니다.
 
-- macOS/Linux: `$HOME/intelephense/license.txt`
-- Windows: `%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux: `$HOME/intelephense/licence.txt`
+- Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 파일에는 추가 내용 없이 라이선스 키만 포함하는 것이 좋습니다.

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -183,7 +183,7 @@ You can add custom LSP servers by specifying the command and file extensions:
 
 PHP Intelephense offers premium features through a license key. You can provide a license key by placing (only) the key in a text file at:
 
-- On macOS/Linux: `$HOME/intelephense/license.txt`
-- On Windows: `%USERPROFILE%/intelephense/license.txt`
+- On macOS/Linux: `$HOME/intelephense/licence.txt`
+- On Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 The file should contain only the license key with no additional content.

--- a/packages/web/src/content/docs/nb/lsp.mdx
+++ b/packages/web/src/content/docs/nb/lsp.mdx
@@ -183,7 +183,7 @@ Du kan legge til egendefinerte LSP-servere ved å spesifisere kommandoen og filt
 
 PHP Intelephense tilbyr førsteklasses funksjoner gjennom en lisensnøkkel. Du kan oppgi en lisensnøkkel ved å plassere (bare) nøkkelen i en tekstfil på:
 
-- På macOS/Linux: `$HOME/intelephense/license.txt`
-- På Windows: `%USERPROFILE%/intelephense/license.txt`
+- På macOS/Linux: `$HOME/intelephense/licence.txt`
+- På Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Filen skal bare inneholde lisensnøkkelen uten ekstra innhold.

--- a/packages/web/src/content/docs/pl/lsp.mdx
+++ b/packages/web/src/content/docs/pl/lsp.mdx
@@ -183,7 +183,7 @@ Możesz dodać niestandardowe serwery LSP, podając polecenie i rozszerzenia pli
 
 PHP Intelephense oferuje funkcje premium poprzez klucz licencyjny. Możesz użyć klucza licencyjnego, umieszczając go (sam klucz) w pliku tekstowym pod adresem:
 
-- macOS/Linux: `$HOME/intelephense/license.txt`
-- Windows: `%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux: `$HOME/intelephense/licence.txt`
+- Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Plik powinien zawierać wyłącznie klucz licencyjny, bez białych znaków.

--- a/packages/web/src/content/docs/pt-br/lsp.mdx
+++ b/packages/web/src/content/docs/pt-br/lsp.mdx
@@ -183,7 +183,7 @@ Você pode adicionar servidores LSP personalizados especificando o comando e as 
 
 PHP Intelephense oferece recursos premium através de uma chave de licença. Você pode fornecer uma chave de licença colocando (apenas) a chave em um arquivo de texto em:
 
-- No macOS/Linux: `$HOME/intelephense/license.txt`
-- No Windows: `%USERPROFILE%/intelephense/license.txt`
+- No macOS/Linux: `$HOME/intelephense/licence.txt`
+- No Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 O arquivo deve conter apenas a chave de licença sem conteúdo adicional.

--- a/packages/web/src/content/docs/ru/lsp.mdx
+++ b/packages/web/src/content/docs/ru/lsp.mdx
@@ -182,7 +182,7 @@ opencode поставляется с несколькими встроенным
 
 PHP Intelephense предлагает дополнительные функции через лицензионный ключ. Вы можете предоставить лицензионный ключ, поместив (только) ключ в текстовый файл по адресу:
 
-- В macOS/Linux: `$HOME/intelephense/license.txt`
-- В Windows: `%USERPROFILE%/intelephense/license.txt`
+- В macOS/Linux: `$HOME/intelephense/licence.txt`
+- В Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 Файл должен содержать только лицензионный ключ без какого-либо дополнительного содержимого.

--- a/packages/web/src/content/docs/th/lsp.mdx
+++ b/packages/web/src/content/docs/th/lsp.mdx
@@ -183,7 +183,7 @@ You can customize LSP servers through the `lsp` section in your opencode config.
 
 PHP Intelephense นำเสนอคุณสมบัติระดับพรีเมียมผ่านรหัสลิขสิทธิ์ คุณสามารถระบุรหัสสัญญาอนุญาตได้โดยการวาง (เท่านั้น) รหัสในไฟล์ข้อความที่:
 
-- บน macOS/Linux: `$HOME/intelephense/license.txt`
-- บน Windows: `%USERPROFILE%/intelephense/license.txt`
+- บน macOS/Linux: `$HOME/intelephense/licence.txt`
+- บน Windows: `%USERPROFILE%/intelephense/licence.txt`
 
 ไฟล์ควรมีเฉพาะรหัสลิขสิทธิ์โดยไม่มีเนื้อหาเพิ่มเติม

--- a/packages/web/src/content/docs/tr/lsp.mdx
+++ b/packages/web/src/content/docs/tr/lsp.mdx
@@ -183,7 +183,7 @@ Komutu ve dosya uzantılarını belirterek özel LSP sunucuları ekleyebilirsini
 
 PHP Intelephense, bir lisans anahtarı aracılığıyla premium özellikler sunar. Anahtarı (yalnızca) şu adresteki bir metin dosyasına yerleştirerek bir lisans anahtarı sağlayabilirsiniz:
 
-- macOS/Linux'ta: `$HOME/intelephense/license.txt`
-- Windows'ta: `%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux'ta: `$HOME/intelephense/licence.txt`
+- Windows'ta: `%USERPROFILE%/intelephense/licence.txt`
 
 Dosya, ek içerik olmadan yalnızca lisans anahtarını içermelidir.

--- a/packages/web/src/content/docs/zh-cn/lsp.mdx
+++ b/packages/web/src/content/docs/zh-cn/lsp.mdx
@@ -183,7 +183,7 @@ OpenCode 内置了多种适用于主流语言的 LSP 服务器：
 
 PHP Intelephense 通过许可证密钥提供高级功能。你可以将许可证密钥单独放在以下路径的文本文件中：
 
-- macOS/Linux：`$HOME/intelephense/license.txt`
-- Windows：`%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux：`$HOME/intelephense/licence.txt`
+- Windows：`%USERPROFILE%/intelephense/licence.txt`
 
 该文件应仅包含许可证密钥，不要添加其他任何内容。

--- a/packages/web/src/content/docs/zh-tw/lsp.mdx
+++ b/packages/web/src/content/docs/zh-tw/lsp.mdx
@@ -183,7 +183,7 @@ OpenCode 內建了多種適用於主流語言的 LSP 伺服器：
 
 PHP Intelephense 透過授權金鑰提供進階功能。您可以將授權金鑰單獨放在以下路徑的文字檔案中：
 
-- macOS/Linux：`$HOME/intelephense/license.txt`
-- Windows：`%USERPROFILE%/intelephense/license.txt`
+- macOS/Linux：`$HOME/intelephense/licence.txt`
+- Windows：`%USERPROFILE%/intelephense/licence.txt`
 
 該檔案應僅包含授權金鑰，不要新增其他任何內容。


### PR DESCRIPTION
### Issue for this PR

Closes #16894

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the LSP docs to use licence.txt (British spelling) for PHP Intelephense premium key file path instead of license.txt.

This aligns docs with actual Intelephense behavior and avoids confusion where users place the key in license.txt and premium features do not activate.

Updated in the main docs and localized LSP docs.

### How did you verify your code works?

- Searched the docs content to confirm there are no remaining /intelephense/license.txt references.
- Confirmed all affected LSP docs now use /intelephense/licence.txt.

### Screenshots / recordings

Not needed (docs-only change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
