### PR TITLE
fix(desktop-electron): Fix how to spawn and kill sidecar process

### DIFF
--- a/packages/desktop-electron/src/main/cli.ts
+++ b/packages/desktop-electron/src/main/cli.ts
@@ -6,7 +6,6 @@ import { dirname, join } from "node:path"
 import readline from "node:readline"
 import { fileURLToPath } from "node:url"
 import { app } from "electron"
-import treeKill from "tree-kill"
 
 import { WSL_ENABLED_KEY } from "./constants"
 import { store } from "./store"
@@ -50,7 +49,7 @@ export function getSidecarPath() {
 }
 
 export async function getConfig(): Promise<Config | null> {
-  const { events } = spawnCommand("debug config", {})
+  const { events } = spawnCommand(["debug", "config"], {})
   let output = ""
 
   await new Promise<void>((resolve) => {
@@ -120,7 +119,7 @@ export function syncCli() {
 }
 
 export function serve(hostname: string, port: number, password: string) {
-  const args = `--print-logs --log-level WARN serve --hostname ${hostname} --port ${port}`
+  const args = ["--print-logs", "--log-level", "WARN", "serve", "--hostname", hostname, "--port", String(port)]
   const env = {
     OPENCODE_SERVER_USERNAME: "opencode",
     OPENCODE_SERVER_PASSWORD: password,
@@ -129,8 +128,8 @@ export function serve(hostname: string, port: number, password: string) {
   return spawnCommand(args, env)
 }
 
-export function spawnCommand(args: string, extraEnv: Record<string, string>) {
-  console.log(`[cli] Spawning command with args: ${args}`)
+export function spawnCommand(args: string[], extraEnv: Record<string, string>) {
+  console.log(`[cli] Spawning command with args: ${args.join(" ")}`)
   const base = Object.fromEntries(
     Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
   )
@@ -188,7 +187,15 @@ export function spawnCommand(args: string, extraEnv: Record<string, string>) {
 
   const kill = () => {
     if (!child.pid) return
-    treeKill(child.pid)
+    if (process.platform === "win32") {
+      child.kill("SIGTERM")
+      return
+    }
+    try {
+      process.kill(-child.pid, "SIGTERM")
+    } catch {
+      child.kill("SIGTERM")
+    }
   }
 
   return { events, child: { kill }, exit }
@@ -209,7 +216,7 @@ function handleSqliteProgress(events: EventEmitter, line: string) {
   return false
 }
 
-function buildCommand(args: string, env: Record<string, string>) {
+function buildCommand(args: string[], env: Record<string, string>) {
   if (process.platform === "win32" && isWslEnabled()) {
     console.log(`[cli] Using WSL mode`)
     const version = app.getVersion()
@@ -219,7 +226,7 @@ function buildCommand(args: string, env: Record<string, string>) {
       'if [ ! -x "$BIN" ]; then',
       `  curl -fsSL https://opencode.ai/install | bash -s -- --version ${shellEscape(version)} --no-modify-path`,
       "fi",
-      `${envPrefix(env)} exec "$BIN" ${args}`,
+      `${envPrefix(env)} exec "$BIN" ${joinShell(args)}`,
     ].join("\n")
 
     return { cmd: "wsl", cmdArgs: ["-e", "bash", "-lc", script] }
@@ -228,14 +235,12 @@ function buildCommand(args: string, env: Record<string, string>) {
   if (process.platform === "win32") {
     const sidecar = getSidecarPath()
     console.log(`[cli] Windows direct mode, sidecar: ${sidecar}`)
-    return { cmd: sidecar, cmdArgs: args.split(" ") }
+    return { cmd: sidecar, cmdArgs: args }
   }
 
   const sidecar = getSidecarPath()
-  const shell = process.env.SHELL || "/bin/sh"
-  const line = shell.endsWith("/nu") ? `^\"${sidecar}\" ${args}` : `\"${sidecar}\" ${args}`
-  console.log(`[cli] Unix mode, shell: ${shell}, command: ${line}`)
-  return { cmd: shell, cmdArgs: ["-l", "-c", line] }
+  console.log(`[cli] Unix direct mode, sidecar: ${sidecar}`)
+  return { cmd: sidecar, cmdArgs: args }
 }
 
 function envPrefix(env: Record<string, string>) {
@@ -246,6 +251,10 @@ function envPrefix(env: Record<string, string>) {
 function shellEscape(input: string) {
   if (!input) return "''"
   return `'${input.replace(/'/g, `'"'"'`)}'`
+}
+
+function joinShell(args: string[]) {
+  return args.map((value) => shellEscape(value)).join(" ")
 }
 
 function getCliInstallPath() {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -56,6 +56,7 @@ setupApp()
 function setupApp() {
   ensureLoopbackNoProxy()
   app.commandLine.appendSwitch("proxy-bypass-list", "<-loopback>")
+  let isQuitting = false
 
   if (!app.requestSingleInstanceLock()) {
     app.quit()
@@ -78,8 +79,29 @@ function setupApp() {
   })
 
   app.on("before-quit", () => {
+    isQuitting = true
     killSidecar()
   })
+
+  app.on("window-all-closed", () => {
+    if (process.platform !== "darwin") {
+      app.quit()
+    }
+  })
+
+  if (process.platform !== "win32") {
+    process.on("SIGINT", () => {
+      if (isQuitting) return
+      isQuitting = true
+      app.quit()
+    })
+
+    process.on("SIGTERM", () => {
+      if (isQuitting) return
+      isQuitting = true
+      app.quit()
+    })
+  }
 
   void app.whenReady().then(async () => {
     // migrate()


### PR DESCRIPTION
### Issue for this PR

Closes [https://github.com/anomalyco/opencode/issues/17068](https://github.com/anomalyco/opencode/issues/17068)

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When closing the OpenCode Electron window, the `opencode-cli` sidecar process is not terminated. Re-launching the app spawns a new `opencode-cli` instance, causing multiple processes to accumulate.

I can confirm this happens on both macOS and Linux OpenCode Desktop Electron after debugging in preview mode, the root cause is how the `opencode-cli` process is spawned. On UNIX based, it spawns two processes — the shell process (bash/zsh/fish) and the `opencode-cli` process itself. So using child.kill() only kills the shell process, leaving `opencode-cli` running.
The current dev code uses the `tree-kill` package to solve this, but `tree-kill` doesn't work reliably on Linux and sometimes fails on macOS too.

My approach is change how `opencode-cli` is spawned by running the binary directly instead of through a shell first, and use process group killing to terminate the entire process group at once.

This PR also add another listener when closing the apps, such `window-all-closed` and `SIGINT` or `SIGTERM`.

### How did you verify your code works?
I built the desktop-electron on both my macOS and Arch Linux devices and confirmed it resolves the multiple sidecar process issue.

### Screenshots / recordings
Before fix when running OpenCode electron Desktop app multiple time
<img width="990" height="140" alt="image" src="https://github.com/user-attachments/assets/7ca771a8-129d-43d7-9eff-8e2793f18185" />

After fix when running Opencode electron Desktop app multiple time
<img width="998" height="150" alt="image" src="https://github.com/user-attachments/assets/f48dd4a0-501c-4666-99f3-30910c02637b" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR