### PR TITLE
fix(tui): improve session scrollbar contrast

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1061,7 +1061,7 @@ export function Session() {
                 visible: showScrollbar(),
                 trackOptions: {
                   backgroundColor: theme.backgroundElement,
-                  foregroundColor: theme.border,
+                  foregroundColor: theme.borderActive,
                 },
               }}
               stickyScroll={true}


### PR DESCRIPTION
### Issue for this PR

Closes #17448

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the main session scrollbar thumb color in the TUI. The session pane was using `theme.border`, which is too close to the track color in the solarized theme. This changes it to `theme.borderActive`, matching the sidebar and permission panels and making the scrollbar visible again.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` after the change and checked the theme code path to confirm the main session scrollbar now uses the active border color.

### Screenshots / recordings

before

<img width="2106" height="1207" alt="image" src="https://github.com/user-attachments/assets/62c1f0a4-3803-4f26-b6fb-84d81edc2984" />

after

<img width="2101" height="1233" alt="image" src="https://github.com/user-attachments/assets/70d26d65-defd-4eec-9e7d-444642dc9713" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
