### PR TITLE
fix: process queued messages after task completion instead of interrupting

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -324,6 +324,13 @@ export namespace SessionPrompt {
         lastUser.id < lastAssistant.id
       ) {
         log.info("exiting loop", { sessionID })
+        // Check if there are queued messages before exiting
+        const queued = state()[sessionID]?.callbacks ?? []
+        if (queued.length > 0) {
+          log.info("processing queued messages", { sessionID, count: queued.length })
+          // Continue loop to process queued messages instead of breaking
+          continue
+        }
         break
       }
 


### PR DESCRIPTION
## Summary

Fixes the queue timing issue where queued messages would either interrupt the running task or get stuck and never execute. This PR ensures queued messages are properly processed after the current task finishes.

## Problem

Currently, when a user sends a message while the agent is working:
- The message gets queued (shows green)
- But it either interrupts the current task immediately (wrong) or gets stuck and never runs (wrong)
- Users have to manually type "go" to trigger queued messages

## Root Cause

In `packages/opencode/src/session/prompt.ts`, the session loop exits immediately when a task finishes, without checking if there are queued messages waiting to be processed.

## Solution

Added a check for queued callbacks before exiting the session loop. If messages are queued, the loop continues to process them instead of breaking.

## Changes

- Check for queued callbacks before exiting the session loop (line 327-334)
- Continue loop iteration to process queued messages instead of breaking
- Prevents premature loop exit when messages are waiting in queue

## Testing

- Manually tested with queued messages during agent execution
- Messages now process correctly after task completion
- No interruption of running tasks

## Related Issues

Closes #2246
Closes #16102
Related to #5333, #5135, #5408

## Implementation Reference

Similar implementation was successfully done in Roo Code: https://github.com/RooCodeInc/Roo-Code/pull/11813