### PR TITLE
feat(opencode): biome LSP sensible defaults and LSP server message visibility

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -103,6 +103,7 @@ export function DialogStatus() {
                   style={{
                     fg: {
                       connected: theme.success,
+                      warning: theme.warning,
                       error: theme.error,
                     }[item.status],
                   }}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useSync } from "@tui/context/sync"
-import { createMemo, For, Show, Switch, Match } from "solid-js"
+import { createMemo, createSignal, For, Show, Switch, Match } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
@@ -189,24 +189,45 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   </text>
                 </Show>
                 <For each={sync.data.lsp}>
-                  {(item) => (
-                    <box flexDirection="row" gap={1}>
-                      <text
-                        flexShrink={0}
-                        style={{
-                          fg: {
-                            connected: theme.success,
-                            error: theme.error,
-                          }[item.status],
-                        }}
-                      >
-                        •
-                      </text>
-                      <text fg={theme.textMuted}>
-                        {item.id} {item.root}
-                      </text>
-                    </box>
-                  )}
+                  {(item) => {
+                    const [open, setOpen] = createSignal(false)
+                    const msgs = () => item.messages ?? []
+                    const statusColor = () =>
+                      ({
+                        connected: theme.success,
+                        warning: theme.warning,
+                        error: theme.error,
+                      })[item.status]
+                    return (
+                      <box>
+                        <box flexDirection="row" gap={1} onMouseDown={() => msgs().length > 0 && setOpen(!open())}>
+                          <Show when={msgs().length > 0}>
+                            <text fg={theme.text}>{open() ? "▼" : "▶"}</text>
+                          </Show>
+                          <text flexShrink={0} style={{ fg: statusColor() }}>
+                            •
+                          </text>
+                          <text fg={theme.textMuted}>
+                            {item.id} {item.root}
+                          </text>
+                        </box>
+                        <Show when={open() && msgs().length > 0}>
+                          <For each={msgs()}>
+                            {(msg) => (
+                              <box paddingLeft={2}>
+                                <text
+                                  wrapMode="none"
+                                  fg={msg.type === 1 ? theme.error : msg.type === 2 ? theme.warning : theme.textMuted}
+                                >
+                                  {msg.message.length > 80 ? msg.message.slice(0, 77) + "..." : msg.message}
+                                </text>
+                              </box>
+                            )}
+                          </For>
+                        </Show>
+                      </box>
+                    )
+                  }}
                 </For>
               </Show>
             </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -216,10 +216,10 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                             {(msg) => (
                               <box paddingLeft={2}>
                                 <text
-                                  wrapMode="none"
+                                  wrapMode="word"
                                   fg={msg.type === 1 ? theme.error : msg.type === 2 ? theme.warning : theme.textMuted}
                                 >
-                                  {msg.message.length > 80 ? msg.message.slice(0, 77) + "..." : msg.message}
+                                  {msg.message}
                                 </text>
                               </box>
                             )}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1160,6 +1160,10 @@ export namespace Config {
                 env: z.record(z.string(), z.string()).optional(),
                 initialization: z.record(z.string(), z.any()).optional(),
               }),
+              z.object({
+                disabled: z.literal(false).optional(),
+                initialization: z.record(z.string(), z.any()),
+              }),
             ]),
           ),
         ])
@@ -1173,7 +1177,7 @@ export namespace Config {
             return Object.entries(data).every(([id, config]) => {
               if (config.disabled) return true
               if (serverIds.has(id)) return true
-              return Boolean(config.extensions)
+              return "extensions" in config && Boolean(config.extensions)
             })
           },
           {

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -53,10 +53,10 @@ export namespace LSPClient {
     const l = log.clone().tag("serverID", input.serverID)
     l.info("starting client")
 
-    const reader = new StreamMessageReader(input.server.process.stdout as any)
-    const writer = new StreamMessageWriter(input.server.process.stdin as any)
-
-    const connection = createMessageConnection(reader, writer)
+    const connection = createMessageConnection(
+      new StreamMessageReader(input.server.process.stdout as any),
+      new StreamMessageWriter(input.server.process.stdin as any),
+    )
 
     const diagnostics = new Map<string, Diagnostic[]>()
 

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -30,12 +30,22 @@ export namespace LSPClient {
     }),
   )
 
+  const MAX_SERVER_MESSAGES = 50
+
   export const Event = {
     Diagnostics: BusEvent.define(
       "lsp.client.diagnostics",
       z.object({
         serverID: z.string(),
         path: z.string(),
+      }),
+    ),
+    Message: BusEvent.define(
+      "lsp.client.message",
+      z.object({
+        serverID: z.string(),
+        type: z.number(),
+        message: z.string(),
       }),
     ),
   }
@@ -144,6 +154,28 @@ export namespace LSPClient {
       serverReadyResolved()
     })
     connection.onRequest("client/unregisterCapability", async () => {})
+
+    const serverMessages: Array<{ type: number; message: string }> = []
+    const seen = new Set<string>()
+    const logLevels = { 1: "error", 2: "warn", 3: "info", 4: "debug" } as const
+    function handleServerMessage(method: string, params: { type: number; message: string }) {
+      const level = logLevels[params.type as keyof typeof logLevels] ?? "info"
+      l[level](method, { messageType: params.type, message: params.message })
+      // Store errors, warnings, and info (type <= 3) for status exposure
+      if (params.type <= 3 && !seen.has(params.message)) {
+        seen.add(params.message)
+        serverMessages.push({ type: params.type, message: params.message })
+        if (serverMessages.length > MAX_SERVER_MESSAGES) serverMessages.shift()
+        Bus.publish(Event.Message, { serverID: input.serverID, type: params.type, message: params.message })
+      }
+    }
+    connection.onNotification("window/logMessage", (params: { type: number; message: string }) => {
+      handleServerMessage("window/logMessage", params)
+    })
+    connection.onNotification("window/showMessage", (params: { type: number; message: string }) => {
+      handleServerMessage("window/showMessage", params)
+    })
+
     connection.onRequest("workspace/workspaceFolders", async () => [
       {
         name: "workspace",
@@ -240,7 +272,7 @@ export namespace LSPClient {
           // reading workspace/configuration). Without this, documents opened
           // during the reload get linted with default settings.
           await Promise.race([serverReady, new Promise<void>((r) => setTimeout(r, 3000))])
-          
+
           input.path = path.isAbsolute(input.path) ? input.path : path.resolve(Instance.directory, input.path)
           const text = await Filesystem.readText(input.path)
           const extension = path.extname(input.path)
@@ -300,6 +332,9 @@ export namespace LSPClient {
       },
       get diagnostics() {
         return diagnostics
+      },
+      get messages() {
+        return serverMessages
       },
       async waitForDiagnostics(input: { path: string }) {
         const normalizedPath = Filesystem.normalizePath(

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -12,6 +12,7 @@ import { NamedError } from "@opencode-ai/util/error"
 import { withTimeout } from "../util/timeout"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
+import fs from "fs"
 
 const DIAGNOSTICS_DEBOUNCE_MS = 150
 
@@ -43,12 +44,81 @@ export namespace LSPClient {
     const l = log.clone().tag("serverID", input.serverID)
     l.info("starting client")
 
-    const connection = createMessageConnection(
-      new StreamMessageReader(input.server.process.stdout as any),
-      new StreamMessageWriter(input.server.process.stdin as any),
-    )
+    const DEBUG_LOG = "/tmp/lsp-debug.log"
+    const debugLog = (direction: string, data: unknown) => {
+      const ts = new Date().toISOString()
+      const line = `[${ts}] [${input.serverID}] ${direction} ${JSON.stringify(data)}\n`
+      fs.appendFileSync(DEBUG_LOG, line)
+    }
+
+    const reader = new StreamMessageReader(input.server.process.stdout as any)
+    const writer = new StreamMessageWriter(input.server.process.stdin as any)
+
+    const connection = createMessageConnection(reader, writer)
+
+    // Intercept outgoing traffic (client -> server)
+    const originalSendRequest = connection.sendRequest.bind(connection)
+    connection.sendRequest = ((...args: any[]) => {
+      debugLog("CLIENT -> SERVER [request]", { method: args[0], params: args[1] })
+      const result = originalSendRequest(...args)
+      if (result && typeof result.then === "function") {
+        result.then(
+          (res: unknown) => debugLog("CLIENT <- SERVER [response]", { method: args[0], result: res }),
+          (err: unknown) => debugLog("CLIENT <- SERVER [error]", { method: args[0], error: String(err) }),
+        )
+      }
+      return result
+    }) as any
+
+    const originalSendNotification = connection.sendNotification.bind(connection)
+    connection.sendNotification = ((...args: any[]) => {
+      debugLog("CLIENT -> SERVER [notification]", { method: args[0], params: args[1] })
+      return originalSendNotification(...args)
+    }) as any
+
+    // Intercept incoming traffic (server -> client) via onNotification/onRequest wrappers
+    const originalOnNotification = connection.onNotification.bind(connection)
+    connection.onNotification = ((method: any, handler: any) => {
+      if (typeof method === "string" && handler) {
+        return originalOnNotification(method, (...args: any[]) => {
+          debugLog("SERVER -> CLIENT [notification]", { method, params: args[0] })
+          return handler(...args)
+        })
+      }
+      // Catch-all / generic notification handler
+      return originalOnNotification(method, handler)
+    }) as any
+
+    const originalOnRequest = connection.onRequest.bind(connection)
+    connection.onRequest = ((method: any, handler: any) => {
+      if (typeof method === "string" && handler) {
+        return originalOnRequest(method, async (...args: any[]) => {
+          debugLog("SERVER -> CLIENT [request]", { method, params: args[0] })
+          const result = await handler(...args)
+          debugLog("CLIENT -> SERVER [response to server request]", { method, result })
+          return result
+        })
+      }
+      return originalOnRequest(method, handler)
+    }) as any
 
     const diagnostics = new Map<string, Diagnostic[]>()
+
+    // Track when the server's initial workspace/configuration request has been served,
+    // so we don't send didChangeConfiguration before the server has its initial config.
+    let configurationResolved: () => void
+    const configurationReady = new Promise<void>((resolve) => {
+      configurationResolved = resolve
+    })
+
+    // Track when the server has finished its post-config reload cycle.
+    // Servers like Biome do: workspace/configuration → unregister → register capabilities.
+    // Documents opened before this cycle completes get linted with stale/default settings.
+    let serverReadyResolved: () => void
+    const serverReady = new Promise<void>((resolve) => {
+      serverReadyResolved = resolve
+    })
+
     connection.onNotification("textDocument/publishDiagnostics", (params) => {
       const filePath = Filesystem.normalizePath(fileURLToPath(params.uri))
       l.info("textDocument/publishDiagnostics", {
@@ -64,11 +134,15 @@ export namespace LSPClient {
       l.info("window/workDoneProgress/create", params)
       return null
     })
+    let configurationServed = false
     connection.onRequest("workspace/configuration", async () => {
-      // Return server initialization options
-      return [input.server.initialization ?? {}]
+      configurationServed = true
+      configurationResolved()
+      return [input.server.settings ?? input.server.initialization ?? {}]
     })
-    connection.onRequest("client/registerCapability", async () => {})
+    connection.onRequest("client/registerCapability", async () => {
+      serverReadyResolved()
+    })
     connection.onRequest("client/unregisterCapability", async () => {})
     connection.onRequest("workspace/workspaceFolders", async () => [
       {
@@ -126,10 +200,25 @@ export namespace LSPClient {
 
     await connection.sendNotification("initialized", {})
 
-    if (input.server.initialization) {
-      await connection.sendNotification("workspace/didChangeConfiguration", {
-        settings: input.server.initialization,
-      })
+    if (input.server.initialization || input.server.settings) {
+      // Wait for the server's initial workspace/configuration request to be handled
+      // before sending didChangeConfiguration. Some servers (e.g. Biome) ask for config
+      // right after initialized, and sending didChangeConfiguration before that response
+      // is processed can cause the config to be overwritten or ignored.
+      await Promise.race([configurationReady, new Promise<void>((r) => setTimeout(r, 2000))])
+      // Yield to let the config response flush to the server before sending didChangeConfiguration
+      await new Promise<void>((r) => setTimeout(r, 50))
+      if (!configurationServed) {
+        await connection.sendNotification("workspace/didChangeConfiguration", {
+          settings: input.server.initialization,
+        })
+        // Server got config via didChangeConfiguration, not workspace/configuration —
+        // it won't do a register cycle, so unblock serverReady
+        serverReadyResolved()
+      }
+    } else {
+      // No config to negotiate — server is ready immediately
+      serverReadyResolved()
     }
 
     const files: {
@@ -146,6 +235,12 @@ export namespace LSPClient {
       },
       notify: {
         async open(input: { path: string }) {
+          // Wait for the server to finish its initial config handshake and any
+          // subsequent reload cycle (e.g. Biome's unregister/register after
+          // reading workspace/configuration). Without this, documents opened
+          // during the reload get linted with default settings.
+          await Promise.race([serverReady, new Promise<void>((r) => setTimeout(r, 3000))])
+          
           input.path = path.isAbsolute(input.path) ? input.path : path.resolve(Instance.directory, input.path)
           const text = await Filesystem.readText(input.path)
           const extension = path.extname(input.path)

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -62,7 +62,7 @@ export namespace LSPClient {
 
     // Track when the server's initial workspace/configuration request has been served,
     // so we don't send didChangeConfiguration before the server has its initial config.
-    let configurationResolved: () => void
+    let configurationResolved: () => void = () => {}
     const configurationReady = new Promise<void>((resolve) => {
       configurationResolved = resolve
     })
@@ -70,7 +70,7 @@ export namespace LSPClient {
     // Track when the server has finished its post-config reload cycle.
     // Servers like Biome do: workspace/configuration → unregister → register capabilities.
     // Documents opened before this cycle completes get linted with stale/default settings.
-    let serverReadyResolved: () => void
+    let serverReadyResolved: () => void = () => {}
     const serverReady = new Promise<void>((resolve) => {
       serverReadyResolved = resolve
     })

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -12,7 +12,6 @@ import { NamedError } from "@opencode-ai/util/error"
 import { withTimeout } from "../util/timeout"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
-import fs from "fs"
 
 const DIAGNOSTICS_DEBOUNCE_MS = 150
 
@@ -54,63 +53,10 @@ export namespace LSPClient {
     const l = log.clone().tag("serverID", input.serverID)
     l.info("starting client")
 
-    const DEBUG_LOG = "/tmp/lsp-debug.log"
-    const debugLog = (direction: string, data: unknown) => {
-      const ts = new Date().toISOString()
-      const line = `[${ts}] [${input.serverID}] ${direction} ${JSON.stringify(data)}\n`
-      fs.appendFileSync(DEBUG_LOG, line)
-    }
-
     const reader = new StreamMessageReader(input.server.process.stdout as any)
     const writer = new StreamMessageWriter(input.server.process.stdin as any)
 
     const connection = createMessageConnection(reader, writer)
-
-    // Intercept outgoing traffic (client -> server)
-    const originalSendRequest = connection.sendRequest.bind(connection)
-    connection.sendRequest = ((...args: any[]) => {
-      debugLog("CLIENT -> SERVER [request]", { method: args[0], params: args[1] })
-      const result = originalSendRequest(...args)
-      if (result && typeof result.then === "function") {
-        result.then(
-          (res: unknown) => debugLog("CLIENT <- SERVER [response]", { method: args[0], result: res }),
-          (err: unknown) => debugLog("CLIENT <- SERVER [error]", { method: args[0], error: String(err) }),
-        )
-      }
-      return result
-    }) as any
-
-    const originalSendNotification = connection.sendNotification.bind(connection)
-    connection.sendNotification = ((...args: any[]) => {
-      debugLog("CLIENT -> SERVER [notification]", { method: args[0], params: args[1] })
-      return originalSendNotification(...args)
-    }) as any
-
-    // Intercept incoming traffic (server -> client) via onNotification/onRequest wrappers
-    const originalOnNotification = connection.onNotification.bind(connection)
-    connection.onNotification = ((method: any, handler: any) => {
-      if (typeof method === "string" && handler) {
-        return originalOnNotification(method, (...args: any[]) => {
-          debugLog("SERVER -> CLIENT [notification]", { method, params: args[0] })
-          return handler(...args)
-        })
-      }
-      // Catch-all / generic notification handler
-      return originalOnNotification(method, handler)
-    }) as any
-
-    const originalOnRequest = connection.onRequest.bind(connection)
-    connection.onRequest = ((method: any, handler: any) => {
-      if (typeof method === "string" && handler) {
-        return originalOnRequest(method, async (...args: any[]) => {
-          debugLog("SERVER -> CLIENT [request]", { method, params: args[0] })
-          const result = await handler(...args)
-          debugLog("CLIENT -> SERVER [response to server request]", { method, result })
-          return result
-        })
-      }
-      return originalOnRequest(method, handler)
-    }) as any
 
     const diagnostics = new Map<string, Diagnostic[]>()
 
@@ -148,12 +94,17 @@ export namespace LSPClient {
     connection.onRequest("workspace/configuration", async () => {
       configurationServed = true
       configurationResolved()
-      return [input.server.settings ?? input.server.initialization ?? {}]
+      const settings = input.server.settings ?? input.server.initialization ?? {}
+      l.debug("workspace/configuration", { settings })
+      return [settings]
     })
-    connection.onRequest("client/registerCapability", async () => {
+    connection.onRequest("client/registerCapability", async (params) => {
+      l.debug("client/registerCapability", params)
       serverReadyResolved()
     })
-    connection.onRequest("client/unregisterCapability", async () => {})
+    connection.onRequest("client/unregisterCapability", async (params) => {
+      l.debug("client/unregisterCapability", params)
+    })
 
     const serverMessages: Array<{ type: number; message: string }> = []
     const seen = new Set<string>()
@@ -169,19 +120,21 @@ export namespace LSPClient {
         Bus.publish(Event.Message, { serverID: input.serverID, type: params.type, message: params.message })
       }
     }
-    connection.onNotification("window/logMessage", (params: { type: number; message: string }) => {
-      handleServerMessage("window/logMessage", params)
-    })
-    connection.onNotification("window/showMessage", (params: { type: number; message: string }) => {
-      handleServerMessage("window/showMessage", params)
-    })
+    for (const msgType of ["window/logMessage", "window/showMessage"]) {
+      connection.onNotification(msgType, (params: { type: number; message: string }) => {
+        handleServerMessage(msgType, params)
+      })
+    }
 
-    connection.onRequest("workspace/workspaceFolders", async () => [
-      {
-        name: "workspace",
-        uri: pathToFileURL(input.root).href,
-      },
-    ])
+    connection.onRequest("workspace/workspaceFolders", async () => {
+      l.debug("workspace/workspaceFolders")
+      return [
+        {
+          name: "workspace",
+          uri: pathToFileURL(input.root).href,
+        },
+      ]
+    })
     connection.listen()
 
     l.info("sending initialize")

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -105,24 +105,47 @@ export namespace LSP {
           delete servers[name]
           continue
         }
-        servers[name] = {
-          ...existing,
-          id: name,
-          root: existing?.root ?? (async () => Instance.directory),
-          extensions: item.extensions ?? existing?.extensions ?? [],
-          spawn: async (root) => {
-            return {
-              process: spawn(item.command[0], item.command.slice(1), {
-                cwd: root,
-                windowsHide: true,
-                env: {
-                  ...process.env,
-                  ...item.env,
+        if ("command" in item) {
+          // Full override: user provides their own command
+          servers[name] = {
+            ...existing,
+            id: name,
+            root: existing?.root ?? (async () => Instance.directory),
+            extensions: item.extensions ?? existing?.extensions ?? [],
+            spawn: async (root) => {
+              return {
+                process: spawn(item.command[0], item.command.slice(1), {
+                  cwd: root,
+                  windowsHide: true,
+                  env: {
+                    ...process.env,
+                    ...item.env,
+                  },
+                }),
+                initialization: item.initialization,
+              }
+            },
+          }
+        } else if (item.initialization && existing) {
+          // Initialization-only override for a built-in server
+          const original = existing.spawn
+          const fallback = item.initialization
+          servers[name] = {
+            ...existing,
+            spawn: async (root) => {
+              const handle = await original(root)
+              if (!handle) return handle
+              // If the built-in server signaled it has its own project config, don't override
+              if (handle.configured) return handle
+              return {
+                ...handle,
+                initialization: {
+                  ...handle.initialization,
+                  ...fallback,
                 },
-              }),
-              initialization: item.initialization,
-            }
-          },
+              }
+            },
+          }
         }
       }
 

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -155,6 +155,11 @@ export namespace LSP {
           .join(", "),
       })
 
+      // Re-publish client messages as LSP.Updated so the TUI sidebar refreshes
+      Bus.subscribe(LSPClient.Event.Message, () => {
+        Bus.publish(Event.Updated, {})
+      })
+
       return {
         broken: new Set<string>(),
         servers,
@@ -171,12 +176,19 @@ export namespace LSP {
     return state()
   }
 
+  export const ServerMessage = z.object({
+    type: z.number(),
+    message: z.string(),
+  })
+  export type ServerMessage = z.infer<typeof ServerMessage>
+
   export const Status = z
     .object({
       id: z.string(),
       name: z.string(),
       root: z.string(),
-      status: z.union([z.literal("connected"), z.literal("error")]),
+      status: z.union([z.literal("connected"), z.literal("warning"), z.literal("error")]),
+      messages: z.array(ServerMessage).optional(),
     })
     .meta({
       ref: "LSPStatus",
@@ -187,11 +199,15 @@ export namespace LSP {
     return state().then((x) => {
       const result: Status[] = []
       for (const client of x.clients) {
+        const msgs = client.messages
+        const errors = msgs.some((m) => m.type === 1)
+        const warnings = msgs.some((m) => m.type === 2)
         result.push({
           id: client.serverID,
           name: x.servers[client.serverID].id,
           root: path.relative(Instance.directory, client.root),
-          status: "connected",
+          status: errors ? "error" : warnings ? "warning" : "connected",
+          messages: msgs.length > 0 ? msgs : undefined,
         })
       }
       return result

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -31,7 +31,12 @@ export namespace LSPServer {
 
   export interface Handle {
     process: ChildProcessWithoutNullStreams
+    /** Sent as initializationOptions in the initialize request and via didChangeConfiguration */
     initialization?: Record<string, any>
+    /** Returned in workspace/configuration responses. Kept separate from initialization
+     *  because some servers (e.g. Biome) read config only from workspace/configuration
+     *  and get confused if the same data appears in initializationOptions. */
+    settings?: Record<string, any>
     /** When true, the project has its own config file — don't apply fallback initialization */
     configured?: boolean
   }
@@ -370,14 +375,15 @@ export namespace LSPServer {
       return {
         process: proc,
         configured,
-        initialization: configured
+        settings: configured
           ? undefined
           : {
-              inline_config: {
+              inlineConfig: {
                 linter: {
                   rules: {
                     suspicious: {
                       useIterableCallbackReturn: {
+                        level: "error",
                         options: {
                           checkForEach: false,
                         },

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -32,6 +32,8 @@ export namespace LSPServer {
   export interface Handle {
     process: ChildProcessWithoutNullStreams
     initialization?: Record<string, any>
+    /** When true, the project has its own config file — don't apply fallback initialization */
+    configured?: boolean
   }
 
   type RootFunction = (file: string) => Promise<string | undefined>
@@ -361,8 +363,30 @@ export namespace LSPServer {
         },
       })
 
+      const configured =
+        (await Filesystem.exists(path.join(root, "biome.json"))) ||
+        (await Filesystem.exists(path.join(root, "biome.jsonc")))
+
       return {
         process: proc,
+        configured,
+        initialization: configured
+          ? undefined
+          : {
+              inline_config: {
+                linter: {
+                  rules: {
+                    suspicious: {
+                      useIterableCallbackReturn: {
+                        options: {
+                          checkForEach: false,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
       }
     },
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -176,6 +176,15 @@ export type EventLspClientDiagnostics = {
   }
 }
 
+export type EventLspClientMessage = {
+  type: "lsp.client.message"
+  properties: {
+    serverID: string
+    type: number
+    message: string
+  }
+}
+
 export type EventLspUpdated = {
   type: "lsp.updated"
   properties: {
@@ -970,6 +979,7 @@ export type Event =
   | EventServerConnected
   | EventGlobalDisposed
   | EventLspClientDiagnostics
+  | EventLspClientMessage
   | EventLspUpdated
   | EventFileEdited
   | EventMessageUpdated
@@ -1448,6 +1458,12 @@ export type Config = {
                 [key: string]: unknown
               }
             }
+          | {
+              disabled?: false
+              initialization: {
+                [key: string]: unknown
+              }
+            }
       }
   /**
    * Additional instruction files or patterns to include
@@ -1898,7 +1914,11 @@ export type LspStatus = {
   id: string
   name: string
   root: string
-  status: "connected" | "error"
+  status: "connected" | "warning" | "error"
+  messages?: Array<{
+    type: number
+    message: string
+  }>
 }
 
 export type FormatterStatus = {


### PR DESCRIPTION
### Issue for this PR

Closes #17656

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The PR offers configuration options for built-in, active by default LSPs (like biome) through opencode.json(c).

Since Biome LSP is active by default, even for projects that don't have biome configured by themselves, its default rules should be configurable on a global OpenCode level (i.e. through the global opencode.json(c)), and have more relaxed default rules for such projects which were not configured for biome and were likely not built for obeying to biome's sometimes overly strict default standards. (Same goes for other LSPs that may be active by default and where turning them off is just an inconvenient little extra step, but I haven't defined a default config for those, because they didn't annoy me like biome).

LSP configuration errors should also be clearer to see and debug. So I added that to the existing LSP status indicator as well as a dropdown, showing the last info and error messages when clicking on them, and also adding an orange light for LSP warnings that are not errors.

Such LSP messages (that are not diagnostics messages, i.e. probably mostly configuration errors or warnings) are now also being logged, including a verbose debug log (when logLevel === "debug" to quickly be able to spot and fix LSP config issues.

Biome LSP now sends a default inlineConfig when the project has no biome.json/biome.jsonc. Currently that only disables annoying complaints about Array.prototype.forEach callbacks returning a value, which is very common. But probably there are more rules that could/should be more relaxed by default.

That configuration stuff also brought some existing potential race conditions to the surface that could happen during LSP initializations when passing a config, that should be mitigated pretty okay now.

The OpenCode config schema now accepts overrides for built-in LSP servers, without also specifying the binary, so users can  more easily globally customize Biome workspace settings in opencode.json without providing a full command override and also without putting a biome.json everywhere.

### How did you verify your code works?
I tried it out a little bit. I also followed the implementation process (of course "vibe-coded") very closely and had to debug that race condition more by hand. Here is the shared opencode sssion: https://opncd.ai/share/EQ2Xb6xA

### Screenshots / recordings

<img width="1865" height="746" alt="image" src="https://github.com/user-attachments/assets/8f2f2b1d-e9cf-453a-9eba-6073236be2ef" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


I hope this time your PR guideline compliance bot can recognize that I checked all the requirements.
There was a closing "]" missing.

Hmm... okay, maybe the spaces inside the [  ] were the problem. Let's see.

Yes, bro, I have tested my changes locally.
No, I have not included unrelated changes in this PR.