### PR TITLE
fix(desktop): fix error handling by adding errorName function to identify NotFoundError rather than statusCode

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -65,16 +65,6 @@ const debugTerminal = (...values: unknown[]) => {
   console.debug("[terminal]", ...values)
 }
 
-const errorStatus = (err: unknown) => {
-  if (!err || typeof err !== "object") return
-  if (!("data" in err)) return
-  const data = err.data
-  if (!data || typeof data !== "object") return
-  if (!("statusCode" in data)) return
-  const status = data.statusCode
-  return typeof status === "number" ? status : undefined
-}
-
 const errorName = (err: unknown) => {
   if (!err || typeof err !== "object") return
   if (!("name" in err)) return

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -75,6 +75,13 @@ const errorStatus = (err: unknown) => {
   return typeof status === "number" ? status : undefined
 }
 
+const errorName = (err: unknown) => {
+  if (!err || typeof err !== "object") return
+  if (!("name" in err)) return
+  const errorName = err.name
+  return typeof errorName === "string" ? errorName : undefined
+}
+
 const useTerminalUiBindings = (input: {
   container: HTMLDivElement
   term: Term
@@ -481,7 +488,7 @@ export const Terminal = (props: TerminalProps) => {
           .get({ ptyID: id })
           .then(() => false)
           .catch((err) => {
-            if (errorStatus(err) === 404) return true
+            if (errorName(err) === "NotFoundError") return true
             debugTerminal("failed to inspect terminal session", err)
             return false
           })


### PR DESCRIPTION


### Issue for this PR

Closes #17590

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Uses the error name returned to determine if the server got a 404 related to a PTY id, previously a check for status code was used, but the SDK does not return status code rather an error name and message, this can be see in the video of the issue, where the logs of the desktop shows it.

This PR changes the function to check for an error name of "NotFoundError" which is what gets retured and allows the terminal instance to be initialised and ends up being responsive.


### How did you verify your code works?

Tested on my local desktop dev environment

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR