### PR TITLE
fix: add retry circuit breaker and backoff cap to prevent infinite retry loops

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -367,6 +367,16 @@ export namespace SessionProcessor {
               const retry = SessionRetry.retryable(error)
               if (retry !== undefined) {
                 attempt++
+                if (attempt > SessionRetry.RETRY_MAX_ATTEMPTS) {
+                  log.error("max retries exceeded", { attempt, sessionID: input.sessionID })
+                  input.assistantMessage.error = error
+                  Bus.publish(Session.Event.Error, {
+                    sessionID: input.sessionID,
+                    error,
+                  })
+                  SessionStatus.set(input.sessionID, { type: "idle" })
+                  break
+                }
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 SessionStatus.set(input.sessionID, {
                   type: "retry",

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -6,7 +6,9 @@ export namespace SessionRetry {
   export const RETRY_INITIAL_DELAY = 2000
   export const RETRY_BACKOFF_FACTOR = 2
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
+  export const RETRY_MAX_DELAY_WITH_HEADERS = 60_000 // 60 seconds — cap for when response headers are present but missing retry-after
   export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+  export const RETRY_MAX_ATTEMPTS = 10 // maximum retry attempts before giving up
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -51,7 +53,7 @@ export namespace SessionRetry {
           }
         }
 
-        return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+        return Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_WITH_HEADERS)
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Relates to #17648

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When API errors trigger retries and response headers are present but don't contain `retry-after`, `delay()` in `retry.ts` computes exponential backoff with no upper bound (line 54). The no-headers path is capped at 30s, but the with-headers fallback path isn't — it just returns `RETRY_INITIAL_DELAY * 2^(attempt-1)` raw.

Meanwhile `processor.ts` has a `while(true)` loop with no exit condition on retries — it increments `attempt`, sleeps the unbounded delay, and `continue`s forever.

I hit this in production: 11 consecutive `AI_APICallError: Could not relay message upstream` errors over 9 minutes, with delays escalating to 202 seconds between attempts. Process never recovered, had to be killed manually.

**Three changes:**

1. **`RETRY_MAX_DELAY_WITH_HEADERS = 60_000`** — caps the with-headers fallback path at 60s (matching the spirit of the existing 30s no-headers cap)
2. **`RETRY_MAX_ATTEMPTS = 10`** — exported constant for max retry count
3. **Circuit breaker in `processor.ts`** — after `attempt > RETRY_MAX_ATTEMPTS`, logs the failure, publishes error event, sets session idle, and breaks the loop

The fix is minimal and doesn't change behavior for successful retries or retries that respect `retry-after` headers.

### How did you verify your code works?

- Analyzed production logs from two stuck processes to confirm the exact failure pattern
- `tsc --noEmit` passes clean
- Verified the 202s delay at attempt 7 would have been capped to 60s, and the loop would have exited at attempt 10 instead of running indefinitely

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR