### PR TITLE
fix(account): resilient orgs fetch

### DIFF
--- a/packages/opencode/src/account/service.ts
+++ b/packages/opencode/src/account/service.ts
@@ -192,11 +192,17 @@ export class AccountService extends ServiceMap.Service<
 
       const orgsByAccount = Effect.fn("AccountService.orgsByAccount")(function* () {
         const accounts = yield* repo.list()
-        return yield* Effect.forEach(
+        const [errors, results] = yield* Effect.partition(
           accounts,
           (account) => orgs(account.id).pipe(Effect.map((orgs) => ({ account, orgs }))),
           { concurrency: 3 },
         )
+        for (const error of errors) {
+          yield* Effect.logWarning("failed to fetch orgs for account").pipe(
+            Effect.annotateLogs({ error: String(error) }),
+          )
+        }
+        return results
       })
 
       const orgs = Effect.fn("AccountService.orgs")(function* (accountID: AccountID) {


### PR DESCRIPTION
## Summary
- `orgsByAccount()` used `Effect.forEach` which fails entirely if any account's server is unreachable
- Replaced with `Effect.partition` so unreachable servers are skipped and remaining accounts still return their orgs
- Failed accounts are logged as warnings

Fixes `oc orgs` and `oc switch` crashing when you have stale accounts pointing to servers that are down.

## Test plan
- [ ] Add a stale account entry pointing to a dead server, verify `oc orgs` still shows orgs from working accounts
- [ ] Verify warning is logged for the unreachable account