### PR TITLE
fix(app): use reconcile for session_status in bootstrap to clear stale entries

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -151,7 +151,7 @@ export async function bootstrapDirectory(input: {
   Promise.all([
     input.sdk.path.get().then((x) => input.setStore("path", x.data!)),
     input.sdk.command.list().then((x) => input.setStore("command", x.data ?? [])),
-    input.sdk.session.status().then((x) => input.setStore("session_status", x.data!)),
+    input.sdk.session.status().then((x) => input.setStore("session_status", reconcile(x.data!))),
     input.loadSessions(input.directory),
     input.sdk.mcp.status().then((x) => input.setStore("mcp", x.data!)),
     input.sdk.lsp.status().then((x) => input.setStore("lsp", x.data!)),


### PR DESCRIPTION
### Issue for this PR

Closes #17657

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `bootstrapDirectory` fetches fresh session statuses from the server via `session.status()`, it uses `setStore("session_status", x.data!)` to update the SolidJS store. SolidJS's `setStore` with a plain object **merges** keys — it iterates `for (const key in value)` and sets each property, but never removes keys absent from the new value.

When the server returns `{}` (all sessions idle), this is a complete no-op — zero keys to iterate, so stale `{ type: "busy" }` entries from previous SSE events survive indefinitely. This causes session spinners to persist in the sidebar even after sessions are idle.

The fix wraps the value in `reconcile()` (already imported in bootstrap.ts), which properly replaces the entire record including deleting stale keys. This matches how `permission` and `question` are already handled in the same file (lines 167-201).

### How did you verify your code works?

- LSP diagnostics clean on the changed file
- `bun typecheck` passes for the `app` package (`tsgo -b`)
- `bun test session-cache` — 3 tests pass
- `bun test event-reducer` — 13 tests pass

### Screenshots / recordings

_N/A — no UI change, behavioral fix only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR