### PR TITLE
fix(provider): drop empty content messages after interleaved reasoning filter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.ts linguist-language=TypeScript
+*.tsx linguist-language=TypeScript
+*.sh eol=lf
+*.bat eol=crlf
+*.cmd eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-* text=auto eol=lf
-*.ts linguist-language=TypeScript
-*.tsx linguist-language=TypeScript
-*.sh eol=lf
-*.bat eol=crlf
-*.cmd eol=crlf

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -185,6 +185,8 @@ function normalizeMessages(
         // Filter out reasoning parts from content
         const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
+        if (filteredContent.length === 0) return undefined
+
         // Include reasoning_content | reasoning_details directly on the message for all assistant messages
         if (reasoningText) {
           return {
@@ -207,7 +209,7 @@ function normalizeMessages(
       }
 
       return msg
-    })
+    }).filter((msg): msg is ModelMessage => msg !== undefined)
   }
 
   return msgs

--- a/packages/opencode/test/provider/interleaved-empty-content.test.ts
+++ b/packages/opencode/test/provider/interleaved-empty-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { ProviderTransform } from "../../src/provider/transform"
+import * as ProviderTransform from "../../src/provider/transform"
 
 // Model with interleaved reasoning (object form with field property)
 const interleavedBedrockModel = {

--- a/packages/opencode/test/provider/interleaved-empty-content.test.ts
+++ b/packages/opencode/test/provider/interleaved-empty-content.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test"
+import { ProviderTransform } from "../../src/provider/transform"
+
+// Model with interleaved reasoning (object form with field property)
+const interleavedBedrockModel = {
+  id: "amazon-bedrock/zai.glm-4.7",
+  providerID: "amazon-bedrock",
+  api: {
+    id: "zai.glm-4.7",
+    url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    npm: "@ai-sdk/amazon-bedrock",
+  },
+  name: "GLM 4.7",
+  capabilities: {
+    temperature: true,
+    reasoning: true,
+    attachment: false,
+    toolcall: true,
+    input: { text: true, audio: false, image: false, video: false, pdf: false },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: { field: "reasoning_content" },
+  },
+  cost: { input: 0.001, output: 0.002, cache: { read: 0, write: 0 } },
+  limit: { context: 128000, output: 8192 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2025-01-01",
+} as any
+
+const interleavedOpenAICompatModel = {
+  ...interleavedBedrockModel,
+  id: "custom/kimi-k2.5",
+  providerID: "custom",
+  api: {
+    id: "kimi-k2.5",
+    url: "https://custom-endpoint.example.com",
+    npm: "@ai-sdk/openai-compatible",
+  },
+  name: "Kimi K2.5",
+} as any
+
+describe("interleaved reasoning - empty content safety net", () => {
+  test("drops assistant message when only reasoning parts are stripped by interleaved filter", () => {
+    const msgs = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "Let me think about this..." }],
+      },
+      { role: "user", content: "go on" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, interleavedBedrockModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ role: "user", content: "hello" })
+    expect(result[1]).toEqual({ role: "user", content: "go on" })
+  })
+
+  test("drops assistant message when multiple reasoning-only parts are stripped", () => {
+    const msgs = [
+      { role: "user", content: "analyze this code" },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "First, let me look at the structure..." },
+          { type: "reasoning", text: "I see several patterns here..." },
+        ],
+      },
+      { role: "user", content: "what did you find?" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, interleavedBedrockModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toBe("analyze this code")
+    expect(result[1].content).toBe("what did you find?")
+  })
+
+  test("drops reasoning-only assistant message for openai-compatible provider", () => {
+    const msgs = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "Thinking..." }],
+      },
+      { role: "user", content: "continue" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, interleavedOpenAICompatModel, {})
+
+    expect(result).toHaveLength(2)
+    expect(result.every((m) => m.role === "user")).toBe(true)
+  })
+
+  test("keeps assistant message when reasoning + text content remains after filter", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "Let me think..." },
+          { type: "text", text: "Here is my answer." },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, interleavedBedrockModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toEqual([{ type: "text", text: "Here is my answer." }])
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think...")
+  })
+
+  test("keeps assistant message when reasoning + tool-call content remains after filter", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "I should read this file..." },
+          { type: "tool-call", toolCallId: "tc_1", toolName: "read", input: { path: "/foo" } },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, interleavedBedrockModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(1)
+    expect(result[0].content[0]).toEqual({
+      type: "tool-call",
+      toolCallId: "tc_1",
+      toolName: "read",
+      input: { path: "/foo" },
+    })
+  })
+
+  test("does not affect non-interleaved models", () => {
+    const nonInterleavedModel = {
+      ...interleavedBedrockModel,
+      capabilities: {
+        ...interleavedBedrockModel.capabilities,
+        interleaved: true,
+      },
+    } as any
+
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "reasoning", text: "Let me think..." }],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, nonInterleavedModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(1)
+    expect(result[0].content[0]).toEqual({ type: "reasoning", text: "Let me think..." })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #17705

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The interleaved reasoning filter in `normalizeMessages()` strips reasoning parts from assistant messages and moves them to `providerOptions`. When an assistant message contains only reasoning parts (no text, no tool-call), this leaves `content: []`, which Bedrock's ConverseAPI rejects with a validation error. The session is permanently broken after this.

The empty content guard at lines 54-72 cannot catch this because it runs before the interleaved filter.

The fix adds a check after filtering reasoning parts: if `filteredContent` is empty, the message is dropped. This follows the same pattern used by the existing empty content guard at line 68.

### How did you verify your code works?

- 6 new unit tests covering reasoning-only messages (single/multiple parts, bedrock, openai-compatible, mixed content, non-interleaved models)
- 115 existing transform tests pass with 0 regressions
- Typecheck passes (`bun turbo typecheck --filter=opencode`)
- Live tested on Bedrock with `amazon-bedrock/zai.glm-4.7` (the only Bedrock model currently with `interleaved: { field: "reasoning_content" }`). Before the fix: crashes at step 14 with validation error. After the fix: completed 199 steps with 0 errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR