### PR TITLE
feat: add global session cycling keybinds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -356,6 +356,27 @@ function App() {
     ),
   )
 
+  // moveGlobal cycles through top-level sessions sorted by most recently updated.
+  function moveGlobal(direction: number) {
+    const topLevel = sync.data.session
+      .filter((x) => !x.parentID)
+      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+
+    if (topLevel.length <= 1) return
+
+    const currentID = route.data.type === "session" ? route.data.sessionID : undefined
+    let idx = currentID ? topLevel.findIndex((x) => x.id === currentID) : -1
+
+    let next = idx + direction
+    if (next >= topLevel.length) next = 0
+    if (next < 0) next = topLevel.length - 1
+
+    route.navigate({
+      type: "session",
+      sessionID: topLevel[next].id,
+    })
+  }
+
   const connected = useConnected()
   command.register(() => [
     {
@@ -409,6 +430,26 @@ function App() {
           initialPrompt: currentPrompt,
           workspaceID,
         })
+        dialog.clear()
+      },
+    },
+    {
+      title: "Next session",
+      value: "session.global.next",
+      keybind: "session_global_cycle",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous session",
+      value: "session.global.previous",
+      keybind: "session_global_cycle_reverse",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(-1)
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -348,6 +348,28 @@ export function Session() {
     }
   }
 
+  // moveGlobal cycles through top-level sessions sorted by most recently updated.
+  function moveGlobal(direction: number) {
+    const topLevel = sync.data.session
+      .filter((x) => !x.parentID)
+      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+
+    if (topLevel.length <= 1) return
+
+    const currentID = session()?.parentID ?? session()?.id
+    let idx = topLevel.findIndex((x) => x.id === currentID)
+    if (idx === -1) return
+
+    let next = idx + direction
+    if (next >= topLevel.length) next = 0
+    if (next < 0) next = topLevel.length - 1
+
+    navigate({
+      type: "session",
+      sessionID: topLevel[next].id,
+    })
+  }
+
   function childSessionHandler(func: (dialog: DialogContext) => void) {
     return (dialog: DialogContext) => {
       if (!session()?.parentID || dialog.stack.length > 0) return
@@ -975,6 +997,26 @@ export function Session() {
         moveChild(-1)
         dialog.clear()
       }),
+    },
+    {
+      title: "Next session",
+      value: "session.global.next",
+      keybind: "session_global_cycle",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous session",
+      value: "session.global.previous",
+      keybind: "session_global_cycle_reverse",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(-1)
+        dialog.clear()
+      },
     },
   ])
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -348,28 +348,6 @@ export function Session() {
     }
   }
 
-  // moveGlobal cycles through top-level sessions sorted by most recently updated.
-  function moveGlobal(direction: number) {
-    const topLevel = sync.data.session
-      .filter((x) => !x.parentID)
-      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
-
-    if (topLevel.length <= 1) return
-
-    const currentID = session()?.parentID ?? session()?.id
-    let idx = topLevel.findIndex((x) => x.id === currentID)
-    if (idx === -1) return
-
-    let next = idx + direction
-    if (next >= topLevel.length) next = 0
-    if (next < 0) next = topLevel.length - 1
-
-    navigate({
-      type: "session",
-      sessionID: topLevel[next].id,
-    })
-  }
-
   function childSessionHandler(func: (dialog: DialogContext) => void) {
     return (dialog: DialogContext) => {
       if (!session()?.parentID || dialog.stack.length > 0) return
@@ -997,26 +975,6 @@ export function Session() {
         moveChild(-1)
         dialog.clear()
       }),
-    },
-    {
-      title: "Next session",
-      value: "session.global.next",
-      keybind: "session_global_cycle",
-      category: "Session",
-      onSelect: (dialog) => {
-        moveGlobal(1)
-        dialog.clear()
-      },
-    },
-    {
-      title: "Previous session",
-      value: "session.global.previous",
-      keybind: "session_global_cycle_reverse",
-      category: "Session",
-      onSelect: (dialog) => {
-        moveGlobal(-1)
-        dialog.clear()
-      },
     },
   ])
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -923,6 +923,16 @@ export namespace Config {
       session_child_first: z.string().optional().default("<leader>down").describe("Go to first child session"),
       session_child_cycle: z.string().optional().default("right").describe("Go to next child session"),
       session_child_cycle_reverse: z.string().optional().default("left").describe("Go to previous child session"),
+      session_global_cycle: z
+        .string()
+        .optional()
+        .default("<leader>right")
+        .describe("Go to next session (sorted by recent)"),
+      session_global_cycle_reverse: z
+        .string()
+        .optional()
+        .default("<leader>left")
+        .describe("Go to previous session (sorted by recent)"),
       session_parent: z.string().optional().default("up").describe("Go to parent session"),
       terminal_suspend: z.string().optional().default("ctrl+z").describe("Suspend terminal"),
       terminal_title_toggle: z.string().optional().default("none").describe("Toggle terminal title"),


### PR DESCRIPTION
### Issue for this PR

Closes #16986

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**1. Global session cycling keybinds (feature)**

Adds `ctrl+x →` / `ctrl+x ←` keybinds to cycle through top-level sessions sorted by most recently updated. Currently the only way to switch sessions is via the list dialog (`ctrl+x l`) — this adds direct cycling for faster navigation.

Two new keybind config entries (`session_global_cycle` / `session_global_cycle_reverse`) default to `<leader>right` / `<leader>left`. The `moveGlobal()` function in `app.tsx` filters to top-level sessions, sorts by update time, and navigates to the next/previous entry with wrap-around. Both commands are registered at the app level so they're available from any screen (home or session view) and show up in the `ctrl+p` command palette.

**2. Graceful serverUrl deprecation (bugfix)**

The `serverUrl` getter on `PluginInput` throws at runtime, which breaks plugins that access `input.serverUrl` using optional chaining (e.g. `ctx.serverUrl?.toString() ?? fallback`). The throw executes before `?.` can short-circuit on `undefined`, causing the plugin to crash during init.

This replaces the throwing getter with `serverUrl: undefined` and marks the type as `serverUrl?: URL` with `@deprecated`. Plugins that already handle the missing value via optional chaining now degrade gracefully instead of crashing.

### How did you verify your code works?

1. Ran `bun dev` from the fork, opened the TUI
2. Confirmed both "Next session" and "Previous session" appear in `ctrl+p` palette with correct keybind labels (`ctrl+x right` / `ctrl+x left`)
3. Verified commands are available from the home screen (not only from inside a session)
4. All 13 package typechecks pass via `turbo typecheck`
5. Ran `opencode debug config --print-logs` — confirmed plugins (oh-my-opencode, antigravity-auth, supermemory) load without errors after the serverUrl fix

### Screenshots / recordings

Command palette showing the new entries:

```
Session
  Next session                            ctrl+x right
  Previous session                         ctrl+x left
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR