### PR TITLE
docs: add JSDoc for three functions

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -165,6 +165,15 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
   return false
 }
 
+/**
+ * Resolves and filters plugin authentication providers.
+ *
+ * Processes hooks to extract unique auth providers, filtering out
+ * disabled providers and those that already have credentials configured.
+ *
+ * @param input Object containing hooks, existing providers, disabled/enabled sets
+ * @returns Array of provider objects with id and name for display
+ */
 export function resolvePluginProviders(input: {
   hooks: Hooks[]
   existingProviders: Record<string, unknown>

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -316,6 +316,16 @@ export async function aggregateSessionStats(days?: number, projectFilter?: strin
   return stats
 }
 
+/**
+ * Displays session statistics in a formatted table.
+ *
+ * Renders a nicely formatted output showing token usage,
+ * tool statistics, model usage, and cost information.
+ *
+ * @param stats The aggregated session statistics to display
+ * @param toolLimit Maximum number of tools to show in the list
+ * @param modelLimit Maximum number of models to show in the list
+ */
 export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit?: number) {
   const width = 56
 

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -92,6 +92,16 @@ async function getAllSessions(): Promise<Session.Info[]> {
   return rows.map((row) => Session.fromRow(row))
 }
 
+/**
+ * Aggregates session statistics for the stats command.
+ *
+ * Collects and analyzes session data including token usage, tool calls,
+ * and model performance across all sessions or filtered by project.
+ *
+ * @param days Number of days to include (undefined for all time, 0 for today only)
+ * @param projectFilter Optional project name to filter sessions
+ * @returns Aggregated statistics for the specified time period
+ */
 export async function aggregateSessionStats(days?: number, projectFilter?: string): Promise<SessionStats> {
   const sessions = await getAllSessions()
   const MS_IN_DAY = 24 * 60 * 60 * 1000


### PR DESCRIPTION
Fixes #17696

This PR adds JSDoc documentation to three exported functions:

## Commits
| Commit | Function | File |
|--------|----------|------|
| 3d7ad5a | aggregateSessionStats | stats.ts |
| de9d6e3 | displayStats | stats.ts |
| 30996f8 | resolvePluginProviders | providers.ts |

## Changes
- Documented function purposes
- Added @param and @returns tags
- Explained key behaviors

**This PR contains 3 commits for contribution tracking.**