### PR TITLE
docs: warn about infinite subagent recursion with global task permissions

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -597,6 +597,45 @@ Rules are evaluated in order, and the **last matching rule wins**. In the exampl
 Users can always invoke any subagent directly via the `@` autocomplete menu, even if the agent's task permissions would deny it.
 :::
 
+:::caution[Recursive subagent nesting]
+Setting `permission.task` rules **globally** (in the top-level `permission` block) or directly on a subagent definition enables that subagent to spawn further subagents. OpenCode has **no depth limit** on this recursion.
+
+Each child session runs independently with its own `steps` counter and context window. If subagents recursively spawn more subagents, token usage grows exponentially — 10 levels of binary branching creates over 2,000 independent sessions, each consuming API tokens.
+
+Neither `steps` nor `doom_loop` protect against this. `steps` limits iterations per session (each child gets its own counter), and `doom_loop` detects repeated calls within a single session, not across parent-child sessions.
+
+**Safe pattern** — set `permission.task` only on primary agents, targeting specific subagents:
+
+```json title="opencode.json"
+{
+  "agent": {
+    "orchestrator": {
+      "mode": "primary",
+      "permission": {
+        "task": {
+          "*": "deny",
+          "explore": "allow",
+          "general": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+**Unsafe pattern** — global `task` permission enables all agents (including subagents) to spawn recursively:
+
+```json title="opencode.json"
+{
+  "permission": {
+    "task": "allow"
+  }
+}
+```
+
+You do **not** need an explicit `"task"` permission for primary agents to spawn subagents — the default `"*": "allow"` already covers this. Adding an explicit `"task": "allow"` globally is what overrides the built-in nesting guard.
+:::
+
 ---
 
 ### Color

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -482,6 +482,10 @@ For example, to ensure that the `edit` and `bash` tools require user approval:
 }
 ```
 
+:::caution
+Be cautious with `"task": "allow"` in the global permission block. Unlike other permissions, this enables subagents to spawn further subagents recursively with no depth limit. See [Agents — Recursive subagent nesting](/docs/agents#recursive-subagent-nesting).
+:::
+
 [Learn more about permissions here](/docs/permissions).
 
 ---

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -135,7 +135,7 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `grep` — content search (matches the regex pattern)
 - `list` — listing files in a directory (matches the directory path)
 - `bash` — running shell commands (matches parsed commands like `git status --porcelain`)
-- `task` — launching subagents (matches the subagent type)
+- `task` — launching subagents (matches the subagent type). See [Agents — Recursive subagent nesting](/docs/agents#recursive-subagent-nesting) for important caveats when setting this globally.
 - `skill` — loading a skill (matches the skill name)
 - `lsp` — running LSP queries (currently non-granular)
 - `todoread`, `todowrite` — reading/updating the todo list


### PR DESCRIPTION
### Issue for this PR

Closes #17722

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adding `"task": "allow"` to the global permission block silently enables infinite subagent recursion. There's no depth limit — I hit 10 levels of nesting and 3+ hours of runaway token usage before noticing.

The root cause is in `task.ts` — the nesting guard checks for explicit `task` permission rules, and a global `"task": "allow"` propagates to all agents including subagents, overriding the guard. The default `"*": "allow"` does NOT trigger this, so users don't expect adding an explicit `task` key to have this effect.

This PR adds warnings to three docs pages:

- **agents.mdx**: `:::caution` callout after the `permission.task` section showing safe vs unsafe patterns and explaining why `steps`/`doom_loop` don't help
- **permissions.mdx**: Cross-reference on the `task` entry pointing to the agents doc warning
- **config.mdx**: `:::caution` callout in the permissions section about global `"task": "allow"`

### How did you verify your code works?

Read all three source files and confirmed the callout syntax (`:::caution`, `:::tip`) matches existing usage throughout the docs codebase. Changes are documentation-only with no code impact.

### Screenshots / recordings

N/A — documentation-only change, no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR