### PR TITLE
fix: include worktree sessions when listing sessions for main project

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,7 +1,7 @@
 import z from "zod"
 import { Filesystem } from "../util/filesystem"
 import path from "path"
-import { and, Database, eq } from "../storage/db"
+import { and, Database, eq, inArray } from "../storage/db"
 import { ProjectTable } from "./project.sql"
 import { SessionTable } from "../session/session.sql"
 import { Log } from "../util/log"
@@ -276,11 +276,12 @@ export namespace Project {
     // Runs on every startup because sessions created before git init
     // accumulate under "global" and need migrating whenever they appear.
     if (data.id !== ProjectID.global) {
+      const migrationDirs = [data.worktree, ...result.sandboxes.filter((s) => s !== data.worktree)]
       Database.use((db) =>
         db
           .update(SessionTable)
           .set({ project_id: data.id })
-          .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
+          .where(and(eq(SessionTable.project_id, ProjectID.global), inArray(SessionTable.directory, migrationDirs)))
           .run(),
       )
     }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -552,7 +552,14 @@ export namespace Session {
       conditions.push(eq(SessionTable.workspace_id, WorkspaceContext.workspaceID))
     }
     if (input?.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+      if (input.directory === project.worktree && project.sandboxes.length > 0) {
+        // When listing sessions for the main worktree, also include sessions
+        // from sandbox directories (worktrees) so they are visible even when
+        // the workspace feature is disabled.
+        conditions.push(or(eq(SessionTable.directory, input.directory), inArray(SessionTable.directory, project.sandboxes))!)
+      } else {
+        conditions.push(eq(SessionTable.directory, input.directory))
+      }
     }
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))


### PR DESCRIPTION
## Summary

Sessions created in git worktree (sandbox) directories are invisible when listing sessions for the main project because `Session.list()` filters by exact directory match.

## Problem

When a session is created in a git worktree:
1. The session stores `directory = /path/to/worktree` (the worktree path)
2. The project correctly tracks the worktree in its `sandboxes` array
3. When listing sessions with `directory = /path/to/main/repo`, the exact match filter excludes worktree sessions
4. Sessions appear in `experimental/session` (global, no directory filter) but not in the project-scoped `GET /session` endpoint

This primarily affects users with the workspace feature disabled, where only `loadSessions(project.worktree)` is called—sandbox sessions are completely invisible.

## Fix

**`Session.list()`** (`packages/opencode/src/session/index.ts`):
- When the `directory` filter matches the project's main worktree AND the project has sandboxes, expand the filter to also include sessions from sandbox directories using an `OR` condition
- When filtering by a specific sandbox directory, keep the exact match (no change)

**`Project.fromDirectory()`** (`packages/opencode/src/project/project.ts`):
- The session migration from `global` project ID now covers all known project directories (main worktree + sandboxes), not just the main worktree
- This ensures sessions created in worktrees before git init are also properly migrated