### PR TITLE
feat(opencode): support .claude/CLAUDE.md as project instruction file

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -14,6 +14,7 @@ const log = Log.create({ service: "instruction" })
 const FILES = [
   "AGENTS.md",
   "CLAUDE.md",
+  path.join(".claude", "CLAUDE.md"),
   "CONTEXT.md", // deprecated
 ]
 

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -49,6 +49,49 @@ describe("InstructionPrompt.resolve", () => {
     })
   })
 
+  test("returns .claude/CLAUDE.md from subdirectory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", ".claude", "CLAUDE.md"), "# Subdir Claude Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const results = await InstructionPrompt.resolve(
+          [],
+          path.join(tmp.path, "subdir", "nested", "file.ts"),
+          "test-message-dotclaude",
+        )
+        expect(results.length).toBe(1)
+        expect(results[0].filepath).toBe(path.join(tmp.path, "subdir", ".claude", "CLAUDE.md"))
+      },
+    })
+  })
+
+  test("CLAUDE.md takes priority over .claude/CLAUDE.md in subdirectory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", "CLAUDE.md"), "# Subdir Instructions")
+        await Bun.write(path.join(dir, "subdir", ".claude", "CLAUDE.md"), "# Subdir Claude Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const results = await InstructionPrompt.resolve(
+          [],
+          path.join(tmp.path, "subdir", "nested", "file.ts"),
+          "test-message-both",
+        )
+        expect(results.length).toBe(1)
+        expect(results[0].filepath).toBe(path.join(tmp.path, "subdir", "CLAUDE.md"))
+      },
+    })
+  })
+
   test("doesn't reload AGENTS.md when reading it directly", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -65,6 +108,57 @@ describe("InstructionPrompt.resolve", () => {
 
         const results = await InstructionPrompt.resolve([], filepath, "test-message-2")
         expect(results).toEqual([])
+      },
+    })
+  })
+})
+
+describe("InstructionPrompt.systemPaths .claude/CLAUDE.md", () => {
+  test("finds .claude/CLAUDE.md at project root", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Claude Instructions")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const paths = await InstructionPrompt.systemPaths()
+        expect(paths.has(path.join(tmp.path, ".claude", "CLAUDE.md"))).toBe(true)
+      },
+    })
+  })
+
+  test("CLAUDE.md takes priority over .claude/CLAUDE.md at project root", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "CLAUDE.md"), "# Root Instructions")
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Claude Instructions")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const paths = await InstructionPrompt.systemPaths()
+        expect(paths.has(path.join(tmp.path, "CLAUDE.md"))).toBe(true)
+        expect(paths.has(path.join(tmp.path, ".claude", "CLAUDE.md"))).toBe(false)
+      },
+    })
+  })
+
+  test("AGENTS.md takes priority over .claude/CLAUDE.md", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Agent Instructions")
+        await Bun.write(path.join(dir, ".claude", "CLAUDE.md"), "# Claude Instructions")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const paths = await InstructionPrompt.systemPaths()
+        expect(paths.has(path.join(tmp.path, "AGENTS.md"))).toBe(true)
+        expect(paths.has(path.join(tmp.path, ".claude", "CLAUDE.md"))).toBe(false)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #17436

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Add `.claude/CLAUDE.md` to the instruction file search list as a fallback after `CLAUDE.md`, matching Claude Code's behavior where projects can use either location
- Priority order: `AGENTS.md` > `CLAUDE.md` > `.claude/CLAUDE.md` > `CONTEXT.md`

### How did you verify your code works?

Unit tests + manual testing.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR