### PR TITLE
feat(opencode): require session ids for tool definitions

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -4,7 +4,7 @@ import { Agent } from "../../../agent/agent"
 import { Provider } from "../../../provider/provider"
 import { Session } from "../../../session"
 import type { MessageV2 } from "../../../session/message-v2"
-import { MessageID, PartID } from "../../../session/schema"
+import { MessageID, PartID, type SessionID } from "../../../session/schema"
 import { ToolRegistry } from "../../../tool/registry"
 import { Instance } from "../../../project/instance"
 import { PermissionNext } from "../../../permission/next"
@@ -40,10 +40,11 @@ export const AgentCommand = cmd({
         )
         process.exit(1)
       }
-      const availableTools = await getAvailableTools(agent)
-      const resolvedTools = await resolveTools(agent, availableTools)
       const toolID = args.tool as string | undefined
       if (toolID) {
+        const session = await Session.create({ title: `Debug tool run (${agent.name})` })
+        const availableTools = await getAvailableTools(agent, session.id)
+        const resolvedTools = await resolveTools(agent, availableTools)
         const tool = availableTools.find((item) => item.id === toolID)
         if (!tool) {
           process.stderr.write(`Tool ${toolID} not found for agent ${agentName}` + EOL)
@@ -54,24 +55,32 @@ export const AgentCommand = cmd({
           process.exit(1)
         }
         const params = parseToolParams(args.params as string | undefined)
-        const ctx = await createToolContext(agent)
+        const ctx = await createToolContext(agent, session.id)
         const result = await tool.execute(params, ctx)
         process.stdout.write(JSON.stringify({ tool: toolID, input: params, result }, null, 2) + EOL)
         return
       }
 
-      const output = {
-        ...agent,
-        tools: resolvedTools,
+      const session = await Session.create({ title: `Debug tool list (${agent.name})` })
+      try {
+        const availableTools = await getAvailableTools(agent, session.id)
+        const resolvedTools = await resolveTools(agent, availableTools)
+
+        const output = {
+          ...agent,
+          tools: resolvedTools,
+        }
+        process.stdout.write(JSON.stringify(output, null, 2) + EOL)
+      } finally {
+        await Session.remove(session.id)
       }
-      process.stdout.write(JSON.stringify(output, null, 2) + EOL)
     })
   },
 })
 
-async function getAvailableTools(agent: Agent.Info) {
+export async function getAvailableTools(agent: Agent.Info, sessionID: SessionID) {
   const model = agent.model ?? (await Provider.defaultModel())
-  return ToolRegistry.tools(model, agent)
+  return ToolRegistry.tools({ model, sessionID, agent })
 }
 
 async function resolveTools(agent: Agent.Info, availableTools: Awaited<ReturnType<typeof getAvailableTools>>) {
@@ -111,14 +120,13 @@ function parseToolParams(input?: string) {
   return parsed as Record<string, unknown>
 }
 
-async function createToolContext(agent: Agent.Info) {
-  const session = await Session.create({ title: `Debug tool run (${agent.name})` })
+async function createToolContext(agent: Agent.Info, sessionID: SessionID) {
   const messageID = MessageID.ascending()
   const model = agent.model ?? (await Provider.defaultModel())
   const now = Date.now()
   const message: MessageV2.Assistant = {
     id: messageID,
-    sessionID: session.id,
+    sessionID,
     role: "assistant",
     time: {
       created: now,
@@ -145,10 +153,10 @@ async function createToolContext(agent: Agent.Info) {
   }
   await Session.updateMessage(message)
 
-  const ruleset = PermissionNext.merge(agent.permission, session.permission ?? [])
+  const ruleset = PermissionNext.merge(agent.permission, (await Session.get(sessionID)).permission ?? [])
 
   return {
-    sessionID: session.id,
+    sessionID,
     messageID,
     callID: PartID.ascending(),
     agent: agent.name,

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -8,10 +8,13 @@ import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
 import { MCP } from "../../mcp"
 import { Session } from "../../session"
+import { SessionID } from "../../session/schema"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { WorkspaceRoutes } from "./workspace"
+import { NotFoundError } from "../../storage/db"
+import { HTTPException } from "hono/http-exception"
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
@@ -43,7 +46,7 @@ export const ExperimentalRoutes = lazy(() =>
       describeRoute({
         summary: "List tools",
         description:
-          "Get a list of available tools with their JSON schema parameters for a specific provider and model combination.",
+          "Get a list of available tools with their JSON schema parameters for a specific provider, model, and session.",
         operationId: "tool.list",
         responses: {
           200: {
@@ -66,6 +69,9 @@ export const ExperimentalRoutes = lazy(() =>
               },
             },
           },
+          404: {
+            description: "Session not found",
+          },
           ...errors(400),
         },
       }),
@@ -74,11 +80,19 @@ export const ExperimentalRoutes = lazy(() =>
         z.object({
           provider: z.string(),
           model: z.string(),
+          sessionID: SessionID.zod,
         }),
       ),
       async (c) => {
-        const { provider, model } = c.req.valid("query")
-        const tools = await ToolRegistry.tools({ providerID: ProviderID.make(provider), modelID: ModelID.make(model) })
+        const { provider, model, sessionID } = c.req.valid("query")
+        await Session.get(sessionID).catch((err) => {
+          if (err instanceof NotFoundError) throw new HTTPException(404, { message: err.message })
+          throw err
+        })
+        const tools = await ToolRegistry.tools({
+          model: { providerID: ProviderID.make(provider), modelID: ModelID.make(model) },
+          sessionID,
+        })
         return c.json(
           tools.map((t) => ({
             id: t.id,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -788,10 +788,11 @@ export namespace SessionPrompt {
       },
     })
 
-    for (const item of await ToolRegistry.tools(
-      { modelID: ModelID.make(input.model.api.id), providerID: input.model.providerID },
-      input.agent,
-    )) {
+    for (const item of await ToolRegistry.tools({
+      model: { modelID: ModelID.make(input.model.api.id), providerID: input.model.providerID },
+      sessionID: input.session.id,
+      agent: input.agent,
+    })) {
       const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
       tools[item.id] = tool({
         id: item.id as any,

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -38,7 +38,10 @@ export const BatchTool = Tool.define("batch", async () => {
       const discardedCalls = params.tool_calls.slice(25)
 
       const { ToolRegistry } = await import("./registry")
-      const availableTools = await ToolRegistry.tools({ modelID: ModelID.make(""), providerID: ProviderID.make("") })
+      const availableTools = await ToolRegistry.tools({
+        model: { modelID: ModelID.make(""), providerID: ProviderID.make("") },
+        sessionID: ctx.sessionID,
+      })
       const toolMap = new Map(availableTools.map((t) => [t.id, t]))
 
       const executeCall = async (call: (typeof toolCalls)[0]) => {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -31,6 +31,7 @@ import { Truncate } from "./truncation"
 import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
+import { SessionID } from "../session/schema"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -129,25 +130,28 @@ export namespace ToolRegistry {
     return all().then((x) => x.map((t) => t.id))
   }
 
-  export async function tools(
+  export async function tools(input: {
     model: {
       providerID: ProviderID
       modelID: ModelID
-    },
-    agent?: Agent.Info,
-  ) {
+    }
+    sessionID: SessionID
+    agent?: Agent.Info
+  }) {
     const tools = await all()
     const result = await Promise.all(
       tools
         .filter((t) => {
           // Enable websearch/codesearch for zen users OR via enable flag
           if (t.id === "codesearch" || t.id === "websearch") {
-            return model.providerID === ProviderID.opencode || Flag.OPENCODE_ENABLE_EXA
+            return input.model.providerID === ProviderID.opencode || Flag.OPENCODE_ENABLE_EXA
           }
 
           // use apply tool in same format as codex
           const usePatch =
-            model.modelID.includes("gpt-") && !model.modelID.includes("oss") && !model.modelID.includes("gpt-4")
+            input.model.modelID.includes("gpt-") &&
+            !input.model.modelID.includes("oss") &&
+            !input.model.modelID.includes("gpt-4")
           if (t.id === "apply_patch") return usePatch
           if (t.id === "edit" || t.id === "write") return !usePatch
 
@@ -155,12 +159,12 @@ export namespace ToolRegistry {
         })
         .map(async (t) => {
           using _ = log.time(t.id)
-          const tool = await t.init({ agent })
+          const tool = await t.init({ agent: input.agent })
           const output = {
             description: tool.description,
             parameters: tool.parameters,
           }
-          await Plugin.trigger("tool.definition", { toolID: t.id }, output)
+          await Plugin.trigger("tool.definition", { toolID: t.id, sessionID: input.sessionID }, output)
           return {
             id: t.id,
             ...tool,

--- a/packages/opencode/test/cli/debug-agent.test.ts
+++ b/packages/opencode/test/cli/debug-agent.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Agent } from "../../src/agent/agent"
+import { getAvailableTools } from "../../src/cli/cmd/debug/agent"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("debug agent tool list", () => {
+  test("passes session id into tool definitions", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const plugin = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+        await Bun.write(
+          path.join(plugin, "tool-definition.ts"),
+          [
+            "export default async () => ({",
+            '  "tool.definition": async (input, output) => {',
+            "    output.description = JSON.stringify(input)",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const agent = await Agent.get("build")
+        if (!agent) throw new Error("expected build agent")
+        const tools = await getAvailableTools(agent, session.id)
+        const bash = tools.find((item) => item.id === "bash")
+
+        expect(bash).toBeDefined()
+        expect(JSON.parse(bash!.description)).toEqual({
+          toolID: "bash",
+          sessionID: session.id,
+        })
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/server/experimental-tool.test.ts
+++ b/packages/opencode/test/server/experimental-tool.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionID } from "../../src/session/schema"
+import { ExperimentalRoutes } from "../../src/server/routes/experimental"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("experimental tool route", () => {
+  test("requires session id", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = ExperimentalRoutes()
+        const query = new URLSearchParams({
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+        })
+
+        const res = await app.request(`/tool?${query}`)
+
+        expect(res.status).toBe(400)
+      },
+    })
+  })
+
+  test("passes session id into tool definitions", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plugin = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+
+        await Bun.write(
+          path.join(plugin, "tool-definition.ts"),
+          [
+            "export default async () => ({",
+            '  "tool.definition": async (input, output) => {',
+            "    output.description = JSON.stringify(input)",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = ExperimentalRoutes()
+        const query = new URLSearchParams({
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          sessionID: session.id,
+        })
+
+        const res = await app.request(`/tool?${query}`)
+        expect(res.status).toBe(200)
+
+        const body = (await res.json()) as { id: string; description: string; parameters: unknown }[]
+        const bash = body.find((item) => item.id === "bash")
+        expect(bash).toBeDefined()
+        expect(JSON.parse(bash!.description)).toEqual({
+          toolID: "bash",
+          sessionID: session.id,
+        })
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("returns 404 for a missing session", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = ExperimentalRoutes()
+        const query = new URLSearchParams({
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          sessionID: SessionID.descending(),
+        })
+
+        const res = await app.request(`/tool?${query}`)
+
+        expect(res.status).toBe(404)
+      },
+    })
+  })
+
+  test("returns 400 for an invalid session id", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = ExperimentalRoutes()
+        const query = new URLSearchParams({
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          sessionID: "bad-session-id",
+        })
+
+        const res = await app.request(`/tool?${query}`)
+
+        expect(res.status).toBe(400)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,11 +1,16 @@
 import path from "path"
+import fs from "fs/promises"
 import { describe, expect, test } from "bun:test"
 import { fileURLToPath } from "url"
 import { Instance } from "../../src/project/instance"
+import { Agent } from "../../src/agent/agent"
+import { Provider } from "../../src/provider/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { SessionProcessor } from "../../src/session/processor"
+import { MessageID } from "../../src/session/schema"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -101,6 +106,92 @@ describe("session.prompt missing file", () => {
         expect(text[0]?.startsWith("Called the Read tool with the following input:")).toBe(true)
         expect(text[1]?.includes("Read tool failed to read")).toBe(true)
         expect(text[2]).toBe("after-file")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})
+
+describe("session.prompt tool definitions", () => {
+  test("passes session id into prompt tool definitions", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+      init: async (dir) => {
+        const plugin = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+        await Bun.write(
+          path.join(plugin, "tool-definition.ts"),
+          [
+            "export default async () => ({",
+            '  "tool.definition": async (input, output) => {',
+            "    output.description = JSON.stringify(input)",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const agent = await Agent.get("build")
+        if (!agent) throw new Error("expected build agent")
+        const ids = await Provider.defaultModel()
+        const model = await Provider.getModel(ids.providerID, ids.modelID)
+        const message = await Session.updateMessage({
+          id: MessageID.ascending(),
+          parentID: MessageID.ascending(),
+          sessionID: session.id,
+          role: "assistant",
+          mode: agent.name,
+          agent: agent.name,
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: model.id,
+          providerID: model.providerID,
+          time: { created: Date.now() },
+        })
+        const processor = {
+          message,
+          partFromToolCall() {
+            return undefined
+          },
+        } as unknown as SessionProcessor.Info
+
+        const tools = await SessionPrompt.resolveTools({
+          agent,
+          model,
+          session,
+          processor,
+          bypassAgentCheck: false,
+          messages: [],
+        })
+
+        const bash = tools.bash
+        expect(bash).toBeDefined()
+        if (!bash) throw new Error("expected bash tool")
+        if (!bash.description) throw new Error("expected bash description")
+        expect(JSON.parse(bash.description)).toEqual({
+          toolID: "bash",
+          sessionID: session.id,
+        })
 
         await Session.remove(session.id)
       },

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -3,7 +3,9 @@ import path from "path"
 import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
 import { ToolRegistry } from "../../src/tool/registry"
+import { ModelID, ProviderID } from "../../src/provider/schema"
 
 describe("tool.registry", () => {
   test("loads tools from .opencode/tool (singular)", async () => {
@@ -116,6 +118,89 @@ describe("tool.registry", () => {
       fn: async () => {
         const ids = await ToolRegistry.ids()
         expect(ids).toContain("cowsay")
+      },
+    })
+  })
+
+  test("passes session id to tool.definition hooks", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plugin = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+
+        await Bun.write(
+          path.join(plugin, "tool-definition.ts"),
+          [
+            "export default async () => ({",
+            '  "tool.definition": async (input, output) => {',
+            "    output.description = JSON.stringify(input)",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const model = {
+          providerID: ProviderID.anthropic,
+          modelID: ModelID.make("claude-sonnet-4-5"),
+        }
+
+        const tools = await ToolRegistry.tools({ model, sessionID: session.id })
+        const bash = tools.find((x) => x.id === "bash")
+        expect(bash).toBeDefined()
+        expect(JSON.parse(bash!.description)).toEqual({
+          toolID: "bash",
+          sessionID: session.id,
+        })
+      },
+    })
+  })
+
+  test("uses the provided session id instead of model fields", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const plugin = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(plugin, { recursive: true })
+
+        await Bun.write(
+          path.join(plugin, "tool-definition.ts"),
+          [
+            "export default async () => ({",
+            '  "tool.definition": async (input, output) => {',
+            "    output.description = JSON.stringify(input)",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const a = await Session.create({})
+        const b = await Session.create({})
+        const tools = await ToolRegistry.tools({
+          model: {
+            providerID: ProviderID.anthropic,
+            modelID: ModelID.make("claude-sonnet-4-5"),
+          },
+          sessionID: b.id,
+        })
+        const bash = tools.find((x) => x.id === "bash")
+        expect(bash).toBeDefined()
+        expect(JSON.parse(bash!.description)).toEqual({
+          toolID: "bash",
+          sessionID: b.id,
+        })
+        expect(bash!.description).not.toContain(a.id)
       },
     })
   })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -230,5 +230,8 @@ export interface Hooks {
   /**
    * Modify tool definitions (description and parameters) sent to LLM
    */
-  "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  "tool.definition"?: (
+    input: { toolID: string; sessionID: string },
+    output: { description: string; parameters: any },
+  ) => Promise<void>
 }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -861,7 +861,7 @@ export class Tool extends HeyApiClient {
   /**
    * List tools
    *
-   * Get a list of available tools with their JSON schema parameters for a specific provider and model combination.
+   * Get a list of available tools with their JSON schema parameters for a specific provider, model, and session.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters: {
@@ -869,6 +869,7 @@ export class Tool extends HeyApiClient {
       workspace?: string
       provider: string
       model: string
+      sessionID: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -881,6 +882,7 @@ export class Tool extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "query", key: "provider" },
             { in: "query", key: "model" },
+            { in: "query", key: "sessionID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2445,6 +2445,7 @@ export type ToolListData = {
     workspace?: string
     provider: string
     model: string
+    sessionID: string
   }
   url: "/experimental/tool"
 }
@@ -2454,6 +2455,10 @@ export type ToolListErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * Session not found
+   */
+  404: unknown
 }
 
 export type ToolListError = ToolListErrors[keyof ToolListErrors]


### PR DESCRIPTION
### Issue for this PR

Closes #17334

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tool.definition` hooks now receive the active `sessionID` everywhere tool definitions are built.

This changes `ToolRegistry.tools(...)` to require session context, threads that through prompt resolution, batch execution, debug agent tool listing, and `/experimental/tool`, and updates the plugin and SDK contracts to match. It also adds regression coverage for the registry, prompt, debug, and server paths so the hook sees the same session-backed context in each entry point.

### How did you verify your code works?

- `bun test test/tool test/server`
- `bun typecheck`
- `./packages/sdk/js/script/build.ts`
- `git push -u ian-pascoe feat/tool-definition-session-id` (repo hook ran the workspace typecheck successfully)

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR