### PR TITLE
fix: correct typo in calculateOccurredCost function name (#17741)

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -228,7 +228,7 @@ export async function handler(
       const body = JSON.stringify(
         responseConverter({
           ...json,
-          cost: calculateOccuredCost(billingSource, costInfo),
+          cost: calculateOccurredCost(billingSource, costInfo),
         }),
       )
       logger.metric({ response_length: body.length })
@@ -272,7 +272,7 @@ export async function handler(
                   await trialLimiter?.track(usageInfo)
                   await trackUsage(sessionId, billingSource, authInfo, modelInfo, providerInfo, usageInfo, costInfo)
                   await reload(billingSource, authInfo, costInfo)
-                  const cost = calculateOccuredCost(billingSource, costInfo)
+                  const cost = calculateOccurredCost(billingSource, costInfo)
                   c.enqueue(encoder.encode(usageParser.buidlCostChunk(cost)))
                 }
                 c.close()
@@ -811,7 +811,7 @@ export async function handler(
     }
   }
 
-  function calculateOccuredCost(billingSource: BillingSource, costInfo: CostInfo) {
+  function calculateOccurredCost(billingSource: BillingSource, costInfo: CostInfo) {
     return billingSource === "balance" ? (costInfo.totalCostInCent / 100).toFixed(8) : "0"
   }
 


### PR DESCRIPTION
## Summary

Fixes #17741 - Fix spelling error in function name

## Changes

- Fix spelling: calculateOccuredCost -> calculateOccurredCost
- Update function definition and all 2 call sites
- Double r is the correct spelling of occurred

## Files Modified

- packages/console/app/src/routes/zen/util/handler.ts (3 lines changed)

## Testing

- Verified all references updated with grep
- No functional changes, typo fix only

Fixes #17741