### PR TITLE
fix(app): defer provider and agent fetches from blocking bootstrap

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -124,11 +124,6 @@ export async function bootstrapDirectory(input: {
 
   const blockingRequests = {
     project: () => input.sdk.project.current().then((x) => input.setStore("project", x.data!.id)),
-    provider: () =>
-      input.sdk.provider.list().then((x) => {
-        input.setStore("provider", normalizeProviderList(x.data!))
-      }),
-    agent: () => input.sdk.app.agents().then((x) => input.setStore("agent", x.data ?? [])),
     config: () => input.sdk.config.get().then((x) => input.setStore("config", x.data!)),
   }
 
@@ -149,6 +144,10 @@ export async function bootstrapDirectory(input: {
   if (input.store.status !== "complete") input.setStore("status", "partial")
 
   Promise.all([
+    input.sdk.provider.list().then((x) => {
+      input.setStore("provider", normalizeProviderList(x.data!))
+    }),
+    input.sdk.app.agents().then((x) => input.setStore("agent", x.data ?? [])),
     input.sdk.path.get().then((x) => input.setStore("path", x.data!)),
     input.sdk.command.list().then((x) => input.setStore("command", x.data ?? [])),
     input.sdk.session.status().then((x) => input.setStore("session_status", x.data!)),


### PR DESCRIPTION
### Issue for this PR

Closes #17408

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

During global sync bootstrap, the provider list, provider auth, and agent list fetches are all marked as blocking requests. The UI cannot render until all three complete. However, provider and agent data are not needed for the initial render — the session list and message timeline are what the user sees first.

This PR moves the provider and agent fetches out of the `blockingRequests` object and into fire-and-forget calls that populate the store asynchronously. The UI now renders as soon as sessions are loaded, with provider/agent data appearing when their respective API calls complete.

The change is a one-file, 4-insertion/5-deletion diff in `bootstrap.ts`.

### How did you verify your code works?

- Tested locally — UI renders faster, provider/agent dropdowns populate shortly after
- No regressions in session list or message rendering

### Screenshots / recordings

_N/A — logic change in bootstrap flow._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR