### PR TITLE
feat(tui): collapsible long responses and thinking blocks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1419,14 +1419,27 @@ const PART_MAPPING = {
   reasoning: ReasoningPart,
 }
 
+const REASONING_PART_MAX_LINES = 5
+
 function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
   const { theme, subtleSyntax } = useTheme()
   const ctx = use()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
+  const [expanded, setExpanded] = createSignal(false)
+
   const content = createMemo(() => {
     // Filter out redacted reasoning chunks from OpenRouter
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
     return props.part.text.replace("[REDACTED]", "").trim()
   })
+  const lines = createMemo(() => content().split("\n"))
+  const overflow = createMemo(() => lines().length > REASONING_PART_MAX_LINES)
+  const limited = createMemo(() => {
+    if (expanded() || !overflow()) return content()
+    return ["…", ...lines().slice(-REASONING_PART_MAX_LINES)].join("\n")
+  })
+
   return (
     <Show when={content() && ctx.showThinking()}>
       <box
@@ -1436,34 +1449,69 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
         flexDirection="column"
         border={["left"]}
         customBorderChars={SplitBorder.customBorderChars}
-        borderColor={theme.backgroundElement}
+        borderColor={hover() && overflow() ? theme.border : theme.backgroundElement}
+        onMouseOver={() => overflow() && setHover(true)}
+        onMouseOut={() => setHover(false)}
+        onMouseUp={() => {
+          if (renderer.getSelection()?.getSelectedText()) return
+          if (overflow()) setExpanded((prev) => !prev)
+        }}
       >
         <code
           filetype="markdown"
           drawUnstyledText={false}
           streaming={true}
           syntaxStyle={subtleSyntax()}
-          content={"_Thinking:_ " + content()}
+          content={"_Thinking:_ " + limited()}
           conceal={ctx.conceal()}
           fg={theme.textMuted}
         />
+        <Show when={overflow()}>
+          <text fg={theme.textMuted}>{expanded() ? "[↑ show less]" : "[↓ show more]"}</text>
+        </Show>
       </box>
     </Show>
   )
 }
 
+const TEXT_PART_MAX_LINES = 8
+
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
+  const [expanded, setExpanded] = createSignal(false)
+
+  const text = () => props.part.text.trim()
+  const lines = createMemo(() => text().split("\n"))
+  const overflow = createMemo(() => lines().length > TEXT_PART_MAX_LINES)
+  const limited = createMemo(() => {
+    if (expanded() || !overflow()) return text()
+    return [...lines().slice(0, TEXT_PART_MAX_LINES), "…"].join("\n")
+  })
+
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+    <Show when={text()}>
+      <box
+        id={"text-" + props.part.id}
+        paddingLeft={3}
+        marginTop={1}
+        flexShrink={0}
+        backgroundColor={hover() && overflow() ? theme.backgroundMenu : theme.backgroundPanel}
+        onMouseOver={() => overflow() && setHover(true)}
+        onMouseOut={() => setHover(false)}
+        onMouseUp={() => {
+          if (renderer.getSelection()?.getSelectedText()) return
+          if (overflow()) setExpanded((prev) => !prev)
+        }}
+      >
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
               streaming={true}
-              content={props.part.text.trim()}
+              content={limited()}
               conceal={ctx.conceal()}
             />
           </Match>
@@ -1473,12 +1521,15 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={limited()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />
           </Match>
         </Switch>
+        <Show when={overflow()}>
+          <text fg={theme.textMuted}>{expanded() ? "[↑ show less]" : "[↓ show more]"}</text>
+        </Show>
       </box>
     </Show>
   )


### PR DESCRIPTION
## Summary

Long assistant responses and thinking blocks in the TUI now truncate with a click-to-expand toggle, preventing older messages from being pushed far up the thread.

- **TextPart**: responses longer than 8 lines are truncated. A `[↓ show more]` indicator appears at the bottom; clicking the block expands it to full content and shows `[↑ show less]` to collapse again.
- **ReasoningPart**: thinking blocks longer than 5 lines show the **last 5 lines** (tail-first), so the most recent thought stays visible during streaming. Same click-to-expand behaviour.

Both use the existing expand/collapse pattern already established in `GenericTool` and `Bash` (`expanded` signal, `overflow` memo, `limited` memo, `onMouseUp` with selection guard, hover feedback). No nested scrollboxes — the global thread scroll is unchanged.

## Test plan

- [ ] Start the TUI and prompt the model with a request that produces a long response (>8 lines)
- [ ] Verify response is truncated to 8 lines with `[↓ show more]` at the bottom
- [ ] Click the block → expands to full content, indicator changes to `[↑ show less]`
- [ ] Click again → collapses back
- [ ] Select text inside the block → clicking does **not** trigger toggle (selection guard works)
- [ ] Enable a reasoning model → verify thinking block shows last 5 lines during streaming
- [ ] Expand thinking block → full content visible
- [ ] Scroll the global thread → no interference from the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)