### PR TITLE
fix(opencode): web UI sidebar not showing session history

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -202,7 +202,7 @@ function createGlobalSync() {
     const promise = loadRootSessionsWithFallback({
       directory,
       limit,
-      list: (query) => globalSDK.client.session.list(query),
+      list: (query) => sdkFor(directory).session.list(query),
     })
       .then((x) => {
         const nonArchived = (x.data ?? [])

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -23,7 +23,7 @@ function sortSessions(now: number) {
 }
 
 const isRootVisibleSession = (session: Session, directory: string) =>
-  workspaceKey(session.directory) === workspaceKey(directory) && !session.parentID && !session.time?.archived
+  workspaceKey(session.directory).toLowerCase() === workspaceKey(directory).toLowerCase() && !session.parentID && !session.time?.archived
 
 export const sortedRootSessions = (store: { session: Session[]; path: { directory: string } }, now: number) =>
   store.session.filter((session) => isRootVisibleSession(session, store.path.directory)).sort(sortSessions(now))

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -57,7 +57,7 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const query = c.req.valid("query")
         const sessions: Session.Info[] = []
-        for await (const session of Session.list({
+        for (const session of Session.listGlobal({
           directory: query.directory,
           roots: query.roots,
           start: query.start,


### PR DESCRIPTION
### Issue for this PR

Closes #15108
Closes #14572
Related #11331

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Root cause:** The `/session` route uses `Session.list()` which always filters by `Instance.project.id` (session/index.ts line 549). The project ID is derived from the directory where `opencode serve` is started.

**Trigger condition:** When the directory used to start `opencode serve` (directory A, a git repo) differs from the directory where sessions were created (directory B, not a git repo or a different git repo), the project IDs do not match. Sessions from directory B get `project_id = "global"`, but the API filters by directory A's project ID (e.g. `4b0ea68...`), so the query returns zero results.

This is easy to reproduce:
1. Create sessions from a non-git directory (they get `project_id = "global"`)
2. Run `opencode serve` from a git repo directory (project ID = git root commit hash)
3. The `/session` API returns `[]` because `WHERE project_id = '4b0ea68...'` does not match `"global"`

**Fix:** Switch the `/session` route from `Session.list()` to `Session.listGlobal()`, which queries across all projects without filtering by `Instance.project.id`. This matches the behavior of the experimental session endpoint.

Also includes two frontend fixes:
- `global-sync.tsx`: Use `sdkFor(directory)` instead of `globalSDK.client` so the correct `x-opencode-directory` header is sent with session list requests
- `helpers.ts`: Case-insensitive path comparison in `isRootVisibleSession` for Windows path compatibility

### How did you verify your code works?

1. Ran `opencode serve --hostname 127.0.0.1 --port 4096`
2. Before fix: `curl http://127.0.0.1:4096/session` returned `[]`
3. Confirmed database had sessions with `project_id = "global"` via sqlite3
4. After fix: API returns all sessions correctly
5. Sidebar displays session history in browser

### Screenshots / recordings

N/A - backend API fix, verified via curl and browser

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR