### PR TITLE
fix(app): improve workspace display for JJ colocated repos and git worktrees

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -145,9 +145,12 @@ export function SessionHeader() {
     return layout.projects.list().find((p) => p.worktree === directory || p.sandboxes?.includes(directory))
   })
   const name = createMemo(() => {
+    const dir = projectDirectory()
     const current = project()
+    // When in a workspace (sandbox), show the workspace name, not the project root
+    if (current && dir && dir !== current.worktree) return getFilename(dir)
     if (current) return current.name || getFilename(current.worktree)
-    return getFilename(projectDirectory())
+    return getFilename(dir)
   })
   const hotkey = createMemo(() => command.keybind("file.open"))
   const os = createMemo(() => detectOS(platform))

--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -27,7 +27,7 @@ export function NewSessionView(props: NewSessionViewProps) {
     if (options().includes(selection)) return selection
     return MAIN_WORKTREE
   })
-  const projectRoot = createMemo(() => sync.project?.worktree ?? sdk.directory)
+  const displayDir = createMemo(() => sdk.directory)
   const isWorktree = createMemo(() => {
     const project = sync.project
     if (!project) return false
@@ -59,8 +59,8 @@ export function NewSessionView(props: NewSessionViewProps) {
           <div class="w-full flex flex-col gap-4 items-center">
             <div class="flex items-start justify-center gap-3 min-h-5">
               <div class="text-12-medium text-text-weak select-text leading-5 min-w-0 max-w-160 break-words text-center">
-                {getDirectory(projectRoot())}
-                <span class="text-text-strong">{getFilename(projectRoot())}</span>
+                {getDirectory(displayDir())}
+                <span class="text-text-strong">{getFilename(displayDir())}</span>
               </div>
             </div>
             <div class="flex items-start justify-center gap-1.5 min-h-5">

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -68,6 +68,7 @@ import {
   effectiveWorkspaceOrder,
   errorMessage,
   latestRootSession,
+  sortSessions,
   sortedRootSessions,
   workspaceKey,
 } from "./layout/helpers"
@@ -586,6 +587,17 @@ export default function Layout(props: ParentProps) {
     return projects.find((p) => p.worktree === root)
   })
 
+  // Auto-enable workspaces when the current directory is a sandbox of a project
+  createEffect(() => {
+    const dir = currentDir()
+    const project = currentProject()
+    if (!dir || !project) return
+    if (dir === project.worktree) return
+    if (project.vcs !== "git") return
+    if (layout.sidebar.workspaces(project.worktree)()) return
+    layout.sidebar.setWorkspaces(project.worktree, true)
+  })
+
   const [autoselecting] = createResource(async () => {
     await ready.promise
     await layout.ready.promise
@@ -624,8 +636,11 @@ export default function Layout(props: ParentProps) {
     setStore("workspaceBranchName", projectId, branch, next)
   }
 
-  const workspaceLabel = (directory: string, branch?: string, projectId?: string) =>
-    workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
+  const workspaceLabel = (directory: string, branch?: string, projectId?: string) => {
+    // For JJ co-located workspaces, branch is "HEAD" (detached) — fall through to directory name
+    const effectiveBranch = branch && branch !== "HEAD" ? branch : undefined
+    return workspaceName(directory, projectId, effectiveBranch) ?? effectiveBranch ?? getFilename(directory)
+  }
 
   const workspaceSetting = createMemo(() => {
     const project = currentProject()
@@ -1287,6 +1302,12 @@ export default function Layout(props: ParentProps) {
     const root = projectRoot(directory)
     server.projects.touch(root)
     const project = layout.projects.list().find((item) => item.worktree === root)
+    // Auto-enable workspaces when navigating to a sandbox directory
+    if (project && directory !== root && project.vcs === "git") {
+      if (!layout.sidebar.workspaces(root)()) {
+        layout.sidebar.setWorkspaces(root, true)
+      }
+    }
     let dirs = project
       ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
       : [root]
@@ -1320,6 +1341,37 @@ export default function Layout(props: ParentProps) {
       setStore("lastProjectSession", root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
       navigateWithSidebarReset(`/${base64Encode(resolved.directory)}/session/${resolved.id}`)
       return true
+    }
+
+    // When user explicitly opened a specific workspace (not the project root),
+    // navigate directly to that workspace instead of searching across all workspaces.
+    if (workspaceKey(directory) !== workspaceKey(root)) {
+      await refreshDirs(directory)
+      if (canOpen(directory)) {
+        const [dirStore] = globalSync.child(directory, { bootstrap: false })
+        const latest = sortedRootSessions(dirStore, Date.now())[0]
+        if (latest) {
+          setStore("lastProjectSession", root, { directory, id: latest.id, at: Date.now() })
+          navigateWithSidebarReset(`/${base64Encode(directory)}/session/${latest.id}`)
+          return
+        }
+        // Try fetching sessions from server for this specific workspace
+        const fetched = await globalSDK.client.session
+          .list({ directory })
+          .then((x) => x.data ?? [])
+          .catch(() => [] as Session[])
+        const visible = fetched
+          .filter((s) => !s.parentID && !s.time?.archived)
+          .sort(sortSessions(Date.now()))
+        if (visible[0]) {
+          setStore("lastProjectSession", root, { directory, id: visible[0].id, at: Date.now() })
+          navigateWithSidebarReset(`/${base64Encode(directory)}/session/${visible[0].id}`)
+          return
+        }
+      }
+      // No sessions in this workspace — navigate to it anyway (empty state)
+      navigateWithSidebarReset(`/${base64Encode(directory)}/session`)
+      return
     }
 
     const projectSession = store.lastProjectSession[root]

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -14,7 +14,7 @@ export const workspaceKey = (directory: string) => {
   return value.replace(/\/+$/, "")
 }
 
-function sortSessions(now: number) {
+export function sortSessions(now: number) {
   const oneMinuteAgo = now - 60 * 1000
   return (a: Session, b: Session) => {
     const aUpdated = a.time.updated ?? a.time.created

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -110,7 +110,7 @@ const WorkspaceHeader = (props: {
       when={!props.local()}
       fallback={
         <span class="text-14-medium text-text-base min-w-0 truncate">
-          {props.branch() ?? getFilename(props.directory)}
+          {props.branch() && props.branch() !== "HEAD" ? props.branch() : getFilename(props.directory)}
         </span>
       }
     >
@@ -326,8 +326,9 @@ export const SortableWorkspace = (props: {
   const active = createMemo(() => workspaceKey(props.ctx.currentDir()) === workspaceKey(props.directory))
   const workspaceValue = createMemo(() => {
     const branch = workspaceStore.vcs?.branch
-    const name = branch ?? getFilename(props.directory)
-    return props.ctx.workspaceName(props.directory, props.project.id, branch) ?? name
+    const effectiveBranch = branch && branch !== "HEAD" ? branch : undefined
+    const name = effectiveBranch ?? getFilename(props.directory)
+    return props.ctx.workspaceName(props.directory, props.project.id, effectiveBranch) ?? name
   })
   const open = createMemo(() => props.ctx.workspaceExpanded(props.directory, local()))
   const boot = createMemo(() => open() || active())


### PR DESCRIPTION
### Issue for this PR

Closes #16474
Related: #5008

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes workspace/worktree display in the sidebar for JJ colocated repos and git worktrees that report detached HEAD.

**Problem:** In JJ colocated repos, `git rev-parse --abbrev-ref HEAD` returns `HEAD` (detached). The sidebar displayed this literal string instead of a useful name. Additionally, navigating to a sandbox directory didn't auto-expand the workspace view.

**Changes:**
- Filter `HEAD` branch names in sidebar labels — fall through to the directory name instead of displaying "HEAD".
- Auto-enable workspace sidebar expansion when navigating to a sandbox directory (not the project root).
- Navigate directly to a workspace's latest session when opening a specific workspace, instead of searching across all workspaces.
- Show workspace directory name in the session header when in a sandbox.
- Show actual working directory (not project root) in the new session view.

**Why this works:** JJ colocated repos use git's worktree mechanism internally — each workspace has a `.git` file pointing to the main repo's `.git/worktrees/<name>`. Git commands in these directories report `HEAD` as the branch. The fix treats `HEAD` as equivalent to "no branch" and falls through to directory-based naming, which is the correct behavior for JJ workspaces.

### How did you verify your code works?

- Tested with a JJ colocated repo with multiple workspaces (`jj workspace list` shows default, voice, etc.).
- Verified sidebar shows workspace directory names instead of "HEAD".
- Verified auto-expansion when navigating to a sandbox workspace.
- Verified session header shows correct workspace name.
- `bun typecheck` passes.

### Screenshots / recordings

_N/A — changes are to sidebar label logic and navigation, no visual design changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR