### PR TITLE
fix(ci): workaround by using hoisted Bun linker on Windows

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -41,5 +41,13 @@ runs:
       shell: bash
 
     - name: Install dependencies
-      run: bun install
+      run: |
+        # Workaround for patched peer variants
+        # e.g. ./patches/ for standard-openapi
+        # https://github.com/oven-sh/bun/issues/28147
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          bun install --linker hoisted
+        else
+          bun install
+        fi
       shell: bash


### PR DESCRIPTION
## Summary
- switch Windows CI installs to `bun install --linker hoisted`
- document this as a temporary workaround for patched peer variants in `./patches/`
- reference the upstream Bun bug affecting patched packages like `standard-openapi`

## Testing
- not run (workflow-only change)

Upstream: oven-sh/bun#28147