### PR TITLE
fix(lsp): set rust-analyzer cargo.targetDir to avoid build conflicts

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -895,6 +895,13 @@ export namespace LSPServer {
         process: spawn(bin, {
           cwd: root,
         }),
+        initialization: {
+          "rust-analyzer": {
+            cargo: {
+              targetDir: true,
+            },
+          },
+        },
       }
     },
   }


### PR DESCRIPTION
### Issue for this PR

Closes #17377

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `cargo.targetDir: true` to the rust-analyzer LSP initialization options in `packages/opencode/src/lsp/server.ts`.

Without this setting, rust-analyzer shares the project's `target/` directory with `cargo build`. When both run concurrently (which is common — you're building while the LSP is analyzing), they fight over file locks and incremental compilation state. This causes:

- `cargo build` failures ("could not rename", "directory not empty")
- Stale analysis results in rust-analyzer
- Lock contention slowing down both processes

Setting `targetDir: true` tells rust-analyzer to use `target/rust-analyzer/` instead, so it never touches the main build directory. This is the same setting VS Code's rust-analyzer extension recommends, and it's already supported by the `Handle.initialization` field in the LSP infrastructure.

The change is 7 lines in one file.

### How did you verify your code works?

- Opened a Rust project in OpenCode desktop, confirmed rust-analyzer starts and indexes correctly
- Verified `target/rust-analyzer/` directory is created (instead of polluting `target/`)
- Ran `cargo build` concurrently with rust-analyzer active — no lock contention or build errors
- `make build` passes (typecheck + vite + Rust + bundle)

### Screenshots / recordings

_N/A — backend LSP config change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._