### PR TITLE
fix(session): skip synthetic delegation nudge in subagent sessions

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1268,15 +1268,24 @@ export namespace SessionPrompt {
         }
 
         if (part.type === "agent") {
+          const agentPart = {
+            ...part,
+            messageID: info.id,
+            sessionID: input.sessionID,
+          }
+          // Only inject the delegation nudge in root sessions. Subagent sessions
+          // already have an explicit task prompt; injecting it there causes
+          // recursive nesting bias when the agent sees @agent mentions in its
+          // own context.
+          const currentSession = await Session.get(input.sessionID)
+          if (currentSession.parentID) {
+            return [agentPart]
+          }
           // Check if this agent would be denied by task permission
           const perm = PermissionNext.evaluate("task", part.name, agent.permission)
           const hint = perm.action === "deny" ? " . Invoked by user; guaranteed to exist." : ""
           return [
-            {
-              ...part,
-              messageID: info.id,
-              sessionID: input.sessionID,
-            },
+            agentPart,
             {
               messageID: info.id,
               sessionID: input.sessionID,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -148,6 +148,87 @@ describe("session.prompt special characters", () => {
   })
 })
 
+
+describe("session.prompt agent part", () => {
+  const delegationNudge =
+    "Use the above message and context to generate a prompt and call the task tool with subagent:";
+
+  test("injects synthetic delegation nudge in root sessions", async () => {
+    await using tmp = await tmpdir({ git: true });
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({});
+
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [
+            { type: "text", text: "do something" },
+            { type: "agent", name: "build" },
+          ],
+        });
+
+        if (msg.info.role !== "user") throw new Error("expected user message");
+
+        const stored = await MessageV2.get({
+          sessionID: session.id,
+          messageID: msg.info.id,
+        });
+        const syntheticDelegation = stored.parts.find(
+          (part) =>
+            part.type === "text" && part.synthetic &&
+            part.text.includes(delegationNudge),
+        );
+        expect(syntheticDelegation).toBeDefined();
+
+        await Session.remove(session.id);
+      },
+    });
+  });
+
+  test("skips synthetic delegation nudge in subagent sessions", async () => {
+    await using tmp = await tmpdir({ git: true });
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const root = await Session.create({});
+        const child = await Session.create({ parentID: root.id });
+
+        const msg = await SessionPrompt.prompt({
+          sessionID: child.id,
+          noReply: true,
+          parts: [
+            { type: "text", text: "do something" },
+            { type: "agent", name: "build" },
+          ],
+        });
+
+        if (msg.info.role !== "user") throw new Error("expected user message");
+
+        const stored = await MessageV2.get({
+          sessionID: child.id,
+          messageID: msg.info.id,
+        });
+        const syntheticDelegation = stored.parts.find(
+          (part) =>
+            part.type === "text" && part.synthetic &&
+            part.text.includes(delegationNudge),
+        );
+        expect(syntheticDelegation).toBeUndefined();
+
+        const agentPart = stored.parts.find((part) => part.type === "agent");
+        expect(agentPart).toBeDefined();
+
+        await Session.remove(child.id);
+        await Session.remove(root.id);
+      },
+    });
+  });
+});
+
 describe("session.prompt agent variant", () => {
   test("applies agent variant only when using agent model", async () => {
     const prev = process.env.OPENAI_API_KEY


### PR DESCRIPTION
### Issue for this PR

Closes #17202

### Type of change

- [x] Bug fix

### What does this PR do?

When a user message contains an `@agent` mention, `SessionPrompt.createUserMessage` injects a synthetic text part instructing the model to call the `task` tool with that subagent. This is correct behaviour in a root session where the user is initiating a delegation.

In a child/subagent session however, the orchestrator has already written an explicit task prompt before the session starts. When the subagent processes its own message history it encounters the `@agent` part and the injection runs again, appending a second delegation instruction. This causes recursive nesting bias: the subagent reads its own context, sees the nudge, and attempts to spawn yet another delegation layer.

The fix is a minimal guard in the `if (part.type === "agent")` branch of `createUserMessage`:

```ts
const currentSession = await Session.get(input.sessionID)
if (currentSession.parentID) {
  return [agentPart]
}
```

`Session.Info.parentID` is already set by the orchestrator when it creates child sessions. The guard is minimal and does not affect any other code path.

### How did you verify your code works?

- Read the injection logic in `packages/opencode/src/session/prompt.ts` to confirm the root cause.
- Confirmed `Session.Info.parentID` is populated for child sessions via `packages/opencode/src/session/index.ts`.
- Built a patched binary locally (`OPENCODE_VERSION=1.2.24 bun run ./packages/opencode/script/build.ts`).
- Ran a multi-agent session end-to-end: root session delegated to a subagent via `@agent`. Verified via DB inspection that the subagent's message history no longer contains the synthetic delegation text part.
- Verified root-session delegation still works correctly (synthetic text still injected when `parentID` is absent).
- Added two unit tests to `packages/opencode/test/session/prompt.test.ts`:
  - `injects synthetic delegation nudge in root sessions`
  - `skips synthetic delegation nudge in subagent sessions`
- All 6 tests in `prompt.test.ts` pass (`bun test ./test/session/prompt.test.ts`).

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR