### PR TITLE
feat: ignore unrecognized fields in MCP config entries

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -576,7 +576,7 @@ export namespace Config {
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
     })
-    .strict()
+    .passthrough()
     .meta({
       ref: "McpLocalConfig",
     })
@@ -590,7 +590,7 @@ export namespace Config {
       clientSecret: z.string().optional().describe("OAuth client secret (if required by the authorization server)"),
       scope: z.string().optional().describe("OAuth scopes to request during authorization"),
     })
-    .strict()
+    .passthrough()
     .meta({
       ref: "McpOAuthConfig",
     })
@@ -615,7 +615,7 @@ export namespace Config {
         .optional()
         .describe("Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds) if not specified."),
     })
-    .strict()
+    .passthrough()
     .meta({
       ref: "McpRemoteConfig",
     })
@@ -1130,7 +1130,7 @@ export namespace Config {
               .object({
                 enabled: z.boolean(),
               })
-              .strict(),
+              .passthrough(),
           ]),
         )
         .optional()


### PR DESCRIPTION
### Issue for this PR

Closes #18077

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Changes `.strict()` to `.passthrough()` on 4 MCP-related Zod schemas (`McpLocal`, `McpOAuth`, `McpRemote`, and the `enabled`-only fallback). This makes the config parser ignore unrecognized fields in MCP entries instead of rejecting them.

The problem: tools like Onyx Security's MCP gateway add metadata fields (e.g., `_onyx_scanner_original`) to MCP config entries. With `.strict()`, Zod rejects these as "Invalid input mcp.mcp_everything", preventing opencode from starting. With `.passthrough()`, unknown fields are preserved in the parsed output but don't cause validation errors. All recognized fields are still validated.

### Why this change is needed

External integrations that wrap or proxy MCP servers often need to store additional metadata in the MCP config entries. For example, security scanning tools may save the original server configuration alongside their wrapper config, or orchestration tools may add tracking fields. Currently, any extra field causes opencode to reject the entire config on startup, which blocks these integrations from working. By allowing unrecognized fields to pass through, opencode becomes compatible with the broader MCP ecosystem without sacrificing validation of its own known fields.

### How did you verify your code works?

- Full test suite: 1342 pass, 0 fail
- Typecheck: all 13 packages pass
- Build: succeeds
- Manually tested with a config containing extra fields in MCP entries — opencode starts without error
- Verified that invalid values for recognized fields (e.g., `"type": 123`) still produce validation errors

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR