### PR TITLE
fix: keep all slash autocomplete matches reachable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -400,13 +400,14 @@ export function Autocomplete(props: {
       return prev
     }
 
+    const limit = store.visible === "/" ? mixed.length : 100
     const result = fuzzysort.go(removeLineRange(searchValue), mixed, {
       keys: [
         (obj) => removeLineRange((obj.value ?? obj.display).trimEnd()),
         "description",
         (obj) => obj.aliases?.join(" ") ?? "",
       ],
-      limit: 10,
+      limit,
       scoreFn: (objResults) => {
         const displayResult = objResults[0]
         let score = objResults.score


### PR DESCRIPTION
### Issue for this PR
Closes #17027

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
This fixes CLI slash-command autocomplete when a keyword matches more commands than fit in the initial result cap.

Previously the prompt autocomplete filtered results with a fixed `fuzzysort` limit of `10`. That meant once the user typed a keyword, additional matching slash commands were discarded before rendering, so keyboard navigation wrapped inside that truncated subset and the remaining matches were unreachable.

This change keeps all filtered slash-command matches available to the scrollable autocomplete list, while leaving `@`-style autocomplete bounded.

### How did you verify your code works?
- Ran `bun run typecheck` in `packages/opencode`
- Confirmed the change is limited to slash-command autocomplete filtering

### Screenshots / recordings
_Not included._

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
