### PR TITLE
feat(tui): add tui.agent.set event for plugin-driven agent handoff

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -6,6 +6,7 @@ import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
+import { Bus } from "@/bus"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
@@ -709,6 +710,14 @@ function App() {
       type: "session",
       sessionID: evt.properties.sessionID,
     })
+  })
+
+  Bus.subscribe(TuiEvent.AgentSet, (evt) => {
+    const { name } = evt.properties
+    const isPrimaryAgent = local.agent.list().some((x) => x.name === name)
+    if (isPrimaryAgent) {
+      local.agent.set(name)
+    }
   })
 
   sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -148,26 +148,24 @@ export function Prompt(props: PromptProps) {
     ),
   )
 
-  // Initialize agent/model/variant from last user message when session changes
-  let syncedSessionID: string | undefined
-  createEffect(() => {
-    const sessionID = props.sessionID
-    const msg = lastUserMessage()
+  // Sync agent/model/variant from last user message whenever it changes
+  createEffect(
+    on(
+      () => lastUserMessage()?.id,
+      () => {
+        const msg = lastUserMessage()
+        if (!msg) return
 
-    if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
-
-      syncedSessionID = sessionID
-
-      // Only set agent if it's a primary agent (not a subagent)
-      const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
-      if (msg.agent && isPrimaryAgent) {
-        local.agent.set(msg.agent)
-        if (msg.model) local.model.set(msg.model)
-        if (msg.variant) local.model.variant.set(msg.variant)
-      }
-    }
-  })
+        // Only set agent if it's a primary agent (not a subagent)
+        const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
+        if (msg.agent && isPrimaryAgent) {
+          local.agent.set(msg.agent)
+          if (msg.model) local.model.set(msg.model)
+          if (msg.variant) local.model.variant.set(msg.variant)
+        }
+      },
+    ),
+  )
 
   command.register(() => {
     return [

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -45,4 +45,10 @@ export const TuiEvent = {
       sessionID: z.string().regex(/^ses/).describe("Session ID to navigate to"),
     }),
   ),
+  AgentSet: BusEvent.define(
+    "tui.agent.set",
+    z.object({
+      name: z.string().describe("Name of the primary agent to activate in the TUI"),
+    }),
+  ),
 }

--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -375,5 +375,29 @@ export const TuiRoutes = lazy(() =>
         return c.json(true)
       },
     )
+    .post(
+      "/set-agent",
+      describeRoute({
+        summary: "Set active TUI agent",
+        description: "Set the active primary agent in the TUI agent selector. Useful for plugins that perform agent handoffs.",
+        operationId: "tui.setAgent",
+        responses: {
+          200: {
+            description: "Agent set successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", TuiEvent.AgentSet.properties),
+      async (c) => {
+        await Bus.publish(TuiEvent.AgentSet, c.req.valid("json"))
+        return c.json(true)
+      },
+    )
     .route("/control", TuiControlRoutes),
 )


### PR DESCRIPTION

Closes #17024

## Summary

This PR implements the `tui.agent.set` event requested in #17024, which allows plugins to
programmatically switch the active primary agent in the TUI agent selector after a custom
agent handoff. It also fixes the underlying sync bug where `local.agent` was not updated
when `promptAsync` switched agents within the same session.

---

## Problem

Two related issues were present:

### 1. TUI agent selector not synced on `promptAsync` agent switch

When a plugin tool called `session.promptAsync` with a different `agent` parameter (e.g.
switching from `test-plan` to `test-build`), the message header correctly showed the new
agent, but the **prompt status bar still displayed the old agent**. The user had to manually
press Tab to cycle the agent.

**Root cause:** `prompt/index.tsx` was only syncing `local.agent` when `props.sessionID`
changed — not when a new user message arrived within the same session:

```ts
// Before (broken) — only fires on session change
createEffect(() => {
  const sessionID = props.sessionID
  const msg = lastUserMessage()
  if (sessionID !== syncedSessionID) {
    // never re-runs within the same session
  }
})
```

```ts
// After (fixed) — fires on every new user message
createEffect(
  on(
    () => lastUserMessage()?.id,
    () => {
      const msg = lastUserMessage()
      if (!msg) return
      const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
      if (msg.agent && isPrimaryAgent) {
        local.agent.set(msg.agent)
        if (msg.model) local.model.set(msg.model)
        if (msg.variant) local.model.variant.set(msg.variant)
      }
    },
  ),
)
```

This now matches the behavior of the web app in `packages/app/src/pages/session.tsx`.

### 2. No first-class primitive for plugins to set the active agent

Plugins that implement custom primary-agent handoff tools (e.g. `ideation_exit`) had no
reliable way to tell the TUI to update its agent selector. The only existing pattern was
the hardcoded `plan_enter`/`plan_exit` in `packages/opencode/src/tool/plan.ts`.

---

## Changes

### `packages/opencode/src/cli/cmd/tui/event.ts`

Added new `AgentSet` Bus event definition:

```ts
AgentSet: BusEvent.define(
  "tui.agent.set",
  z.object({
    name: z.string().describe("Name of the primary agent to activate in the TUI"),
  }),
),
```

### `packages/opencode/src/cli/cmd/tui/app.tsx`

- Imported `Bus` from `@/bus`
- Added `Bus.subscribe(TuiEvent.AgentSet, ...)` handler that validates the agent name is a
  primary agent and calls `local.agent.set(name)`
- Uses `Bus.subscribe` directly (TUI runs server-side in the same process) instead of
  `sdk.event.on` to avoid requiring SDK type regeneration

```ts
Bus.subscribe(TuiEvent.AgentSet, (evt) => {
  const { name } = evt.properties
  const isPrimaryAgent = local.agent.list().some((x) => x.name === name)
  if (isPrimaryAgent) {
    local.agent.set(name)
  }
})
```

### `packages/opencode/src/server/routes/tui.ts`

Added `POST /tui/set-agent` HTTP endpoint that accepts `{ name: string }` and publishes
`TuiEvent.AgentSet` on the Bus. Follows the same pattern as `/tui/select-session` and
`/tui/show-toast`.

### `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`

Fixed the reactive sync effect to trigger on `lastUserMessage()?.id` instead of
`props.sessionID`, so agent/model/variant are updated whenever a new user message arrives —
not only on session change.

---

## How Plugins Can Use This

After injecting a synthetic user message with the new agent, plugins can now call:

```ts
await client.tui.setAgent({ name: "build" })
```

This immediately updates the TUI agent selector so the next user prompt is sent under the
correct agent.

**Example plugin tool (custom handoff):**

```ts
Tool.define("ideation_exit", {
  async execute(_params, ctx) {
    // 1. Inject synthetic user message to switch agent server-side
    const userMsg = { ..., agent: "build", ... }
    await Session.updateMessage(userMsg)

    // 2. Sync the TUI selector immediately
    await client.tui.setAgent({ name: "build" })

    return { output: "Switched to build agent." }
  }
})
```

---

## Testing

- All 13 typecheck tasks pass (`bun typecheck` via turbo — `FULL TURBO` on subsequent runs)
- The pre-push Husky hook passes cleanly with `bun@1.3.10`

---

## References

- Fixes #17024
- Existing pattern this generalizes: `packages/opencode/src/tool/plan.ts` (`plan_exit`)
- Event plumbing: `packages/opencode/src/cli/cmd/tui/event.ts`,
  `packages/opencode/src/server/routes/tui.ts`
