### PR TITLE
fix(tui): allow (@ to trigger file selector in prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -153,7 +153,8 @@ export function Autocomplete(props: {
     const currentCursorOffset = input.cursorOffset
 
     const charAfterCursor = props.value.at(currentCursorOffset)
-    const needsSpace = charAfterCursor !== " "
+    const charBeforeTrigger = store.index > 0 ? props.value.at(store.index - 1) : undefined
+    const needsSpace = charAfterCursor !== " " && charBeforeTrigger !== "("
     const append = "@" + text + (needsSpace ? " " : "")
 
     input.cursorOffset = store.index
@@ -535,7 +536,8 @@ export function Autocomplete(props: {
 
         const between = text.slice(idx)
         const before = idx === 0 ? undefined : value[idx - 1]
-        if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
+        const parenBefore = before === "(" && (idx <= 1 || /\s/.test(value[idx - 2]))
+        if ((before === undefined || /\s/.test(before) || parenBefore) && !between.match(/\s/)) {
           show("@")
           setStore("index", idx)
         }
@@ -585,7 +587,11 @@ export function Autocomplete(props: {
             const cursorOffset = props.input().cursorOffset
             const charBeforeCursor =
               cursorOffset === 0 ? undefined : props.input().getTextRange(cursorOffset - 1, cursorOffset)
-            const canTrigger = charBeforeCursor === undefined || charBeforeCursor === "" || /\s/.test(charBeforeCursor)
+            const parenTrigger =
+              charBeforeCursor === "(" &&
+              (cursorOffset <= 1 || /\s/.test(props.input().getTextRange(cursorOffset - 2, cursorOffset - 1)))
+            const canTrigger =
+              charBeforeCursor === undefined || charBeforeCursor === "" || /\s/.test(charBeforeCursor) || parenTrigger
             if (canTrigger) show("@")
           }
 


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/17129

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Allow `(@` to trigger the file selector popup in the TUI, so you can write things like `See this file (@path/to/file)`
- Only triggers when `(` is preceded by whitespace or is at the start of input — `foo(@` does not trigger
- Skips the trailing space after file selection when triggered via `(@` 

### How did you verify your code works?

Manually tested the dev build

### Screenshots / recordings

https://github.com/user-attachments/assets/3c515561-76df-4c2e-bd4f-0bfa3ce317a9

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
