### PR TITLE
fix(tui): correct pasted preview replacement for CJK and multi-width characters

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -97,6 +97,29 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
+  // Converts a visual column offset into a JavaScript string index so extmark
+  // ranges tracked in terminal display cells can be used safely with slice().
+  function toIndex(text: string, col: number) {
+    if (col <= 0) return 0
+    let width = 0
+    let idx = 0
+
+    for (const ch of text) {
+      if (width >= col) return idx
+      width += Bun.stringWidth(ch)
+      idx += ch.length
+      if (width >= col) return idx
+    }
+
+    return text.length
+  }
+
+  function replace(text: string, start: number, end: number, value: string) {
+    const from = toIndex(text, start)
+    const to = toIndex(text, end)
+    return text.slice(0, from) + value + text.slice(to)
+  }
+
   sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
@@ -573,9 +596,7 @@ export function Prompt(props: PromptProps) {
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
         if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
-          inputText = before + part.text + after
+          inputText = replace(inputText, extmark.start, extmark.end, part.text)
         }
       }
     }
@@ -678,7 +699,7 @@ export function Prompt(props: PromptProps) {
   function pasteText(text: string, virtualText: string) {
     const currentOffset = input.visualCursor.offset
     const extmarkStart = currentOffset
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
 
     input.insertText(virtualText + " ")
 
@@ -714,7 +735,7 @@ export function Prompt(props: PromptProps) {
     const extmarkStart = currentOffset
     const count = store.prompt.parts.filter((x) => x.type === "file" && x.mime.startsWith("image/")).length
     const virtualText = `[Image ${count + 1}]`
-    const extmarkEnd = extmarkStart + virtualText.length
+    const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
     const textToInsert = virtualText + " "
 
     input.insertText(textToInsert)


### PR DESCRIPTION
### Issue for this PR

Closes #17032 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix a TUI bug where `[Pasted ~N lines]` preview tokens are not correctly replaced when the prompt contains CJK characters before the paste.

The previous implementation used terminal visual column offsets but performed the replacement using JavaScript string slicing. This works for ASCII input but becomes misaligned for multi-width characters such as Chinese, Japanese and Korean.

This PR converts the visual column offsets to the correct string indices before performing the replacement, ensuring the preview token is fully replaced by the actual pasted content.

This issue is particularly important for users typing CJK characters, since the incorrect truncation could leak part of the paste preview token into the submitted prompt, resulting in a polluted prompt.

### How did you verify your code works?

Tested locally with `bun dev .`.

Reproduction steps:

1. Enter Chinese text in the prompt.
2. Paste multi-line content so `[Pasted ~N lines]` appears.
3. Submit the prompt.

Before the fix, part of the preview token could appear in the submitted prompt.  
After the fix, the preview is correctly replaced with the pasted content.

Tested with:
- ASCII input
- Chinese input

### Screenshots / recordings

TUI after the fix:

- Pasted multi-line content is previewed correctly in the input area.
- After sending, the submitted prompt no longer contains leaked `[Pasted ~N lines]` fragments when the input includes CJK characters.
- Verified with Chinese input and multi-line paste in the TUI.

<img width="1152" height="432" alt="image" src="https://github.com/user-attachments/assets/bf3d7e12-f5fc-432d-a2c6-97669209471c" />
<img width="861" height="460" alt="image" src="https://github.com/user-attachments/assets/12fc373a-a85b-44b8-8847-4a6ce0f431c3" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR