### PR TITLE
fix: diff per-step and aggregate file changes so sidebar shows tool-only modifications

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -134,29 +134,45 @@ export namespace SessionSummary {
   )
 
   export async function computeDiff(input: { messages: MessageV2.WithParts[] }) {
-    let from: string | undefined
-    let to: string | undefined
+    // pair step-start -> step-finish snapshots and run git diffs per pair
+    const agg = new Map<string, Snapshot.FileDiff>()
+    const stack: string[] = []
 
-    // scan assistant messages to find earliest from and latest to
-    // snapshot
-    for (const item of input.messages) {
-      if (!from) {
-        for (const part of item.parts) {
-          if (part.type === "step-start" && part.snapshot) {
-            from = part.snapshot
-            break
-          }
+    const merge = (fds: Snapshot.FileDiff[]) => {
+      for (const fd of fds) {
+        const file = fd.file
+        const prev = agg.get(file)
+        if (!prev) {
+          agg.set(file, { ...fd })
+          continue
         }
+        prev.additions += fd.additions
+        prev.deletions += fd.deletions
+        // keep earliest before, update after to latest
+        if (fd.after) prev.after = fd.after
+        if (fd.status) prev.status = fd.status
       }
+    }
 
-      for (const part of item.parts) {
+    for (const msg of input.messages) {
+      const parts = msg.parts ?? []
+      for (const part of parts) {
+        if (part.type === "step-start" && part.snapshot) {
+          stack.push(part.snapshot)
+          continue
+        }
         if (part.type === "step-finish" && part.snapshot) {
-          to = part.snapshot
+          const from = stack.pop()
+          const to = part.snapshot
+          if (!from) continue
+          try {
+            const fds = await Snapshot.diffFull(from, to)
+            merge(fds)
+          } catch (e) {}
         }
       }
     }
 
-    if (from && to) return Snapshot.diffFull(from, to)
-    return []
+    return Array.from(agg.values())
   }
 }


### PR DESCRIPTION

### Issue for this PR

Closes #17983 and #7555 

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

i m not sure whether to call it a bug fix or a new feature.

### What does this PR do?

Currently, the sidebar shows a net diff between earliest agent start and the latest agent work. this includes changes made by other actors , like the user or any other tools , which is , weird.
This pr fixes that by computing session diffs by pairing each step-start → step-finish snapshot and running Snapshot.diffFull for each pair, then aggregating per-file additions/deletions. This prevents manual edits outside tool steps from being counted in the "Modified Files" listing.
One note, errors from individual step diffs are tolerated. 

### How did you verify your code works?
I created a `test.txt` and asked the agent to append 2 lines. then appened some (6-7) lines myself. then asked it to append 2 again. for the production version of opencode, it shows +11 (or 10 if i added 6, don't remember). for the dev version, after applying the chagnes, it shows +4. which is the correct behavior ig.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
