### PR TITLE
fix: Fix default timeout value.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -37,7 +37,7 @@ export const TuiEvent = {
       title: z.string().optional(),
       message: z.string(),
       variant: z.enum(["info", "success", "warning", "error"]),
-      duration: z.number().default(5000).optional().describe("Duration in milliseconds"),
+      duration: z.number().optional().default(5000).describe("Duration in milliseconds"),
     }),
   ),
   SessionSelect: BusEvent.define(


### PR DESCRIPTION
Many callsites don’t pass duration, relying on the default. The way the default was specified was wrong, resulting in an 'undefined' value if no duration is passed instead of 5000.
Passing `undefined` to setTimeout causes an immediate timeout (in practise a very shortly visible TUI toast UI.

### Issue for this PR

Closes #17191

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It fixes that the default of 5000 is actually used if nothing is passed, instead of getting `undefined`.

### How did you verify your code works?

I run opencode in a container with a network namespace; everything is firewalled, so I got for every attempt to connect some https:// url the vague error "Unable to connect. Is the computer able to access the url?" which showed up so short that there was hardly time to read it.

I could reproduce this simply by testing "test" and hitting enter on a prompt.
After applying this patch that changed to a neat 5 seconds long visible error, as it should.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
