### PR TITLE
docs: add JSDoc for work, withTimeout, which, signal

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`

--- a/packages/opencode/src/util/queue.ts
+++ b/packages/opencode/src/util/queue.ts
@@ -18,6 +18,16 @@ export class AsyncQueue<T> implements AsyncIterable<T> {
   }
 }
 
+/**
+ * Process items concurrently with limited concurrency.
+ *
+ * Executes the provided function on each item in parallel, but limits
+ * the number of concurrent executions to the specified concurrency level.
+ *
+ * @param concurrency Maximum number of concurrent executions
+ * @param items Array of items to process
+ * @param fn Function to execute for each item
+ */
 export async function work<T>(concurrency: number, items: T[], fn: (item: T) => Promise<void>) {
   const pending = [...items]
   await Promise.all(

--- a/packages/opencode/src/util/signal.ts
+++ b/packages/opencode/src/util/signal.ts
@@ -1,3 +1,11 @@
+/**
+ * Creates a simple signal/trigger mechanism.
+ *
+ * Returns an object with trigger and wait methods for one-time
+ * notification patterns. Useful for coordinating async operations.
+ *
+ * @returns Object with trigger function and wait promise
+ */
 export function signal() {
   let resolve: any
   const promise = new Promise((r) => (resolve = r))

--- a/packages/opencode/src/util/timeout.ts
+++ b/packages/opencode/src/util/timeout.ts
@@ -1,3 +1,13 @@
+/**
+ * Wraps a promise with a timeout.
+ *
+ * Returns a promise that rejects with a timeout error if the original
+ * promise doesn't resolve within the specified milliseconds.
+ *
+ * @param promise The promise to wrap with timeout
+ * @param ms Timeout duration in milliseconds
+ * @returns Promise that resolves with the original result or rejects on timeout
+ */
 export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   let timeout: NodeJS.Timeout
   return Promise.race([

--- a/packages/opencode/src/util/which.ts
+++ b/packages/opencode/src/util/which.ts
@@ -1,5 +1,15 @@
 import whichPkg from "which"
 
+/**
+ * Locates the path to a command executable.
+ *
+ * Searches for the command in the system PATH and returns
+ * the full path if found, or null if not found.
+ *
+ * @param cmd The command to locate
+ * @param env Optional environment variables to use for path lookup
+ * @returns Full path to the command or null if not found
+ */
 export function which(cmd: string, env?: NodeJS.ProcessEnv) {
   const result = whichPkg.sync(cmd, {
     nothrow: true,


### PR DESCRIPTION
### Issue for this PR
Closes #17738

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds JSDoc documentation to four utility functions:
- work function in queue.ts - Concurrent work processor with limited concurrency
- withTimeout function in timeout.ts - Promise timeout wrapper
- which function in which.ts - Command path locator utility
- signal function in signal.ts - Signal/trigger utility for async coordination

Part of the comprehensive documentation effort for src/util/ directory.

### How did you verify your code works?
- Added JSDoc comments to all functions
- Documented parameters and return types
- TypeScript compiles without errors

### Screenshots / recordings
N/A - Documentation changes only

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR