### PR TITLE
fix(session): recover legacy parts for old sessions

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -15,6 +15,10 @@ import { ProviderError } from "@/provider/error"
 import { iife } from "@/util/iife"
 import { type SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
+import { Filesystem } from "../util/filesystem"
+import { Glob } from "../util/glob"
+import { Global } from "../global"
+import path from "path"
 
 export namespace MessageV2 {
   export function isMedia(mime: string) {
@@ -493,6 +497,28 @@ export namespace MessageV2 {
   })
   export type WithParts = z.infer<typeof WithParts>
 
+  async function legacy(messageID: string, sessionID: string) {
+    const dir = path.join(Global.Path.data, "storage", "part", messageID)
+    if (!(await Filesystem.isDir(dir))) return []
+    const files = await Glob.scan("*.json", {
+      cwd: dir,
+      absolute: true,
+      include: "file",
+    }).catch(() => [])
+    const rows = await Promise.all(files.map((file) => Filesystem.readJson(file).catch(() => undefined)))
+    return rows.flatMap((row, i) => {
+      if (!row || typeof row !== "object") return []
+      const part = {
+        ...(row as Record<string, unknown>),
+        id: typeof (row as { id?: unknown }).id === "string" ? (row as { id: string }).id : path.basename(files[i], ".json"),
+        sessionID,
+        messageID,
+      }
+      const parsed = Part.safeParse(part)
+      return parsed.success ? [parsed.data] : []
+    })
+  }
+
   export function toModelMessages(
     input: WithParts[],
     model: Provider.Model,
@@ -770,9 +796,10 @@ export namespace MessageV2 {
 
       for (const row of rows) {
         const info = { ...row.data, id: row.id, sessionID: row.session_id } as MessageV2.Info
+        const parts = partsByMessage.get(row.id) ?? (await legacy(row.id, row.session_id))
         yield {
           info,
-          parts: partsByMessage.get(row.id) ?? [],
+          parts,
         }
       }
 
@@ -799,9 +826,10 @@ export namespace MessageV2 {
       const row = Database.use((db) => db.select().from(MessageTable).where(eq(MessageTable.id, input.messageID)).get())
       if (!row) throw new Error(`Message not found: ${input.messageID}`)
       const info = { ...row.data, id: row.id, sessionID: row.session_id } as MessageV2.Info
+      const result = await parts(input.messageID)
       return {
         info,
-        parts: await parts(input.messageID),
+        parts: result.length ? result : await legacy(input.messageID, row.session_id),
       }
     },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #16878

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes one specific old-session failure mode: the session is discoverable and can be opened, but the body renders as metadata-only rows because the SQLite `part` rows are missing.

In the case I traced locally, widening the session-history window made the old sessions show up again, but opening them only showed assistant headers like `Sisyphus · claude-opus-4-5-20251101-max · 29.8s` with no actual message body.

The underlying issue is that current reads rely on SQLite `part` rows, while some older sessions still have recoverable part JSON in legacy on-disk storage. This change adds a narrow read-time fallback in `MessageV2` so that when SQL parts are missing, opencode can still hydrate the message from legacy part storage.

### How is this different from other recent session fixes?

This PR is intentionally separate from the recent session-list fixes:

- #17046 fixes session discovery in the TUI when older sessions are filtered out by the 30-day history window
- #16389, #16795, and related issues fix project/worktree/project-id problems that orphan sessions or hide them from the list

This PR does **not** change how sessions are discovered. It fixes the next failure mode after discovery succeeds: old sessions open, but their bodies are empty because the read path cannot recover missing `part` rows.

### How did you verify your code works?

- reproduced the issue against a real old session where SQLite had message rows but no `part` rows
- confirmed legacy part files still existed on disk under `storage/part/...`
- verified the fallback restores parts for that historical message, including `text` content
- ran typecheck successfully

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR