### PR TITLE
fix: avoid blank session history on oversized summary diffs

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -52,13 +52,14 @@ export namespace Session {
   type SessionRow = typeof SessionTable.$inferSelect
 
   export function fromRow(row: SessionRow): Info {
+    const summaryDiffs = row.summary_diffs ? Snapshot.sanitizeFileDiffs(row.summary_diffs).diffs : undefined
     const summary =
       row.summary_additions !== null || row.summary_deletions !== null || row.summary_files !== null
         ? {
             additions: row.summary_additions ?? 0,
             deletions: row.summary_deletions ?? 0,
             files: row.summary_files ?? 0,
-            diffs: row.summary_diffs ?? undefined,
+            diffs: summaryDiffs,
           }
         : undefined
     const share = row.share_url ? { url: row.share_url } : undefined
@@ -684,8 +685,19 @@ export namespace Session {
   })
 
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
-    const time_created = msg.time.created
-    const { id, sessionID, ...data } = msg
+    const sanitized =
+      msg.role === "user" && msg.summary?.diffs?.length
+        ? ({
+            ...msg,
+            summary: {
+              ...msg.summary,
+              diffs: Snapshot.sanitizeFileDiffs(msg.summary.diffs).diffs,
+            },
+          } as MessageV2.Info)
+        : msg
+
+    const time_created = sanitized.time.created
+    const { id, sessionID, ...data } = sanitized
     Database.use((db) => {
       db.insert(MessageTable)
         .values({
@@ -698,11 +710,11 @@ export namespace Session {
         .run()
       Database.effect(() =>
         Bus.publish(MessageV2.Event.Updated, {
-          info: msg,
+          info: sanitized,
         }),
       )
     })
-    return msg
+    return sanitized
   })
 
   export const removeMessage = fn(

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -509,12 +509,29 @@ export namespace MessageV2 {
     },
   }
 
+  export function sanitizeInfoForRead<T extends MessageV2.Info>(input: T): T {
+    if (input.role !== "user") return input
+    const diffs = input.summary?.diffs
+    if (!diffs?.length) return input
+
+    const sanitized = Snapshot.sanitizeFileDiffs(diffs)
+    if (!sanitized.changed) return input
+
+    return {
+      ...input,
+      summary: {
+        ...input.summary,
+        diffs: sanitized.diffs,
+      },
+    } as T
+  }
+
   const info = (row: typeof MessageTable.$inferSelect) =>
-    ({
+    sanitizeInfoForRead({
       ...row.data,
       id: row.id,
       sessionID: row.session_id,
-    }) as MessageV2.Info
+    } as MessageV2.Info)
 
   const part = (row: typeof PartTable.$inferSelect) =>
     ({

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -119,7 +119,7 @@ export namespace SessionSummary {
     }),
     async (input) => {
       const diffs = await Storage.read<Snapshot.FileDiff[]>(["session_diff", input.sessionID]).catch(() => [])
-      const next = diffs.map((item) => {
+      const normalized = diffs.map((item) => {
         const file = unquoteGitPath(item.file)
         if (file === item.file) return item
         return {
@@ -127,9 +127,11 @@ export namespace SessionSummary {
           file,
         }
       })
-      const changed = next.some((item, i) => item.file !== diffs[i]?.file)
-      if (changed) Storage.write(["session_diff", input.sessionID], next).catch(() => {})
-      return next
+      const sanitized = Snapshot.sanitizeFileDiffs(normalized)
+      const changed =
+        sanitized.changed || normalized.some((item, i) => item.file !== diffs[i]?.file)
+      if (changed) Storage.write(["session_diff", input.sessionID], sanitized.diffs).catch(() => {})
+      return sanitized.diffs
     },
   )
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -260,11 +260,57 @@ export namespace Snapshot {
       additions: z.number(),
       deletions: z.number(),
       status: z.enum(["added", "deleted", "modified"]).optional(),
+      before_bytes: z.number().optional(),
+      after_bytes: z.number().optional(),
+      trimmed: z.boolean().optional(),
     })
     .meta({
       ref: "FileDiff",
     })
   export type FileDiff = z.infer<typeof FileDiff>
+
+  export const MAX_INLINE_DIFF_BYTES = 32 * 1024
+
+  export function sanitizeFileDiff(diff: FileDiff, maxBytes = MAX_INLINE_DIFF_BYTES): FileDiff {
+    if (diff.trimmed) return diff
+
+    const beforeBytes = Buffer.byteLength(diff.before, "utf-8")
+    const afterBytes = Buffer.byteLength(diff.after, "utf-8")
+    const totalBytes = beforeBytes + afterBytes
+    if (beforeBytes <= maxBytes && afterBytes <= maxBytes && totalBytes <= maxBytes) return diff
+
+    return {
+      ...diff,
+      before: beforeBytes === 0 ? "" : "",
+      after: afterBytes === 0 ? "" : "",
+      before_bytes: beforeBytes,
+      after_bytes: afterBytes,
+      trimmed: true,
+    }
+  }
+
+  export function sanitizeFileDiffs(
+    diffs: FileDiff[],
+    maxBytes = MAX_INLINE_DIFF_BYTES,
+  ): { diffs: FileDiff[]; changed: boolean } {
+    let changed = false
+    const next = diffs.map((diff) => {
+      const sanitized = sanitizeFileDiff(diff, maxBytes)
+      if (
+        !changed &&
+        (sanitized.before !== diff.before ||
+          sanitized.after !== diff.after ||
+          sanitized.before_bytes !== diff.before_bytes ||
+          sanitized.after_bytes !== diff.after_bytes ||
+          sanitized.trimmed !== diff.trimmed)
+      ) {
+        changed = true
+      }
+      return sanitized
+    })
+    return { diffs: next, changed }
+  }
+
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
     const result: FileDiff[] = []
@@ -350,14 +396,16 @@ export namespace Snapshot {
           ).then((x) => x.text)
       const added = isBinaryFile ? 0 : parseInt(additions)
       const deleted = isBinaryFile ? 0 : parseInt(deletions)
-      result.push({
-        file,
-        before,
-        after,
-        additions: Number.isFinite(added) ? added : 0,
-        deletions: Number.isFinite(deleted) ? deleted : 0,
-        status: status.get(file) ?? "modified",
-      })
+      result.push(
+        sanitizeFileDiff({
+          file,
+          before,
+          after,
+          additions: Number.isFinite(added) ? added : 0,
+          deletions: Number.isFinite(deleted) ? deleted : 0,
+          status: status.get(file) ?? "modified",
+        }),
+      )
     }
     return result
   }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -4,6 +4,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import type { Provider } from "../../src/provider/provider"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
+import { Snapshot } from "../../src/snapshot"
 
 const sessionID = SessionID.make("session")
 const providerID = ProviderID.make("test")
@@ -894,5 +895,46 @@ describe("session.message-v2.fromError", () => {
         message: "123",
       },
     })
+  })
+})
+
+describe("session.message-v2.sanitizeInfoForRead", () => {
+  test("trims oversized summary diffs on legacy user messages", () => {
+    const input = {
+      id: MessageID.make("msg_1"),
+      sessionID: SessionID.make("ses_1"),
+      role: "user" as const,
+      time: { created: 1 },
+      summary: {
+        diffs: [
+          {
+            file: ".agent-history/EVENTS.jsonl",
+            before: "a".repeat(Snapshot.MAX_INLINE_DIFF_BYTES + 1),
+            after: "b".repeat(Snapshot.MAX_INLINE_DIFF_BYTES + 2),
+            additions: 10,
+            deletions: 3,
+            status: "modified" as const,
+          },
+        ],
+      },
+      agent: "agent",
+      model: {
+        providerID: ProviderID.make("openai"),
+        modelID: ModelID.make("gpt-5"),
+      },
+      tools: {},
+      mode: "",
+    } as unknown as MessageV2.User
+
+    const result = MessageV2.sanitizeInfoForRead(input)
+    expect(result.summary && typeof result.summary !== "boolean").toBe(true)
+    if (!result.summary || typeof result.summary === "boolean") throw new Error("summary missing")
+    const diff = result.summary.diffs[0] as Snapshot.FileDiff
+
+    expect(diff.trimmed).toBe(true)
+    expect(diff.before).toBe("")
+    expect(diff.after).toBe("")
+    expect(diff.before_bytes).toBeGreaterThan(Snapshot.MAX_INLINE_DIFF_BYTES)
+    expect(diff.after_bytes).toBeGreaterThan(Snapshot.MAX_INLINE_DIFF_BYTES)
   })
 })

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1178,3 +1178,32 @@ test("diffFull with whitespace changes", async () => {
     },
   })
 })
+
+test("diffFull trims oversized file contents while keeping metadata", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const large = "x".repeat(Snapshot.MAX_INLINE_DIFF_BYTES + 1024)
+      await Filesystem.write(`${tmp.path}/large.txt`, large)
+
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+
+      const diffs = await Snapshot.diffFull(before!, after!)
+      expect(diffs.length).toBe(1)
+
+      const diff = diffs[0]
+      expect(diff.file).toBe("large.txt")
+      expect(diff.trimmed).toBe(true)
+      expect(diff.before).toBe("")
+      expect(diff.after).toBe("")
+      expect(diff.before_bytes).toBe(0)
+      expect(diff.after_bytes).toBeGreaterThan(Snapshot.MAX_INLINE_DIFF_BYTES)
+      expect(diff.additions).toBe(1)
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Fix blank session history caused by oversized inline summary diffs.

This change prevents large `summary.diffs[*].before/after` payloads from being persisted into session history and also sanitizes legacy oversized rows on read so existing broken sessions can load again.

## Root Cause

`Snapshot.diffFull()` returned full file contents for every changed file. Those `FileDiff` objects were then persisted into:

- `session_diff` storage
- `user.summary.diffs` inside `message.data`

For large files like `.agent-history/EVENTS.jsonl`, this could create individual `message.data` rows tens of megabytes large. Reopening a session then forced the history hydration path to load those huge payloads just to render the timeline, which could surface as a blank session view.

## What Changed

- Added write-side diff sanitization in `packages/opencode/src/snapshot/index.ts`
  - oversized diff contents are cleared
  - `before_bytes`, `after_bytes`, and `trimmed` are preserved
- Applied the same sanitization on read for legacy message rows in `packages/opencode/src/session/message-v2.ts`
- Applied read-time sanitization to session-level diff storage in `packages/opencode/src/session/summary.ts`
- Sanitized session row summaries in `packages/opencode/src/session/index.ts`
- Added regression coverage for:
  - oversized `diffFull()` output trimming
  - legacy user-message summary diff sanitization on read

## Verification

- `bun test test/snapshot/snapshot.test.ts test/session/message-v2.test.ts` in `packages/opencode`
- `bun test --preload ./happydom.ts ./src/context/global-sync.test.ts` in `packages/app`
- `bunx turbo run typecheck --filter=opencode --filter=@opencode-ai/app`
- `bun run build` in `packages/app`
- `bun run build` in `packages/opencode`

## Notes

This intentionally keeps the file-level diff entry itself instead of dropping it entirely, so the session still knows which files changed and by how much. It only removes the unbounded inline file contents that were making history hydration unsafe.
