### PR TITLE
fix(opencode): handle errors in session prompt route handlers

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -17,6 +17,8 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { PermissionID } from "@/permission/schema"
 import { ModelID, ProviderID } from "@/provider/schema"
+import { Bus } from "@/bus"
+import { NamedError } from "@opencode-ai/util/error"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 
@@ -814,8 +816,15 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async (stream) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
+          try {
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            stream.write(JSON.stringify(msg))
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            stream.write(JSON.stringify({
+              error: { message },
+            }))
+          }
         })
       },
     )
@@ -846,7 +855,14 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            console.error(`[session] prompt_async error for ${sessionID}:`, message)
+            Bus.publish(Session.Event.Error, {
+              sessionID,
+              error: new NamedError.Unknown({ message }).toObject(),
+            })
+          })
         })
       },
     )


### PR DESCRIPTION
### Issue for this PR: https://github.com/anomalyco/opencode/issues/17536

Closes #17536

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes #<issue-number>

## Summary

- Add try-catch to `POST /session/{id}/message` so prompt errors return `{"error": {"message": "..."}}` instead of an empty response body
- Add `.catch()` to the fire-and-forget `SessionPrompt.prompt()` in `POST /session/{id}/prompt_async` to log errors and publish `Session.Event.Error` on the bus

## What changed

When `SessionPrompt.prompt()` throws (e.g. provider unavailable, rate limit, model resolution failure), the error was silently swallowed. Clients received a 200 with an empty body and no indication of failure.

Now:
- `/message` writes a structured error JSON to the stream
- `/prompt_async` logs the error and notifies SSE subscribers via the bus


**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
