### PR TITLE
Fix ESM imports for @opencode-ai/plugin

### DIFF
--- a/packages/plugin/src/example.ts
+++ b/packages/plugin/src/example.ts
@@ -1,5 +1,5 @@
-import { Plugin } from "./index"
-import { tool } from "./tool"
+import { Plugin } from "./index.js"
+import { tool } from "./tool.js"
 
 export const ExamplePlugin: Plugin = async (ctx) => {
   return {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -12,10 +12,10 @@ import type {
   Config,
 } from "@opencode-ai/sdk"
 
-import type { BunShell } from "./shell"
-import { type ToolDefinition } from "./tool"
+import type { BunShell } from "./shell.js"
+import { type ToolDefinition } from "./tool.js"
 
-export * from "./tool"
+export * from "./tool.js"
 
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -3,9 +3,9 @@
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "module": "preserve",
+    "module": "nodenext",
     "declaration": true,
-    "moduleResolution": "bundler",
+    "moduleResolution": "nodenext",
     "lib": ["es2022", "dom", "dom.iterable"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- Added `.js` extensions to relative imports for proper ESM compatibility
- Updated `tsconfig.json` to use `nodenext` for both `module` and `moduleResolution`

These changes ensure the package works correctly with ES modules and Node.js module resolution.