### PR TITLE
fix(util): use 24-hour time format

### DIFF
--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -5,7 +5,7 @@ export namespace Locale {
 
   export function time(input: number): string {
     const date = new Date(input)
-    return date.toLocaleTimeString(undefined, { timeStyle: "short" })
+    return date.toLocaleTimeString(undefined, { timeStyle: "short", hour12: false})
   }
 
   export function datetime(input: number): string {


### PR DESCRIPTION
### Issue for this PR

Closes #7208

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Locale.time()` was in fact ignoring the locale and always displaying the time (for sessions at least?) in 12h format. I fixed it to use 24h format instead (for lack of better use of a locale). It also works better as an international default.

### How did you verify your code works?

The change is a single line addition to an existing function. `bun turbo typecheck` passed.

### Screenshots / recordings

Change is highlighed in red:

<img width="691" height="224" alt="Screenshot 2026-03-11 at 13 46 39" src="https://github.com/user-attachments/assets/0f1d49a4-c759-4a10-83c7-d008cbf44ee4" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
