### PR TITLE
docs(providers): clarify npm choice for chat vs responses APIs

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1890,7 +1890,7 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
    ```
 
    Here are the configuration options:
-   - **npm**: AI SDK package to use, `@ai-sdk/openai-compatible` for OpenAI-compatible providers
+   - **npm**: AI SDK package to use, `@ai-sdk/openai-compatible` for OpenAI-compatible providers (for `/v1/chat/completions`). If your provider/model uses `/v1/responses`, use `@ai-sdk/openai`.
    - **name**: Display name in UI.
    - **models**: Available models.
    - **options.baseURL**: API endpoint URL.
@@ -1957,5 +1957,5 @@ If you are having trouble with configuring a provider, check the following:
 
 2. For custom providers, check the opencode config and:
    - Make sure the provider ID used in the `/connect` command matches the ID in your opencode config.
-   - The right npm package is used for the provider. For example, use `@ai-sdk/cerebras` for Cerebras. And for all other OpenAI-compatible providers, use `@ai-sdk/openai-compatible`.
+   - The right npm package is used for the provider. For example, use `@ai-sdk/cerebras` for Cerebras. And for all other OpenAI-compatible providers, use `@ai-sdk/openai-compatible` (for `/v1/chat/completions`); if a model uses `/v1/responses`, use `@ai-sdk/openai`. For mixed setups under one provider, you can override per model via `provider.npm`.
    - Check correct API endpoint is used in the `options.baseURL` field.

--- a/packages/web/src/content/docs/zh-cn/providers.mdx
+++ b/packages/web/src/content/docs/zh-cn/providers.mdx
@@ -1845,7 +1845,7 @@ Vercel AI Gateway 允许你通过统一端点访问来自 OpenAI、Anthropic、G
    ```
 
    以下是配置选项说明：
-   - **npm**：要使用的 AI SDK 包，对于 OpenAI 兼容的提供商使用 `@ai-sdk/openai-compatible`
+   - **npm**：要使用的 AI SDK 包，对于 OpenAI 兼容的提供商使用 `@ai-sdk/openai-compatible`（适用于 `/v1/chat/completions`）。如果你的提供商/模型走 `/v1/responses`，请使用 `@ai-sdk/openai`。
    - **name**：在 UI 中显示的名称。
    - **models**：可用模型。
    - **options.baseURL**：API 端点 URL。
@@ -1911,5 +1911,5 @@ Vercel AI Gateway 允许你通过统一端点访问来自 OpenAI、Anthropic、G
 
 2. 对于自定义提供商，请检查 OpenCode 配置并确认：
    - `/connect` 命令中使用的提供商 ID 与 OpenCode 配置中的 ID 一致。
-   - 使用了正确的 npm 包。例如，Cerebras 应使用 `@ai-sdk/cerebras`。对于其他所有 OpenAI 兼容的提供商，使用 `@ai-sdk/openai-compatible`。
+   - 使用了正确的 npm 包。例如，Cerebras 应使用 `@ai-sdk/cerebras`。对于其他所有 OpenAI 兼容的提供商，使用 `@ai-sdk/openai-compatible`（`/v1/chat/completions`）；如果模型走 `/v1/responses`，请使用 `@ai-sdk/openai`。同一 provider 混用时，可在模型下设置 `provider.npm` 覆盖默认值。
    - `options.baseURL` 字段中的 API 端点地址正确。


### PR DESCRIPTION
### Issue for this PR

Related to #16154

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a minimal clarification in provider docs that:
- `@ai-sdk/openai-compatible` applies to chat-completions style APIs (`/v1/chat/completions`)
- responses-based models/providers (`/v1/responses`) should use `@ai-sdk/openai`
- mixed setups can override per model via `provider.npm`

Updated both:
- English docs: `packages/web/src/content/docs/providers.mdx`
- Simplified Chinese docs: `packages/web/src/content/docs/zh-cn/providers.mdx`

### How did you verify your code works?

- Verified both edited sections render valid markdown and remain in existing structure.
- Kept change intentionally minimal (4 line edits total).

### Screenshots / recordings

N/A (docs-only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR