### PR TITLE
fix(app): skip editor reconcile during IME composition

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -490,6 +490,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setComposing(false)
   }
 
+  const handleCompositionStart = () => {
+    setComposing(true)
+  }
+
+  const handleCompositionEnd = () => {
+    setComposing(false)
+    requestAnimationFrame(() => {
+      if (composing()) return
+      reconcile(prompt.current().filter((part) => part.type !== "image"))
+    })
+  }
+
   const agentList = createMemo(() =>
     sync.data.agent
       .filter((agent) => !agent.hidden && agent.mode !== "primary")
@@ -680,24 +692,27 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
   }
 
+  const reconcile = (input: Prompt) => {
+    if (mirror.input) {
+      mirror.input = false
+      if (isNormalizedEditor()) return
+
+      renderEditorWithCursor(input)
+      return
+    }
+
+    const dom = parseFromDOM()
+    if (isNormalizedEditor() && isPromptEqual(input, dom)) return
+
+    renderEditorWithCursor(input)
+  }
+
   createEffect(
     on(
       () => prompt.current(),
-      (currentParts) => {
-        const inputParts = currentParts.filter((part) => part.type !== "image")
-
-        if (mirror.input) {
-          mirror.input = false
-          if (isNormalizedEditor()) return
-
-          renderEditorWithCursor(inputParts)
-          return
-        }
-
-        const domParts = parseFromDOM()
-        if (isNormalizedEditor() && isPromptEqual(inputParts, domParts)) return
-
-        renderEditorWithCursor(inputParts)
+      (parts) => {
+        if (composing()) return
+        reconcile(parts.filter((part) => part.type !== "image"))
       },
     ),
   )
@@ -1208,8 +1223,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               spellcheck={store.mode === "normal"}
               onInput={handleInput}
               onPaste={handlePaste}
-              onCompositionStart={() => setComposing(true)}
-              onCompositionEnd={() => setComposing(false)}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={handleCompositionEnd}
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}
               classList={{


### PR DESCRIPTION
### Issue for this PR

Closes #14371
Also related: #15506

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `contenteditable` prompt editor reconciles (re-renders) the DOM whenever prompt state updates via a `createEffect`. When Korean IME composition is active (e.g. typing after Shift+Enter), this reconcile destroys the in-progress composition node, causing the first consonant to split off and duplicate to the right of the cursor.

The fix:
- Guard the `createEffect` so it skips reconcile while `composing()` is true
- On `compositionend`, schedule a single deferred reconcile via `requestAnimationFrame` (bails out if a new composition started)
- Extract reconcile logic into a shared function so both the effect and `compositionend` use the same path

No new dependencies, no behavior change for non-IME input.

### How did you verify your code works?

Tested locally on macOS desktop (Tauri) with Korean IME:
1. Type Korean text -> Shift+Enter -> type consonant then vowel -> correctly composes (no duplicate consonant)
2. Normal Enter still submits
3. @mention / slash command popovers still work
4. `bun run typecheck` and `bun test` pass in `packages/app`

### Screenshots / recordings

_N/A - input behavior fix, not a visual change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

code written by gpt-5.4