### PR TITLE
docs: Add JSDoc for fn and proxied utility functions

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/fn.ts
+++ b/packages/opencode/src/util/fn.ts
@@ -1,5 +1,17 @@
 import { z } from "zod"
 
+/**
+ * Creates a type-safe function wrapper with schema validation using zod.
+ *
+ * This utility wraps a callback function with runtime input validation.
+ * If validation fails, it logs a stack trace and re-throws the error.
+ * The returned function includes a `force` method for bypassing validation
+ * and a `schema` property for accessing the validation schema.
+ *
+ * @param schema - Zod schema to validate input against
+ * @param cb - Callback function that receives validated input
+ * @returns A validated function with `force` and `schema` properties
+ */
 export function fn<T extends z.ZodType, Result>(schema: T, cb: (input: z.infer<T>) => Result) {
   const result = (input: z.infer<T>) => {
     let parsed

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`

--- a/packages/opencode/src/util/proxied.ts
+++ b/packages/opencode/src/util/proxied.ts
@@ -1,3 +1,13 @@
+/**
+ * Checks if any HTTP proxy environment variables are configured.
+ *
+ * This utility detects whether the application should use a proxy by
+ * checking for common proxy environment variables (HTTP_PROXY, HTTPS_PROXY,
+ * http_proxy, https_proxy). Used to conditionally configure HTTP clients
+ * for proxy support.
+ *
+ * @returns true if any proxy environment variable is set, false otherwise
+ */
 export function proxied() {
   return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
 }


### PR DESCRIPTION
### Issue for this PR
Closes #17738

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds JSDoc documentation to utility functions:
- fn function in fn.ts - type-safe function wrapper with zod schema validation
- proxied function in proxied.ts - HTTP proxy environment detector

Part of the comprehensive documentation effort for src/util/ directory.

### How did you verify your code works?
- Added JSDoc comments to all functions
- Documented parameters and return types
- TypeScript compiles without errors

### Screenshots / recordings
N/A - Documentation changes only

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR