### PR TITLE
fix(app): desktop app & Safari comments via button click

### DIFF
--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -115,7 +115,12 @@ export const LineCommentAnchor = (props: LineCommentAnchorProps) => {
           on:mousedown={(e) => e.stopPropagation()}
           on:click={props.onClick as any}
           on:mouseenter={props.onMouseEnter as any}
-          on:focusout={props.onPopoverFocusOut as any}
+          on:focusout={(...args) => {
+            // Super ugly setTimeout to work around Safari's event handling
+            // where shadow DOM focusout event are updating UI before the button
+            // click event is called preventing to create click event.
+            return setTimeout(() => (props.onPopoverFocusOut as any)(...args), 0)
+          }}
         >
           {props.children}
         </div>


### PR DESCRIPTION
### Issue for this PR

Closes #11947

### Type of change

- [x] Bug fix


### What does this PR do?

This PR fixes the bug in desktop app and in Safari where adding comments to file view via button mouse click was impossible in OSX.

Issue was present because of Safari different handling of the shadow dom events propagation compared to other browsers.

Chain of (important) actions happening on submit button click in Safari:
1. line comment textarea loses focus
2. on:focusout event is being called
3. annotation list is being updated
4. UI updates (this is unique for Safari)
5. Button click event is never triggered because button isn't longer a valid target.

### How did you verify your code works?
I've run local version of Opencode desktop Tauri app in OSX. Verified that it's broken before fixes.
Also I've verified that the same happens in web view in Safari.

I've run following manual tests in lastest Chrome, Firefox and Safari:
I've tested that comments are added on button clicks.
I've tested that line comment popover isn't closed on clicks within popover.
I've tested that clicking on other lines closes line comment popover.

### Screenshots / recordings

https://github.com/user-attachments/assets/fce2b5e7-9ed9-482a-88cc-644382401fa7

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
