### PR TITLE
tweak: ensure that compaction message is tracked as agent initiated

### DIFF
--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -309,6 +309,11 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         output.headers["anthropic-beta"] = "interleaved-thinking-2025-05-14"
       }
 
+      if (incoming.agent === "compaction") {
+        output.headers["x-initiator"] = "agent"
+        return
+      }
+
       const session = await sdk.session
         .get({
           path: {

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -315,6 +315,9 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             id: incoming.message.sessionID,
             messageID: incoming.message.id,
           },
+          query: {
+            directory: input.directory,
+          },
           throwOnError: true,
         })
         .catch(() => undefined)

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -309,7 +309,17 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         output.headers["anthropic-beta"] = "interleaved-thinking-2025-05-14"
       }
 
-      if (incoming.agent === "compaction") {
+      const parts = await sdk.session
+        .message({
+          path: {
+            id: incoming.message.sessionID,
+            messageID: incoming.message.id,
+          },
+          throwOnError: true,
+        })
+        .catch(() => undefined)
+
+      if (parts?.data.parts?.some((part) => part.type === "compaction")) {
         output.headers["x-initiator"] = "agent"
         return
       }


### PR DESCRIPTION
Matches github copilot cli behavior

relates to: https://github.com/anomalyco/opencode/issues/8030

The [synthetic user message](https://github.com/anomalyco/opencode/blob/f2d3a4c70f6e9c5e233e1a47c55bb068639fd821/packages/opencode/src/session/compaction.ts#L277) sent after compaction will still count against quota, looking into a better way to solving that... but at least it won't double bill now


Lol ^^ looks like someone updated compaction while I was out so technically u shouldnt be billed for compaction at all now but it seems like that synthetic user message never gets sent anymore (a bug)