### PR TITLE
fix(e2e): re-focus prompt after terminal opens in slash-terminal test

### DIFF
--- a/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
@@ -6,16 +6,24 @@ test("/terminal toggles the terminal panel", async ({ page, gotoSession }) => {
 
   const prompt = page.locator(promptSelector)
   const terminal = page.locator(terminalSelector)
+  const slash = page.locator('[data-slash-id="terminal.toggle"]').first()
 
   await expect(terminal).not.toBeVisible()
 
   await prompt.fill("/terminal")
-  await expect(page.locator('[data-slash-id="terminal.toggle"]').first()).toBeVisible()
+  await expect(slash).toBeVisible()
   await page.keyboard.press("Enter")
   await expect(terminal).toBeVisible()
 
-  await prompt.fill("/terminal")
-  await expect(page.locator('[data-slash-id="terminal.toggle"]').first()).toBeVisible()
+  // Terminal panel retries focus (immediate, RAF, 120ms, 240ms) after opening,
+  // which can steal focus from the prompt and prevent fill() from triggering
+  // the slash popover. Re-attempt click+fill until all retries are exhausted
+  // and the popover appears.
+  await expect.poll(async () => {
+    await prompt.click().catch(() => false)
+    await prompt.fill("/terminal").catch(() => false)
+    return slash.isVisible().catch(() => false)
+  }, { timeout: 10_000 }).toBe(true)
   await page.keyboard.press("Enter")
   await expect(terminal).not.toBeVisible()
 })


### PR DESCRIPTION
## Summary

- Fixes flaky `/terminal` toggle e2e test that fails under CI parallel load
- Root cause: `terminal-panel.tsx` steals focus via `setTimeout(focusTerminal, 0)` after the panel opens, so the second `prompt.fill("/terminal")` fires while the terminal input has focus, preventing the slash popover from appearing
- Fix: retry prompt.click() + prompt.fill() in an expect.poll loop until the terminal's focus-steal retries (immediate, RAF, 120ms, 240ms) are exhausted and the slash popover appears

## Reproduction

Fails ~1 in 5 runs when executed alongside other tests with `--workers=4`. Passes 10/10 in isolation. Passes 5/5 under parallel stress with the fix.