### PR TITLE
fix(web): fix broken mobile sidebar (in workflows mode) sizing issue by adding flex-1

### DIFF
--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -116,7 +116,7 @@ export const SidebarContent = (props: {
         ref={(el) => {
           panel = el
         }}
-        classList={{ "flex h-full min-h-0 min-w-0 overflow-hidden": true, "pointer-events-none": !expanded() }}
+        classList={{ "flex-1 flex h-full min-h-0 min-w-0 overflow-hidden": true, "pointer-events-none": !expanded() }}
         aria-hidden={!expanded()}
       >
         {props.renderPanel()}


### PR DESCRIPTION
### Issue for this PR

Closes #17057

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the sizing of workspace layout in mobile sidebar UI.

### How did you verify your code works?

I've checked it visually.

### Screenshots / recordings

Pre-change:
<img width="1074" height="393" alt="image" src="https://github.com/user-attachments/assets/6339c41e-d739-496e-a04c-e5e113c51f7c" />

After change:
<img width="1059" height="426" alt="image" src="https://github.com/user-attachments/assets/a879dff8-9dc6-4e28-945a-9f8f9992b726" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._