### PR TITLE
fix: make snapshot prune interval configurable

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1053,6 +1053,7 @@ export namespace Config {
         .optional(),
       plugin: z.string().array().optional(),
       snapshot: z.boolean().optional(),
+      snapshotPruneDays: z.number().min(1).max(30).optional().describe("Days to keep snapshots before pruning (default: 7)"),
       share: z
         .enum(["manual", "auto", "disabled"])
         .optional()

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -13,7 +13,7 @@ import { Process } from "@/util/process"
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
-  const prune = "7.days"
+  const defaultPruneDays = 7
 
   function args(git: string, cmd: string[]) {
     return ["--git-dir", git, "--work-tree", Instance.worktree, ...cmd]
@@ -38,6 +38,8 @@ export namespace Snapshot {
       .then(() => true)
       .catch(() => false)
     if (!exists) return
+    const pruneDays = cfg.snapshotPruneDays ?? defaultPruneDays
+    const prune = `${pruneDays}.days`
     const result = await Process.run(["git", ...args(git, ["gc", `--prune=${prune}`])], {
       cwd: Instance.directory,
       nothrow: true,


### PR DESCRIPTION
### Issue for this PR

Closes #17397

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR makes the snapshot prune interval configurable to prevent massive disk usage.

**Changes:**
- Add `snapshotPruneDays` config option (1-30 days, default: 7)
- Read from user config before using hardcoded 7-day default
- Helps prevent massive disk usage by allowing shorter retention periods

The change allows users to customize how long snapshots are kept before pruning, reducing disk usage for those who need shorter retention.

### How did you verify your code works?

Tested locally by setting different `snapshotPruneDays` values in config and verifying that snapshots are pruned according to the configured interval. Also confirmed that the default (7 days) is used when the option is not set.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._  
(Not applicable – this is a configuration change.)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR