### PR TITLE
docs: add OpenCode Remote to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -67,7 +67,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
-| [OpenCode Remote](https://github.com/AbdullahElTiby/opencode-remote)                       | Self-hosted remote control for OpenCode with a hardened gateway and native Expo mobile client |
+| [OpenCode Remote](https://github.com/AbdullahElTiby/opencode-remote)                       | Alpha self-hosted remote control for OpenCode with a hardened gateway and native Expo mobile client |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -67,6 +67,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OpenCode Remote](https://github.com/AbdullahElTiby/opencode-remote)                       | Self-hosted remote control for OpenCode with a hardened gateway and native Expo mobile client |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #17421

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds OpenCode Remote to the ecosystem Projects list in the documentation. The new entry links to the public repository and describes it as an alpha self-hosted remote control companion for OpenCode with a hardened gateway and a native Expo mobile client.

### How did you verify your code works?

I verified this change locally by reviewing the markdown diff in packages/web/src/content/docs/ecosystem.mdx, confirming the new row is in the Projects table, and checking that the table formatting stays consistent with the surrounding entries. This is a docs-only change.

### Screenshots / recordings

Not applicable for this docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR