### PR TITLE
fix: support numpad Enter (kpenter) for submitting messages and confirming dialogs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -10,6 +10,7 @@ import { useTheme, selectedForeground } from "@tui/context/theme"
 import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useTerminalDimensions } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
@@ -564,7 +565,7 @@ export function Autocomplete(props: {
             e.preventDefault()
             return
           }
-          if (name === "return") {
+          if (name && isReturn(name)) {
             select()
             e.preventDefault()
             return

--- a/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
@@ -66,6 +66,7 @@ export function useTextareaKeybindings() {
 
     return [
       { name: "return", action: "submit" },
+      { name: "kpenter", action: "submit" },
       { name: "return", meta: true, action: "newline" },
       ...TEXTAREA_ACTIONS.flatMap((action) => mapTextareaKeybindings(keybinds, action)),
     ] satisfies KeyBinding[]

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -11,7 +11,7 @@ import { useSync } from "../../context/sync"
 import { useTextareaKeybindings } from "../../component/textarea-keybindings"
 import path from "path"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
-import { Keybind } from "@/util/keybind"
+import { isReturn, Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 import { Global } from "@/global"
 import { useDialog } from "../../ui/dialog"
@@ -482,7 +482,7 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
       props.onCancel()
       return
     }
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       evt.preventDefault()
       props.onConfirm(input.plainText)
     }
@@ -575,7 +575,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       setStore("selected", next)
     }
 
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       evt.preventDefault()
       props.onSelect(store.selected)
     }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -3,6 +3,7 @@ import { createMemo, createSignal, For, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
+import { isReturn } from "@/util/keybind"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
@@ -143,7 +144,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         textarea?.setText("")
         return
       }
-      if (evt.name === "return") {
+      if (isReturn(evt.name)) {
         evt.preventDefault()
         const text = textarea?.plainText?.trim() ?? ""
         const prev = store.custom[store.tab]
@@ -206,7 +207,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     }
 
     if (confirm()) {
-      if (evt.name === "return") {
+      if (isReturn(evt.name)) {
         evt.preventDefault()
         submit()
       }
@@ -238,7 +239,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         moveTo((store.selected + 1) % total)
       }
 
-      if (evt.name === "return") {
+      if (isReturn(evt.name)) {
         evt.preventDefault()
         selectOption()
       }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,6 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 
 export type DialogAlertProps = {
   title: string
@@ -14,7 +15,7 @@ export function DialogAlert(props: DialogAlertProps) {
   const { theme } = useTheme()
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       props.onConfirm?.()
       dialog.clear()
     }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -4,6 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
 import { For } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 
 export type DialogConfirmProps = {
@@ -21,7 +22,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
   })
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       if (store.active === "confirm") props.onConfirm?.()
       if (store.active === "cancel") props.onCancel?.()
       dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -4,6 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
 import { onMount, Show, type JSX } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 
 export type DialogExportOptionsProps = {
   defaultFilename: string
@@ -34,7 +35,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
   })
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       props.onConfirm?.({
         filename: textarea.plainText,
         thinking: store.thinking,
@@ -99,7 +100,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
             })
           }}
           height={3}
-          keyBindings={[{ name: "return", action: "submit" }]}
+          keyBindings={[{ name: "return", action: "submit" }, { name: "kpenter", action: "submit" }]}
           ref={(val: TextareaRenderable) => (textarea = val)}
           initialValue={props.defaultFilename}
           placeholder="Enter filename"

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
@@ -2,6 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "@tui/context/theme"
 import { useDialog } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 import { useKeybind } from "@tui/context/keybind"
 
 export function DialogHelp() {
@@ -10,7 +11,7 @@ export function DialogHelp() {
   const keybind = useKeybind()
 
   useKeyboard((evt) => {
-    if (evt.name === "return" || evt.name === "escape") {
+    if (isReturn(evt.name) || evt.name === "escape") {
       dialog.clear()
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { onMount, type JSX } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
+import { isReturn } from "@/util/keybind"
 
 export type DialogPromptProps = {
   title: string
@@ -19,7 +20,7 @@ export function DialogPrompt(props: DialogPromptProps) {
   let textarea: TextareaRenderable
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       props.onConfirm?.(textarea.plainText)
     }
   })
@@ -50,7 +51,7 @@ export function DialogPrompt(props: DialogPromptProps) {
             props.onConfirm?.(textarea.plainText)
           }}
           height={3}
-          keyBindings={[{ name: "return", action: "submit" }]}
+          keyBindings={[{ name: "return", action: "submit" }, { name: "kpenter", action: "submit" }]}
           ref={(val: TextareaRenderable) => (textarea = val)}
           initialValue={props.value}
           placeholder={props.placeholder ?? "Enter text"}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -8,7 +8,7 @@ import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
-import { Keybind } from "@/util/keybind"
+import { isReturn, Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 
 export interface DialogSelectProps<T> {
@@ -194,7 +194,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     if (evt.name === "home") moveTo(0)
     if (evt.name === "end") moveTo(flat().length - 1)
 
-    if (evt.name === "return") {
+    if (isReturn(evt.name)) {
       const option = selected()
       if (option) {
         evt.preventDefault()

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -1,6 +1,10 @@
 import { isDeepEqual } from "remeda"
 import type { ParsedKey } from "@opentui/core"
 
+export function isReturn(name: string) {
+  return name === "return" || name === "kpenter"
+}
+
 export namespace Keybind {
   /**
    * Keybind info derived from OpenTUI's ParsedKey with our custom `leader` field.
@@ -90,6 +94,9 @@ export namespace Keybind {
             break
           case "esc":
             info.name = "escape"
+            break
+          case "kpenter":
+            info.name = "kpenter"
             break
           default:
             info.name = part

--- a/packages/opencode/test/keybind.test.ts
+++ b/packages/opencode/test/keybind.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { Keybind } from "../src/util/keybind"
+import { isReturn, Keybind } from "../src/util/keybind"
 
 describe("Keybind.toString", () => {
   test("should convert simple key to string", () => {
@@ -417,5 +417,35 @@ describe("Keybind.parse", () => {
         name: "z",
       },
     ])
+  })
+
+  test("should parse kpenter as key name", () => {
+    const result = Keybind.parse("kpenter")
+    expect(result).toEqual([
+      {
+        ctrl: false,
+        meta: false,
+        shift: false,
+        leader: false,
+        name: "kpenter",
+      },
+    ])
+  })
+})
+
+describe("isReturn", () => {
+  test("should match return", () => {
+    expect(isReturn("return")).toBe(true)
+  })
+
+  test("should match kpenter", () => {
+    expect(isReturn("kpenter")).toBe(true)
+  })
+
+  test("should not match other keys", () => {
+    expect(isReturn("enter")).toBe(false)
+    expect(isReturn("escape")).toBe(false)
+    expect(isReturn("space")).toBe(false)
+    expect(isReturn("")).toBe(false)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #17457

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Terminals using the Kitty keyboard protocol report numpad Enter as `kpenter` (codepoint 57414), which is distinct from `return` (main Enter). The TUI only checked for `evt.name === "return"`, so pressing numpad Enter did nothing — no message submission, no dialog confirmation, no option selection.

This PR adds an `isReturn` helper that matches both `"return"` and `"kpenter"`, and uses it across all keyboard handlers and textarea keybindings in the TUI.

**Changes:**
- Added `isReturn()` helper in `src/util/keybind.ts`
- Replaced all `evt.name === "return"` checks in TUI keyboard handlers with `isReturn(evt.name)`
- Added `{ name: "kpenter", action: "submit" }` to textarea keybindings (main prompt, dialog-prompt, dialog-export-options)
- Added `kpenter` case to `Keybind.parse()` for config support

### How did you verify your code works?

- Ran `bun typecheck` from `packages/opencode` — passes cleanly
- Full `turbo typecheck` across all 13 packages passes with zero errors
- Verified no remaining `evt.name === "return"` checks exist in the CLI/TUI code via grep

### Screenshots / recordings

_N/A — keyboard input behavior change, no visual UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR