### PR TITLE
fix: handle assistant messages with clock skew in session-turn

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -268,6 +268,15 @@ export function SessionTurn(
       if (index < 0) return emptyAssistant
 
       const result: AssistantMessage[] = []
+      // Scan backwards for assistant messages that may sort before the user
+      // message due to client/server clock skew (client-generated user message
+      // IDs can have a higher timestamp than server-generated assistant IDs)
+      for (let i = index - 1; i >= 0; i--) {
+        const item = messages[i]
+        if (!item) continue
+        if (item.role === "user") break
+        if (item.role === "assistant" && item.parentID === msg.id) result.unshift(item as AssistantMessage)
+      }
       for (let i = index + 1; i < messages.length; i++) {
         const item = messages[i]
         if (!item) continue


### PR DESCRIPTION
Scan backwards from user message index to find assistant messages that may sort before the user message due to client/server clock skew (client-generated user message IDs can have a higher timestamp than server-generated assistant IDs).

### Issue for this PR

Closes #17255

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Scan backwards from user message index to find assistant messages that may sort before the user message due to client/server clock skew (client-generated user message IDs can have a higher timestamp than server-generated assistant IDs).

### How did you verify your code works?

I have tested my changes locally

### Screenshots / recordings

Logic-only change, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
 
