### PR TITLE
fix: log cleanup threshold and bus subscription memory leak

### DIFF
--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -100,6 +100,9 @@ export namespace Bus {
       const index = match.indexOf(callback)
       if (index === -1) return
       match.splice(index, 1)
+      if (match.length === 0) {
+        subscriptions.delete(type)
+      }
     }
   }
 }

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -83,7 +83,7 @@ export namespace Log {
       absolute: true,
       include: "file",
     })
-    if (files.length <= 5) return
+    if (files.length <= 10) return
 
     const filesToDelete = files.slice(0, -10)
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))


### PR DESCRIPTION
Two small bug fixes:
1. Log cleanup threshold (src/util/log.ts): Fixed inconsistent threshold check - was checking files.length <= 5 but keeping last 10 files with slice. Changed to files.length <= 10 to match the slice logic.
2. Bus subscription memory leak (src/bus/index.ts): When all subscribers for an event type unsubscribed, the empty array remained in the subscriptions Map. Added cleanup to delete the key when the array becomes empty.

Fixes #17185