### PR TITLE
fix(web): set locale cookie on docs language switch

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -298,6 +298,7 @@ export default defineConfig({
         Header: "./src/components/Header.astro",
         Footer: "./src/components/Footer.astro",
         SiteTitle: "./src/components/SiteTitle.astro",
+        LanguageSelect: "./src/components/LanguageSelect.astro",
       },
       plugins: [
         theme({

--- a/packages/web/src/components/LanguageSelect.astro
+++ b/packages/web/src/components/LanguageSelect.astro
@@ -1,0 +1,45 @@
+---
+import Default from '@astrojs/starlight/components/LanguageSelect.astro';
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<script>
+	const LOCALE_MAP: Record<string, string> = {
+		ar: "ar",
+		bs: "bs",
+		da: "da",
+		de: "de",
+		es: "es",
+		fr: "fr",
+		it: "it",
+		ja: "ja",
+		ko: "ko",
+		nb: "no",
+		pl: "pl",
+		"pt-br": "br",
+		ru: "ru",
+		th: "th",
+		tr: "tr",
+		"zh-cn": "zh",
+		"zh-tw": "zht",
+	};
+
+	function cookieValueFromPath(pathname: string): string {
+		const match = pathname.match(/^\/docs\/([^/]+)/);
+		const segment = match?.[1]?.toLowerCase();
+		if (segment && segment in LOCALE_MAP) {
+			return LOCALE_MAP[segment]!;
+		}
+		return "en";
+	}
+
+	document.querySelectorAll('starlight-lang-select select').forEach((select) => {
+		select.addEventListener('change', (e) => {
+			if (e.currentTarget instanceof HTMLSelectElement) {
+				const locale = cookieValueFromPath(e.currentTarget.value);
+				document.cookie = `oc_locale=${encodeURIComponent(locale)}; Path=/; Max-Age=31536000; SameSite=Lax`;
+			}
+		});
+	});
+</script>


### PR DESCRIPTION
### Issue for this PR

Closes #12063
Closes #14409
Closes #14997
Closes #15194
Closes #15904
Closes #15984
Closes #16278
Closes #17665 
Closes #18541 
Closes #22415 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The docs language selector can't switch back to English from any other language. English is the root locale (/docs/) while others have a prefix (/docs/fr/). When navigating to /docs/, the console proxy falls back to the `oc_locale` cookie to detect locale, but the cookie still holds the previous language, so it serves that language again.

This PR overrides Starlight's LanguageSelect component to set the `oc_locale` cookie to the correct value before window.location.pathname triggers navigation. The proxy then reads the updated cookie and serves the right locale.

### How did you verify your code works?
Ran the docs site and console app locally. Switched from English to French, then back to English - previously stuck on French, now correctly returns to English. Tested multiple language round-trips (English -> French -> English -> Chinese) and verified the `oc_locale` cookie updates correctly in devtools after each switch.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
