### PR TITLE
docs: add JSDoc for Process, Wildcard, effect-http-client, and effect-zod

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/effect-http-client.ts
+++ b/packages/opencode/src/util/effect-http-client.ts
@@ -1,6 +1,18 @@
 import { Schedule } from "effect"
 import { HttpClient } from "effect/unstable/http"
 
+/**
+ * HTTP client utilities with retry logic for Effect.
+ *
+ * Provides retry configurations for transient HTTP failures using exponential
+ * backoff with jitter to avoid thundering herd problems.
+ *
+ * @example
+ * ```typescript
+ * const client = HttpClient.make(...).pipe(withTransientReadRetry)
+ * ```
+ */
+
 export const withTransientReadRetry = <E, R>(client: HttpClient.HttpClient.With<E, R>) =>
   client.pipe(
     HttpClient.retryTransient({

--- a/packages/opencode/src/util/effect-zod.ts
+++ b/packages/opencode/src/util/effect-zod.ts
@@ -1,6 +1,19 @@
 import { Schema, SchemaAST } from "effect"
 import z from "zod"
 
+/**
+ * Converts Effect Schema definitions to Zod schemas.
+ *
+ * Provides interoperability between Effect Schema and Zod by converting
+ * Effect Schema AST to equivalent Zod type definitions.
+ *
+ * @example
+ * ```typescript
+ * const UserSchema = Schema.Struct({ name: Schema.String })
+ * const UserZod = zod(UserSchema) // z.ZodType<{ name: string }>
+ * ```
+ */
+
 export function zod<S extends Schema.Top>(schema: S): z.ZodType<Schema.Schema.Type<S>> {
   return walk(schema.ast) as z.ZodType<Schema.Schema.Type<S>>
 }

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -1,6 +1,19 @@
 import { spawn as launch, type ChildProcess } from "child_process"
 import { buffer } from "node:stream/consumers"
 
+/**
+ * Process execution utilities with support for timeouts, abort signals,
+ * and comprehensive error handling.
+ *
+ * Provides functions for spawning processes, running commands with captured
+ * output, and handling process lifecycle including graceful termination.
+ *
+ * @example
+ * ```typescript
+ * const result = await Process.run(["git", "status"])
+ * const lines = await Process.lines(["ls", "-la"])
+ * ```
+ */
 export namespace Process {
   export type Stdio = "inherit" | "pipe" | "ignore"
 

--- a/packages/opencode/src/util/wildcard.ts
+++ b/packages/opencode/src/util/wildcard.ts
@@ -1,5 +1,18 @@
 import { sortBy, pipe } from "remeda"
 
+/**
+ * Wildcard pattern matching utilities for commands and file paths.
+ *
+ * Provides functions for matching strings against wildcard patterns with support
+ * for glob-style wildcards (* and ?) and command-specific matching with
+ * structured input (head/tail format).
+ *
+ * @example
+ * ```typescript
+ * Wildcard.match("ls -la", "ls *") // true
+ * Wildcard.all("my-command", { "my-*": handler, "other": otherHandler })
+ * ```
+ */
 export namespace Wildcard {
   export function match(str: string, pattern: string) {
     if (str) str = str.replaceAll("\\", "/")


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to four utility modules:
- Process: Process execution with timeout and abort support
- Wildcard: Wildcard pattern matching for commands
- effect-http-client: HTTP client retry utilities
- effect-zod: Effect Schema to Zod converter

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR