### PR TITLE
fix(app): sort session list by updated time instead of id

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -208,7 +208,7 @@ function createGlobalSync() {
         const nonArchived = (x.data ?? [])
           .filter((s) => !!s?.id)
           .filter((s) => !s.time?.archived)
-          .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+          .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
         const limit = store.limit
         const childSessions = store.session.filter((s) => !!s.parentID)
         const sessions = trimSessions([...nonArchived, ...childSessions], {

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -39,7 +39,7 @@ export function trimSessions(
   const all = input
     .filter((s) => !!s?.id)
     .filter((s) => !s.time?.archived)
-    .sort((a, b) => cmp(a.id, b.id))
+    .sort((a, b) => compareSessionRecent(a, b))
   const roots = all.filter((s) => !s.parentID)
   const children = all.filter((s) => !!s.parentID)
   const base = roots.slice(0, limit)


### PR DESCRIPTION
## Summary
- Fix session list sorting to use `time.updated` (with `time.created` fallback) instead of `id`
- Change two sort comparators in `global-sync.tsx` and `session-trim.ts`

## Why
Fixes #17474 - Session list was sorted by id, making the order appear random.

## Changes
- `packages/app/src/context/global-sync.tsx`: Use `(b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created)` for sorting
- `packages/app/src/context/global-sync/session-trim.ts`: Use existing `compareSessionRecent()` function for sorting

The `compareSessionRecent` helper already implements correct recency ordering with id tiebreaker.