### PR TITLE
fix: resolve skill resource relative paths against skill directory

### DIFF
--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -207,7 +207,7 @@ export namespace Skill {
           `  <skill>`,
           `    <name>${skill.name}</name>`,
           `    <description>${skill.description}</description>`,
-          `    <location>${pathToFileURL(skill.location).href}</location>`,
+          `    <location>${skill.location}</location>`,
           `  </skill>`,
         ]),
         "</available_skills>",

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -56,7 +56,6 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
       })
 
       const dir = path.dirname(skill.location)
-      const base = pathToFileURL(dir).href
 
       const limit = 10
       const files = await iife(async () => {
@@ -84,10 +83,10 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
           `<skill_content name="${skill.name}">`,
           `# Skill: ${skill.name}`,
           "",
-          skill.content.trim(),
+          skill.content.trim().replace(/\{\{SKILL_DIR\}\}/g, () => dir),
           "",
-          `Base directory for this skill: ${base}`,
-          "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
+          `Base directory for this skill: ${dir}`,
+          "IMPORTANT: When reading files requested by this loaded skill's instructions, you MUST resolve relative paths against the skill's base directory above, NOT the project root.",
           "Note: file list is sampled.",
           "",
           "<skill_files>",

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -102,7 +102,7 @@ Use this skill.
 
           expect(result.metadata.dir).toBe(dir)
           expect(result.output).toContain(`<skill_content name="tool-skill">`)
-          expect(result.output).toContain(`Base directory for this skill: ${pathToFileURL(dir).href}`)
+          expect(result.output).toContain(`Base directory for this skill: ${dir}`)
           expect(result.output).toContain(`<file>${file}</file>`)
         },
       })


### PR DESCRIPTION
## Summary
- Updated loaded skill prompt output to explicitly override the project root relative path rule, ensuring agents correctly resolve relative paths against the skill's directory.
- Stripped `file://` protocol formatting from skill locations in context so the agent's file tools recognize them as absolute paths.
- Added variable interpolation for `{{SKILL_DIR}}` in skill content.

Fixes #17101