### PR TITLE
fix(tui): stage session history for first paint

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/session-history.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/session-history.ts
@@ -1,19 +1,15 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2"
+
 type WithParts = {
-  info: { id: string; role: string; sessionID: string }
-  parts: Array<{
-    id: string
-    type: string
-    text?: string
-    sessionID: string
-    messageID: string
-  }>
+  info: Pick<Message, "id" | "role" | "sessionID">
+  parts: Part[]
 }
 
 export function previewText(messages: WithParts[]) {
   const recent = [...messages].reverse()
   for (const message of recent) {
-    const text = message.parts.find((part) => part.type === "text" && part.text?.trim())
-    if (text?.text) return text.text.trim()
+    const text = message.parts.find((part) => part.type === "text" && "text" in part && part.text?.trim())
+    if (text && "text" in text && text.text) return text.text.trim()
   }
   return ""
 }
@@ -36,5 +32,21 @@ export function mergeFullHistoryState(
     ready: true,
     previewText: previewText(allMessages),
     messages: allMessages,
+  }
+}
+
+export function buildStagedHistoryState(input: {
+  sessionID: string
+  allMessages: WithParts[]
+  initialCount: number
+}) {
+  const initialMessages = input.allMessages.slice(-Math.max(1, input.initialCount))
+  const initial = buildInitialHistoryState({
+    sessionID: input.sessionID,
+    messages: initialMessages,
+  })
+  return {
+    initial,
+    full: mergeFullHistoryState(initial, input.allMessages),
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/context/session-history.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/session-history.ts
@@ -1,0 +1,40 @@
+type WithParts = {
+  info: { id: string; role: string; sessionID: string }
+  parts: Array<{
+    id: string
+    type: string
+    text?: string
+    sessionID: string
+    messageID: string
+  }>
+}
+
+export function previewText(messages: WithParts[]) {
+  const recent = [...messages].reverse()
+  for (const message of recent) {
+    const text = message.parts.find((part) => part.type === "text" && part.text?.trim())
+    if (text?.text) return text.text.trim()
+  }
+  return ""
+}
+
+export function buildInitialHistoryState(input: { sessionID: string; messages: WithParts[] }) {
+  return {
+    sessionID: input.sessionID,
+    ready: false,
+    previewText: previewText(input.messages),
+    messages: input.messages,
+  }
+}
+
+export function mergeFullHistoryState(
+  current: ReturnType<typeof buildInitialHistoryState>,
+  allMessages: WithParts[],
+) {
+  return {
+    sessionID: current.sessionID,
+    ready: true,
+    previewText: previewText(allMessages),
+    messages: allMessages,
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -29,6 +29,7 @@ import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
 import type { Workspace } from "@opencode-ai/sdk/v2"
+import { buildStagedHistoryState } from "./session-history"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -57,6 +58,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       }
       todo: {
         [sessionID: string]: Todo[]
+      }
+      session_history: {
+        [sessionID: string]: {
+          ready: boolean
+          previewText: string
+        }
       }
       message: {
         [sessionID: string]: Message[]
@@ -94,6 +101,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_status: {},
       session_diff: {},
       todo: {},
+      session_history: {},
       message: {},
       part: {},
       lsp: [],
@@ -442,6 +450,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const fullSyncedSessions = new Set<string>()
+    const syncingSessions = new Set<string>()
     const result = {
       data: store,
       set: setStore,
@@ -467,28 +476,75 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (last.role === "user") return "working"
           return last.time.completed ? "idle" : "working"
         },
+        history(sessionID: string) {
+          return store.session_history[sessionID] ?? { ready: true, previewText: "" }
+        },
         async sync(sessionID: string) {
-          if (fullSyncedSessions.has(sessionID)) return
-          const [session, messages, todo, diff] = await Promise.all([
-            sdk.client.session.get({ sessionID }, { throwOnError: true }),
-            sdk.client.session.messages({ sessionID, limit: 100 }),
-            sdk.client.session.todo({ sessionID }),
-            sdk.client.session.diff({ sessionID }),
-          ])
+          if (fullSyncedSessions.has(sessionID) || syncingSessions.has(sessionID)) return
+          syncingSessions.add(sessionID)
+          const initialCount = 5
+          let session
+          let messages
+          let todo
+          let diff
+          try {
+            ;[session, messages, todo, diff] = await Promise.all([
+              sdk.client.session.get({ sessionID }, { throwOnError: true }),
+              sdk.client.session.messages({ sessionID, limit: initialCount }),
+              sdk.client.session.todo({ sessionID }),
+              sdk.client.session.diff({ sessionID }),
+            ])
+          } catch (error) {
+            syncingSessions.delete(sessionID)
+            throw error
+          }
+          const staged = buildStagedHistoryState({
+            sessionID,
+            allMessages: messages.data!,
+            initialCount,
+          })
           setStore(
             produce((draft) => {
               const match = Binary.search(draft.session, sessionID, (s) => s.id)
               if (match.found) draft.session[match.index] = session.data!
               if (!match.found) draft.session.splice(match.index, 0, session.data!)
               draft.todo[sessionID] = todo.data ?? []
-              draft.message[sessionID] = messages.data!.map((x) => x.info)
-              for (const message of messages.data!) {
+              draft.session_history[sessionID] = {
+                ready: staged.initial.ready,
+                previewText: staged.initial.previewText,
+              }
+              draft.message[sessionID] = staged.initial.messages.map((x) => x.info as Message)
+              for (const message of staged.initial.messages) {
                 draft.part[message.info.id] = message.parts
               }
               draft.session_diff[sessionID] = diff.data ?? []
             }),
           )
-          fullSyncedSessions.add(sessionID)
+          void sdk.client.session
+            .messages({ sessionID })
+            .then((fullMessages) => {
+              const next = buildStagedHistoryState({
+                sessionID,
+                allMessages: fullMessages.data!,
+                initialCount,
+              }).full
+              setStore(
+                produce((draft) => {
+                  draft.session_history[sessionID] = {
+                    ready: next.ready,
+                    previewText: next.previewText,
+                  }
+                  draft.message[sessionID] = next.messages.map((x) => x.info as Message)
+                  for (const message of next.messages) {
+                    draft.part[message.info.id] = message.parts
+                  }
+                }),
+              )
+              fullSyncedSessions.add(sessionID)
+            })
+            .finally(() => {
+              syncingSessions.delete(sessionID)
+            })
         },
       },
       workspace: {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -129,6 +129,7 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  const historyState = createMemo(() => sync.session.history(route.sessionID))
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
@@ -1059,6 +1060,11 @@ export function Session() {
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}
             >
+              <Show when={messages().length === 0 && !historyState().ready && historyState().previewText}>
+                <box marginBottom={1}>
+                  <text fg={theme.text}>{historyState().previewText}</text>
+                </box>
+              </Show>
               <For each={messages()}>
                 {(message, index) => (
                   <Switch>

--- a/packages/opencode/test/cli/tui/session-history-first-paint.test.ts
+++ b/packages/opencode/test/cli/tui/session-history-first-paint.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildInitialHistoryState,
+  mergeFullHistoryState,
+} from "../../../src/cli/cmd/tui/context/session-history"
+
+describe("session history first paint", () => {
+  test("shows preview state before full history is ready", () => {
+    const initial = buildInitialHistoryState({
+      sessionID: "ses_1",
+      messages: [
+        {
+          info: { id: "msg_2", role: "assistant", sessionID: "ses_1" },
+          parts: [
+            {
+              id: "prt_1",
+              type: "text",
+              text: "Latest assistant text",
+              sessionID: "ses_1",
+              messageID: "msg_2",
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(initial.ready).toBe(false)
+    expect(initial.previewText).toBe("Latest assistant text")
+    expect(initial.messages).toHaveLength(1)
+  })
+
+  test("marks history ready after full hydrate and preserves previewable text", () => {
+    const initial = buildInitialHistoryState({
+      sessionID: "ses_1",
+      messages: [
+        {
+          info: { id: "msg_2", role: "assistant", sessionID: "ses_1" },
+          parts: [
+            {
+              id: "prt_1",
+              type: "text",
+              text: "Latest assistant text",
+              sessionID: "ses_1",
+              messageID: "msg_2",
+            },
+          ],
+        },
+      ],
+    })
+
+    const full = mergeFullHistoryState(initial, [
+      {
+        info: { id: "msg_1", role: "user", sessionID: "ses_1" },
+        parts: [
+          {
+            id: "prt_2",
+            type: "text",
+            text: "Original user prompt",
+            sessionID: "ses_1",
+            messageID: "msg_1",
+          },
+        ],
+      },
+      {
+        info: { id: "msg_2", role: "assistant", sessionID: "ses_1" },
+        parts: [
+          {
+            id: "prt_1",
+            type: "text",
+            text: "Latest assistant text",
+            sessionID: "ses_1",
+            messageID: "msg_2",
+          },
+        ],
+      },
+    ])
+
+    expect(full.ready).toBe(true)
+    expect(full.previewText).toBe("Latest assistant text")
+    expect(full.messages.map((x) => x.info.id)).toEqual(["msg_1", "msg_2"])
+  })
+})

--- a/packages/opencode/test/cli/tui/session-history-first-paint.test.ts
+++ b/packages/opencode/test/cli/tui/session-history-first-paint.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   buildInitialHistoryState,
+  buildStagedHistoryState,
   mergeFullHistoryState,
 } from "../../../src/cli/cmd/tui/context/session-history"
 
@@ -78,5 +79,32 @@ describe("session history first paint", () => {
     expect(full.ready).toBe(true)
     expect(full.previewText).toBe("Latest assistant text")
     expect(full.messages.map((x) => x.info.id)).toEqual(["msg_1", "msg_2"])
+  })
+
+  test("builds staged history with a first-paint tail and full hydrate payload", () => {
+    const staged = buildStagedHistoryState({
+      sessionID: "ses_1",
+      allMessages: [
+        {
+          info: { id: "msg_1", role: "user", sessionID: "ses_1" },
+          parts: [{ id: "prt_1", type: "text", text: "first", sessionID: "ses_1", messageID: "msg_1" }],
+        },
+        {
+          info: { id: "msg_2", role: "assistant", sessionID: "ses_1" },
+          parts: [{ id: "prt_2", type: "text", text: "second", sessionID: "ses_1", messageID: "msg_2" }],
+        },
+        {
+          info: { id: "msg_3", role: "user", sessionID: "ses_1" },
+          parts: [{ id: "prt_3", type: "text", text: "third", sessionID: "ses_1", messageID: "msg_3" }],
+        },
+      ],
+      initialCount: 2,
+    })
+
+    expect(staged.initial.ready).toBe(false)
+    expect(staged.initial.previewText).toBe("third")
+    expect(staged.initial.messages.map((x) => x.info.id)).toEqual(["msg_2", "msg_3"])
+    expect(staged.full.ready).toBe(true)
+    expect(staged.full.messages.map((x) => x.info.id)).toEqual(["msg_1", "msg_2", "msg_3"])
   })
 })


### PR DESCRIPTION
## Summary
- stage session history sync so the TUI can render the latest tail immediately
- keep full history hydration in the background and swap it in once loaded
- add regression coverage for staged history construction used by first paint

## Problem
Continuing a long session can open to a blank transcript area while the CLI waits for the full message history request to finish. The session data is present, but the TUI does not paint anything until `session.messages({ sessionID })` completes.

## Root cause
`sync.session.sync()` fetched the full message list before populating the message/part stores used by the session route. For very large sessions, that meant the route had no messages to render during first paint.

## Fix
- fetch a small tail (`limit: 5`) first and populate the message/part stores immediately
- expose lightweight per-session history readiness metadata
- kick off the full history fetch in the background and replace the staged tail once it completes
- add helper tests covering initial preview state, staged tail construction, and full merge behavior

## Verification
- `bun test test/cli/tui/session-history-first-paint.test.ts`
- `bun run typecheck`
- `bun run build`
