### PR TITLE
fix(opencode): apply message transforms during compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -200,6 +200,8 @@ When constructing the summary, try to stick to this template:
 ---`
 
     const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
+    const msgs = structuredClone(messages)
+    await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
     const result = await processor.process({
       user: userMessage,
       agent,
@@ -208,7 +210,7 @@ When constructing the summary, try to stick to this template:
       tools: {},
       system: [],
       messages: [
-        ...MessageV2.toModelMessages(messages, model, { stripMedia: true }),
+        ...MessageV2.toModelMessages(msgs, model, { stripMedia: true }),
         {
           role: "user",
           content: [


### PR DESCRIPTION
### Issue for this PR

Closes #17820

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Applies the `experimental.chat.messages.transform` hook during compaction before messages are converted for the model.

### How did you verify your code works?

Reproduced the issue with a plugin using `experimental.chat.messages.transform`:

1. Send a normal prompt and confirm the hook modifies it
2. Trigger `/compact`
3. Confirm the same message changes are now applied during compaction too

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR