### PR TITLE
fix(app): reinitialize SDK providers when switching servers

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -212,7 +212,9 @@ function ConnectionGate(props: ParentProps<{ disableHealthCheck?: boolean }>) {
           />
         }
       >
-        {props.children}
+        <Show when={server.key} keyed>
+          {props.children}
+        </Show>
       </Show>
     </Show>
   )


### PR DESCRIPTION
### Issue for this PR

Closes #17418

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `v1.2.25`, commit `b76ead3f` replaced the `ServerKey` component with `ConnectionGate`. The old `ServerKey` used `<Show when={server.key} keyed>`, which in SolidJS means children are destroyed and recreated whenever the value changes. This ensured that when switching servers, `GlobalSDKProvider` (and the rest of the provider tree) reinitialized with the new server's URL.

`ConnectionGate`'s `<Show>` conditions only depend on the startup health check result, not `server.key`. When the user switches servers, children are never recreated, so the SDK keeps its original `baseUrl` (the local sidecar). Any API calls (`file.list`, `path.get`, etc.) still go to the old server.

This is observable on the desktop app when connecting to a remote server on a different OS, where the directory picker shows local paths instead of remote paths.

The fix restores `<Show when={server.key} keyed>` around `ConnectionGate`'s children.

### How did you verify your code works?

Tested on the Tauri desktop app on Windows, connected to a Linux server via `opencode server --hostname 0.0.0.0`.

Before the fix, the "Open project" dialog showed Windows-style paths (`C:`, `C:\Windows`). After the fix, it correctly shows Linux paths (`/`, `/home`, etc.) from the remote server.

### Screenshots / recordings

_n/a_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

