### PR TITLE
docs: add PR template directive to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,7 @@ const table = sqliteTable("session", {
 ## Type Checking
 
 - Always run `bun typecheck` from package directories (e.g., `packages/opencode`), never `tsc` directly.
+
+## Pull Requests
+
+Before creating any pull request with `gh pr create`, read `.github/pull_request_template.md` and use its exact section structure in the PR body. The CI bot will auto-close PRs that don't match the template. Fill in all sections; mark N/A where not applicable.


### PR DESCRIPTION
### Issue for this PR

Closes #17086

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `## Pull Requests` section to `AGENTS.md` directing agents to read `.github/pull_request_template.md` and use its exact section structure before creating any PR. Without this, agents default to their own generic PR body format and the CI compliance bot flags and auto-closes the PR.

### How did you verify your code works?

Verified the added markdown renders correctly and matches the intent of the existing PR template requirements.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR