### PR TITLE
fix(format): resolve mix format cwd from nearest .formatter.exs or mix.exs

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -1,4 +1,5 @@
 import { text } from "node:stream/consumers"
+import path from "path"
 import { BunProc } from "../bun"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
@@ -12,6 +13,7 @@ export interface Info {
   environment?: Record<string, string>
   extensions: string[]
   enabled(): Promise<boolean>
+  cwd?(file: string): Promise<string | undefined>
 }
 
 export const gofmt: Info = {
@@ -29,6 +31,14 @@ export const mix: Info = {
   extensions: [".ex", ".exs", ".eex", ".heex", ".leex", ".neex", ".sface"],
   async enabled() {
     return which("mix") !== null
+  },
+  async cwd(file: string) {
+    const dir = path.dirname(file)
+    for (const target of [".formatter.exs", "mix.exs"]) {
+      const found = await Filesystem.findUp(target, dir, Instance.worktree)
+      if (found.length > 0) return path.dirname(found[0])
+    }
+    return undefined
   },
 }
 

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -110,10 +110,11 @@ export class FormatService extends ServiceMap.Service<FormatService, FormatServi
           for (const item of await getFormatter(ext)) {
             log.info("running", { command: item.command })
             try {
+              const cwd = (await item.cwd?.(file)) ?? instance.directory
               const proc = Process.spawn(
                 item.command.map((x) => x.replace("$FILE", file)),
                 {
-                  cwd: instance.directory,
+                  cwd,
                   env: { ...process.env, ...item.environment },
                   stdout: "ignore",
                   stderr: "ignore",


### PR DESCRIPTION
### Issue for this PR

Closes #17051

### Type of change

- [x] Bug fix

### What does this PR do?

`mix format` resolves `.formatter.exs` relative to `cwd`, but OpenCode always spawns formatters with `cwd` set to the session root directory. In monorepos or nested Mix projects, this means the wrong `.formatter.exs` (or none at all) gets applied.

The fix adds an optional `cwd?(file: string)` method to the `Formatter.Info` interface. When present, the formatter execution uses its return value as the working directory instead of the session root.

For the `mix` formatter, the `cwd` method walks up from the file being formatted and returns the directory of the nearest `.formatter.exs` or `mix.exs`. This matches how `mix format` itself resolves its config — from the project root containing the formatter config.

Other formatters are unaffected — `cwd` is optional and defaults to the session directory when not provided.

### How did you verify your code works?

- Traced the `findUp` walk-up logic: given `/project/apps/web/lib/demo.ex`, it finds `/project/apps/web/.formatter.exs` and returns `/project/apps/web` as cwd
- Confirmed that formatters without a `cwd` method still use `instance.directory` (via `?? instance.directory` fallback)
- TypeScript compiles with no new errors

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR