### PR TITLE
docs(config): document global directories

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -119,7 +119,10 @@ opencode auth [command]
 
 #### login
 
-OpenCode is powered by the provider list at [Models.dev](https://models.dev), so you can use `opencode auth login` to configure API keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`.
+OpenCode is powered by the provider list at [Models.dev](https://models.dev), so
+you can use `opencode auth login` to configure API keys for any provider you'd
+like to use. Credentials are stored in the OpenCode data directory, which is
+`~/.local/share/opencode/auth.json` on Linux by default.
 
 ```bash
 opencode auth login
@@ -486,6 +489,28 @@ This command starts an ACP server that communicates via stdin/stdout using nd-JS
 | `--cwd`      | Working directory     |
 | `--port`     | Port to listen on     |
 | `--hostname` | Hostname to listen on |
+
+---
+
+### debug
+
+Debugging and troubleshooting tools.
+
+```bash
+opencode debug [command]
+```
+
+#### paths
+
+Print the resolved global OpenCode directories for the current machine.
+
+```bash
+opencode debug paths
+```
+
+This is useful when you need to locate config files, credentials, session
+storage, caches, or other generated files without guessing platform-specific
+paths.
 
 ---
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -149,6 +149,30 @@ The custom directory is loaded after the global config and `.opencode` directori
 
 ---
 
+### Global directories
+
+OpenCode stores different kinds of files in different global directories.
+To see the exact resolved paths on your machine, run:
+
+```bash
+opencode debug paths
+```
+
+On Linux, the defaults typically look like this:
+
+| Directory | Default path | What lives there |
+| --------- | ------------ | ---------------- |
+| Config | `~/.config/opencode/` | User-managed config and assets such as `opencode.json`, `tui.json`, `AGENTS.md`, and global `agents/`, `commands/`, `modes/`, `plugins/`, `skills/`, and `themes/` directories. Writable config directories may also contain generated `package.json`, `bun.lock`, and `node_modules/` for plugin/tool dependencies. |
+| Data | `~/.local/share/opencode/` | Persistent data such as `auth.json`, `mcp-auth.json`, the session database (`opencode.db`), `plans/`, `snapshot/`, `worktree/`, `tool-output/`, `log/`, and downloaded binaries in `bin/`. Older installs or imports may also contain `storage/`. |
+| State | `~/.local/state/opencode/` | Local runtime state that OpenCode manages for you, including `model.json`, `kv.json`, `prompt-history.jsonl`, `prompt-stash.jsonl`, and `frecency.jsonl`. |
+| Cache | `~/.cache/opencode/` | Rebuildable caches such as `models.json`, cached skills, and package-manager files like `package.json`, `version`, and cached `node_modules/`. |
+
+If you're backing up or migrating OpenCode, preserve `config` and `data`.
+Preserve `state` too if you want things like recent model choices and prompt
+history to carry over. `cache` can be regenerated.
+
+---
+
 ## Schema
 
 The server/runtime config schema is defined in [**`opencode.ai/config.json`**](https://opencode.ai/config.json).


### PR DESCRIPTION
### Issue for this PR

Closes #4170

### Type of change

- [x] Documentation

### What does this PR do?

Documents the global OpenCode directory layout, including what lives in config, data, state, and cache directories, and adds `opencode debug paths` to the CLI docs so users can inspect the exact resolved paths on their machine.

### How did you verify your code works?

- Ran `bun --cwd packages/web build`
- Ran `git diff --check`
- Checked the docs text against the current path and storage behavior in the codebase

### Screenshots / recordings

Not applicable - docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
