### PR TITLE
Fix SSE relay backlog during delta storms

### DIFF
--- a/packages/opencode/src/bus/index.ts
+++ b/packages/opencode/src/bus/index.ts
@@ -46,9 +46,15 @@ export namespace Bus {
       type: def.type,
       properties,
     }
-    log.info("publishing", {
-      type: def.type,
-    })
+    if (def.type === "message.part.delta") {
+      log.debug("publishing", {
+        type: def.type,
+      })
+    } else {
+      log.info("publishing", {
+        type: def.type,
+      })
+    }
     const pending = []
     for (const key of [def.type, "*"]) {
       const match = state().subscriptions.get(key)

--- a/packages/opencode/src/control-plane/workspace-server/routes.ts
+++ b/packages/opencode/src/control-plane/workspace-server/routes.ts
@@ -1,19 +1,32 @@
 import { GlobalBus } from "../../bus/global"
 import { Hono } from "hono"
 import { streamSSE } from "hono/streaming"
+import { Relay } from "../../server/relay"
+
+type Event = { type: string; properties: Record<string, unknown> }
+type Item = { directory?: string; payload: Event }
 
 export function WorkspaceServerRoutes() {
   return new Hono().get("/event", async (c) => {
     c.header("X-Accel-Buffering", "no")
     c.header("X-Content-Type-Options", "nosniff")
     return streamSSE(c, async (stream) => {
-      const send = async (event: unknown) => {
+      const relay = Relay.create({
+        event: (item: Item) => item.payload,
+        scope: (item: Item) => item.directory ?? "global",
+        write: async (item: Item) => {
+          await stream.writeSSE({
+            data: JSON.stringify(item.payload),
+          })
+        },
+      })
+      const send = async (event: Event) => {
         await stream.writeSSE({
           data: JSON.stringify(event),
         })
       }
-      const handler = async (event: { directory?: string; payload: unknown }) => {
-        await send(event.payload)
+      const handler = (event: Item) => {
+        relay.push(event)
       }
       GlobalBus.on("event", handler)
       await send({ type: "server.connected", properties: {} })
@@ -24,6 +37,7 @@ export function WorkspaceServerRoutes() {
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
           clearInterval(heartbeat)
+          relay.stop()
           GlobalBus.off("event", handler)
           resolve()
         })

--- a/packages/opencode/src/server/relay.ts
+++ b/packages/opencode/src/server/relay.ts
@@ -1,0 +1,143 @@
+type Event = {
+  type: string
+  properties: Record<string, unknown>
+}
+
+export namespace Relay {
+  type Input<T> = {
+    event: (item: T) => Event
+    write: (item: T) => Promise<void>
+    scope?: (item: T) => string
+  }
+
+  const delta = (scope: string, event: Event) => {
+    if (event.type !== "message.part.delta") return
+    const props = event.properties as {
+      messageID: string
+      partID: string
+    }
+    return `${scope}:${props.messageID}:${props.partID}`
+  }
+
+  const part = (scope: string, event: Event) => {
+    if (event.type !== "message.part.updated") return
+    const next = event.properties.part as {
+      messageID: string
+      id: string
+    }
+    return `${scope}:${next.messageID}:${next.id}`
+  }
+
+  const key = (scope: string, event: Event) => {
+    if (event.type === "session.status") {
+      const props = event.properties as {
+        sessionID: string
+      }
+      return `session.status:${scope}:${props.sessionID}`
+    }
+    if (event.type === "lsp.updated") {
+      return `lsp.updated:${scope}`
+    }
+    if (event.type === "message.part.updated") {
+      const next = event.properties.part as {
+        messageID: string
+        id: string
+      }
+      return `message.part.updated:${scope}:${next.messageID}:${next.id}`
+    }
+    if (event.type === "message.part.delta") {
+      const props = event.properties as {
+        messageID: string
+        partID: string
+        field: string
+      }
+      return `message.part.delta:${scope}:${props.messageID}:${props.partID}:${props.field}`
+    }
+  }
+
+  export function create<T>(input: Input<T>) {
+    let queue: T[] = []
+    let pool: T[] = []
+    let active = false
+    let closed = false
+    const coalesced = new Map<string, number>()
+    const stale = new Set<string>()
+
+    const scope = (item: T) => input.scope?.(item) ?? ""
+
+    const flush = async () => {
+      if (active) return
+      active = true
+      try {
+        while (queue.length > 0) {
+          const items = queue
+          const skip = stale.size > 0 ? new Set(stale) : undefined
+          queue = pool
+          pool = items
+          queue.length = 0
+          coalesced.clear()
+          stale.clear()
+
+          for (const item of items) {
+            if (closed) break
+            const event = input.event(item)
+            const part = delta(scope(item), event)
+            if (part && skip?.has(part)) continue
+            await input.write(item)
+          }
+
+          pool.length = 0
+        }
+      } finally {
+        active = false
+      }
+    }
+
+    return {
+      push(item: T) {
+        if (closed) return
+        const event = input.event(item)
+        const root = scope(item)
+        const itemPart = delta(root, event)
+        if (itemPart && stale.has(itemPart)) return
+
+        const id = key(root, event)
+        if (id) {
+          const index = coalesced.get(id)
+          if (index !== undefined) {
+            if (event.type === "message.part.delta") {
+              const prev = input.event(queue[index])
+              if (prev.type === "message.part.delta") {
+                const prevProps = prev.properties as {
+                  delta: string
+                }
+                const nextProps = event.properties as {
+                  delta: string
+                }
+                prevProps.delta += nextProps.delta
+                return
+              }
+            }
+            const nextPart = part(root, event)
+            if (nextPart) {
+              stale.add(nextPart)
+            }
+            queue[index] = item
+            return
+          }
+          coalesced.set(id, queue.length)
+        }
+
+        queue.push(item)
+        void flush()
+      },
+      stop() {
+        closed = true
+        queue.length = 0
+        pool.length = 0
+        coalesced.clear()
+        stale.clear()
+      },
+    }
+  }
+}

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -10,8 +10,11 @@ import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
+import { Relay } from "../relay"
 
 const log = Log.create({ service: "server" })
+type Event = { type: string; properties: Record<string, unknown> }
+type Item = { directory?: string; payload: Event }
 
 export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
 
@@ -75,12 +78,19 @@ export const GlobalRoutes = lazy(() =>
                 type: "server.connected",
                 properties: {},
               },
-            }),
-          })
-          async function handler(event: any) {
-            await stream.writeSSE({
-              data: JSON.stringify(event),
             })
+          })
+          const relay = Relay.create({
+            event: (item: Item) => item.payload,
+            scope: (item: Item) => item.directory ?? "global",
+            write: async (item: Item) => {
+              await stream.writeSSE({
+                data: JSON.stringify(item),
+              })
+            },
+          })
+          function handler(event: Item) {
+            relay.push(event)
           }
           GlobalBus.on("event", handler)
 
@@ -99,6 +109,7 @@ export const GlobalRoutes = lazy(() =>
           await new Promise<void>((resolve) => {
             stream.onAbort(() => {
               clearInterval(heartbeat)
+              relay.stop()
               GlobalBus.off("event", handler)
               resolve()
               log.info("global event disconnected")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -46,9 +46,11 @@ import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
+import { Relay } from "./relay"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
+type Event = { type: string; properties: Record<string, unknown> }
 
 export namespace Server {
   const log = Log.create({ service: "server" })
@@ -525,13 +527,19 @@ export namespace Server {
                 properties: {},
               }),
             })
-            const unsub = Bus.subscribeAll(async (event) => {
-              await stream.writeSSE({
-                data: JSON.stringify(event),
-              })
-              if (event.type === Bus.InstanceDisposed.type) {
-                stream.close()
-              }
+            const relay = Relay.create({
+              event: (item: Event) => item,
+              write: async (item: Event) => {
+                await stream.writeSSE({
+                  data: JSON.stringify(item),
+                })
+                if (item.type === Bus.InstanceDisposed.type) {
+                  stream.close()
+                }
+              },
+            })
+            const unsub = Bus.subscribeAll((event) => {
+              relay.push(event)
             })
 
             // Send heartbeat every 10s to prevent stalled proxy streams.
@@ -547,6 +555,7 @@ export namespace Server {
             await new Promise<void>((resolve) => {
               stream.onAbort(() => {
                 clearInterval(heartbeat)
+                relay.stop()
                 unsub()
                 resolve()
                 log.info("event disconnected")

--- a/packages/opencode/test/server/relay.test.ts
+++ b/packages/opencode/test/server/relay.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import { Relay } from "../../src/server/relay"
+
+type Event = {
+  type: string
+  properties: Record<string, unknown>
+}
+
+const wait = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+const delta = (text: string): Event => ({
+  type: "message.part.delta",
+  properties: {
+    sessionID: "ses_1",
+    messageID: "msg_1",
+    partID: "part_1",
+    field: "text",
+    delta: text,
+  },
+})
+
+const part = (text: string): Event => ({
+  type: "message.part.updated",
+  properties: {
+    part: {
+      id: "part_1",
+      messageID: "msg_1",
+      sessionID: "ses_1",
+      type: "text",
+      text,
+    },
+  },
+})
+
+describe("server relay", () => {
+  test("writes queued events sequentially", async () => {
+    let active = 0
+    let max = 0
+    let done = false
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    const relay = Relay.create<Event>({
+      event: (item) => item,
+      write: async (item) => {
+        active++
+        max = Math.max(max, active)
+        if (item.type === "block") await gate
+        if (item.type === "next") done = true
+        active--
+      },
+    })
+
+    relay.push({ type: "block", properties: {} })
+    relay.push({ type: "next", properties: {} })
+    await wait()
+
+    expect(done).toBe(false)
+    expect(max).toBe(1)
+
+    release()
+    await wait()
+    await wait()
+
+    expect(done).toBe(true)
+    expect(max).toBe(1)
+  })
+
+  test("merges repeated deltas for the same part while a write is in flight", async () => {
+    const seen: Event[] = []
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    const relay = Relay.create<Event>({
+      event: (item) => item,
+      write: async (item) => {
+        seen.push(JSON.parse(JSON.stringify(item)))
+        if (item.type === "block") await gate
+      },
+    })
+
+    relay.push({ type: "block", properties: {} })
+    relay.push(delta("a"))
+    relay.push(delta("b"))
+    relay.push(delta("c"))
+    await wait()
+
+    release()
+    await wait()
+    await wait()
+
+    expect(seen).toHaveLength(2)
+    expect(seen[1]).toEqual(delta("abc"))
+  })
+
+  test("drops stale deltas once a newer part update supersedes them in the queue", async () => {
+    const seen: Event[] = []
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    const relay = Relay.create<Event>({
+      event: (item) => item,
+      write: async (item) => {
+        seen.push(JSON.parse(JSON.stringify(item)))
+        if (item.type === "block") await gate
+      },
+    })
+
+    relay.push({ type: "block", properties: {} })
+    relay.push(part(""))
+    relay.push(delta("a"))
+    relay.push(delta("b"))
+    relay.push(part("ab"))
+    await wait()
+
+    release()
+    await wait()
+    await wait()
+
+    expect(seen).toHaveLength(2)
+    expect(seen[1]).toEqual(part("ab"))
+  })
+})


### PR DESCRIPTION
## Summary
- add a coalescing server-side relay for SSE event streams so one hot session cannot queue unbounded async `writeSSE()` work
- use the relay for `/event`, `/global/event`, and the workspace control-plane event stream
- lower `message.part.delta` bus publish logging from info to debug and add relay regression tests

## Root cause
`message.part.delta` storms were being forwarded one-by-one through async EventEmitter listeners that called `await stream.writeSSE(...)`. Since EventEmitter does not await async listeners, slow consumers could accumulate an unbounded backlog of pending writes and payload allocations, eventually wedging the shared `serve` instance.

## Testing
- `bun test test/server/relay.test.ts test/acp/event-subscription.test.ts --timeout 30000` (from `packages/opencode`)
- `bun typecheck` (from `packages/opencode`)
- `bun turbo typecheck` (ran via push hook)

Closes #17977.
