### PR TITLE
docs: add JSDoc for Log, Locale, Schema, and Token

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -1,3 +1,17 @@
+/**
+ * Locale-aware formatting utilities for strings, dates, numbers, and durations.
+ *
+ * Provides functions for formatting various data types according to locale conventions,
+ * including title case conversion, time/date formatting, number abbreviation, and
+ * duration formatting.
+ *
+ * @example
+ * ```typescript
+ * Locale.titlecase("hello world") // "Hello World"
+ * Locale.number(1500) // "1.5K"
+ * Locale.duration(65000) // "1m 5s"
+ * ```
+ */
 export namespace Locale {
   export function titlecase(str: string) {
     return str.replace(/\b\w/g, (c) => c.toUpperCase())

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -5,6 +5,20 @@ import { Global } from "../global"
 import z from "zod"
 import { Glob } from "./glob"
 
+/**
+ * Logging utilities for the OpenCode CLI.
+ *
+ * Provides a structured logging system with multiple log levels (DEBUG, INFO, WARN, ERROR),
+ * file output, and tagged loggers for different services.
+ *
+ * @example
+ * ```typescript
+ * Log.init({ print: false, level: "DEBUG" })
+ * const logger = Log.create({ service: "my-service" })
+ * logger.info("Application started")
+ * logger.time("Processing request").stop()
+ * ```
+ */
 export namespace Log {
   export const Level = z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).meta({ ref: "LogLevel", description: "Log level" })
   export type Level = z.infer<typeof Level>

--- a/packages/opencode/src/util/schema.ts
+++ b/packages/opencode/src/util/schema.ts
@@ -1,6 +1,20 @@
 import { Schema } from "effect"
 
 /**
+ * Schema utilities for Effect schema definitions.
+ *
+ * Provides helpers for attaching static methods to schemas and creating nominal
+ * wrapper types for scalar types.
+ *
+ * @example
+ * ```typescript
+ * const MySchema = Schema.String.pipe(withStatics((s) => ({
+ *   fromString: Schema.decodeUnknownOption(s)
+ * })))
+ * ```
+ */
+
+/**
  * Attach static methods to a schema object. Designed to be used with `.pipe()`:
  *
  * @example

--- a/packages/opencode/src/util/token.ts
+++ b/packages/opencode/src/util/token.ts
@@ -1,3 +1,14 @@
+/**
+ * Token estimation utilities for LLM context windows.
+ *
+ * Provides methods to estimate the number of tokens that text will consume
+ * when sent to a language model. Uses a simple heuristic of ~4 characters per token.
+ *
+ * @example
+ * ```typescript
+ * Token.estimate("Hello world") // ~3 tokens
+ * ```
+ */
 export namespace Token {
   const CHARS_PER_TOKEN = 4
 


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to four utility modules:
- Log: Logging utilities with level-based filtering and file output
- Locale: Locale-aware formatting for dates, numbers, and durations
- Schema: Effect schema utilities including withStatics and Newtype
- Token: Token estimation for LLM context windows

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR