### PR TITLE
fix: suppress stale baseline-browser-mapping warning

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,3 +1,4 @@
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = "true"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"


### PR DESCRIPTION
## Summary

- Suppresses the noisy `[baseline-browser-mapping] The data in this module is over two months old` console warning that appears when running CLI commands in dev builds
- Sets `BROWSERSLIST_IGNORE_OLD_DATA=true` at process startup before any imports

## Context

`baseline-browser-mapping@2.10.0` is already the latest version on npm. The package has a built-in runtime check that warns when its baked-in data is >2 months old, but no newer release exists. The env var is the documented suppression mechanism from the package's README.

Dependency chain: `@jsx-email/cli` → `autoprefixer` → `browserslist` → `baseline-browser-mapping`