### PR TITLE
feat: add /skills command and inline skill autocomplete

### DIFF
--- a/packages/app/src/components/dialog-select-skill.tsx
+++ b/packages/app/src/components/dialog-select-skill.tsx
@@ -1,0 +1,53 @@
+import { Component, createMemo, createResource, Show } from "solid-js"
+import { useSDK } from "@/context/sdk"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { List } from "@opencode-ai/ui/list"
+import { Tag } from "@opencode-ai/ui/tag"
+import { useLanguage } from "@/context/language"
+
+export const DialogSelectSkill: Component<{ onSelect: (skill: string) => void }> = (props) => {
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const language = useLanguage()
+
+  const [skills] = createResource(async () => {
+    const result = await sdk.client.app.skills()
+    return result.data ?? []
+  })
+
+  const items = createMemo(() =>
+    (skills() ?? [])
+      .map((s) => ({ name: s.name, description: s.description }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  )
+
+  return (
+    <Dialog title={language.t("dialog.skill.title")}>
+      <List
+        search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
+        emptyMessage={language.t("dialog.skill.empty")}
+        key={(x) => x?.name ?? ""}
+        items={items}
+        filterKeys={["name", "description"]}
+        sortBy={(a, b) => a.name.localeCompare(b.name)}
+        onSelect={(x) => {
+          if (!x) return
+          props.onSelect(x.name)
+          dialog.close()
+        }}
+      >
+        {(i) => (
+          <div class="w-full flex items-center gap-x-3">
+            <div class="flex flex-col gap-0.5 min-w-0">
+              <span class="truncate">{i.name}</span>
+              <Show when={i.description}>
+                <span class="text-11-regular text-text-weaker truncate">{i.description}</span>
+              </Show>
+            </div>
+          </div>
+        )}
+      </List>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -249,6 +249,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const [store, setStore] = createStore<{
     popover: "at" | "slash" | null
+    inline: boolean
+    slashStart: number
     historyIndex: number
     savedPrompt: PromptHistoryEntry | null
     placeholder: number
@@ -257,6 +259,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     applyingHistory: boolean
   }>({
     popover: null,
+    inline: false,
+    slashStart: 0,
     historyIndex: -1,
     savedPrompt: null as PromptHistoryEntry | null,
     placeholder: Math.floor(Math.random() * EXAMPLES.length),
@@ -606,9 +610,31 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const handleSlashSelect = (cmd: SlashCommand | undefined) => {
     if (!cmd) return
+    const inline = store.inline
+    const start = store.slashStart
     closePopover()
 
     if (cmd.type === "custom") {
+      if (inline) {
+        // Replace just the /partial text with /{trigger}
+        const selection = window.getSelection()
+        if (selection && selection.rangeCount > 0) {
+          const range = selection.getRangeAt(0)
+          if (editorRef.contains(range.startContainer)) {
+            const cursorPosition = getCursorPosition(editorRef)
+            setRangeEdge(editorRef, range, "start", start)
+            setRangeEdge(editorRef, range, "end", cursorPosition)
+            range.deleteContents()
+            const text = `/${cmd.trigger} `
+            range.insertNode(document.createTextNode(text))
+            range.collapse(false)
+            selection.removeAllRanges()
+            selection.addRange(range)
+          }
+        }
+        handleInput()
+        return
+      }
       const text = `/${cmd.trigger} `
       setEditorText(text)
       prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
@@ -616,6 +642,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return
     }
 
+    if (inline) return
     clearEditor()
     prompt.set([{ type: "text", content: "", start: 0, end: 0 }], 0)
     command.trigger(cmd.id, "slash")
@@ -851,11 +878,23 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       if (atMatch) {
         atOnInput(atMatch[1])
         setStore("popover", "at")
+        setStore("inline", false)
       } else if (slashMatch) {
         slashOnInput(slashMatch[1])
         setStore("popover", "slash")
+        setStore("inline", false)
       } else {
-        closePopover()
+        // Check for inline / after whitespace — triggers skill-only autocomplete
+        const textBefore = rawText.substring(0, cursorPosition)
+        const inlineMatch = textBefore.match(/(?:^|\s)\/(\S*)$/)
+        if (inlineMatch) {
+          slashOnInput(inlineMatch[1])
+          setStore("popover", "slash")
+          setStore("inline", true)
+          setStore("slashStart", cursorPosition - inlineMatch[1].length - 1)
+        } else {
+          closePopover()
+        }
       }
     } else {
       closePopover()
@@ -1224,7 +1263,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         atKey={atKey}
         setAtActive={setAtActive}
         onAtSelect={handleAtSelect}
-        slashFlat={slashFlat()}
+        slashFlat={
+          store.inline
+            ? slashFlat().filter((cmd) => {
+                if (cmd.source !== "skill") return false
+                const text = prompt
+                  .current()
+                  .map((p) => ("content" in p ? p.content : ""))
+                  .join("")
+                return !text.includes(`/${cmd.trigger} `)
+              })
+            : slashFlat()
+        }
         slashActive={slashActive() ?? undefined}
         setSlashActive={setSlashActive}
         onSlashSelect={handleSlashSelect}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -590,14 +590,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         type: "builtin" as const,
       }))
 
-    const custom = sync.data.command.map((cmd) => ({
-      id: `custom.${cmd.name}`,
-      trigger: cmd.name,
-      title: cmd.name,
-      description: cmd.description,
-      type: "custom" as const,
-      source: cmd.source,
-    }))
+    const custom = sync.data.command
+      .filter((cmd) => cmd.source !== "skill" || sync.data.config.skills?.slash)
+      .map((cmd) => ({
+        id: `custom.${cmd.name}`,
+        trigger: cmd.name,
+        title: cmd.name,
+        description: cmd.description,
+        type: "custom" as const,
+        source: cmd.source,
+      }))
 
     return [...custom, ...builtin]
   })

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const dict = {
   "command.category.agent": "Agent",
   "command.category.permissions": "Permissions",
   "command.category.workspace": "Workspace",
+  "command.category.skill": "Skill",
   "command.category.settings": "Settings",
 
   "theme.scheme.system": "System",
@@ -63,6 +64,8 @@ export const dict = {
   "command.model.choose.description": "Select a different model",
   "command.mcp.toggle": "Toggle MCPs",
   "command.mcp.toggle.description": "Toggle MCPs",
+  "command.skill.choose": "Browse skills",
+  "command.skill.choose.description": "Select a skill to invoke",
   "command.agent.cycle": "Cycle agent",
   "command.agent.cycle.description": "Switch to the next agent",
   "command.agent.cycle.reverse": "Cycle agent backwards",
@@ -292,6 +295,9 @@ export const dict = {
   "dialog.mcp.title": "MCPs",
   "dialog.mcp.description": "{{enabled}} of {{total}} enabled",
   "dialog.mcp.empty": "No MCPs configured",
+
+  "dialog.skill.title": "Skills",
+  "dialog.skill.empty": "No skills available",
 
   "dialog.lsp.empty": "LSPs auto-detected from file types",
   "dialog.plugins.empty": "Plugins configured in opencode.json",

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -15,6 +15,7 @@ import { DialogSelectFile } from "@/components/dialog-select-file"
 import { DialogSelectModel } from "@/components/dialog-select-model"
 import { DialogSelectMcp } from "@/components/dialog-select-mcp"
 import { DialogFork } from "@/components/dialog-fork"
+import { DialogSelectSkill } from "@/components/dialog-select-skill"
 import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/util/array"
 import { createSessionTabs } from "@/pages/session/helpers"
@@ -124,6 +125,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const terminalCommand = withCategory(language.t("command.category.terminal"))
   const modelCommand = withCategory(language.t("command.category.model"))
   const mcpCommand = withCategory(language.t("command.category.mcp"))
+  const skillCommand = withCategory(language.t("command.category.skill"))
   const agentCommand = withCategory(language.t("command.category.agent"))
   const permissionsCommand = withCategory(language.t("command.category.permissions"))
 
@@ -360,6 +362,20 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         keybind: "mod+;",
         slash: "mcp",
         onSelect: () => dialog.show(() => <DialogSelectMcp />),
+      }),
+      skillCommand({
+        id: "skill.choose",
+        title: language.t("command.skill.choose"),
+        description: language.t("command.skill.choose.description"),
+        slash: "skills",
+        onSelect: () =>
+          dialog.show(() => (
+            <DialogSelectSkill
+              onSelect={(skill) => {
+                prompt.set([{ type: "text" as const, content: `/${skill} `, start: 0, end: skill.length + 2 }])
+              }}
+            />
+          )),
       }),
       agentCommand({
         id: "agent.cycle",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -354,6 +354,39 @@ export function Autocomplete(props: {
   })
 
   const commands = createMemo((): AutocompleteOption[] => {
+    const inline = store.visible === "/" && store.index > 0
+
+    // When inline, only show skill-sourced commands
+    if (inline) {
+      const text = props.input().plainText
+      const results: AutocompleteOption[] = []
+      for (const serverCommand of sync.data.command) {
+        if (serverCommand.source !== "skill") continue
+        if (text.includes(`/${serverCommand.name} `)) continue
+        results.push({
+          display: "/" + serverCommand.name,
+          description: serverCommand.description,
+          onSelect: () => {
+            const input = props.input()
+            const newText = "/" + serverCommand.name + " "
+            const cursor = input.logicalCursor
+            input.cursorOffset = store.index
+            const start = input.logicalCursor
+            input.cursorOffset = cursor.col + cursor.row * 1000
+            input.deleteRange(start.row, start.col, cursor.row, cursor.col)
+            input.insertText(newText)
+          },
+        })
+      }
+      results.sort((a, b) => a.display.localeCompare(b.display))
+      const max = firstBy(results, [(x) => x.display.length, "desc"])?.display.length
+      if (!max) return results
+      return results.map((item) => ({
+        ...item,
+        display: item.display.padEnd(max + 2),
+      }))
+    }
+
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
@@ -485,7 +518,7 @@ export function Autocomplete(props: {
 
   function hide() {
     const text = props.input().plainText
-    if (store.visible === "/" && !text.endsWith(" ") && text.startsWith("/")) {
+    if (store.visible === "/" && store.index === 0 && !text.endsWith(" ") && text.startsWith("/")) {
       const cursor = props.input().logicalCursor
       props.input().deleteRange(0, 0, cursor.row, cursor.col)
       // Sync the prompt store immediately since onContentChange is async
@@ -509,8 +542,8 @@ export function Autocomplete(props: {
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
             props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
-            // "/<command>" is not the sole content
-            (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
+            // "/<command>" is not the sole content (only for position-0 slash)
+            (store.visible === "/" && store.index === 0 && value.match(/^\S+\s+\S+\s*$/))
           ) {
             hide()
           }
@@ -526,6 +559,19 @@ export function Autocomplete(props: {
           show("/")
           setStore("index", 0)
           return
+        }
+
+        // Check for inline "/" trigger - reopen skill autocomplete
+        const slashText = value.slice(0, offset)
+        const slashIdx = slashText.lastIndexOf("/")
+        if (slashIdx > 0) {
+          const beforeSlash = value[slashIdx - 1]
+          const between = slashText.slice(slashIdx)
+          if (/\s/.test(beforeSlash) && !between.match(/\s/)) {
+            show("/")
+            setStore("index", slashIdx)
+            return
+          }
         }
 
         // Check for "@" trigger - find the nearest "@" before cursor with no whitespace between
@@ -590,7 +636,13 @@ export function Autocomplete(props: {
           }
 
           if (e.name === "/") {
-            if (props.input().cursorOffset === 0) show("/")
+            if (props.input().cursorOffset === 0) {
+              show("/")
+            } else {
+              const offset = props.input().cursorOffset
+              const before = props.input().getTextRange(offset - 1, offset)
+              if (/\s/.test(before)) show("/")
+            }
           }
         }
       },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -357,7 +357,7 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
-      if (serverCommand.source === "skill") continue
+      if (serverCommand.source === "skill" && !sync.data.config.skills?.slash) continue
       const label = serverCommand.source === "mcp" ? ":mcp" : ""
       results.push({
         display: "/" + serverCommand.name + label,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -706,6 +706,7 @@ export namespace Config {
       .array(z.string())
       .optional()
       .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
+    slash: z.boolean().optional().describe("Show individual skills as slash commands in autocomplete (default: false)"),
   })
   export type Skills = z.infer<typeof Skills>
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -707,6 +707,10 @@ export namespace Config {
       .optional()
       .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
     slash: z.boolean().optional().describe("Show individual skills as slash commands in autocomplete (default: false)"),
+    inline: z
+      .boolean()
+      .optional()
+      .describe("Inline full skill content into prompt on slash command invocation (default: true)"),
   })
   export type Skills = z.infer<typeof Skills>
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2,6 +2,7 @@ import path from "path"
 import os from "os"
 import fs from "fs/promises"
 import z from "zod"
+import { Config } from "@/config/config"
 import { Filesystem } from "../util/filesystem"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
@@ -1761,7 +1762,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const raw = input.arguments.match(argsRegex) ?? []
     const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
 
-    const templateCommand = await command.template
+    const cfg = await Config.get()
+    const inline = cfg.skills?.inline !== false
+    const templateCommand =
+      command.source === "skill" && !inline
+        ? `Use the skill tool to load the "${input.command}" skill and follow its instructions.`
+        : await command.template
 
     const placeholders = templateCommand.match(placeholderRegex) ?? []
     let last = 0

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1764,10 +1764,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const cfg = await Config.get()
     const inline = cfg.skills?.inline !== false
-    const templateCommand =
-      command.source === "skill" && !inline
-        ? `Use the skill tool to load the "${input.command}" skill and follow its instructions.`
-        : await command.template
+    const templateCommand = command.source === "skill" && !inline ? `/${input.command}` : await command.template
 
     const placeholders = templateCommand.match(placeholderRegex) ?? []
     let last = 0

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1338,6 +1338,10 @@ export type Config = {
      * URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)
      */
     urls?: Array<string>
+    /**
+     * Show individual skills as slash commands in autocomplete (default: false)
+     */
+    slash?: boolean
   }
   watcher?: {
     ignore?: Array<string>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1342,6 +1342,10 @@ export type Config = {
      * Show individual skills as slash commands in autocomplete (default: false)
      */
     slash?: boolean
+    /**
+     * Inline full skill content into prompt on slash command invocation (default: true)
+     */
+    inline?: boolean
   }
   watcher?: {
     ignore?: Array<string>


### PR DESCRIPTION
## Summary

Adds a `/skills` slash command to the web app (matching existing TUI functionality) and introduces inline skill autocomplete — typing `/` after whitespace mid-text shows a skill-only autocomplete popover.

Individual `/{skillname}` entries in the `/` autocomplete are now controlled by a new `skills.slash` config option rather than being hardcoded.

Closes #7846

Went with the `/` implementation mentioned in https://github.com/anomalyco/opencode/issues/7846#issuecomment-3757942237 which has quite a few upvotes

## `skills.slash` config

| `skills.slash` config | `/` at position 0 | `/` mid-text (inline) | `/skills` picker |
|---|---|---|---|
| `false` (default) | Built-in commands only | Skill-only autocomplete | ✅ Always available |
| `true` | Built-in + individual skills | Skill-only autocomplete | ✅ Always available |

## `skills.inline` config

Controls whether skill slash commands inject the full `SKILL.md` content into the prompt or send a short `/<skill-name>` message that lets the model load the skill via the `skill` tool on-demand.

| `skills.inline` config | Slash command behavior |
|---|---|
| `true` (default) | Full skill content injected as user message |
| `false` | Sends `/<name>`, model loads skill via tool |

## Testing

- Checked `/<skillname>` in TUI
- Checked `prompt /<skillname` autocomplete in TUI
- Verified  `skills.inline` behavior in TUI (does not dump the full skill.md file into the prompt)