### PR TITLE
docs: link to official OpenCode extensions

### DIFF
--- a/packages/web/src/content/docs/ide.mdx
+++ b/packages/web/src/content/docs/ide.mdx
@@ -30,7 +30,12 @@ If on the other hand you want to use your own IDE when you run `/editor` or `/ex
 
 ### Manual Install
 
-Search for **OpenCode** in the Extension Marketplace and click **Install**.
+Install the official OpenCode extension from one of the marketplaces:
+
+- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode
+- Open VSX: https://open-vsx.org/extension/sst-dev/opencode
+
+If installing via search, verify the publisher is **sst-dev** and the extension ID is `sst-dev.opencode`.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The docs previously instructed users to search for "OpenCode" in the extension marketplace, which can surface clone or impersonation extensions.

Add direct links to the official listings on VS Code Marketplace and Open VSX, and include a short note to verify the publisher (sst-dev) and extension ID (`sst-dev.opencode`) when installing via search.

There are currently a ton of hits for "OpenCode" when searching the marketplaces, and malicious extensions in general are becoming more of a threat. Hopefully this will help some folks avoid falling for one.

### How did you verify your code works?

There is no code change, but I have verified both URLs are the correct extension.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
