### PR TITLE
fix(agent): honor model:inherit in subagent frontmatter

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -217,7 +217,7 @@ export namespace Agent {
           options: {},
           native: false,
         }
-      if (value.model) item.model = Provider.parseModel(value.model)
+      if (value.model && value.model !== "inherit") item.model = Provider.parseModel(value.model)
       item.variant = value.variant ?? item.variant
       item.prompt = value.prompt ?? item.prompt
       item.description = value.description ?? item.description


### PR DESCRIPTION
### Issue for this PR

Closes #17890.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Agents with `model: inherit` had "inherit" passed to Provider.parseModel(), producing { providerID: "inherit", modelID: "" }. The non-null result caused task.ts to skip its ?? fallback to the parent session's model, resulting in a ProviderModelNotFoundError on every subagent invocation.

Fix: skip parseModel when model value is "inherit", leaving item.model undefined so the parent model is inherited as intended.
Tested with get-shit-done global install (~/.config/opencode/agents/).

### How did you verify your code works?

Tested with get-shit-done global install (~/.config/opencode/agents/).

### Screenshots / recordings

<img width="926" height="672" alt="image" src="https://github.com/user-attachments/assets/985ce2e5-ab47-4f80-86b2-f61e61379b01" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
