### PR TITLE
fix: correct typo in calculateOccuredCost function name

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -228,7 +228,7 @@ export async function handler(
       const body = JSON.stringify(
         responseConverter({
           ...json,
-          cost: calculateOccuredCost(billingSource, costInfo),
+          cost: calculateOccurredCost(billingSource, costInfo),
         }),
       )
       logger.metric({ response_length: body.length })
@@ -272,7 +272,7 @@ export async function handler(
                   await trialLimiter?.track(usageInfo)
                   await trackUsage(sessionId, billingSource, authInfo, modelInfo, providerInfo, usageInfo, costInfo)
                   await reload(billingSource, authInfo, costInfo)
-                  const cost = calculateOccuredCost(billingSource, costInfo)
+                  const cost = calculateOccurredCost(billingSource, costInfo)
                   c.enqueue(encoder.encode(usageParser.buidlCostChunk(cost)))
                 }
                 c.close()
@@ -811,7 +811,7 @@ export async function handler(
     }
   }
 
-  function calculateOccuredCost(billingSource: BillingSource, costInfo: CostInfo) {
+  function calculateOccurredCost(billingSource: BillingSource, costInfo: CostInfo) {
     return billingSource === "balance" ? (costInfo.totalCostInCent / 100).toFixed(8) : "0"
   }
 


### PR DESCRIPTION
Fixes #17683

This PR corrects the spelling of `calculateOccuredCost` to `calculateOccurredCost` (double 'r' is the correct spelling).

Changes:
- Line 231: Function call
- Line 275: Function call  
- Line 814: Function definition

All 3 occurrences have been updated.