### PR TITLE
docs: add opencode-enhance-plan to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,6 +49,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
+| [opencode-enhance-plan](https://github.com/spartawhy117/opencode-enhance-plan)                    | Enhanced planning workflow with persistent feature artifacts, structured todos, and review gates   |
 
 ---
 


### PR DESCRIPTION
## Summary

Add [opencode-enhance-plan](https://github.com/spartawhy117/opencode-enhance-plan) to the community ecosystem plugins list.

## What is opencode-enhance-plan?

An enhanced planning workflow plugin for OpenCode that adds structured feature development on top of the built-in plan mode.

**Key features:**
- Persistent feature artifacts (plan.md, todo.md, handoff.md)
- Explicit review gates before execution
- Structured todo state with progress tracking
- Feature-level session management with /feature-switch
- Clean handoff documents via /plan-handoff

**Links:**
- npm: [opencode-enhance-plan](https://www.npmjs.com/package/opencode-enhance-plan)
- GitHub: [spartawhy117/opencode-enhance-plan](https://github.com/spartawhy117/opencode-enhance-plan)

## Changes

- Added one row to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`

## Checklist

- [x] Only modifies ecosystem.mdx (docs only, no code changes)
- [x] Plugin is published on npm and installable
- [x] Plugin uses @opencode-ai/plugin API (v1.2.25 verified)
- [x] Table formatting matches existing entries