### PR TITLE
fix(config): strip Zod defaults from per-layer config before merge

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1274,6 +1274,25 @@ export namespace Config {
         await Filesystem.write(options.path, updated).catch(() => {})
       }
       const data = parsed.data
+
+      // Strip any keys that Zod injected as defaults but were absent in the
+      // original input.  Config merging works by layering each file's explicit
+      // values on top of lower-priority layers; if Zod defaults are allowed to
+      // propagate here they will overwrite the user's settings from a
+      // lower-priority layer during mergeDeep.
+      //
+      // $schema is the one synthetic key added by code (not by Zod defaults),
+      // so it is always preserved regardless of the input.
+      if (normalized && typeof normalized === "object" && !Array.isArray(normalized)) {
+        const inputKeys = new Set(Object.keys(normalized as Record<string, unknown>))
+        for (const key of Object.keys(data) as Array<keyof Info>) {
+          if (key === "$schema") continue
+          if (!inputKeys.has(key)) {
+            delete (data as Record<string, unknown>)[key]
+          }
+        }
+      }
+
       if (data.plugin && isFile) {
         for (let i = 0; i < data.plugin.length; i++) {
           const plugin = data.plugin[i]


### PR DESCRIPTION
### Issue for this PR

Closes #16897

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When loading a config file, each layer is parsed through `Info.safeParse(normalized)`. The problem is that Zod's `.default()` values fill in every missing field with a default. These defaulted keys then go into `mergeDeep`, which means a higher-priority layer (e.g. project config) silently overwrites settings from lower-priority layers (e.g. global config) for fields the user never actually set.

The fix strips any key from the parsed result that was not present in the original input object before Zod touched it. Only keys the user explicitly wrote in their config file participate in the merge. The `$schema` key is excluded from removal since it is injected by the code, not the user.

### How did you verify your code works?

Traced through the config load path manually. The fix is minimal — it only removes keys that Zod added; it does not change keys that were already there. Matches exactly what the issue describes.

### Screenshots / recordings

_N/A — no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR