### PR TITLE
fix(app): remount server-scoped providers on server switch

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -265,6 +265,39 @@ function ConnectionError(props: { onRetry?: () => void; onServerSelected?: (key:
   )
 }
 
+function ServerScopedProviders(
+  props: ParentProps<{
+    router?: Component<BaseRouterProps>
+    disableHealthCheck?: boolean
+    appChildren?: JSX.Element
+  }>,
+) {
+  const server = useServer()
+
+  return (
+    <Show when={server.key} keyed>
+      {() => (
+        <ConnectionGate disableHealthCheck={props.disableHealthCheck}>
+          <GlobalSDKProvider>
+            <GlobalSyncProvider>
+              <Dynamic
+                component={props.router ?? Router}
+                root={(routerProps) => <RouterRoot appChildren={props.appChildren}>{routerProps.children}</RouterRoot>}
+              >
+                <Route path="/" component={HomeRoute} />
+                <Route path="/:dir" component={DirectoryLayout}>
+                  <Route path="/" component={SessionIndexRoute} />
+                  <Route path="/session/:id?" component={SessionRoute} />
+                </Route>
+              </Dynamic>
+            </GlobalSyncProvider>
+          </GlobalSDKProvider>
+        </ConnectionGate>
+      )}
+    </Show>
+  )
+}
+
 export function AppInterface(props: {
   children?: JSX.Element
   defaultServer: ServerConnection.Key
@@ -274,22 +307,11 @@ export function AppInterface(props: {
 }) {
   return (
     <ServerProvider defaultServer={props.defaultServer} servers={props.servers}>
-      <ConnectionGate disableHealthCheck={props.disableHealthCheck}>
-        <GlobalSDKProvider>
-          <GlobalSyncProvider>
-            <Dynamic
-              component={props.router ?? Router}
-              root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
-            >
-              <Route path="/" component={HomeRoute} />
-              <Route path="/:dir" component={DirectoryLayout}>
-                <Route path="/" component={SessionIndexRoute} />
-                <Route path="/session/:id?" component={SessionRoute} />
-              </Route>
-            </Dynamic>
-          </GlobalSyncProvider>
-        </GlobalSDKProvider>
-      </ConnectionGate>
+      <ServerScopedProviders
+        router={props.router}
+        disableHealthCheck={props.disableHealthCheck}
+        appChildren={props.children}
+      />
     </ServerProvider>
   )
 }

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -276,7 +276,7 @@ function ServerScopedProviders(
 
   return (
     <Show when={server.key} keyed>
-      {() => (
+      {(_) => (
         <ConnectionGate disableHealthCheck={props.disableHealthCheck}>
           <GlobalSDKProvider>
             <GlobalSyncProvider>


### PR DESCRIPTION
### Issue for this PR

Closes #17654 

### Type of change
- [x]  Bug fix
- [ ]  New feature
- [ ]    Refactor / code improvement
- [ ]    Documentation

### What does this PR do?

This fix remounts the server-scoped app providers when the active server changes.

Without that remount, the desktop app can keep the global SDK/event stream bound to the previous server after switching, which means remote responses are processed but the UI does not update until a later refresh/switch.

### How did you verify your code works?
- built the desktop Windows app locally and confirmed the fix is included in the build
- validated that the server-scoped providers are recreated from the selected server key instead of reusing the initial connection
- for me this fixes #17654

### Screenshots / recordings
<img width="804" height="309" alt="image" src="https://github.com/user-attachments/assets/083f81bb-995f-458d-98f7-35ddd7f7f0df" />

### Checklist
- [x]    I have tested my changes locally
- [x]    I have not included unrelated changes in this PR
