### PR TITLE
fix(opencode): don't double-count OpenAI reasoning tokens in cost calculation

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -857,9 +857,13 @@ export namespace Session {
             .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
             .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
             .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
-            // TODO: update models.dev to have better pricing model, for now:
-            // charge reasoning tokens at the same rate as output tokens
-            .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+            // Anthropic bills thinking/reasoning tokens separately (not included in outputTokens).
+            // OpenAI reasoning tokens are already a subset of outputTokens, so do NOT add them again.
+            .add(
+              excludesCachedTokens
+                ? new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000)
+                : new Decimal(0),
+            )
             .toNumber(),
         ),
         tokens,


### PR DESCRIPTION
### Issue for this PR

Closes #17566

### Type of change

- [x] Bug fix

### What does this PR do?

`getUsage` in `session/index.ts` was adding `reasoning_tokens * output_price` for all providers. For OpenAI, reasoning tokens are a subset of `completion_tokens` (already in `outputTokens`), so the extra term was double-charging them.

The fix gates the reasoning cost term on `excludesCachedTokens`, which is `true` only for Anthropic/Bedrock.

### How did you verify your code works?

**Math check:** gpt-5.4-pro, 14,746 input @ $30/M + 1,944 output @ $180/M = $0.44238 + $0.34992 = **$0.7923**, matching the actual OpenAI charge.

**Other providers checked:**

- **Anthropic / Bedrock** — `@ai-sdk/anthropic` always sets `outputTokens.reasoning = undefined`, so `tokens.reasoning` is 0. No change in behaviour.
- **Anthropic via Vertex** — uses `AnthropicMessagesLanguageModel` internally, emits metadata under the `"anthropic"` key, so `excludesCachedTokens = true`. Same as direct Anthropic.
- **OpenRouter / Gemini / others** — do not populate `reasoningTokens`, so `tokens.reasoning` is 0. No change.

Only OpenAI reasoning models were affected.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR