### PR TITLE
fix(tui): keep Tab behavior in shell mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -33,6 +33,7 @@ import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import { shellPassthrough } from "./key"
 import { DialogSkill } from "../dialog-skill"
 
 export type PromptProps = {
@@ -894,6 +895,10 @@ export function Prompt(props: PromptProps) {
                   return
                 }
                 if (store.mode === "shell") {
+                  if (shellPassthrough(keybind, e, store.mode)) {
+                    e.stopPropagation()
+                    return
+                  }
                   if ((e.name === "backspace" && input.visualCursor.offset === 0) || e.name === "escape") {
                     setStore("mode", "normal")
                     e.preventDefault()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -98,6 +98,21 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
+  createEffect(
+    on(
+      () => store.mode,
+      (mode, prev) => {
+        if (prev === "shell") command.keybinds(true)
+        if (mode === "shell") command.keybinds(false)
+      },
+      { defer: true },
+    ),
+  )
+
+  onCleanup(() => {
+    if (store.mode === "shell") command.keybinds(true)
+  })
+
   sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/key.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/key.ts
@@ -1,0 +1,16 @@
+import type { KeybindKey } from "@/cli/cmd/tui/context/keybind"
+
+type Mode = "normal" | "shell"
+
+type Key = {
+  readonly name?: string
+  readonly shift?: boolean
+}
+
+export function shellPassthrough<E extends Key>(
+  keybind: { readonly match: (key: KeybindKey, evt: E) => boolean | undefined },
+  evt: E,
+  mode: Mode,
+) {
+  return mode === "shell" && (keybind.match("agent_cycle", evt) || keybind.match("agent_cycle_reverse", evt))
+}

--- a/packages/opencode/test/cli/tui/prompt-key.test.ts
+++ b/packages/opencode/test/cli/tui/prompt-key.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { shellPassthrough } from "../../../src/cli/cmd/tui/component/prompt/key"
+
+const key = (name: string, extra: { readonly shift?: boolean } = {}) => ({
+  name,
+  shift: false,
+  ...extra,
+})
+
+describe("shellPassthrough", () => {
+  test("allows tab agent-cycle bindings to pass through in shell mode", () => {
+    const match = (target: string, evt: { readonly name?: string }) => target === "agent_cycle" && evt.name === "tab"
+    expect(shellPassthrough({ match }, key("tab"), "shell")).toBe(true)
+  })
+
+  test("allows reverse agent-cycle bindings to pass through in shell mode", () => {
+    const match = (target: string, evt: { readonly name?: string; readonly shift?: boolean }) =>
+      target === "agent_cycle_reverse" && evt.name === "tab" && evt.shift
+    expect(shellPassthrough({ match }, key("tab", { shift: true }), "shell")).toBe(true)
+  })
+
+  test("does not bypass agent-cycle outside shell mode", () => {
+    const match = (target: string, evt: { readonly name?: string }) => target === "agent_cycle" && evt.name === "tab"
+    expect(shellPassthrough({ match }, key("tab"), "normal")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- keep the agent-cycle Tab keybind from hijacking prompt input while the TUI prompt is in shell mode
- extract the shell-mode passthrough decision into a tiny helper with focused tests
- preserve normal-mode agent cycling behavior

## Testing
- `bun run test test/cli/tui/prompt-key.test.ts`
- `bun typecheck`