### PR TITLE
feat(notifications): add option to notify even when window is focused

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -378,6 +378,18 @@ export const SettingsGeneral: Component = () => {
             />
           </div>
         </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.notifications.notifyWhenFocused.title")}
+          description={language.t("settings.general.notifications.notifyWhenFocused.description")}
+        >
+          <div data-action="settings-notifications-notify-when-focused">
+            <Switch
+              checked={settings.notifications.notifyWhenFocused()}
+              onChange={(checked) => settings.notifications.setNotifyWhenFocused(checked)}
+            />
+          </div>
+        </SettingsRow>
       </SettingsList>
     </div>
   )

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -247,7 +247,8 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
 
         const href = `/${base64Encode(directory)}/session/${sessionID}`
         if (settings.notifications.agent()) {
-          void platform.notify(language.t("notification.session.responseReady.title"), session.title ?? sessionID, href)
+          const notifyOpts = settings.notifications.notifyWhenFocused() ? { skipFocusCheck: true } : undefined
+          void platform.notify(language.t("notification.session.responseReady.title"), session.title ?? sessionID, href, notifyOpts)
         }
       })
     }
@@ -280,7 +281,8 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
           (typeof error === "string" ? error : language.t("notification.session.error.fallbackDescription"))
         const href = sessionID ? `/${base64Encode(directory)}/session/${sessionID}` : `/${base64Encode(directory)}`
         if (settings.notifications.errors()) {
-          void platform.notify(language.t("notification.session.error.title"), description, href)
+          const notifyOpts = settings.notifications.notifyWhenFocused() ? { skipFocusCheck: true } : undefined
+          void platform.notify(language.t("notification.session.error.title"), description, href, notifyOpts)
         }
       })
     }

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -35,7 +35,7 @@ export type Platform = {
   forward(): void
 
   /** Send a system notification (optional deep link) */
-  notify(title: string, description?: string, href?: string): Promise<void>
+  notify(title: string, description?: string, href?: string, opts?: { skipFocusCheck?: boolean }): Promise<void>
 
   /** Open directory picker dialog (native on Tauri, server-backed on web) */
   openDirectoryPickerDialog?(opts?: OpenDirectoryPickerOptions): Promise<PickerPaths>

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -7,6 +7,7 @@ export interface NotificationSettings {
   agent: boolean
   permissions: boolean
   errors: boolean
+  notifyWhenFocused: boolean
 }
 
 export interface SoundSettings {
@@ -66,6 +67,7 @@ const defaultSettings: Settings = {
     agent: true,
     permissions: true,
     errors: false,
+    notifyWhenFocused: false,
   },
   sounds: {
     agentEnabled: true,
@@ -205,6 +207,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         errors: withFallback(() => store.notifications?.errors, defaultSettings.notifications.errors),
         setErrors(value: boolean) {
           setStore("notifications", "errors", value)
+        },
+        notifyWhenFocused: withFallback(
+          () => store.notifications?.notifyWhenFocused,
+          defaultSettings.notifications.notifyWhenFocused,
+        ),
+        setNotifyWhenFocused(value: boolean) {
+          setStore("notifications", "notifyWhenFocused", value)
         },
       },
       sounds: {

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -52,7 +52,7 @@ const setStorage = (key: string, value: string | null) => {
 const readDefaultServerUrl = () => getStorage(DEFAULT_SERVER_URL_KEY)
 const writeDefaultServerUrl = (url: string | null) => setStorage(DEFAULT_SERVER_URL_KEY, url)
 
-const notify: Platform["notify"] = async (title, description, href) => {
+const notify: Platform["notify"] = async (title, description, href, opts) => {
   if (!("Notification" in window)) return
 
   const permission =
@@ -62,8 +62,10 @@ const notify: Platform["notify"] = async (title, description, href) => {
 
   if (permission !== "granted") return
 
-  const inView = document.visibilityState === "visible" && document.hasFocus()
-  if (inView) return
+  if (!opts?.skipFocusCheck) {
+    const inView = document.visibilityState === "visible" && document.hasFocus()
+    if (inView) return
+  }
 
   const notification = new Notification(title, {
     body: description ?? "",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -824,6 +824,9 @@ export const dict = {
   "settings.general.notifications.permissions.description": "Show system notification when a permission is required",
   "settings.general.notifications.errors.title": "Errors",
   "settings.general.notifications.errors.description": "Show system notification when an error occurs",
+  "settings.general.notifications.notifyWhenFocused.title": "Notify when focused",
+  "settings.general.notifications.notifyWhenFocused.description":
+    "Show system notifications even when the app window is focused",
 
   "settings.general.sounds.agent.title": "Agent",
   "settings.general.sounds.agent.description": "Play sound when the agent is complete or needs attention",

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -302,14 +302,16 @@ const createPlatform = (): Platform => {
       await relaunch()
     },
 
-    notify: async (title, description, href) => {
+    notify: async (title, description, href, opts) => {
       const granted = await isPermissionGranted().catch(() => false)
       const permission = granted ? "granted" : await requestPermission().catch(() => "denied")
       if (permission !== "granted") return
 
-      const win = getCurrentWindow()
-      const focused = await win.isFocused().catch(() => document.hasFocus())
-      if (focused) return
+      if (!opts?.skipFocusCheck) {
+        const win = getCurrentWindow()
+        const focused = await win.isFocused().catch(() => document.hasFocus())
+        if (focused) return
+      }
 
       await Promise.resolve()
         .then(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #18004

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a "Notify when focused" toggle under Settings > Notifications. When enabled, system notifications fire even when the OpenCode window has focus, instead of being suppressed.

I ran into this because I run long agent tasks while working in other sessions within the same OpenCode window. The focus-suppression meant I'd miss notifications for completed background sessions.

The implementation adds an optional `{ skipFocusCheck?: boolean }` parameter to `Platform.notify()`. The notification context threads the new `notifyWhenFocused` setting into both notify call sites (agent idle and error). Both platform implementations (web entry.tsx and desktop index.tsx) conditionally skip the existing focus check when the flag is set.

Default is off — zero behavior change for existing users.

### How did you verify your code works?

Read the source to understand the existing notification flow, traced through both web and desktop platform implementations, and verified the type changes are consistent across the Platform interface, both implementations, and the caller in notification.tsx.

### Screenshots / recordings

_No UI screenshot yet — the change adds one additional toggle row to the existing notification settings section, following the same SettingsRow + Switch pattern as the Agent/Permissions/Errors toggles above it._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR