### PR TITLE
fix(app): fix session list sorting by id rather than updated time

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -249,8 +249,8 @@ describe("applyDirectoryEvent", () => {
   })
 
   test("cleans caches for trimmed sessions on session.created", () => {
-    const dropped = rootSession({ id: "ses_b" })
-    const kept = rootSession({ id: "ses_a" })
+    const dropped = rootSession({ id: "ses_a" })
+    const kept = rootSession({ id: "ses_b" })
     const message = userMessage("msg_1", dropped.id)
     const todos: string[] = []
     const [store, setStore] = createStore(

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -10,7 +10,7 @@ export function compareSessionRecent(a: Session, b: Session) {
   const aUpdated = sessionUpdatedAt(a)
   const bUpdated = sessionUpdatedAt(b)
   if (aUpdated !== bUpdated) return bUpdated - aUpdated
-  return cmp(a.id, b.id)
+  return cmp(b.id, a.id)
 }
 
 export function takeRecentSessions(sessions: Session[], limit: number, cutoff: number) {
@@ -39,7 +39,7 @@ export function trimSessions(
   const all = input
     .filter((s) => !!s?.id)
     .filter((s) => !s.time?.archived)
-    .sort((a, b) => cmp(a.id, b.id))
+    .sort((a, b) => compareSessionRecent(a, b))
   const roots = all.filter((s) => !s.parentID)
   const children = all.filter((s) => !!s.parentID)
   const base = roots.slice(0, limit)

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -15,7 +15,7 @@ function sortSessions(now: number) {
     const bUpdated = b.time.updated ?? b.time.created
     const aRecent = aUpdated > oneMinuteAgo
     const bRecent = bUpdated > oneMinuteAgo
-    if (aRecent && bRecent) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+    if (aRecent && bRecent) return a.id > b.id ? -1 : a.id < b.id ? 1 : 0
     if (aRecent && !bRecent) return -1
     if (!aRecent && bRecent) return 1
     return bUpdated - aUpdated


### PR DESCRIPTION
### Issue for this PR

Closes #17474

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a bug where the session list is sorted by ID rather than updated time, leading to older sessions randomly appearing at the top until "Load More" is clicked. 

The root cause was `trimSessions` in the local cache sorting sessions ascending (oldest-first) instead of newest-first before slicing. This PR updates `trimSessions` to properly keep the most recent sessions. It also fixes the 60-second fallback sorting logic in `helpers.ts` so active sessions appear at the top chronologically. 

### How did you verify your code works?

Tested the changes locally by building the frontend and running the backend server via Tailscale. Verified that new and updated sessions properly surface to the top of the sidebar. Also fixed and ran the unit tests in `event-reducer.test.ts` to assert `session.created` behaves as expected with trimming.

### Screenshots / recordings

**@Rohansguliani - Please attach a screen recording to this PR to satisfy the UI changes compliance rule!**

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR