### PR TITLE
fix(opencode): Prevent unwanted character insertion when switching input method

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -852,6 +852,18 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                // Filter out IME (Input Method Editor) switching keys to prevent unwanted character insertion
+                // When switching input methods on Mac (e.g., pressing Caps Lock or using Cmd+Space),
+                // terminals like Kitty send special key events with:
+                // - empty name and sequence fields
+                // - raw escape sequences (e.g., "\u001b[57358u" for key code 0xE00E)
+                // - no modifier keys pressed
+                // These should not insert any visible characters into the input
+                const disabledWhenChangeIME = e.source ==='kitty' && e.name === ""
+                if(disabledWhenChangeIME) {
+                  e.preventDefault()
+                  return
+                }
                 // Handle clipboard paste (Ctrl+V) - check for images first on Windows
                 // This is needed because Windows terminal doesn't properly send image data
                 // through bracketed paste, so we need to intercept the keypress and


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/18026

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes an issue on macOS where switching input methods (e.g., via Caps Lock) inserts an unrendered special character into the prompt input field.

**Root Cause:**
In terminals that support enhanced keyboard protocols (such as the VS Code integrated terminal using the Kitty protocol), switching the IME triggers a specific key event. This event carries the raw sequence `\u001b[57358u` and the name ``, which the input component was previously capturing as a valid character input.
```json
{
  "name": "",
  "sequence": "",
  "raw": "\u001b[57358u",
  "eventType": "press",
  "source": "kitty",
  "ctrl": false,
  "meta": false,
  "shift": false,
  "option": false
}
```
**Changes:**
I added a filter in the `onKeyDown` handler to intercept and prevent the default behavior for this specific IME switching event. 

```typescript
const disabledWhenChangeIME = e.source ==='kitty' && e.name === ""
if(disabledWhenChangeIME) {
  e.preventDefault()
  return
}
```

### How did you verify your code works?

I rebuilt the project from source and verified the fix locally in the VS Code terminal on macOS. Switching input methods no longer results in unexpected characters appearing in the prompt.

### Screenshots / recordings
#### before fix:
![iShot_2026-03-17_19 36 53](https://github.com/user-attachments/assets/77017dda-ab85-42f7-bf39-aa18f8c8ca72)
#### after fix:
![iShot_2026-03-17_19 55 58](https://github.com/user-attachments/assets/0ec5583c-eebe-4a60-9657-470bb02fc257)


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

