### PR TITLE
feat(tui): add prompt enhancement via ctrl+x p

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,9 +1,11 @@
+import { Log } from "@/util/log"
 import { Config } from "../config/config"
 import z from "zod"
 import { Provider } from "../provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
-import { generateObject, streamObject, type ModelMessage } from "ai"
+import { generateObject, generateText, streamObject, type ModelMessage } from "ai"
 import { SystemPrompt } from "../session/system"
+import { InstructionPrompt } from "../session/instruction"
 import { Instance } from "../project/instance"
 import { Truncate } from "../tool/truncation"
 import { Auth } from "../auth"
@@ -11,6 +13,7 @@ import { ProviderTransform } from "../provider/transform"
 
 import PROMPT_GENERATE from "./generate.txt"
 import PROMPT_COMPACTION from "./prompt/compaction.txt"
+import PROMPT_ENHANCE from "./prompt/enhance.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
@@ -161,6 +164,22 @@ export namespace Agent {
         native: true,
         hidden: true,
         prompt: PROMPT_COMPACTION,
+        permission: PermissionNext.merge(
+          defaults,
+          PermissionNext.fromConfig({
+            "*": "deny",
+          }),
+          user,
+        ),
+        options: {},
+      },
+      enhance: {
+        name: "enhance",
+        mode: "primary",
+        native: true,
+        hidden: true,
+        prompt: PROMPT_ENHANCE,
+        temperature: 0.3,
         permission: PermissionNext.merge(
           defaults,
           PermissionNext.fromConfig({
@@ -326,7 +345,7 @@ export namespace Agent {
           instructions: SystemPrompt.instructions(),
           store: false,
         }),
-        onError: () => {},
+        onError: () => { },
       })
       for await (const part of result.fullStream) {
         if (part.type === "error") throw part.error
@@ -336,5 +355,55 @@ export namespace Agent {
 
     const result = await generateObject(params)
     return result.object
+  }
+
+  export async function enhancePrompt(input: {
+    prompt: string
+    model?: { providerID: ProviderID; modelID: ModelID }
+    abortSignal?: AbortSignal
+    history?: string[]
+    onModel?: (name: string) => void
+  }) {
+    return Instance.provide({
+      directory: process.cwd(),
+      fn: async () => {
+        const [agent, fallback, instructions] = await Promise.all([
+          Agent.get("enhance"),
+          input.model ?? Provider.defaultModel(),
+          InstructionPrompt.system(),
+        ])
+        const model = await (async () => {
+          if (agent?.model) return await Provider.getModel(agent.model.providerID, agent.model.modelID)
+          return (
+            (await Provider.getSmallModel(fallback.providerID)) ??
+            (await Provider.getModel(fallback.providerID, fallback.modelID))
+          )
+        })()
+        input.onModel?.(model.name)
+        const language = await Provider.getLanguage(model)
+        const systemParts = [agent?.prompt ?? PROMPT_ENHANCE, ...instructions]
+        if (input.history?.length) {
+          systemParts.push(
+            `Recent conversation context (for resolving references like "that bug" or "the function above"):\n${input.history.join("\n---\n")}`,
+          )
+        }
+        const result = await generateText({
+          temperature: agent?.temperature ?? 0.3,
+          messages: [
+            {
+              role: "system",
+              content: systemParts.join("\n\n"),
+            },
+            {
+              role: "user",
+              content: `Enhance this prompt: \"${input.prompt}\"`,
+            },
+          ],
+          model: language,
+          abortSignal: input.abortSignal,
+        })
+        return { text: result.text, model }
+      },
+    })
   }
 }

--- a/packages/opencode/src/agent/prompt/enhance.txt
+++ b/packages/opencode/src/agent/prompt/enhance.txt
@@ -1,0 +1,39 @@
+You are an expert prompt engineer specializing in transforming user requests into highly effective prompts for AI coding agents. Your goal is to enhance prompts to get better results from code-focused AI assistants.
+
+When given a user prompt, you will:
+
+1. **Analyze the Request**: Understand what the user is trying to accomplish, identifying:
+   - The core task or goal
+   - Any implicit requirements or context that might be missing
+   - The type of work involved (debugging, feature development, refactoring, exploration, etc.)
+   - Expected outputs or success criteria
+
+2. **Enhance with Context**: Add relevant context and details such as:
+   - Clarify ambiguities by making reasonable assumptions explicit
+   - Specify the scope and boundaries of the task
+   - Include relevant best practices for the task type
+   - Consider edge cases and error handling
+   - Define clear success criteria
+
+3. **Structure Effectively**: Organize the enhanced prompt to:
+   - Start with clear context about what the user wants
+   - Provide step-by-step guidance if the task is complex
+   - Include specific instructions about code style, patterns, or constraints
+   - Ask clarifying questions if critical information is missing (rather than assuming)
+   - Request relevant checks or validations
+
+4. **Optimize for AI Coding Agents**: Tailor the prompt specifically for AI agents by:
+   - Using clear, concrete language that an AI can act on
+   - Breaking down complex tasks into logical steps
+   - Specifying exact file operations, tool usage, or code modifications needed
+   - Including context about testing, documentation, and error handling expectations
+   - Making the desired output format explicit
+
+Your output should be the enhanced prompt text only - no explanations, no meta-commentary, just the improved prompt that the user can send to their AI assistant.
+
+Important guidelines:
+- Preserve the user's original intent - don't change what they're asking for
+- Add value through structure, clarity, and helpful context
+- Don't over-complicate simple requests
+- If the original prompt is already clear and complete, make minimal additions
+- Write in a way that guides the AI to produce high-quality, production-ready code

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -374,19 +374,19 @@ function App() {
     },
     ...(Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
       ? [
-          {
-            title: "Manage workspaces",
-            value: "workspace.list",
-            category: "Workspace",
-            suggested: true,
-            slash: {
-              name: "workspaces",
-            },
-            onSelect: () => {
-              dialog.replace(() => <DialogWorkspaceList />)
-            },
+        {
+          title: "Manage workspaces",
+          value: "workspace.list",
+          category: "Workspace",
+          suggested: true,
+          slash: {
+            name: "workspaces",
           },
-        ]
+          onSelect: () => {
+            dialog.replace(() => <DialogWorkspaceList />)
+          },
+        },
+      ]
       : []),
     {
       title: "New session",
@@ -518,6 +518,7 @@ function App() {
         local.agent.move(-1)
       },
     },
+
     {
       title: "Connect provider",
       value: "provider.connect",
@@ -578,7 +579,7 @@ function App() {
       title: "Open docs",
       value: "docs.open",
       onSelect: () => {
-        open("https://opencode.ai/docs").catch(() => {})
+        open("https://opencode.ai/docs").catch(() => { })
         dialog.clear()
       },
       category: "System",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -21,7 +21,7 @@ import { useRenderer } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
-import type { FilePart } from "@opencode-ai/sdk/v2"
+import type { FilePart, TextPart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
@@ -34,6 +34,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { Agent } from "@/agent/agent"
 
 export type PromptProps = {
   sessionID?: string
@@ -63,6 +64,7 @@ export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
   let autocomplete: AutocompleteRef
+  let enhanceAbort: AbortController | undefined
 
   const keybind = useKeybind()
   const local = useLocal()
@@ -127,6 +129,9 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: Map<number, number>
     interrupt: number
     placeholder: number
+    enhancing: boolean
+    preEnhance: string | undefined
+    preEnhanceModel: string | undefined
   }>({
     placeholder: Math.floor(Math.random() * PLACEHOLDERS.length),
     prompt: {
@@ -136,6 +141,9 @@ export function Prompt(props: PromptProps) {
     mode: "normal",
     extmarkToPartIndex: new Map(),
     interrupt: 0,
+    enhancing: false,
+    preEnhance: undefined,
+    preEnhanceModel: undefined,
   })
 
   createEffect(
@@ -195,6 +203,73 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Enhance prompt",
+        value: "prompt.enhance",
+        keybind: "prompt_enhance",
+        category: "Prompt",
+        enabled: store.prompt.input.length > 0 && !store.enhancing,
+        onSelect: (dialog) => {
+          if (store.enhancing || !store.prompt.input) return
+
+          const original = store.prompt.input
+          const history = (() => {
+            if (!props.sessionID) return []
+            const msgs = sync.data.message[props.sessionID]
+            if (!msgs) return []
+            return msgs
+              .filter((m) => m.role === "user")
+              .slice(-5)
+              .map((m) => {
+                const parts = sync.data.part[m.id] ?? []
+                return parts
+                  .filter((p): p is TextPart => p.type === "text")
+                  .map((p) => p.text)
+                  .join("")
+              })
+              .filter(Boolean)
+          })()
+
+          setStore("enhancing", true)
+          enhanceAbort = new AbortController()
+          Agent.enhancePrompt({
+            prompt: store.prompt.input,
+            abortSignal: enhanceAbort.signal,
+            history,
+            onModel: (name) => setStore("preEnhanceModel", name),
+          })
+            .then((result) => {
+              if (result?.text) {
+                input.setText(result.text)
+                setStore("prompt", {
+                  input: result.text,
+                  parts: [],
+                })
+                setStore("preEnhance", original)
+                input.gotoBufferEnd()
+                toast.show({
+                  variant: "success",
+                  message: `Enhanced with ${result.model.name} — esc to revert`,
+                  duration: 2000,
+                })
+              }
+            })
+            .catch((err: unknown) => {
+              if ((err as { name?: string })?.name === "AbortError") return
+              const msg = err instanceof Error ? err.message : String(err)
+              toast.show({
+                variant: "error",
+                message: `Failed to enhance prompt: ${msg.slice(0, 50)}`,
+                duration: 5000,
+              })
+            })
+            .finally(() => {
+              enhanceAbort = undefined
+              setStore("enhancing", false)
+              dialog.clear()
+            })
+        },
+      },
+      {
         title: "Paste",
         value: "prompt.paste",
         keybind: "input_paste",
@@ -217,13 +292,34 @@ export function Prompt(props: PromptProps) {
         keybind: "session_interrupt",
         category: "Session",
         hidden: true,
-        enabled: status().type !== "idle",
+        enabled: status().type !== "idle" || store.enhancing || store.preEnhance !== undefined,
         onSelect: (dialog) => {
           if (autocomplete.visible) return
           if (!input.focused) return
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
+            return
+          }
+          if (store.enhancing) {
+            enhanceAbort?.abort()
+            enhanceAbort = undefined
+            setStore("enhancing", false)
+            dialog.clear()
+            toast.show({
+              variant: "info",
+              message: "Prompt enhancement interrupted",
+              duration: 2000,
+            })
+            return
+          }
+          if (store.preEnhance !== undefined) {
+            input.setText(store.preEnhance)
+            setStore("prompt", { input: store.preEnhance, parts: [] })
+            input.gotoBufferEnd()
+            setStore("preEnhance", undefined)
+            setStore("preEnhanceModel", undefined)
+            dialog.clear()
             return
           }
           if (!props.sessionID) return
@@ -660,6 +756,8 @@ export function Prompt(props: PromptProps) {
       input: "",
       parts: [],
     })
+    setStore("preEnhance", undefined)
+    setStore("preEnhanceModel", undefined)
     setStore("extmarkToPartIndex", new Map())
     props.onSubmit?.()
 
@@ -1060,7 +1158,10 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box flexDirection="row" justifyContent="space-between">
-          <Show when={status().type !== "idle"} fallback={<text />}>
+          <Show
+            when={status().type !== "idle" || store.enhancing || store.preEnhance !== undefined}
+            fallback={<text />}
+          >
             <box
               flexDirection="row"
               gap={1}
@@ -1132,12 +1233,31 @@ export function Prompt(props: PromptProps) {
                   })()}
                 </box>
               </box>
-              <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
-                esc{" "}
-                <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
-                  {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                </span>
-              </text>
+              <Switch>
+                <Match when={store.enhancing}>
+                  <text fg={theme.primary}>
+                    enhancing
+                    {store.preEnhanceModel ? (
+                      <span style={{ fg: theme.textMuted }}> ({store.preEnhanceModel})</span>
+                    ) : null}
+                  </text>
+                </Match>
+                <Match when={store.preEnhance !== undefined}>
+                  <text fg={theme.text}>
+                    esc <span style={{ fg: theme.textMuted }}>revert</span>
+                  </text>
+                </Match>
+                <Match when={store.interrupt > 0}>
+                  <text fg={theme.primary}>
+                    esc <span style={{ fg: theme.primary }}>again to interrupt</span>
+                  </text>
+                </Match>
+                <Match when={store.interrupt === 0}>
+                  <text fg={theme.text}>
+                    esc <span style={{ fg: theme.textMuted }}>interrupt</span>
+                  </text>
+                </Match>
+              </Switch>
             </box>
           </Show>
           <Show when={status().type !== "retry"}>
@@ -1155,6 +1275,11 @@ export function Prompt(props: PromptProps) {
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
+                  <Show when={store.prompt.input.length > 0}>
+                    <text fg={theme.text}>
+                      {keybind.print("prompt_enhance")} <span style={{ fg: theme.textMuted }}>enhance</span>
+                    </text>
+                  </Show>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -943,6 +943,7 @@ export namespace Config {
         .describe("Delete word backward in input"),
       history_previous: z.string().optional().default("up").describe("Previous history item"),
       history_next: z.string().optional().default("down").describe("Next history item"),
+      prompt_enhance: z.string().optional().default("<leader>p").describe("Enhance current prompt"),
       session_child_first: z.string().optional().default("<leader>down").describe("Go to first child session"),
       session_child_cycle: z.string().optional().default("right").describe("Go to next child session"),
       session_child_cycle_reverse: z.string().optional().default("left").describe("Go to previous child session"),

--- a/packages/opencode/test/agent-enhance.test.ts
+++ b/packages/opencode/test/agent-enhance.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test"
+import { Agent } from "../src/agent/agent"
+import { Config } from "../src/config/config"
+import { Instance } from "../src/project/instance"
+import { PermissionNext } from "../src/permission/next"
+import { tmpdir } from "./fixture/fixture"
+
+describe("enhance agent definition", () => {
+  test("exists in the built-in agents map", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        expect(agent).toBeDefined()
+      },
+    })
+  })
+
+  test("has correct built-in properties", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        expect(agent!.name).toBe("enhance")
+        expect(agent!.mode).toBe("primary")
+        expect(agent!.native).toBe(true)
+        expect(agent!.hidden).toBe(true)
+        expect(agent!.temperature).toBe(0.3)
+        expect(agent!.prompt).toBeTruthy()
+      },
+    })
+  })
+
+  test("is hidden and excluded from default agent selection", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const name = await Agent.defaultAgent()
+        expect(name).not.toBe("enhance")
+      },
+    })
+  })
+
+  test("denies all tool access", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        const perm = agent!.permission
+        expect(PermissionNext.evaluate("read", "any-file.ts", perm).action).toBe("deny")
+        expect(PermissionNext.evaluate("edit", "any-file.ts", perm).action).toBe("deny")
+        expect(PermissionNext.evaluate("bash", "any-command", perm).action).toBe("deny")
+      },
+    })
+  })
+})
+
+describe("enhance agent user config", () => {
+  test("model can be overridden via config", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          enhance: {
+            model: "anthropic/claude-haiku-4-5",
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        expect(agent!.model).toBeDefined()
+        expect(String(agent!.model!.providerID)).toBe("anthropic")
+        expect(String(agent!.model!.modelID)).toBe("claude-haiku-4-5")
+      },
+    })
+  })
+
+  test("temperature can be overridden via config", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          enhance: {
+            temperature: 0.7,
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        expect(agent!.temperature).toBe(0.7)
+      },
+    })
+  })
+
+  test("without config, no model is set (uses runtime fallback)", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("enhance")
+        expect(agent!.model).toBeUndefined()
+      },
+    })
+  })
+})
+
+describe("prompt_enhance keybind", () => {
+  test("defaults to <leader>p in the keybinds schema", () => {
+    const keybinds = Config.Keybinds.parse({})
+    expect(keybinds.prompt_enhance).toBe("<leader>p")
+  })
+
+  test("accepts a custom binding", () => {
+    const keybinds = Config.Keybinds.parse({ prompt_enhance: "ctrl+e" })
+    expect(keybinds.prompt_enhance).toBe("ctrl+e")
+  })
+})

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -108,6 +108,30 @@ Hidden system agent that creates session summaries. It runs automatically and is
 
 ---
 
+### Use enhance
+
+_Mode_: `primary`
+
+Hidden system agent that rewrites prompts for clarity and specificity. Triggered by `ctrl+x p` in the TUI input field. Not selectable in the UI.
+
+You can configure its model and system prompt via `opencode.json`:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "enhance": {
+      "model": "anthropic/claude-haiku-4-5",
+      "temperature": 0.3
+    }
+  }
+}
+```
+
+[Learn more about prompt enhancement](/docs/tui#prompt-enhancement).
+
+---
+
 ## Usage
 
 1. For primary agents, use the **Tab** key to cycle through them during a session. You can also use your configured `switch_agent` keybind.

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -54,6 +54,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "model_cycle_favorite_reverse": "none",
     "variant_cycle": "ctrl+t",
     "command_list": "ctrl+p",
+    "prompt_enhance": "<leader>p",
     "agent_list": "<leader>a",
     "agent_cycle": "tab",
     "agent_cycle_reverse": "shift+tab",

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -55,6 +55,33 @@ The output of the command is added to the conversation as a tool result.
 
 ---
 
+## Prompt enhancement
+
+Press `ctrl+x p` to have a lightweight model rewrite and expand your current prompt before submitting. The enhanced text replaces what's in the input field.
+
+:::tip
+Press `esc` immediately after enhancing to revert to your original prompt.
+:::
+
+The footer shows `enhancing (model-name)` while the enhancement is running, then switches to `esc revert` once complete.
+
+By default, enhancement uses the provider's small model (e.g., Haiku for Anthropic). You can pin a specific model in `opencode.json`:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "enhance": {
+      "model": "anthropic/claude-haiku-4-5"
+    }
+  }
+}
+```
+
+**Keybind:** `ctrl+x p` — configurable via `prompt_enhance` in `tui.json`. [Learn more](/docs/keybinds).
+
+---
+
 ## Commands
 
 When using the OpenCode TUI, you can type `/` followed by a command name to quickly execute actions. For example:


### PR DESCRIPTION
### Issue for this PR

Closes #10237

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `prompt_enhance` command to the TUI. With text in the input field, pressing `<leader>p` (default: `ctrl+x p`) sends the draft to a lightweight model that rewrites it for clarity, then replaces the input with the result. Pressing `esc` immediately reverts to the original, or cancels an in-flight request.

**Changes:**

- `agent.ts` — new `enhance` built-in agent and `Agent.enhancePrompt()`. Uses the provider's small model by default; falls back to the session model. Last 5 user turns are passed as context so references like "fix that bug" resolve correctly.
- `prompt/enhance.txt` — system prompt for the enhancer.
- `config.ts` — `prompt_enhance` keybind (default `<leader>p`).
- `prompt/index.tsx` — wires up the command, loading state, esc-to-revert, and footer hints.
- Docs: `tui.mdx`, `agents.mdx`, `keybinds.mdx` updated.

The `enhance` agent is hidden, excluded from `Agent.defaultAgent()`, and has all tool access denied (text-in/text-out only). Model is configurable via `agent.enhance.model` in `opencode.json`.

### How did you verify your code works?

- `bun test test/agent-enhance.test.ts` — 9 tests pass covering agent definition, permission rules, config overrides, and keybind defaults.
- `bun typecheck` — no errors.
- Manual testing: triggered enhancement with Anthropic (Haiku auto-selected as small model) and with a local Qwen model via Ollama. Tested esc-to-revert, esc-to-cancel-in-flight, provider-not-found error path, and rate-limit error path.

### Screenshots / recordings

**Enhance Prompt Demo**
https://github.com/user-attachments/assets/4c9955c5-2e8b-401c-b1e3-05973ac32b88

**Input field with `ctrl+x p` hint in footer**
<img width="1990" height="1646" alt="1-oc-prompt-with-leader-p-hint" src="https://github.com/user-attachments/assets/3f5e2f62-fee6-48c2-a9bc-3290d8f35399" />


**"Enhance prompt" entry in the command menu**
<img width="1980" height="1636" alt="1 1-command-screen-menu" src="https://github.com/user-attachments/assets/025e4c4f-1401-47f6-a3ee-2343b19a00e1" />


**Enhancement in progress (Claude Haiku 4.5)**
<img width="1990" height="1646" alt="2-oc-enhance-with-haiku" src="https://github.com/user-attachments/assets/057773d3-229a-4b6a-90ea-62421acdf838" />


**Enhancement in progress (qwen3.5:35b via Ollama)**
<img width="1990" height="1646" alt="2 1-oc-enhance-with-qwen35" src="https://github.com/user-attachments/assets/067e7aad-a304-44c6-8714-e4d5eca906eb" />


**Enhanced result with esc-to-revert hint**
<img width="1990" height="1646" alt="3-oc-enhanced-esc-to-revert" src="https://github.com/user-attachments/assets/50724ad9-68f6-47d9-b8c0-6979906f661b" />


**Error: provider model not found**
<img width="1990" height="1646" alt="4-oc-enhanced-error-provider-not-found" src="https://github.com/user-attachments/assets/76c3305e-80e4-423b-a988-a262ca748a82" />


**Error: rate limit / retry exhausted**
<img width="995" height="823" alt="4 1-oc-enhance-failed-message" src="https://github.com/user-attachments/assets/3d6b4b87-3066-40d0-88bc-257b85d9bff8" />


**Enhancement cancelled via esc**
<img width="797" height="634" alt="4 2-oc-enhance-process-interrupted" src="https://github.com/user-attachments/assets/f638c2d1-bf04-4b7d-9509-1caebd11e75d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR