### PR TITLE
fix(todo): emit todo.updated event when clearing todos with empty array

### DIFF
--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -28,18 +28,18 @@ export namespace Todo {
   export function update(input: { sessionID: SessionID; todos: Info[] }) {
     Database.transaction((db) => {
       db.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
-      if (input.todos.length === 0) return
-      db.insert(TodoTable)
-        .values(
-          input.todos.map((todo, position) => ({
-            session_id: input.sessionID,
-            content: todo.content,
-            status: todo.status,
-            priority: todo.priority,
-            position,
-          })),
-        )
-        .run()
+      if (input.todos.length > 0)
+        db.insert(TodoTable)
+          .values(
+            input.todos.map((todo, position) => ({
+              session_id: input.sessionID,
+              content: todo.content,
+              status: todo.status,
+              priority: todo.priority,
+              position,
+            })),
+          )
+          .run()
     })
     Bus.publish(Event.Updated, input)
   }


### PR DESCRIPTION
## Summary

Fixes #17495

- Replace `if (input.todos.length === 0) return` (early return inside transaction) with `if (input.todos.length > 0)` positive guard
- `Bus.publish(Event.Updated, input)` is now always reached, even when `todos` is empty
- Subscribers relying on `todo.updated` to clear their state now correctly receive the event when todos are cleared