### PR TITLE
fix(opencode): fixed js lsp servers detection in monorepos

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -104,7 +104,7 @@ export namespace LSPServer {
     ),
     extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
     async spawn(root) {
-      const tsserver = Module.resolve("typescript/lib/tsserver.js", Instance.directory)
+      const tsserver = Module.resolve("typescript/lib/tsserver.js", root)
       log.info("typescript server", { tsserver })
       if (!tsserver) return
       const proc = spawn(BunProc.which(), ["x", "typescript-language-server", "--stdio"], {
@@ -179,7 +179,7 @@ export namespace LSPServer {
     root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
     extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue"],
     async spawn(root) {
-      const eslint = Module.resolve("eslint", Instance.directory)
+      const eslint = Module.resolve("eslint", root)
       if (!eslint) return
       log.info("spawning eslint server")
       const serverPath = path.join(Global.Path.bin, "vscode-eslint", "server", "out", "eslintServer.js")
@@ -1090,7 +1090,7 @@ export namespace LSPServer {
     extensions: [".astro"],
     root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
     async spawn(root) {
-      const tsserver = Module.resolve("typescript/lib/tsserver.js", Instance.directory)
+      const tsserver = Module.resolve("typescript/lib/tsserver.js", root)
       if (!tsserver) {
         log.info("typescript not found, required for Astro language server")
         return


### PR DESCRIPTION
### Issue for this PR

Closes #7690

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In monorepo setups, LSP servers for JavaScript/TypeScript languages (TypeScript, ESLint, and Astro) were failing to start because the module resolution for `tsserver` and `eslint` was using `Instance.directory` (the monorepo root) instead of the detected package root. This caused issues when TypeScript or ESLint were installed locally in individual packages rather than at the monorepo root. This is how [biome is configured already](https://github.com/tumenbaev/opencode/blob/4039182dd7c2d088c4964a5f7976e176a84fb9f0/packages/opencode/src/lsp/server.ts#L350-L350) and it works correctly.

The fix updates the `Module.resolve` calls in the `spawn` functions for TypeScript, ESLint, and Astro LSP servers to use the `root` parameter (the package-specific directory) instead of `Instance.directory`. 

This ensures LSP servers can properly detect and use locally installed dependencies in monorepo environments.

### How did you verify your code works?

I tested the changes in a monorepo setup with multiple JavaScript/TypeScript packages, verifying that LSP servers now start correctly and resolve dependencies from the correct package directories.

### Screenshots / recordings

`-`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
