### PR TITLE
fix: pass --log-level to worker thread

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -129,9 +129,14 @@ export const TuiThreadCommand = cmd({
       const cwd = Filesystem.resolve(process.cwd())
 
       const worker = new Worker(file, {
-        env: Object.fromEntries(
-          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-        ),
+        env: {
+          ...Object.fromEntries(
+            Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+          ),
+          OPENCODE_LOG_LEVEL: process.argv.includes("--log-level")
+            ? process.argv[process.argv.indexOf("--log-level") + 1] || ""
+            : "",
+        },
       })
       worker.onerror = (e) => {
         Log.Default.error(e)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -16,6 +16,7 @@ await Log.init({
   print: process.argv.includes("--print-logs"),
   dev: Installation.isLocal(),
   level: (() => {
+    if (process.env.OPENCODE_LOG_LEVEL) return process.env.OPENCODE_LOG_LEVEL as Log.Level
     if (Installation.isLocal()) return "DEBUG"
     return "INFO"
   })(),


### PR DESCRIPTION
## Summary

Passes the `--log-level` CLI flag from the main thread to the Worker thread via an environment variable, so that both the TUI and the Worker use the same log level.

## Changes

### `packages/opencode/src/cli/cmd/tui/thread.ts`

- Added `OPENCODE_LOG_LEVEL` to the worker's environment variables
- Reads the value from the `--log-level` CLI argument

### `packages/opencode/src/cli/cmd/tui/worker.ts`

- Added check for `OPENCODE_LOG_LEVEL` environment variable
- Falls back to existing behavior if not set

## Problem Solved

Before this fix, running `opencode --log-level ERROR` only affected the main thread (TUI). The Worker thread, which writes log files, always used `INFO` level, causing log files to grow to 100MB+ in long sessions regardless of the CLI flag.

## Testing

Manual verification:
1. Run `opencode --log-level ERROR`
2. Check `~/.local/share/opencode/log/*.log`
3. Verify only ERROR level logs are written to file

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Changes follow code style guidelines
- [ ] No breaking changes

## Related Issues

Fixes #13158

---

<!-- Thank you for contributing to OpenCode! -->