### PR TITLE
fix(opencode): allow copying auth URL during OAuth connect flow

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -119,6 +119,11 @@ function AutoMethod(props: AutoMethodProps) {
         .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
         .catch(toast.error)
     }
+    if (evt.name === "u" && !evt.ctrl && !evt.meta) {
+      Clipboard.copy(props.authorization.url)
+        .then(() => toast.show({ message: "URL copied to clipboard", variant: "info" }))
+        .catch(toast.error)
+    }
   })
 
   onMount(async () => {
@@ -151,7 +156,8 @@ function AutoMethod(props: AutoMethodProps) {
       </box>
       <text fg={theme.textMuted}>Waiting for authorization...</text>
       <text fg={theme.text}>
-        c <span style={{ fg: theme.textMuted }}>copy</span>
+        c <span style={{ fg: theme.textMuted }}>copy code</span>{"  "}
+        u <span style={{ fg: theme.textMuted }}>copy url</span>
       </text>
     </box>
   )
@@ -168,7 +174,16 @@ function CodeMethod(props: CodeMethodProps) {
   const sdk = useSDK()
   const sync = useSync()
   const dialog = useDialog()
+  const toast = useToast()
   const [error, setError] = createSignal(false)
+
+  useKeyboard((evt) => {
+    if (evt.name === "u" && !evt.ctrl && !evt.meta) {
+      Clipboard.copy(props.authorization.url)
+        .then(() => toast.show({ message: "URL copied to clipboard", variant: "info" }))
+        .catch(toast.error)
+    }
+  })
 
   return (
     <DialogPrompt
@@ -195,6 +210,9 @@ function CodeMethod(props: CodeMethodProps) {
           <Show when={error()}>
             <text fg={theme.error}>Invalid code</text>
           </Show>
+          <text fg={theme.text}>
+            u <span style={{ fg: theme.textMuted }}>copy url</span>
+          </text>
         </box>
       )}
     />

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -11,15 +11,26 @@ export interface LinkProps {
 /**
  * Link component that renders clickable hyperlinks.
  * Clicking anywhere on the link text opens the URL in the default browser.
+ * A click-and-drag (text selection) is not treated as a click and does not open the browser.
  */
 export function Link(props: LinkProps) {
   const displayText = props.children ?? props.href
+  let mouseDownX = -1
+  let mouseDownY = -1
 
   return (
     <text
       fg={props.fg}
-      onMouseUp={() => {
-        open(props.href).catch(() => {})
+      onMouseDown={(evt) => {
+        mouseDownX = evt.x
+        mouseDownY = evt.y
+      }}
+      onMouseUp={(evt) => {
+        if (evt.x === mouseDownX && evt.y === mouseDownY) {
+          open(props.href).catch(() => {})
+        }
+        mouseDownX = -1
+        mouseDownY = -1
       }}
     >
       {displayText}


### PR DESCRIPTION
The Link component's onMouseUp handler opened the browser on every mouse-up, preventing drag-to-select for copying the URL text. Track mouseDown position and only open the browser when the mouse has not moved (a true click, not a selection drag).

Add a dedicated `u` keyboard shortcut to copy the URL to clipboard in both AutoMethod and CodeMethod dialogs so users in headless/remote environments (e.g. GCP Cloud Shell) have a reliable way to get the URL.


### Issue for this PR

https://github.com/anomalyco/opencode/issues/17887

Closes [#17887](https://github.com/anomalyco/opencode/issues/17887)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes:  https://github.com/anomalyco/opencode/issues/17887

When using /connect with Anthropic OAuth, the authorization URL cannot be copied:

  • The Link component fires open() on every mouseUp, so drag-to-select opens the browser instead of letting you select the text.
  • In headless/remote environments (e.g. GCP Cloud Shell), OSC 52 and system clipboard tools (xclip, etc.) are unavailable, so the
  shortcut silently fails with no way to get the URL.

What changed:

  • link.tsx: Track mouse-down position and only open the browser when the mouse hasn't moved (true click). Drag-to-select now works
  as expected.
  • dialog-provider.tsx: Added a u keyboard shortcut to explicitly copy the URL in both AutoMethod and CodeMethod dialogs. Updated
  hint text to show both c (copy code) and u (copy url).

Verified by: Testing drag-select on the URL text and pressing u to copy the URL in both OAuth dialog variants.
**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tested on Cloud Shell

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

Checklist

  • [x] I have tested my changes locally
  • [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
