### PR TITLE
docs(config): explain pruning behavior

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -562,7 +562,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
 | `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
 | `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of older completed tool outputs   |
 | `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
 | `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
 | `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -502,8 +502,19 @@ You can control context compaction behavior through the `compaction` option.
 ```
 
 - `auto` - Automatically compact the session when context is full (default: `true`).
-- `prune` - Remove old tool outputs to save tokens (default: `true`).
+- `prune` - Remove older completed tool outputs from model context to save tokens (default: `true`).
 - `reserved` - Token buffer for compaction. Leaves enough window to avoid overflow during compaction
+
+:::note
+When pruning is enabled, OpenCode trims older completed tool outputs after a turn
+finishes while keeping recent activity intact. The tool call itself stays in
+session history, but its old output is cleared from model context once pruning
+can recover a meaningful amount of space.
+
+This is why the used-context indicator can sometimes drop between turns. If you
+need agents to keep full historical tool output in context, set
+`compaction.prune` to `false` or export `OPENCODE_DISABLE_PRUNE=true`.
+:::
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #3917

### Type of change

- [x] Documentation

### What does this PR do?

Clarifies what pruning removes from model context, explains why the used-context indicator can drop between turns, and documents how to disable pruning with either `compaction.prune: false` or `OPENCODE_DISABLE_PRUNE=true`.

### How did you verify your code works?

- Ran `bun --cwd packages/web build`
- Ran `git diff --check`
- Checked the docs text against the current pruning behavior in the codebase

### Screenshots / recordings

Not applicable - docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
