### PR TITLE
fix: remove prohibition of TodoWrite and Task tool usage

### DIFF
--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -80,8 +80,6 @@ Git Safety Protocol:
 4. If the commit fails due to pre-commit hook, fix the issue and create a NEW commit (see amend rules above)
 
 Important notes:
-- NEVER run additional commands to read or explore code, besides git bash commands
-- NEVER use the TodoWrite or Task tools
 - DO NOT push to the remote repository unless the user explicitly asks you to do so
 - IMPORTANT: Never use git commands with the -i flag (like git rebase -i or git add -i) since they require interactive input which is not supported.
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
@@ -108,7 +106,6 @@ gh pr create --title "the pr title" --body "$(cat <<'EOF'
 </example>
 
 Important:
-- DO NOT use the TodoWrite or Task tools
 - Return the PR URL when you're done, so the user can see it
 
 # Other common operations


### PR DESCRIPTION
### Issue for this PR

#18061 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the prohibition in bash instructions that prevented agents from using TodoWrite and Task tools. This restriction caused confusion since agents should be encouraged to use these tools for task management and complex codebase exploration. I don't think it's suitable to specify this instruction in the bash tool guide. By removing this restriction, agents can now properly leverage TodoWrite for task tracking and Task for specialized agent workflows without conflicting guidance.

### How did you verify your code works?

Ask the agent which ran into the confusion about using TodoWrite and Task tools to confirm its instructions.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
