### PR TITLE
fix(skill): dedupe symlinked external skill paths

### DIFF
--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -55,14 +55,19 @@ export namespace Skill {
   export const state = Instance.state(async () => {
     const skills: Record<string, Info> = {}
     const dirs = new Set<string>()
+    const seen = new Set<string>()
 
     const addSkill = async (match: string) => {
-      const md = await ConfigMarkdown.parse(match).catch((err) => {
+      const file = Filesystem.resolve(match)
+      if (seen.has(file)) return
+      seen.add(file)
+
+      const md = await ConfigMarkdown.parse(file).catch((err) => {
         const message = ConfigMarkdown.FrontmatterError.isInstance(err)
           ? err.data.message
-          : `Failed to parse skill ${match}`
+          : `Failed to parse skill ${file}`
         Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-        log.error("failed to load skill", { skill: match, err })
+        log.error("failed to load skill", { skill: file, err })
         return undefined
       })
 
@@ -76,16 +81,16 @@ export namespace Skill {
         log.warn("duplicate skill name", {
           name: parsed.data.name,
           existing: skills[parsed.data.name].location,
-          duplicate: match,
+          duplicate: file,
         })
       }
 
-      dirs.add(path.dirname(match))
+      dirs.add(path.dirname(file))
 
       skills[parsed.data.name] = {
         name: parsed.data.name,
         description: parsed.data.description,
-        location: match,
+        location: file,
         content: md.content,
       }
     }

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -386,3 +386,39 @@ description: A skill in the .opencode/skills directory.
     },
   })
 })
+
+test("deduplicates symlinked skill directories by canonical path", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const agentDir = path.join(dir, ".agents", "skills", "shared-skill")
+      const claudeDir = path.join(dir, ".claude", "skills", "shared-skill")
+      await fs.mkdir(agentDir, { recursive: true })
+      await fs.mkdir(path.dirname(claudeDir), { recursive: true })
+      await Bun.write(
+        path.join(agentDir, "SKILL.md"),
+        `---
+name: shared-skill
+description: A shared skill.
+---
+
+# Shared Skill
+`,
+      )
+      await fs.symlink(agentDir, claudeDir, process.platform === "win32" ? "junction" : "dir")
+      return { agentDir }
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      const dirs = await Skill.dirs()
+      expect(skills.length).toBe(1)
+      expect(skills[0].location).toBe(path.join(tmp.extra.agentDir, "SKILL.md"))
+      expect(dirs).toContain(tmp.extra.agentDir)
+      expect(dirs.length).toBe(1)
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #17219

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the same external skill is discovered through both a real path and a symlinked path, we were treating them as separate entries while building the skill directory allowlist. That produced duplicate `external_directory` rules even though both paths pointed at the same physical skill.

This change resolves each discovered skill to its canonical path before storing it, skips repeated physical files, and stores canonical skill directories for the permission allowlist. That removes duplicate rules for symlinked skill installs while keeping distinct physical skills unchanged.

### How did you verify your code works?

- added a regression test that creates a symlinked `.claude/skills` entry pointing at `.agents/skills` and checks that `Skill.all()` and `Skill.dirs()` only report one canonical location
- ran `bun test test/skill/skill.test.ts test/tool/skill.test.ts`
- ran `bun typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR