### PR TITLE
fix(cli): hide console command from help output

### DIFF
--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -195,7 +195,7 @@ export const OrgsCommand = cmd({
 
 export const ConsoleCommand = cmd({
   command: "console",
-  describe: "manage console account",
+  describe: false,
   builder: (yargs) =>
     yargs
       .command({


### PR DESCRIPTION
The `console` subcommand was showing in `opencode --help` output. The subcommands inside it (login, logout, switch, orgs) are already hidden with `describe: false` — this makes the parent `console` command consistent.

Subcommands are still accessible and described when running `opencode console --help`.