### PR TITLE
fix: prioritize .bash_profile over .bashrc for bash on macOS

### DIFF
--- a/install
+++ b/install
@@ -386,7 +386,13 @@ case $current_shell in
         config_files="${ZDOTDIR:-$HOME}/.zshrc ${ZDOTDIR:-$HOME}/.zshenv $XDG_CONFIG_HOME/zsh/.zshrc $XDG_CONFIG_HOME/zsh/.zshenv"
     ;;
     bash)
-        config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+        # On macOS, Terminal opens login shells which source .bash_profile, not .bashrc.
+        # Prioritize .bash_profile on macOS to ensure the PATH update takes effect.
+        if [[ "$os" == "darwin" ]]; then
+            config_files="$HOME/.bash_profile $HOME/.bashrc $HOME/.profile $XDG_CONFIG_HOME/bash/.bash_profile $XDG_CONFIG_HOME/bash/.bashrc"
+        else
+            config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+        fi
     ;;
     ash)
         config_files="$HOME/.ashrc $HOME/.profile /etc/profile"


### PR DESCRIPTION
### Issue for this PR

Closes #17132

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On macOS, Terminal.app opens login shells which source `~/.bash_profile`, not `~/.bashrc`. The installer was checking `~/.bashrc` first in its candidate list, so if that file existed (common on macOS), the PATH export was written there instead of `~/.bash_profile`. This caused `opencode` to be missing from PATH in new terminal sessions.

The fix detects macOS via `uname -s` and reorders the config file candidates so `~/.bash_profile` is checked first for bash users on macOS. Linux behavior is unchanged.

### How did you verify your code works?

- Tested in Docker with a mocked `uname -s` returning `Darwin` — installer selects `.bash_profile`
- Tested on Linux (real `uname`) — installer still selects `.bashrc`
- No change in behaviour for zsh, fish, or other shells

### Screenshots / recordings

_N/A — this is a shell script change with no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR