### PR TITLE
feat(cuda): add parser and tui language support

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -250,5 +250,18 @@ export default {
         ],
       },
     },
+    {
+      filetype: "cuda",
+      wasm: "https://cdn.jsdelivr.net/npm/tree-sitter-cuda@0.21.1/tree-sitter-cuda.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/cpp/highlights.scm",
+          "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-cuda/master/queries/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/cpp/locals.scm",
+        ],
+      },
+    },
   ],
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -241,6 +241,8 @@ export namespace File {
     "graphql",
     "gql",
     "sql",
+    "cu",
+    "cuh",
     "ini",
     "cfg",
     "conf",

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -149,7 +149,10 @@ export namespace LSPClient {
           input.path = path.isAbsolute(input.path) ? input.path : path.resolve(Instance.directory, input.path)
           const text = await Filesystem.readText(input.path)
           const extension = path.extname(input.path)
-          const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
+          const languageId =
+            result.serverID === "clangd" && [".cu", ".cuh"].includes(extension)
+              ? "cuda-cpp"
+              : LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
 
           const version = files[input.path]
           if (version !== undefined) {

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -9,6 +9,8 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".edn": "clojure",
   ".coffee": "coffeescript",
   ".c": "c",
+  ".cu": "cuda",
+  ".cuh": "cuda",
   ".cpp": "cpp",
   ".cxx": "cpp",
   ".cc": "cpp",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -902,7 +902,7 @@ export namespace LSPServer {
   export const Clangd: Info = {
     id: "clangd",
     root: NearestRoot(["compile_commands.json", "compile_flags.txt", ".clangd", "CMakeLists.txt", "Makefile"]),
-    extensions: [".c", ".cpp", ".cc", ".cxx", ".c++", ".h", ".hpp", ".hh", ".hxx", ".h++"],
+    extensions: [".c", ".cpp", ".cc", ".cxx", ".c++", ".cu", ".h", ".hpp", ".hh", ".hxx", ".h++", ".cuh"],
     async spawn(root) {
       const args = ["--background-index", "--clang-tidy"]
       const fromPath = which("clangd")

--- a/packages/ui/src/components/file-icon.tsx
+++ b/packages/ui/src/components/file-icon.tsx
@@ -218,6 +218,8 @@ const ICON_MAPS: IconMaps = {
     cs: "Csharp",
     vb: "Visualstudio",
     cpp: "Cpp",
+    cu: "Cuda",
+    cuh: "Cuda",
     cc: "Cpp",
     cxx: "Cpp",
     c: "C",


### PR DESCRIPTION
### Issue for this PR

Closes #17447

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds first-class CUDA support in `packages/opencode`. `.cu` and `.cuh` files are mapped as CUDA, the TUI loads a CUDA tree-sitter parser for syntax highlighting, clangd is used for CUDA LSP support, and CUDA files get a dedicated icon.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` and `packages/ui`, then built a local `opencode` binary and verified it starts successfully.

### Screenshots / recordings

before
<img width="2058" height="918" alt="image" src="https://github.com/user-attachments/assets/d12dff72-418b-464d-98cd-029674460c39" />

after
<img width="1992" height="1219" alt="image" src="https://github.com/user-attachments/assets/288ca85b-04e6-4161-b182-2a86d4f4bf17" />
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
