### PR TITLE
fix(tui): show prompt when viewing subagent sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1173,7 +1173,7 @@ export function Session() {
                 <QuestionPrompt request={questions()[0]} />
               </Show>
               <Prompt
-                visible={!session()?.parentID && permissions().length === 0 && questions().length === 0}
+                visible={permissions().length === 0 && questions().length === 0}
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)


### PR DESCRIPTION
### Issue for this PR

Closes #4422

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When navigating to a subagent session view, the prompt was hidden because of a `!session()?.parentID` condition on the `visible` prop. This prevented users from interacting with subagent sessions entirely.

The fix removes the `parentID` check from the Prompt visibility condition. The `sessionID` prop already correctly tracks the viewed session via `route.sessionID`, so when a user navigates to a child session and types, the message is routed to the correct subagent session.

The one-line change is in `routes/session/index.tsx`:

```diff
- visible={!session()?.parentID && permissions().length === 0 && questions().length === 0}
+ visible={permissions().length === 0 && questions().length === 0}
```

### How did you verify your code works?

- Built locally with `bun dev`
- Created a session that delegates to a subagent
- Navigated to the subagent view using the sidebar
- Confirmed the prompt is now visible and accepts input
- Confirmed messages are routed to the subagent session (not the parent)
- Confirmed navigating back to the parent session works normally
- Confirmed the prompt still hides correctly when permissions/questions are pending
- `bun turbo typecheck` passes (all 13 packages)

### Screenshots / recordings

_The prompt now appears when viewing subagent sessions, with messages correctly routed to the subagent._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

This contribution was developed with AI assistance (Claude Code).