### PR TITLE
docs: add JSDoc for Filesystem, Editor, Selection, and Clipboard

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -22,6 +22,19 @@ function writeOsc52(text: string): void {
   process.stdout.write(sequence)
 }
 
+/**
+ * Cross-platform clipboard operations for text and images.
+ *
+ * Supports reading and writing to the clipboard across macOS, Windows, Linux (X11/Wayland),
+ * and WSL. Automatically detects the best available method for the current platform.
+ * Also supports OSC 52 for clipboard operations over SSH.
+ *
+ * @example
+ * ```typescript
+ * await Clipboard.copy("Hello, world!")
+ * const content = await Clipboard.read()
+ * ```
+ */
 export namespace Clipboard {
   export interface Content {
     data: string

--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -6,6 +6,20 @@ import { CliRenderer } from "@opentui/core"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 
+/**
+ * External editor integration for the TUI.
+ *
+ * Opens the system's default editor ($VISUAL or $EDITOR) for editing text,
+ * with automatic cleanup of temporary files.
+ *
+ * @example
+ * ```typescript
+ * const content = await Editor.open({
+ *   value: "Initial content",
+ *   renderer: cliRenderer
+ * })
+ * ```
+ */
 export namespace Editor {
   export async function open(opts: { value: string; renderer: CliRenderer }): Promise<string | undefined> {
     const editor = process.env["VISUAL"] || process.env["EDITOR"]

--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -10,6 +10,17 @@ type Renderer = {
   clearSelection: () => void
 }
 
+/**
+ * Text selection utilities for the TUI.
+ *
+ * Provides functionality for copying selected text to the clipboard
+ * with user feedback via toast notifications.
+ *
+ * @example
+ * ```typescript
+ * Selection.copy(renderer, toast)
+ * ```
+ */
 export namespace Selection {
   export function copy(renderer: Renderer, toast: Toast): boolean {
     const text = renderer.getSelection()?.getSelectedText()

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -7,6 +7,20 @@ import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "./glob"
 
+/**
+ * Filesystem utilities for reading, writing, and path manipulation.
+ *
+ * Provides convenient wrappers for common filesystem operations including
+ * reading/writing files, path normalization (especially for Windows),
+ * directory traversal, and MIME type detection.
+ *
+ * @example
+ * ```typescript
+ * const content = await Filesystem.readText("file.txt")
+ * await Filesystem.write("file.json", JSON.stringify(data))
+ * const found = await Filesystem.findUp("package.json", process.cwd())
+ * ```
+ */
 export namespace Filesystem {
   // Fast sync version for metadata checks
   export async function exists(p: string): Promise<boolean> {

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to four utility modules:
- Filesystem: File system operations and path utilities
- Editor: External editor integration for TUI
- Selection: Text selection and clipboard operations
- Clipboard: Cross-platform clipboard operations

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR