### PR TITLE
fix(session): use parentID instead of message ID ordering in prompt loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -319,7 +319,7 @@ export namespace SessionPrompt {
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
+        lastAssistant.parentID === lastUser.id
       ) {
         log.info("exiting loop", { sessionID })
         break

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { describe, expect, test } from "bun:test"
 import { fileURLToPath } from "url"
+import { Identifier } from "../../src/id/id"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -208,4 +209,66 @@ describe("session.prompt agent variant", () => {
       else process.env.OPENAI_API_KEY = prev
     }
   })
+})
+
+describe("session.prompt loop exit", () => {
+  test(
+    "stops after the first finished assistant when the user id is provided externally",
+    async () => {
+      await using tmp = await tmpdir({
+        config: {},
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "loop exit" })
+          const messageID = Identifier.create("message", false, Date.now() + 60_000)
+          await Session.updateMessage({
+            id: messageID,
+            sessionID: session.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "build",
+            model: { providerID: "missing", modelID: "missing" },
+            tools: {},
+          })
+          const reply = await Session.updateMessage({
+            id: Identifier.ascending("message"),
+            sessionID: session.id,
+            role: "assistant",
+            parentID: messageID,
+            modelID: "missing",
+            providerID: "missing",
+            mode: "build",
+            agent: "build",
+            path: {
+              cwd: tmp.path,
+              root: tmp.path,
+            },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: {
+              created: Date.now(),
+              completed: Date.now(),
+            },
+            finish: "stop",
+          })
+
+          const result = await SessionPrompt.loop({ sessionID: session.id })
+          expect(result.info.role).toBe("assistant")
+          expect(result.info.id).toBe(reply.id)
+          if (result.info.role !== "assistant") return
+          expect(result.info.parentID).toBe(messageID)
+
+          await Session.remove(session.id)
+        },
+      })
+    },
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #17012

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an infinite assistant loop in web sessions.

`SessionPrompt.loop()` was using message ID ordering to decide whether the latest finished assistant message belonged to the latest user message:

```ts
lastUser.id < lastAssistant.id
```

That is not reliable for web prompts, because the user `messageID` is generated in the browser while assistant message IDs are generated on the server.

This change replaces that check with:

```ts
lastAssistant.parentID === lastUser.id
```

This is the correct relationship because `parentID` directly links an assistant message to the user message it answers.

### How did you verify your code works?

Added a regression test covering a web-style prompt flow where the user `messageID` is provided externally and does not sort safely against a later server-generated assistant message ID.

Also verified locally that prompt processing stops after the first finished assistant response instead of creating repeated assistant messages for the same user prompt.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
