### PR TITLE
fix: guard Npm.which() against infinite loop when .bin is empty

### DIFF
--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -151,7 +151,9 @@ export namespace Npm {
     const files = await readdir(dir).catch(() => [])
     if (!files.length) {
       await add(pkg)
-      return which(pkg)
+      const retry = await readdir(dir).catch(() => [])
+      if (!retry.length) throw new Error(`No binary found for package "${pkg}" after install`)
+      return path.join(dir, retry[0])
     }
     return path.join(dir, files[0])
   }


### PR DESCRIPTION
`Npm.which()` recurses after `add()` without checking if `.bin` was actually populated. If the install succeeds but `.bin` stays empty (stale cache, failed bin-linking, etc.), it loops forever — blocking any tool that triggers the formatter via `Bus.publish(File.Event.Edited)`.

Throw instead of recursing when `.bin` is still empty after install.