### PR TITLE
fix(github): skip assertPermissions when use_github_token is true

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -540,7 +540,12 @@ export const GithubRunCommand = cmd({
         }
         // Skip permission check and reactions for repo events (no actor to check, no issue to react to)
         if (isUserEvent) {
-          await assertPermissions()
+          // Skip permission check when using a custom GitHub token, since the caller
+          // manages their own auth and the collaborator API returns "none" for GitHub
+          // App bot actors (e.g. my-bot[bot]) even though they have valid installation tokens.
+          if (!useGithubToken) {
+            await assertPermissions()
+          }
           await addReaction(commentType)
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #17224

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `opencode github run` is triggered by a `pull_request` event where the actor is a GitHub App bot (e.g. `my-bot[bot]`), the `assertPermissions()` check fails because the GitHub [collaborator permissions API](https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user) always returns `permission: none` for App bot accounts. Apps authenticate via installation tokens, not as traditional collaborators.

When `use_github_token: true`, the caller is explicitly providing their own `GITHUB_TOKEN` and managing authentication. The collaborator-level permission check is both unnecessary and broken for bot actors in this mode.

The fix wraps `assertPermissions()` in `if (!useGithubToken)` so the check is skipped when the caller provides their own token:

```diff
 if (isUserEvent) {
-  await assertPermissions()
+  if (!useGithubToken) {
+    await assertPermissions()
+  }
   await addReaction(commentType)
 }
```

### How did you verify your code works?

- Verified the failing CI run where `spiko-bot[bot]` triggers a `pull_request` event with `use_github_token: true` and gets `permission: none` from the collaborators API
- Confirmed the GitHub collaborators API returns `permission: none` for all GitHub App bot accounts (documented platform behavior)
- The `e2e (windows)` failure is pre-existing on the `dev` branch (same Playwright flake), unrelated to this change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR