### PR TITLE
fix(core): read stdout and stderr in PackageRegistry.info before waiting for the process to exit

### DIFF
--- a/packages/opencode/src/bun/registry.ts
+++ b/packages/opencode/src/bun/registry.ts
@@ -1,5 +1,4 @@
 import semver from "semver"
-import { text } from "node:stream/consumers"
 import { Log } from "../util/log"
 import { Process } from "../util/process"
 
@@ -11,26 +10,21 @@ export namespace PackageRegistry {
   }
 
   export async function info(pkg: string, field: string, cwd?: string): Promise<string | null> {
-    const result = Process.spawn([which(), "info", pkg, field], {
+    const { code, stdout, stderr } = await Process.run([which(), "info", pkg, field], {
       cwd,
-      stdout: "pipe",
-      stderr: "pipe",
       env: {
         ...process.env,
         BUN_BE_BUN: "1",
       },
+      nothrow: true,
     })
 
-    const code = await result.exited
-    const stdout = result.stdout ? await text(result.stdout) : ""
-    const stderr = result.stderr ? await text(result.stderr) : ""
-
     if (code !== 0) {
-      log.warn("bun info failed", { pkg, field, code, stderr })
+      log.warn("bun info failed", { pkg, field, code, stderr: stderr.toString() })
       return null
     }
 
-    const value = stdout.trim()
+    const value = stdout.toString().trim()
     if (!value) return null
     return value
   }


### PR DESCRIPTION
### Issue for this PR

Fixes #16608
Fixes #10546
Fixes #15673

### Type of change

- [x] Bug fix

### What does this PR do?

The previous implementation waited for the process to exit first, which resulted in empty `stdout` and `stderr`. Subsequently, this caused the PackageRegistry.isOutdated check to always return false and log
> Failed to resolve latest version, using cached

Therefore, plugins that were configured to use `latest` as version were never actually updated.

To fix this, this change ensures `stdout` and `stderr` are read while still available. It uses the exact same approach as `Process.run`.

### How did you verify your code works?

I manually tested it with a plugin. I first intentionally installed an older version of the plugin. Then changed it to `@latest` in the opencode config. Then we can observe in the logs that the new plugin version is automatically installed when running OpenCode:

> INFO  2026-03-11T08:35:16 +8ms service=plugin path=opencode-handoff@latest loading plugin
> INFO  2026-03-11T08:35:17 +524ms service=bun pkg=opencode-handoff cachedVersion=0.4.0 Cached version is outdated, proceeding with install
> INFO  2026-03-11T08:35:17 +0ms service=bun pkg=opencode-handoff version=latest installing package using Bun's default registry resolution
> INFO  2026-03-11T08:35:17 +0ms service=bun cmd=["/usr/bin/bun","add","--force","--exact","--no-cache","--cwd","/home/loherj/.cache/opencode","opencode-handoff@latest"] cwd=/home/loherj/.cache/opencode running
> INFO  2026-03-11T08:35:17 +293ms service=bun code=0 stdout= stderr= done

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR