### PR TITLE
fix(core): fix usage price when provider doesn't discount cache reads

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -761,7 +761,7 @@ export namespace Provider {
         input: model.cost?.input ?? 0,
         output: model.cost?.output ?? 0,
         cache: {
-          read: model.cost?.cache_read ?? 0,
+          read: model.cost?.cache_read ?? model.cost?.input ?? 0,
           write: model.cost?.cache_write ?? 0,
         },
         experimentalOver200K: model.cost?.context_over_200k
@@ -922,7 +922,12 @@ export namespace Provider {
             input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
             output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
             cache: {
-              read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
+              read:
+                model?.cost?.cache_read ??
+                existingModel?.cost?.cache.read ??
+                model?.cost?.input ??
+                existingModel?.cost?.input ??
+                0,
               write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
             },
           },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -493,6 +493,98 @@ test("model cost defaults to zero when not specified", async () => {
   })
 })
 
+test("cache read cost falls back to input cost when not specified", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "test-provider": {
+              name: "Test Provider",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "test-model": {
+                  name: "Test Model",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                  cost: {
+                    input: 5,
+                    output: 15,
+                  },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers[ProviderID.make("test-provider")].models["test-model"]
+      expect(model.cost.input).toBe(5)
+      expect(model.cost.output).toBe(15)
+      expect(model.cost.cache.read).toBe(5)
+      expect(model.cost.cache.write).toBe(0)
+    },
+  })
+})
+
+test("cache read cost uses explicit value when provided", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "test-provider": {
+              name: "Test Provider",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "test-model": {
+                  name: "Test Model",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                  cost: {
+                    input: 5,
+                    output: 15,
+                    cache_read: 1,
+                    cache_write: 2,
+                  },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers[ProviderID.make("test-provider")].models["test-model"]
+      expect(model.cost.input).toBe(5)
+      expect(model.cost.output).toBe(15)
+      expect(model.cost.cache.read).toBe(1)
+      expect(model.cost.cache.write).toBe(2)
+    },
+  })
+})
+
 test("model options are merged from existing model", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #17121

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When setting up the model object, the cost calculation for cache reads was falling back to 0. For providers that charge the same price for input caching, this caused the calculated cost to be dramatically lower than it should be. Changed the fallback to use the input token cost instead of 0 in both fromModelsDevModel() and the config provider section.

### How did you verify your code works?

Added unit tests, also ran opencode via `bun run dev serve` on the same project, with the same prompt and same initial starting conditions as described in #17121. I checked the context view and validated that the cost shown roughly matches what Together.AI charged.

### Screenshots / recordings

Proof of manual testing:
<img width="696" height="496" alt="image" src="https://github.com/user-attachments/assets/e3957ac5-8126-4d0a-a8e8-d980dacd6119" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
