### PR TITLE
fix: improve success icon contrast in light theme

### DIFF
--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -260,7 +260,7 @@
   --icon-strong-focus: #020202;
   --icon-brand-base: #171717;
   --icon-interactive-base: #034cff;
-  --icon-success-base: #7add71;
+  --icon-success-base: #16a34a;
   --icon-success-hover: #4cc944;
   --icon-success-active: #078901;
   --icon-warning-base: #ebb76e;


### PR DESCRIPTION
### Issue for this PR

Closes #17555

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem**: Success icons (like the shield icon for permissions) were barely visible in light theme and appeared disabled. The color `#7add71` was too pale and lacked sufficient contrast against light backgrounds.

**Solution**: Updated the --icon-success-base color in light theme from `#7add71` → ` #16a34a` (Tailwind `green-600`). This provides much better contrast (36% vs the previous ~70% lightness) while maintaining the intended success state visual.

**Why this works**: 
- `#16a34a` is darker and more saturated, meeting WCAG contrast requirements
- It's a proven, accessible color (Tailwind's **green-600**)
- The warmer tone feels more appropriately "success-like"
- Works well with the existing dark theme color (**#12c905**) while being distinctly adapted for light backgrounds

### How did you verify your code works?

Tested locally in light theme - the success icon (shield) is now clearly visible when selected, with good contrast and no "disabled" appearance. The color also looks appropriate in dark theme.

### Screenshots / recordings

Before: Icon appeared pale/disabled in light theme  
After: Icon is clearly visible with good contrast in light theme
<img width="832" height="377" alt="image" src="https://github.com/user-attachments/assets/f1508e4c-26a9-4882-9f33-0c60ed84a134" />

<img width="840" height="211" alt="image" src="https://github.com/user-attachments/assets/bf9278e9-6450-4917-8663-662a01bf8cc3" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR