### PR TITLE
fix: remove dead LSP clients to prevent unbounded memory growth

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -76,6 +76,15 @@ export namespace LSPClient {
         uri: pathToFileURL(input.root).href,
       },
     ])
+    let alive = true
+    connection.onClose(() => {
+      l.info("connection closed")
+      alive = false
+    })
+    connection.onError((err) => {
+      l.error("connection error", { error: err })
+    })
+
     connection.listen()
 
     l.info("sending initialize")
@@ -140,6 +149,9 @@ export namespace LSPClient {
       root: input.root,
       get serverID() {
         return input.serverID
+      },
+      get alive() {
+        return alive
       },
       get connection() {
         return connection

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -275,18 +275,42 @@ export namespace LSP {
     return false
   }
 
+  async function removeClient(s: Awaited<ReturnType<typeof state>>, client: LSPClient.Info) {
+    const idx = s.clients.indexOf(client)
+    if (idx !== -1) s.clients.splice(idx, 1)
+    s.broken.add(client.root + client.serverID)
+    client.shutdown().catch(() => {})
+    log.info("removed dead LSP client", {
+      serverID: client.serverID,
+      root: client.root,
+    })
+  }
+
   export async function touchFile(input: string, waitForDiagnostics?: boolean) {
     log.info("touching file", { file: input })
+    const s = await state()
     const clients = await getClients(input)
     await Promise.all(
       clients.map(async (client) => {
-        const wait = waitForDiagnostics ? client.waitForDiagnostics({ path: input }) : Promise.resolve()
-        await client.notify.open({ path: input })
-        return wait
+        if (!client.alive) {
+          await removeClient(s, client)
+          return
+        }
+        try {
+          const wait = waitForDiagnostics ? client.waitForDiagnostics({ path: input }) : Promise.resolve()
+          await client.notify.open({ path: input })
+          return wait
+        } catch (err: any) {
+          log.error("failed to touch file", { err, file: input })
+          if (
+            err?.message?.includes("Connection is closed") ||
+            err?.message?.includes("connection is disposed")
+          ) {
+            await removeClient(s, client)
+          }
+        }
       }),
-    ).catch((err) => {
-      log.error("failed to touch file", { err, file: input })
-    })
+    )
   }
 
   export async function diagnostics() {

--- a/packages/opencode/src/tool/write.txt
+++ b/packages/opencode/src/tool/write.txt
@@ -3,6 +3,7 @@ Writes a file to the local filesystem.
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
 - If this is an existing file, you MUST use the Read tool first to read the file's contents. This tool will fail if you did not read the file first.
-- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
+- ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required. Use the Edit tool instead of Write when only a portion of the file changed.
+- When creating or writing multiple files, avoid writing more than 5 files in rapid succession. Each write triggers formatting, LSP, and snapshot operations that need time to complete.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.


### PR DESCRIPTION
### Issue for this PR

Fixes #13796

Also relates to #15675 and #16697

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an LSP connection dies during a session, the dead client is never removed from `s.clients`. Every subsequent file write/edit calls `touchFile`, which retries the dead connection, waits 3s for diagnostics that will never arrive, and leaks memory from accumulated error state. The dead client is never detected, never removed, and never stops being retried.

I hit this in production: a single session grew to 16.9 GB RSS over 2 days, with 807 "Connection is closed" errors across 129 files. The cascade:

1. Heavy file editing session (many files written/edited in sequence)
2. Each write triggers formatter checks + LSP touch + file watcher + git snapshot
3. LSP connection dies under load (`err=Connection is closed`)
4. `touchFile` catches the error and logs it, but the client stays in the list
5. Next file operation retries the dead client — same error, same leak
6. 807 iterations later: 16.9 GB RSS, 3 threads spinning at ~1160 CPU-hours each

**The fix has three parts:**

**`client.ts`**: Register `connection.onClose()` to detect when the jsonrpc connection actually closes (stream EOF, process exit). This sets an `alive` flag to `false`. `onError` is registered for logging only — protocol errors aren't necessarily fatal. The `alive` flag is exposed as a getter.

**`index.ts`**: New `removeClient()` helper that splices the client from `s.clients`, adds `root+serverID` to the `broken` set (so `getClients()` never returns it), and attempts graceful shutdown. `touchFile()` now checks `client.alive` before attempting, and has per-client try/catch instead of a single `.catch()` on `Promise.all`. If a client throws "Connection is closed" or "connection is disposed", it gets removed. One dead client no longer blocks or masks errors from healthy clients.

**`write.txt`**: Added guidance to prefer Edit over Write for partial changes, and to avoid >5 rapid successive writes since each triggers the full post-write pipeline (formatters, LSP, snapshots).

The `broken` set is permanent for the session — once marked, that LSP server won't be respawned for that root. This is consistent with the existing behavior for spawn/init failures and prevents respawn-crash loops.

| | Before | After |
|---|---|---|
| Dead LSP client detected? | Never | On connection close or first failed call |
| Dead client removed? | Never — stays forever | Immediately on detection |
| Subsequent file ops | Retry dead client every time | Skip it entirely |
| Memory impact | Unbounded growth | One-time cleanup, no further cost |
| One dead client affects others? | Yes — single `.catch()` on `Promise.all` | No — per-client handling |

### How did you verify your code works?

- `bun run typecheck` passes clean (zero errors)
- `bun test --timeout 30000` — 1312 pass, 8 skip, 1 fail
  - The single failure is a pre-existing flaky PTY timing test (`pty-session.test.ts`) that also fails on `main`
- Verified the cascade mechanism by analyzing production logs from the session that triggered the 16.9 GB leak

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR