### PR TITLE
refactor(schema): inline branded ID schemas

### DIFF
--- a/packages/opencode/src/session/schema.ts
+++ b/packages/opencode/src/session/schema.ts
@@ -1,41 +1,38 @@
 import { Schema } from "effect"
 import z from "zod"
 
-import { withStatics } from "@/util/schema"
 import { Identifier } from "@/id/id"
+import { withStatics } from "@/util/schema"
 
-const sessionIdSchema = Schema.String.pipe(Schema.brand("SessionID"))
-
-export type SessionID = typeof sessionIdSchema.Type
-
-export const SessionID = sessionIdSchema.pipe(
-  withStatics((schema: typeof sessionIdSchema) => ({
-    make: (id: string) => schema.makeUnsafe(id),
-    descending: (id?: string) => schema.makeUnsafe(Identifier.descending("session", id)),
-    zod: Identifier.schema("session").pipe(z.custom<SessionID>()),
+export const SessionID = Schema.String.pipe(
+  Schema.brand("SessionID"),
+  withStatics((s) => ({
+    make: (id: string) => s.makeUnsafe(id),
+    descending: (id?: string) => s.makeUnsafe(Identifier.descending("session", id)),
+    zod: Identifier.schema("session").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
   })),
 )
 
-const messageIdSchema = Schema.String.pipe(Schema.brand("MessageID"))
+export type SessionID = Schema.Schema.Type<typeof SessionID>
 
-export type MessageID = typeof messageIdSchema.Type
-
-export const MessageID = messageIdSchema.pipe(
-  withStatics((schema: typeof messageIdSchema) => ({
-    make: (id: string) => schema.makeUnsafe(id),
-    ascending: (id?: string) => schema.makeUnsafe(Identifier.ascending("message", id)),
-    zod: Identifier.schema("message").pipe(z.custom<MessageID>()),
+export const MessageID = Schema.String.pipe(
+  Schema.brand("MessageID"),
+  withStatics((s) => ({
+    make: (id: string) => s.makeUnsafe(id),
+    ascending: (id?: string) => s.makeUnsafe(Identifier.ascending("message", id)),
+    zod: Identifier.schema("message").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
   })),
 )
 
-const partIdSchema = Schema.String.pipe(Schema.brand("PartID"))
+export type MessageID = Schema.Schema.Type<typeof MessageID>
 
-export type PartID = typeof partIdSchema.Type
-
-export const PartID = partIdSchema.pipe(
-  withStatics((schema: typeof partIdSchema) => ({
-    make: (id: string) => schema.makeUnsafe(id),
-    ascending: (id?: string) => schema.makeUnsafe(Identifier.ascending("part", id)),
-    zod: Identifier.schema("part").pipe(z.custom<PartID>()),
+export const PartID = Schema.String.pipe(
+  Schema.brand("PartID"),
+  withStatics((s) => ({
+    make: (id: string) => s.makeUnsafe(id),
+    ascending: (id?: string) => s.makeUnsafe(Identifier.ascending("part", id)),
+    zod: Identifier.schema("part").pipe(z.custom<Schema.Schema.Type<typeof s>>()),
   })),
 )
+
+export type PartID = Schema.Schema.Type<typeof PartID>

--- a/packages/opencode/src/util/schema.ts
+++ b/packages/opencode/src/util/schema.ts
@@ -46,9 +46,8 @@ export function Newtype<Self>() {
 
     Object.setPrototypeOf(Base, schema)
 
-    return Base as unknown as
-      & (abstract new (_: never) => Branded)
-      & { readonly makeUnsafe: (value: Schema.Schema.Type<S>) => Self }
-      & Omit<Schema.Opaque<Self, S, {}>, "makeUnsafe">
+    return Base as unknown as (abstract new (_: never) => Branded) & {
+      readonly makeUnsafe: (value: Schema.Schema.Type<S>) => Self
+    } & Omit<Schema.Opaque<Self, S, {}>, "makeUnsafe">
   }
 }


### PR DESCRIPTION
## Summary
- Collapse two-step ID pattern (private schema var + exported const) into single chained expression for SessionID, MessageID, PartID
- Derive type exports from const via `Schema.Schema.Type<typeof X>` instead of `typeof xSchema.Type`
- Reformat Newtype return type (no semantic change)

## Test plan
- [ ] Verify existing tests pass (`bun run test`)
- [ ] Confirm no type errors in dependent files