### PR TITLE
fix(ui): force wasm highlighter for markdown code blocks

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -428,7 +428,11 @@ async function highlightCodeBlocks(html: string): Promise<string> {
   const matches = [...html.matchAll(codeBlockRegex)]
   if (matches.length === 0) return html
 
-  const highlighter = await getSharedHighlighter({ themes: ["OpenCode"], langs: [] })
+  const highlighter = await getSharedHighlighter({
+    themes: ["OpenCode"],
+    langs: [],
+    preferredHighlighter: "shiki-wasm",
+  })
 
   let result = html
   for (const match of matches) {
@@ -479,7 +483,11 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       }),
       markedShiki({
         async highlight(code, lang) {
-          const highlighter = await getSharedHighlighter({ themes: ["OpenCode"], langs: [] })
+          const highlighter = await getSharedHighlighter({
+            themes: ["OpenCode"],
+            langs: [],
+            preferredHighlighter: "shiki-wasm",
+          })
           if (!(lang in bundledLanguages)) {
             lang = "text"
           }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a reproducible desktop black screen when opening certain sessions with heavy markdown/code-block content.

In packages/ui/src/context/marked.tsx, markdown highlighting used getSharedHighlighter(...) without explicitly setting preferredHighlighter, so it could still use the default JS regex engine (shiki-js).

This PR updates both markdown highlighter call sites to explicitly use: preferredHighlighter: "shiki-wasm"

This aligns markdown behavior with our diff rendering path, which already uses the correct wasm highlighter setting (preferredHighlighter: "shiki-wasm" in the diff worker.

### How did you verify your code works?

A/B on the same problematic sessions:

With fix: no black screen
Revert fix: black screen reproduces
Also verified with bun run typecheck in packages/ui (pass).

### Screenshots / recordings

before fix:

https://github.com/user-attachments/assets/392f9f4d-ba97-4cfd-b364-709de03cc3c1



after fix:

https://github.com/user-attachments/assets/298b85b2-e855-4ea1-8e80-d2f298b172c5





_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
