### PR TITLE
fix(tui): add Alt+V as fallback keybind for image paste on Windows Terminal

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -861,7 +861,7 @@ export namespace Config {
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
-      input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
+      input_paste: z.string().optional().default("ctrl+v,alt+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z
         .string()


### PR DESCRIPTION
### Issue for this PR

Closes #13800, #10154
Related issues: #13322, #12075
Related unmerged PRs from other contributors: #13161, #13871, #8626

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows Terminal, Ctrl+V is intercepted by the terminal before the TUI's onKeyDown fires. When the clipboard has only an image, Windows Terminal sends nothing — so the existing clipboard image read path never triggers.

Adds `alt+v` as a second default for input_paste ("ctrl+v,alt+v"). Windows Terminal doesn't intercept `Alt+V`, so it reaches onKeyDown and the existing PowerShell clipboard read works as intended.

Safe cross-platform: @opentui/core blocks character insertion when key.meta is true, so `Alt+V` with no image in clipboard does nothing. On macOS/Linux where `Ctrl+V` already passes through, it's a harmless extra binding.

### How did you verify your code works?
Tested on Windows 11 + Windows Terminal.  `Alt+V` with an image in clipboard inserts [Image 1] in the prompt. `Ctrl+V` text paste unaffected.

### Screenshots / recordings
<img width="1214" height="714" alt="image" src="https://github.com/user-attachments/assets/1b85b543-0ee1-4305-b6b6-ddcaa23578e6" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR



