### PR TITLE
docs: add JSDoc for three utility functions

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`


### PR DESCRIPTION
### Issue for this PR
Closes #17738

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds JSDoc documentation to three utility functions:
- cmd function in cmd.ts - yargs command wrapper with double-dash argument support
- formatDuration function in format.ts - human-readable duration formatter
- decodeDataUrl function in data-url.ts - data URL content extractor

Part of the comprehensive documentation effort for src/util/ directory.

### How did you verify your code works?
- Added JSDoc comments to all functions
- Documented parameters and return types
- TypeScript compiles without errors

### Screenshots / recordings
N/A - Documentation changes only

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR