### PR TITLE
fix(snapshot): add disk space warning when snapshot grows large

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -14,6 +14,8 @@ export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
   const prune = "7.days"
+  // Warn when snapshot exceeds 1GB
+  const warnThreshold = 1024 * 1024 * 1024
 
   function args(git: string, cmd: string[]) {
     return ["--git-dir", git, "--work-tree", Instance.worktree, ...cmd]
@@ -58,6 +60,17 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
+
+    // Check snapshot directory size and warn if it's too large
+    const size = await getDirSize(git)
+    if (size > warnThreshold) {
+      log.warn("snapshot directory is large", {
+        size: formatBytes(size),
+        threshold: formatBytes(warnThreshold),
+        hint: 'Consider setting `"snapshot": false` in config or running cleanup',
+      })
+    }
+
     if (await fs.mkdir(git, { recursive: true })) {
       await Process.run(["git", "init"], {
         env: {
@@ -360,6 +373,26 @@ export namespace Snapshot {
       })
     }
     return result
+  }
+
+  async function getDirSize(dir: string): Promise<number> {
+    const exists = await fs
+      .stat(dir)
+      .then(() => true)
+      .catch(() => false)
+    if (!exists) return 0
+    // Use du to get directory size in bytes
+    const result = await Process.text(["du", "-s", dir], { nothrow: true })
+    if (result.code !== 0) return 0
+    const kb = parseInt(result.text.split("\t")[0], 10)
+    return Number.isFinite(kb) ? kb * 1024 : 0
+  }
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes}B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`
   }
 
   function gitdir() {


### PR DESCRIPTION
## Problem

The snapshot feature can silently consume hundreds of GBs of disk space. In my case, it accumulated **170GB** over time without any warning.

Related issue: #17753

## Solution

Add a disk space check in the `track()` function that warns users when the snapshot directory exceeds 1GB.

Changes:
- Added `getDirSize()` helper to calculate directory size using `du`
- Added `formatBytes()` helper for human-readable size display
- Added size check with warning when threshold is exceeded

## Testing

- Ran `bun run typecheck` - all 13 packages pass
- The warning is non-blocking and doesn't change existing behavior

## Example Output

When snapshot exceeds 1GB, users will see a warning like:
```
WARN snapshot directory is large
  size: 2.5GB
  threshold: 1.0GB
  hint: Consider setting `"snapshot": false` in config or running cleanup
```

This gives users visibility into the space usage before it becomes a problem.