### PR TITLE
reorder provider list in providers login

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -318,10 +318,10 @@ export const ProvidersLoginCommand = cmd({
 
         const priority: Record<string, number> = {
           opencode: 0,
-          anthropic: 1,
+          openai: 1,
           "github-copilot": 2,
-          openai: 3,
-          google: 4,
+          google: 3,
+          anthropic: 4,
           openrouter: 5,
           vercel: 6,
         }


### PR DESCRIPTION
## Summary
- Reorder the provider priority list in `oc providers login`: OpenCode Zen → OpenAI → GitHub Copilot → Google → Anthropic → OpenRouter → Vercel

## Test plan
- [ ] Run `oc providers login` and verify the new ordering