### PR TITLE
fix(cli): propagate signal exits from wrapper

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -13,8 +13,20 @@ function run(target) {
     console.error(result.error.message)
     process.exit(1)
   }
-  const code = typeof result.status === "number" ? result.status : 0
-  process.exit(code)
+  if (result.signal) {
+    try {
+      process.kill(process.pid, result.signal)
+      return
+    } catch {
+      process.exit(1)
+    }
+  }
+
+  if (typeof result.status !== "number") {
+    process.exit(1)
+  }
+
+  process.exit(result.status)
 }
 
 const envPath = process.env.OPENCODE_BIN_PATH


### PR DESCRIPTION
### Issue for this PR

Closes #17978

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the `packages/opencode/bin/opencode` wrapper so signal-based child termination is not reported as exit code `0`.

Today the wrapper treats `spawnSync(...).status === null` as success, even though that can mean the wrapped child died from a signal. This change preserves the signal path and falls back to `1` if there is no numeric exit status.

### How did you verify your code works?

Ran a local reproduction where the wrapped child terminates with `SIGTERM` and verified the wrapper exits via signal instead of reporting a clean `0`.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR