### PR TITLE
fix(config): update() writes to existing config file instead of hardcoding config.json

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1318,10 +1318,33 @@ export namespace Config {
     return global()
   }
 
+  function localConfigFile() {
+    const candidates = ["opencode.jsonc", "opencode.json"].map((file) => path.join(Instance.directory, file))
+    for (const file of candidates) {
+      if (existsSync(file)) return file
+    }
+    // Default to opencode.json when no project config file exists yet.
+    // Note: config.json is only a valid config filename in the global config
+    // directory, not in project directories.
+    return candidates[1]!
+  }
+
   export async function update(config: Info) {
-    const filepath = path.join(Instance.directory, "config.json")
-    const existing = await loadFile(filepath)
-    await Filesystem.writeJson(filepath, mergeDeep(existing, config))
+    const filepath = localConfigFile()
+    const before = await Filesystem.readText(filepath).catch((err: any) => {
+      if (err.code === "ENOENT") return "{}"
+      throw err
+    })
+
+    if (!filepath.endsWith(".jsonc")) {
+      const existing = parseConfig(before, filepath)
+      await Filesystem.writeJson(filepath, mergeDeep(existing, config))
+    } else {
+      const updated = patchJsonc(before, config)
+      parseConfig(updated, filepath)
+      await Filesystem.write(filepath, updated)
+    }
+
     await Instance.dispose()
   }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -683,8 +683,34 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await Config.update(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "opencode.json"))
       expect(writtenConfig.model).toBe("updated/model")
+    },
+  })
+})
+
+test("update writes to existing opencode.jsonc instead of creating config.json", async () => {
+  await using tmp = await tmpdir()
+  await Filesystem.write(
+    path.join(tmp.path, "opencode.jsonc"),
+    JSON.stringify({ $schema: "https://opencode.ai/config.json", model: "anthropic/claude-sonnet-4-20250514" }),
+  )
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Config.update({ permission: { read: "allow" } } as any)
+
+      // Should update the existing opencode.jsonc
+      const updated = await Filesystem.readText(path.join(tmp.path, "opencode.jsonc"))
+      expect(updated).toContain('"permission"')
+      expect(updated).toContain('"read"')
+
+      // Should NOT create a separate config.json
+      const configJsonExists = await Filesystem.readText(path.join(tmp.path, "config.json")).then(
+        () => true,
+        () => false,
+      )
+      expect(configJsonExists).toBe(false)
     },
   })
 })


### PR DESCRIPTION
## Summary

- `Config.update()` hardcoded `config.json` as the write target, ignoring the project's actual config file. Projects using `opencode.jsonc` got a spurious `config.json` created alongside their real config, and changes (e.g. persisted permission rules via `PATCH /config`) were effectively lost since `config.json` is not loaded as project config.
- Adds `localConfigFile()` to resolve the existing project config file (`opencode.jsonc` > `opencode.json`), mirroring the existing `globalConfigFile()` pattern. Handles `.jsonc` files with `patchJsonc()` to preserve comments, matching `updateGlobal()`.

## Reproduction

1. Create a project with `opencode.jsonc` as the config file
2. Use `PATCH /config` (e.g. via "Always Allow" on a permission prompt)
3. Observe: a new `config.json` is created instead of `opencode.jsonc` being updated
4. The permission rule is silently lost on next startup since `config.json` is not a valid project config filename

## Changes

- **`packages/opencode/src/config/config.ts`**: Added `localConfigFile()` resolver; rewrote `update()` to use it with `.jsonc` support
- **`packages/opencode/test/config/config.test.ts`**: Updated existing test; added new test verifying `opencode.jsonc` is updated and `config.json` is not created

## Verification

- All 66 config tests pass (`bun test test/config/config.test.ts`)
- Typecheck passes across all 13 packages (pre-push hook)