### PR TITLE
Add opencode-papersflow plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,7 +49,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
-| [opencode-papersflow](https://github.com/papersflow-ai/opencode-papersflow)                        | Search 474M+ academic papers, verify citations, and explore citation graphs via [PapersFlow](https://papersflow.ai) |
+| [@papersflow/opencode-papersflow](https://github.com/papersflow-ai/opencode-papersflow)             | Search 474M+ academic papers, verify citations, and explore citation graphs via [PapersFlow](https://papersflow.ai) |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,6 +49,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-papersflow](https://github.com/papersflow-ai/opencode-papersflow)                        | Search 474M+ academic papers, verify citations, and explore citation graphs via [PapersFlow](https://papersflow.ai) |
 
 ---
 


### PR DESCRIPTION
Adds [opencode-papersflow](https://github.com/papersflow-ai/opencode-papersflow) to the Plugins section.

An OpenCode plugin by [PapersFlow](https://papersflow.ai) that exposes academic research tools — search 474M+ papers from Semantic Scholar and OpenAlex, verify citations (DOI/arXiv/PubMed), and explore citation graphs.

**Install**: `"plugin": ["opencode-papersflow"]` in `opencode.json`
**npm**: `opencode-papersflow`
**License**: MIT