### PR TITLE
fix(question): clean up pending entry on abort

### DIFF
--- a/packages/opencode/src/question/service.ts
+++ b/packages/opencode/src/question/service.ts
@@ -134,7 +134,12 @@ export class QuestionService extends ServiceMap.Service<QuestionService, Questio
         pending.set(id, { info, deferred })
         Bus.publish(Event.Asked, info)
 
-        return yield* Deferred.await(deferred)
+        return yield* Effect.ensuring(
+          Deferred.await(deferred),
+          Effect.sync(() => {
+            pending.delete(id)
+          }),
+        )
       })
 
       const reply = Effect.fn("QuestionService.reply")(function* (input: { requestID: QuestionID; answers: Answer[] }) {


### PR DESCRIPTION
## Summary

- Wrap `Deferred.await` with `Effect.ensuring` so the pending Map entry is deleted when the fiber is interrupted
- Without this, aborting a question request (e.g., via AbortController) leaks the entry in the pending Map forever
- Same bug pattern we found and fixed in PermissionService (#17511)

## Test plan

- [x] 11 question tests pass
- [x] Typecheck passes
- `pending.delete(id)` is idempotent — no conflict with `reply`/`reject` which also delete