### PR TITLE
feat(opencode): add native video and audio file reading support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -585,6 +585,7 @@
   "patchedDependencies": {
     "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
+    "@ai-sdk/openai-compatible@1.0.32": "patches/@ai-sdk%2Fopenai-compatible@1.0.32.patch",
   },
   "overrides": {
     "@types/bun": "catalog:",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   },
   "patchedDependencies": {
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
-    "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch"
+    "@openrouter/ai-sdk-provider@1.5.4": "patches/@openrouter%2Fai-sdk-provider@1.5.4.patch",
+    "@ai-sdk/openai-compatible@1.0.32": "patches/@ai-sdk%2Fopenai-compatible@1.0.32.patch"
   }
 }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -19,7 +19,9 @@ import { ModelID, ProviderID } from "@/provider/schema"
 
 export namespace MessageV2 {
   export function isMedia(mime: string) {
-    return mime.startsWith("image/") || mime === "application/pdf"
+    return (
+      mime.startsWith("image/") || mime === "application/pdf" || mime.startsWith("video/") || mime.startsWith("audio/")
+    )
   }
 
   export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -141,8 +141,34 @@ export const ReadTool = Tool.define("read", {
       }
     }
 
-    const isBinary = await isBinaryFile(filepath, Number(stat.size))
-    if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
+    const binary = await isBinaryFile(filepath, Number(stat.size))
+    const isVideo = mime.startsWith("video/") && binary
+    const isAudio = mime.startsWith("audio/") && binary
+    if (isVideo || isAudio) {
+      if (Number(stat.size) > 20 * 1024 * 1024)
+        throw new Error(
+          `File too large for media attachment (${Math.round(Number(stat.size) / 1024 / 1024)}MB). Maximum is 20MB: ${filepath}`,
+        )
+      const msg = `${isVideo ? "Video" : "Audio"} read successfully`
+      return {
+        title,
+        output: msg,
+        metadata: {
+          preview: msg,
+          truncated: false,
+          loaded: instructions.map((i) => i.filepath),
+        },
+        attachments: [
+          {
+            type: "file",
+            mime,
+            url: `data:${mime};base64,${Buffer.from(await Filesystem.readBytes(filepath)).toString("base64")}`,
+          },
+        ],
+      }
+    }
+
+    if (binary) throw new Error(`Cannot read binary file: ${filepath}`)
 
     const stream = createReadStream(filepath, { encoding: "utf8" })
     const rl = createInterface({

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -916,3 +916,33 @@ describe("session.message-v2.fromError", () => {
     })
   })
 })
+
+describe("isMedia", () => {
+  test("identifies image types", () => {
+    expect(MessageV2.isMedia("image/png")).toBe(true)
+    expect(MessageV2.isMedia("image/jpeg")).toBe(true)
+    expect(MessageV2.isMedia("image/svg+xml")).toBe(true)
+  })
+
+  test("identifies pdf", () => {
+    expect(MessageV2.isMedia("application/pdf")).toBe(true)
+  })
+
+  test("identifies video types", () => {
+    expect(MessageV2.isMedia("video/mp4")).toBe(true)
+    expect(MessageV2.isMedia("video/webm")).toBe(true)
+    expect(MessageV2.isMedia("video/mp2t")).toBe(true)
+  })
+
+  test("identifies audio types", () => {
+    expect(MessageV2.isMedia("audio/mpeg")).toBe(true)
+    expect(MessageV2.isMedia("audio/wav")).toBe(true)
+    expect(MessageV2.isMedia("audio/ogg")).toBe(true)
+  })
+
+  test("rejects non-media types", () => {
+    expect(MessageV2.isMedia("text/plain")).toBe(false)
+    expect(MessageV2.isMedia("application/json")).toBe(false)
+    expect(MessageV2.isMedia("application/octet-stream")).toBe(false)
+  })
+})

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -503,3 +503,85 @@ describe("tool.read binary detection", () => {
     })
   })
 })
+
+describe("tool.read video and audio files", () => {
+  test("video file (.mp4) returns base64 attachment", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const mp4 = Buffer.from([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d])
+        await Bun.write(path.join(dir, "video.mp4"), mp4)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "video.mp4") }, ctx)
+        expect(result.attachments).toHaveLength(1)
+        expect(result.attachments![0].type).toBe("file")
+        expect(result.attachments![0].mime!.startsWith("video/")).toBe(true)
+        expect(result.attachments![0].url!.startsWith("data:video/")).toBe(true)
+        expect(result.output).toContain("Video read successfully")
+        expect(result.metadata.truncated).toBe(false)
+      },
+    })
+  })
+
+  test("audio file (.mp3) returns base64 attachment", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const mp3 = Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+        await Bun.write(path.join(dir, "audio.mp3"), mp3)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "audio.mp3") }, ctx)
+        expect(result.attachments).toHaveLength(1)
+        expect(result.attachments![0].type).toBe("file")
+        expect(result.attachments![0].mime!.startsWith("audio/")).toBe(true)
+        expect(result.attachments![0].url!.startsWith("data:audio/")).toBe(true)
+        expect(result.output).toContain("Audio read successfully")
+        expect(result.metadata.truncated).toBe(false)
+      },
+    })
+  })
+
+  test(".ts file is NOT treated as video", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "code.ts"), "const x = 1\nexport default x\n")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "code.ts") }, ctx)
+        expect(result.attachments).toBeUndefined()
+        expect(result.output).toContain("const x = 1")
+      },
+    })
+  })
+
+  test("video file over 20MB throws error", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const buf = Buffer.alloc(21 * 1024 * 1024)
+        buf.set([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d])
+        await Bun.write(path.join(dir, "huge.mp4"), buf)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, "huge.mp4") }, ctx)).rejects.toThrow(
+          /File too large.*20MB/,
+        )
+      },
+    })
+  })
+})

--- a/patches/@ai-sdk%2Fopenai-compatible@1.0.32.patch
+++ b/patches/@ai-sdk%2Fopenai-compatible@1.0.32.patch
@@ -1,0 +1,152 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index e6f9923d1d91f832d8a15d126b900a7f5303d767..a000000000000000000000000000000000000001 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -59,11 +59,28 @@
+                     },
+                     ...partMetadata
+                   };
+-                } else {
+-                  throw new UnsupportedFunctionalityError({
+-                    functionality: `file part media type ${part.mediaType}`
+-                  });
+-                }
++                } else if (part.mediaType.startsWith("video/")) {
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: part.data instanceof URL ? part.data.toString() : `data:${part.mediaType};base64,${convertToBase64(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                } else if (part.mediaType.startsWith("audio/")) {
++                  return {
++                    type: "input_audio",
++                    input_audio: {
++                      data: part.data instanceof URL ? part.data.toString() : convertToBase64(part.data),
++                      format: part.mediaType.split("/")[1]
++                    },
++                    ...partMetadata
++                  };
++                } else {
++                  throw new UnsupportedFunctionalityError({
++                    functionality: `file part media type ${part.mediaType}`
++                  });
++                }
+               }
+             }
+           }),
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index 2b8e41cfea4ef1491ee79e270c8fd0de005f6ef5..a000000000000000000000000000000000000002 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -43,11 +43,28 @@
+                     },
+                     ...partMetadata
+                   };
+-                } else {
+-                  throw new UnsupportedFunctionalityError({
+-                    functionality: `file part media type ${part.mediaType}`
+-                  });
+-                }
++                } else if (part.mediaType.startsWith("video/")) {
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: part.data instanceof URL ? part.data.toString() : `data:${part.mediaType};base64,${convertToBase64(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                } else if (part.mediaType.startsWith("audio/")) {
++                  return {
++                    type: "input_audio",
++                    input_audio: {
++                      data: part.data instanceof URL ? part.data.toString() : convertToBase64(part.data),
++                      format: part.mediaType.split("/")[1]
++                    },
++                    ...partMetadata
++                  };
++                } else {
++                  throw new UnsupportedFunctionalityError({
++                    functionality: `file part media type ${part.mediaType}`
++                  });
++                }
+               }
+             }
+           }),
+diff --git a/dist/index.js b/dist/index.js
+index 210819172d611c64900564de97c1f23c5f5c132f..a000000000000000000000000000000000000003 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -77,11 +77,28 @@
+                     },
+                     ...partMetadata
+                   };
+-                } else {
+-                  throw new import_provider.UnsupportedFunctionalityError({
+-                    functionality: `file part media type ${part.mediaType}`
+-                  });
+-                }
++                } else if (part.mediaType.startsWith("video/")) {
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: part.data instanceof URL ? part.data.toString() : `data:${part.mediaType};base64,${(0, import_provider_utils.convertToBase64)(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                } else if (part.mediaType.startsWith("audio/")) {
++                  return {
++                    type: "input_audio",
++                    input_audio: {
++                      data: part.data instanceof URL ? part.data.toString() : (0, import_provider_utils.convertToBase64)(part.data),
++                      format: part.mediaType.split("/")[1]
++                    },
++                    ...partMetadata
++                  };
++                } else {
++                  throw new import_provider.UnsupportedFunctionalityError({
++                    functionality: `file part media type ${part.mediaType}`
++                  });
++                }
+               }
+             }
+           }),
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index 41eb4555dbc1321a531e464c2f562ee3e56374a5..a000000000000000000000000000000000000004 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -69,11 +69,28 @@
+                     },
+                     ...partMetadata
+                   };
+-                } else {
+-                  throw new import_provider.UnsupportedFunctionalityError({
+-                    functionality: `file part media type ${part.mediaType}`
+-                  });
+-                }
++                } else if (part.mediaType.startsWith("video/")) {
++                  return {
++                    type: "video_url",
++                    video_url: {
++                      url: part.data instanceof URL ? part.data.toString() : `data:${part.mediaType};base64,${(0, import_provider_utils.convertToBase64)(part.data)}`
++                    },
++                    ...partMetadata
++                  };
++                } else if (part.mediaType.startsWith("audio/")) {
++                  return {
++                    type: "input_audio",
++                    input_audio: {
++                      data: part.data instanceof URL ? part.data.toString() : (0, import_provider_utils.convertToBase64)(part.data),
++                      format: part.mediaType.split("/")[1]
++                    },
++                    ...partMetadata
++                  };
++                } else {
++                  throw new import_provider.UnsupportedFunctionalityError({
++                    functionality: `file part media type ${part.mediaType}`
++                  });
++                }
+               }
+             }
+           }),


### PR DESCRIPTION
> **🎬 Community requested feature** — Issue #10531 has **7 upvotes and 9 comments** requesting native video/audio support. This PR implements it.

### Issue for this PR

Closes #10531

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds native video and audio file reading to the `read` tool. When a model-capable provider (e.g. Kimi K2.5 via Chutes) asks to read a video or audio file, it's base64-encoded and returned as a file attachment — same pattern as existing PDF/image support.

Three changes:

1. **read.ts** — Detect video/* and audio/* MIME types on binary files, return as base64 attachment (20MB cap). Moved the binary file check before MIME detection to prevent `.ts` files (MIME `video/mp2t`) from being misdetected.

2. **message-v2.ts** — Extended `isMedia()` to include video/* and audio/* so compaction handles them correctly.

3. **@ai-sdk/openai-compatible patch** — The bundled v1.0.32 only handles image/* in its chat converter. This patch adds video_url and input_audio types for OpenAI-compatible providers that support video (like Kimi K2.5).

Related: #16338 (same package fails for PDF — a follow-up patch could cover that too).

### 20MB file size limit

Files over 20MB are rejected with a clear error message. This is the safe lowest-common-denominator across LLM providers:

| Provider | Inline Limit |
|----------|-------------|
| OpenAI | 20MB (images), 25MB (audio) |
| Anthropic | 30MB per file, 32MB max request |
| Gemini (legacy) | 20MB inline (now 100MB) |

There is currently no built-in tool to compress oversized media — users can rely on the model invoking `ffmpeg` via the `bash` tool if installed.

### How did you verify your code works?

- Tested end-to-end with Kimi K2.5 via Chutes (OpenAI-compatible provider)
- Read a 1.5MB MP4 file through the read tool — model successfully described video content
- Verified .ts files are still read as text (not misdetected as video)
- Verified files over 20MB are rejected with clear error message
- Added 9 new tests (4 for read tool, 5 for isMedia) — all pass
- Existing test suite passes (39/39 read tests, 24/24 message-v2 tests)
- `bun typecheck` passes with zero errors

### Screenshots / recordings

Session transcript: https://gist.github.com/mugnimaestra/fd39a67ca38e0551287c0da93aa20bef

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR