### PR TITLE
add session.retry.delegate_to_plugin configuration

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1199,6 +1199,21 @@ export namespace Config {
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
         })
         .optional(),
+      session: z
+        .object({
+          retry: z
+            .object({
+              enabled: z.boolean().optional().describe("Enable native retry logic (default: true)"),
+              delegate_to_plugin: z
+                .boolean()
+                .optional()
+                .describe("Delegate retry logic to active plugins (e.g., oh-my-opencode). When true, native retry is disabled."),
+            })
+            .optional()
+            .describe("Session retry configuration"),
+        })
+        .optional()
+        .describe("Session configuration"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -364,8 +364,13 @@ export namespace SessionProcessor {
                 error,
               })
             } else {
+              // Check if retry should be delegated to plugins
+              const config = await Config.get()
+              const delegateRetryToPlugin = config.session?.retry?.delegate_to_plugin === true
+              const nativeRetryEnabled = config.session?.retry?.enabled !== false
+
               const retry = SessionRetry.retryable(error)
-              if (retry !== undefined) {
+              if (retry !== undefined && nativeRetryEnabled && !delegateRetryToPlugin) {
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 SessionStatus.set(input.sessionID, {


### PR DESCRIPTION
## Summary

 This PR adds a configuration option to delegate retry logic to active plugins (e.g., oh-my-opencode).

 ## Problem

 When a provider is rate-limited, OpenCode's native retry:
 1. Reads the retry-after header (often 2-4 hours)
 2. Sleeps for that duration
 3. Retries the SAME model
 4. Gets rate-limited again
 5. Repeats infinitely

 Plugins like oh-my-opencode have sophisticated fallback logic (global blacklist, multiple fallback models) but can't intervene because OpenCode handles
 the error internally.

 ## Solution

 Added session.retry.delegate_to_plugin configuration:
 - When true: OpenCode skips native retry and lets plugins handle fallback
 - When false or unset: OpenCode uses native retry (backward compatible)
 - Default: native retry enabled

 ## Changes

 ### config.ts
 - Added session.retry.delegate_to_plugin config option
 - Schema validation for new configuration

 ### processor.ts
 - Check delegate_to_plugin flag before scheduling native retry
 - Skip native retry when plugin delegation is enabled

 ## Integration with oh-my-opencode

 The oh-my-opencode plugin automatically sets this flag to true on initialization, ensuring:
 - Rate-limited providers are globally blacklisted for 1 hour
 - All new sessions/subagents skip blacklisted providers
 - Automatic fallback to available models (Kimi, GLM, OpenAI, etc.)
 - No more infinite retry loops

 ## Testing

 - Type checking passes ✅
 - Backward compatible (default behavior unchanged) ✅
 - Tested with oh-my-opencode plugin ✅
