### PR TITLE
fix(app): fix slow workspace creation

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -22,12 +22,11 @@ declare const OPENCODE_LIBC: string | undefined
 
 export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
-  const hold = new Map<string, number>()
+  const hold = new Set<string>()
 
   export function paused(file: string) {
     const input = path.resolve(file)
-    for (const [dir, count] of hold) {
-      if (count < 1) continue
+    for (const dir of hold) {
       if (input === dir) return true
       if (input.startsWith(dir + path.sep)) return true
     }
@@ -36,17 +35,12 @@ export namespace FileWatcher {
 
   export function pause(dir: string) {
     const id = path.resolve(dir)
-    hold.set(id, (hold.get(id) ?? 0) + 1)
+    hold.add(id)
     let live = true
     return () => {
       if (!live) return
       live = false
-      const count = hold.get(id) ?? 0
-      if (count <= 1) {
-        hold.delete(id)
-        return
-      }
-      hold.set(id, count - 1)
+      hold.delete(id)
     }
   }
 

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -24,12 +24,8 @@ export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
   const hold = new Map<string, number>()
 
-  function key(input: string) {
-    return path.resolve(input)
-  }
-
   export function paused(file: string) {
-    const input = key(file)
+    const input = path.resolve(file)
     for (const [dir, count] of hold) {
       if (count < 1) continue
       if (input === dir) return true
@@ -39,7 +35,7 @@ export namespace FileWatcher {
   }
 
   export function pause(dir: string) {
-    const id = key(dir)
+    const id = path.resolve(dir)
     hold.set(id, (hold.get(id) ?? 0) + 1)
     let live = true
     return () => {

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -22,6 +22,42 @@ declare const OPENCODE_LIBC: string | undefined
 
 export namespace FileWatcher {
   const log = Log.create({ service: "file.watcher" })
+  const hold = new Map<string, number>()
+
+  function key(input: string) {
+    return path.resolve(input)
+  }
+
+  export function paused(file: string) {
+    const input = key(file)
+    for (const [dir, count] of hold) {
+      if (count < 1) continue
+      if (input === dir) return true
+      if (input.startsWith(dir + path.sep)) return true
+    }
+    return false
+  }
+
+  export function pause(dir: string) {
+    const id = key(dir)
+    hold.set(id, (hold.get(id) ?? 0) + 1)
+    let live = true
+    return () => {
+      if (!live) return
+      live = false
+      const count = hold.get(id) ?? 0
+      if (count <= 1) {
+        hold.delete(id)
+        return
+      }
+      hold.set(id, count - 1)
+    }
+  }
+
+  export function withPause<T>(dir: string, fn: () => Promise<T>) {
+    const done = pause(dir)
+    return fn().finally(done)
+  }
 
   export const Event = {
     Updated: BusEvent.define(
@@ -66,6 +102,7 @@ export namespace FileWatcher {
       const subscribe: ParcelWatcher.SubscribeCallback = (err, evts) => {
         if (err) return
         for (const evt of evts) {
+          if (paused(evt.path)) continue
           if (evt.type === "create") Bus.publish(Event.Updated, { file: evt.path, event: "add" })
           if (evt.type === "update") Bus.publish(Event.Updated, { file: evt.path, event: "change" })
           if (evt.type === "delete") Bus.publish(Event.Updated, { file: evt.path, event: "unlink" })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -14,6 +14,7 @@ import { Process } from "../util/process"
 import { git } from "../util/git"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
+import { FileWatcher } from "@/file/watcher"
 
 export namespace Worktree {
   const log = Log.create({ service: "worktree" })
@@ -361,7 +362,9 @@ export namespace Worktree {
 
     return () => {
       const start = async () => {
-        const populated = await git(["reset", "--hard"], { cwd: info.directory })
+        const populated = await FileWatcher.withPause(info.directory, () =>
+          git(["reset", "--hard"], { cwd: info.directory }),
+        )
         if (populated.exitCode !== 0) {
           const message = errorText(populated) || "Failed to populate worktree"
           log.error("worktree checkout failed", { directory: info.directory, message })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -364,7 +364,7 @@ export namespace Worktree {
       const start = async () => {
         const populated = await FileWatcher.withPause(info.directory, () =>
           git(["reset", "--hard"], { cwd: info.directory }),
-        )
+        ) //during reset pause file watcher events since they cause cpu pressure and slow workspace creation
         if (populated.exitCode !== 0) {
           const message = errorText(populated) || "Failed to populate worktree"
           log.error("worktree checkout failed", { directory: info.directory, message })


### PR DESCRIPTION
### Issue for this PR

Closes #16951

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Creating a new workspace within a large codebase on the desktop app results in a long wait time (12-15s+ on my MacBook, depending on the size of codebase) before creation. Users can not chat with models or look at other sessions during this long period causing inconvenience.  

The root cause of this problem is during workspace creation `git reset --hard` is called, creating many files, which causes a large burst of `file.watcher.updated` events. These events cause a significant amount of CPU pressure during the time`git reset` is running.

Our fix pauses `file.watcher.updated` events only in the new workspace directory while `git reset` is running. This significantly reduces CPU pressure and increases speed. 

Pausing file watcher events for only the new workspace during the `git reset` causes no issues because once the workspace is done being created normal bootstraps and syncs reload the file state

### How did you verify your code works?
`bun typecheck` and manual testing

### Screenshots / recordings

[![Watch the video](https://img.youtube.com/vi/8FQBhxuCAmk/maxresdefault.jpg)](https://www.youtube.com/watch?v=8FQBhxuCAmk)
watch video -> https://www.youtube.com/watch?v=8FQBhxuCAmk <-

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR