### PR TITLE
[FIX] session list should be sorted by updated time, not id

### DIFF
--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -15,7 +15,7 @@ function sortSessions(now: number) {
     const bUpdated = b.time.updated ?? b.time.created
     const aRecent = aUpdated > oneMinuteAgo
     const bRecent = bUpdated > oneMinuteAgo
-    if (aRecent && bRecent) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+    if (aRecent && bRecent) return bUpdated - aUpdated
     if (aRecent && !bRecent) return -1
     if (!aRecent && bRecent) return 1
     return bUpdated - aUpdated


### PR DESCRIPTION
Fix #17474 - Session list is sorted by id instead of updated time

The sort function was using `a.id` when both sessions were recently updated, causing random ordering.

Fix: Change to `bUpdated - aUpdated` to sort by most recent.