### PR TITLE
fix(opencode): guard against large files in diffFull

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -269,6 +269,28 @@ export namespace Snapshot {
     const git = gitdir()
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
+    const maxFileSize = 2 * 1024 * 1024
+
+    const read = async (rev: string, file: string) => {
+      const size = await Process.text(["git", ...args(git, ["cat-file", "-s", `${rev}:${file}`])], {
+        nothrow: true,
+      }).then((x) => parseInt(x.text.trim(), 10))
+      // guard against large files being loaded into session
+      if (Number.isFinite(size) && size > maxFileSize) return ""
+      return Process.text(
+        [
+          "git",
+          "-c",
+          "core.autocrlf=false",
+          "-c",
+          "core.longpaths=true",
+          "-c",
+          "core.symlinks=true",
+          ...args(git, ["show", `${rev}:${file}`]),
+        ],
+        { nothrow: true },
+      ).then((x) => x.text)
+    }
 
     const statuses = await Process.text(
       [
@@ -318,36 +340,8 @@ export namespace Snapshot {
       if (!line) continue
       const [additions, deletions, file] = line.split("\t")
       const isBinaryFile = additions === "-" && deletions === "-"
-      const before = isBinaryFile
-        ? ""
-        : await Process.text(
-            [
-              "git",
-              "-c",
-              "core.autocrlf=false",
-              "-c",
-              "core.longpaths=true",
-              "-c",
-              "core.symlinks=true",
-              ...args(git, ["show", `${from}:${file}`]),
-            ],
-            { nothrow: true },
-          ).then((x) => x.text)
-      const after = isBinaryFile
-        ? ""
-        : await Process.text(
-            [
-              "git",
-              "-c",
-              "core.autocrlf=false",
-              "-c",
-              "core.longpaths=true",
-              "-c",
-              "core.symlinks=true",
-              ...args(git, ["show", `${to}:${file}`]),
-            ],
-            { nothrow: true },
-          ).then((x) => x.text)
+      const before = isBinaryFile ? "" : await read(from, file)
+      const after = isBinaryFile ? "" : await read(to, file)
       const added = isBinaryFile ? 0 : parseInt(additions)
       const deleted = isBinaryFile ? 0 : parseInt(deletions)
       result.push({

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1155,6 +1155,30 @@ test("diffFull with binary file changes", async () => {
   })
 })
 
+test("diffFull with large file changes", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      await Filesystem.write(`${tmp.path}/too_large_txt.txt`, "x".repeat(1 + 2 * 1024 * 1024))
+
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+
+      const diffs = await Snapshot.diffFull(before!, after!)
+      expect(diffs.length).toBe(1)
+
+      const largeFileDiff = diffs[0]
+      expect(largeFileDiff.file).toBe("too_large_txt.txt")
+      expect(largeFileDiff.after).toBe("")
+      expect(largeFileDiff.before).toBe("")
+    },
+  })
+})
+
 test("diffFull with whitespace changes", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
Prevent large files from being stored in sessions potentially causing oom issues.

This is a small, targeted, non AI slop PR. I have carefully reviewed and understand the changes myself.

### Issue for this PR

Closes #17252 #2585 #17226 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Use `git file-stat -s` to check size of text file before reading it in `Snapshot.diffFull`. If it is larger than 2MB the file is not read.

This simple fix mitigates one avenue that causes OpenCodes memory usage to balloon w/o harming current functionality.

### How did you verify your code works?

1. Have large text file (easy way to generate a large file is by doing `Write heap snapshot` in opencode).
2. Start a session and send a message.
3. Delete large file
4. send another message
5. export session via `opencode export <session id>`

w/ fix the exported session will be small
w/o fix the exported session will be large (at least the size of the heapsnapshot file).

If the heap snapshot is very large then you can just look at memory usage and see it jump.

This fix applies to many large text files - the heap snapshot is just an easy way to generate a large text file.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
