### PR TITLE
docs: add JSDoc for abort, InstanceState, Keybind, and Rpc

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/abort.ts
+++ b/packages/opencode/src/util/abort.ts
@@ -1,4 +1,14 @@
 /**
+ * AbortController utilities with automatic timeout support.
+ *
+ * Provides functions for creating AbortControllers that automatically abort after
+ * a specified timeout, with support for combining multiple abort signals.
+ *
+ * Uses bind() instead of arrow functions to avoid capturing the surrounding
+ * scope in closures, preventing GC issues.
+ */
+
+/**
  * Creates an AbortController that automatically aborts after a timeout.
  *
  * Uses bind() instead of arrow functions to avoid capturing the surrounding

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`

--- a/packages/opencode/src/util/instance-state.ts
+++ b/packages/opencode/src/util/instance-state.ts
@@ -8,6 +8,20 @@ const disposers = new Set<Disposer>()
 const TypeId = "~opencode/InstanceState"
 
 /**
+ * Effect-based state management for OpenCode instances.
+ *
+ * Provides a lazily-initialized, per-directory cached state for Effect services.
+ * Values are created on first access for a given directory and cached for
+ * subsequent reads. Concurrent access shares a single initialization.
+ *
+ * @example
+ * ```typescript
+ * const myState = yield* InstanceState.make((dir) => Effect.succeed({ count: 0 }))
+ * const value = yield* InstanceState.get(myState)
+ * ```
+ */
+
+/**
  * Effect version of `Instance.state` — lazily-initialized, per-directory
  * cached state for Effect services.
  *

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -1,6 +1,19 @@
 import { isDeepEqual } from "remeda"
 import type { ParsedKey } from "@opentui/core"
 
+/**
+ * Keyboard binding utilities for parsing and matching key combinations.
+ *
+ * Provides functions for parsing keybinding strings, converting between formats,
+ * and matching key combinations. Supports modifiers like ctrl, alt, shift, super,
+ * and a custom leader key.
+ *
+ * @example
+ * ```typescript
+ * const key = Keybind.parse("ctrl+shift+p")[0]
+ * Keybind.toString(key) // "ctrl+shift+p"
+ * ```
+ */
 export namespace Keybind {
   /**
    * Keybind info derived from OpenTUI's ParsedKey with our custom `leader` field.

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -1,3 +1,21 @@
+/**
+ * RPC (Remote Procedure Call) utilities for worker communication.
+ *
+ * Provides a simple RPC implementation for communication between the main thread
+ * and Web Workers. Supports method calls and event emission with type safety.
+ *
+ * @example
+ * ```typescript
+ * // In worker
+ * Rpc.listen({
+ *   add: (a: number, b: number) => a + b
+ * })
+ *
+ * // In main thread
+ * const client = Rpc.client<typeof rpc>(worker)
+ * const result = await client.call("add", 1, 2)
+ * ```
+ */
 export namespace Rpc {
   type Definition = {
     [method: string]: (input: any) => any


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to four utility modules:
- abort: AbortController utilities with timeout support
- InstanceState: Effect-based state management for instances
- Keybind: Keyboard binding parsing and matching
- Rpc: RPC utilities for worker communication

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR