### PR TITLE
fix: remove dead LSP clients to prevent unbounded memory growth

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -76,6 +76,15 @@ export namespace LSPClient {
         uri: pathToFileURL(input.root).href,
       },
     ])
+    let alive = true
+    connection.onClose(() => {
+      l.info("connection closed")
+      alive = false
+    })
+    connection.onError((err) => {
+      l.error("connection error", { error: err })
+    })
+
     connection.listen()
 
     l.info("sending initialize")
@@ -140,6 +149,9 @@ export namespace LSPClient {
       root: input.root,
       get serverID() {
         return input.serverID
+      },
+      get alive() {
+        return alive
       },
       get connection() {
         return connection

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -275,18 +275,42 @@ export namespace LSP {
     return false
   }
 
+  async function removeClient(s: Awaited<ReturnType<typeof state>>, client: LSPClient.Info) {
+    const idx = s.clients.indexOf(client)
+    if (idx !== -1) s.clients.splice(idx, 1)
+    s.broken.add(client.root + client.serverID)
+    client.shutdown().catch(() => {})
+    log.info("removed dead LSP client", {
+      serverID: client.serverID,
+      root: client.root,
+    })
+  }
+
   export async function touchFile(input: string, waitForDiagnostics?: boolean) {
     log.info("touching file", { file: input })
+    const s = await state()
     const clients = await getClients(input)
     await Promise.all(
       clients.map(async (client) => {
-        const wait = waitForDiagnostics ? client.waitForDiagnostics({ path: input }) : Promise.resolve()
-        await client.notify.open({ path: input })
-        return wait
+        if (!client.alive) {
+          await removeClient(s, client)
+          return
+        }
+        try {
+          const wait = waitForDiagnostics ? client.waitForDiagnostics({ path: input }) : Promise.resolve()
+          await client.notify.open({ path: input })
+          return wait
+        } catch (err: any) {
+          log.error("failed to touch file", { err, file: input })
+          if (
+            err?.message?.includes("Connection is closed") ||
+            err?.message?.includes("connection is disposed")
+          ) {
+            await removeClient(s, client)
+          }
+        }
       }),
-    ).catch((err) => {
-      log.error("failed to touch file", { err, file: input })
-    })
+    )
   }
 
   export async function diagnostics() {

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -92,4 +92,30 @@ describe("LSPClient interop", () => {
 
     await client.shutdown()
   })
+
+  test("alive becomes false when server process is killed", async () => {
+    const handle = spawnFakeServer() as any
+
+    const client = await Instance.provide({
+      directory: process.cwd(),
+      fn: () =>
+        LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: process.cwd(),
+        }),
+    })
+
+    expect(client.alive).toBe(true)
+
+    // Kill the server process (simulates unexpected LSP death)
+    handle.process.kill()
+
+    // Wait for onClose to propagate
+    await new Promise((r) => setTimeout(r, 200))
+    expect(client.alive).toBe(false)
+
+    // Cleanup
+    client.shutdown().catch(() => {})
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #13796

Also relates to #15675 and #16697

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an LSP connection dies during a session, the dead client is never removed from `s.clients`. Every subsequent file write/edit calls `touchFile`, which retries the dead connection, waits 3s for diagnostics that will never arrive, and leaks memory from accumulated error state. The dead client is never detected, never removed, and never stops being retried.

In a long-running session this compounds to GB-scale memory growth. The cascade:

1. Heavy file editing session (many files written/edited in sequence)
2. Each write triggers formatter checks + LSP touch + file watcher + git snapshot
3. LSP connection dies under load (`err=Connection is closed`)
4. `touchFile` catches the error and logs it, but the client stays in the list
5. Next file operation retries the dead client — same error, same leak
6. Hundreds of iterations: unbounded RSS growth, threads spinning indefinitely

**The fix has two parts:**

**`client.ts`**: Register `connection.onClose()` to detect when the jsonrpc connection actually closes (stream EOF, process exit). This sets an `alive` flag to `false`. `onError` is registered for logging only — protocol errors aren't necessarily fatal. The `alive` flag is exposed as a getter.

**`index.ts`**: New `removeClient()` helper that splices the client from `s.clients`, adds `root+serverID` to the `broken` set (so `getClients()` never returns it), and attempts graceful shutdown. `touchFile()` now checks `client.alive` before attempting notification — skips and removes clients already known dead. Per-client try/catch replaces the previous single `.catch()` on `Promise.all`, so one dead client doesn't mask errors from others. Catches "Connection is closed" / "connection is disposed" at call time as a fallback for cases where `onClose` hasn't fired yet.

The `broken` set is permanent for the session — once marked, that LSP server won't be respawned for that root. This is consistent with the existing behavior for spawn/init failures and prevents respawn-crash loops.

| | Before | After |
|---|---|---|
| Dead LSP client detected? | Never | On connection close or first failed call |
| Dead client removed? | Never — stays forever | Immediately on detection |
| Subsequent file ops | Retry dead client every time | Skip it entirely |
| Memory impact | Unbounded growth | One-time cleanup, no further cost |
| One dead client affects others? | Yes — single `.catch()` on `Promise.all` | No — per-client handling |

### How did you verify your code works?

- `bun run typecheck` passes clean (zero errors)
- `bun test --timeout 15000` — 1313 pass, 8 skip, 1 fail
  - 1313 vs 1312 on `main` — new test included
  - The single failure is a pre-existing flaky PTY timing test (`pty-session.test.ts`) that also fails on `main`
- New test: `test/lsp/client.test.ts` — "alive becomes false when server process is killed" — creates a client with the fake LSP server, verifies `alive` is true, kills the server process, verifies `onClose` fires and `alive` becomes false

**Live testing with patched local build:**

Built the patched binary and installed it locally. Tested the dead-client eviction path:

1. Started a session in a TypeScript project, performed a file edit to trigger LSP server spawn
2. Confirmed typescript LSP initialized successfully and returned diagnostics
3. Killed the typescript-language-server process externally mid-session
4. Confirmed `onClose` handler fired and set `alive = false`
5. Performed another file edit — `touchFile` detected `!client.alive`, logged `"removed dead LSP client"`, and evicted the client. Zero `"Connection is closed"` errors, zero `"failed to touch file"` errors
6. Performed a third file edit — `touchFile` called with zero errors, dead client never retried
7. All file edits completed successfully with correct content on disk

In contrast, unpatched behavior produces repeated `"Connection is closed"` errors on every file operation for the rest of the session, with no recovery.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR