### PR TITLE
fix: recover unquoted custom agent hex colors

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -6,6 +6,8 @@ import { Filesystem } from "../util/filesystem"
 export namespace ConfigMarkdown {
   export const FILE_REGEX = /(?<![\w`])@(\.?[^\s`,.]*(?:\.[^\s`,.]+)*)/g
   export const SHELL_REGEX = /!`([^`]+)`/g
+  export const UNQUOTED_HEX_FRONTMATTER_REGEX =
+    /^---\r?\n[\s\S]*?^\s*[a-zA-Z_][a-zA-Z0-9_]*\s*:\s*#[0-9a-fA-F]{6}\s*$/m
 
   export function files(template: string) {
     return Array.from(template.matchAll(FILE_REGEX))
@@ -54,6 +56,12 @@ export namespace ConfigMarkdown {
         continue
       }
 
+      // quote unquoted hex colors because YAML treats #... as a comment
+      if (value.match(/^#[0-9a-fA-F]{6}$/)) {
+        result.push(`${key}: "${value}"`)
+        continue
+      }
+
       // if value contains a colon, convert to block scalar
       if (value.includes(":")) {
         result.push(`${key}: |-`)
@@ -70,9 +78,10 @@ export namespace ConfigMarkdown {
 
   export async function parse(filePath: string) {
     const template = await Filesystem.readText(filePath)
+    const shouldUseFallback = UNQUOTED_HEX_FRONTMATTER_REGEX.test(template)
 
     try {
-      const md = matter(template)
+      const md = matter(shouldUseFallback ? fallbackSanitization(template) : template)
       return md
     } catch {
       try {

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -1,4 +1,7 @@
-import { expect, test, describe } from "bun:test"
+import { afterAll, beforeAll, expect, test, describe } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
 import { ConfigMarkdown } from "../../src/config/markdown"
 
 describe("ConfigMarkdown: normal template", () => {
@@ -224,5 +227,49 @@ describe("ConfigMarkdown: frontmatter has weird model id", async () => {
     expect(result.data["stuff"]).toBe("This is some stuff\n")
 
     expect(result.content.trim()).toBe("Strictly follow da rules")
+  })
+})
+
+describe("ConfigMarkdown: frontmatter parsing w/ hex colors", () => {
+  let dir: string
+
+  beforeAll(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "opencode-markdown-"))
+
+    await writeFile(
+      path.join(dir, "quoted-hex.md"),
+      `---
+name: Quoted Hex
+color: "#008080"
+---
+
+Content
+`,
+    )
+
+    await writeFile(
+      path.join(dir, "unquoted-hex.md"),
+      `---
+name: Unquoted Hex
+color: #008080
+---
+
+Content
+`,
+    )
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test("should preserve quoted hex colors", async () => {
+    const result = await ConfigMarkdown.parse(path.join(dir, "quoted-hex.md"))
+    expect(result.data.color).toBe("#008080")
+  })
+
+  test("should recover unquoted hex colors that YAML treats as comments", async () => {
+    const result = await ConfigMarkdown.parse(path.join(dir, "unquoted-hex.md"))
+    expect(result.data.color).toBe("#008080")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #17118

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Recovers valid unquoted hex color values when parsing agent frontmatter so custom colors are preserved instead of being dropped.

### How did you verify your code works?

- Reproduced with unquoted hex custom color input.
- Confirmed parsed value is retained and custom color is restored.

### Screenshots / recordings

N/A (parser behavior fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
