### PR TITLE
feat(opencode): add local server provider with auto model discovery

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1091,10 +1091,13 @@ export namespace Provider {
     for (const [id, fn] of Object.entries(CUSTOM_LOADERS)) {
       const providerID = ProviderID.make(id)
       if (disabled.has(providerID)) continue
-      const data = database[providerID]
-      if (!data) {
-        log.error("Provider does not exist in model list " + providerID)
-        continue
+      const data = database[providerID] ?? {
+        id: providerID,
+        name: id,
+        source: "custom" as const,
+        env: [],
+        options: configProviders.find(([k]) => k === id)?.[1]?.options ?? {},
+        models: {},
       }
       const result = await fn(data)
       if (result && (result.autoload || providers[providerID])) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -668,6 +668,49 @@ export namespace Provider {
         },
       }
     },
+    async local(input) {
+      const baseURL = input.options?.baseURL
+      if (!baseURL) return { autoload: false }
+      try {
+        const url = `${String(baseURL).replace(/\/+$/, "")}/models`
+        const headers: Record<string, string> = { Accept: "application/json" }
+        const apiKey = input.options?.apiKey ?? input.key
+        if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`
+        const res = await fetch(url, { headers, signal: AbortSignal.timeout(3000) })
+        if (!res.ok) return { autoload: false }
+        const json = (await res.json()) as { data?: Array<{ id: string }> }
+        if (!json.data?.length) return { autoload: false }
+        for (const model of json.data) {
+          if (!model.id || input.models[model.id]) continue
+          input.models[model.id] = {
+            id: ModelID.make(model.id),
+            providerID: ProviderID.make("local"),
+            name: model.id,
+            api: { id: model.id, url: baseURL, npm: "@ai-sdk/openai-compatible" },
+            status: "active",
+            headers: {},
+            options: {},
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 0, output: 0 },
+            capabilities: {
+              temperature: true,
+              reasoning: false,
+              attachment: false,
+              toolcall: true,
+              input: { text: true, audio: false, image: false, video: false, pdf: false },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            family: "",
+            release_date: "",
+          }
+        }
+        log.info("auto-discovered local models", { count: json.data.length })
+        return { autoload: true }
+      } catch {
+        return { autoload: false }
+      }
+    },
   }
 
   export const Model = z

--- a/packages/opencode/test/provider/local.test.ts
+++ b/packages/opencode/test/provider/local.test.ts
@@ -1,0 +1,127 @@
+import { test, expect, mock, afterEach } from "bun:test"
+import path from "path"
+
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID } from "../../src/provider/schema"
+
+const originalFetch = globalThis.fetch
+
+function mockFetch(handler: (url: string) => Response | undefined) {
+  ;(globalThis as any).fetch = mock((url: string | URL | Request) => {
+    const u = typeof url === "string" ? url : url instanceof URL ? url.href : url.url
+    const result = handler(u)
+    if (result) return Promise.resolve(result)
+    return originalFetch(url as RequestInfo, undefined)
+  })
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("local provider discovers models from /models endpoint", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            local: {
+              options: {
+                baseURL: "http://localhost:11434/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  mockFetch((url) => {
+    if (url === "http://localhost:11434/v1/models") {
+      return new Response(
+        JSON.stringify({
+          data: [{ id: "llama-3-8b" }, { id: "mistral-7b" }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    }
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const local = providers["local"]
+      expect(local).toBeDefined()
+      expect(local.models["llama-3-8b"]).toBeDefined()
+      expect(local.models["mistral-7b"]).toBeDefined()
+      expect(local.models["llama-3-8b"].providerID).toBe(ProviderID.make("local"))
+    },
+  })
+})
+
+test("local provider not loaded when endpoint unreachable", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            local: {
+              options: {
+                baseURL: "http://localhost:9999/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  ;(globalThis as any).fetch = mock((url: string | URL | Request) => {
+    const u = typeof url === "string" ? url : url instanceof URL ? url.href : url.url
+    if (u === "http://localhost:9999/v1/models") {
+      return Promise.reject(new Error("ECONNREFUSED"))
+    }
+    return originalFetch(url as RequestInfo, undefined)
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["local"]).toBeUndefined()
+    },
+  })
+})
+
+test("local provider not loaded without baseURL", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            local: {
+              options: {},
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["local"]).toBeUndefined()
+    },
+  })
+})


### PR DESCRIPTION
Closes #6231

## Type of change

New feature

## What it does

Adds a built-in `local` provider that automatically discovers models from any OpenAI-compatible `/models` endpoint. Configure a `baseURL`, and the provider fetches available models at startup — no manual model listing required.

Also fixes the `CUSTOM_LOADERS` loop to allow custom loaders that don't have a models.dev entry (previously they were silently skipped).

## Why this approach

PR #17670 solves the same problem with 700+ lines across 3 files and a new `dynamicModelList` config flag. This PR does it in ~50 lines with no new config surface. The `local` provider is a first-class built-in: it hits `/models`, registers whatever it finds, and returns `autoload: true`. If the endpoint is unreachable or returns nothing useful, it silently returns `autoload: false`. Nothing new to learn, nothing to break.

## How to use it

```json
{
  "provider": {
    "local": {
      "options": {
        "baseURL": "http://localhost:11434/v1"
      }
    }
  }
}
```

With an API key (e.g. LM Studio):

```json
{
  "provider": {
    "local": {
      "options": {
        "baseURL": "http://localhost:1234/v1",
        "apiKey": "lm-studio"
      }
    }
  }
}
```

## Tests

Three tests covering successful discovery, unreachable endpoint, and missing baseURL.