### PR TITLE
docs: add opencode-log-sanitizer plugin to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -26,6 +26,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                             |
+| [opencode-log-sanitizer](https://github.com/errhythm/opencode-log-sanitizer)                       | Sanitizes pasted logs by redacting long strings, JWTs, bcrypt hashes, and base64 blobs            |
 | [opencode-vibeguard](https://github.com/inkdust2021/opencode-vibeguard)                            | Redact secrets/PII into VibeGuard-style placeholders before LLM calls; restore locally            |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                   |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.           |


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-log-sanitizer](https://github.com/errhythm/opencode-log-sanitizer) plugin to the ecosystem Plugins table in packages/web/src/content/docs/ecosystem.mdx.

OpenCode Log Sanitizer is a plugin that automatically redacts JWT tokens, bcrypt hashes, base64 blobs, and long quoted strings from the prompts before they reach the AI which reduces token usage and doesn't make the prompt too long. Useful if you are pasting whole logs and it might contain PDF base64 which might not be necessary for AI.

The change is a single table row addition to the existing Plugins section. No code logic or configuration is modified.

### How did you verify your code works?
- I have checked the line I changed in mdx matches other rows as well, then use prettier formatting to make sure its formatted correctly. 
- The plugin has been tested with multiple tests and I have also personally used it. 

### Screenshots / recordings

It is not any UI Change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
