### PR TITLE
fix(opencode): align tool visibility with session permissions

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -7,6 +7,8 @@ import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
 import { MCP } from "../../mcp"
 import { Session } from "../../session"
+import { Agent } from "../../agent/agent"
+import { PermissionNext } from "../../permission/next"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
@@ -33,8 +35,31 @@ export const ExperimentalRoutes = lazy(() =>
           ...errors(400),
         },
       }),
+      validator(
+        "query",
+        z.object({
+          provider: z.string().optional(),
+          model: z.string().optional(),
+          agent: z.string().optional(),
+          sessionID: z.string().optional(),
+        }),
+      ),
       async (c) => {
-        return c.json(await ToolRegistry.ids())
+        const { provider, model, agent: agentName, sessionID } = c.req.valid("query")
+        if (!provider || !model) {
+          return c.json(await ToolRegistry.ids())
+        }
+
+        const agent = await Agent.get(agentName ?? (await Agent.defaultAgent()))
+        const sessionPermission = sessionID ? ((await Session.get(sessionID)).permission ?? []) : []
+
+        const tools = await ToolRegistry.tools({ providerID: provider, modelID: model }, agent)
+        const disabled = PermissionNext.disabled(
+          tools.map((tool) => tool.id),
+          PermissionNext.merge(agent.permission, sessionPermission),
+        )
+
+        return c.json(tools.filter((tool) => !disabled.has(tool.id)).map((tool) => tool.id))
       },
     )
     .get(
@@ -73,18 +98,30 @@ export const ExperimentalRoutes = lazy(() =>
         z.object({
           provider: z.string(),
           model: z.string(),
+          agent: z.string().optional(),
+          sessionID: z.string().optional(),
         }),
       ),
       async (c) => {
-        const { provider, model } = c.req.valid("query")
-        const tools = await ToolRegistry.tools({ providerID: provider, modelID: model })
+        const { provider, model, agent: agentName, sessionID } = c.req.valid("query")
+        const agent = await Agent.get(agentName ?? (await Agent.defaultAgent()))
+        const sessionPermission = sessionID ? ((await Session.get(sessionID)).permission ?? []) : []
+
+        const tools = await ToolRegistry.tools({ providerID: provider, modelID: model }, agent)
+        const disabled = PermissionNext.disabled(
+          tools.map((tool) => tool.id),
+          PermissionNext.merge(agent.permission, sessionPermission),
+        )
+
         return c.json(
-          tools.map((t) => ({
-            id: t.id,
-            description: t.description,
-            // Handle both Zod schemas and plain JSON schemas
-            parameters: (t.parameters as any)?._def ? zodToJsonSchema(t.parameters as any) : t.parameters,
-          })),
+          tools
+            .filter((tool) => !disabled.has(tool.id))
+            .map((t) => ({
+              id: t.id,
+              description: t.description,
+              // Handle both Zod schemas and plain JSON schemas
+              parameters: (t.parameters as any)?._def ? zodToJsonSchema(t.parameters as any) : t.parameters,
+            })),
         )
       },
     )

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -32,6 +32,7 @@ export namespace LLM {
     sessionID: string
     model: Provider.Model
     agent: Agent.Info
+    sessionPermission?: PermissionNext.Ruleset
     system: string[]
     abort: AbortSignal
     messages: ModelMessage[]
@@ -255,8 +256,9 @@ export namespace LLM {
     })
   }
 
-  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user" | "sessionPermission">) {
+    const ruleset = PermissionNext.merge(input.agent.permission, input.sessionPermission ?? [])
+    const disabled = PermissionNext.disabled(Object.keys(input.tools), ruleset)
     for (const tool of Object.keys(input.tools)) {
       if (input.user.tools?.[tool] === false || disabled.has(tool)) {
         delete input.tools[tool]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -659,6 +659,7 @@ export namespace SessionPrompt {
       const result = await processor.process({
         user: lastUser,
         agent,
+        sessionPermission: session.permission,
         abort,
         sessionID,
         system,

--- a/packages/opencode/test/server/experimental-tools.test.ts
+++ b/packages/opencode/test/server/experimental-tools.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import { Hono } from "hono"
+import { ExperimentalRoutes } from "../../src/server/routes/experimental"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function route() {
+  return new Hono().route("/experimental", ExperimentalRoutes())
+}
+
+async function listTools(query: Record<string, string>) {
+  const qs = new URLSearchParams(query)
+  const res = await route().request(`/experimental/tool?${qs.toString()}`)
+  expect(res.status).toBe(200)
+  return (await res.json()) as Array<{ id: string }>
+}
+
+async function listToolIDs(query: Record<string, string>) {
+  const qs = new URLSearchParams(query)
+  const suffix = qs.toString()
+  const res = await route().request(`/experimental/tool/ids${suffix ? `?${suffix}` : ""}`)
+  expect(res.status).toBe(200)
+  return (await res.json()) as string[]
+}
+
+describe("ExperimentalRoutes /experimental/tool", () => {
+  test("applies agent permissions when listing visible tools", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const buildTools = await listTools({ provider: "openai", model: "qwen-plus", agent: "build" })
+        const exploreTools = await listTools({ provider: "openai", model: "qwen-plus", agent: "explore" })
+
+        expect(buildTools.some((tool) => tool.id === "edit")).toBe(true)
+        expect(exploreTools.some((tool) => tool.id === "edit")).toBe(false)
+      },
+    })
+  })
+
+  test("applies session permissions when sessionID is provided", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        await Session.setPermission({
+          sessionID: session.id,
+          permission: [{ permission: "bash", pattern: "*", action: "deny" }],
+        })
+
+        const withSession = await listTools({
+          provider: "openai",
+          model: "qwen-plus",
+          agent: "build",
+          sessionID: session.id,
+        })
+
+        expect(withSession.some((tool) => tool.id === "bash")).toBe(false)
+      },
+    })
+  })
+})
+
+describe("ExperimentalRoutes /experimental/tool/ids", () => {
+  test("applies agent permissions when listing visible tool IDs", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const buildToolIDs = await listToolIDs({ provider: "openai", model: "qwen-plus", agent: "build" })
+        const exploreToolIDs = await listToolIDs({ provider: "openai", model: "qwen-plus", agent: "explore" })
+
+        expect(buildToolIDs.includes("edit")).toBe(true)
+        expect(exploreToolIDs.includes("edit")).toBe(false)
+      },
+    })
+  })
+
+  test("applies session permissions to tool IDs when sessionID is provided", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        await Session.setPermission({
+          sessionID: session.id,
+          permission: [{ permission: "bash", pattern: "*", action: "deny" }],
+        })
+
+        const withSession = await listToolIDs({
+          provider: "openai",
+          model: "qwen-plus",
+          agent: "build",
+          sessionID: session.id,
+        })
+
+        expect(withSession.includes("bash")).toBe(false)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
-import type { ModelMessage } from "ai"
+import { jsonSchema, type ModelMessage, tool } from "ai"
 import { LLM } from "../../src/session/llm"
 import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
@@ -221,6 +221,125 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
+  test("applies session permissions before exposing tools to the model", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+
+    const allowedRequest = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("allowed"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    const deniedRequest = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("denied"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(providerID, fixture.model.id)
+        const sessionID = "session-test-session-permissions"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-permission-1",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const bashTool = tool({
+          description: "Run shell commands",
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: {
+              command: { type: "string" },
+            },
+            required: ["command"],
+            additionalProperties: false,
+          }),
+          execute: async () => ({ output: "", title: "", metadata: {} }),
+        })
+
+        const allowedStream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: { bash: bashTool },
+        })
+        for await (const _ of allowedStream.fullStream) {
+        }
+
+        const allowedCapture = await allowedRequest
+        const allowedTools = allowedCapture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(Array.isArray(allowedTools)).toBe(true)
+        expect(allowedTools?.some((item) => item.function?.name === "bash")).toBe(true)
+
+        const deniedStream = await LLM.stream({
+          user: { ...user, id: "user-permission-2" },
+          sessionID,
+          model: resolved,
+          agent,
+          sessionPermission: [{ permission: "bash", pattern: "*", action: "deny" }],
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello again" }],
+          tools: { bash: bashTool },
+        })
+        for await (const _ of deniedStream.fullStream) {
+        }
+
+        const deniedCapture = await deniedRequest
+        const deniedTools = deniedCapture.body.tools as Array<{ function?: { name?: string } }> | undefined
+        expect(deniedTools?.some((item) => item.function?.name === "bash") ?? false).toBe(false)
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1953,6 +1953,10 @@ export type ToolIdsData = {
   path?: never
   query?: {
     directory?: string
+    provider?: string
+    model?: string
+    agent?: string
+    sessionID?: string
   }
   url: "/experimental/tool/ids"
 }
@@ -1982,6 +1986,8 @@ export type ToolListData = {
     directory?: string
     provider: string
     model: string
+    agent?: string
+    sessionID?: string
   }
   url: "/experimental/tool"
 }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -837,6 +837,10 @@ export class Tool extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
+      provider?: string
+      model?: string
+      agent?: string
+      sessionID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -847,6 +851,10 @@ export class Tool extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "query", key: "provider" },
+            { in: "query", key: "model" },
+            { in: "query", key: "agent" },
+            { in: "query", key: "sessionID" },
           ],
         },
       ],
@@ -869,6 +877,8 @@ export class Tool extends HeyApiClient {
       workspace?: string
       provider: string
       model: string
+      agent?: string
+      sessionID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -881,6 +891,8 @@ export class Tool extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "query", key: "provider" },
             { in: "query", key: "model" },
+            { in: "query", key: "agent" },
+            { in: "query", key: "sessionID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2415,6 +2415,10 @@ export type ToolIdsData = {
   query?: {
     directory?: string
     workspace?: string
+    provider?: string
+    model?: string
+    agent?: string
+    sessionID?: string
   }
   url: "/experimental/tool/ids"
 }
@@ -2445,6 +2449,8 @@ export type ToolListData = {
     workspace?: string
     provider: string
     model: string
+    agent?: string
+    sessionID?: string
   }
   url: "/experimental/tool"
 }


### PR DESCRIPTION
### Issue for this PR

Closes #17090

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This patch aligns tool visibility with permission enforcement so the model and API only see tools that are actually callable.

Concretely:
- merges session permission rules into runtime tool filtering before tool exposure in `session/llm.ts`
- passes session permissions through `session/prompt.ts` into the LLM stream path
- makes `/experimental/tool` and `/experimental/tool/ids` permission-aware via optional `agent` and `sessionID` query params
- updates generated SDK query types/signatures for these optional params
- adds regression tests for session-level filtering and experimental route filtering

### How did you verify your code works?

- `bun test test/session/llm.test.ts`
- `bun test test/server/experimental-tools.test.ts`
- `bun test test/server/experimental-tools.test.ts test/session/llm.test.ts`
- `bun run typecheck` (packages/opencode)
- `bun run typecheck` (packages/sdk/js)
- `bun run typecheck` (repo root, also required by pre-push hook)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
