### PR TITLE
docs: Add JSDoc for aggregateSessionStats, displayStats, and resolvePluginProviders

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -165,6 +165,15 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
   return false
 }
 
+/**
+ * Resolves and filters plugin authentication providers.
+ *
+ * Processes hooks to extract unique auth providers, filtering out
+ * disabled providers and those that already have credentials configured.
+ *
+ * @param input Object containing hooks, existing providers, disabled/enabled sets
+ * @returns Array of provider objects with id and name for display
+ */
 export function resolvePluginProviders(input: {
   hooks: Hooks[]
   existingProviders: Record<string, unknown>

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -316,6 +316,16 @@ export async function aggregateSessionStats(days?: number, projectFilter?: strin
   return stats
 }
 
+/**
+ * Displays session statistics in a formatted table.
+ *
+ * Renders a nicely formatted output showing token usage,
+ * tool statistics, model usage, and cost information.
+ *
+ * @param stats The aggregated session statistics to display
+ * @param toolLimit Maximum number of tools to show in the list
+ * @param modelLimit Maximum number of models to show in the list
+ */
 export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit?: number) {
   const width = 56
 

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -92,6 +92,16 @@ async function getAllSessions(): Promise<Session.Info[]> {
   return rows.map((row) => Session.fromRow(row))
 }
 
+/**
+ * Aggregates session statistics for the stats command.
+ *
+ * Collects and analyzes session data including token usage, tool calls,
+ * and model performance across all sessions or filtered by project.
+ *
+ * @param days Number of days to include (undefined for all time, 0 for today only)
+ * @param projectFilter Optional project name to filter sessions
+ * @returns Aggregated statistics for the specified time period
+ */
 export async function aggregateSessionStats(days?: number, projectFilter?: string): Promise<SessionStats> {
   const sessions = await getAllSessions()
   const MS_IN_DAY = 24 * 60 * 60 * 1000


### PR DESCRIPTION
### Issue for this PR
Closes #17738

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds JSDoc documentation to three utility functions:
- aggregateSessionStats function in stats.ts - Aggregates statistics from session data
- displayStats function in stats.ts - Displays formatted statistics in the console
- resolvePluginProviders function in providers.ts - Resolves and filters authentication providers from hooks

Part of the comprehensive documentation effort for src/util/ directory.

### How did you verify your code works?
- Added JSDoc comments to all functions
- Documented parameters and return types
- TypeScript compiles without errors

### Screenshots / recordings
N/A - Documentation changes only

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR