### PR TITLE
fix: prevent xAI/Grok tool payloads from tripping grammar complexity

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -201,7 +201,11 @@ export namespace LLM {
     }
 
     const all = Object.keys(tools).filter((x) => x !== "invalid")
-    const cap = input.model.limit.tools
+    const cap = (() => {
+      const value = (input.model.limit as Record<string, unknown>)["tools"]
+      if (typeof value === "number") return value
+      return undefined
+    })()
     let active = all
     if (cap && all.length > cap) {
       l.warn("capping tools", {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -26,6 +26,22 @@ import { Auth } from "@/auth"
 export namespace LLM {
   const log = Log.create({ service: "llm" })
   export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
+  const XAI_SCHEMA_MAX = 20_000
+  const XAI_TOOL_MAX = 40
+
+  function xaiToolBytes(id: string, tool: Tool) {
+    const schema = tool.inputSchema as { jsonSchema?: unknown }
+    return new TextEncoder().encode(
+      JSON.stringify({
+        type: "function",
+        function: {
+          name: id,
+          description: tool.description,
+          parameters: schema.jsonSchema ?? {},
+        },
+      }),
+    ).length
+  }
 
   export type StreamInput = {
     user: MessageV2.User
@@ -184,6 +200,70 @@ export namespace LLM {
       })
     }
 
+    const all = Object.keys(tools).filter((x) => x !== "invalid")
+    const cap = input.model.limit.tools
+    let active = all
+    if (cap && all.length > cap) {
+      l.warn("capping tools", {
+        total: all.length,
+        limit: cap,
+        dropped: all.length - cap,
+      })
+      active = all.slice(0, cap)
+    }
+
+    const xai = input.model.api.npm === "@ai-sdk/xai" || input.model.id.toLowerCase().includes("grok")
+    if (xai && active.length > 0) {
+      if (active.length > XAI_TOOL_MAX) {
+        const sized = active.map((id) => ({ id, bytes: xaiToolBytes(id, tools[id]!) }))
+        const keep = sized.slice(0, XAI_TOOL_MAX)
+        l.warn("capping xai tool count", {
+          total: sized.length,
+          final: keep.length,
+          dropped: sized.length - keep.length,
+          limit: XAI_TOOL_MAX,
+        })
+        active = keep.map((item) => item.id)
+      }
+
+      const sized = active.map((id) => ({ id, bytes: xaiToolBytes(id, tools[id]!) }))
+      let total = sized.reduce((acc, item) => acc + item.bytes, 0)
+      if (total > XAI_SCHEMA_MAX) {
+        const keep = [...sized]
+        const drop = [...sized].sort((a, b) => b.bytes - a.bytes)
+        for (const item of drop) {
+          if (total <= XAI_SCHEMA_MAX) break
+          if (keep.length <= 1) break
+          const idx = keep.findIndex((v) => v.id === item.id)
+          if (idx < 0) continue
+          keep.splice(idx, 1)
+          total -= item.bytes
+        }
+        l.warn("capping xai tool schema budget", {
+          totalBytes: sized.reduce((acc, item) => acc + item.bytes, 0),
+          finalBytes: total,
+          budget: XAI_SCHEMA_MAX,
+          dropped: sized.length - keep.length,
+          total: sized.length,
+        })
+        active = keep.map((item) => item.id)
+        if (total > XAI_SCHEMA_MAX && input.toolChoice !== "required") {
+          l.warn("dropping all xai tools because single tool exceeds schema budget", {
+            finalBytes: total,
+            budget: XAI_SCHEMA_MAX,
+          })
+          active = []
+        }
+      }
+    }
+
+    let finalTools = tools
+    if (xai) {
+      const keep = new Set(active)
+      if (tools["invalid"]) keep.add("invalid")
+      if (tools["_noop"] && active.length > 0) keep.add("_noop")
+      finalTools = Object.fromEntries(Object.entries(tools).filter(([id]) => keep.has(id)))
+    }
     return streamText({
       onError(error) {
         l.error("stream error", {
@@ -215,8 +295,8 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-      tools,
+      activeTools: active,
+      tools: finalTools,
       toolChoice: input.toolChoice,
       maxOutputTokens,
       abortSignal: input.abort,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -764,7 +764,7 @@ describe("session.llm.stream", () => {
     if (!server) throw new Error("Server not initialized")
 
     const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
-    const modelID = "grok-4"
+    const modelID = "grok-4" as Parameters<typeof Provider.getModel>[1]
     await loadFixture(providerID, modelID)
 
     const request = waitRequest(
@@ -860,7 +860,7 @@ describe("session.llm.stream", () => {
     if (!server) throw new Error("Server not initialized")
 
     const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
-    const modelID = "grok-4"
+    const modelID = "grok-4" as Parameters<typeof Provider.getModel>[1]
     await loadFixture(providerID, modelID)
 
     const request = waitRequest(

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
-import { tool, type ModelMessage } from "ai"
+import { jsonSchema, tool, type ModelMessage } from "ai"
 import z from "zod"
 import { LLM } from "../../src/session/llm"
 import { Global } from "../../src/global"
@@ -107,6 +107,8 @@ type Capture = {
   headers: Headers
   body: Record<string, unknown>
 }
+
+type StreamTools = Parameters<typeof LLM.stream>[0]["tools"]
 
 const state = {
   server: null as ReturnType<typeof Bun.serve> | null,
@@ -753,6 +755,190 @@ describe("session.llm.stream", () => {
         expect(config?.temperature).toBe(0.3)
         expect(config?.topP).toBe(0.8)
         expect(config?.maxOutputTokens).toBe(ProviderTransform.maxOutputTokens(resolved))
+      },
+    })
+  })
+
+  test("caps xai tools by schema budget", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const fixture = await loadFixture("xai", "grok-4")
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["xai"],
+            provider: {
+              xai: {
+                options: {
+                  apiKey: "test-xai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make("xai"), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-xai-cap")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-xai-cap"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("xai"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const tools: Record<string, unknown> = {}
+        for (let i = 0; i < 120; i++) {
+          const props: Record<string, { type: "string"; description: string }> = {}
+          for (let j = 0; j < 25; j++) {
+            props[`f_${i}_${j}`] = { type: "string", description: "x".repeat(120) }
+          }
+          tools[`tool_${i}`] = tool({
+            description: `tool ${i}`,
+            inputSchema: jsonSchema({ type: "object", properties: props }),
+            execute: async () => ({ output: "", title: "", metadata: {} }),
+          })
+        }
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: tools as StreamTools,
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+        expect(Array.isArray(body.tools)).toBe(true)
+        const sent = body.tools as unknown[]
+        expect(sent.length).toBeLessThanOrEqual(40)
+        const bytes = new TextEncoder().encode(JSON.stringify(sent)).length
+        expect(bytes).toBeLessThanOrEqual(20000)
+      },
+    })
+  })
+
+  test("drops single oversized xai tool when tool choice is auto", async () => {
+    const server = state.server
+    if (!server) throw new Error("Server not initialized")
+
+    const fixture = await loadFixture("xai", "grok-4")
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["xai"],
+            provider: {
+              xai: {
+                options: {
+                  apiKey: "test-xai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make("xai"), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-xai-single")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-xai-single"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("xai"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const props: Record<string, { type: "string"; description: string }> = {}
+        for (let i = 0; i < 400; i++) {
+          props[`f_${i}`] = { type: "string", description: "x".repeat(220) }
+        }
+        const tools: Record<string, unknown> = {
+          giant: tool({
+            description: "giant",
+            inputSchema: jsonSchema({ type: "object", properties: props }),
+            execute: async () => ({ output: "", title: "", metadata: {} }),
+          }),
+        }
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: tools as StreamTools,
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+        expect(body.tools).toBeUndefined()
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -765,8 +765,7 @@ describe("session.llm.stream", () => {
 
     const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
     const modelID = "grok-4"
-    const fixture = await loadFixture(providerID, modelID)
-    const model = fixture.model
+    await loadFixture(providerID, modelID)
 
     const request = waitRequest(
       "/chat/completions",
@@ -799,7 +798,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(providerID, model.id)
+        const resolved = await Provider.getModel(providerID, modelID)
         const sessionID = SessionID.make("session-test-xai-cap")
         const agent = {
           name: "test",
@@ -862,8 +861,7 @@ describe("session.llm.stream", () => {
 
     const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
     const modelID = "grok-4"
-    const fixture = await loadFixture(providerID, modelID)
-    const model = fixture.model
+    await loadFixture(providerID, modelID)
 
     const request = waitRequest(
       "/chat/completions",
@@ -896,7 +894,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(providerID, model.id)
+        const resolved = await Provider.getModel(providerID, modelID)
         const sessionID = SessionID.make("session-test-xai-single")
         const agent = {
           name: "test",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -763,7 +763,7 @@ describe("session.llm.stream", () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")
 
-    const providerID = "xai"
+    const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
     const modelID = "grok-4"
     const fixture = await loadFixture(providerID, modelID)
     const model = fixture.model
@@ -860,7 +860,7 @@ describe("session.llm.stream", () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")
 
-    const providerID = "xai"
+    const providerID = "xai" as Parameters<typeof Provider.getModel>[0]
     const modelID = "grok-4"
     const fixture = await loadFixture(providerID, modelID)
     const model = fixture.model

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -763,7 +763,9 @@ describe("session.llm.stream", () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")
 
-    const fixture = await loadFixture("xai", "grok-4")
+    const providerID = "xai"
+    const modelID = "grok-4"
+    const fixture = await loadFixture(providerID, modelID)
     const model = fixture.model
 
     const request = waitRequest(
@@ -780,9 +782,9 @@ describe("session.llm.stream", () => {
           path.join(dir, "opencode.json"),
           JSON.stringify({
             $schema: "https://opencode.ai/config.json",
-            enabled_providers: ["xai"],
+            enabled_providers: [providerID],
             provider: {
-              xai: {
+              [providerID]: {
                 options: {
                   apiKey: "test-xai-key",
                   baseURL: `${server.url.origin}/v1`,
@@ -797,7 +799,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel("xai", model.id)
+        const resolved = await Provider.getModel(providerID, model.id)
         const sessionID = SessionID.make("session-test-xai-cap")
         const agent = {
           name: "test",
@@ -812,7 +814,7 @@ describe("session.llm.stream", () => {
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID: "xai", modelID: resolved.id },
+          model: { providerID, modelID: resolved.id },
         } satisfies MessageV2.User
 
         const tools: Record<string, unknown> = {}
@@ -858,7 +860,9 @@ describe("session.llm.stream", () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")
 
-    const fixture = await loadFixture("xai", "grok-4")
+    const providerID = "xai"
+    const modelID = "grok-4"
+    const fixture = await loadFixture(providerID, modelID)
     const model = fixture.model
 
     const request = waitRequest(
@@ -875,9 +879,9 @@ describe("session.llm.stream", () => {
           path.join(dir, "opencode.json"),
           JSON.stringify({
             $schema: "https://opencode.ai/config.json",
-            enabled_providers: ["xai"],
+            enabled_providers: [providerID],
             provider: {
-              xai: {
+              [providerID]: {
                 options: {
                   apiKey: "test-xai-key",
                   baseURL: `${server.url.origin}/v1`,
@@ -892,7 +896,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel("xai", model.id)
+        const resolved = await Provider.getModel(providerID, model.id)
         const sessionID = SessionID.make("session-test-xai-single")
         const agent = {
           name: "test",
@@ -907,7 +911,7 @@ describe("session.llm.stream", () => {
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID: "xai", modelID: resolved.id },
+          model: { providerID, modelID: resolved.id },
         } satisfies MessageV2.User
 
         const props: Record<string, { type: "string"; description: string }> = {}

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -797,7 +797,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(ProviderID.make("xai"), ModelID.make(model.id))
+        const resolved = await Provider.getModel("xai", model.id)
         const sessionID = SessionID.make("session-test-xai-cap")
         const agent = {
           name: "test",
@@ -812,7 +812,7 @@ describe("session.llm.stream", () => {
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID: ProviderID.make("xai"), modelID: resolved.id },
+          model: { providerID: "xai", modelID: resolved.id },
         } satisfies MessageV2.User
 
         const tools: Record<string, unknown> = {}
@@ -892,7 +892,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(ProviderID.make("xai"), ModelID.make(model.id))
+        const resolved = await Provider.getModel("xai", model.id)
         const sessionID = SessionID.make("session-test-xai-single")
         const agent = {
           name: "test",
@@ -907,7 +907,7 @@ describe("session.llm.stream", () => {
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID: ProviderID.make("xai"), modelID: resolved.id },
+          model: { providerID: "xai", modelID: resolved.id },
         } satisfies MessageV2.User
 
         const props: Record<string, { type: "string"; description: string }> = {}


### PR DESCRIPTION
### Issue for this PR

Closes #17405

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Grok requests were still able to include oversized tool payloads even when `activeTools` was reduced, because the full `tools` map could still be sent to `streamText`. On xAI models this can trigger `grammar is too complex` failures.

This PR hardens the xAI path by:
- capping xAI tools by count (`40`)
- budgeting by estimated wire payload per tool (name + description + schema), not schema-only bytes
- pruning the actual `tools` object sent to `streamText` for xAI so dropped tools cannot leak through
- adding tests for schema-budget capping and dropping a single oversized tool when tool choice is auto

Why this works: xAI grammar complexity is sensitive to total tool schema payload; enforcing limits on the exact outgoing tool payload prevents over-budget requests from reaching Grok.

Related context:
- Existing xAI schema-sanitization work in this repo (same failure family)
- External reference: vercel/ai issue around xAI grammar complexity (`vercel/ai#8024`)

### How did you verify your code works?

- `bun test test/session/llm.test.ts` (packages/opencode) -> pass (12/12)
- `bun typecheck` (packages/opencode) -> pass
- Real CLI oneshot smoke test against a local mocked xAI `/chat/completions` endpoint:
  - invokes `opencode run ... --model xai/grok-4`
  - asserts outgoing `tools` payload stays within count <= 40 and bytes <= 20000
  - pass (`CLI oneshot xAI smoke test passed`, `requests=1`)

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR