### PR TITLE
fix(opencode): update isLocal function to recognize pre-release versions and prevents plugin version upgrade except beta

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -87,7 +87,7 @@ export namespace Installation {
   }
 
   export function isLocal() {
-    return CHANNEL === "local"
+    return CHANNEL === "local" || (VERSION.startsWith("0.0.0-") && !VERSION.startsWith("0.0.0-beta")) // Prevents all other versions exepct beta from being installed
   }
 
   export async function method() {


### PR DESCRIPTION


### Issue for this PR

Closes #17584

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It prevents dev or other branch versions of the app running locally from overriding correct `@opencode-ai/plugin` package versions. This solves installation error when running the desktop locally.

I did allow any version with the `0.0.0-beta` as the team might want to make beta plugin updates and this helps that users on the beta versions can properly install these, since they are also published on NPM so wont cause that error. Only issue is users who are on the `beta` branch and run `bun run tauri dev`, they will get a beta version local to their machine not published and will get the error, as they try to fetch from a beta version not published but made on their machine.

### How did you verify your code works?

Tested with running the desktop locally and I did not get the errors anymore and my `@opencode-ai/plugin` package version was not updated.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR