### PR TITLE
fix(core): consider code: context_length_exceeded as context overflow in API call errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -167,7 +167,8 @@ export namespace ProviderError {
 
   export function parseAPICallError(input: { providerID: ProviderID; error: APICallError }): ParsedAPICallError {
     const m = message(input.providerID, input.error)
-    if (isOverflow(m) || input.error.statusCode === 413) {
+    const body = json(input.error.responseBody)
+    if (isOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
       return {
         type: "context_overflow",
         message: m,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -869,6 +869,26 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("detects context overflow from context_length_exceeded code in response body", () => {
+    const error = new APICallError({
+      message: "Request failed",
+      url: "https://example.com",
+      requestBodyValues: {},
+      statusCode: 422,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({
+        error: {
+          message: "Some message",
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+        },
+      }),
+      isRetryable: false,
+    })
+    const result = MessageV2.fromError(error, { providerID })
+    expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(true)
+  })
+
   test("does not classify 429 no body as context overflow", () => {
     const result = MessageV2.fromError(
       new APICallError({


### PR DESCRIPTION
### Issue for this PR

Closes #17746

### Type of change

- [x] Bug fix

### What does this PR do?

Before this change, the code `context_length_exceeded` was only considered in stream errors for triggering auto compaction. With this change, it's also considered for API call errors.

### How did you verify your code works?

I manually tested it against our company internal provider that return responses of the form

```json
{
    "error": {
        "message": "You passed 99073 input tokens and requested 32000 output tokens. However, the model's context length is only 131072 tokens, resulting in a maximum input length of 99072 tokens. Please reduce the length of the input prompt. (parameter=input_tokens, value=99073)",
        "type": "invalid_request_error",
        "param": null,
        "code": "context_length_exceeded"
    }
}
```
when the context length is exceeded.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
