### PR TITLE
fix(log): sort files before cleanup to delete oldest logs first

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -83,8 +83,9 @@ export namespace Log {
       absolute: true,
       include: "file",
     })
-    if (files.length <= 5) return
+    if (files.length <= 10) return
 
+    files.sort()
     const filesToDelete = files.slice(0, -10)
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }


### PR DESCRIPTION
Log cleanup was deleting the newest log files instead of oldest because `Glob.scan` returns paths in reverse-chronological order.

Added `files.sort()` before `slice(0, -10)` so ISO-8601 filenames sort chronologically and the oldest files are removed. Also corrected the guard threshold from `<= 5` to `<= 10` to match the slice window.

Fixes #14731
Fixes #16876