### PR TITLE
fix(project): use case-insensitive path comparison for global session migration on Windows

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,7 +1,7 @@
 import z from "zod"
 import { Filesystem } from "../util/filesystem"
 import path from "path"
-import { and, Database, eq } from "../storage/db"
+import { and, Database, eq, sql } from "../storage/db"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
 import { Log } from "../util/log"
@@ -276,11 +276,17 @@ export namespace Project {
     // Runs on every startup because sessions created before git init
     // accumulate under "global" and need migrating whenever they appear.
     if (data.id !== ProjectID.global) {
+      // On Windows, use case-insensitive directory matching since the
+      // filesystem is case-insensitive and stored paths may differ in case.
+      const directory =
+        process.platform === "win32"
+          ? sql`LOWER(${SessionTable.directory}) = ${path.normalize(data.worktree).toLowerCase()}`
+          : eq(SessionTable.directory, data.worktree)
       Database.use((db) =>
         db
           .update(SessionTable)
           .set({ project_id: data.id })
-          .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
+          .where(and(eq(SessionTable.project_id, ProjectID.global), directory))
           .run(),
       )
     }


### PR DESCRIPTION
### Issue for this PR

Closes [ #17518](https://github.com/anomalyco/opencode/issues/17518)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The global session migration (inlined in #16814) uses `eq(SessionTable.directory, data.worktree)` — SQLite strict equality. On Windows, paths are case-insensitive but this comparison is case-sensitive, so sessions stored under `C:\ai-work\dtd\project` never match `C:\ai-work\DTD\project` after a parent directory rename.

Fix: on Windows, use `LOWER()` in the SQL comparison and `path.normalize()` to handle mixed slash directions. Non-Windows platforms keep the exact comparison since their filesystems are case-sensitive.

### How did you verify your code works?

- Confirmed 23 sessions orphaned under `global` after a parent directory was renamed from `dtd` to `DTD`
- Applied SQL migration with `LOWER()` matching — all sessions correctly reassigned
- Typecheck passes (zero errors in project.ts)

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
