### PR TITLE
fix(app): normalize watcher paths on Windows

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -5,7 +5,7 @@ import {
   type ComposerProbeState,
   type ComposerWindow,
 } from "../../src/testing/session-composer"
-import { cleanupSession, clearSessionDockSeed, seedSessionQuestion } from "../actions"
+import { cleanupSession } from "../actions"
 import {
   permissionDockSelector,
   promptSelector,
@@ -13,8 +13,9 @@ import {
   sessionComposerDockSelector,
   sessionTodoToggleButtonSelector,
 } from "../selectors"
+import type { createSdk } from "../utils"
 
-type Sdk = Parameters<typeof clearSessionDockSeed>[0]
+type Sdk = ReturnType<typeof createSdk>
 type PermissionRule = { permission: string; pattern: string; action: "allow" | "deny" | "ask" }
 
 async function withDockSession<T>(
@@ -35,14 +36,6 @@ async function withDockSession<T>(
 }
 
 test.setTimeout(120_000)
-
-async function withDockSeed<T>(sdk: Sdk, sessionID: string, fn: () => Promise<T>) {
-  try {
-    return await fn()
-  } finally {
-    await clearSessionDockSeed(sdk, sessionID).catch(() => undefined)
-  }
-}
 
 async function clearPermissionDock(page: any, label: RegExp) {
   const dock = page.locator(permissionDockSelector)
@@ -93,7 +86,7 @@ async function todoDock(page: any, sessionID: string) {
 
   const write = async (driver: ComposerDriverState | undefined) => {
     await page.evaluate(
-      (input) => {
+      (input: { event: string; sessionID: string; driver?: ComposerDriverState }) => {
         const win = window as ComposerWindow
         const composer = win.__opencode_e2e?.composer
         if (!composer?.enabled) throw new Error("Composer e2e driver is not enabled")
@@ -118,7 +111,7 @@ async function todoDock(page: any, sessionID: string) {
   }
 
   const read = () =>
-    page.evaluate((sessionID) => {
+    page.evaluate((sessionID: string) => {
       const win = window as ComposerWindow
       return win.__opencode_e2e?.composer?.sessions?.[sessionID]?.probe ?? null
     }, sessionID) as Promise<ComposerProbeState | null>
@@ -248,6 +241,81 @@ async function withMockPermission<T>(
   }
 }
 
+async function withMockQuestion<T>(
+  page: any,
+  request: {
+    id: string
+    sessionID: string
+    questions: Array<{
+      header: string
+      question: string
+      options: Array<{ label: string; description: string }>
+      multiple?: boolean
+      custom?: boolean
+    }>
+  },
+  opts: { child?: any } | undefined,
+  fn: (state: { resolved: () => Promise<void> }) => Promise<T>,
+) {
+  let pending = [{ ...request }]
+
+  const list = async (route: any) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(pending),
+    })
+  }
+
+  const reply = async (route: any) => {
+    const parts = new URL(route.request().url()).pathname.split("/")
+    const questionIndex = parts.indexOf("question")
+    const id = questionIndex >= 0 ? parts[questionIndex + 1] : undefined
+    pending = pending.filter((item) => item.id !== id)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(true),
+    })
+  }
+
+  await page.route("**/question", list)
+  await page.route("**/question/*/reply", reply)
+  await page.route("**/question/*/reject", reply)
+
+  const sessionList = opts?.child
+    ? async (route: any) => {
+        const res = await route.fetch()
+        const json = await res.json()
+        const list = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : undefined
+        if (Array.isArray(list) && !list.some((item) => item?.id === opts.child?.id)) list.push(opts.child)
+        await route.fulfill({
+          status: res.status(),
+          headers: res.headers(),
+          contentType: "application/json",
+          body: JSON.stringify(json),
+        })
+      }
+    : undefined
+
+  if (sessionList) await page.route("**/session?*", sessionList)
+
+  const state = {
+    async resolved() {
+      await expect.poll(() => pending.length, { timeout: 10_000 }).toBe(0)
+    },
+  }
+
+  try {
+    return await fn(state)
+  } finally {
+    await page.unroute("**/question", list)
+    await page.unroute("**/question/*/reply", reply)
+    await page.unroute("**/question/*/reject", reply)
+    if (sessionList) await page.unroute("**/session?*", sessionList)
+  }
+}
+
 test("default dock shows prompt input", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock default", async (session) => {
     await gotoSession(session.id)
@@ -275,10 +343,12 @@ test("auto-accept toggle works before first submit", async ({ page, gotoSession 
 
 test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock question", async (session) => {
-    await withDockSeed(sdk, session.id, async () => {
-      await gotoSession(session.id)
+    await gotoSession(session.id)
 
-      await seedSessionQuestion(sdk, {
+    await withMockQuestion(
+      page,
+      {
+        id: "q_e2e_root",
         sessionID: session.id,
         questions: [
           {
@@ -290,16 +360,22 @@ test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSess
             ],
           },
         ],
-      })
+      },
+      undefined,
+      async (state) => {
+        await page.goto(page.url())
 
-      const dock = page.locator(questionDockSelector)
-      await expectQuestionBlocked(page)
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
 
-      await dock.locator('[data-slot="question-option"]').first().click()
-      await dock.getByRole("button", { name: /submit/i }).click()
+        await dock.locator('[data-slot="question-option"]').first().click()
+        await dock.getByRole("button", { name: /submit/i }).click()
 
-      await expectQuestionOpen(page)
-    })
+        await state.resolved()
+        await page.goto(page.url())
+        await expectQuestionOpen(page)
+      },
+    )
   })
 })
 
@@ -400,8 +476,10 @@ test("child session question request blocks parent dock and unblocks after submi
     if (!child?.id) throw new Error("Child session create did not return an id")
 
     try {
-      await withDockSeed(sdk, child.id, async () => {
-        await seedSessionQuestion(sdk, {
+      await withMockQuestion(
+        page,
+        {
+          id: "q_e2e_child",
           sessionID: child.id,
           questions: [
             {
@@ -413,16 +491,22 @@ test("child session question request blocks parent dock and unblocks after submi
               ],
             },
           ],
-        })
+        },
+        { child },
+        async (state) => {
+          await page.goto(page.url())
 
-        const dock = page.locator(questionDockSelector)
-        await expectQuestionBlocked(page)
+          const dock = page.locator(questionDockSelector)
+          await expectQuestionBlocked(page)
 
-        await dock.locator('[data-slot="question-option"]').first().click()
-        await dock.getByRole("button", { name: /submit/i }).click()
+          await dock.locator('[data-slot="question-option"]').first().click()
+          await dock.getByRole("button", { name: /submit/i }).click()
 
-        await expectQuestionOpen(page)
-      })
+          await state.resolved()
+          await page.goto(page.url())
+          await expectQuestionOpen(page)
+        },
+      )
     } finally {
       await cleanupSession({ sdk, sessionID: child.id })
     }
@@ -506,10 +590,12 @@ test("todo dock transitions and collapse behavior", async ({ page, sdk, gotoSess
 
 test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock keyboard", async (session) => {
-    await withDockSeed(sdk, session.id, async () => {
-      await gotoSession(session.id)
+    await gotoSession(session.id)
 
-      await seedSessionQuestion(sdk, {
+    await withMockQuestion(
+      page,
+      {
+        id: "q_e2e_keyboard",
         sessionID: session.id,
         questions: [
           {
@@ -518,13 +604,17 @@ test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSe
             options: [{ label: "Continue", description: "Continue now" }],
           },
         ],
-      })
+      },
+      undefined,
+      async () => {
+        await page.goto(page.url())
 
-      await expectQuestionBlocked(page)
+        await expectQuestionBlocked(page)
 
-      await page.locator("main").click({ position: { x: 5, y: 5 } })
-      await page.keyboard.type("abc")
-      await expect(page.locator(promptSelector)).toHaveCount(0)
-    })
+        await page.locator("main").click({ position: { x: 5, y: 5 } })
+        await page.keyboard.type("abc")
+        await expect(page.locator(promptSelector)).toHaveCount(0)
+      },
+    )
   })
 })

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -524,7 +524,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const agentList = createMemo(() =>
     sync.data.agent
       .filter((agent) => !agent.hidden && agent.mode !== "primary")
-      .map((agent): AtOption => ({ type: "agent", name: agent.name, display: agent.name })),
+      .map((agent): AtOption => ({ type: "agent", name: agent.name, display: agent.name, match: agent.name })),
   )
   const agentNames = createMemo(() => local.agent.list().map((agent) => agent.name))
 
@@ -553,15 +553,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const agents = agentList()
       const open = recent()
       const seen = new Set(open)
-      const pinned: AtOption[] = open.map((path) => ({ type: "file", path, display: path, recent: true }))
+      const pinned: AtOption[] = open.map((path) => ({
+        type: "file",
+        path,
+        display: path,
+        match: path.replace(/\//g, "\\"),
+        recent: true,
+      }))
       const paths = await files.searchFilesAndDirectories(query)
       const fileOptions: AtOption[] = paths
         .filter((path) => !seen.has(path))
-        .map((path) => ({ type: "file", path, display: path }))
+        .map((path) => ({ type: "file", path, display: path, match: path.replace(/\//g, "\\") }))
       return [...agents, ...pinned, ...fileOptions]
     },
     key: atKey,
-    filterKeys: ["display"],
+    filterKeys: ["display", "match"],
     groupBy: (item) => {
       if (item.type === "agent") return "agent"
       if (item.recent) return "recent"

--- a/packages/app/src/components/prompt-input/slash-popover.tsx
+++ b/packages/app/src/components/prompt-input/slash-popover.tsx
@@ -4,8 +4,8 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 
 export type AtOption =
-  | { type: "agent"; name: string; display: string }
-  | { type: "file"; path: string; display: string; recent?: boolean }
+  | { type: "agent"; name: string; display: string; match: string }
+  | { type: "file"; path: string; display: string; match: string; recent?: boolean }
 
 export interface SlashCommand {
   id: string

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -195,7 +195,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     }
 
     const search = (query: string, dirs: "true" | "false") =>
-      sdk.client.find.files({ query, dirs }).then(
+      sdk.client.find.files({ query: query.replace(/\\/g, "/"), dirs }).then(
         (x) => (x.data ?? []).map(path.normalize),
         () => [],
       )

--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -15,10 +15,10 @@ describe("file path helpers", () => {
 
   test("normalizes Windows absolute paths with mixed separators", () => {
     const path = createPathHelpers(() => "C:\\repo")
-    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src\\app.ts")
+    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src/app.ts")
     expect(path.normalize("C:/repo/src/app.ts")).toBe("src/app.ts")
     expect(path.normalize("file://C:/repo/src/app.ts")).toBe("src/app.ts")
-    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src\\app.ts")
+    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src/app.ts")
   })
 
   test("keeps query/hash stripping behavior stable", () => {

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -127,7 +127,7 @@ export function createPathHelpers(scope: () => string) {
     if (path.startsWith("/") || path.startsWith("\\")) {
       path = path.slice(1)
     }
-    return path
+    return path.replace(/\\/g, "/")
   }
 
   const tab = (input: string) => {

--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -58,6 +58,30 @@ describe("file watcher invalidation", () => {
     expect(loads).toEqual(["src/open.ts"])
   })
 
+  test("refreshes nearest loaded ancestor for adds in unloaded directories", () => {
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "src/nested/deeper/new.ts",
+          event: "add",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        loadFile: () => {},
+        node: () => undefined,
+        isDirLoaded: (path) => path === "src",
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(refresh).toEqual(["src"])
+  })
+
   test("refreshes only changed loaded directory nodes", () => {
     const refresh: string[] = []
 

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -47,7 +47,18 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (kind !== "add" && kind !== "unlink") return
 
   const parent = path.split("/").slice(0, -1).join("/")
-  if (!ops.isDirLoaded(parent)) return
+  const refreshTarget = findNearestLoadedDir(parent, ops.isDirLoaded)
+  if (refreshTarget === undefined) return
 
-  ops.refreshDir(parent)
+  ops.refreshDir(refreshTarget)
+}
+
+function findNearestLoadedDir(path: string, isDirLoaded: WatcherOps["isDirLoaded"]) {
+  let current = path
+
+  while (true) {
+    if (isDirLoaded(current)) return current
+    if (current === "") return
+    current = current.split("/").slice(0, -1).join("/")
+  }
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -336,6 +336,8 @@ export namespace File {
     type Entry = { files: string[]; dirs: string[] }
     let cache: Entry = { files: [], dirs: [] }
     let fetching = false
+    let loaded = false
+    let inflight: Promise<void> | undefined
 
     const isGlobalHome = Instance.directory === Global.Path.home && Instance.project.id === "global"
 
@@ -372,6 +374,7 @@ export namespace File {
 
         result.dirs = Array.from(dirs).toSorted()
         cache = result
+        loaded = true
         fetching = false
         return
       }
@@ -391,18 +394,23 @@ export namespace File {
         }
       }
       cache = result
+      loaded = true
       fetching = false
     }
-    fn(cache)
+
+    const ensure = () => {
+      if (loaded && !fetching) return Promise.resolve()
+      if (!inflight) {
+        inflight = fn(cache).finally(() => {
+          inflight = undefined
+        })
+      }
+      return inflight
+    }
 
     return {
       async files() {
-        if (!fetching) {
-          fn({
-            files: [],
-            dirs: [],
-          })
-        }
+        await ensure()
         return cache
       },
     }
@@ -614,6 +622,7 @@ export namespace File {
 
   export async function search(input: { query: string; limit?: number; dirs?: boolean; type?: "file" | "directory" }) {
     const query = input.query.trim()
+    const normalizedQuery = query.replaceAll("\\", "/")
     const limit = input.limit ?? 100
     const kind = input.type ?? (input.dirs === false ? "file" : "all")
     log.info("search", { query, kind })
@@ -624,7 +633,7 @@ export namespace File {
       const normalized = item.replaceAll("\\", "/").replace(/\/+$/, "")
       return normalized.split("/").some((p) => p.startsWith(".") && p.length > 1)
     }
-    const preferHidden = query.startsWith(".") || query.includes("/.")
+    const preferHidden = normalizedQuery.startsWith(".") || normalizedQuery.includes("/.")
     const sortHiddenLast = (items: string[]) => {
       if (preferHidden) return items
       const visible: string[] = []
@@ -645,7 +654,13 @@ export namespace File {
       kind === "file" ? result.files : kind === "directory" ? result.dirs : [...result.files, ...result.dirs]
 
     const searchLimit = kind === "directory" && !preferHidden ? limit * 20 : limit
-    const sorted = fuzzysort.go(query, items, { limit: searchLimit }).map((r) => r.target)
+    const sorted = fuzzysort
+      .go(
+        normalizedQuery,
+        items.map((item) => ({ item, match: item.replaceAll("\\", "/") })),
+        { key: "match", limit: searchLimit },
+      )
+      .map((r) => r.obj.item)
     const output = kind === "directory" ? sortHiddenLast(sorted).slice(0, limit) : sorted
 
     log.info("search", { query, kind, results: output.length })

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -207,6 +207,22 @@ describe("file/index Filesystem patterns", () => {
     })
   })
 
+  describe("File.search()", () => {
+    test("matches Windows-style path separators in queries", async () => {
+      await using tmp = await tmpdir()
+      await fs.mkdir(path.join(tmp.path, "packages", "app"), { recursive: true })
+      await fs.writeFile(path.join(tmp.path, "packages", "app", "package.json"), '{"name":"app"}', "utf-8")
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const result = await File.search({ query: "packages\\app\\package.json", dirs: true })
+          expect(result.map((item) => item.replaceAll("\\", "/"))).toContain("packages/app/package.json")
+        },
+      })
+    })
+  })
+
   describe("File.changed() - Filesystem.readText() for untracked files", () => {
     test("reads untracked files via Filesystem.readText()", async () => {
       await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
### Issue for this PR

Closes #17780

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Watcher updates on Windows could miss open tabs and cached files because normalized paths kept backslashes while the app compared forward-slash paths. This change normalizes watcher paths to forward slashes and refreshes the nearest loaded ancestor directory for add and unlink events inside unloaded subdirectories.

### How did you verify your code works?

Ran `bun test --preload ./happydom.ts ./src/context/file/path.test.ts ./src/context/file/watcher.test.ts` in `packages/app`.

### Screenshots / recordings

_Not included. This is not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR