### PR TITLE
feat(opencode): add lsp_min_severity config option

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -2228,10 +2228,29 @@ function Skill(props: ToolProps<typeof SkillTool>) {
 
 function Diagnostics(props: { diagnostics?: Record<string, Record<string, any>[]>; filePath: string }) {
   const { theme } = useTheme()
+  const sync = useSync()
   const errors = createMemo(() => {
     const normalized = Filesystem.normalizePath(props.filePath)
     const arr = props.diagnostics?.[normalized] ?? []
-    return arr.filter((x) => x.severity === 1).slice(0, 3)
+    const ext = path.extname(props.filePath)
+    let min = 1
+    // Look up min_severity from LSP config by matching file extension
+    const lspConfig = sync.data.config.lsp
+    if (lspConfig && typeof lspConfig === "object") {
+      for (const [id, cfg] of Object.entries(lspConfig)) {
+        if (!cfg || "disabled" in cfg) continue
+        const lsp = sync.data.lsp.find((l) => l.id === id)
+        if (lsp && "min_severity" in cfg && typeof cfg.min_severity === "number") {
+          // Check if this LSP handles this file extension
+          const exts = cfg.extensions
+          if (!exts || exts.includes(ext)) {
+            min = cfg.min_severity
+            break
+          }
+        }
+      }
+    }
+    return arr.filter((x) => (x.severity ?? 1) <= min).slice(0, 3)
   })
 
   return (

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1154,11 +1154,18 @@ export namespace Config {
                 disabled: z.literal(true),
               }),
               z.object({
-                command: z.array(z.string()),
+                command: z.array(z.string()).optional(),
                 extensions: z.array(z.string()).optional(),
                 disabled: z.boolean().optional(),
                 env: z.record(z.string(), z.string()).optional(),
                 initialization: z.record(z.string(), z.any()).optional(),
+                min_severity: z
+                  .number()
+                  .int()
+                  .min(1)
+                  .max(4)
+                  .optional()
+                  .describe("Minimum diagnostic severity to show (1=Error, 2=Warning, 3=Info, 4=Hint). Default: 1"),
               }),
             ]),
           ),
@@ -1173,11 +1180,12 @@ export namespace Config {
             return Object.entries(data).every(([id, config]) => {
               if (config.disabled) return true
               if (serverIds.has(id)) return true
-              return Boolean(config.extensions)
+              return Boolean(config.extensions) || Boolean(config.min_severity)
             })
           },
           {
-            error: "For custom LSP servers, 'extensions' array is required.",
+            error:
+              "For custom LSP servers, 'extensions' array is required (unless only setting min_severity for a built-in server).",
           },
         ),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -105,6 +105,16 @@ export namespace LSP {
           delete servers[name]
           continue
         }
+        // If no command provided, just update config for existing server
+        if (!item.command) {
+          if (existing) {
+            servers[name] = {
+              ...existing,
+              extensions: item.extensions ?? existing.extensions,
+            }
+          }
+          continue
+        }
         servers[name] = {
           ...existing,
           id: name,
@@ -112,7 +122,7 @@ export namespace LSP {
           extensions: item.extensions ?? existing?.extensions ?? [],
           spawn: async (root) => {
             return {
-              process: spawn(item.command[0], item.command.slice(1), {
+              process: spawn(item.command![0], item.command!.slice(1), {
                 cwd: root,
                 windowsHide: true,
                 env: {
@@ -482,5 +492,28 @@ export namespace LSP {
 
       return `${severity} [${line}:${col}] ${diagnostic.message}`
     }
+
+    export function filter(items: LSPClient.Diagnostic[], min: number) {
+      return items.filter((d) => (d.severity ?? 1) <= min)
+    }
+  }
+
+  export async function minSeverity(file: string) {
+    const cfg = await Config.get()
+    if (!cfg.lsp || typeof cfg.lsp !== "object") return 1
+
+    const ext = path.extname(file)
+    const s = await state()
+
+    // Find servers that handle this file extension
+    for (const server of Object.values(s.servers)) {
+      if (server.extensions.length && !server.extensions.includes(ext)) continue
+      const item = cfg.lsp[server.id]
+      if (item && !("disabled" in item && item.disabled) && "min_severity" in item && item.min_severity) {
+        return item.min_severity
+      }
+    }
+
+    return 1
   }
 }

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -259,7 +259,8 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
       const target = change.movePath ?? change.filePath
       const normalized = Filesystem.normalizePath(target)
       const issues = diagnostics[normalized] ?? []
-      const errors = issues.filter((item) => item.severity === 1)
+      const min = await LSP.minSeverity(target)
+      const errors = LSP.Diagnostic.filter(issues, min)
       if (errors.length > 0) {
         const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
         const suffix =

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -147,7 +147,8 @@ export const EditTool = Tool.define("edit", {
     const diagnostics = await LSP.diagnostics()
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []
-    const errors = issues.filter((item) => item.severity === 1)
+    const min = await LSP.minSeverity(filePath)
+    const errors = LSP.Diagnostic.filter(issues, min)
     if (errors.length > 0) {
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -57,7 +57,8 @@ export const WriteTool = Tool.define("write", {
     const normalizedFilepath = Filesystem.normalizePath(filepath)
     let projectDiagnosticsCount = 0
     for (const [file, issues] of Object.entries(diagnostics)) {
-      const errors = issues.filter((item) => item.severity === 1)
+      const min = await LSP.minSeverity(file)
+      const errors = LSP.Diagnostic.filter(issues, min)
       if (errors.length === 0) continue
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =

--- a/packages/opencode/test/lsp/min-severity.test.ts
+++ b/packages/opencode/test/lsp/min-severity.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "bun:test"
+import { Config } from "../../src/config/config"
+import { LSP } from "../../src/lsp/index"
+
+describe("LSP min_severity", () => {
+  describe("Config schema", () => {
+    it("accepts min_severity per-LSP", () => {
+      const testConfig = {
+        lsp: {
+          typescript: {
+            min_severity: 2
+          }
+        }
+      }
+      
+      const result = Config.Info.safeParse(testConfig)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.lsp).toBeDefined()
+        expect((result.data.lsp as any).typescript.min_severity).toBe(2)
+      }
+    })
+    
+    it("accepts min_severity with command and extensions", () => {
+      const testConfig = {
+        lsp: {
+          markdownlint: {
+            command: ["markdownlint-lsp"],
+            extensions: [".md"],
+            min_severity: 3
+          }
+        }
+      }
+      
+      const result = Config.Info.safeParse(testConfig)
+      expect(result.success).toBe(true)
+    })
+    
+    it("rejects min_severity > 4", () => {
+      const testConfig = {
+        lsp: {
+          typescript: {
+            min_severity: 5
+          }
+        }
+      }
+      
+      const result = Config.Info.safeParse(testConfig)
+      expect(result.success).toBe(false)
+    })
+    
+    it("rejects min_severity < 1", () => {
+      const testConfig = {
+        lsp: {
+          typescript: {
+            min_severity: 0
+          }
+        }
+      }
+      
+      const result = Config.Info.safeParse(testConfig)
+      expect(result.success).toBe(false)
+    })
+    
+    it("accepts non-integer min_severity as invalid", () => {
+      const testConfig = {
+        lsp: {
+          typescript: {
+            min_severity: 1.5
+          }
+        }
+      }
+      
+      const result = Config.Info.safeParse(testConfig)
+      expect(result.success).toBe(false)
+    })
+  })
+  
+  describe("LSP.Diagnostic.filter", () => {
+    const diagnostics = [
+      { severity: 1, message: "Error", range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } } },
+      { severity: 2, message: "Warning", range: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } } },
+      { severity: 3, message: "Info", range: { start: { line: 2, character: 0 }, end: { line: 2, character: 0 } } },
+      { severity: 4, message: "Hint", range: { start: { line: 3, character: 0 }, end: { line: 3, character: 0 } } },
+    ] as any
+    
+    it("returns only errors when min=1", () => {
+      const filtered = LSP.Diagnostic.filter(diagnostics, 1)
+      expect(filtered.length).toBe(1)
+      expect(filtered[0].message).toBe("Error")
+    })
+    
+    it("returns errors and warnings when min=2", () => {
+      const filtered = LSP.Diagnostic.filter(diagnostics, 2)
+      expect(filtered.length).toBe(2)
+      expect(filtered.map(d => d.message)).toEqual(["Error", "Warning"])
+    })
+    
+    it("returns errors, warnings, and info when min=3", () => {
+      const filtered = LSP.Diagnostic.filter(diagnostics, 3)
+      expect(filtered.length).toBe(3)
+    })
+    
+    it("returns all diagnostics when min=4", () => {
+      const filtered = LSP.Diagnostic.filter(diagnostics, 4)
+      expect(filtered.length).toBe(4)
+    })
+    
+    it("handles diagnostics without severity (defaults to 1)", () => {
+      const noSeverity = [
+        { message: "No severity", range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } } },
+      ] as any
+      
+      const filtered = LSP.Diagnostic.filter(noSeverity, 1)
+      expect(filtered.length).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #17869

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `min_severity` config option per-LSP server to control the minimum diagnostic severity level shown to the AI agent.

Currently, only Error (severity 1) diagnostics are displayed. Many LSP servers report style violations and linting issues as Warnings (severity 2), which are filtered out. This prevents the AI from seeing and fixing these issues.

With this change, users can configure each LSP to show warnings (or info/hints) by adding `min_severity` to their LSP config:

```json
{
  "lsp": {
    "markdownlint": {
      "command": ["markdownlint-lsp"],
      "extensions": [".md"],
      "min_severity": 2
    }
  }
}
```

Severity levels: 1=Error (default), 2=Warning, 3=Info, 4=Hint.

**Disclaimer:** I would like to contribute this feature, as it's something I would really like to have! This MR was created only using AI. I'm not a TypeScript developer, so please be gentle on me :)

### How did you verify your code works?

- Typecheck passes (`bun typecheck`)
- All existing tests pass (1332 pass, 1 unrelated flaky test failure)
- Added new test file `test/lsp/min-severity.test.ts` with 10 tests covering:
  - Config schema accepts `min_severity` per-LSP
  - Config schema validates range (1-4, integers only)
  - `LSP.Diagnostic.filter()` correctly filters by severity level
- Locally built opencode and integrated markdownlint-lsp server with the new option `min_severity` set to 4. Afterwards ask opencode to remove empty lines after headings and show the LSP output with severity. Here's a screenshot of the output, which verifies, that the warning for no empty line around headings (MD022) is actually reported as warning and visible to opencode:
    - to reproduce you have to disable formatter for opencode in your opencode.json, because the formatter automatically adds the newline again... `("formatter": false)`
<img width="1422" height="342" alt="image" src="https://github.com/user-attachments/assets/fe8d31b5-f4ae-4ba6-aaee-3dc720a67f56" />


### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR