### PR TITLE
fix(opencode): prevent 400 errors from lone surrogates in tool results

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -18,6 +18,7 @@ import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
+import { sanitizeJsonSurrogates } from "../util/sanitize-surrogates"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -1165,6 +1166,12 @@ export namespace Provider {
             }
             opts.body = JSON.stringify(body)
           }
+        }
+
+        // Sanitize JSON-escaped lone surrogates that may exist in previously
+        // stored session data. See: https://github.com/anomalyco/opencode/issues/14630
+        if (typeof opts.body === "string") {
+          opts.body = sanitizeJsonSurrogates(opts.body)
         }
 
         const res = await fetchFn(input, {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -186,7 +186,7 @@ export namespace SessionProcessor {
                       state: {
                         status: "completed",
                         input: value.input ?? match.state.input,
-                        output: value.output.output,
+                        output: value.output.output?.toWellFormed?.() ?? value.output.output,
                         metadata: value.output.metadata,
                         title: value.output.title,
                         time: {
@@ -210,7 +210,7 @@ export namespace SessionProcessor {
                       state: {
                         status: "error",
                         input: value.input ?? match.state.input,
-                        error: (value.error as any).toString(),
+                        error: (value.error as any).toString()?.toWellFormed?.() ?? (value.error as any).toString(),
                         time: {
                           start: match.state.time.start,
                           end: Date.now(),

--- a/packages/opencode/src/util/sanitize-surrogates.ts
+++ b/packages/opencode/src/util/sanitize-surrogates.ts
@@ -1,0 +1,17 @@
+// Regex that matches a JSON-escaped high surrogate (\uD800–\uDBFF)
+// NOT followed by a JSON-escaped low surrogate (\uDC00–\uDFFF),
+// or a JSON-escaped low surrogate NOT preceded by a high surrogate.
+//
+// This is necessary because JSON.stringify() (per ECMA-262) encodes lone
+// surrogate code units as \uD8xx ASCII escapes, which are valid JavaScript
+// but violate RFC 8259. Strict JSON parsers (Anthropic serde_json, OpenAI)
+// reject these with errors like "no low surrogate in string".
+const LONE_HIGH_SURROGATE = /\\u[dD][89aAbB][0-9a-fA-F]{2}(?!\\u[dD][cCdDeEfF][0-9a-fA-F]{2})/g
+const LONE_LOW_SURROGATE = /(?<!\\u[dD][89aAbB][0-9a-fA-F]{2})\\u[dD][cCdDeEfF][0-9a-fA-F]{2}/g
+
+const REPLACEMENT = "\\uFFFD"
+
+export function sanitizeJsonSurrogates(json: string): string {
+  if (!json.includes("\\uD") && !json.includes("\\ud")) return json
+  return json.replace(LONE_HIGH_SURROGATE, REPLACEMENT).replace(LONE_LOW_SURROGATE, REPLACEMENT)
+}


### PR DESCRIPTION
### Issue for this PR

Closes #14630
Closes #13988

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When MCP tools (web search, file read, bash) return content containing lone Unicode surrogates (U+D800–U+DFFF), the surrogates flow through to `JSON.stringify()`, which encodes them as `\uD8xx` ASCII escapes per ECMA-262. These violate RFC 8259, and strict JSON parsers (Anthropic's `serde_json`, OpenAI's backend) reject the entire request body with:

```
"The request body is not valid JSON: no low surrogate in string: line 1 column N"
```

Once a tool result with surrogates is stored in the session, **every subsequent API call fails** because the corrupted content stays in the conversation context.

**Two-layer fix:**

1. **Ingestion (commit 1)**: Apply `String.prototype.toWellFormed()` (ES2024) to tool outputs in `processor.ts` at the `tool-result` and `tool-error` handlers. This sanitizes surrogates before they reach the database, preventing future corruption.

2. **Fetch wrapper (commit 2)**: Add `sanitizeJsonSurrogates()` regex pass in the custom fetch wrapper in `provider.ts`. This catches JSON-escaped lone surrogates (`\uD8xx`) in the serialized request body right before API calls. This is necessary because sessions with **previously stored** corrupted tool results would still fail without it — `toWellFormed()` alone only prevents new corruption.

**Cross-provider impact observed in the wild:**
- Anthropic (Claude): 400 error — strict RFC 8259 validation
- OpenAI (GPT): Also fails — strict JSON parsing
- Google (Gemini): Works — more lenient JSON acceptance

### How did you verify your code works?

Built from this branch and tested against the exact scenario that caused the original failure — Korean web search results via MCP tools producing lone surrogates in tool output.

- **Ingestion fix only**: New tool results are clean, but resuming sessions with previously corrupted data still fails
- **Both fixes together**: Both new and existing sessions work correctly

### Screenshots / recordings

**Before (v1.2.27)** — Korean web search via MCP triggers lone surrogate in tool result. Session permanently stuck with repeated 400 errors on every subsequent turn:

<img width="1493" alt="Before: session stuck with repeated surrogate errors" src="https://github.com/user-attachments/assets/1868ea5a-eaf7-4927-9136-7e1216e85a43" />

**After (patched build)** — Same session, same conversation context. Surrogates sanitized at both ingestion and fetch time, session resumes normally:

<img width="1490" alt="After: session resumes normally with patched build" src="https://github.com/user-attachments/assets/b2777c09-e52d-4815-a9af-6082e68eb7cb" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR