### PR TITLE
feat(tui): make session history window configurable

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -355,12 +355,14 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const exit = useExit()
     const args = useArgs()
 
+    function sessionStart(config?: Config) {
+      const days = config?.session_history_days ?? 30
+      if (days <= 0) return undefined
+      return Date.now() - days * 24 * 60 * 60 * 1000
+    }
+
     async function bootstrap() {
       console.log("bootstrapping")
-      const start = Date.now() - 30 * 24 * 60 * 60 * 1000
-      const sessionListPromise = sdk.client.session
-        .list({ start: start })
-        .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session
       const providersPromise = sdk.client.config.providers({}, { throwOnError: true })
@@ -372,8 +374,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         providerListPromise,
         agentsPromise,
         configPromise,
-        ...(args.continue ? [sessionListPromise] : []),
       ]
+
+      const sessionListPromise = configPromise.then((x) => {
+        const start = sessionStart(x.data!)
+        return sdk.client.session
+          .list({ ...(start !== undefined ? { start } : {}) })
+          .then((r) => (r.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
+      })
+
+      if (args.continue) blockingRequests.push(sessionListPromise)
 
       await Promise.all(blockingRequests)
         .then(() => {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1166,6 +1166,15 @@ export namespace Config {
           url: z.string().optional().describe("Enterprise URL"),
         })
         .optional(),
+      session_history_days: z
+        .number()
+        .int()
+        .min(0)
+        .max(3650)
+        .optional()
+        .describe(
+          "Number of days of session history to load in the TUI session picker. 0 disables the time filter entirely (default: 30)",
+        ),
       compaction: z
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1464,6 +1464,10 @@ export type Config = {
      */
     url?: string
   }
+  /**
+   * Number of days of session history to load in the TUI session picker. 0 disables the time filter entirely (default: 30)
+   */
+  session_history_days?: number
   compaction?: {
     /**
      * Enable automatic compaction when context is full (default: true)


### PR DESCRIPTION
### Issue for this PR

Related: #16270, #16733, #13877, #16878

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI bootstrap **hard-codes** a 30-day window when fetching sessions. If
you haven't touched a project in over a month, the `/sessions` picker
comes up empty — even though the data is right there in the DB and the
CLI returns it fine. This trips up a lot of people (#16270, #16733,
#13877) into thinking their sessions got nuked.

The 30-day cap makes sense as a default — nobody wants to pull thousands
of sessions on every boot. But it shouldn't be a wall you can't move.

This adds `session_history_days` to the main config:

```jsonc
// opencode.json
{
  "session_history_days": 90  // default: 30, set 0 to disable
}
```

Since the value lives in server config, the session list request is
chained after the config fetch so the setting is available before the
query fires. No extra round-trip — config was already being fetched in
the same bootstrap batch.

### How did you verify your code works?

Tested against a real DB (2,823 sessions, project last active 41 days ago):

| Setting | Result |
|---------|--------|
| default (30) | 0 sessions — same behavior as before |
| `60` | All 77 root sessions show up |
| `0` | All 77 root sessions show up (no time filter) |

Typecheck and build both pass.

### Note

This only addresses the time window. The child session dilution issue
(missing `roots: true`) is tracked separately in #16273.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR