### PR TITLE
fix(format): preserve built-in fields when partially overriding a formatter

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -6,7 +6,6 @@ import z from "zod"
 
 import * as Formatter from "./formatter"
 import { Config } from "../config/config"
-import { mergeDeep } from "remeda"
 import { Instance } from "../project/instance"
 import { Process } from "../util/process"
 import { InstanceContext } from "@/effect/instance-context"
@@ -63,16 +62,12 @@ export class FormatService extends ServiceMap.Service<FormatService, FormatServi
             delete formatters[name]
             continue
           }
-          const result = mergeDeep(formatters[name] ?? {}, {
-            command: [],
-            extensions: [],
-            ...item,
-          }) as Formatter.Info
+          const { disabled: _, ...overrides } = item
+          const base = formatters[name] ?? { command: [] as string[], extensions: [] as string[] }
+          const result = Object.assign({}, base, overrides, { name, enabled: async () => true }) as Formatter.Info
 
           if (result.command.length === 0) continue
 
-          result.enabled = async () => true
-          result.name = name
           formatters[name] = result
         }
       } else {


### PR DESCRIPTION
### Issue for this PR

Closes #17050
Closes #14857

### Type of change

- [x] Bug fix

### What does this PR do?

When a user partially overrides a built-in formatter in their config, unspecified fields get silently dropped:

- Override only `command` → built-in `extensions` replaced with `[]`, formatter never matches any files (#17050)
- Override only `extensions` → built-in `command` replaced with `[]`, `command.length === 0` guard skips the formatter entirely (#14857)

Both bugs share the same root cause: `mergeDeep` receives `{ command: [], extensions: [], ...item }` as the override object. The empty-array defaults replace built-in values for any field the user didn't provide, because `mergeDeep` uses replace semantics for arrays.

The fix replaces `mergeDeep` with `Object.assign` using the merge order `defaults < built-in < user config`. `Object.assign` only overwrites keys present in the source objects, so omitted fields inherit from the built-in formatter. For fully custom formatters (no built-in match), the base object provides `command: []` and `extensions: []` as defaults — same behavior as before.

### How did you verify your code works?

Traced the merge logic for all cases:
- Built-in override with only `extensions` → built-in `command` preserved
- Built-in override with only `command` → built-in `extensions` preserved
- Built-in override with both → both replaced as expected
- New custom formatter with both → works (base provides empty defaults)
- New custom formatter missing `command` → skipped by `command.length === 0` guard (same as before)
- `disabled: true` → formatter deleted (unchanged)

Verified TypeScript compiles with no new errors.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR