### PR TITLE
docs: fix MCP Servers title casing

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -1,5 +1,5 @@
 ---
-title: MCP servers
+title: MCP Servers
 description: Add local and remote MCP tools.
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This updates the English docs title from `MCP servers` to `MCP Servers` in `packages/web/src/content/docs/mcp-servers.mdx`.

This fixes the sidebar/page title casing so it matches the capitalization style used elsewhere in the English docs.

### How did you verify your code works?

I verified the change locally by checking the diff and confirming the title change is limited to the docs frontmatter.

### Screenshots / recordings

Not needed for this docs-only text change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR