### PR TITLE
fix(opencode): cap exponential retry backoff to 30s max

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -50,8 +50,6 @@ export namespace SessionRetry {
             return Math.ceil(parsed)
           }
         }
-
-        return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #8769

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The retry logic had two fallback paths for exponential backoff:
1. Unbounded: `RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)` — no cap
2. Capped: `Math.min(..., RETRY_MAX_DELAY_NO_HEADERS)` — 30s max

When response headers were present but didn't contain `retry-after-ms` or `retry-after`, the code fell through to the unbounded path. After 13 retries this results in 4+ hour delays.

This removes the unbounded fallback so all cases use the capped version (30s max).

### How did you verify your code works?

Ran the retry tests: all 18 pass.

### Screenshots / recordings

N/A - no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR