### PR TITLE
feat(lsp): auto-enable WordPress stubs for WordPress projects

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1580,12 +1580,84 @@ export namespace LSPServer {
           BUN_BE_BUN: "1",
         },
       })
+
+      // Detect WordPress projects (core, themes, or plugins)
+      const isWordPress = await (async () => {
+        // Check 1: WordPress core files (for full WP installations)
+        const wpCoreFiles = [
+          "wp-config.php",
+          "wp-content",
+          "wp-admin",
+          "wp-includes",
+          "wp-settings.php",
+          "wp-load.php",
+        ]
+        for (const wpFile of wpCoreFiles) {
+          const wpPath = path.join(root, wpFile)
+          if (await pathExists(wpPath)) {
+            log.info("WordPress core installation detected", { file: wpFile, root })
+            return true
+          }
+        }
+
+        // Check 2: WordPress plugin/theme headers in PHP files
+        // Plugins and themes don't have core files but have specific headers
+        const phpFiles = await fs.readdir(root).then(files =>
+          files.filter(f => f.endsWith(".php")).map(f => path.join(root, f))
+        ).catch(() => [])
+
+        for (const phpFile of phpFiles.slice(0, 10)) { // Check up to 10 PHP files
+          try {
+            const content = await fs.readFile(phpFile, "utf-8")
+            // WordPress plugin header: Plugin Name: xxx
+            // WordPress theme header: Theme Name: xxx
+            // Both use the WordPress PHP header pattern
+            if (
+              /\*\s*Plugin Name:/.test(content) ||
+              /\*\s*Theme Name:/.test(content) ||
+              /\*\s*Text Domain:\s*\S+/.test(content)
+            ) {
+              log.info("WordPress plugin/theme detected", { file: path.basename(phpFile), root })
+              return true
+            }
+            // Check for WordPress function calls in the first 500 chars
+            const wpFunctions = [
+              "add_action(",
+              "add_filter(",
+              "do_action(",
+              "apply_filters(",
+              "wp_enqueue_script(",
+              "wp_enqueue_style(",
+              "register_activation_hook(",
+              "register_deactivation_hook(",
+              "register_uninstall_hook(",
+            ]
+            const sample = content.slice(0, 2000)
+            if (wpFunctions.some(fn => sample.includes(fn))) {
+              log.info("WordPress code patterns detected", { file: path.basename(phpFile), root })
+              return true
+            }
+          } catch {
+            // Skip files we can't read
+            continue
+          }
+        }
+
+        return false
+      })()
+
       return {
         process: proc,
         initialization: {
           telemetry: {
             enabled: false,
           },
+          // Include WordPress stubs for WordPress projects
+          ...(isWordPress && {
+            intelephense: {
+              stubs: ["wordpress"],
+            },
+          }),
         },
       }
     },


### PR DESCRIPTION
## Summary

Automatically detect WordPress projects (core, plugins, themes) and enable WordPress stubs for the Intelephense PHP language server.

## Problem

When working on WordPress projects with OpenCode, PHP functions like `add_action()`, `add_filter()`, `wp_send_json()` are not recognized by the Intelephense LSP. The original issue only detected full WordPress installations (with wp-config.php, etc.) but not WordPress plugins or themes that don't include core files.

See: https://github.com/bmewburn/vscode-intelephense/issues/1302

## Solution

This PR detects WordPress projects using multiple heuristics:

### Check 1: WordPress Core Files
For full WordPress installations:
- `wp-config.php`
- `wp-content/`
- `wp-admin/`
- `wp-includes/`
- `wp-settings.php`
- `wp-load.php`

### Check 2: Plugin/Theme Headers
For WordPress plugins and themes (which don't have core files):
- `Plugin Name:` header in PHP files
- `Theme Name:` header in PHP files
- `Text Domain:` header (common in internationalized plugins)

### Check 3: WordPress Code Patterns
Detects WordPress-specific function calls in PHP files:
- `add_action()`, `add_filter()`
- `do_action()`, `apply_filters()`
- `wp_enqueue_script()`, `wp_enqueue_style()`
- `register_activation_hook()`, `register_deactivation_hook()`
- `register_uninstall_hook()`

When any check passes, the Intelephense LSP is automatically configured with:

```json
{
  "intelephense": {
    "stubs": ["wordpress"]
  }
}
```

## Changes

- Modified `packages/opencode/src/lsp/server.ts`
- Added multi-layer WordPress detection:
  1. Core file detection (for WP installations)
  2. Header pattern detection (for plugins/themes)
  3. Function call detection (for any WP code)
- Checks up to 10 PHP files in the project root for efficiency
- WordPress stubs are automatically included when detected

## Testing

1. Open a WordPress core project with OpenCode
2. Open a WordPress plugin project with OpenCode  
3. Open a WordPress theme project with OpenCode
4. Verify that `add_action()`, `add_filter()`, etc. are recognized with proper completions and hover information

## Benefits

- **Zero configuration** needed for any WordPress project type
- Works for: full WordPress sites, plugins, and themes
- Better out-of-the-box experience for WordPress developers
- Extensible pattern for detecting other frameworks/CMSs

## To Answer Your Questions

**Q: Does this check only happen once PHP has been selected?**
**A:** Yes! The detection runs when the Intelephense LSP server is spawned, which happens when you open a PHP file in the project. This is the correct time to configure the LSP.
