### PR TITLE
fix(edit): raise BlockAnchorReplacer threshold when anchors are non-unique

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -280,6 +280,15 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
     const { startLine, endLine } = candidates[0]
     const actualBlockSize = endLine - startLine + 1
 
+    // When anchors are non-unique (appear more than once in the file), use a
+    // stricter threshold to avoid false-positive matches on hallucinated content.
+    const firstLineCount = originalLines.filter((l) => l.trim() === firstLineSearch).length
+    const lastLineCount = originalLines.filter((l) => l.trim() === lastLineSearch).length
+    const singleCandidateThreshold =
+      firstLineCount > 1 || lastLineCount > 1
+        ? MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD
+        : SINGLE_CANDIDATE_SIMILARITY_THRESHOLD
+
     let similarity = 0
     let linesToCheck = Math.min(searchBlockSize - 2, actualBlockSize - 2) // Middle lines only
 
@@ -295,7 +304,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
         similarity += (1 - distance / maxLen) / linesToCheck
 
         // Exit early when threshold is reached
-        if (similarity >= SINGLE_CANDIDATE_SIMILARITY_THRESHOLD) {
+        if (similarity >= singleCandidateThreshold) {
           break
         }
       }
@@ -304,7 +313,7 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
       similarity = 1.0
     }
 
-    if (similarity >= SINGLE_CANDIDATE_SIMILARITY_THRESHOLD) {
+    if (similarity >= singleCandidateThreshold) {
       let matchStartIndex = 0
       for (let k = 0; k < startLine; k++) {
         matchStartIndex += originalLines[k].length + 1

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
-import { EditTool } from "../../src/tool/edit"
+import { EditTool, replace } from "../../src/tool/edit"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import { FileTime } from "../../src/file/time"
@@ -448,6 +448,71 @@ describe("tool.edit", () => {
           expect(result.metadata.filediff.additions).toBeGreaterThan(0)
         },
       })
+    })
+
+    test("BlockAnchorReplacer rejects hallucinated content when last anchor is non-unique", () => {
+      // Repro from issue #14046: when the last anchor (e.g. `}`) appears many
+      // times in the file, a single-candidate match must still require content
+      // similarity rather than accepting with threshold 0.0.
+      const content = `class DatabaseConnection {
+  private pool: ConnectionPool
+
+  constructor(config: DbConfig) {
+    this.pool = new ConnectionPool(config)
+  }
+
+  async query(sql: string, params: unknown[]) {
+    const conn = await this.pool.acquire()
+    try {
+      const result = await conn.execute(sql, params)
+      return result.rows
+    } finally {
+      this.pool.release(conn)
+    }
+  }
+
+  async transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T> {
+    const conn = await this.pool.acquire()
+    const tx = await conn.beginTransaction()
+    try {
+      const result = await fn(tx)
+      await tx.commit()
+      return result
+    } catch (e) {
+      await tx.rollback()
+      throw e
+    } finally {
+      this.pool.release(conn)
+    }
+  }
+}`
+
+      // oldString has the correct first/last anchor lines but completely
+      // hallucinated middle content — replace() should throw, not silently apply.
+      const oldString = `  async query(sql: string, params: unknown[]) {
+    validateSqlInjection(sql)
+    const sanitized = escapeSqlParams(params)
+    const cache = QueryCache.get(sql)
+    if (cache) return cache
+    const response = await fetch("/api/query", { body: JSON.stringify({ sql, params: sanitized }) })
+    const data = await response.json()
+    QueryCache.set(sql, data)
+    return data
+  }`
+
+      const newString = `  async query(sql: string, params: unknown[]) {
+    validateSqlInjection(sql)
+    const sanitized = escapeSqlParams(params)
+    const cache = QueryCache.get(sql)
+    if (cache) return cache
+    logger.debug("Executing query", { sql })
+    const response = await fetch("/api/query", { body: JSON.stringify({ sql, params: sanitized }) })
+    const data = await response.json()
+    QueryCache.set(sql, data)
+    return data
+  }`
+
+      expect(() => replace(content, oldString, newString)).toThrow()
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #14046

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`BlockAnchorReplacer` picks the best candidate block by matching anchor lines (first and last lines of the search content). When only one candidate exists it used `SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.0`, meaning any single match was accepted unconditionally even if the replacement content was completely hallucinated.

The problem shows up when the anchor lines are not unique in the file (e.g. a closing brace `}` or a common line that appears many times). In that case the single candidate is found by coincidence rather than by a real match.

The fix counts how many times each anchor line actually appears in the file. If either anchor appears more than once, we use `MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD` (0.3) instead, requiring the content to genuinely resemble the target block before accepting the replacement.

### How did you verify your code works?

Added a regression test in `edit.test.ts` based on the repro case from #14046 — a file where the last anchor line is a non-unique `}`. The test confirms the replacer now rejects the hallucinated content. All 28 tests pass (`bun test packages/opencode/test/tool/edit.test.ts`).

### Screenshots / recordings

_N/A — no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
