### PR TITLE
fix(install): prioritize .bash_profile over .bashrc on macOS

### DIFF
--- a/install
+++ b/install
@@ -386,7 +386,13 @@ case $current_shell in
         config_files="${ZDOTDIR:-$HOME}/.zshrc ${ZDOTDIR:-$HOME}/.zshenv $XDG_CONFIG_HOME/zsh/.zshrc $XDG_CONFIG_HOME/zsh/.zshenv"
     ;;
     bash)
-        config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+        # On macOS, Terminal.app and iTerm open login shells which source .bash_profile,
+        # not .bashrc. Prioritize .bash_profile on macOS to ensure PATH is set correctly.
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            config_files="$HOME/.bash_profile $HOME/.bashrc $HOME/.profile $XDG_CONFIG_HOME/bash/.bash_profile $XDG_CONFIG_HOME/bash/.bashrc"
+        else
+            config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"
+        fi
     ;;
     ash)
         config_files="$HOME/.ashrc $HOME/.profile /etc/profile"


### PR DESCRIPTION
## Summary

On macOS, Terminal.app and iTerm open login shells by default, which source `~/.bash_profile` but not `~/.bashrc`. The installer was checking `~/.bashrc` first, causing the PATH export to be written to a file that's never sourced in new terminal sessions.

## Changes

- Reorder the config file candidates for bash on macOS to check `~/.bash_profile` first
- Linux behavior is unchanged since non-login interactive shells source `~/.bashrc`

## Testing

Tested on macOS with bash:
1. `~/.bashrc` exists
2. Run installer
3. Verify PATH is written to `~/.bash_profile`
4. Open new terminal → `opencode` is found

Fixes #17132