### PR TITLE
feat(cli): add branch name display to TUI prompt interface

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1060,6 +1060,15 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box flexDirection="row" justifyContent="space-between">
+          <Show when={status().type === "idle" && sync.data.vcs?.branch}>
+            <box marginLeft={1} flexDirection="row">
+              <text>
+                <span style={{ fg: theme.secondary }}>git:(</span>
+                <span style={{ fg: theme.error }}>{sync.data.vcs?.branch}</span>
+                <span style={{ fg: theme.secondary }}>)</span>
+              </text>
+            </box>
+          </Show>
           <Show when={status().type !== "idle"} fallback={<text />}>
             <box
               flexDirection="row"


### PR DESCRIPTION
### Issue for this PR

Closes #18047 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds display of the current git branch name below the TUI (Terminal UI) prompt component.

- Displays as: `git:(branch-name)`
- Theme aware text colour update

**When the branch displays**:

- ✅ Only when session is IDLE (status().type === "idle")
- ✅ Only when branch data exists (sync.data.vcs?.branch)
- ✅ Positioned on the left side of the status area

**When the branch is hidden**:
- ❌ During working state (processing requests)
- ❌ During error states (retry, failure)
- ❌ When no branch data available

### How did you verify your code works?

**Manual testing**:

1. Started TUI with `bun run dev`
2. Verified branch displays when session is idle
3. Verified branch hides when submitting prompts (working state)
4. Verified branch hides during errors/retry states
5. Verified branch updates when switching git branches
6. Confirmed no interference with existing states or UI elements

**State verification**:
- Confirmed branch only shows in idle state
- Confirmed keyboard shortcuts remain visible in all states except retry
- Confirmed working status (spinner) displays correctly when not idle
- Confirmed no layout issues or overlapping elements

### Screenshots / recordings

<img width="883" height="506" alt="image" src="https://github.com/user-attachments/assets/b28aca87-fc86-4dd9-875a-99d18aa220ec" />

<img width="1023" height="963" alt="image" src="https://github.com/user-attachments/assets/d2f4e699-eaaf-43f4-817f-2abb0a2c92cb" />

<img width="1029" height="968" alt="image" src="https://github.com/user-attachments/assets/2a35d8c5-4b4c-429a-892a-62ade8517a91" />


https://github.com/user-attachments/assets/1c855aa9-2c7e-44e6-9b08-a2ebc0e50917



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR