### PR TITLE
fix(cli): resolve Windows upgrade by routing commands through shell

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -15,12 +15,14 @@ declare global {
 
 export namespace Installation {
   const log = Log.create({ service: "installation" })
+  const win = process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : false as const
 
   async function text(cmd: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
     return Process.text(cmd, {
       cwd: opts.cwd,
       env: opts.env,
       nothrow: true,
+      shell: win,
     }).then((x) => x.text)
   }
 
@@ -101,10 +103,6 @@ export namespace Installation {
         command: () => text(["npm", "list", "-g", "--depth=0"]),
       },
       {
-        name: "yarn" as const,
-        command: () => text(["yarn", "global", "list"]),
-      },
-      {
         name: "pnpm" as const,
         command: () => text(["pnpm", "list", "-g", "--depth=0"]),
       },
@@ -162,19 +160,19 @@ export namespace Installation {
   }
 
   export async function upgrade(method: Method, target: string) {
-    let result: Awaited<ReturnType<typeof upgradeCurl>> | undefined
+    let result: Process.Result | undefined
     switch (method) {
       case "curl":
         result = await upgradeCurl(target)
         break
       case "npm":
-        result = await Process.run(["npm", "install", "-g", `opencode-ai@${target}`], { nothrow: true })
+        result = await Process.run(["npm", "install", "-g", `opencode-ai@${target}`], { nothrow: true, shell: win })
         break
       case "pnpm":
-        result = await Process.run(["pnpm", "install", "-g", `opencode-ai@${target}`], { nothrow: true })
+        result = await Process.run(["pnpm", "install", "-g", `opencode-ai@${target}`], { nothrow: true, shell: win })
         break
       case "bun":
-        result = await Process.run(["bun", "install", "-g", `opencode-ai@${target}`], { nothrow: true })
+        result = await Process.run(["bun", "install", "-g", `opencode-ai@${target}`], { nothrow: true, shell: win })
         break
       case "brew": {
         const formula = await getBrewFormula()
@@ -207,10 +205,10 @@ export namespace Installation {
       }
 
       case "choco":
-        result = await Process.run(["choco", "upgrade", "opencode", `--version=${target}`, "-y"], { nothrow: true })
+        result = await Process.run(["choco", "upgrade", "opencode", `--version=${target}`, "-y"], { nothrow: true, shell: win })
         break
       case "scoop":
-        result = await Process.run(["scoop", "install", `opencode@${target}`], { nothrow: true })
+        result = await Process.run(["scoop", "install", `opencode@${target}`], { nothrow: true, shell: win })
         break
       default:
         throw new Error(`Unknown method: ${method}`)

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -13,6 +13,7 @@ export namespace Process {
     abort?: AbortSignal
     kill?: NodeJS.Signals | number
     timeout?: number
+    shell?: boolean | string
   }
 
   export interface RunOptions extends Omit<Options, "stdout" | "stderr"> {
@@ -61,6 +62,7 @@ export namespace Process {
       env: opts.env === null ? {} : opts.env ? { ...process.env, ...opts.env } : undefined,
       stdio: [opts.stdin ?? "ignore", opts.stdout ?? "ignore", opts.stderr ?? "ignore"],
       windowsHide: process.platform === "win32",
+      shell: opts.shell,
     })
 
     let closed = false
@@ -113,6 +115,7 @@ export namespace Process {
       abort: opts.abort,
       kill: opts.kill,
       timeout: opts.timeout,
+      shell: opts.shell,
       stdout: "pipe",
       stderr: "pipe",
     })


### PR DESCRIPTION
### Issue for this PR

Closes #17295

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, package manager CLIs like npm, pnpm, bun, choco, and scoop are `.cmd`/`.bat` batch scripts, not real executables. When `child_process.spawn` tries to run them directly without a shell, it fails with ENOENT. This causes `Installation.method()` to silently fail every detection check and return `"unknown"`, which blocks `opencode upgrade` with the "may be managed by a package manager" prompt.

The fix adds a `shell` option to `Process.Options` and passes `COMSPEC` (or `cmd.exe`) as the shell on Windows. This lets `cmd.exe` resolve `.cmd` scripts correctly. On non-Windows platforms, `shell` is `false` (default behavior, no change).

Also fixes a pre-existing `Buffer` type mismatch by typing `result` as `Process.Result` instead of inferring from `upgradeCurl`, and removes yarn from detection since it's no longer a supported install method.

### How did you verify your code works?

Tested `opencode upgrade` on Windows 11 with an npm-managed installation. Before the fix, `method()` returned `"unknown"`. After the fix, it correctly detects `"npm"` and the upgrade proceeds normally.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR