### PR TITLE
Wrap question option descriptions instead of truncating

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -1050,18 +1050,8 @@
     line-height: var(--line-height-large);
     color: var(--text-base);
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  [data-slot="question-option"][data-custom="true"] {
-    [data-slot="option-description"] {
-      overflow: visible;
-      text-overflow: clip;
-      white-space: normal;
-      overflow-wrap: anywhere;
-    }
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   [data-slot="question-custom"] {


### PR DESCRIPTION
### Issue for this PR

Closes #17781

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Question option descriptions in dialogs were being forced to a single line and truncated with ellipsis. This change updates the shared question option description CSS to use normal wrapping and `overflow-wrap: anywhere` so long text can flow across lines. It also removes the redundant custom-option override so regular and custom options share the same wrapping behavior. This applies to the option rendering used by the session question dock and message question prompt components.

### How did you verify your code works?

Reviewed the staged diff for `packages/ui/src/components/message-part.css` and confirmed the truncation rules were removed from the option description slot.

### Screenshots / recordings

_Not included.

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR
