### PR TITLE
fix: route prompt input to parent session when viewing subagent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -421,7 +421,7 @@ export function Session() {
               })
               if (child) scroll.scrollBy(child.y - scroll.y - 1)
             }}
-            sessionID={route.sessionID}
+            sessionID={session()?.parentID ?? route.sessionID}
             setPrompt={(promptInfo) => prompt.set(promptInfo)}
           />
         ))
@@ -444,7 +444,7 @@ export function Session() {
               })
               if (child) scroll.scrollBy(child.y - scroll.y - 1)
             }}
-            sessionID={route.sessionID}
+            sessionID={session()?.parentID ?? route.sessionID}
           />
         ))
       },
@@ -1144,7 +1144,7 @@ export function Session() {
                           dialog.replace(() => (
                             <DialogMessage
                               messageID={message.id}
-                              sessionID={route.sessionID}
+                              sessionID={session()?.parentID ?? route.sessionID}
                               setPrompt={(promptInfo) => prompt.set(promptInfo)}
                             />
                           ))
@@ -1186,7 +1186,7 @@ export function Session() {
                 onSubmit={() => {
                   toBottom()
                 }}
-                sessionID={route.sessionID}
+                sessionID={session()?.parentID ?? route.sessionID}
               />
             </box>
           </Show>
@@ -1195,7 +1195,7 @@ export function Session() {
         <Show when={sidebarVisible()}>
           <Switch>
             <Match when={wide()}>
-              <Sidebar sessionID={route.sessionID} />
+              <Sidebar sessionID={session()?.parentID ?? route.sessionID} />
             </Match>
             <Match when={!wide()}>
               <box
@@ -1207,7 +1207,7 @@ export function Session() {
                 alignItems="flex-end"
                 backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
               >
-                <Sidebar sessionID={route.sessionID} />
+                <Sidebar sessionID={session()?.parentID ?? route.sessionID} />
               </box>
             </Match>
           </Switch>


### PR DESCRIPTION
### Issue for this PR
Closes #4422

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When viewing a subagent (child) session, the Prompt component was always 
sending input to route.sessionID which is the child session ID. So any 
input typed while in a subagent view would go to the incorrect wrong session.

Fixed by passing session()?.parentID ?? route.sessionID to the Prompt's 
sessionID prop, so when you're in a child session it routes input correctly to the 
parent instead.

### How did you verify your code works?
Ran the project locally with bun dev, navigated into a subagent session 
and verified that input now goes to the parent session correctly.

### Screenshots / recordings
Terminal UI change
Unable to capture a before/after screenshot as the bug 
requires navigating into an active subagent session to reproduce. The fix is 
a one-line change to the sessionID prop on the Prompt component.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR