### PR TITLE
fix: Return undefined instead of throwing in serverUrl getter

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -34,8 +34,8 @@ export namespace Plugin {
       project: Instance.project,
       worktree: Instance.worktree,
       directory: Instance.directory,
-      get serverUrl(): URL {
-        throw new Error("Server URL is no longer supported in plugins")
+      get serverUrl(): URL | undefined {
+        return undefined
       },
       $: Bun.$,
     }


### PR DESCRIPTION
## Description

The `serverUrl` getter on `PluginInput` was throwing an error, which breaks plugins that access `ctx.serverUrl` with optional chaining (`?.`), since the getter body executes before the operator can short-circuit.

This PR changes the getter to return `undefined` instead, making it a non-breaking change that allows plugins to handle the missing value gracefully.

## Changes
- Changed getter to return `undefined` instead of throwing

## Testing

```js
const obj = { get serverUrl() { return undefined } }
obj.serverUrl?.toString() // works fine, returns undefined
```

Fixes #17023