### PR TITLE
fix(ci): use dynamic bun cache path for cross-platform support

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -32,7 +32,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-bun-
 

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -3,14 +3,6 @@ description: "Setup Bun with caching and install dependencies"
 runs:
   using: "composite"
   steps:
-    - name: Cache Bun dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.bun/install/cache
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
-        restore-keys: |
-          ${{ runner.os }}-bun-
-
     - name: Get baseline download URL
       id: bun-url
       shell: bash
@@ -30,6 +22,19 @@ runs:
       with:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Get cache directory
+      id: cache
+      shell: bash
+      run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Bun dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.cache.outputs.dir }}
+        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
 
     - name: Install setuptools for distutils compatibility
       run: python3 -m pip install setuptools || pip install setuptools || true


### PR DESCRIPTION
## Summary

- Fixes bun install cache not being restored on Windows CI runners (Blacksmith and GitHub-hosted)
- Root cause: the cache path was hardcoded to `~/.bun/install/cache`, but bun resolves the cache directory through a priority chain (`BUN_INSTALL_CACHE_DIR` > `BUN_INSTALL` > `XDG_CACHE_HOME` > `USERPROFILE`/`HOME`) — and `~` tilde expansion by `actions/cache` isn't guaranteed to match bun's actual resolution on all runner environments
- Fix: install bun first, then use `bun pm cache` to get the real cache directory and feed that into `actions/cache`

## Details

From the bun source (`src/install/PackageManager/PackageManagerDirectories.zig`), `fetchCacheDirectoryPath` resolves the install cache through:

1. ``
2. bunfig.toml `cache_directory`
3. `/install/cache/`
4. `/.bun/install/cache/`
5. `C:\Users\Lukem` (POSIX) / `%USERPROFILE%` (Windows) `/.bun/install/cache/`
6. Fallback: `node_modules/.bun-cache`

`bun pm cache` returns the exact resolved path, so using it as the source of truth eliminates any mismatch.