### PR TITLE
add prompt schema validation debug logs

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1318,6 +1318,31 @@ export namespace SessionPrompt {
       },
     )
 
+    const parsedInfo = MessageV2.Info.safeParse(info)
+    if (!parsedInfo.success) {
+      log.error("invalid user message before save", {
+        sessionID: input.sessionID,
+        messageID: info.id,
+        agent: info.agent,
+        model: info.model,
+        issues: parsedInfo.error.issues,
+      })
+    }
+
+    parts.forEach((part, index) => {
+      const parsedPart = MessageV2.Part.safeParse(part)
+      if (parsedPart.success) return
+      log.error("invalid user part before save", {
+        sessionID: input.sessionID,
+        messageID: info.id,
+        partID: part.id,
+        partType: part.type,
+        index,
+        issues: parsedPart.error.issues,
+        part,
+      })
+    })
+
     await Session.updateMessage(info)
     for (const part of parts) {
       await Session.updatePart(part)

--- a/packages/opencode/src/util/fn.ts
+++ b/packages/opencode/src/util/fn.ts
@@ -7,6 +7,9 @@ export function fn<T extends z.ZodType, Result>(schema: T, cb: (input: z.infer<T
       parsed = schema.parse(input)
     } catch (e) {
       console.trace("schema validation failure stack trace:")
+      if (e instanceof z.ZodError) {
+        console.error("schema validation issues:", JSON.stringify(e.issues, null, 2))
+      }
       throw e
     }
 


### PR DESCRIPTION
## Summary
- log Zod issue details when the generic schema wrapper fails so the TUI trace includes actionable validation output
- validate the constructed user message and each prompt part before save so we can see whether the failure is in `MessageV2.Info` or a specific `MessageV2.Part`
- keep the change isolated to debugging so we can reproduce the prompt-box failure on a branch based on the latest `dev`