### PR TITLE
feat(server): support OPENCODE_WEB_URL for local frontend serving

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -71,6 +71,7 @@ export namespace Flag {
   export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"]
   export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"]
   export const OPENCODE_DB = process.env["OPENCODE_DB"]
+  export const OPENCODE_WEB_URL = process.env["OPENCODE_WEB_URL"]
   export const OPENCODE_DISABLE_CHANNEL_DB = truthy("OPENCODE_DISABLE_CHANNEL_DB")
   export const OPENCODE_SKIP_MIGRATIONS = truthy("OPENCODE_SKIP_MIGRATIONS")
   export const OPENCODE_STRICT_CONFIG_DEPS = truthy("OPENCODE_STRICT_CONFIG_DEPS")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -534,14 +534,79 @@ export namespace Server {
       )
       .all("/*", async (c) => {
         const path = c.req.path
+        const appDir = Flag.OPENCODE_WEB_URL
 
-        const response = await proxy(`https://app.opencode.ai${path}`, {
+        // Serve from local dist directory if OPENCODE_WEB_URL is a file path
+        if (appDir && !appDir.startsWith("http")) {
+          const fs = await import("fs")
+          const nodePath = await import("path")
+          const mimeTypes: Record<string, string> = {
+            ".html": "text/html",
+            ".js": "application/javascript",
+            ".mjs": "application/javascript",
+            ".css": "text/css",
+            ".json": "application/json",
+            ".svg": "image/svg+xml",
+            ".png": "image/png",
+            ".woff": "font/woff",
+            ".woff2": "font/woff2",
+            ".wasm": "application/wasm",
+            ".onnx": "application/octet-stream",
+          }
+          const getMime = (p: string) => mimeTypes[nodePath.default.extname(p)] || "application/octet-stream"
+          const filePath = nodePath.default.join(appDir, path === "/" ? "index.html" : path)
+          if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            const stat = fs.statSync(filePath)
+            const etag = `W/"${stat.size.toString(16)}-${stat.mtimeMs.toString(16)}"`
+            const hashed = /\/assets\/.*-[a-zA-Z0-9]{6,}\.[a-z]+$/.test(path)
+            const cache = hashed ? "public, max-age=31536000, immutable" : "no-cache"
+            return new Response(Bun.file(filePath), {
+              headers: { "Content-Type": getMime(filePath), "Cache-Control": cache, ETag: etag },
+            })
+          }
+          // SPA fallback — only for paths that look like client-side routes
+          const apiPrefixes = [
+            "/global",
+            "/project",
+            "/pty",
+            "/config",
+            "/experimental",
+            "/session",
+            "/permission",
+            "/question",
+            "/provider",
+            "/mcp",
+            "/tui",
+            "/voice",
+            "/tts",
+          ]
+          const isApiPath = apiPrefixes.some((prefix) => path.startsWith(prefix))
+          if (!isApiPath) {
+            const indexPath = nodePath.default.join(appDir, "index.html")
+            if (fs.existsSync(indexPath)) {
+              return new Response(Bun.file(indexPath), {
+                headers: { "Content-Type": "text/html", "Cache-Control": "no-cache" },
+              })
+            }
+          }
+          return c.notFound()
+        }
+
+        const appHost = appDir || "https://app.opencode.ai"
+        const appHostname = new URL(appHost).hostname
+
+        const response = await proxy(`${appHost}${path}`, {
           ...c.req,
           headers: {
             ...c.req.raw.headers,
-            host: "app.opencode.ai",
+            host: appHostname,
           },
         })
+        // Override cache headers for hashed assets (GH Pages only sends max-age=600)
+        const hashed = /\/assets\/.*-[a-zA-Z0-9]{6,}\.[a-z]+$/.test(path)
+        if (hashed) {
+          response.headers.set("Cache-Control", "public, max-age=31536000, immutable")
+        }
         const match = response.headers.get("content-type")?.includes("text/html")
           ? (await response.clone().text()).match(
               /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,


### PR DESCRIPTION
### Issue for this PR

Closes #12445
Related: #8549, #11981, #16787

### Type of change

- [x] New feature

### What does this PR do?

Adds `OPENCODE_WEB_URL` environment variable to override the default `app.opencode.ai` proxy in the server's catch-all route. Two modes:

1. **File path** (`OPENCODE_WEB_URL=./packages/app/dist`) — serves the built frontend directly from disk with proper MIME types and SPA fallback for client-side routes. Returns 404 for unmatched API-prefixed paths instead of attempting `new URL()` on a file path.

2. **HTTP URL** (`OPENCODE_WEB_URL=https://internal-host.corp/opencode-app`) — proxies to a custom host instead of `app.opencode.ai`, with correct `Host` header rewriting.

Without the variable, behavior is unchanged (proxies to `app.opencode.ai`).

The catch-all route sits at the end of the Hono chain, after all API routes. It only handles requests that don't match any API endpoint — static assets, SPA routes, etc.

### How did you verify your code works?

- Built the app (`bun run build` in `packages/app`), ran `OPENCODE_WEB_URL=../app/dist bun run --conditions=browser ./src/index.ts serve --port 8080` from `packages/opencode` — app loads, all API endpoints work, SPA routing works for client-side routes.
- Verified without the env var — behavior unchanged, proxies to `app.opencode.ai` as before.
- `bun typecheck` passes.

### Screenshots / recordings

_N/A — backend-only change, no UI modifications._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR