### PR TITLE
docs: add JSDoc for Bus, Terminal, signal, and transcript utilities

### DIFF
--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -1,5 +1,11 @@
 import { EventEmitter } from "events"
 
+/**
+ * Global event bus for cross-instance communication.
+ *
+ * Used to broadcast events between different OpenCode instances,
+ * enabling coordination across multiple directories.
+ */
 export const GlobalBus = new EventEmitter<{
   event: [
     {

--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -4,6 +4,20 @@ import { Instance } from "../project/instance"
 import { BusEvent } from "./bus-event"
 import { GlobalBus } from "./global"
 
+/**
+ * Event bus for publishing and subscribing to typed events.
+ *
+ * Provides a type-safe pub/sub system for cross-component communication
+ * within an OpenCode instance. Supports filtering by event type and
+ * broadcasting to all subscribers.
+ *
+ * @example
+ * ```typescript
+ * const MyEvent = BusEvent.define("my.event", z.object({ id: z.string() }))
+ * Bus.subscribe(MyEvent, (event) => console.log(event.properties.id))
+ * await Bus.publish(MyEvent, { id: "123" })
+ * ```
+ */
 export namespace Bus {
   const log = Log.create({ service: "bus" })
   type Subscription = (event: any) => void

--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/cli/cmd/tui/util/signal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/signal.ts
@@ -1,6 +1,18 @@
 import { createSignal, type Accessor } from "solid-js"
 import { debounce, type Scheduled } from "@solid-primitives/scheduled"
 
+/**
+ * Creates a Solid signal with debounced updates.
+ *
+ * Returns a tuple with a getter function and a debounced setter that delays
+ * updates until the specified milliseconds have passed since the last call.
+ *
+ * @example
+ * ```typescript
+ * const [value, setValue] = createDebouncedSignal("", 300)
+ * setValue("new value") // Will update after 300ms of inactivity
+ * ```
+ */
 export function createDebouncedSignal<T>(value: T, ms: number): [Accessor<T>, Scheduled<[value: T]>] {
   const [get, set] = createSignal(value)
   return [get, debounce((v: T) => set(() => v), ms)]

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -1,5 +1,18 @@
 import { RGBA } from "@opentui/core"
 
+/**
+ * Terminal color detection and querying utilities.
+ *
+ * Provides functions to query terminal colors using OSC escape sequences,
+ * including background, foreground, and palette colors. Also supports
+ * detecting whether the terminal has a dark or light background.
+ *
+ * @example
+ * ```typescript
+ * const colors = await Terminal.colors()
+ * const theme = await Terminal.getTerminalBackgroundColor()
+ * ```
+ */
 export namespace Terminal {
   export type Colors = Awaited<ReturnType<typeof colors>>
   /**

--- a/packages/opencode/src/cli/cmd/tui/util/transcript.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/transcript.ts
@@ -1,6 +1,23 @@
 import type { AssistantMessage, Part, UserMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "@/util/locale"
 
+/**
+ * Transcript formatting utilities for chat sessions.
+ *
+ * Converts chat sessions and messages to markdown format for export.
+ * Supports formatting user messages, assistant responses, tool calls,
+ * and reasoning content with configurable options.
+ *
+ * @example
+ * ```typescript
+ * const transcript = formatTranscript(session, messages, {
+ *   thinking: true,
+ *   toolDetails: true,
+ *   assistantMetadata: true
+ * })
+ * ```
+ */
+
 export type TranscriptOptions = {
   thinking: boolean
   toolDetails: boolean

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to five modules:
- Bus: Event bus for pub/sub communication
- GlobalBus: Global event bus for cross-instance communication
- Terminal: Terminal color detection utilities
- createDebouncedSignal: Debounced Solid signal helper
- transcript: Session transcript formatting utilities

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR