### PR TITLE
fix: Add apply_patch to EDIT_TOOLS filter

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -69,7 +69,7 @@ export namespace PermissionNext {
     return S.evaluate(permission, pattern, ...rulesets)
   }
 
-  const EDIT_TOOLS = ["edit", "write", "patch", "multiedit"]
+  const EDIT_TOOLS = ["edit", "write", "apply_patch", "multiedit"]
 
   export function disabled(tools: string[], ruleset: Ruleset): Set<string> {
     const result = new Set<string>()

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -395,9 +395,9 @@ test("disabled - disables tool when denied", () => {
   expect(result.has("read")).toBe(false)
 })
 
-test("disabled - disables edit/write/patch/multiedit when edit denied", () => {
+test("disabled - disables edit/write/apply_patch/multiedit when edit denied", () => {
   const result = PermissionNext.disabled(
-    ["edit", "write", "patch", "multiedit", "bash"],
+    ["edit", "write", "apply_patch", "multiedit", "bash"],
     [
       { permission: "*", pattern: "*", action: "allow" },
       { permission: "edit", pattern: "*", action: "deny" },
@@ -405,7 +405,7 @@ test("disabled - disables edit/write/patch/multiedit when edit denied", () => {
   )
   expect(result.has("edit")).toBe(true)
   expect(result.has("write")).toBe(true)
-  expect(result.has("patch")).toBe(true)
+  expect(result.has("apply_patch")).toBe(true)
   expect(result.has("multiedit")).toBe(true)
   expect(result.has("bash")).toBe(false)
 })


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco#18008

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The apply_patch tool was not being filtered in plan mode because the EDIT_TOOLS array used the old name 'patch' instead of 'apply_patch'. Adding 'apply_patch' ensures it's properly filtered when models are in plan mode.

Additionally, this removes references to the deprecated/obsolete `patch` tool in the same locations and updates the CI test to use the current `apply_patch` tool name. 

Credit to Carlo Wood on the OC Discord for discovering the underlying issue!

### How did you verify your code works?

`bun test`, `bun typecheck`, admittedly could not test behaviour completely, as I do not have access to the GPT models. 

### Checklist

- [x] I have tested my changes locally (to the degree possible for me, see above note)
- [x] I have not included unrelated changes in this PR
