### PR TITLE
feat(ui): add current branch name display in prompt input component

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -35,6 +35,7 @@ import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { decode64 } from "@/utils/base64"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { promptEnabled, promptProbe } from "@/testing/prompt"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
@@ -236,6 +237,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     return paths
   })
+  const projectDirectory = createMemo(() => decode64(params.dir) ?? "")
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const status = createMemo(
     () =>
@@ -1570,6 +1572,29 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     <Icon name="shield" size="small" classList={{ "text-icon-success-base": accepting() }} />
                   </Button>
                 </TooltipKeybind>
+
+                <Show when={projectDirectory() && sync.data.vcs?.branch}>
+                  <div class="flex items-end gap-1 shrink-0" style={control()}>
+                    <Tooltip placement="top" gutter={4} value={sync.data.vcs?.branch}>
+                      <div
+                        class="flex items-center gap-1.5 px-1.5 h-7 rounded-md hover:bg-background-weak transition-colors cursor-default group"
+                        aria-label={language.t("prompt.branch.ariaLabel", {
+                          branch: sync.data.vcs?.branch ?? "",
+                        })}
+                      >
+                        <Icon
+                          name="branch"
+                          size="small"
+                          class="text-icon-base opacity-40 group-hover:opacity-100 transition-opacity"
+                        />
+                        <span class="text-13-regular text-text-weak group-hover:text-text-base truncate max-w-[150px] transition-colors font-mono!">
+                          {sync.data.vcs?.branch}
+                        </span>
+                      </div>
+                    </Tooltip>
+                    <div class="w-px h-3 bg-border-base shrink-0 opacity-30" />
+                  </div>
+                </Show>
               </div>
             </div>
           </div>

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1573,11 +1573,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   </Button>
                 </TooltipKeybind>
 
-                <Show when={projectDirectory() && sync.data.vcs?.branch}>
-                  <div class="flex items-end gap-1 shrink-0" style={control()}>
+                <Show when={projectDirectory() && sync.project?.vcs === "git" && sync.data.vcs?.branch}>
+                  <div class="flex items-center justify-end gap-1 shrink-0" style={control()}>
                     <Tooltip placement="top" gutter={4} value={sync.data.vcs?.branch}>
                       <div
-                        class="flex items-center gap-1.5 px-1.5 h-7 rounded-md hover:bg-background-weak transition-colors cursor-default group"
+                        class="flex items-center gap-1.5 px-1.5 h-7 rounded-md hover:bg-surface-raised-strong transition-colors cursor-default group"
                         aria-label={language.t("prompt.branch.ariaLabel", {
                           branch: sync.data.vcs?.branch ?? "",
                         })}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -277,6 +277,7 @@ export const dict = {
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",
   "prompt.action.stop": "Stop",
+  "prompt.branch.ariaLabel": "Current branch: {{branch}}",
 
   "prompt.toast.pasteUnsupported.title": "Unsupported attachment",
   "prompt.toast.pasteUnsupported.description": "Only images, PDFs, or text files can be attached here.",


### PR DESCRIPTION
### Issue for this PR

Closes #18015

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the current git branch name to the web interface prompt input bar, so users can see which branch they're working on without leaving the browser.

**Initial approach & iteration**:

First implemented this in the session header, but it felt off - the header is already crowded with search, open-in-app button, and status indicators. The branch didn't fit naturally there.

**Final solution**:

Moved the branch display to the prompt input bar (where model/agent/permission controls are). This makes more sense because:
- It's always visible while working
- It groups with other relevant information (model, permissions, etc.)

Implementation:
- Reads branch from existing sync.data.vcs?.branch data source (no new API calls)
- Shows icon + branch name after the shield button
- Truncates long names, with hover tooltip showing full branch
- Only displays for git repositories (gracefully hides for non-git dirs)
- Added translation key prompt.branch.ariaLabel for accessibility

### How did you verify your code works?

1. Ran bun typecheck in packages/app - all types valid
2. Ran bun test in packages/app - all 288 tests pass
3. Manually tested with a git repo on a feature branch - branch name appears correctly
4. Tested with non-git directory - branch display hides gracefully
5. Verified branch updates when switching branches (reactive updates work)

### Screenshots / recordings

<img width="1007" height="236" alt="image" src="https://github.com/user-attachments/assets/6704c515-bed5-4fbf-be73-33888f906366" />

#### On Hover
<img width="925" height="208" alt="image" src="https://github.com/user-attachments/assets/17ed13f3-5558-462e-aa57-1ffeb20bfd14" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
