### PR TITLE
fix(server): resolve session directory context for prompt routes

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -19,6 +19,7 @@ import { PermissionID } from "@/permission/schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Instance } from "../../project/instance"
 
 const log = Log.create({ service: "server" })
 
@@ -520,27 +521,32 @@ export const SessionRoutes = lazy(() =>
         const sessionID = c.req.valid("param").sessionID
         const body = c.req.valid("json")
         const session = await Session.get(sessionID)
-        await SessionRevert.cleanup(session)
-        const msgs = await Session.messages({ sessionID })
-        let currentAgent = await Agent.defaultAgent()
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const info = msgs[i].info
-          if (info.role === "user") {
-            currentAgent = info.agent || (await Agent.defaultAgent())
-            break
-          }
-        }
-        await SessionCompaction.create({
-          sessionID,
-          agent: currentAgent,
-          model: {
-            providerID: body.providerID,
-            modelID: body.modelID,
+        return Instance.provide({
+          directory: session.directory,
+          async fn() {
+            await SessionRevert.cleanup(session)
+            const msgs = await Session.messages({ sessionID })
+            let currentAgent = await Agent.defaultAgent()
+            for (let i = msgs.length - 1; i >= 0; i--) {
+              const info = msgs[i].info
+              if (info.role === "user") {
+                currentAgent = info.agent || (await Agent.defaultAgent())
+                break
+              }
+            }
+            await SessionCompaction.create({
+              sessionID,
+              agent: currentAgent,
+              model: {
+                providerID: body.providerID,
+                modelID: body.modelID,
+              },
+              auto: body.auto,
+            })
+            await SessionPrompt.loop({ sessionID })
+            return c.json(true)
           },
-          auto: body.auto,
         })
-        await SessionPrompt.loop({ sessionID })
-        return c.json(true)
       },
     )
     .get(
@@ -761,13 +767,19 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(200)
-        c.header("Content-Type", "application/json")
-        return stream(c, async (stream) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
+        const sessionID = c.req.valid("param").sessionID
+        const session = await Session.get(sessionID)
+        return Instance.provide({
+          directory: session.directory,
+          async fn() {
+            c.status(200)
+            c.header("Content-Type", "application/json")
+            return stream(c, async (stream) => {
+              const body = c.req.valid("json")
+              const msg = await SessionPrompt.prompt({ ...body, sessionID })
+              stream.write(JSON.stringify(msg))
+            })
+          },
         })
       },
     )
@@ -793,12 +805,18 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+        const sessionID = c.req.valid("param").sessionID
+        const session = await Session.get(sessionID)
+        return Instance.provide({
+          directory: session.directory,
+          async fn() {
+            c.status(204)
+            c.header("Content-Type", "application/json")
+            return stream(c, async () => {
+              const body = c.req.valid("json")
+              SessionPrompt.prompt({ ...body, sessionID })
+            })
+          },
         })
       },
     )
@@ -834,9 +852,15 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const msg = await SessionPrompt.command({ ...body, sessionID })
-        return c.json(msg)
+        const session = await Session.get(sessionID)
+        return Instance.provide({
+          directory: session.directory,
+          async fn() {
+            const body = c.req.valid("json")
+            const msg = await SessionPrompt.command({ ...body, sessionID })
+            return c.json(msg)
+          },
+        })
       },
     )
     .post(
@@ -866,9 +890,15 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const body = c.req.valid("json")
-        const msg = await SessionPrompt.shell({ ...body, sessionID })
-        return c.json(msg)
+        const session = await Session.get(sessionID)
+        return Instance.provide({
+          directory: session.directory,
+          async fn() {
+            const body = c.req.valid("json")
+            const msg = await SessionPrompt.shell({ ...body, sessionID })
+            return c.json(msg)
+          },
+        })
       },
     )
     .post(


### PR DESCRIPTION
## Summary

Fixes #12271 — child sessions created via `POST /session?directory=/path` return empty body on subsequent `POST /session/{id}/message` calls.

**Root cause:** The server middleware resolves the `Instance` context from the request's `?directory=` query param, defaulting to `process.cwd()`. When a session is created with an explicit directory, but subsequent prompt requests omit it, the prompt processing runs under the wrong `Instance` context. Since `Instance.state()` (used by `SessionPrompt`, `Agent`, etc.) is scoped per-directory, the mismatch causes failures that are silently swallowed by Hono's `stream()` handler — resulting in HTTP 200 with `Content-Length: 0`.

**Fix:** Before processing prompts, read the session's stored `directory` and re-enter the correct `Instance` context via `Instance.provide()`. This is safe because `Instance.provide()` caches instances by directory — if the correct instance already exists (the common case), the cached instance is reused with zero overhead.

## Changes

- Added `Instance.provide({ directory: session.directory })` wrapper to 5 session routes that process prompts:
  - `POST /:sessionID/message` (sync prompt)
  - `POST /:sessionID/prompt_async` (async prompt)
  - `POST /:sessionID/command` (command execution)
  - `POST /:sessionID/shell` (shell execution)
  - `POST /:sessionID/summarize` (session compaction)

## Test plan

- [x] TypeScript compiles cleanly (all 13 packages pass)
- [x] All 1286 existing tests pass
- [ ] Manual: `opencode web`, create session with `?directory=`, send message — should return full response
- [ ] Manual: verify sessions without `?directory=` continue working (no regression)