### PR TITLE
fix(ui): prevent long filenames from overlapping actions

### DIFF
--- a/packages/ui/src/components/session-review.css
+++ b/packages/ui/src/components/session-review.css
@@ -125,7 +125,10 @@
 
   [data-slot="session-review-filename"] {
     color: var(--text-strong);
-    flex-shrink: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   [data-slot="session-review-view-button"] {

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -190,9 +190,12 @@
   }
 
   [data-slot="session-turn-diff-filename"] {
-    flex-shrink: 0;
+    min-width: 0;
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   [data-slot="session-turn-diff-meta"] {


### PR DESCRIPTION
### Issue for this PR

Closes #17112

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- truncate long filenames (by using ellipsis) in the diff viewer (session and last turn changes view)

### How did you verify your code works?

Tested the fixes locally

### Screenshots / recordings

https://github.com/user-attachments/assets/dd5a1e11-0fdc-42a4-8d92-ec14d4057669

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
