### PR TITLE
fix(tui): prevent keybind dispatch during modal prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -60,6 +60,7 @@ function init() {
   useKeyboard((evt) => {
     if (suspended()) return
     if (dialog.stack.length > 0) return
+    if (evt.defaultPrevented) return
     for (const option of entries()) {
       if (!isEnabled(option)) continue
       if (option.keybind && keybind.match(option.keybind, evt)) {
@@ -93,7 +94,7 @@ function init() {
       })
     },
     keybinds(enabled: boolean) {
-      setSuspendCount((count) => count + (enabled ? -1 : 1))
+      setSuspendCount((count) => Math.max(0, count + (enabled ? -1 : 1)))
     },
     suspended,
     show() {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, For, Match, Show, Switch } from "solid-js"
+import { createMemo, For, Match, onCleanup, onMount, Show, Switch } from "solid-js"
 import { Portal, useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
@@ -16,6 +16,7 @@ import { Locale } from "@/util/locale"
 import { Global } from "@/global"
 import { useDialog } from "../../ui/dialog"
 import { useTuiConfig } from "../../context/tui-config"
+import { useCommandDialog } from "../../component/dialog-command"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -129,9 +130,13 @@ function TextBody(props: { title: string; description?: string; icon?: string })
 export function PermissionPrompt(props: { request: PermissionRequest }) {
   const sdk = useSDK()
   const sync = useSync()
+  const command = useCommandDialog()
   const [store, setStore] = createStore({
     stage: "permission" as PermissionStage,
   })
+
+  onMount(() => command.keybinds(false))
+  onCleanup(() => command.keybinds(true))
 
   const session = createMemo(() => sync.data.session.find((s) => s.id === props.request.sessionID))
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, createSignal, For, Show } from "solid-js"
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
@@ -9,12 +9,17 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
 import { useTextareaKeybindings } from "../../component/textarea-keybindings"
 import { useDialog } from "../../ui/dialog"
+import { useCommandDialog } from "../../component/dialog-command"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
   const { theme } = useTheme()
   const keybind = useKeybind()
   const bindings = useTextareaKeybindings()
+  const command = useCommandDialog()
+
+  onMount(() => command.keybinds(false))
+  onCleanup(() => command.keybinds(true))
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)


### PR DESCRIPTION
### Issue for this PR

Closes #7496

### Type of change

- [x] Bug fix

### What does this PR do?

CommandProvider's `useKeyboard` handler fires before QuestionPrompt's handler because opentui dispatches in parent-first mount order. So pressing Tab during a question triggers `agent_cycle` before the prompt can handle it.

This PR suspends command keybinds while QuestionPrompt/PermissionPrompt are active, using the same `keybinds(false/true)` pattern already used in autocomplete.tsx. Also added `defaultPrevented` guard and clamped `suspendCount` to prevent mismatched calls.

### How did you verify your code works?

- `bun test` — 598 pass, 0 fail
- Ran `bun run dev`, triggered QuestionPrompt, pressed Tab — tab navigation works, no agent switch

### Screen recording

https://github.com/user-attachments/assets/1a1e05d0-56a5-4b10-b500-d2ec63fed1b4


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR