### PR TITLE
fix(windows): restore /editor support on Windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -17,17 +17,21 @@ export namespace Editor {
     await Filesystem.write(filepath, opts.value)
     opts.renderer.suspend()
     opts.renderer.currentRenderBuffer.clear()
-    const parts = editor.split(" ")
-    const proc = Process.spawn([...parts, filepath], {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    })
-    await proc.exited
-    const content = await Filesystem.readText(filepath)
-    opts.renderer.currentRenderBuffer.clear()
-    opts.renderer.resume()
-    opts.renderer.requestRender()
-    return content || undefined
+    try {
+      const parts = editor.split(" ")
+      const proc = Process.spawn([...parts, filepath], {
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+        shell: process.platform === "win32",
+      })
+      await proc.exited
+      const content = await Filesystem.readText(filepath)
+      return content || undefined
+    } finally {
+      opts.renderer.currentRenderBuffer.clear()
+      opts.renderer.resume()
+      opts.renderer.requestRender()
+    }
   }
 }

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -3,6 +3,7 @@ import { buffer } from "node:stream/consumers"
 
 export namespace Process {
   export type Stdio = "inherit" | "pipe" | "ignore"
+  export type Shell = boolean | string
 
   export interface Options {
     cwd?: string
@@ -10,6 +11,7 @@ export namespace Process {
     stdin?: Stdio
     stdout?: Stdio
     stderr?: Stdio
+    shell?: Shell
     abort?: AbortSignal
     kill?: NodeJS.Signals | number
     timeout?: number
@@ -60,6 +62,7 @@ export namespace Process {
       cwd: opts.cwd,
       env: opts.env === null ? {} : opts.env ? { ...process.env, ...opts.env } : undefined,
       stdio: [opts.stdin ?? "ignore", opts.stdout ?? "ignore", opts.stderr ?? "ignore"],
+      shell: opts.shell,
       windowsHide: process.platform === "win32",
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #17117

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes `/editor` being unavailable on Windows.

I referred to the Node.js `child_process` documentation for Windows command
spawning behavior:
https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows

According to that documentation, `.bat` and `.cmd` files may need to be launched
through a shell on Windows. In practice, commands such as `$env:EDITOR = "code --wait"`
could hang or fail to launch correctly when spawned without shell support.

This PR enables `shell` when launching the editor on Windows, so editor commands
like `code --wait` can be started correctly there and `/editor` works again.

### How did you verify your code works?

Tested locally on Windows by running `/editor` and confirming:
- the editor opens correctly
- the edited content is saved and returned correctly

### Screenshots / recordings

Included below.
<img width="1606" height="577" alt="image" src="https://github.com/user-attachments/assets/cacbc472-59f2-4341-a286-73c168968f09" />
<img width="974" height="370" alt="image" src="https://github.com/user-attachments/assets/0ec51430-0394-4e0f-bac8-fbcb97f811f2" />
Then close code.
<img width="1551" height="557" alt="image" src="https://github.com/user-attachments/assets/a146129e-a796-4f79-b88a-78c7f167423b" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR