### PR TITLE
docs: add opencode-enhance-plan to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,6 +49,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-enhance-plan](https://github.com/spartawhy117/opencode-enhance-plan)                                    | Enhanced planning workflow with persistent artifacts, review gates, and feature switching          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — Community contribution adding a new plugin to the ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-enhance-plan](https://github.com/spartawhy117/opencode-enhance-plan) to the ecosystem Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

**opencode-enhance-plan** is an enhanced planning workflow plugin for OpenCode. It provides persistent plan artifacts, explicit review gates, structured todo state, and multi-feature switching — designed for heavier feature planning where the built-in plan mode is too lightweight.

The change is a single table row addition to the existing Plugins section. No code logic or configuration is modified.

### How did you verify your code works?

- Verified the Markdown table renders correctly by inspecting the raw `.mdx` diff
- Confirmed the plugin repository link (https://github.com/spartawhy117/opencode-enhance-plan) resolves to a valid public repository with complete README and package.json
- No code changes — documentation only

### Screenshots / recordings

N/A — Text-only documentation change (single table row addition).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR