### PR TITLE
fix(provider): raise default chunk timeout and retry on TypeValidationError from transient provider errors

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1019,12 +1019,19 @@ export namespace Config {
               "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
             ),
           chunkTimeout: z
-            .number()
-            .int()
-            .positive()
+            .union([
+              z
+                .number()
+                .int()
+                .positive()
+                .describe(
+                  "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted. Set to false to disable chunk timeout.",
+                ),
+              z.literal(false).describe("Disable chunk timeout for this provider entirely."),
+            ])
             .optional()
             .describe(
-              "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+              "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted. Set to false to disable chunk timeout.",
             ),
         })
         .catchall(z.any())

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -47,7 +47,7 @@ import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
 
-const DEFAULT_CHUNK_TIMEOUT = 120_000
+const DEFAULT_CHUNK_TIMEOUT = 300_000
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -1185,7 +1185,7 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
-      const chunkTimeout = options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT
+      const chunkTimeout = options["chunkTimeout"] === false ? false : (options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT)
       delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1185,7 +1185,8 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
-      const chunkTimeout = options["chunkTimeout"] === false ? false : (options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT)
+      const chunkTimeout =
+        options["chunkTimeout"] === false ? false : (options["chunkTimeout"] ?? DEFAULT_CHUNK_TIMEOUT)
       delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -2,7 +2,14 @@ import { BusEvent } from "@/bus/bus-event"
 import { SessionID, MessageID, PartID } from "./schema"
 import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
-import { APICallError, convertToModelMessages, LoadAPIKeyError, TypeValidationError, type ModelMessage, type UIMessage } from "ai"
+import {
+  APICallError,
+  convertToModelMessages,
+  LoadAPIKeyError,
+  TypeValidationError,
+  type ModelMessage,
+  type UIMessage,
+} from "ai"
 import { LSP } from "../lsp"
 import { Snapshot } from "@/snapshot"
 import { fn } from "@/util/fn"
@@ -956,8 +963,18 @@ export namespace MessageV2 {
           { cause: e },
         ).toObject()
       case TypeValidationError.isInstance(e): {
-        const body = typeof e.value === "string" ? e.value : JSON.stringify(e.value)
-        const transient = /InternalServerException|ServiceUnavailableException|ThrottlingException|Too Many Requests|BadGatewayException/i.test(body)
+        const body = (() => {
+          if (typeof e.value === "string") return e.value
+          try {
+            return JSON.stringify(e.value) ?? String(e.value)
+          } catch {
+            return String(e.value)
+          }
+        })()
+        const transient =
+          /InternalServerException|ServiceUnavailableException|ThrottlingException|TooManyRequestsException|BadGatewayException|Bad Gateway|Too Many Requests|\b(429|500|502|503|504)\b/i.test(
+            body,
+          )
         if (transient)
           return new MessageV2.APIError(
             {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -2,7 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { SessionID, MessageID, PartID } from "./schema"
 import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
-import { APICallError, convertToModelMessages, LoadAPIKeyError, type ModelMessage, type UIMessage } from "ai"
+import { APICallError, convertToModelMessages, LoadAPIKeyError, TypeValidationError, type ModelMessage, type UIMessage } from "ai"
 import { LSP } from "../lsp"
 import { Snapshot } from "@/snapshot"
 import { fn } from "@/util/fn"
@@ -955,6 +955,20 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case TypeValidationError.isInstance(e): {
+        const body = typeof e.value === "string" ? e.value : JSON.stringify(e.value)
+        const transient = /InternalServerException|ServiceUnavailableException|ThrottlingException|Too Many Requests|BadGatewayException/i.test(body)
+        if (transient)
+          return new MessageV2.APIError(
+            {
+              message: body.slice(0, 500),
+              isRetryable: true,
+              responseBody: body,
+            },
+            { cause: e },
+          ).toObject()
+        return new NamedError.Unknown({ message: e.message }, { cause: e }).toObject()
+      }
       case e instanceof Error:
         return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
       default:


### PR DESCRIPTION
## Summary

Two fixes for provider error handling that improve reliability with proxied providers and slow/local models:

1. **Raise default SSE chunk timeout from 2min to 5min and allow disabling via `chunkTimeout: false`** — Proxy servers and slow local models frequently exceed the 2-minute inter-chunk timeout during extended thinking or response buffering, causing premature request aborts. The config schema now supports `chunkTimeout: false` to completely disable chunk timeout (matching the existing `timeout: false` pattern).

2. **Retry on `TypeValidationError` caused by transient provider errors** — When providers like AWS Bedrock return 500-class errors (e.g. `InternalServerException`), the AI SDK throws `TypeValidationError` instead of `APICallError` because the error response doesn't match the expected SSE event schema. Previously these errors fell through to `NamedError.Unknown` and were not retried. Now `fromError()` detects known transient error patterns in the `TypeValidationError.value` and creates a retryable `APIError`.

## Changes

- `packages/opencode/src/provider/provider.ts`: `DEFAULT_CHUNK_TIMEOUT` 120_000 → 300_000; explicit `=== false` check with `??` fallback
- `packages/opencode/src/config/config.ts`: `chunkTimeout` schema now accepts `false` via `z.union([...])` 
- `packages/opencode/src/session/message-v2.ts`: New `TypeValidationError` case in `fromError()` with safe stringify and broad transient pattern matching

## Testing

- All related module tests pass (provider 70/70, session 3/3, config 66/66)
- Full test suite: 1282 pass / 18 fail / 8 skip — zero new failures vs origin/dev baseline (1280 pass / 20 fail / 8 skip)

Relates to #17307 #13040 #13579