### PR TITLE
feat: enable GitLab Agent Platform with dynamic model discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -325,7 +325,6 @@
         "@aws-sdk/credential-providers": "3.993.0",
         "@clack/prompts": "1.0.0-alpha.1",
         "@effect/platform-node": "4.0.0-beta.31",
-        "@gitlab/gitlab-ai-provider": "3.6.0",
         "@gitlab/opencode-gitlab-auth": "1.3.3",
         "@hono/standard-validator": "0.1.5",
         "@hono/zod-validator": "catalog:",
@@ -357,6 +356,7 @@
         "drizzle-orm": "1.0.0-beta.16-ea816b6",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
+        "gitlab-ai-provider": "5.1.2",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -1104,8 +1104,6 @@
     "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.2.5", "", {}, "sha512-G09N3GfuT9qj3Ax2FDZvKqZttzM3v+cco2l8uXamhKyXLdmlaUDH5o88/C3vtTHj2oT7yRKsvxz9F+BXbWKMYA=="],
 
     "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
-
-    "@gitlab/gitlab-ai-provider": ["@gitlab/gitlab-ai-provider@3.6.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-8LmcIQ86xkMtC7L4P1/QYVEC+yKMTRerfPeniaaQGalnzXKtX6iMHLjLPOL9Rxp55lOXi6ed0WrFuJzZx+fNRg=="],
 
     "@gitlab/opencode-gitlab-auth": ["@gitlab/opencode-gitlab-auth@1.3.3", "", { "dependencies": { "@fastify/rate-limit": "^10.2.0", "@opencode-ai/plugin": "*", "fastify": "^5.2.0", "open": "^10.0.0" } }, "sha512-FT+KsCmAJjtqWr1YAq0MywGgL9kaLQ4apmsoowAXrPqHtoYf2i/nY10/A+L06kNj22EATeEDRpbB1NWXMto/SA=="],
 
@@ -3022,6 +3020,8 @@
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "gitlab-ai-provider": ["gitlab-ai-provider@5.1.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-ItYtVisOCQD88+sRUvVzFcuiB/ZlZTGkVWCP3UzSuXSB06H1WQLjxrxP27cVQ6+erkX9XyGLIO7w4MjMx6qi1A=="],
 
     "glob": ["glob@13.0.5", "", { "dependencies": { "minimatch": "^10.2.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw=="],
 
@@ -5047,10 +5047,6 @@
 
     "@fastify/proxy-addr/ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
-    "@gitlab/gitlab-ai-provider/openai": ["openai@6.27.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ=="],
-
-    "@gitlab/gitlab-ai-provider/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@hey-api/openapi-ts/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "@hey-api/openapi-ts/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
@@ -5444,6 +5440,10 @@
     "fs-extra/jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "gitlab-ai-provider/openai": ["openai@6.27.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ=="],
+
+    "gitlab-ai-provider/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -80,7 +80,7 @@
     "@ai-sdk/xai": "2.0.51",
     "@aws-sdk/credential-providers": "3.993.0",
     "@clack/prompts": "1.0.0-alpha.1",
-    "@gitlab/gitlab-ai-provider": "3.6.0",
+    "gitlab-ai-provider": "5.1.2",
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -40,7 +40,16 @@ import { createGateway } from "@ai-sdk/gateway"
 import { createTogetherAI } from "@ai-sdk/togetherai"
 import { createPerplexity } from "@ai-sdk/perplexity"
 import { createVercel } from "@ai-sdk/vercel"
-import { createGitLab, VERSION as GITLAB_PROVIDER_VERSION } from "@gitlab/gitlab-ai-provider"
+import {
+  createGitLab,
+  VERSION as GITLAB_PROVIDER_VERSION,
+  GitLabModelDiscovery,
+  GitLabModelConfigRegistry,
+  GitLabProjectDetector,
+  MODEL_MAPPINGS,
+  isWorkflowModel,
+  type GitLabProject,
+} from "gitlab-ai-provider"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { GoogleAuth } from "google-auth-library"
 import { ProviderTransform } from "./transform"
@@ -126,23 +135,27 @@ export namespace Provider {
     "@ai-sdk/togetherai": createTogetherAI,
     "@ai-sdk/perplexity": createPerplexity,
     "@ai-sdk/vercel": createVercel,
-    "@gitlab/gitlab-ai-provider": createGitLab,
+    "gitlab-ai-provider": createGitLab,
     // @ts-ignore (TODO: kill this code so we dont have to maintain it)
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
   }
 
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
   type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
+  type CustomDiscoverModels = () => Promise<Record<string, Model>>
   type CustomLoader = (provider: Info) => Promise<{
     autoload: boolean
     getModel?: CustomModelLoader
     vars?: CustomVarsLoader
     options?: Record<string, any>
+    discoverModels?: CustomDiscoverModels
   }>
 
   function useLanguageModel(sdk: any) {
     return sdk.responses === undefined && sdk.chat === undefined
   }
+
+  const gitlabModelConfigRegistry = new GitLabModelConfigRegistry()
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic() {
@@ -527,27 +540,147 @@ export namespace Provider {
         ...(providerConfig?.options?.aiGatewayHeaders || {}),
       }
 
+      const featureFlags = {
+        duo_agent_platform_agentic_chat: true,
+        duo_agent_platform: true,
+        ...(providerConfig?.options?.featureFlags || {}),
+      }
+
       return {
         autoload: !!apiKey,
         options: {
           instanceUrl,
           apiKey,
           aiGatewayHeaders,
-          featureFlags: {
-            duo_agent_platform_agentic_chat: true,
-            duo_agent_platform: true,
-            ...(providerConfig?.options?.featureFlags || {}),
-          },
+          featureFlags,
         },
-        async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string) {
+        async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string, options?: Record<string, any>) {
+          if (modelID.startsWith("duo-workflow-")) {
+            const workflowRef = options?.workflowRef as string | undefined
+            // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
+            const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
+            const model = sdk.workflowChat(sdkModelID, {
+              featureFlags,
+            })
+            if (workflowRef) {
+              model.selectedModelRef = workflowRef
+            }
+            return model
+          }
           return sdk.agenticChat(modelID, {
             aiGatewayHeaders,
-            featureFlags: {
-              duo_agent_platform_agentic_chat: true,
-              duo_agent_platform: true,
-              ...(providerConfig?.options?.featureFlags || {}),
-            },
+            featureFlags,
           })
+        },
+        async discoverModels(): Promise<Record<string, Model>> {
+          if (!apiKey) {
+            log.info("gitlab model discovery skipped: no apiKey")
+            return {}
+          }
+
+          try {
+            const token = apiKey
+            const getHeaders = (): Record<string, string> =>
+              auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
+
+            const discovery = new GitLabModelDiscovery({
+              instanceUrl,
+              getHeaders,
+            })
+
+            const detector = new GitLabProjectDetector({
+              instanceUrl,
+              getHeaders,
+            })
+            let project: GitLabProject | null = null
+            try {
+              project = await detector.detectProject(process.cwd())
+            } catch (e) {
+              log.info("gitlab project detection failed", { error: e, cwd: process.cwd() })
+            }
+
+            const namespaceId = project?.namespaceId
+            if (!namespaceId) {
+              log.info("gitlab model discovery skipped: no namespaceId", {
+                project: project ? { id: project.id, path: project.pathWithNamespace } : null,
+                cwd: process.cwd(),
+              })
+              return {}
+            }
+
+            log.info("gitlab model discovery starting", { namespaceId, instanceUrl })
+            const [discovered, modelConfigs] = await Promise.all([
+              discovery.discover(`gid://gitlab/Group/${namespaceId}`),
+              gitlabModelConfigRegistry.getConfigs(),
+            ])
+            log.info("gitlab model discovery result", {
+              selectableModels: discovered.selectableModels?.length ?? 0,
+              defaultModel: discovered.defaultModel?.ref ?? null,
+              pinnedModel: discovered.pinnedModel?.ref ?? null,
+            })
+            const models: Record<string, Model> = {}
+
+            // Build reverse map: discovery ref → duo-workflow-* model ID
+            const refToModelID = new Map<string, string>()
+            for (const [modelID, mapping] of Object.entries(MODEL_MAPPINGS)) {
+              if (mapping.provider === "workflow" && modelID !== "duo-workflow" && modelID !== "duo-workflow-default") {
+                refToModelID.set(mapping.model, modelID)
+              }
+            }
+
+            // If a model is pinned by admin, only that model is available
+            const allModels = discovered.pinnedModel
+              ? [discovered.pinnedModel]
+              : [...(discovered.selectableModels ?? []), ...(discovered.defaultModel ? [discovered.defaultModel] : [])]
+
+            const seen = new Set<string>()
+            for (const model of allModels) {
+              if (!model.ref || seen.has(model.ref)) continue
+              seen.add(model.ref)
+
+              // Use static mapping if available, otherwise generate an ID from the ref
+              const workflowModelID = refToModelID.get(model.ref) ?? `duo-workflow-${model.ref.replace(/[/_]/g, "-")}`
+              const limits = modelConfigs.get(model.ref)
+              if (!input.models[workflowModelID]) {
+                models[workflowModelID] = {
+                  id: ModelID.make(workflowModelID),
+                  providerID: ProviderID.make("gitlab"),
+                  name: `Agent Platform (${model.name})`,
+                  family: "",
+                  api: {
+                    id: workflowModelID,
+                    url: instanceUrl,
+                    npm: "gitlab-ai-provider",
+                  },
+                  status: "active",
+                  headers: {},
+                  options: { workflowRef: model.ref },
+                  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+                  limit: { context: limits?.context ?? 200000, output: limits?.output ?? 64000 },
+                  capabilities: {
+                    temperature: false,
+                    reasoning: true,
+                    attachment: true,
+                    toolcall: true,
+                    input: { text: true, audio: false, image: true, video: false, pdf: true },
+                    output: { text: true, audio: false, image: false, video: false, pdf: false },
+                    interleaved: false,
+                  },
+                  release_date: "",
+                  variants: {},
+                }
+              }
+            }
+
+            log.info("gitlab model discovery complete", {
+              count: Object.keys(models).length,
+              models: Object.keys(models),
+            })
+            return models
+          } catch (e) {
+            log.warn("gitlab model discovery failed", { error: e })
+            return {}
+          }
         },
       }
     },
@@ -847,6 +980,9 @@ export namespace Provider {
     const varsLoaders: {
       [providerID: string]: CustomVarsLoader
     } = {}
+    const discoveryLoaders: {
+      [providerID: string]: CustomDiscoverModels
+    } = {}
     const sdk = new Map<string, SDK>()
 
     log.info("init")
@@ -1003,6 +1139,7 @@ export namespace Provider {
       if (result && (result.autoload || providers[providerID])) {
         if (result.getModel) modelLoaders[providerID] = result.getModel
         if (result.vars) varsLoaders[providerID] = result.vars
+        if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
@@ -1070,11 +1207,53 @@ export namespace Provider {
       sdk,
       modelLoaders,
       varsLoaders,
+      discoveryLoaders,
     }
   })
 
   export async function list() {
     return state().then((state) => state.providers)
+  }
+
+  const discoveryCache = new Map<string, Promise<void>>()
+
+  export async function discoverModels(providerID: ProviderID): Promise<void> {
+    log.debug("discoverModels called", { providerID })
+    const cached = discoveryCache.get(providerID)
+    if (cached) {
+      log.debug("discoverModels returning cached", { providerID })
+      return cached
+    }
+
+    const promise = (async () => {
+      const s = await state()
+      const loader = s.discoveryLoaders[providerID]
+      if (!loader) {
+        log.debug("discoverModels no loader", { providerID, loaders: Object.keys(s.discoveryLoaders) })
+        return
+      }
+
+      const provider = s.providers[providerID]
+      if (!provider) {
+        log.debug("discoverModels no provider", { providerID })
+        return
+      }
+
+      const discovered = await loader()
+      log.debug("discoverModels discovered", { providerID, count: Object.keys(discovered).length })
+      for (const [modelID, model] of Object.entries(discovered)) {
+        if (!provider.models[modelID]) {
+          provider.models[modelID] = model
+        }
+      }
+    })()
+
+    promise.catch(() => {
+      discoveryCache.delete(providerID)
+    })
+
+    discoveryCache.set(providerID, promise)
+    return promise
   }
 
   async function getSDK(model: Model) {
@@ -1244,7 +1423,7 @@ export namespace Provider {
 
     try {
       const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
+        ? await s.modelLoaders[model.providerID](sdk, model.api.id, { ...provider.options, ...model.options })
         : sdk.languageModel(model.api.id)
       s.models.set(key, language)
       return language

--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -83,6 +83,14 @@ export const ConfigRoutes = lazy(() =>
       async (c) => {
         using _ = log.time("providers")
         const providers = await Provider.list().then((x) => mapValues(x, (item) => item))
+        // Trigger lazy model discovery for connected providers
+        await Promise.all(
+          Object.keys(providers).map((id) =>
+            Provider.discoverModels(id as any).catch((e) => {
+              log.warn("config.providers discovery error", { id, error: e })
+            }),
+          ),
+        )
         return c.json({
           providers: Object.values(providers),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -9,6 +9,9 @@ import { ProviderID } from "../../provider/schema"
 import { mapValues } from "remeda"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Log } from "../../util/log"
+
+const log = Log.create({ service: "server" })
 
 export const ProviderRoutes = lazy(() =>
   new Hono()
@@ -49,6 +52,14 @@ export const ProviderRoutes = lazy(() =>
         }
 
         const connected = await Provider.list()
+        // Trigger lazy model discovery for connected providers
+        await Promise.all(
+          Object.keys(connected).map((id) =>
+            Provider.discoverModels(id as any).catch((e) => {
+              log.warn("provider discovery error", { id, error: e })
+            }),
+          ),
+        )
         const providers = Object.assign(
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -12,6 +12,7 @@ import {
   jsonSchema,
 } from "ai"
 import { mergeDeep, pipe } from "remeda"
+import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider/transform"
 import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
@@ -168,6 +169,34 @@ export namespace LLM {
         inputSchema: jsonSchema({ type: "object", properties: {} }),
         execute: async () => ({ output: "", title: "", metadata: {} }),
       })
+    }
+
+    // Wire up toolExecutor for DWS workflow models so that tool calls
+    // from the workflow service are executed via opencode's tool system
+    // and results sent back over the WebSocket.
+    if (language instanceof GitLabWorkflowLanguageModel) {
+      const workflowModel = language
+      workflowModel.toolExecutor = async (toolName, argsJson, _requestID) => {
+        const t = tools[toolName]
+        if (!t || !t.execute) {
+          return { result: "", error: `Unknown tool: ${toolName}` }
+        }
+        try {
+          const result = await t.execute!(JSON.parse(argsJson), {
+            toolCallId: _requestID,
+            messages: input.messages,
+            abortSignal: input.abort,
+          })
+          const output = typeof result === "string" ? result : (result?.output ?? JSON.stringify(result))
+          return {
+            result: output,
+            metadata: typeof result === "object" ? result?.metadata : undefined,
+            title: typeof result === "object" ? result?.title : undefined,
+          }
+        } catch (e: any) {
+          return { result: "", error: e.message ?? String(e) }
+        }
+      }
     }
 
     return streamText({

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -32933,7 +32933,7 @@
   "gitlab": {
     "id": "gitlab",
     "env": ["GITLAB_TOKEN"],
-    "npm": "@gitlab/gitlab-ai-provider",
+    "npm": "gitlab-ai-provider",
     "name": "GitLab Duo",
     "doc": "https://docs.gitlab.com/user/duo_agent_platform/",
     "models": {


### PR DESCRIPTION
## Summary

Enable GitLab Agent Platform (Duo Workflow Service) integration with dynamic model discovery, workflow model routing, and local tool execution.

## Changes

### Package Migration
- Replaced `@gitlab/gitlab-ai-provider` v3.6.0 with unscoped `gitlab-ai-provider` v5.1.2
- Updated all imports, lockfile entries, and test fixtures to reflect the new package name

### Dynamic Model Discovery (`provider.ts`)
- Introduced `CustomDiscoverModels` type and `discoveryLoaders` registry so providers can dynamically register models at runtime
- Added `discoverModels(providerID)` function with a per-provider cache that:
  1. Uses `GitLabProjectDetector` to detect the current GitLab project from `process.cwd()`
  2. Resolves the project's `namespaceId` (group)
  3. Calls `GitLabModelDiscovery.discover()` to fetch selectable, default, and admin-pinned models for that namespace
  4. Queries `GitLabModelConfigRegistry` for context/output token limits per model
  5. Registers discovered models as `duo-workflow-*` entries with full capability metadata (reasoning, attachments, tool calls, image/PDF input)
- Honors admin-pinned models: when a model is pinned, only that model is available
- Falls back gracefully when project detection or discovery fails (logs warnings, returns empty)

### Workflow Model Routing (`provider.ts`)
- GitLab custom model loader now routes `duo-workflow-*` model IDs through `sdk.workflowChat()` instead of `sdk.agenticChat()`
- Supports a `workflowRef` option for selecting a specific upstream model reference
- Static `MODEL_MAPPINGS` are respected; unknown refs get a generated `duo-workflow-{ref}` ID
- Model options are merged and passed through to the model loader (`{ ...provider.options, ...model.options }`)

### Workflow Tool Executor (`session/llm.ts`)
- When the resolved language model is a `GitLabWorkflowLanguageModel`, a `toolExecutor` callback is wired up
- Tool calls originating from the Duo Workflow Service are executed locally via opencode's tool system
- Results (including metadata and title) are serialized and sent back over the WebSocket connection
- Errors are caught and returned as structured error responses

### Server Routes (`config.ts`, `provider.ts`)
- Both `/config` and `/provider` routes now trigger `Provider.discoverModels()` for all connected providers before returning responses
- Discovery errors are caught per-provider and logged as warnings without blocking the response

### Feature Flags
- `duo_agent_platform_agentic_chat` and `duo_agent_platform` are enabled by default for GitLab provider

## Testing
- Updated `models-api.json` test fixture to reflect the new npm package name (`gitlab-ai-provider`)