### PR TITLE
feat(skill): expand shell directives in skill content (#10892)

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -1,4 +1,5 @@
 import { NamedError } from "@opencode-ai/util/error"
+import { $ } from "bun"
 import matter from "gray-matter"
 import { z } from "zod"
 import { Filesystem } from "../util/filesystem"
@@ -13,6 +14,28 @@ export namespace ConfigMarkdown {
 
   export function shell(template: string) {
     return Array.from(template.matchAll(SHELL_REGEX))
+  }
+
+  /**
+   * Expand !`command` directives in text by executing each command and
+   * replacing the directive with its stdout.
+   */
+  export async function expandShell(text: string): Promise<string> {
+    const matches = shell(text)
+    if (matches.length > 0) {
+      const results = await Promise.all(
+        matches.map(async ([, cmd]) => {
+          try {
+            return await $`${{ raw: cmd }}`.quiet().nothrow().text()
+          } catch (error) {
+            return `Error executing command: ${error instanceof Error ? error.message : String(error)}`
+          }
+        }),
+      )
+      let index = 0
+      text = text.replace(SHELL_REGEX, () => results[index++]!.trim())
+    }
+    return text
   }
 
   // other coding agents like claude code allow invalid yaml in their

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -32,7 +32,6 @@ import { Flag } from "../flag/flag"
 import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
-import { $ } from "bun"
 import { pathToFileURL, fileURLToPath } from "url"
 import { ConfigMarkdown } from "../config/markdown"
 import { SessionSummary } from "./summary"
@@ -1741,7 +1740,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       .optional(),
   })
   export type CommandInput = z.infer<typeof CommandInput>
-  const bashRegex = /!`([^`]+)`/g
   // Match [Image N] as single token, quoted strings, or non-space sequences
   const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
   const placeholderRegex = /\$(\d+)/g
@@ -1786,21 +1784,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       template = template + "\n\n" + input.arguments
     }
 
-    const shell = ConfigMarkdown.shell(template)
-    if (shell.length > 0) {
-      const results = await Promise.all(
-        shell.map(async ([, cmd]) => {
-          try {
-            return await $`${{ raw: cmd }}`.quiet().nothrow().text()
-          } catch (error) {
-            return `Error executing command: ${error instanceof Error ? error.message : String(error)}`
-          }
-        }),
-      )
-      let index = 0
-      template = template.replace(bashRegex, () => results[index++])
-    }
-    template = template.trim()
+    template = (await ConfigMarkdown.expandShell(template)).trim()
 
     const taskModel = await (async () => {
       if (command.model) {

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -3,6 +3,7 @@ import { pathToFileURL } from "url"
 import z from "zod"
 import { Tool } from "./tool"
 import { Skill } from "../skill"
+import { ConfigMarkdown } from "../config/markdown"
 import { Ripgrep } from "../file/ripgrep"
 import { iife } from "@/util/iife"
 
@@ -84,7 +85,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
           `<skill_content name="${skill.name}">`,
           `# Skill: ${skill.name}`,
           "",
-          skill.content.trim(),
+          (await ConfigMarkdown.expandShell(skill.content)).trim(),
           "",
           `Base directory for this skill: ${base}`,
           "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -110,4 +110,46 @@ Use this skill.
       process.env.OPENCODE_TEST_HOME = home
     }
   })
+
+  test("execute expands shell directives in skill content", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const skillDir = path.join(dir, ".opencode", "skill", "shell-skill")
+        await Bun.write(
+          path.join(skillDir, "SKILL.md"),
+          `---
+name: shell-skill
+description: Skill with shell directives.
+---
+
+# Shell Skill
+
+Output: !\`echo expanded-ok\`
+`,
+        )
+      },
+    })
+
+    const home = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tool = await SkillTool.init()
+          const ctx: Tool.Context = {
+            ...baseCtx,
+            ask: async () => {},
+          }
+
+          const result = await tool.execute({ name: "shell-skill" }, ctx)
+          expect(result.output).toContain("expanded-ok")
+          expect(result.output).not.toContain("!`")
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = home
+    }
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #10892

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Support the !\`command\` syntax in skills to inject dynamic content at load time, compatible with [Claude Code's implementation](https://docs.anthropic.com/en/docs/claude-code/skills#inject-dynamic-context).

I know there's another PR implementing the same feature, but I think it's stalled out due to feedback needing to be addressed (https://github.com/anomalyco/opencode/pull/10891). 

### How did you verify your code works?

To manaully QA, I ran opencode with the following prompt (which references a personal skill of mine that uses a shell directive to include a script's help in the skill markdown file): 

```
Load the browser-cli skill. What subcommands are offered?
Do not do anything except load the skill to find the answer.
```

When I run opencode on `dev`, I get answers like:

```
The skill loaded but the content is minimal. Let me check the actual browser-cli script to see what subcommands it offers.
```

When I run opencode on this branch / PR, I get answers like:

```
The browser-cli skill offers the following subcommands:
Setup / Lifecycle:
- install - Install native messaging host manifest
- launch - Kill Chrome and relaunch with extension loaded (--headless for Xvfb)
- stop - Kill Chrome and Xvfb
Navigation:
- navigate <url> (aliases: open, goto) - Navigate to URL
- back / forward / reload - Browser history navigation
- url - Get current URL
- title - Get page title
...
```

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

---

Happy to address any feedback. And thanks for opencode!