### PR TITLE
fix: migrate sessions from global to git project after init

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -230,9 +230,6 @@ export namespace Project {
           updated: Date.now(),
         },
       }
-      if (data.id !== ProjectID.global) {
-        await migrateFromGlobal(data.id, data.worktree)
-      }
       return fresh
     })
 
@@ -277,6 +274,11 @@ export namespace Project {
     Database.use((db) =>
       db.insert(ProjectTable).values(insert).onConflictDoUpdate({ target: ProjectTable.id, set: updateSet }).run(),
     )
+
+    if (data.id !== ProjectID.global) {
+      await migrateFromGlobal(data.id, data.worktree)
+    }
+
     GlobalBus.emit("event", {
       payload: {
         type: Event.Updated.type,

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -7,6 +7,11 @@ import { tmpdir } from "../fixture/fixture"
 import { Filesystem } from "../../src/util/filesystem"
 import { GlobalBus } from "../../src/bus/global"
 import { ProjectID } from "../../src/project/schema"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
+import { Database } from "../../src/storage/db"
+import { SessionTable } from "../../src/session/session.sql"
+import { eq } from "../../src/storage/db"
 
 Log.init({ print: false })
 
@@ -345,5 +350,57 @@ describe("Project.update", () => {
     expect(updated.icon?.url).toBe("https://example.com/favicon.ico")
     expect(updated.icon?.color).toBe("#00ff00")
     expect(updated.commands?.start).toBe("make start")
+  })
+})
+
+describe("Project session migration", () => {
+  test("migrates sessions from global to git project after git init", async () => {
+    await using tmp = await tmpdir()
+
+    const globalProject = await Project.fromDirectory(tmp.path)
+    expect(globalProject.project.id).toBe(ProjectID.global)
+
+    const sessions = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session1 = await Session.create({ title: "Session before git init" })
+        const session2 = await Session.create({ title: "Another pre-git session" })
+
+        const globalSessions = [...Session.list({ roots: true })]
+        expect(globalSessions.length).toBe(2)
+        expect(globalSessions.map((s) => s.id)).toContain(session1.id)
+        expect(globalSessions.map((s) => s.id)).toContain(session2.id)
+
+        return { session1, session2 }
+      },
+    })
+
+    await $`git init`.cwd(tmp.path).quiet()
+    await $`git config user.email "test@test.com"`.cwd(tmp.path).quiet()
+    await $`git config user.name "Test User"`.cwd(tmp.path).quiet()
+    await $`git commit --allow-empty -m "initial commit"`.cwd(tmp.path).quiet()
+
+    const gitProject = await Project.fromDirectory(tmp.path)
+    expect(gitProject.project.id).not.toBe(ProjectID.global)
+    expect(gitProject.project.vcs).toBe("git")
+
+    const migratedRows = Database.use((db) =>
+      db.select().from(SessionTable).where(eq(SessionTable.project_id, gitProject.project.id)).all(),
+    )
+    expect(migratedRows.length).toBe(2)
+
+    await Instance.reload({
+      directory: tmp.path,
+      project: gitProject.project,
+      worktree: gitProject.project.worktree,
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const gitSessions = [...Session.list({ roots: true })]
+        expect(gitSessions.length).toBe(2)
+      },
+    })
   })
 })


### PR DESCRIPTION
Fixes #16812

## Problem
Sessions created before a git repository has commits are stored under `project_id = "global"`. When a commit is made and opencode resolves a real project ID (the root commit SHA), the sessions were not being migrated properly.

## Root Causes
1. **FK constraint violation:** `migrateFromGlobal()` was called *before* the target project row was inserted into the `project` table, causing the UPDATE to be rejected due to the foreign key constraint on `session.project_id`.
2. **One-shot gate:** The migration only ran inside the `if (!row)` branch — i.e., only when a new project row was created. Sessions accumulated under "global" after the real project row already existed were never migrated.

## Solution
- Moved `migrateFromGlobal()` call to **after** the project row is inserted/updated
- The migration now runs every time `fromDirectory` is called with a non-global project ID, not just when creating a new project row
- Added a test case that reproduces the bug scenario

## Verification
- New test passes: `migrates sessions from global to git project after git init`
- All existing project tests pass (18 tests)
- Typecheck passes for all packages