### PR TITLE
fix(session): persist interrupted streamed text

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -48,8 +48,8 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          let currentText: MessageV2.TextPart | undefined
           try {
-            let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
             const stream = await LLM.stream(streamInput)
 
@@ -384,6 +384,15 @@ export namespace SessionProcessor {
               })
               SessionStatus.set(input.sessionID, { type: "idle" })
             }
+          }
+          if (currentText) {
+            currentText.text = currentText.text.trimEnd()
+            currentText.time = {
+              start: currentText.time?.start ?? Date.now(),
+              end: Date.now(),
+            }
+            await Session.updatePart(currentText)
+            currentText = undefined
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)

--- a/packages/opencode/test/session/interrupted-text.test.ts
+++ b/packages/opencode/test/session/interrupted-text.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { Bus } from "../../src/bus"
+import { Instance } from "../../src/project/instance"
+import type { Provider } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { LLM } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionProcessor } from "../../src/session/processor"
+import { MessageID } from "../../src/session/schema"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+const model: Provider.Model = {
+  id: ModelID.make("gpt-5.4"),
+  providerID: ProviderID.make("openai"),
+  api: {
+    id: "openai",
+    url: "https://api.openai.com/v1",
+    npm: "@ai-sdk/openai",
+  },
+  name: "GPT-5.4",
+  capabilities: {
+    temperature: true,
+    reasoning: true,
+    attachment: false,
+    toolcall: false,
+    input: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    output: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    interleaved: false,
+  },
+  cost: {
+    input: 0,
+    output: 0,
+    cache: { read: 0, write: 0 },
+  },
+  limit: {
+    context: 128_000,
+    output: 8_000,
+  },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+describe("interrupted streamed text reproducers", () => {
+  test("persists streamed assistant text on abort so reconnect sees the same partial reply", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "manual" })
+        const user = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: {
+            providerID: model.providerID,
+            modelID: model.id,
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+        const assistant: MessageV2.Assistant = {
+          id: MessageID.ascending(),
+          role: "assistant",
+          sessionID: session.id,
+          parentID: user.id,
+          providerID: model.providerID,
+          modelID: model.id,
+          mode: "build",
+          agent: "build",
+          path: {
+            cwd: tmp.path,
+            root: tmp.path,
+          },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: {
+            created: Date.now(),
+          },
+        }
+        await Session.updateMessage(assistant)
+
+        const seen = Promise.withResolvers<void>()
+        let live = ""
+        const off = Bus.subscribe(MessageV2.Event.PartDelta, (evt) => {
+          if (evt.properties.messageID !== assistant.id) return
+          if (evt.properties.field !== "text") return
+          live += evt.properties.delta
+          seen.resolve()
+        })
+
+        const mock = spyOn(LLM, "stream").mockImplementation(async (input) => {
+          return {
+            fullStream: (async function* () {
+              yield { type: "start" }
+              yield { type: "text-start" }
+              yield { type: "text-delta", text: "Here is a long one:" }
+              await new Promise((resolve) => input.abort.addEventListener("abort", resolve, { once: true }))
+              throw new DOMException("Aborted", "AbortError")
+            })(),
+          } as never
+        })
+
+        const abort = new AbortController()
+        const proc = SessionProcessor.create({
+          assistantMessage: assistant,
+          sessionID: session.id,
+          model,
+          abort: abort.signal,
+        })
+        const run = proc.process({} as never)
+
+        await seen.promise
+        abort.abort()
+
+        expect(await run).toBe("stop")
+
+        const msg = await MessageV2.get({
+          sessionID: session.id,
+          messageID: assistant.id,
+        })
+        const text = msg.parts.find((part) => part.type === "text")
+
+        expect(live).toBe("Here is a long one:")
+        expect(text?.type).toBe("text")
+        expect(text && text.type === "text" ? text.text : undefined).toBe(live)
+        expect(msg.info.role === "assistant" ? msg.info.time.completed : undefined).toBeDefined()
+
+        off()
+        mock.mockRestore()
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a regression test for interrupted streamed assistant text disappearing after reconnect
- flush in-progress assistant text during session finalization so aborted runs keep the partial text users already saw
- preserve existing aborted-message semantics where partial assistant output remains visible after interruption

## Verify
- `bun typecheck`
- `bun test test/session/interrupted-text.test.ts test/session/message-v2.test.ts`

## Context
The bug shows up when one attached client receives streamed `message.part.delta` text and another client later reconnects from durable session state. Before this change, interrupting before `text-end` left the assistant message row in place but the persisted text part empty, so reconnecting clients could show less text than live clients had already seen.

## Notes
- This is a provisional fix.
- The implementation keeps the current streaming design and writes any in-progress text part once during finalization instead of persisting every delta token.