### PR TITLE
fix(provider): load config providers before custom loaders

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1045,6 +1045,18 @@ export namespace Provider {
       }
     }
 
+    // load config options into providers BEFORE custom loaders,
+    // so that config-defined providers (e.g. "openai") exist in providers[]
+    // when custom loaders check for them (autoload || providers[providerID]).
+    for (const [id, provider] of configProviders) {
+      const providerID = ProviderID.make(id)
+      const partial: Partial<Info> = { source: "config" }
+      if (provider.env) partial.env = provider.env
+      if (provider.name) partial.name = provider.name
+      if (provider.options) partial.options = provider.options
+      mergeProvider(providerID, partial)
+    }
+
     for (const [id, fn] of Object.entries(CUSTOM_LOADERS)) {
       const providerID = ProviderID.make(id)
       if (disabled.has(providerID)) continue
@@ -1063,15 +1075,6 @@ export namespace Provider {
       }
     }
 
-    // load config
-    for (const [id, provider] of configProviders) {
-      const providerID = ProviderID.make(id)
-      const partial: Partial<Info> = { source: "config" }
-      if (provider.env) partial.env = provider.env
-      if (provider.name) partial.name = provider.name
-      if (provider.options) partial.options = provider.options
-      mergeProvider(providerID, partial)
-    }
 
     for (const [id, provider] of Object.entries(providers)) {
       const providerID = ProviderID.make(id)


### PR DESCRIPTION
## Summary

Config-defined providers (e.g. `openai` pointing to a LiteLLM proxy) don't get their custom model loaders registered because `CUSTOM_LOADERS` runs before the config merge step creates `providers[providerID]`.

## Problem

When a user defines an `openai` provider in `opencode.json` with a custom `baseURL` (e.g. LiteLLM proxy), the `CUSTOM_LOADERS["openai"]` check at line 1052:

```typescript
if (result && (result.autoload || providers[providerID])) {
```

fails because `providers["openai"]` doesn't exist yet — the config merge step that creates it runs **after** the custom loaders loop.

This means `sdk.responses()` is never registered as the model loader, and `getLanguage()` falls back to `sdk.languageModel()`. For `@ai-sdk/github-copilot` SDK, `languageModel()` defaults to chat completions. Models that only support the Responses API (e.g. GPT-5.4 on Azure) become unusable.

**Current init order:**
```
1. extend database from config
2. load env → mergeProvider
3. load apikeys → mergeProvider
4. plugins → mergeProvider
5. CUSTOM_LOADERS → checks providers[providerID]  ← config providers don't exist yet
6. load config → mergeProvider                     ← too late
```

## Fix

Move step 6 before step 5:

```
1. extend database from config
2. load env → mergeProvider
3. load apikeys → mergeProvider
4. plugins → mergeProvider
5. load config → mergeProvider                     ← now providers["openai"] exists
6. CUSTOM_LOADERS → checks providers[providerID]   ← finds it, registers sdk.responses()
```

## Impact

- Config-defined providers now correctly get custom model loaders (e.g. `sdk.responses()` for OpenAI)
- No change for providers registered via env vars, API keys, or plugins (they already exist before custom loaders)
- No change for autoload providers