### PR TITLE
fix(opencode): preserve prompt tool enables with empty agent permissions

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -32,6 +32,7 @@ export namespace LLM {
     sessionID: string
     model: Provider.Model
     agent: Agent.Info
+    permission?: PermissionNext.Ruleset
     system: string[]
     abort: AbortSignal
     messages: ModelMessage[]
@@ -255,8 +256,11 @@ export namespace LLM {
     })
   }
 
-  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
+    const disabled = PermissionNext.disabled(
+      Object.keys(input.tools),
+      PermissionNext.merge(input.agent.permission, input.permission ?? []),
+    )
     for (const tool of Object.keys(input.tools)) {
       if (input.user.tools?.[tool] === false || disabled.has(tool)) {
         delete input.tools[tool]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -659,6 +659,7 @@ export namespace SessionPrompt {
       const result = await processor.process({
         user: lastUser,
         agent,
+        permission: session.permission,
         abort,
         sessionID,
         system,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
-import type { ModelMessage } from "ai"
+import { tool, type ModelMessage } from "ai"
+import z from "zod"
 import { LLM } from "../../src/session/llm"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -319,6 +320,95 @@ describe("session.llm.stream", () => {
 
         const reasoning = (body.reasoningEffort as string | undefined) ?? (body.reasoning_effort as string | undefined)
         expect(reasoning).toBe("high")
+      },
+    })
+  })
+
+  test("keeps tools enabled by prompt permissions", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(providerID, model.id)
+        const sessionID = "session-test-tools"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "question", pattern: "*", action: "deny" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-tools",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id },
+          tools: { question: true },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          permission: [{ permission: "question", pattern: "*", action: "allow" }],
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            question: tool({
+              description: "Ask a question",
+              inputSchema: z.object({}),
+              execute: async () => ({ output: "" }),
+            }),
+          },
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const tools = capture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(tools?.some((item) => item.function?.name === "question")).toBe(true)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #17063

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an agent has `permission: {}`, prompt-level tool enables can be dropped before the model request is built.

This PR applies session/prompt permission overrides in the same pre-request filtering path that decides which tools are exposed to the model, and adds a regression test for the `tools: { question: true }` case.

### How did you verify your code works?

- added regression coverage in `packages/opencode/test/session/llm.test.ts`
- reproduced the bug with a local SDK repro script
- confirmed the repro succeeds against the local dev server with this change

<details>
<summary>Repro script used for testing</summary>

`packages/sdk/js/example/question-permission-repro.ts`

```ts
import { createOpencodeClient } from "@opencode-ai/sdk/v2"
import { spawn } from "node:child_process"

const key = process.env.ANTHROPIC_API_KEY

if (!key) {
  throw new Error("Set ANTHROPIC_API_KEY before running this repro")
}

const port = 4100 + Math.floor(Math.random() * 1000)
const proc = spawn("bun", ["run", "dev", "--", "serve", `--hostname=127.0.0.1`, `--port=${port}`], {
  cwd: new URL("../../../../", import.meta.url),
  env: {
    ...process.env,
    OPENCODE_CONFIG_CONTENT: JSON.stringify({
      enabled_providers: ["anthropic"],
      provider: {
        anthropic: {
          options: {
            apiKey: key,
          },
        },
      },
      agent: {
        repro: {
          mode: "primary",
          model: "anthropic/claude-sonnet-4-5-20250929",
          permission: {},
        },
      },
    }),
  },
})

proc.stdout?.pipe(process.stdout)
proc.stderr?.pipe(process.stderr)

const url = await new Promise<string>((resolve, reject) => {
  let out = ""
  const timeout = setTimeout(() => done(new Error(`timed out waiting for dev server\n${out}`)), 15000)
  const done = (err?: Error) => {
    clearTimeout(timeout)
    proc.stdout?.off("data", onStdout)
    proc.stderr?.off("data", onStderr)
    proc.off("error", onError)
    proc.off("exit", onExit)
    if (err) reject(err)
  }
  const onStdout = (chunk: Buffer) => {
    out += chunk.toString()
    for (const line of out.split("\n")) {
      const match = line.match(/opencode server listening on\s+(https?:\/\/\S+)/)
      if (!match) continue
      done()
      resolve(match[1]!)
      return
    }
  }
  const onStderr = (chunk: Buffer) => {
    out += chunk.toString()
  }
  const onError = (err: Error) => done(err)
  const onExit = (code: number | null) => done(new Error(`dev server exited early: ${code}\n${out}`))
  proc.stdout?.on("data", onStdout)
  proc.stderr?.on("data", onStderr)
  proc.on("error", onError)
  proc.on("exit", onExit)
})

const client = createOpencodeClient({ baseUrl: url })
const session = await client.session.create()
const sessionID = session.data!.id

console.log("session:", sessionID)
console.log("sending prompt")

const result = await client.session.prompt({
  sessionID,
  agent: "repro",
  tools: {
    question: true,
  },
  parts: [
    {
      type: "text",
      text: "do you have a question tool?",
    },
  ],
})

console.log(result.data?.parts?.find((part) => part.type === "text")?.text)

proc.kill()
```
</details>

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
