### PR TITLE
docs: add opencode-plan-todo to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,6 +49,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-plan-todo](https://github.com/spartawhy117/opencode-plan-todo)                          | Planning workflow plugin with structured plan/todo lifecycle, auto-deploy agents and commands      |
 
 ---
 


### PR DESCRIPTION
## Issue for this PR

N/A - This is a community contribution to add a new plugin to the ecosystem list.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

## What does this PR do?

This PR adds [opencode-plan-todo](https://github.com/spartawhy117/opencode-plan-todo) to the ecosystem plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

**opencode-plan-todo** is a planning workflow plugin for OpenCode that provides structured plan/todo lifecycle management. It auto-deploys Markdown-based agents, commands, and templates to the user's OpenCode config directory on startup.

The change is a single table row addition to the existing Plugins section — no code logic or configuration is modified.

## How did you verify your code works?

- Verified the Markdown table renders correctly by previewing the `.mdx` file locally
- Confirmed the plugin link (https://github.com/spartawhy117/opencode-plan-todo) resolves to a valid, public repository with a complete README and package.json
- No code changes involved — documentation only

## Screenshots / recordings

N/A — This is a text-only documentation change (one table row added).

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR