### PR TITLE
feat(desktop-electron): Enable auto hide menu bar on main window

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -56,6 +56,7 @@ export function createMainWindow(globals: Globals) {
     y: state.y,
     width: state.width,
     height: state.height,
+    autoHideMenuBar: true,
     show: true,
     title: "OpenCode",
     icon: iconPath(),


### PR DESCRIPTION
### Issue for this PR

Closes [https://github.com/anomalyco/opencode/issues/17242](https://github.com/anomalyco/opencode/issues/17242)

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

During creating browser window in desktop electron. Enable auto hide menu bar on window.

Based on the documentation, autoHideMenuBar is Auto hide the menu bar unless the Alt key is pressed. Default is false. available on linux and win32 platform. This will hide the gtk decoration specially on Linux.

This PR actually just add the autoHideMenuBar during main window creation.

```diff
  const win = new BrowserWindow({
    x: state.x,
    y: state.y,
    width: state.width,
    height: state.height,
+   autoHideMenuBar: true,
    show: true,
    title: "OpenCode",
    icon: iconPath(),
    ...(process.platform === "darwin"
      ? {
          titleBarStyle: "hidden" as const,
          trafficLightPosition: { x: 12, y: 14 },
        }
      : {}),
    ...(process.platform === "win32"
      ? {
          frame: false,
          titleBarStyle: "hidden" as const,
          titleBarOverlay: overlay({ mode }),
        }
      : {}),
    webPreferences: {
      preload: join(root, "../preload/index.mjs"),
      sandbox: false,
    },
  })


```

### How did you verify your code works?
I ran `bun run preview`, `bun run package:linux`, and run the produced electron binary.

### Screenshots / recordings
Before:
<img width="1920" height="1200" alt="screenshot-2026-03-13_04-15-11" src="https://github.com/user-attachments/assets/157a43cf-9e9e-404f-8b74-d3a94b712204" />

After:
<img width="1920" height="1200" alt="screenshot-2026-03-13_04-14-25" src="https://github.com/user-attachments/assets/d89f3a4c-2a9e-4b10-a294-c845ec4a66f6" />

After with alt clicked:
<img width="1920" height="1200" alt="screenshot-2026-03-13_04-24-06" src="https://github.com/user-attachments/assets/ce154686-6696-4fdd-8093-b74ed6896c43" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

