### PR TITLE
fix(cost): charge cached tokens at input rate when provider has no cache pricing

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -849,12 +849,20 @@ export namespace Session {
         input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
           ? input.model.cost.experimentalOver200K
           : input.model.cost
+
+      // When a provider reports cached tokens but doesn't actually support input caching
+      // (cache.read price is 0), charge those tokens at the full input rate.
+      // This fixes cost underestimation for providers like Together.AI that report
+      // cached_tokens from vLLM but don't offer discounted cache pricing.
+      const cacheReadPrice = costInfo?.cache?.read ?? 0
+      const effectiveCacheReadPrice = cacheReadPrice === 0 ? (costInfo?.input ?? 0) : cacheReadPrice
+
       return {
         cost: safe(
           new Decimal(0)
             .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
             .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.cache.read).mul(effectiveCacheReadPrice).div(1_000_000))
             .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
             // TODO: update models.dev to have better pricing model, for now:
             // charge reasoning tokens at the same rate as output tokens


### PR DESCRIPTION
### Issue for this PR

Closes #17121

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes incorrect cost calculation for providers that report cached tokens but do not actually support input caching (e.g., Together.AI).

**The Problem:**
Together.AI forwards `cached_tokens` from vLLM in their usage response, but they charge these tokens at the full input rate (no cache discount). The current code calculates:
```typescript
.add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
```
When `cache.read` is 0 (no caching support), all cached tokens are calculated as $0.

**Real Example from #17121:**
- Kimi K2.5 via Together.AI: 564,382 cached tokens at $0.5/MTok input rate
- Before fix: $0.07 (cached tokens = $0)
- After fix: $0.32 (cached tokens charged at input rate)

**The Fix:**
```typescript
const cacheReadPrice = costInfo?.cache?.read ?? 0
const effectiveCacheReadPrice = cacheReadPrice === 0 ? (costInfo?.input ?? 0) : cacheReadPrice
```
When cache_read price is 0 (provider doesnt support caching), fall back to input token rate.

**Why it works:**
If a provider reports cached tokens but has no cache pricing, those tokens were still processed and should be charged. The only sensible fallback is the standard input rate.

### How did you verify your code works?

1. Traced the cost calculation logic in `session/index.ts`
2. Verified the math: 564,382 tokens × $0.5/1M = $0.28 (plus output tokens ≈ $0.32 total)
3. Confirmed the change only affects providers with cache.read = 0

### Screenshots / recordings

N/A - backend calculation change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR