### PR TITLE
feat(windows): add core pwsh/powershell shell support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -371,6 +371,7 @@
         "solid-js": "catalog:",
         "strip-ansi": "7.1.2",
         "tree-sitter-bash": "0.25.0",
+        "tree-sitter-powershell": "0.25.10",
         "turndown": "7.2.0",
         "ulid": "catalog:",
         "vscode-jsonrpc": "8.2.1",
@@ -574,8 +575,9 @@
     },
   },
   "trustedDependencies": [
-    "electron",
     "esbuild",
+    "tree-sitter-powershell",
+    "electron",
     "web-tree-sitter",
     "tree-sitter-bash",
   ],
@@ -4425,6 +4427,8 @@
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "tree-sitter-bash": ["tree-sitter-bash@0.25.0", "", { "dependencies": { "node-addon-api": "^8.2.1", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-gZtlj9+qFS81qKxpLfD6H0UssQ3QBc/F0nKkPsiFDyfQF2YBqYvglFJUzchrPpVhZe9kLZTrJ9n2J6lmka69Vg=="],
+
+    "tree-sitter-powershell": ["tree-sitter-powershell@0.25.10", "", { "dependencies": { "node-addon-api": "^7.1.0", "node-gyp-build": "^4.8.0" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-bEt8QoySpGFnU3aa8WedQyNMaN6aTwy/WUbvIVt0JSKF+BbJoSHNHu+wCbhj7xLMsfB0AuffmiJm+B8gzva8Lg=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "protobufjs",
     "tree-sitter",
     "tree-sitter-bash",
+    "tree-sitter-powershell",
     "web-tree-sitter",
     "electron"
   ],

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -129,6 +129,7 @@
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",
+    "tree-sitter-powershell": "0.25.10",
     "turndown": "7.2.0",
     "ulid": "catalog:",
     "vscode-jsonrpc": "8.2.1",

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -121,7 +121,7 @@ export namespace Pty {
     const id = PtyID.ascending()
     const command = input.command || Shell.preferred()
     const args = input.args || []
-    if (command.endsWith("sh")) {
+    if (Shell.login(command)) {
       args.push("-l")
     }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1571,9 +1571,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }
     await Session.updatePart(part)
     const shell = Shell.preferred()
-    const shellName = (
-      process.platform === "win32" ? path.win32.basename(shell, ".exe") : path.basename(shell)
-    ).toLowerCase()
+    const shellName = Shell.name(shell)
 
     const invocations: Record<string, { args: string[] }> = {
       nu: {

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -9,6 +9,9 @@ import { setTimeout as sleep } from "node:timers/promises"
 const SIGKILL_TIMEOUT_MS = 200
 
 export namespace Shell {
+  const BLACKLIST = new Set(["fish", "nu"])
+  const LOGIN = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"])
+
   export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
     const pid = proc.pid
     if (!pid || opts?.exited?.()) return
@@ -39,7 +42,29 @@ export namespace Shell {
       }
     }
   }
-  const BLACKLIST = new Set(["fish", "nu"])
+
+  function full(file: string) {
+    if (process.platform !== "win32") return file
+    const shell = Filesystem.windowsPath(file)
+    if (path.win32.dirname(shell) !== ".") return shell
+    return Bun.which(shell) || shell
+  }
+
+  function pick() {
+    const pwsh = Bun.which("pwsh")
+    if (pwsh) return pwsh
+    const powershell = Bun.which("powershell")
+    if (powershell) return powershell
+  }
+
+  function select(file: string | undefined, opts?: { acceptable?: boolean }) {
+    if (file && (!opts?.acceptable || !BLACKLIST.has(name(file)))) return full(file)
+    if (process.platform === "win32") {
+      const shell = pick()
+      if (shell) return shell
+    }
+    return fallback()
+  }
 
   function fallback() {
     if (process.platform === "win32") {
@@ -59,15 +84,16 @@ export namespace Shell {
     return "/bin/sh"
   }
 
-  export const preferred = lazy(() => {
-    const s = process.env.SHELL
-    if (s) return s
-    return fallback()
-  })
+  export function name(file: string) {
+    if (process.platform === "win32") return path.win32.parse(Filesystem.windowsPath(file)).name.toLowerCase()
+    return path.basename(file).toLowerCase()
+  }
 
-  export const acceptable = lazy(() => {
-    const s = process.env.SHELL
-    if (s && !BLACKLIST.has(process.platform === "win32" ? path.win32.basename(s) : path.basename(s))) return s
-    return fallback()
-  })
+  export function login(file: string) {
+    return LOGIN.has(name(file))
+  }
+
+  export const preferred = lazy(() => select(process.env.SHELL))
+
+  export const acceptable = lazy(() => select(process.env.SHELL, { acceptable: true }))
 }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -20,6 +20,7 @@ import { Plugin } from "@/plugin"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
+const PS = new Set(["powershell", "pwsh"])
 
 export const log = Log.create({ service: "bash-tool" })
 
@@ -44,20 +45,55 @@ const parser = lazy(async () => {
   const { default: bashWasm } = await import("tree-sitter-bash/tree-sitter-bash.wasm" as string, {
     with: { type: "wasm" },
   })
+  const { default: psWasm } = await import("tree-sitter-powershell/tree-sitter-powershell.wasm" as string, {
+    with: { type: "wasm" },
+  })
   const bashPath = resolveWasm(bashWasm)
-  const bashLanguage = await Language.load(bashPath)
-  const p = new Parser()
-  p.setLanguage(bashLanguage)
-  return p
+  const psPath = resolveWasm(psWasm)
+  const [bashLanguage, psLanguage] = await Promise.all([Language.load(bashPath), Language.load(psPath)])
+  const bash = new Parser()
+  bash.setLanguage(bashLanguage)
+  const ps = new Parser()
+  ps.setLanguage(psLanguage)
+  return { bash, ps }
 })
+
+function launch(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
+  if (process.platform === "win32" && PS.has(name)) {
+    return spawn(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    windowsHide: true,
+    })
+  }
+
+  return spawn(command, {
+    shell,
+    cwd,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    windowsHide: true,
+  })
+}
 
 // TODO: we may wanna rename this tool so it works better on other shells
 export const BashTool = Tool.define("bash", async () => {
   const shell = Shell.acceptable()
+  const name = Shell.name(shell)
+  const chain =
+    name === "powershell"
+      ? "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
+      : "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
   log.info("bash tool using shell", { shell })
 
   return {
     description: DESCRIPTION.replaceAll("${directory}", Instance.directory)
+      .replaceAll("${os}", process.platform)
+      .replaceAll("${shell}", name)
+      .replaceAll("${chaining}", chain)
       .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
       .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES)),
     parameters: z.object({
@@ -81,7 +117,8 @@ export const BashTool = Tool.define("bash", async () => {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
       const timeout = params.timeout ?? DEFAULT_TIMEOUT
-      const tree = await parser().then((p) => p.parse(params.command))
+      // Always use bash parser for permission scanning — PS-aware parsing comes later
+      const tree = await parser().then((p) => p.bash.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")
       }
@@ -164,16 +201,9 @@ export const BashTool = Tool.define("bash", async () => {
         { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
         { env: {} },
       )
-      const proc = spawn(params.command, {
-        shell,
-        cwd,
-        env: {
-          ...process.env,
-          ...shellEnv.env,
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-        detached: process.platform !== "win32",
-        windowsHide: process.platform === "win32",
+      const proc = launch(shell, name, params.command, cwd, {
+        ...process.env,
+        ...shellEnv.env,
       })
 
       let output = ""

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -1,5 +1,7 @@
 Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
 
+Be aware: OS: ${os}, Shell: ${shell}
+
 All commands run in ${directory} by default. Use the `workdir` parameter if you need to run a command in a different directory. AVOID using `cd <directory> && <command>` patterns - use `workdir` instead.
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO NOT use it for file operations (reading, writing, editing, searching, finding files) - use the specialized tools for this instead.
@@ -35,7 +37,7 @@ Usage notes:
     - Communication: Output text directly (NOT echo/printf)
   - When issuing multiple commands:
     - If the commands are independent and can run in parallel, make multiple Bash tool calls in a single message. For example, if you need to run "git status" and "git diff", send a single message with two Bash tool calls in parallel.
-    - If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m "message" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead.
+    - ${chaining}
     - Use ';' only when you need to run commands sequentially but don't care if earlier commands fail
     - DO NOT use newlines to separate commands (newlines are ok in quoted strings)
   - AVOID using `cd <directory> && <command>`. Use the `workdir` parameter to change directories instead.

--- a/packages/opencode/test/pty/pty-shell.test.ts
+++ b/packages/opencode/test/pty/pty-shell.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Pty } from "../../src/pty"
+import { tmpdir } from "../fixture/fixture"
+
+describe("pty shell args", () => {
+  if (process.platform !== "win32") return
+
+  const ps = Bun.which("pwsh") || Bun.which("powershell")
+  if (ps) {
+    test(
+      "does not add login args to pwsh",
+      async () => {
+        await using dir = await tmpdir()
+        await Instance.provide({
+          directory: dir.path,
+          fn: async () => {
+            const info = await Pty.create({ command: ps, title: "pwsh" })
+            try {
+              expect(info.args).toEqual([])
+            } finally {
+              await Pty.remove(info.id)
+            }
+          },
+        })
+      },
+      { timeout: 30000 },
+    )
+  }
+
+  const bash = Bun.which("bash")
+  if (bash) {
+    test(
+      "adds login args to bash",
+      async () => {
+        await using dir = await tmpdir()
+        await Instance.provide({
+          directory: dir.path,
+          fn: async () => {
+            const info = await Pty.create({ command: bash, title: "bash" })
+            try {
+              expect(info.args).toEqual(["-l"])
+            } finally {
+              await Pty.remove(info.id)
+            }
+          },
+        })
+      },
+      { timeout: 30000 },
+    )
+  }
+})

--- a/packages/opencode/test/shell/shell.test.ts
+++ b/packages/opencode/test/shell/shell.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Shell } from "../../src/shell/shell"
+import { Filesystem } from "../../src/util/filesystem"
+
+const withShell = async (shell: string | undefined, fn: () => void | Promise<void>) => {
+  const prev = process.env.SHELL
+  if (shell === undefined) delete process.env.SHELL
+  else process.env.SHELL = shell
+  Shell.acceptable.reset()
+  Shell.preferred.reset()
+  try {
+    await fn()
+  } finally {
+    if (prev === undefined) delete process.env.SHELL
+    else process.env.SHELL = prev
+    Shell.acceptable.reset()
+    Shell.preferred.reset()
+  }
+}
+
+describe("shell", () => {
+  test("normalizes shell names", () => {
+    expect(Shell.name("/bin/bash")).toBe("bash")
+    if (process.platform === "win32") {
+      expect(Shell.name("C:/tools/NU.EXE")).toBe("nu")
+      expect(Shell.name("C:/tools/PWSH.EXE")).toBe("pwsh")
+    }
+  })
+
+  test("detects login shells", () => {
+    expect(Shell.login("/bin/bash")).toBe(true)
+    expect(Shell.login("C:/tools/pwsh.exe")).toBe(false)
+  })
+
+  if (process.platform === "win32") {
+    test("rejects blacklisted shells case-insensitively", async () => {
+      await withShell("NU.EXE", async () => {
+        expect(Shell.name(Shell.acceptable())).not.toBe("nu")
+      })
+    })
+
+    test("normalizes Git Bash shell paths from env", async () => {
+      const shell = "/cygdrive/c/Program Files/Git/bin/bash.exe"
+      await withShell(shell, async () => {
+        expect(Shell.preferred()).toBe(Filesystem.windowsPath(shell))
+      })
+    })
+
+    test("resolves bare PowerShell shells", async () => {
+      const shell = Bun.which("pwsh") || Bun.which("powershell")
+      if (!shell) return
+      await withShell(path.win32.basename(shell), async () => {
+        expect(Shell.preferred()).toBe(shell)
+      })
+    })
+  }
+})

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -30,7 +30,7 @@ describe("tool.bash", () => {
         const bash = await BashTool.init()
         const result = await bash.execute(
           {
-            command: "echo 'test'",
+            command: "echo test",
             description: "Echo test message",
           },
           ctx,

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,8 @@
     },
     "opencode#test": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": [],
+      "passThroughEnv": ["*"]
     },
     "@opencode-ai/app#test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Surgical PR that adds first-class pwsh/powershell execution support on Windows, without refactoring the bash tool's inline logic. Split from #16069 to keep scope tight.

- **Shell resolution**: New `Shell.name()`, `Shell.login()`, `full()`, `pick()`, `select()` helpers. On Windows, prefers `pwsh` > `powershell` > Git Bash > cmd as fallback chain. Normalizes cygdrive/MSYS paths and resolves bare shell names via `Bun.which()`.
- **PowerShell execution**: `launch()` function spawns pwsh with `-NoLogo -NoProfile -NonInteractive -Command` instead of using `shell` option. Adds `tree-sitter-powershell` for future PS-aware parsing.
- **Shell-aware tool description**: Bash tool prompt now includes OS/shell info and PowerShell-specific chaining guidance (no `&&` in PS 5.1).
- **PTY login fix**: Uses `Shell.login()` allowlist instead of `.endsWith("sh")` so pwsh doesn't get `-l` flag.

### What's deferred (PR 2+)
- PowerShell-aware permission parsing (cmdlet recognition, `$env:` expansion, PS flag/switch handling)
- Windows path normalization (`normalizePath` improvements, `normalizePathPattern`)
- Bash tool structural refactor (extract inline execute into helpers)

### Testing
- New `test/shell/shell.test.ts` — name normalization, login detection, blacklist, Git Bash paths, bare PS resolution
- New `test/pty/pty-shell.test.ts` — pwsh gets no `-l`, bash gets `-l`
- Existing bash tool tests pass (permission scanning still uses bash parser)
