### PR TITLE
fix(ci): keep test runs on dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Keep every run on dev so cancelled checks do not pollute the default branch
+  # commit history. PRs and other branches still share a group and cancel stale runs.
+  group: ${{ case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), format('{0}-{1}', github.workflow, github.event.pull_request.number || github.ref)) }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- keep `dev` runs out of the shared workflow concurrency group by using a unique `github.run_id` key
- preserve stale-run cancellation for pull requests and other non-default branches with `case()`
- document the workflow behavior so the default-branch commit view is easier to interpret