### PR TITLE
fix: add JSON validation for tool call arguments (#17750)

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -244,11 +244,18 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
     // tool calls:
     if (choice.message.tool_calls != null) {
       for (const toolCall of choice.message.tool_calls) {
+        // Strip XML artifacts from providers like SiliconFlow
+        let args = toolCall.function.arguments!
+        args = args.replace(/<\/?tool_call>/g, '').trim()
+        if (!isParsableJson(args)) {
+          console.warn(`Invalid tool call arguments: ${args}`)
+          continue
+        }
         content.push({
           type: "tool-call",
           toolCallId: toolCall.id ?? generateId(),
           toolName: toolCall.function.name,
-          input: toolCall.function.arguments!,
+          input: args,
           providerMetadata: choice.message.reasoning_opaque
             ? { copilot: { reasoningOpaque: choice.message.reasoning_opaque } }
             : undefined,
@@ -644,11 +651,19 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
                 id: toolCall.id,
               })
 
+              // Strip XML artifacts from providers like SiliconFlow
+              let args = toolCall.function.arguments
+              args = args.replace(/<\/?tool_call>/g, '').trim()
+              if (!isParsableJson(args)) {
+                console.warn(`Invalid tool call arguments: ${args}`)
+                continue
+              }
+
               controller.enqueue({
                 type: "tool-call",
                 toolCallId: toolCall.id ?? generateId(),
                 toolName: toolCall.function.name,
-                input: toolCall.function.arguments,
+                input: args,
               })
             }
 


### PR DESCRIPTION
## Summary

Fixes #17750 - Tool call arguments may contain invalid JSON from providers like SiliconFlow

## Problem

When using SiliconFlow Qwen3-8B model, tool call arguments contain XML tags that break JSON parsing.

## Changes

- Strip XML artifacts (tool_call tags) from provider responses
- Validate JSON with isParsableJson before emitting tool-call events
- Apply to both streaming and non-streaming modes
- Skip invalid tool calls with warning log

## Testing

- Code verification test passed in Docker sandbox
- Verified regex pattern for XML tag removal
- Verified JSON validation logic applied to both modes
- Verified proper indentation and TypeScript syntax

## Files Modified

- packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts (+17, -2)

Fixes #17750