### PR TITLE
feat(ci): PR size label

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -27,17 +27,21 @@ jobs:
             const total = (pr.additions ?? 0) + (pr.deletions ?? 0);
             const sizes = ["size:XS", "size:S", "size:M", "size:L", "size:XL", "size:XXL"];
 
-            const next = total < 10
-              ? "size:XS"
-              : total < 30
-                ? "size:S"
-                : total < 100
-                  ? "size:M"
-                  : total < 500
-                    ? "size:L"
-                    : total < 1000
-                      ? "size:XL"
-                      : "size:XXL";
+            const thresholds = [
+              { limit: 10, label: "size:XS" },
+              { limit: 30, label: "size:S" },
+              { limit: 100, label: "size:M" },
+              { limit: 500, label: "size:L" },
+              { limit: 1000, label: "size:XL" },
+            ];
+
+            let next = "size:XXL";
+            for (const { limit, label } of thresholds) {
+              if (total < limit) {
+                next = label;
+                break;
+              }
+            }
 
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,77 @@
+name: pr-size
+
+on:
+  pull_request_target:
+    branches: [dev]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: label pr size
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: pr-size-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Sync PR size label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const total = (pr.additions ?? 0) + (pr.deletions ?? 0);
+            const sizes = ["size:XS", "size:S", "size:M", "size:L", "size:XL", "size:XXL"];
+
+            const next = total < 10
+              ? "size:XS"
+              : total < 30
+                ? "size:S"
+                : total < 100
+                  ? "size:M"
+                  : total < 500
+                    ? "size:L"
+                    : total < 1000
+                      ? "size:XL"
+                      : "size:XXL";
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            for (const label of labels) {
+              if (!sizes.includes(label.name) || label.name === next) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label.name,
+                });
+              } catch (err) {
+                if (err.status !== 404) {
+                  throw err;
+                }
+              }
+            }
+
+            if (!labels.some((label) => label.name === next)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [next],
+              });
+            }
+
+            core.info(`PR #${pr.number}: ${total} changed lines -> ${next}`);


### PR DESCRIPTION
### Issue for this PR

Closes #17476

STOLEN FROM https://github.com/pingdotgg/t3code/blob/main/.github/workflows/pr-size.yml

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a workflow for adding a label with PR Size

Though before merging maintainers should create these labels

`size:XS` - 0-9 changed lines (additions + deletions).
`size:S` - 10-29 changed lines (additions + deletions).
`size:M` - 30-99 changed lines (additions + deletions).
`size:L` - 100-499 changed lines (additions + deletions).
`size:XL` - 500-999 changed lines (additions + deletions).
`size:XXL` - 1,000+ changed lines (additions + deletions).

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

run CI

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
