### PR TITLE
docs: Remove duplicate data usage note for MiniMax M2.5 Free

### DIFF
--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -223,7 +223,6 @@ All our models are hosted in the US. Our providers follow a zero-retention polic
 
 - Big Pickle: During its free period, collected data may be used to improve the model.
 - MiniMax M2.5 Free: During its free period, collected data may be used to improve the model.
-- MiniMax M2.5 Free: During its free period, collected data may be used to improve the model.
 - Nemotron 3 Super Free: During its free period, collected data may be used to improve the model.
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).


### PR DESCRIPTION
Removed duplicate entry for MiniMax M2.5 Free regarding data usage.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Removes duplicate entry in the documentation about MiniMax M2.5 Free data usage.

### How did you verify your code works?

Not necessary.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR