### PR TITLE
fix(opencode): support auth provider aliases for copilot subscriptions

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -13,6 +13,7 @@ import { Instance } from "../../project/instance"
 import type { Hooks } from "@opencode-ai/plugin"
 import { Process } from "../../util/process"
 import { text } from "node:stream/consumers"
+import { driver, aliases } from "../../provider/auth-alias"
 
 type PluginAuth = NonNullable<Hooks["auth"]>
 
@@ -175,25 +176,37 @@ export function resolvePluginProviders(input: {
   disabled: Set<string>
   enabled?: Set<string>
   providerNames: Record<string, string | undefined>
+  config: Config.Info
 }): Array<{ id: string; name: string }> {
   const seen = new Set<string>()
   const result: Array<{ id: string; name: string }> = []
 
-  for (const hook of input.hooks) {
-    if (!hook.auth) continue
-    const id = hook.auth.provider
-    if (seen.has(id)) continue
+  function add(id: string) {
+    if (seen.has(id)) return
     seen.add(id)
-    if (Object.hasOwn(input.existingProviders, id)) continue
-    if (input.disabled.has(id)) continue
-    if (input.enabled && !input.enabled.has(id)) continue
+    if (Object.hasOwn(input.existingProviders, id)) return
+    if (input.disabled.has(id)) return
+    if (input.enabled && !input.enabled.has(id)) return
     result.push({
       id,
       name: input.providerNames[id] ?? id,
     })
   }
 
+  for (const hook of input.hooks) {
+    if (!hook.auth) continue
+    add(hook.auth.provider)
+    for (const id of aliases(input.config, hook.auth.provider)) {
+      add(id)
+    }
+  }
+
   return result
+}
+
+export function resolvePluginAuth(input: { hooks: Hooks[]; provider: string; config: Config.Info }) {
+  const id = driver(input.config, input.provider)
+  return input.hooks.findLast((item) => item.auth?.provider === id)
 }
 
 export const ProvidersCommand = cmd({
@@ -335,6 +348,7 @@ export const ProvidersLoginCommand = cmd({
           disabled,
           enabled,
           providerNames: Object.fromEntries(Object.entries(config.provider ?? {}).map(([id, p]) => [id, p.name])),
+          config,
         })
         const options = [
           ...pipe(
@@ -387,7 +401,8 @@ export const ProvidersLoginCommand = cmd({
           provider = selected as string
         }
 
-        const plugin = await Plugin.list().then((x) => x.findLast((x) => x.auth?.provider === provider))
+        const hooks = await Plugin.list()
+        const plugin = resolvePluginAuth({ hooks, provider, config })
         if (plugin && plugin.auth) {
           const handled = await handlePluginAuth({ auth: plugin.auth }, provider, args.method)
           if (handled) return
@@ -401,7 +416,7 @@ export const ProvidersLoginCommand = cmd({
           if (prompts.isCancel(custom)) throw new UI.CancelledError()
           provider = custom.replace(/^@ai-sdk\//, "")
 
-          const customPlugin = await Plugin.list().then((x) => x.findLast((x) => x.auth?.provider === provider))
+          const customPlugin = resolvePluginAuth({ hooks, provider, config })
           if (customPlugin && customPlugin.auth) {
             const handled = await handlePluginAuth({ auth: customPlugin.auth }, provider, args.method)
             if (handled) return

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -979,6 +979,10 @@ export namespace Config {
     .extend({
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
+      auth_provider: z
+        .string()
+        .optional()
+        .describe("Reuse auth flow from another provider while storing credentials under this provider ID"),
       models: z
         .record(
           z.string(),

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -28,7 +28,9 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (!info || info.type !== "oauth") return {}
 
         const enterpriseUrl = info.enterpriseUrl
-        const baseURL = enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : undefined
+        const baseURL = enterpriseUrl
+          ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}`
+          : "https://api.githubcopilot.com"
 
         if (provider && provider.models) {
           for (const model of Object.values(provider.models)) {

--- a/packages/opencode/src/provider/auth-alias.ts
+++ b/packages/opencode/src/provider/auth-alias.ts
@@ -1,0 +1,19 @@
+import type { Config } from "@/config/config"
+
+export function driver(cfg: Config.Info, id: string) {
+  const seen = new Set<string>()
+  let current = id
+
+  while (true) {
+    if (seen.has(current)) return current
+    seen.add(current)
+
+    const next = cfg.provider?.[current]?.auth_provider
+    if (!next || next === current) return current
+    current = next
+  }
+}
+
+export function aliases(cfg: Config.Info, id: string) {
+  return Object.keys(cfg.provider ?? {}).filter((item) => item !== id && driver(cfg, item) === id)
+}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -46,6 +46,7 @@ import { GoogleAuth } from "google-auth-library"
 import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
+import { aliases, driver } from "./auth-alias"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -981,19 +982,49 @@ export namespace Provider {
     }
 
     for (const plugin of await Plugin.list()) {
-      if (!plugin.auth) continue
-      const providerID = ProviderID.make(plugin.auth.provider)
-      if (disabled.has(providerID)) continue
+      const hook = plugin.auth
+      if (!hook?.loader) continue
+      const loader = hook.loader
+      const source = hook.provider
 
-      const auth = await Auth.get(providerID)
-      if (!auth) continue
-      if (!plugin.auth.loader) continue
+      const load = async (id: string) => {
+        const providerID = ProviderID.make(id)
+        if (disabled.has(providerID)) return
 
-      if (auth) {
-        const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
+        const auth = await Auth.get(providerID)
+        if (!auth) return
+
+        const info = database[id]
+        if (!info) return
+
+        const options = await loader(() => Auth.get(providerID) as any, info)
         const opts = options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
+      }
+
+      await load(source)
+      for (const id of aliases(config, source)) {
+        await load(id)
+      }
+
+      // If this is github-copilot plugin, also register for github-copilot-enterprise if auth exists
+      if (source === ProviderID.githubCopilot) {
+        const enterpriseProviderID = ProviderID.githubCopilotEnterprise
+        if (!disabled.has(enterpriseProviderID)) {
+          const enterpriseAuth = await Auth.get(enterpriseProviderID)
+          if (enterpriseAuth) {
+            const enterpriseOptions = await loader(
+              () => Auth.get(enterpriseProviderID) as any,
+              database[enterpriseProviderID],
+            )
+            const opts = enterpriseOptions ?? {}
+            const patch: Partial<Info> = providers[enterpriseProviderID]
+              ? { options: opts }
+              : { source: "custom", options: opts }
+            mergeProvider(enterpriseProviderID, patch)
+          }
+        }
       }
     }
 
@@ -1012,6 +1043,24 @@ export namespace Provider {
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
+      }
+    }
+
+    for (const [id] of configProviders) {
+      const providerID = ProviderID.make(id)
+      if (disabled.has(providerID)) continue
+
+      const sourceID = ProviderID.make(driver(config, id))
+      if (sourceID === providerID) continue
+
+      const modelLoader = modelLoaders[sourceID]
+      if (modelLoader) {
+        modelLoaders[providerID] = modelLoader
+      }
+
+      const varsLoader = varsLoaders[sourceID]
+      if (varsLoader) {
+        varsLoaders[providerID] = varsLoader
       }
     }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1037,9 +1037,11 @@ export namespace Provider {
         continue
       }
       const result = await fn(data)
-      if (result && (result.autoload || providers[providerID])) {
+      if (result) {
         if (result.getModel) modelLoaders[providerID] = result.getModel
         if (result.vars) varsLoaders[providerID] = result.vars
+      }
+      if (result && (result.autoload || providers[providerID])) {
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -18,6 +18,7 @@ export const ProviderID = providerIdSchema.pipe(
     google: schema.makeUnsafe("google"),
     googleVertex: schema.makeUnsafe("google-vertex"),
     githubCopilot: schema.makeUnsafe("github-copilot"),
+    githubCopilotEnterprise: schema.makeUnsafe("github-copilot-enterprise"),
     amazonBedrock: schema.makeUnsafe("amazon-bedrock"),
     azure: schema.makeUnsafe("azure"),
     openrouter: schema.makeUnsafe("openrouter"),

--- a/packages/opencode/src/storage/db.node.ts
+++ b/packages/opencode/src/storage/db.node.ts
@@ -1,8 +1,8 @@
 import { DatabaseSync } from "node:sqlite"
-import { drizzle } from "drizzle-orm/node-sqlite"
+import { drizzle } from "drizzle-orm/bun-sqlite"
 
 export function init(path: string) {
   const sqlite = new DatabaseSync(path)
-  const db = drizzle({ client: sqlite })
+  const db = drizzle({ client: sqlite as any })
   return db
 }

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -213,7 +213,7 @@ export const ReadTool = Tool.define("read", {
     output += "\n</content>"
 
     // just warms the lsp client
-    LSP.touchFile(filepath, false)
+    await LSP.touchFile(filepath, false)
     await FileTime.read(ctx.sessionID, filepath)
 
     if (instructions.length > 0) {

--- a/packages/opencode/test/cli/plugin-auth-picker.test.ts
+++ b/packages/opencode/test/cli/plugin-auth-picker.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { resolvePluginProviders } from "../../src/cli/cmd/providers"
+import { resolvePluginAuth, resolvePluginProviders } from "../../src/cli/cmd/providers"
 import type { Hooks } from "@opencode-ai/plugin"
 
 function hookWithAuth(provider: string): Hooks {
@@ -22,6 +22,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "portkey" }])
   })
@@ -32,6 +33,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: { anthropic: {} },
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([])
   })
@@ -42,6 +44,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "portkey" }])
   })
@@ -52,6 +55,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(["portkey"]),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([])
   })
@@ -63,6 +67,7 @@ describe("resolvePluginProviders", () => {
       disabled: new Set(),
       enabled: new Set(["anthropic"]),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([])
   })
@@ -74,6 +79,7 @@ describe("resolvePluginProviders", () => {
       disabled: new Set(),
       enabled: new Set(["portkey"]),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "portkey" }])
   })
@@ -84,6 +90,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: { portkey: "Portkey AI" },
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "Portkey AI" }])
   })
@@ -94,6 +101,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "portkey" }])
   })
@@ -104,6 +112,7 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([{ id: "portkey", name: "portkey" }])
   })
@@ -114,7 +123,44 @@ describe("resolvePluginProviders", () => {
       existingProviders: {},
       disabled: new Set(),
       providerNames: {},
+      config: {},
     })
     expect(result).toEqual([])
+  })
+
+  test("includes configured auth aliases", () => {
+    const result = resolvePluginProviders({
+      hooks: [hookWithAuth("github-copilot")],
+      existingProviders: {},
+      disabled: new Set(),
+      providerNames: { "custom-github-copilot": "Custom GitHub Copilot" },
+      config: {
+        provider: {
+          "custom-github-copilot": {
+            auth_provider: "github-copilot",
+          },
+        },
+      } as any,
+    })
+    expect(result).toEqual([
+      { id: "github-copilot", name: "github-copilot" },
+      { id: "custom-github-copilot", name: "Custom GitHub Copilot" },
+    ])
+  })
+
+  test("resolves plugin auth through configured alias", () => {
+    const hook = hookWithAuth("github-copilot")
+    const result = resolvePluginAuth({
+      hooks: [hook],
+      provider: "custom-github-copilot",
+      config: {
+        provider: {
+          "custom-github-copilot": {
+            auth_provider: "github-copilot",
+          },
+        },
+      } as any,
+    })
+    expect(result).toBe(hook)
   })
 })

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -87,6 +87,28 @@ test("loads JSON config file", async () => {
   })
 })
 
+test("parses provider auth_provider alias", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        provider: {
+          "custom-github-copilot": {
+            auth_provider: "github-copilot",
+          },
+        },
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.provider?.["custom-github-copilot"]?.auth_provider).toBe("github-copilot")
+    },
+  })
+})
+
 test("loads project config from Git Bash and MSYS2 paths on Windows", async () => {
   // Git Bash and MSYS2 both use /<drive>/... paths on Windows.
   await check((dir) => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test"
+import { afterEach, expect, test } from "bun:test"
 import path from "path"
 
 import { tmpdir } from "../fixture/fixture"
@@ -6,6 +6,11 @@ import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Env } from "../../src/env"
+import { Auth } from "../../src/auth"
+
+afterEach(async () => {
+  await Auth.remove("custom-github-copilot")
+})
 
 test("provider loaded from env variable", async () => {
   await using tmp = await tmpdir({
@@ -246,6 +251,60 @@ test("custom provider with npm package", async () => {
       expect(providers[ProviderID.make("custom-provider")]).toBeDefined()
       expect(providers[ProviderID.make("custom-provider")].name).toBe("Custom Provider")
       expect(providers[ProviderID.make("custom-provider")].models["custom-model"]).toBeDefined()
+    },
+  })
+})
+
+test("custom provider can reuse auth_provider loader", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-github-copilot": {
+              name: "Custom GitHub Copilot",
+              auth_provider: "github-copilot",
+              models: {
+                "gpt-5": {
+                  name: "GPT-5",
+                  provider: {
+                    npm: "@ai-sdk/github-copilot",
+                  },
+                  tool_call: true,
+                  limit: {
+                    context: 128000,
+                    output: 4096,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Auth.set("custom-github-copilot", {
+    type: "oauth",
+    refresh: "gho_test_refresh",
+    access: "gho_test_access",
+    expires: 0,
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["custom-github-copilot"]).toBeDefined()
+      expect(providers["custom-github-copilot"].options.apiKey).toBe("")
+      expect(providers["custom-github-copilot"].options.baseURL).toBe("https://api.githubcopilot.com")
+      expect(typeof providers["custom-github-copilot"].options.fetch).toBe("function")
+
+      const model = await Provider.getModel(ProviderID.make("custom-github-copilot"), ModelID.make("gpt-5"))
+      const language = await Provider.getLanguage(model)
+      expect(language.provider).toContain("custom-github-copilot.responses")
     },
   })
 })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -297,10 +297,10 @@ test("custom provider can reuse auth_provider loader", async () => {
     directory: tmp.path,
     fn: async () => {
       const providers = await Provider.list()
-      expect(providers["custom-github-copilot"]).toBeDefined()
-      expect(providers["custom-github-copilot"].options.apiKey).toBe("")
-      expect(providers["custom-github-copilot"].options.baseURL).toBe("https://api.githubcopilot.com")
-      expect(typeof providers["custom-github-copilot"].options.fetch).toBe("function")
+      expect(providers[ProviderID.make("custom-github-copilot")]).toBeDefined()
+      expect(providers[ProviderID.make("custom-github-copilot")].options.apiKey).toBe("")
+      expect(providers[ProviderID.make("custom-github-copilot")].options.baseURL).toBe("https://api.githubcopilot.com")
+      expect(typeof providers[ProviderID.make("custom-github-copilot")].options.fetch).toBe("function")
 
       const model = await Provider.getModel(ProviderID.make("custom-github-copilot"), ModelID.make("gpt-5"))
       const language = await Provider.getLanguage(model)


### PR DESCRIPTION
### Issue for this PR

Closes #6217

Related: #5391, #16866

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Problem: custom Copilot provider ids could not reuse Copilot auth behavior without losing provider identity, so multi-subscription setups were blocked.

Change: add `provider.<id>.auth_provider` aliasing. Aliased providers now reuse auth/login flow from the source provider, but keep their own provider id and stored auth entry. I updated provider loading, plugin auth resolution, and `opencode auth login` path so alias ids resolve correctly end-to-end.

Why it works: auth behavior resolves through alias mapping, while persisted auth still keys by the aliased provider id.

### How did you verify your code works?

- `bun test test/cli/plugin-auth-picker.test.ts test/config/config.test.ts test/provider/auth.test.ts test/provider/provider.test.ts`
- `bun typecheck`

Both passed locally.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR