### PR TITLE
feat: add `/tui` and `/config` slash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,3 +1,6 @@
+import fs from "fs"
+import path from "path"
+import { Global } from "@/global"
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
@@ -568,6 +571,44 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogHelp />)
+      },
+      category: "System",
+    },
+    {
+      title: "Open TUI settings",
+      value: "config.tui",
+      slash: {
+        name: "tui",
+        aliases: ["tuisettings"],
+      },
+      onSelect: () => {
+        const tuiPath = path.join(Global.Path.config, "tui.json")
+        if (!fs.existsSync(tuiPath)) {
+          fs.writeFileSync(tuiPath, JSON.stringify({
+            $schema: "https://opencode.ai/tui.json"
+          }, null, 2))
+        }
+        open(tuiPath).catch(() => {})
+        dialog.clear()
+      },
+      category: "System",
+    },
+    {
+      title: "Open global config",
+      value: "config.global",
+      slash: {
+        name: "config",
+        aliases: ["settings"],
+      },
+      onSelect: () => {
+        const configPath = path.join(Global.Path.config, "opencode.json")
+        if (!fs.existsSync(configPath)) {
+          fs.writeFileSync(configPath, JSON.stringify({
+            $schema: "https://opencode.ai/config.json"
+          }, null, 2))
+        }
+        open(configPath).catch(() => {})
+        dialog.clear()
       },
       category: "System",
     },


### PR DESCRIPTION
### Issue for this PR

Closes #16911

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR introduces two new slash commands to the OpenCode TUI:
- `/tui` (aliases: `tuisettings`) -> opens `tui.json`
- `/config` (aliases: `settings`) -> opens `opencode.json`

**Implementation details:**
1. It uses the `Global.Path.config` utility to resolve the correct, OS-specific path for both configuration files.
2. It uses Node's `fs.existsSync()` to verify if the file exists. If it does not exist, it creates a blank file referencing the correct `$schema` so that code intelligence works immediately in the user's editor.
3. It uses the `open` package to launch the system's default JSON editor cross-platform.

### How did you verify your code works?

- Manually verified the slash commands populate in the TUI autocomplete menu.
- Tested execution; the `tui.json` file correctly opens in the system's default editor.
- Tested fallback behavior where the file does not exist (the schema file is properly created and opened).
- Ran `bun turbo typecheck` locally to ensure no typing regressions.
- Ran `bun run test` across the suite to verify no breakages.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR