### PR TITLE
fix(opencode): handle PDFs in tool results when using Amazon Bedrock

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -567,8 +567,11 @@ export namespace MessageV2 {
     // for providers that don't support media in tool results.
     //
     // OpenAI-compatible APIs only support string content in tool results, so we need
-    // to extract media and inject as user messages. Other SDKs (anthropic, google,
-    // bedrock) handle type: "content" with media parts natively.
+    // to extract media and inject as user messages. Other SDKs (anthropic, google)
+    // handle type: "content" with media parts natively.
+    //
+    // Bedrock is a special case: the SDK only supports images in tool results,
+    // so non-image media (PDFs, etc.) need to be extracted and injected as user messages.
     //
     // Only apply this workaround if the model actually supports image input -
     // otherwise there's no point extracting images.
@@ -704,10 +707,27 @@ export namespace MessageV2 {
               // (images, PDFs) to be sent as a separate user message
               const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
               const nonMediaAttachments = attachments.filter((a) => !isMedia(a.mime))
+
+              // Bedrock SDK only supports images in tool results, not other media types (PDFs, etc.)
+              // This is an SDK limitation - the Bedrock API does support DocumentBlock in tool results
+              // Extract non-image media to be injected as user messages
+              const isBedrock = model.api.npm === "@ai-sdk/amazon-bedrock"
+              const bedrockNonImages = isBedrock ? mediaAttachments.filter((a) => !a.mime.startsWith("image/")) : []
+              const bedrockImages = isBedrock ? mediaAttachments.filter((a) => a.mime.startsWith("image/")) : mediaAttachments
+
               if (!supportsMediaInToolResults && mediaAttachments.length > 0) {
                 media.push(...mediaAttachments)
               }
-              const finalAttachments = supportsMediaInToolResults ? attachments : nonMediaAttachments
+              // Bedrock: extract non-image media even though it "supports" media in tool results
+              if (bedrockNonImages.length > 0) {
+                media.push(...bedrockNonImages)
+              }
+
+              const finalAttachments = supportsMediaInToolResults
+                ? isBedrock
+                  ? [...nonMediaAttachments, ...bedrockImages]
+                  : attachments
+                : nonMediaAttachments
 
               const output =
                 finalAttachments.length > 0


### PR DESCRIPTION
### Issue for this PR

Closes #17400 

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `@ai-sdk/amazon-bedrock` package doesn't support non-image media in tool results. When the Read tool returns a PDF, it throws:

```
AI_UnsupportedFunctionalityError: 'media type: application/pdf' functionality not supported
```

This is an upstream ai-sdk limitation — the Bedrock API supports `DocumentBlock` in tool results, but the SDK only implements images.

The fix consists on extracting non-image media from tool results for Bedrock and injecting as user messages (like we already do for providers that don't support media in tool results). Images continue to work in tool results. Only non-image media gets extracted.

### How did you verify your code works?

I tested it by uploading a pdf and verifying that it could be read.

### Screenshots / recordings

Before fix:
<img width="975" height="549" alt="Screenshot 2026-03-13 at 17 54 06" src="https://github.com/user-attachments/assets/0b757d0c-5719-44b0-8198-c814d10f734d" />

After fix:
<img width="978" height="552" alt="Screenshot 2026-03-13 at 17 54 15" src="https://github.com/user-attachments/assets/eb5bddd0-f786-47ad-9133-5d6d6a079099" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
