### PR TITLE
fix(app): prevent session scroll interference when navigating messages from prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1223,7 +1223,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               aria-label={placeholder()}
               contenteditable="true"
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
-              autocorrect={store.mode === "normal" ? "on" : "off"}
+              autocorrect="off"
               spellcheck={store.mode === "normal"}
               onInput={handleInput}
               onPaste={handlePaste}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1118,7 +1118,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (event.key === "ArrowUp" || event.key === "ArrowDown") {
-      if (event.altKey || event.ctrlKey || event.metaKey) return
+      if (event.altKey || event.ctrlKey || event.metaKey) {
+        event.stopImmediatePropagation()
+        return
+      }
+
       const { collapsed } = getCaretState()
       if (!collapsed) return
 


### PR DESCRIPTION
### Issue for this PR

Closes #17139 #17931

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two issues with the prompt input on macOS:

1. **Cursor jump on mod+Arrow keys** — `cmd+ArrowUp` / `cmd+ArrowDown` was triggering global session navigation commands (`message.previous` / `message.next`) even when the prompt input was focused, scrolling the chat history instead of moving the cursor. Fixed by calling `stopImmediatePropagation` in the prompt input's `onKeyDown` handler when modifier keys are held with arrow keys.

2. **Cursor desync from macOS text substitution** — macOS autocorrect (e.g. `---` → `—`) mutates the DOM outside the app's control, causing the cursor position to jump unexpectedly. Fixed by setting `autocorrect="off"` unconditionally on the `contenteditable` element.

### How did you verify your code works?

1. Opened a session with multiple messages
2. Focused the prompt input
3. Pressed `cmd+ArrowUp` / `cmd+ArrowDown` — cursor moves within prompt, not session
4. Typed `---` — text stays as-is, cursor position remains stable

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
