### PR TITLE
fix(app): agent switch should not reset thinking level

### DIFF
--- a/packages/app/e2e/session/session-model-persistence.spec.ts
+++ b/packages/app/e2e/session/session-model-persistence.spec.ts
@@ -349,3 +349,25 @@ test("session model restore across workspaces", async ({ page, withProject }) =>
     await waitFooter(page, firstState)
   })
 })
+
+test("variant preserved when switching agent modes", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+
+  await withProject(async ({ directory, gotoSession }) => {
+    await gotoSession()
+
+    await ensureVariant(page, directory)
+    const updated = await chooseDifferentVariant(page)
+
+    const available = await agents(page)
+    const other = available.find((name) => name !== updated.agent)
+    test.skip(!other, "only one agent available")
+    if (!other) return
+
+    await choose(page, promptAgentSelector, other)
+    await waitFooter(page, { agent: other, variant: updated.variant })
+
+    await choose(page, promptAgentSelector, updated.agent)
+    await waitFooter(page, { agent: updated.agent, variant: updated.variant })
+  })
+})

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -192,10 +192,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             model: item.model,
             variant: item.variant ?? null,
           })
+          const prev = scope()
           const next = {
             agent: item.name,
-            model: item.model,
-            variant: item.variant,
+            model: item.model ?? prev?.model,
+            variant: item.variant ?? prev?.variant,
           } satisfies State
           const session = id()
           if (session) {


### PR DESCRIPTION
### Issue for this PR

Closes #17469

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`agent.set()` in `local.tsx` overwrites the entire per-session state when switching modes (Build/Plan/Docs). Since most agents don't configure a model or variant, the user's thinking level selection gets replaced with `undefined`, resetting it to default.

The fix merges with the existing `scope()` state using `??` so user selections are preserved when the agent doesn't explicitly override them.

### How did you verify your code works?

1. Selected Claude Sonnet with "Max thinking"
2. Switched from Build to Plan and back
3. Variant stays on "Max thinking" throughout

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

#### Before
https://github.com/user-attachments/assets/81d75f6b-d171-4178-bde0-d1d1dbaffdbe
#### After
https://github.com/user-attachments/assets/f13030f6-17e7-4acd-8e61-0c17dc18106b