### PR TITLE
fix(desktop): set default WebSocket username and prevent repeated calling of terminal spawn properly closing the terminal

### DIFF
--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -16,6 +16,8 @@ import { usePlatform } from "@/context/platform"
 import { normalizeServerUrl, ServerConnection, useServer } from "@/context/server"
 import { checkServerHealth, type ServerHealth } from "@/utils/server-health"
 
+const DEFAULT_USERNAME = "opencode"
+
 interface ServerFormProps {
   value: string
   name: string
@@ -178,7 +180,7 @@ export function DialogSelectServer() {
     addServer: {
       url: "",
       name: "",
-      username: "",
+      username: DEFAULT_USERNAME,
       password: "",
       adding: false,
       error: "",
@@ -201,7 +203,7 @@ export function DialogSelectServer() {
     setStore("addServer", {
       url: "",
       name: "",
-      username: "",
+      username: DEFAULT_USERNAME,
       password: "",
       adding: false,
       error: "",
@@ -441,7 +443,7 @@ export function DialogSelectServer() {
       showForm: true,
       url: "",
       name: "",
-      username: "",
+      username: DEFAULT_USERNAME,
       password: "",
       error: "",
       status: undefined,

--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -364,8 +364,8 @@ export function DialogSelectServer() {
       http: { url: normalized },
     }
     if (store.addServer.name.trim()) conn.displayName = store.addServer.name.trim()
-    if (store.addServer.username) conn.http.username = store.addServer.username
     if (store.addServer.password) conn.http.password = store.addServer.password
+    if (store.addServer.password && store.addServer.username) conn.http.username = store.addServer.username
     const result = await checkServerHealth(conn.http, fetcher)
     setStore("addServer", { adding: false })
     if (!result.healthy) {

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -452,7 +452,7 @@ export const Terminal = (props: TerminalProps) => {
       url.searchParams.set("directory", sdk.directory)
       url.searchParams.set("cursor", String(start !== undefined ? start : restore ? -1 : 0))
       url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
-      url.username = server.current?.http.username ?? ""
+      url.username = server.current?.http.username ?? "opencode"
       url.password = server.current?.http.password ?? ""
 
       const socket = new WebSocket(url)

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -5,7 +5,6 @@ import { Tabs } from "@opencode-ai/ui/tabs"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
-import { showToast } from "@opencode-ai/ui/toast"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
@@ -296,14 +295,7 @@ export function TerminalPanel() {
                             autoFocus={opened()}
                             onConnect={() => terminal.trim(id)}
                             onCleanup={terminal.update}
-                            onConnectError={async (err) => {
-                              await terminal.close(id)
-                              showToast({
-                                variant: "error",
-                                title: language.t("terminal.connectionLost.title"),
-                                description: language.t("terminal.connectionLost.description"),
-                              })
-                            }}
+                            onConnectError={() => terminal.clone(id)}
                           />
                         </div>
                       )}

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -5,6 +5,7 @@ import { Tabs } from "@opencode-ai/ui/tabs"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
+import { showToast } from "@opencode-ai/ui/toast"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
@@ -295,7 +296,14 @@ export function TerminalPanel() {
                             autoFocus={opened()}
                             onConnect={() => terminal.trim(id)}
                             onCleanup={terminal.update}
-                            onConnectError={() => terminal.clone(id)}
+                            onConnectError={async (err) => {
+                              await terminal.close(id)
+                              showToast({
+                                variant: "error",
+                                title: language.t("terminal.connectionLost.title"),
+                                description: language.t("terminal.connectionLost.description"),
+                              })
+                            }}
                           />
                         </div>
                       )}


### PR DESCRIPTION

### Issue for this PR

Closes #17058

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently if you dont pass in a username when adding an authenticated opencode server, the desktop tries to spawn and connect to the terminal ws without a username and causes a 401 error. Also when this happens rather than the terminal closing it just keeps trying to connect to the terminal ws causing the desktop to attack the server till it crashes. 

This PR does the following

- Adds a fallback "opencode" username when the setup server username was not added in.
- Username is pre-filled with "opencode" by default when user is adding in a new server.

### How did you verify your code works?

Tested on my local machine, with a remote opencode server running on railway and connecting to it on my local dev desktop build with the changes.

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
