### PR TITLE
feat: add global session cycling keybinds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -356,6 +356,27 @@ function App() {
     ),
   )
 
+  // moveGlobal cycles through top-level sessions sorted by most recently updated.
+  function moveGlobal(direction: number) {
+    const topLevel = sync.data.session
+      .filter((x) => !x.parentID)
+      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+
+    if (topLevel.length <= 1) return
+
+    const currentID = route.data.type === "session" ? route.data.sessionID : undefined
+    let idx = currentID ? topLevel.findIndex((x) => x.id === currentID) : -1
+
+    let next = idx + direction
+    if (next >= topLevel.length) next = 0
+    if (next < 0) next = topLevel.length - 1
+
+    route.navigate({
+      type: "session",
+      sessionID: topLevel[next].id,
+    })
+  }
+
   const connected = useConnected()
   command.register(() => [
     {
@@ -409,6 +430,26 @@ function App() {
           initialPrompt: currentPrompt,
           workspaceID,
         })
+        dialog.clear()
+      },
+    },
+    {
+      title: "Next session",
+      value: "session.global.next",
+      keybind: "session_global_cycle",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous session",
+      value: "session.global.previous",
+      keybind: "session_global_cycle_reverse",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(-1)
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -348,6 +348,28 @@ export function Session() {
     }
   }
 
+  // moveGlobal cycles through top-level sessions sorted by most recently updated.
+  function moveGlobal(direction: number) {
+    const topLevel = sync.data.session
+      .filter((x) => !x.parentID)
+      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+
+    if (topLevel.length <= 1) return
+
+    const currentID = session()?.parentID ?? session()?.id
+    let idx = topLevel.findIndex((x) => x.id === currentID)
+    if (idx === -1) return
+
+    let next = idx + direction
+    if (next >= topLevel.length) next = 0
+    if (next < 0) next = topLevel.length - 1
+
+    navigate({
+      type: "session",
+      sessionID: topLevel[next].id,
+    })
+  }
+
   function childSessionHandler(func: (dialog: DialogContext) => void) {
     return (dialog: DialogContext) => {
       if (!session()?.parentID || dialog.stack.length > 0) return
@@ -975,6 +997,26 @@ export function Session() {
         moveChild(-1)
         dialog.clear()
       }),
+    },
+    {
+      title: "Next session",
+      value: "session.global.next",
+      keybind: "session_global_cycle",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous session",
+      value: "session.global.previous",
+      keybind: "session_global_cycle_reverse",
+      category: "Session",
+      onSelect: (dialog) => {
+        moveGlobal(-1)
+        dialog.clear()
+      },
     },
   ])
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -348,28 +348,6 @@ export function Session() {
     }
   }
 
-  // moveGlobal cycles through top-level sessions sorted by most recently updated.
-  function moveGlobal(direction: number) {
-    const topLevel = sync.data.session
-      .filter((x) => !x.parentID)
-      .toSorted((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
-
-    if (topLevel.length <= 1) return
-
-    const currentID = session()?.parentID ?? session()?.id
-    let idx = topLevel.findIndex((x) => x.id === currentID)
-    if (idx === -1) return
-
-    let next = idx + direction
-    if (next >= topLevel.length) next = 0
-    if (next < 0) next = topLevel.length - 1
-
-    navigate({
-      type: "session",
-      sessionID: topLevel[next].id,
-    })
-  }
-
   function childSessionHandler(func: (dialog: DialogContext) => void) {
     return (dialog: DialogContext) => {
       if (!session()?.parentID || dialog.stack.length > 0) return
@@ -997,26 +975,6 @@ export function Session() {
         moveChild(-1)
         dialog.clear()
       }),
-    },
-    {
-      title: "Next session",
-      value: "session.global.next",
-      keybind: "session_global_cycle",
-      category: "Session",
-      onSelect: (dialog) => {
-        moveGlobal(1)
-        dialog.clear()
-      },
-    },
-    {
-      title: "Previous session",
-      value: "session.global.previous",
-      keybind: "session_global_cycle_reverse",
-      category: "Session",
-      onSelect: (dialog) => {
-        moveGlobal(-1)
-        dialog.clear()
-      },
     },
   ])
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -923,6 +923,16 @@ export namespace Config {
       session_child_first: z.string().optional().default("<leader>down").describe("Go to first child session"),
       session_child_cycle: z.string().optional().default("right").describe("Go to next child session"),
       session_child_cycle_reverse: z.string().optional().default("left").describe("Go to previous child session"),
+      session_global_cycle: z
+        .string()
+        .optional()
+        .default("<leader>right")
+        .describe("Go to next session (sorted by recent)"),
+      session_global_cycle_reverse: z
+        .string()
+        .optional()
+        .default("<leader>left")
+        .describe("Go to previous session (sorted by recent)"),
       session_parent: z.string().optional().default("up").describe("Go to parent session"),
       terminal_suspend: z.string().optional().default("ctrl+z").describe("Suspend terminal"),
       terminal_title_toggle: z.string().optional().default("none").describe("Toggle terminal title"),


### PR DESCRIPTION
Closes #16986

## What changed

`ctrl+x →` / `ctrl+x ←` cycle through top-level sessions sorted by most recently updated. Two new keybind entries (`session_global_cycle` / `session_global_cycle_reverse`) registered at the app level so they work from any screen and appear in the `ctrl+p` palette.

## Files changed

- `packages/opencode/src/cli/cmd/tui/app.tsx` — `moveGlobal()` + command registrations
- `packages/opencode/src/config/config.ts` — keybind schema entries

## Verification

- Keybinds tested in TUI with multiple sessions — cycling works in both directions with wrap-around
- Commands visible in `ctrl+p` palette
- All package typechecks pass (pre-existing `effect` module error in `packages/app` is on upstream dev, not introduced here)

## Screenshots / recordings

_Will be added separately._