### PR TITLE
docs: add JSDoc for BusEvent, BunProc, PackageRegistry, and TuiEvent

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -9,6 +9,18 @@ import { PackageRegistry } from "./registry"
 import { proxied } from "@/util/proxied"
 import { Process } from "../util/process"
 
+/**
+ * Bun process execution and package management utilities.
+ *
+ * Provides functions for running Bun commands and installing packages
+ * with caching and version management.
+ *
+ * @example
+ * ```typescript
+ * await BunProc.run(["--version"])
+ * const modPath = await BunProc.install("lodash", "latest")
+ * ```
+ */
 export namespace BunProc {
   const log = Log.create({ service: "bun" })
 

--- a/packages/opencode/src/bun/registry.ts
+++ b/packages/opencode/src/bun/registry.ts
@@ -2,6 +2,18 @@ import semver from "semver"
 import { Log } from "../util/log"
 import { Process } from "../util/process"
 
+/**
+ * Package registry utilities for checking package versions.
+ *
+ * Provides functions to query package information from the registry
+ * and check if cached versions are outdated.
+ *
+ * @example
+ * ```typescript
+ * const version = await PackageRegistry.info("lodash", "version")
+ * const outdated = await PackageRegistry.isOutdated("lodash", "4.17.0")
+ * ```
+ */
 export namespace PackageRegistry {
   const log = Log.create({ service: "bun" })
 

--- a/packages/opencode/src/bus/bus-event.ts
+++ b/packages/opencode/src/bus/bus-event.ts
@@ -2,6 +2,21 @@ import z from "zod"
 import type { ZodType } from "zod"
 import { Log } from "../util/log"
 
+/**
+ * Typed event definitions for the event bus.
+ *
+ * Provides a way to define events with Zod schemas for type-safe
+ * publishing and subscribing. All defined events are tracked in a
+ * registry for payload validation.
+ *
+ * @example
+ * ```typescript
+ * const UserCreatedEvent = BusEvent.define(
+ *   "user.created",
+ *   z.object({ id: z.string(), name: z.string() })
+ * )
+ * ```
+ */
 export namespace BusEvent {
   const log = Log.create({ service: "event" })
 

--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -2,6 +2,15 @@ import type { CommandModule } from "yargs"
 
 type WithDoubleDash<T> = T & { "--"?: string[] }
 
+/**
+ * Wraps a yargs command module with double-dash argument support.
+ *
+ * This helper ensures command modules properly handle arguments after `--`,
+ * which is essential for passing arguments through to underlying commands.
+ *
+ * @param input The yargs command module to wrap
+ * @returns The same command module with proper type inference for double-dash args
+ */
 export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -3,6 +3,20 @@ import { Bus } from "@/bus"
 import { SessionID } from "@/session/schema"
 import z from "zod"
 
+/**
+ * TUI-specific events for prompt handling, commands, and toasts.
+ *
+ * Defines typed events for the TUI including prompt appending,
+ * command execution, toast notifications, and session selection.
+ *
+ * @example
+ * ```typescript
+ * Bus.publish(TuiEvent.ToastShow, {
+ *   message: "Hello",
+ *   variant: "info"
+ * })
+ * ```
+ */
 export const TuiEvent = {
   PromptAppend: BusEvent.define("tui.prompt.append", z.object({ text: z.string() })),
   CommandExecute: BusEvent.define(

--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -1,3 +1,12 @@
+/**
+ * Decodes a data URL to extract its content.
+ *
+ * Handles both base64 encoded and URL-encoded data URLs.
+ * Returns the decoded string content.
+ *
+ * @param url The data URL to decode (e.g., "data:text/plain;base64,...")
+ * @returns The decoded content as a string
+ */
 export function decodeDataUrl(url: string) {
   const idx = url.indexOf(",")
   if (idx === -1) return ""

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -1,3 +1,12 @@
+/**
+ * Formats a duration in seconds to a human-readable string.
+ *
+ * Converts seconds to appropriate units (seconds, minutes, hours, days, weeks)
+ * and returns a formatted string like "5m 30s" or "~2 days".
+ *
+ * @param secs Duration in seconds
+ * @returns Formatted duration string
+ */
 export function formatDuration(secs: number) {
   if (secs <= 0) return ""
   if (secs < 60) return `${secs}s`


### PR DESCRIPTION
### Issue for this PR

Closes #17738

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds JSDoc documentation to four modules:
- BusEvent: Typed event definitions for the event bus
- BunProc: Bun process execution and package management
- PackageRegistry: Package registry version checking
- TuiEvent: TUI-specific events for prompts and commands

### How did you verify your code works?

TypeScript compilation passes without errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR