### PR TITLE
fix(app): fix narrow desktop sidebar toggle

### DIFF
--- a/packages/app/e2e/sidebar/sidebar.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar.spec.ts
@@ -15,6 +15,31 @@ test("sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
   await expect(button).toHaveAttribute("aria-expanded", "true")
 })
 
+test("narrow desktop sidebar toggle shows tooltip and controls mobile nav", async ({ page, gotoSession }) => {
+  await page.setViewportSize({ width: 1100, height: 800 })
+  await gotoSession()
+
+  const button = page.getByRole("button", { name: /toggle sidebar/i }).first()
+  const nav = page.locator('[data-component="sidebar-nav-mobile"]').first()
+  const tip = page.locator('[data-component="tooltip"]').filter({ hasText: /toggle sidebar/i }).last()
+
+  await expect(button).toBeVisible()
+  await expect(button).toHaveAttribute("aria-expanded", "false")
+  await expect(nav).toHaveClass(/-translate-x-full/)
+
+  await button.hover()
+  await expect(tip).toBeVisible()
+  await expect(tip).toContainText("B")
+
+  await toggleSidebar(page)
+  await expect(button).toHaveAttribute("aria-expanded", "true")
+  await expect(nav).toHaveClass(/translate-x-0/)
+
+  await toggleSidebar(page)
+  await expect(button).toHaveAttribute("aria-expanded", "false")
+  await expect(nav).toHaveClass(/-translate-x-full/)
+})
+
 test("sidebar collapsed state persists across navigation and reload", async ({ page, sdk, gotoSession }) => {
   await withSession(sdk, "sidebar persist session 1", async (session1) => {
     await withSession(sdk, "sidebar persist session 2", async (session2) => {

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -93,6 +93,8 @@ export function Titlebar() {
     navigate(next.to)
   }
 
+  const toggleSidebar = () => command.trigger("sidebar.toggle")
+
   command.register(() => [
     {
       id: "common.goBack",
@@ -177,26 +179,38 @@ export function Titlebar() {
         <Show when={mac()}>
           <div class="h-full shrink-0" style={{ width: `${72 / zoom()}px` }} />
           <div class="xl:hidden w-10 shrink-0 flex items-center justify-center">
-            <IconButton
-              icon="menu"
-              variant="ghost"
-              class="titlebar-icon rounded-md"
-              onClick={layout.mobileSidebar.toggle}
-              aria-label={language.t("sidebar.menu.toggle")}
-              aria-expanded={layout.mobileSidebar.opened()}
-            />
+            <TooltipKeybind
+              placement="bottom"
+              title={language.t("command.sidebar.toggle")}
+              keybind={command.keybind("sidebar.toggle")}
+            >
+              <IconButton
+                icon="menu"
+                variant="ghost"
+                class="titlebar-icon rounded-md"
+                onClick={toggleSidebar}
+                aria-label={language.t("command.sidebar.toggle")}
+                aria-expanded={layout.mobileSidebar.opened()}
+              />
+            </TooltipKeybind>
           </div>
         </Show>
         <Show when={!mac()}>
           <div class="xl:hidden w-[48px] shrink-0 flex items-center justify-center">
-            <IconButton
-              icon="menu"
-              variant="ghost"
-              class="titlebar-icon rounded-md"
-              onClick={layout.mobileSidebar.toggle}
-              aria-label={language.t("sidebar.menu.toggle")}
-              aria-expanded={layout.mobileSidebar.opened()}
-            />
+            <TooltipKeybind
+              placement="bottom"
+              title={language.t("command.sidebar.toggle")}
+              keybind={command.keybind("sidebar.toggle")}
+            >
+              <IconButton
+                icon="menu"
+                variant="ghost"
+                class="titlebar-icon rounded-md"
+                onClick={toggleSidebar}
+                aria-label={language.t("command.sidebar.toggle")}
+                aria-expanded={layout.mobileSidebar.opened()}
+              />
+            </TooltipKeybind>
           </div>
         </Show>
         <div class="flex items-center gap-1 shrink-0">
@@ -209,7 +223,7 @@ export function Titlebar() {
             <Button
               variant="ghost"
               class="group/sidebar-toggle titlebar-icon w-8 h-6 p-0 box-border"
-              onClick={layout.sidebar.toggle}
+              onClick={toggleSidebar}
               aria-label={language.t("command.sidebar.toggle")}
               aria-expanded={layout.sidebar.opened()}
             >

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -12,6 +12,7 @@ import {
   type Accessor,
 } from "solid-js"
 import { useNavigate, useParams } from "@solidjs/router"
+import { createMediaQuery } from "@solid-primitives/media"
 import { useLayout, LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
@@ -137,6 +138,7 @@ export default function Layout(props: ParentProps) {
   }
   const colorSchemeLabel = (scheme: ColorScheme) => language.t(colorSchemeKey[scheme])
   const currentDir = createMemo(() => decode64(params.dir) ?? "")
+  const wide = createMediaQuery("(min-width: 1280px)")
 
   const [state, setState] = createStore({
     autoselect: !initialDirectory,
@@ -964,6 +966,14 @@ export default function Layout(props: ParentProps) {
     }
   }
 
+  const toggleSidebar = () => {
+    if (wide()) {
+      layout.sidebar.toggle()
+      return
+    }
+    layout.mobileSidebar.toggle()
+  }
+
   async function archiveSession(session: Session) {
     const [store, setStore] = globalSync.child(session.directory)
     const sessions = store.session ?? []
@@ -997,7 +1007,7 @@ export default function Layout(props: ParentProps) {
         title: language.t("command.sidebar.toggle"),
         category: language.t("command.category.view"),
         keybind: "mod+b",
-        onSelect: () => layout.sidebar.toggle(),
+        onSelect: toggleSidebar,
       },
       {
         id: "project.open",


### PR DESCRIPTION
### Issue for this PR
Fixes #17430

Sidebar has no shortcut + tooltip on xl or lower size of window width. see below :) it should be consistent i believe. 

Maybe @adamdotdevin or @Brendonovich you might look at this. thank you <3

<img width="265" height="149" alt="image" src="https://github.com/user-attachments/assets/de017340-fe42-47ab-98a9-6959c087ec9b" />

https://github.com/user-attachments/assets/00cbc6e7-66b7-4726-bced-96d3c9e6111e



### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?
fixes the narrow desktop sidebar toggle so it shows the tooltip/keybind and toggles correctly on smaller widths.

### How did you verify your code works?

Added an e2e test for the narrow layout and checked it in desktop.

### Screenshots / recordings

Already attached.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR