### PR TITLE
feat: auto-convert unsupported image formats (AVIF, HEIC) to PNG

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -139,6 +139,9 @@
     "zod": "catalog:",
     "zod-to-json-schema": "3.24.5"
   },
+  "optionalDependencies": {
+    "sharp": ">=0.33.0"
+  },
   "overrides": {
     "drizzle-orm": "1.0.0-beta.16-ea816b6"
   }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1223,6 +1223,9 @@ const MIME_BADGE: Record<string, string> = {
   "image/jpeg": "img",
   "image/gif": "img",
   "image/webp": "img",
+  "image/avif": "img",
+  "image/heic": "img",
+  "image/heif": "img",
   "application/pdf": "pdf",
   "application/x-directory": "dir",
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -12,6 +12,7 @@ import fuzzysort from "fuzzysort"
 import { Global } from "../global"
 import { git } from "@/util/git"
 import { Protected } from "./protected"
+import { Process } from "../util/process"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -258,6 +259,58 @@ export namespace File {
     ".prettierrc",
     ".eslintrc",
   ])
+
+  // Image formats universally supported by AI provider APIs (Anthropic, OpenAI, Google, etc.)
+  const apiSupportedImageMimes = new Set([
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+  ])
+
+  // Formats that need conversion before sending to provider APIs
+  const convertibleImageExtensions = new Set([
+    "avif",
+    "heic",
+    "heif",
+    "jxl",
+    "tif",
+    "tiff",
+    "bmp",
+  ])
+
+  async function convertImageToPng(buffer: Buffer): Promise<Buffer | null> {
+    // Try sharp first (fast, reliable)
+    try {
+      const sharp = (await import("sharp")).default
+      return await sharp(buffer).png().toBuffer()
+    } catch {}
+
+    // Fallback: write to temp file and use system tools
+    const os = await import("os")
+    const tmp = path.join(os.tmpdir(), `opencode-img-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    const tmpIn = tmp + ".bin"
+    const tmpOut = tmp + ".png"
+    try {
+      await fs.promises.writeFile(tmpIn, buffer)
+
+      if (process.platform === "darwin") {
+        // macOS: use sips (always available)
+        const result = await Process.run(["sips", "-s", "format", "png", tmpIn, "--out", tmpOut], { nothrow: true })
+        if (result.code === 0) return await fs.promises.readFile(tmpOut)
+      }
+
+      // Cross-platform: try ffmpeg
+      const result = await Process.run(["ffmpeg", "-y", "-i", tmpIn, tmpOut], { nothrow: true })
+      if (result.code === 0) return await fs.promises.readFile(tmpOut)
+    } catch {
+    } finally {
+      fs.promises.unlink(tmpIn).catch(() => {})
+      fs.promises.unlink(tmpOut).catch(() => {})
+    }
+
+    return null
+  }
 
   function isImageByExtension(filepath: string): boolean {
     const ext = path.extname(filepath).toLowerCase().slice(1)
@@ -509,9 +562,23 @@ export namespace File {
     // Fast path: check extension before any filesystem operations
     if (isImageByExtension(file)) {
       if (await Filesystem.exists(full)) {
-        const buffer = await Filesystem.readBytes(full).catch(() => Buffer.from([]))
+        let buffer = await Filesystem.readBytes(full).catch(() => Buffer.from([]))
+        let mimeType = getImageMimeType(file)
+        const ext = path.extname(file).toLowerCase().slice(1)
+
+        // Auto-convert unsupported image formats (avif, heic, etc.) to PNG
+        if (convertibleImageExtensions.has(ext) && !apiSupportedImageMimes.has(mimeType)) {
+          const converted = await convertImageToPng(buffer)
+          if (converted) {
+            buffer = converted
+            mimeType = "image/png"
+            log.info("converted image to png", { file, originalFormat: ext })
+          } else {
+            log.warn("failed to convert image, sending as-is", { file, format: ext })
+          }
+        }
+
         const content = buffer.toString("base64")
-        const mimeType = getImageMimeType(file)
         return { type: "text", content, mimeType, encoding: "base64" }
       }
       return { type: "text", content: "" }


### PR DESCRIPTION
### Issue for this PR

Closes #17772
Also addresses #12519 and #10609 (same root cause — unsupported image formats hitting provider APIs)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

AI provider APIs (Anthropic, OpenAI, Google) only accept PNG, JPEG, GIF, and WebP images. When users reference AVIF, HEIC, TGA, or other unsupported files, the API returns a 400 error like `image/avif is not a supported media type`.

This adds transparent conversion in `File.read()` — when an image has an unsupported MIME type (AVIF, HEIC, HEIF, JXL, TIFF, BMP), it converts to PNG before base64-encoding. The conversion uses a 3-tier fallback:

1. `sharp` (added as optional dependency — fast, cross-platform)
2. `sips` (always available on macOS)
3. `ffmpeg` (cross-platform fallback)

If none are available, the original format is sent as-is (same as current behavior — no regression).

Also adds AVIF/HEIC/HEIF entries to the TUI `MIME_BADGE` map so these formats display the "img" badge.

### How did you verify your code works?

- Tested AVIF→PNG conversion with `sips` on macOS using real AVIF web assets
- Verified standard PNG/JPEG images pass through unchanged (no conversion overhead)
- Confirmed graceful fallback when no converter is available

### Screenshots / recordings

_N/A — no UI change beyond badge labels._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR