### PR TITLE
fix: add retry circuit breaker and backoff cap to prevent infinite retry loops

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -367,6 +367,16 @@ export namespace SessionProcessor {
               const retry = SessionRetry.retryable(error)
               if (retry !== undefined) {
                 attempt++
+                if (attempt > SessionRetry.RETRY_MAX_ATTEMPTS) {
+                  log.error("max retries exceeded", { attempt, sessionID: input.sessionID })
+                  input.assistantMessage.error = error
+                  Bus.publish(Session.Event.Error, {
+                    sessionID: input.sessionID,
+                    error,
+                  })
+                  SessionStatus.set(input.sessionID, { type: "idle" })
+                  break
+                }
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 SessionStatus.set(input.sessionID, {
                   type: "retry",

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -6,7 +6,9 @@ export namespace SessionRetry {
   export const RETRY_INITIAL_DELAY = 2000
   export const RETRY_BACKOFF_FACTOR = 2
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
+  export const RETRY_MAX_DELAY_WITH_HEADERS = 60_000 // 60 seconds — cap for when response headers are present but missing retry-after
   export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+  export const RETRY_MAX_ATTEMPTS = 10 // maximum retry attempts before giving up
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -51,7 +53,7 @@ export namespace SessionRetry {
           }
         }
 
-        return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+        return Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_WITH_HEADERS)
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #17648

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes an infinite retry loop in the session processor.

Today `processor.ts` retries inside a `while (true)` loop with no exit condition. At the same time, `retry.ts` caps backoff only when response headers are missing. If headers are present but `retry-after` is missing, the fallback path returns raw exponential backoff with no cap.

In practice this means transient upstream API failures can leave a session stuck retrying for hours. In my logs this showed up as repeated `AI_APICallError: Could not relay message upstream` failures with delays growing to 202 seconds between attempts, and the process never recovered without manual intervention.

This PR makes three small changes:

1. adds `RETRY_MAX_ATTEMPTS = 10`
2. adds `RETRY_MAX_DELAY_WITH_HEADERS = 60_000`
3. breaks out of the retry loop in `processor.ts` after max attempts, publishes the error event, and returns the session to idle

This is a minimal fix. It does not change behavior for successful retries or for responses that already provide a valid `retry-after` header.

This is also the same underlying problem described in #12234 and #17169.

### How did you verify your code works?

- Rebasing onto the latest `dev` pulled in the recent Windows CI fix (#17751)
- `bun turbo typecheck` passes locally across all packages
- I reproduced the failure mode from production logs and checked that the new cap would reduce the 202s retry delay to 60s
- I verified the retry loop now stops after the configured max attempts instead of continuing indefinitely
- The PR CI now passes typecheck, unit (linux), and unit (windows), with e2e jobs running after that

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR