### PR TITLE
test(app): deflake composer dock question flows

### DIFF
--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -1,4 +1,5 @@
 import type { Page, Route } from "@playwright/test"
+import type { Event as AppEvent, Session as SessionInfo } from "@opencode-ai/sdk/v2/client"
 import { test, expect } from "../fixtures"
 import {
   composerEvent,
@@ -6,7 +7,7 @@ import {
   type ComposerProbeState,
   type ComposerWindow,
 } from "../../src/testing/session-composer"
-import { cleanupSession, withSession } from "../actions"
+import { cleanupSession } from "../actions"
 import {
   permissionDockSelector,
   promptSelector,
@@ -15,9 +16,39 @@ import {
   sessionTodoToggleButtonSelector,
 } from "../selectors"
 
-type Sdk = Parameters<typeof withSession>[0]
-type Child = { id: string }
+const e2eEvent = "opencode:e2e:global-event"
+
+type Sdk = NonNullable<Parameters<typeof cleanupSession>[0]["sdk"]>
+type Child = SessionInfo
 type PermissionRule = { permission: string; pattern: string; action: "allow" | "deny" | "ask" }
+
+async function enableEvents(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as ComposerWindow & {
+      __opencode_e2e?: {
+        event?: {
+          enabled?: boolean
+        }
+      }
+    }
+    win.__opencode_e2e = {
+      ...win.__opencode_e2e,
+      event: {
+        ...win.__opencode_e2e?.event,
+        enabled: true,
+      },
+    }
+  })
+}
+
+async function emitEvent(page: Page, directory: string, payload: AppEvent) {
+  await page.evaluate(
+    (input) => {
+      window.dispatchEvent(new CustomEvent(input.name, { detail: input.detail }))
+    },
+    { name: e2eEvent, detail: { directory, payload } },
+  )
+}
 
 async function withDockSession<T>(
   sdk: Sdk,
@@ -169,6 +200,7 @@ async function todoDock(page: Page, sessionID: string) {
 
 async function withMockPermission<T>(
   page: Page,
+  directory: string,
   request: {
     id: string
     sessionID: string
@@ -178,7 +210,7 @@ async function withMockPermission<T>(
     always?: string[]
   },
   opts: { child?: Child } | undefined,
-  fn: (state: { resolved: () => Promise<void> }) => Promise<T>,
+  fn: (state: { ask: () => Promise<void>; resolved: () => Promise<void> }) => Promise<T>,
 ) {
   let pending = [
     {
@@ -199,7 +231,14 @@ async function withMockPermission<T>(
   const reply = async (route: Route) => {
     const url = new URL(route.request().url())
     const id = url.pathname.split("/").pop()
+    const item = pending.find((entry) => entry.id === id)
     pending = pending.filter((item) => item.id !== id)
+    if (item) {
+      await emitEvent(page, directory, {
+        type: "permission.replied",
+        properties: { sessionID: item.sessionID, requestID: item.id },
+      })
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -210,24 +249,19 @@ async function withMockPermission<T>(
   await page.route("**/permission", list)
   await page.route("**/session/*/permissions/*", reply)
 
-  const sessionList = opts?.child
-    ? async (route: Route) => {
-        const res = await route.fetch()
-        const json = await res.json()
-        const list = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : undefined
-        if (Array.isArray(list) && !list.some((item) => item?.id === opts.child?.id)) list.push(opts.child)
-        await route.fulfill({
-          status: res.status(),
-          headers: res.headers(),
-          contentType: "application/json",
-          body: JSON.stringify(json),
+  const state = {
+    async ask() {
+      if (opts?.child) {
+        await emitEvent(page, directory, {
+          type: "session.created",
+          properties: { info: opts.child },
         })
       }
-    : undefined
-
-  if (sessionList) await page.route("**/session?*", sessionList)
-
-  const state = {
+      await emitEvent(page, directory, {
+        type: "permission.asked",
+        properties: pending[0],
+      })
+    },
     async resolved() {
       await expect.poll(() => pending.length, { timeout: 10_000 }).toBe(0)
     },
@@ -238,12 +272,12 @@ async function withMockPermission<T>(
   } finally {
     await page.unroute("**/permission", list)
     await page.unroute("**/session/*/permissions/*", reply)
-    if (sessionList) await page.unroute("**/session?*", sessionList)
   }
 }
 
 async function withMockQuestion<T>(
   page: Page,
+  directory: string,
   request: {
     id: string
     sessionID: string
@@ -255,7 +289,7 @@ async function withMockQuestion<T>(
     }>
   },
   opts: { child?: Child } | undefined,
-  fn: (state: { resolved: () => Promise<void> }) => Promise<T>,
+  fn: (state: { ask: () => Promise<void>; resolved: () => Promise<void> }) => Promise<T>,
 ) {
   let pending = [request]
 
@@ -270,7 +304,14 @@ async function withMockQuestion<T>(
   const reply = async (route: Route) => {
     const url = new URL(route.request().url())
     const id = url.pathname.split("/").at(-2)
-    pending = pending.filter((item) => item.id !== id)
+    const item = pending.find((entry) => entry.id === id)
+    pending = pending.filter((entry) => entry.id !== id)
+    if (item) {
+      await emitEvent(page, directory, {
+        type: url.pathname.endsWith("/reject") ? "question.rejected" : "question.replied",
+        properties: { sessionID: item.sessionID, requestID: item.id },
+      })
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -282,24 +323,19 @@ async function withMockQuestion<T>(
   await page.route("**/question/*/reply", reply)
   await page.route("**/question/*/reject", reply)
 
-  const sessionList = opts?.child
-    ? async (route: Route) => {
-        const res = await route.fetch()
-        const json = await res.json()
-        const list = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : undefined
-        if (Array.isArray(list) && !list.some((item) => item?.id === opts.child?.id)) list.push(opts.child)
-        await route.fulfill({
-          status: res.status(),
-          headers: res.headers(),
-          contentType: "application/json",
-          body: JSON.stringify(json),
+  const state = {
+    async ask() {
+      if (opts?.child) {
+        await emitEvent(page, directory, {
+          type: "session.created",
+          properties: { info: opts.child },
         })
       }
-    : undefined
-
-  if (sessionList) await page.route("**/session?*", sessionList)
-
-  const state = {
+      await emitEvent(page, directory, {
+        type: "question.asked",
+        properties: pending[0],
+      })
+    },
     async resolved() {
       await expect.poll(() => pending.length, { timeout: 10_000 }).toBe(0)
     },
@@ -311,7 +347,6 @@ async function withMockQuestion<T>(
     await page.unroute("**/question", list)
     await page.unroute("**/question/*/reply", reply)
     await page.unroute("**/question/*/reject", reply)
-    if (sessionList) await page.unroute("**/session?*", sessionList)
   }
 }
 
@@ -342,9 +377,12 @@ test("auto-accept toggle works before first submit", async ({ page, gotoSession 
 
 test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock question", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await withMockQuestion(
       page,
+      directory,
       {
         id: "q_e2e_blocked",
         sessionID: session.id,
@@ -361,7 +399,7 @@ test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSess
       },
       undefined,
       async (state) => {
-        await page.goto(page.url())
+        await state.ask()
 
         const dock = page.locator(questionDockSelector)
         await expectQuestionBlocked(page)
@@ -369,7 +407,6 @@ test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSess
         await dock.locator('[data-slot="question-option"]').first().click()
         await dock.getByRole("button", { name: /submit/i }).click()
         await state.resolved()
-        await page.goto(page.url())
 
         await expectQuestionOpen(page)
       },
@@ -379,10 +416,13 @@ test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSess
 
 test("blocked permission flow supports allow once", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock permission once", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await setAutoAccept(page, false)
     await withMockPermission(
       page,
+      directory,
       {
         id: "per_e2e_once",
         sessionID: session.id,
@@ -392,12 +432,11 @@ test("blocked permission flow supports allow once", async ({ page, sdk, gotoSess
       },
       undefined,
       async (state) => {
-        await page.goto(page.url())
+        await state.ask()
         await expectPermissionBlocked(page)
 
         await clearPermissionDock(page, /allow once/i)
         await state.resolved()
-        await page.goto(page.url())
         await expectPermissionOpen(page)
       },
     )
@@ -406,10 +445,13 @@ test("blocked permission flow supports allow once", async ({ page, sdk, gotoSess
 
 test("blocked permission flow supports reject", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock permission reject", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await setAutoAccept(page, false)
     await withMockPermission(
       page,
+      directory,
       {
         id: "per_e2e_reject",
         sessionID: session.id,
@@ -418,12 +460,11 @@ test("blocked permission flow supports reject", async ({ page, sdk, gotoSession 
       },
       undefined,
       async (state) => {
-        await page.goto(page.url())
+        await state.ask()
         await expectPermissionBlocked(page)
 
         await clearPermissionDock(page, /deny/i)
         await state.resolved()
-        await page.goto(page.url())
         await expectPermissionOpen(page)
       },
     )
@@ -432,10 +473,13 @@ test("blocked permission flow supports reject", async ({ page, sdk, gotoSession 
 
 test("blocked permission flow supports allow always", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock permission always", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await setAutoAccept(page, false)
     await withMockPermission(
       page,
+      directory,
       {
         id: "per_e2e_always",
         sessionID: session.id,
@@ -445,12 +489,11 @@ test("blocked permission flow supports allow always", async ({ page, sdk, gotoSe
       },
       undefined,
       async (state) => {
-        await page.goto(page.url())
+        await state.ask()
         await expectPermissionBlocked(page)
 
         await clearPermissionDock(page, /allow always/i)
         await state.resolved()
-        await page.goto(page.url())
         await expectPermissionOpen(page)
       },
     )
@@ -463,6 +506,8 @@ test("child session question request blocks parent dock and unblocks after submi
   gotoSession,
 }) => {
   await withDockSession(sdk, "e2e composer dock child question parent", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
 
     const child = await sdk.session
@@ -476,6 +521,7 @@ test("child session question request blocks parent dock and unblocks after submi
     try {
       await withMockQuestion(
         page,
+        directory,
         {
           id: "q_e2e_child",
           sessionID: child.id,
@@ -492,7 +538,7 @@ test("child session question request blocks parent dock and unblocks after submi
         },
         { child },
         async (state) => {
-          await page.goto(page.url())
+          await state.ask()
 
           const dock = page.locator(questionDockSelector)
           await expectQuestionBlocked(page)
@@ -500,7 +546,6 @@ test("child session question request blocks parent dock and unblocks after submi
           await dock.locator('[data-slot="question-option"]').first().click()
           await dock.getByRole("button", { name: /submit/i }).click()
           await state.resolved()
-          await page.goto(page.url())
 
           await expectQuestionOpen(page)
         },
@@ -517,6 +562,8 @@ test("child session permission request blocks parent dock and supports allow onc
   gotoSession,
 }) => {
   await withDockSession(sdk, "e2e composer dock child permission parent", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await setAutoAccept(page, false)
 
@@ -531,6 +578,7 @@ test("child session permission request blocks parent dock and supports allow onc
     try {
       await withMockPermission(
         page,
+        directory,
         {
           id: "per_e2e_child",
           sessionID: child.id,
@@ -540,12 +588,11 @@ test("child session permission request blocks parent dock and supports allow onc
         },
         { child },
         async (state) => {
-          await page.goto(page.url())
+          await state.ask()
           await expectPermissionBlocked(page)
 
           await clearPermissionDock(page, /allow once/i)
           await state.resolved()
-          await page.goto(page.url())
 
           await expectPermissionOpen(page)
         },
@@ -588,9 +635,12 @@ test("todo dock transitions and collapse behavior", async ({ page, sdk, gotoSess
 
 test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock keyboard", async (session) => {
+    const directory = await sdk.path.get().then((x) => x.data?.directory ?? "")
+    await enableEvents(page)
     await gotoSession(session.id)
     await withMockQuestion(
       page,
+      directory,
       {
         id: "q_e2e_keyboard",
         sessionID: session.id,
@@ -603,8 +653,8 @@ test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSe
         ],
       },
       undefined,
-      async () => {
-        await page.goto(page.url())
+      async (state) => {
+        await state.ask()
         await expectQuestionBlocked(page)
 
         await page.locator("main").click({ position: { x: 5, y: 5 } })

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -1,3 +1,4 @@
+import type { Page, Route } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import {
   composerEvent,
@@ -5,7 +6,7 @@ import {
   type ComposerProbeState,
   type ComposerWindow,
 } from "../../src/testing/session-composer"
-import { cleanupSession, clearSessionDockSeed, seedSessionQuestion } from "../actions"
+import { cleanupSession, withSession } from "../actions"
 import {
   permissionDockSelector,
   promptSelector,
@@ -14,7 +15,8 @@ import {
   sessionTodoToggleButtonSelector,
 } from "../selectors"
 
-type Sdk = Parameters<typeof clearSessionDockSeed>[0]
+type Sdk = Parameters<typeof withSession>[0]
+type Child = { id: string }
 type PermissionRule = { permission: string; pattern: string; action: "allow" | "deny" | "ask" }
 
 async function withDockSession<T>(
@@ -36,21 +38,13 @@ async function withDockSession<T>(
 
 test.setTimeout(120_000)
 
-async function withDockSeed<T>(sdk: Sdk, sessionID: string, fn: () => Promise<T>) {
-  try {
-    return await fn()
-  } finally {
-    await clearSessionDockSeed(sdk, sessionID).catch(() => undefined)
-  }
-}
-
-async function clearPermissionDock(page: any, label: RegExp) {
+async function clearPermissionDock(page: Page, label: RegExp) {
   const dock = page.locator(permissionDockSelector)
   await expect(dock).toBeVisible()
   await dock.getByRole("button", { name: label }).click()
 }
 
-async function setAutoAccept(page: any, enabled: boolean) {
+async function setAutoAccept(page: Page, enabled: boolean) {
   const button = page.locator('[data-action="prompt-permissions"]').first()
   await expect(button).toBeVisible()
   const pressed = (await button.getAttribute("aria-pressed")) === "true"
@@ -59,27 +53,27 @@ async function setAutoAccept(page: any, enabled: boolean) {
   await expect(button).toHaveAttribute("aria-pressed", enabled ? "true" : "false")
 }
 
-async function expectQuestionBlocked(page: any) {
+async function expectQuestionBlocked(page: Page) {
   await expect(page.locator(questionDockSelector)).toBeVisible()
   await expect(page.locator(promptSelector)).toHaveCount(0)
 }
 
-async function expectQuestionOpen(page: any) {
+async function expectQuestionOpen(page: Page) {
   await expect(page.locator(questionDockSelector)).toHaveCount(0)
   await expect(page.locator(promptSelector)).toBeVisible()
 }
 
-async function expectPermissionBlocked(page: any) {
+async function expectPermissionBlocked(page: Page) {
   await expect(page.locator(permissionDockSelector)).toBeVisible()
   await expect(page.locator(promptSelector)).toHaveCount(0)
 }
 
-async function expectPermissionOpen(page: any) {
+async function expectPermissionOpen(page: Page) {
   await expect(page.locator(permissionDockSelector)).toHaveCount(0)
   await expect(page.locator(promptSelector)).toBeVisible()
 }
 
-async function todoDock(page: any, sessionID: string) {
+async function todoDock(page: Page, sessionID: string) {
   await page.addInitScript(() => {
     const win = window as ComposerWindow
     win.__opencode_e2e = {
@@ -174,7 +168,7 @@ async function todoDock(page: any, sessionID: string) {
 }
 
 async function withMockPermission<T>(
-  page: any,
+  page: Page,
   request: {
     id: string
     sessionID: string
@@ -183,7 +177,7 @@ async function withMockPermission<T>(
     metadata?: Record<string, unknown>
     always?: string[]
   },
-  opts: { child?: any } | undefined,
+  opts: { child?: Child } | undefined,
   fn: (state: { resolved: () => Promise<void> }) => Promise<T>,
 ) {
   let pending = [
@@ -194,7 +188,7 @@ async function withMockPermission<T>(
     },
   ]
 
-  const list = async (route: any) => {
+  const list = async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -202,7 +196,7 @@ async function withMockPermission<T>(
     })
   }
 
-  const reply = async (route: any) => {
+  const reply = async (route: Route) => {
     const url = new URL(route.request().url())
     const id = url.pathname.split("/").pop()
     pending = pending.filter((item) => item.id !== id)
@@ -217,7 +211,7 @@ async function withMockPermission<T>(
   await page.route("**/session/*/permissions/*", reply)
 
   const sessionList = opts?.child
-    ? async (route: any) => {
+    ? async (route: Route) => {
         const res = await route.fetch()
         const json = await res.json()
         const list = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : undefined
@@ -244,6 +238,79 @@ async function withMockPermission<T>(
   } finally {
     await page.unroute("**/permission", list)
     await page.unroute("**/session/*/permissions/*", reply)
+    if (sessionList) await page.unroute("**/session?*", sessionList)
+  }
+}
+
+async function withMockQuestion<T>(
+  page: Page,
+  request: {
+    id: string
+    sessionID: string
+    questions: Array<{
+      header: string
+      question: string
+      options: Array<{ label: string; description: string }>
+      multiple?: boolean
+    }>
+  },
+  opts: { child?: Child } | undefined,
+  fn: (state: { resolved: () => Promise<void> }) => Promise<T>,
+) {
+  let pending = [request]
+
+  const list = async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(pending),
+    })
+  }
+
+  const reply = async (route: Route) => {
+    const url = new URL(route.request().url())
+    const id = url.pathname.split("/").at(-2)
+    pending = pending.filter((item) => item.id !== id)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(true),
+    })
+  }
+
+  await page.route("**/question", list)
+  await page.route("**/question/*/reply", reply)
+  await page.route("**/question/*/reject", reply)
+
+  const sessionList = opts?.child
+    ? async (route: Route) => {
+        const res = await route.fetch()
+        const json = await res.json()
+        const list = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : undefined
+        if (Array.isArray(list) && !list.some((item) => item?.id === opts.child?.id)) list.push(opts.child)
+        await route.fulfill({
+          status: res.status(),
+          headers: res.headers(),
+          contentType: "application/json",
+          body: JSON.stringify(json),
+        })
+      }
+    : undefined
+
+  if (sessionList) await page.route("**/session?*", sessionList)
+
+  const state = {
+    async resolved() {
+      await expect.poll(() => pending.length, { timeout: 10_000 }).toBe(0)
+    },
+  }
+
+  try {
+    return await fn(state)
+  } finally {
+    await page.unroute("**/question", list)
+    await page.unroute("**/question/*/reply", reply)
+    await page.unroute("**/question/*/reject", reply)
     if (sessionList) await page.unroute("**/session?*", sessionList)
   }
 }
@@ -275,10 +342,11 @@ test("auto-accept toggle works before first submit", async ({ page, gotoSession 
 
 test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock question", async (session) => {
-    await withDockSeed(sdk, session.id, async () => {
-      await gotoSession(session.id)
-
-      await seedSessionQuestion(sdk, {
+    await gotoSession(session.id)
+    await withMockQuestion(
+      page,
+      {
+        id: "q_e2e_blocked",
         sessionID: session.id,
         questions: [
           {
@@ -290,16 +358,22 @@ test("blocked question flow unblocks after submit", async ({ page, sdk, gotoSess
             ],
           },
         ],
-      })
+      },
+      undefined,
+      async (state) => {
+        await page.goto(page.url())
 
-      const dock = page.locator(questionDockSelector)
-      await expectQuestionBlocked(page)
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
 
-      await dock.locator('[data-slot="question-option"]').first().click()
-      await dock.getByRole("button", { name: /submit/i }).click()
+        await dock.locator('[data-slot="question-option"]').first().click()
+        await dock.getByRole("button", { name: /submit/i }).click()
+        await state.resolved()
+        await page.goto(page.url())
 
-      await expectQuestionOpen(page)
-    })
+        await expectQuestionOpen(page)
+      },
+    )
   })
 })
 
@@ -400,8 +474,10 @@ test("child session question request blocks parent dock and unblocks after submi
     if (!child?.id) throw new Error("Child session create did not return an id")
 
     try {
-      await withDockSeed(sdk, child.id, async () => {
-        await seedSessionQuestion(sdk, {
+      await withMockQuestion(
+        page,
+        {
+          id: "q_e2e_child",
           sessionID: child.id,
           questions: [
             {
@@ -413,16 +489,22 @@ test("child session question request blocks parent dock and unblocks after submi
               ],
             },
           ],
-        })
+        },
+        { child },
+        async (state) => {
+          await page.goto(page.url())
 
-        const dock = page.locator(questionDockSelector)
-        await expectQuestionBlocked(page)
+          const dock = page.locator(questionDockSelector)
+          await expectQuestionBlocked(page)
 
-        await dock.locator('[data-slot="question-option"]').first().click()
-        await dock.getByRole("button", { name: /submit/i }).click()
+          await dock.locator('[data-slot="question-option"]').first().click()
+          await dock.getByRole("button", { name: /submit/i }).click()
+          await state.resolved()
+          await page.goto(page.url())
 
-        await expectQuestionOpen(page)
-      })
+          await expectQuestionOpen(page)
+        },
+      )
     } finally {
       await cleanupSession({ sdk, sessionID: child.id })
     }
@@ -506,10 +588,11 @@ test("todo dock transitions and collapse behavior", async ({ page, sdk, gotoSess
 
 test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSession }) => {
   await withDockSession(sdk, "e2e composer dock keyboard", async (session) => {
-    await withDockSeed(sdk, session.id, async () => {
-      await gotoSession(session.id)
-
-      await seedSessionQuestion(sdk, {
+    await gotoSession(session.id)
+    await withMockQuestion(
+      page,
+      {
+        id: "q_e2e_keyboard",
         sessionID: session.id,
         questions: [
           {
@@ -518,13 +601,16 @@ test("keyboard focus stays off prompt while blocked", async ({ page, sdk, gotoSe
             options: [{ label: "Continue", description: "Continue now" }],
           },
         ],
-      })
+      },
+      undefined,
+      async () => {
+        await page.goto(page.url())
+        await expectQuestionBlocked(page)
 
-      await expectQuestionBlocked(page)
-
-      await page.locator("main").click({ position: { x: 5, y: 5 } })
-      await page.keyboard.type("abc")
-      await expect(page.locator(promptSelector)).toHaveCount(0)
-    })
+        await page.locator("main").click({ position: { x: 5, y: 5 } })
+        await page.keyboard.type("abc")
+        await expect(page.locator(promptSelector)).toHaveCount(0)
+      },
+    )
   })
 })

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -12,6 +12,8 @@ const abortError = z.object({
   name: z.literal("AbortError"),
 })
 
+const e2eEvent = "opencode:e2e:global-event"
+
 export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleContext({
   name: "GlobalSDK",
   init: () => {
@@ -200,9 +202,28 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       document.addEventListener("visibilitychange", onVisibility)
     }
 
+    const onE2E = (evt: globalThis.Event) => {
+      if (!(evt instanceof CustomEvent)) return
+      const detail = evt.detail as { directory?: string; payload?: Event } | undefined
+      if (!detail?.directory || !detail.payload) return
+      const dir = detail.directory
+      const payload = detail.payload
+      batch(() => {
+        emitter.emit(dir, payload)
+      })
+    }
+    if (typeof window !== "undefined") {
+      const e2e = (window as Window & { __opencode_e2e?: { event?: { enabled?: boolean } } }).__opencode_e2e
+      if (e2e?.event?.enabled) window.addEventListener(e2eEvent, onE2E)
+    }
+
     onCleanup(() => {
       if (typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", onVisibility)
+      }
+      if (typeof window !== "undefined") {
+        const e2e = (window as Window & { __opencode_e2e?: { event?: { enabled?: boolean } } }).__opencode_e2e
+        if (e2e?.event?.enabled) window.removeEventListener(e2eEvent, onE2E)
       }
       abort.abort()
       flush()


### PR DESCRIPTION
## Summary
- replace model-driven question setup in `session-composer-dock.spec.ts` with deterministic request mocks so the affected dock tests no longer depend on real inference
- drive those mocked requests through the app's live global event path, so the tests still cover in-session block/unblock behavior instead of refresh-only bootstrap behavior
- use the same live event pattern for the related permission dock mocks in the same spec to keep the request-flow coverage consistent

## Validation
- bun typecheck
- bun test:e2e:local -- e2e/session/session-composer-dock.spec.ts --repeat-each 4 --workers 1
- bun test:e2e:local -- e2e/session/session-composer-dock.spec.ts -g \"(blocked question flow unblocks after submit|child session question request blocks parent dock and unblocks after submit|keyboard focus stays off prompt while blocked)\" --repeat-each 8 --workers 1
- bun test:e2e:local -- e2e/session/session-composer-dock.spec.ts -g \"(blocked question flow unblocks after submit|child session question request blocks parent dock and unblocks after submit|keyboard focus stays off prompt while blocked)\" --repeat-each 8 --workers 3