### PR TITLE
feat(cli): add console account subcommands

### DIFF
--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -192,3 +192,28 @@ export const OrgsCommand = cmd({
     await runtime.runPromise(orgsEffect())
   },
 })
+
+export const ConsoleCommand = cmd({
+  command: "console",
+  describe: "manage opencode console account",
+  builder: (yargs) =>
+    yargs
+      .command({
+        ...LoginCommand,
+        describe: "log in to opencode console",
+      })
+      .command({
+        ...LogoutCommand,
+        describe: "log out from opencode console",
+      })
+      .command({
+        ...SwitchCommand,
+        describe: "switch active console org",
+      })
+      .command({
+        ...OrgsCommand,
+        describe: "list console orgs",
+      })
+      .demandCommand(),
+  async handler() {},
+})

--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -195,24 +195,24 @@ export const OrgsCommand = cmd({
 
 export const ConsoleCommand = cmd({
   command: "console",
-  describe: "manage opencode console account",
+  describe: "manage console account",
   builder: (yargs) =>
     yargs
       .command({
         ...LoginCommand,
-        describe: "log in to opencode console",
+        describe: "log in to console",
       })
       .command({
         ...LogoutCommand,
-        describe: "log out from opencode console",
+        describe: "log out from console",
       })
       .command({
         ...SwitchCommand,
-        describe: "switch active console org",
+        describe: "switch active org",
       })
       .command({
         ...OrgsCommand,
-        describe: "list console orgs",
+        describe: "list orgs",
       })
       .demandCommand(),
   async handler() {},

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -3,7 +3,7 @@ import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
 import { GenerateCommand } from "./cli/cmd/generate"
 import { Log } from "./util/log"
-import { LoginCommand, LogoutCommand, SwitchCommand, OrgsCommand } from "./cli/cmd/account"
+import { ConsoleCommand, LoginCommand, LogoutCommand, SwitchCommand, OrgsCommand } from "./cli/cmd/account"
 import { ProvidersCommand } from "./cli/cmd/providers"
 import { AgentCommand } from "./cli/cmd/agent"
 import { UpgradeCommand } from "./cli/cmd/upgrade"
@@ -135,6 +135,7 @@ let cli = yargs(hideBin(process.argv))
   .command(RunCommand)
   .command(GenerateCommand)
   .command(DebugCommand)
+  .command(ConsoleCommand)
   .command(LoginCommand)
   .command(LogoutCommand)
   .command(SwitchCommand)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -3,7 +3,7 @@ import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
 import { GenerateCommand } from "./cli/cmd/generate"
 import { Log } from "./util/log"
-import { ConsoleCommand, LoginCommand, LogoutCommand, SwitchCommand, OrgsCommand } from "./cli/cmd/account"
+import { ConsoleCommand } from "./cli/cmd/account"
 import { ProvidersCommand } from "./cli/cmd/providers"
 import { AgentCommand } from "./cli/cmd/agent"
 import { UpgradeCommand } from "./cli/cmd/upgrade"
@@ -136,10 +136,6 @@ let cli = yargs(hideBin(process.argv))
   .command(GenerateCommand)
   .command(DebugCommand)
   .command(ConsoleCommand)
-  .command(LoginCommand)
-  .command(LogoutCommand)
-  .command(SwitchCommand)
-  .command(OrgsCommand)
   .command(ProvidersCommand)
   .command(AgentCommand)
   .command(UpgradeCommand)


### PR DESCRIPTION
## Summary
- add a `console` command group for account flows so `login`, `logout`, `switch`, and `orgs` can live under `opencode console`
- wire the new command into the root CLI while keeping the existing hidden top-level commands for compatibility
- make the console account path easier to dogfood internally without breaking current usage

## Testing
- bun typecheck
- bun run --conditions=browser ./src/index.ts console --help