### PR TITLE
docs: add describe annotation to snapshot config field

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1056,7 +1056,7 @@ export namespace Config {
         .boolean()
         .optional()
         .describe(
-          "Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and session undo/revert will be unavailable. Defaults to true.",
+          "Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and undoing or reverting will not undo/redo file changes. Defaults to true.",
         ),
       share: z
         .enum(["manual", "auto", "disabled"])

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1052,7 +1052,12 @@ export namespace Config {
         })
         .optional(),
       plugin: z.string().array().optional(),
-      snapshot: z.boolean().optional(),
+      snapshot: z
+        .boolean()
+        .optional()
+        .describe(
+          "Enable or disable snapshot tracking. When false, filesystem snapshots are not recorded and session undo/revert will be unavailable. Defaults to true.",
+        ),
       share: z
         .enum(["manual", "auto", "disabled"])
         .optional()

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -437,7 +437,7 @@ For large repositories or projects with many submodules, the snapshot system can
 }
 ```
 
-Note that disabling snapshots means session undo/revert will be unavailable — changes made by the agent cannot be rolled back through the UI.
+Note that disabling snapshots means changes made by the agent cannot be rolled back through the UI.
 
 ---
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -424,6 +424,23 @@ Customize keybinds in `tui.json`.
 
 ---
 
+### Snapshot
+
+OpenCode uses snapshots to track file changes during agent operations, enabling you to undo and revert changes within a session. Snapshots are enabled by default.
+
+For large repositories or projects with many submodules, the snapshot system can cause slow indexing and significant disk usage as it tracks all changes using an internal git repository. You can disable snapshots using the `snapshot` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "snapshot": false
+}
+```
+
+Note that disabling snapshots means session undo/revert will be unavailable — changes made by the agent cannot be rolled back through the UI.
+
+---
+
 ### Autoupdate
 
 OpenCode will automatically download any new updates when it starts up. You can disable this with the `autoupdate` option.


### PR DESCRIPTION
### Issue for this PR

Closes #17863

Related: #4753 (prior attempt), #10626, #6845, #3182, #17753, #16336 (users struggling with snapshot disk usage)

### Type of change

- [x] Documentation

### What does this PR do?

The `snapshot` config field was added in 28a4517ec but was never documented. This PR:

1. Adds a `.describe()` annotation to the `snapshot` schema field in `config.ts`, matching the pattern used by other config fields.
2. Adds a "Snapshot" section to `config.mdx` explaining what snapshots do, how to disable them, and the tradeoff (no undo/revert when disabled). Placed between Keybinds and Autoupdate sections.

### How did you verify your code works?

Read the schema definition and confirmed the `.describe()` follows the same chaining pattern as adjacent fields. Verified the config.mdx section renders consistently with surrounding sections.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR