### PR TITLE
feat(tui): show prompt after /compact to choose continue or branch

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/compaction-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/compaction-prompt.tsx
@@ -1,0 +1,126 @@
+import { createStore } from "solid-js/store"
+import { For } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import { useKeybind } from "../../context/keybind"
+import { selectedForeground, useTheme } from "../../context/theme"
+import { SplitBorder } from "../../component/border"
+import { useRoute } from "../../context/route"
+import { useDialog } from "../../ui/dialog"
+
+export type CompactionPromptProps = {
+  summary: string
+  onDismiss: () => void
+}
+
+export function CompactionPrompt(props: CompactionPromptProps) {
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+  const route = useRoute()
+  const dialog = useDialog()
+
+  const options = [
+    { key: "continue", label: "Continue" },
+    { key: "new", label: "New Session" },
+  ]
+
+  const [store, setStore] = createStore({
+    selected: "continue" as "continue" | "new",
+  })
+
+  useKeyboard((evt) => {
+    if (dialog.stack.length > 0) return
+
+    if (evt.name === "return") {
+      evt.preventDefault()
+      handleSelect(store.selected)
+      return
+    }
+
+    if (evt.name === "left" || evt.name === "right" || evt.name === "tab") {
+      evt.preventDefault()
+      setStore("selected", store.selected === "continue" ? "new" : "continue")
+    }
+
+    if (evt.name === "escape" || keybind.match("app_exit", evt)) {
+      evt.preventDefault()
+      props.onDismiss()
+    }
+  })
+
+  function handleSelect(option: "continue" | "new") {
+    if (option === "continue") {
+      props.onDismiss()
+      return
+    }
+
+    if (option === "new") {
+      const summaryText = props.summary ?? ""
+      props.onDismiss()
+      route.navigate({
+        type: "home",
+        initialPrompt: {
+          input: `Continue from previous session:\n\n${summaryText}`,
+          parts: [],
+        },
+      })
+    }
+  }
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.primary}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box flexDirection="row" gap={1}>
+          <text fg={theme.primary}>◆</text>
+          <text fg={theme.text}>Context summarized</text>
+        </box>
+      </box>
+
+      <box
+        flexDirection="row"
+        flexShrink={0}
+        gap={1}
+        paddingLeft={2}
+        paddingRight={3}
+        paddingBottom={1}
+        backgroundColor={theme.backgroundElement}
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <box flexDirection="row" gap={1}>
+          <For each={options}>
+            {(opt) => (
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={opt.key === store.selected ? theme.primary : undefined}
+                onMouseOver={() => setStore("selected", opt.key as "continue" | "new")}
+                onMouseUp={() => handleSelect(opt.key as "continue" | "new")}
+              >
+                <text fg={opt.key === store.selected ? selectedForeground(theme, theme.primary) : theme.textMuted}>
+                  {opt.label}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+
+        <box flexDirection="row" gap={2}>
+          <text fg={theme.text}>
+            {"⇆"} <span style={{ fg: theme.textMuted }}>select</span>
+          </text>
+          <text fg={theme.text}>
+            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+          </text>
+          <text fg={theme.text}>
+            esc <span style={{ fg: theme.textMuted }}>dismiss</span>
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { Global } from "@/global"
 import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
+import { CompactionPrompt } from "./compaction-prompt"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
@@ -159,6 +160,7 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [compactionSummary, setCompactionSummary] = createSignal<string | null>(null)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -229,6 +231,23 @@ export function Session() {
       local.agent.set("plan")
       lastSwitch = part.id
     }
+  })
+
+  // Handle session.compacted event - show inline prompt with summary options
+  sdk.event.on("session.compacted", (evt) => {
+    if (evt.properties.sessionID !== route.sessionID) return
+
+    const lastCompaction = messages().findLast((m) => m.role === "assistant" && m.mode === "compaction")
+    if (!lastCompaction) return
+
+    const parts = sync.data.part[lastCompaction.id]
+    if (!parts) return
+
+    const textParts = parts.filter((p) => p.type === "text").map((p) => p.text)
+    if (textParts.length === 0) return
+
+    const summary = textParts.join("\n")
+    setCompactionSummary(summary)
   })
 
   let scroll: ScrollBoxRenderable
@@ -1172,8 +1191,13 @@ export function Session() {
               <Show when={permissions().length === 0 && questions().length > 0}>
                 <QuestionPrompt request={questions()[0]} />
               </Show>
+              <Show when={compactionSummary()}>
+                <CompactionPrompt summary={compactionSummary()!} onDismiss={() => setCompactionSummary(null)} />
+              </Show>
               <Prompt
-                visible={!session()?.parentID && permissions().length === 0 && questions().length === 0}
+                visible={
+                  !session()?.parentID && permissions().length === 0 && questions().length === 0 && !compactionSummary()
+                }
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)
@@ -1182,7 +1206,7 @@ export function Session() {
                     r.set(route.initialPrompt)
                   }
                 }}
-                disabled={permissions().length > 0 || questions().length > 0}
+                disabled={permissions().length > 0 || questions().length > 0 || !!compactionSummary()}
                 onSubmit={() => {
                   toBottom()
                 }}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -233,7 +233,7 @@ export function Session() {
     }
   })
 
-  // Handle session.compacted event - show inline prompt with summary options
+  // Handle session.compacted event - show inline prompt with summary options (only for manual compaction)
   sdk.event.on("session.compacted", (evt) => {
     if (evt.properties.sessionID !== route.sessionID) return
 
@@ -242,6 +242,10 @@ export function Session() {
 
     const parts = sync.data.part[lastCompaction.id]
     if (!parts) return
+
+    // Skip prompt for auto compaction - it should continue automatically
+    const compactionPart = parts.find((p) => p.type === "compaction")
+    if (compactionPart?.auto === true) return
 
     const textParts = parts.filter((p) => p.type === "text").map((p) => p.text)
     if (textParts.length === 0) return


### PR DESCRIPTION
### Issue for this PR

Closes #17802

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After running `/compact`, show an inline prompt letting users choose:
- **Continue** - Keep working in the current session
- **New Session** - Start a new session with the compaction summary as context

This addresses the missing UX after compaction - users previously had no feedback on what happened or how to continue. Auto compaction continues silently without interruption.

### How did you verify your code works?

1. Run `/compact` manually → prompt appears
2. Select Continue → prompt closes, continue in current session
3. Select New Session → navigates to home with summary in prompt
4. Trigger auto compaction → continues without prompt

### Screenshots / recordings

```
◆ Context summarized
[Continue] [New Session]
⇆ select  enter confirm  esc dismiss
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR