### PR TITLE
fix(opencode): teach Kit's test what an ID is

### DIFF
--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -368,8 +368,8 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(providerID, model.id)
-        const sessionID = "session-test-tools"
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-tools")
         const agent = {
           name: "test",
           mode: "primary",
@@ -378,12 +378,12 @@ describe("session.llm.stream", () => {
         } satisfies Agent.Info
 
         const user = {
-          id: "user-tools",
+          id: MessageID.make("user-tools"),
           sessionID,
           role: "user",
           time: { created: Date.now() },
           agent: agent.name,
-          model: { providerID, modelID: resolved.id },
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
           tools: { question: true },
         } satisfies MessageV2.User
 


### PR DESCRIPTION
## Summary
- wrap the new `llm.test.ts` IDs with `ProviderID.make`, `ModelID.make`, `SessionID.make`, and `MessageID.make`
- fix the typecheck regression introduced by PR #17064 after branded IDs landed
- gently remind Kit's latest PR that raw strings are not, in fact, character development for strong IDs

## Testing
- `bun run typecheck` in `packages/opencode`
- `bun test test/session/llm.test.ts --test-name-pattern \"keeps tools enabled by prompt permissions\"`
- `git push -u origin fix/llm-test-strong-ids` (pre-push hook runs repo typecheck)