### PR TITLE
fix(mcp): treat CallToolResult isError as tool failure

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -116,10 +116,11 @@ export namespace MCP {
     })
   }
 
-  type CallToolResult = z.infer<typeof CallToolResultSchema>
-
-  function callToolErrorText(result: CallToolResult): string {
-    const content = Array.isArray(result.content) ? result.content : []
+  function callToolErrorText(result: unknown): string {
+    const content =
+      result && typeof result === "object" && "content" in result && Array.isArray((result as any).content)
+        ? ((result as any).content as unknown[])
+        : []
     const lines = content
       .map((item) => {
         if (item && typeof item === "object") {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -116,6 +116,30 @@ export namespace MCP {
     })
   }
 
+  type CallToolResult = z.infer<typeof CallToolResultSchema>
+
+  function callToolErrorText(result: CallToolResult): string {
+    const content = Array.isArray(result.content) ? result.content : []
+    const lines = content
+      .map((item) => {
+        if (item && typeof item === "object") {
+          if ("text" in item && typeof item.text === "string") return item.text
+          if ("data" in item) {
+            try {
+              return JSON.stringify(item.data)
+            } catch {
+              return String(item.data)
+            }
+          }
+        }
+        return ""
+      })
+      .filter(Boolean)
+
+    const joined = lines.join("\n").trim()
+    return joined || "MCP tool returned isError=true"
+  }
+
   // Convert MCP tool definition to AI SDK Tool type
   async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
@@ -132,7 +156,7 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
-        return client.callTool(
+        const result = await client.callTool(
           {
             name: mcpTool.name,
             arguments: (args || {}) as Record<string, unknown>,
@@ -143,6 +167,10 @@ export namespace MCP {
             timeout,
           },
         )
+        if (result.isError) {
+          throw new Error(callToolErrorText(result))
+        }
+        return result
       },
     })
   }


### PR DESCRIPTION
### Issue for this PR

Closes #16969

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an MCP tool returns `CallToolResult` with `isError: true`, this PR throws an error from the MCP tool execution path instead of returning it as a successful tool result.

Before this change:
- MCP `isError=true` responses were returned through normal result flow.
- Session processor handled them as `tool-result` and set `state.status = "completed"`.

After this change:
- MCP `isError=true` responses are converted to thrown errors with extracted text.
- Session processor follows the `tool-error` path.
- Tool part status maps to `error` as expected.

### How did you verify your code works?

- Confirmed MCP dynamic tool execute path now checks `result.isError`.
- Added conversion of MCP content payload to a readable error message.
- Verified successful MCP calls still return normal results unchanged.

### Screenshots / recordings

Not included (logic change only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
