### PR TITLE
docs: clarify skill/skills directory support across implementations

### DIFF
--- a/packages/web/src/content/docs/ar/skills.mdx
+++ b/packages/web/src/content/docs/ar/skills.mdx
@@ -13,12 +13,14 @@ description: "عرّف سلوكاً قابلاً لإعادة الاستخدام
 أنشئ مجلداً واحداً لكل اسم مهارة وضع بداخله ملف `SKILL.md`.
 يبحث OpenCode في هذه المواقع:
 
-- إعدادات المشروع: `.opencode/skills/<name>/SKILL.md`
-- إعدادات عامة: `~/.config/opencode/skills/<name>/SKILL.md`
+- إعدادات المشروع: `.opencode/skills/<name>/SKILL.md` أو `.opencode/skill/<name>/SKILL.md`
+- إعدادات عامة: `~/.config/opencode/skills/<name>/SKILL.md` أو `~/.config/opencode/skill/<name>/SKILL.md`
 - مشروع متوافق مع Claude: `.claude/skills/<name>/SKILL.md`
 - عام متوافق مع Claude: `~/.claude/skills/<name>/SKILL.md`
 - مشروع متوافق مع الوكلاء: `.agents/skills/<name>/SKILL.md`
 - عام متوافق مع الوكلاء: `~/.agents/skills/<name>/SKILL.md`
+
+ملاحظة: يدعم OpenCode اسمي الدليل `skills` (الجمع) و `skill` (المفرد)، بينما يدعم Claude و agents فقط `skills` (الجمع).
 
 ---
 

--- a/packages/web/src/content/docs/bs/skills.mdx
+++ b/packages/web/src/content/docs/bs/skills.mdx
@@ -13,12 +13,14 @@ Skills se ucitavaju po potrebi kroz ugradeni `skill` alat - agenti vide dostupne
 Kreirajte jedan folder po nazivu skill-a i stavite `SKILL.md` unutar njega.
 OpenCode pretrazuje ove lokacije:
 
-- Konfiguracija projekta: `.opencode/skills/<name>/SKILL.md`
-- Globalna konfiguracija: `~/.config/opencode/skills/<name>/SKILL.md`
+- Konfiguracija projekta: `.opencode/skills/<name>/SKILL.md` ili `.opencode/skill/<name>/SKILL.md`
+- Globalna konfiguracija: `~/.config/opencode/skills/<name>/SKILL.md` ili `~/.config/opencode/skill/<name>/SKILL.md`
 - Claude kompatibilno u projektu: `.claude/skills/<name>/SKILL.md`
 - Globalno Claude kompatibilno: `~/.claude/skills/<name>/SKILL.md`
 - Agent kompatibilno u projektu: `.agents/skills/<name>/SKILL.md`
 - Globalno agent kompatibilno: `~/.agents/skills/<name>/SKILL.md`
+
+Napomena: OpenCode podrzava nazive direktorija `skills` (mnozina) i `skill` (jednina), dok Claude i agents podrzavaju samo `skills` (mnozina).
 
 ---
 

--- a/packages/web/src/content/docs/da/skills.mdx
+++ b/packages/web/src/content/docs/da/skills.mdx
@@ -11,14 +11,16 @@ Ferdigheter lastes inn på forespørsel via det opprinnelige `skill`-verktøyet 
 ## Placer filer
 
 Opret én mappe per ferdighetsnavn og tilføj inn en `SKILL.md` i den.
-OpenCode søker etter disse stedene:
+OpenCode søger etter disse stedene:
 
-- Prosjektkonfigurasjon: `.opencode/skills/<name>/SKILL.md`
-- Global konfigurasjon: `~/.config/opencode/skills/<name>/SKILL.md`
+- Prosjektkonfigurasjon: `.opencode/skills/<name>/SKILL.md` eller `.opencode/skill/<name>/SKILL.md`
+- Global konfigurasjon: `~/.config/opencode/skills/<name>/SKILL.md` eller `~/.config/opencode/skill/<name>/SKILL.md`
 - Prosjekt Claude-kompatibel: `.claude/skills/<name>/SKILL.md`
 - Global Claude-kompatibel: `~/.claude/skills/<name>/SKILL.md`
 - Prosjektagent-kompatibel: `.agents/skills/<name>/SKILL.md`
 - Global agent-kompatibel: `~/.agents/skills/<name>/SKILL.md`
+
+Bemærk: OpenCode understøtter både `skills` (flertal) og `skill` (ental) som mappnavne, mens Claude og agents kun understøtter `skills` (flertal).
 
 ---
 

--- a/packages/web/src/content/docs/de/skills.mdx
+++ b/packages/web/src/content/docs/de/skills.mdx
@@ -13,12 +13,14 @@ Sie werden bei Bedarf ueber das native `skill`-Tool geladen, wenn ein Agent sie 
 Erstelle pro Skill-Namen einen Ordner und lege dort eine `SKILL.md` ab.
 OpenCode sucht in folgenden Pfaden:
 
-- Project config: `.opencode/skills/<name>/SKILL.md`
-- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
+- Project config: `.opencode/skills/<name>/SKILL.md` oder `.opencode/skill/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skills/<name>/SKILL.md` oder `~/.config/opencode/skill/<name>/SKILL.md`
 - Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
 - Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
 - Project agent-compatible: `.agents/skills/<name>/SKILL.md`
 - Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+
+Hinweis: OpenCode unterstützt sowohl `skills` (Plural) als auch `skill` (Singular) als Verzeichnisnamen, während Claude und agents nur `skills` (Plural) unterstützen.
 
 ---
 

--- a/packages/web/src/content/docs/es/skills.mdx
+++ b/packages/web/src/content/docs/es/skills.mdx
@@ -13,12 +13,14 @@ Las habilidades se cargan bajo demanda a través de la herramienta nativa `skill
 Cree una carpeta por nombre de habilidad y coloque un `SKILL.md` dentro de ella.
 OpenCode busca estas ubicaciones:
 
-- Configuración del proyecto: `.opencode/skills/<name>/SKILL.md`
-- Configuración global: `~/.config/opencode/skills/<name>/SKILL.md`
+- Configuración del proyecto: `.opencode/skills/<name>/SKILL.md` o `.opencode/skill/<name>/SKILL.md`
+- Configuración global: `~/.config/opencode/skills/<name>/SKILL.md` o `~/.config/opencode/skill/<name>/SKILL.md`
 - Compatible con Proyecto Claude: `.claude/skills/<name>/SKILL.md`
 - Compatible con Claude global: `~/.claude/skills/<name>/SKILL.md`
 - Compatible con agente de proyecto: `.agents/skills/<name>/SKILL.md`
 - Compatible con agentes globales: `~/.agents/skills/<name>/SKILL.md`
+
+Nota: OpenCode admite nombres de directorio `skills` (plural) y `skill` (singular), mientras que Claude y agents solo admiten `skills` (plural).
 
 ---
 

--- a/packages/web/src/content/docs/fr/skills.mdx
+++ b/packages/web/src/content/docs/fr/skills.mdx
@@ -11,14 +11,16 @@ Les compétences sont chargées à la demande via l'outil natif `skill` : les a
 ## Placer des fichiers
 
 Créez un dossier par nom de compétence et insérez-y un `SKILL.md`.
-OpenCode recherche ces emplacements :
+OpenCode recherche ces emplacements :
 
-- Configuration du projet : `.opencode/skills/<name>/SKILL.md`
-- Configuration globale : `~/.config/opencode/skills/<name>/SKILL.md`
-- Compatible Projet Claude : `.claude/skills/<name>/SKILL.md`
-- Compatible Global Claude : `~/.claude/skills/<name>/SKILL.md`
-- Compatible avec l'agent de projet : `.agents/skills/<name>/SKILL.md`
-- Compatible avec les agents globaux : `~/.agents/skills/<name>/SKILL.md`
+- Configuration du projet : `.opencode/skills/<name>/SKILL.md` ou `.opencode/skill/<name>/SKILL.md`
+- Configuration globale : `~/.config/opencode/skills/<name>/SKILL.md` ou `~/.config/opencode/skill/<name>/SKILL.md`
+- Compatible Projet Claude : `.claude/skills/<name>/SKILL.md`
+- Compatible Global Claude : `~/.claude/skills/<name>/SKILL.md`
+- Compatible avec l'agent de projet : `.agents/skills/<name>/SKILL.md`
+- Compatible avec les agents globaux : `~/.agents/skills/<name>/SKILL.md`
+
+Remarque : OpenCode prend en charge les noms de répertoire `skills` (pluriel) et `skill` (singulier), tandis que Claude et agents ne prennent en charge que `skills` (pluriel).
 
 ---
 

--- a/packages/web/src/content/docs/it/skills.mdx
+++ b/packages/web/src/content/docs/it/skills.mdx
@@ -13,12 +13,14 @@ Le skill vengono caricate on-demand tramite lo strumento nativo `skill`: gli age
 Crea una cartella per ogni nome di skill e metti un `SKILL.md` al suo interno.
 OpenCode cerca in queste posizioni:
 
-- Config di progetto: `.opencode/skills/<name>/SKILL.md`
-- Config globale: `~/.config/opencode/skills/<name>/SKILL.md`
+- Config di progetto: `.opencode/skills/<name>/SKILL.md` o `.opencode/skill/<name>/SKILL.md`
+- Config globale: `~/.config/opencode/skills/<name>/SKILL.md` o `~/.config/opencode/skill/<name>/SKILL.md`
 - Progetto compatibile con Claude: `.claude/skills/<name>/SKILL.md`
 - Globale compatibile con Claude: `~/.claude/skills/<name>/SKILL.md`
 - Progetto compatibile con agent: `.agents/skills/<name>/SKILL.md`
 - Globale compatibile con agent: `~/.agents/skills/<name>/SKILL.md`
+
+Nota: OpenCode supporta sia `skills` (plurale) che `skill` (singolare) come nomi di directory, mentre Claude e agents supportano solo `skills` (plurale).
 
 ---
 

--- a/packages/web/src/content/docs/ja/skills.mdx
+++ b/packages/web/src/content/docs/ja/skills.mdx
@@ -13,12 +13,14 @@ description: SKILL.md 定義による再利用可能な動作の定義
 スキル名ごとにフォルダーを 1 つ作成し、その中に `SKILL.md` を置きます。
 OpenCode は次の場所を検索します。
 
-- プロジェクト設定: `.opencode/skills/<name>/SKILL.md`
-- グローバル設定: `~/.config/opencode/skills/<name>/SKILL.md`
+- プロジェクト設定: `.opencode/skills/<name>/SKILL.md` または `.opencode/skill/<name>/SKILL.md`
+- グローバル設定: `~/.config/opencode/skills/<name>/SKILL.md` または `~/.config/opencode/skill/<name>/SKILL.md`
 - プロジェクト Claude 互換: `.claude/skills/<name>/SKILL.md`
 - グローバル Claude 互換: `~/.claude/skills/<name>/SKILL.md`
 - プロジェクトエージェント互換: `.agents/skills/<name>/SKILL.md`
 - グローバルエージェント互換: `~/.agents/skills/<name>/SKILL.md`
+
+注意: OpenCode は `skills`(複数形)と `skill`(単数形)の両方のディレクトリ名をサポートしていますが、Claude と agents は `skills`(複数形)のみをサポートしています。
 
 ---
 

--- a/packages/web/src/content/docs/ko/skills.mdx
+++ b/packages/web/src/content/docs/ko/skills.mdx
@@ -13,12 +13,14 @@ Skills are loaded on-demand via native `skill` tool-agents see available skills 
 기술 이름 당 하나의 폴더를 만들고 내부 `SKILL.md`를 넣어.
 opencode 이 위치를 검색:
 
-- 프로젝트 구성: `.opencode/skills/<name>/SKILL.md`
-- 글로벌 구성: `~/.config/opencode/skills/<name>/SKILL.md`
+- 프로젝트 구성: `.opencode/skills/<name>/SKILL.md` 또는 `.opencode/skill/<name>/SKILL.md`
+- 글로벌 구성: `~/.config/opencode/skills/<name>/SKILL.md` 또는 `~/.config/opencode/skill/<name>/SKILL.md`
 - 프로젝트 클로드 호환 : `.claude/skills/<name>/SKILL.md`
 - 글로벌 클로드 호환 : `~/.claude/skills/<name>/SKILL.md`
 - 프로젝트 에이전트 호환 : `.agents/skills/<name>/SKILL.md`
 - 글로벌 에이전트 호환 : `~/.agents/skills/<name>/SKILL.md`
+
+참고: OpenCode는 `skills`(복수형)와 `skill`(단수형) 디렉토리 이름을 모두 지원하지만, Claude와 agents는 `skills`(복수형)만 지원합니다.
 
 ---
 

--- a/packages/web/src/content/docs/nb/skills.mdx
+++ b/packages/web/src/content/docs/nb/skills.mdx
@@ -13,12 +13,14 @@ Ferdigheter lastes inn på forespørsel via det innebygde `skill`-verktøyet –
 Opprett én mappe per ferdighetsnavn og legg inn en `SKILL.md` i den.
 opencode søker etter disse stedene:
 
-- Prosjektkonfigurasjon: `.opencode/skills/<name>/SKILL.md`
-- Global konfigurasjon: `~/.config/opencode/skills/<name>/SKILL.md`
+- Prosjektkonfigurasjon: `.opencode/skills/<name>/SKILL.md` eller `.opencode/skill/<name>/SKILL.md`
+- Global konfigurasjon: `~/.config/opencode/skills/<name>/SKILL.md` eller `~/.config/opencode/skill/<name>/SKILL.md`
 - Prosjekt Claude-kompatibel: `.claude/skills/<name>/SKILL.md`
 - Global Claude-kompatibel: `~/.claude/skills/<name>/SKILL.md`
 - Prosjektagent-kompatibel: `.agents/skills/<name>/SKILL.md`
 - Global agent-kompatibel: `~/.agents/skills/<name>/SKILL.md`
+
+Merk: OpenCode støtter både `skills` (flertall) og `skill` (entall) som mappenavn, mens Claude og agents bare støtter `skills` (flertall).
 
 ---
 

--- a/packages/web/src/content/docs/pl/skills.mdx
+++ b/packages/web/src/content/docs/pl/skills.mdx
@@ -13,12 +13,14 @@ Umiejętności są ładowane na żądanie za pośrednictwem natywnego narzędzia
 Utwórz jeden folder na nazwę umiejętności i umieść w nim `SKILL.md`.
 opencode przeszukuje te lokalizacje:
 
-- Project config: `.opencode/skills/<name>/SKILL.md`
-- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
+- Project config: `.opencode/skills/<name>/SKILL.md` lub `.opencode/skill/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skills/<name>/SKILL.md` lub `~/.config/opencode/skill/<name>/SKILL.md`
 - Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
 - Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
 - Project agent-compatible: `.agents/skills/<name>/SKILL.md`
 - Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+
+Uwaga: OpenCode obsługuje nazwy katalogów `skills` (liczba mnoga) i `skill` (liczba pojedyncza), podczas gdy Claude i agents obsługują tylko `skills` (liczba mnoga).
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/skills.mdx
+++ b/packages/web/src/content/docs/pt-br/skills.mdx
@@ -13,12 +13,14 @@ As habilidades são carregadas sob demanda através da ferramenta nativa `skill`
 Crie uma pasta por nome de habilidade e coloque um `SKILL.md` dentro dela.
 O opencode pesquisa nesses locais:
 
-- Configuração do projeto: `.opencode/skills/<name>/SKILL.md`
-- Configuração global: `~/.config/opencode/skills/<name>/SKILL.md`
+- Configuração do projeto: `.opencode/skills/<name>/SKILL.md` ou `.opencode/skill/<name>/SKILL.md`
+- Configuração global: `~/.config/opencode/skills/<name>/SKILL.md` ou `~/.config/opencode/skill/<name>/SKILL.md`
 - Projeto compatível com Claude: `.claude/skills/<name>/SKILL.md`
 - Global compatível com Claude: `~/.claude/skills/<name>/SKILL.md`
 - Projeto compatível com agente: `.agents/skills/<name>/SKILL.md`
 - Global compatível com agente: `~/.agents/skills/<name>/SKILL.md`
+
+Nota: O OpenCode suporta os nomes de diretório `skills` (plural) e `skill` (singular), enquanto Claude e agents suportam apenas `skills` (plural).
 
 ---
 

--- a/packages/web/src/content/docs/ru/skills.mdx
+++ b/packages/web/src/content/docs/ru/skills.mdx
@@ -13,12 +13,14 @@ description: Определите повторно используемое по
 Создайте одну папку для каждого имени навыка и поместите в нее `SKILL.md`.
 opencode выполняет поиск в следующих местах:
 
-- Конфигурация проекта: `.opencode/skills/<name>/SKILL.md`
-- Глобальная конфигурация: `~/.config/opencode/skills/<name>/SKILL.md`.
+- Конфигурация проекта: `.opencode/skills/<name>/SKILL.md` или `.opencode/skill/<name>/SKILL.md`
+- Глобальная конфигурация: `~/.config/opencode/skills/<name>/SKILL.md` или `~/.config/opencode/skill/<name>/SKILL.md`
 - Совместимость с Project Claude: `.claude/skills/<name>/SKILL.md`
 - Глобальная совместимость с Claude: `~/.claude/skills/<name>/SKILL.md`
 - Совместимость с агентом проекта: `.agents/skills/<name>/SKILL.md`
 - Совместимость с глобальным агентом: `~/.agents/skills/<name>/SKILL.md`
+
+Примечание: OpenCode поддерживает оба имени каталога `skills` (множественное число) и `skill` (единственное число), в то время как Claude и agents поддерживают только `skills` (множественное число).
 
 ---
 

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -13,12 +13,14 @@ Skills are loaded on-demand via the native `skill` tool—agents see available s
 Create one folder per skill name and put a `SKILL.md` inside it.
 OpenCode searches these locations:
 
-- Project config: `.opencode/skills/<name>/SKILL.md`
-- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
+- Project config: `.opencode/skills/<name>/SKILL.md` or `.opencode/skill/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skills/<name>/SKILL.md` or `~/.config/opencode/skill/<name>/SKILL.md`
 - Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
 - Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
 - Project agent-compatible: `.agents/skills/<name>/SKILL.md`
 - Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+
+Note: OpenCode supports both `skills` (plural) and `skill` (singular) directory names, while Claude and agents only support `skills` (plural).
 
 ---
 

--- a/packages/web/src/content/docs/th/skills.mdx
+++ b/packages/web/src/content/docs/th/skills.mdx
@@ -13,12 +13,14 @@ description: "กำหนดพฤติกรรมที่นำมาใช
 สร้างหนึ่งโฟลเดอร์ต่อชื่อทักษะ และใส่ `SKILL.md` ไว้ข้างใน
 OpenCode ค้นหาตำแหน่งเหล่านี้:
 
-- การกำหนดค่าโครงการ: `.opencode/skills/<name>/SKILL.md`
-- การกำหนดค่าส่วนกลาง: `~/.config/opencode/skills/<name>/SKILL.md`
+- การกำหนดค่าโครงการ: `.opencode/skills/<name>/SKILL.md` หรือ `.opencode/skill/<name>/SKILL.md`
+- การกำหนดค่าส่วนกลาง: `~/.config/opencode/skills/<name>/SKILL.md` หรือ `~/.config/opencode/skill/<name>/SKILL.md`
 - เข้ากันได้กับโครงการ Claude: `.claude/skills/<name>/SKILL.md`
 - เข้ากันได้กับ Global Claude: `~/.claude/skills/<name>/SKILL.md`
 - เข้ากันได้กับตัวแทนโครงการ: `.agents/skills/<name>/SKILL.md`
 - รองรับตัวแทนทั่วโลก: `~/.agents/skills/<name>/SKILL.md`
+
+หมายเหตุ: OpenCode รองรับชื่อไดเร็กทอรี `skills` (พหูพจน์) และ `skill` (เอกพจน์) ในขณะที่ Claude และ agents รองรับเฉพาะ `skills` (พหูพจน์)
 
 ---
 

--- a/packages/web/src/content/docs/tr/skills.mdx
+++ b/packages/web/src/content/docs/tr/skills.mdx
@@ -13,12 +13,14 @@ Beceriler, yerel `skill` araci uzerinden ihtiyac aninda yuklenir; ajanlar mevcut
 Her beceri adi icin bir klasor olusturun ve icine bir `SKILL.md` koyun.
 opencode su konumlari tarar:
 
-- Proje konfigurasyonu: `.opencode/skills/<name>/SKILL.md`
-- Genel konfigurasyon: `~/.config/opencode/skills/<name>/SKILL.md`
+- Proje konfigurasyonu: `.opencode/skills/<name>/SKILL.md` veya `.opencode/skill/<name>/SKILL.md`
+- Genel konfigurasyon: `~/.config/opencode/skills/<name>/SKILL.md` veya `~/.config/opencode/skill/<name>/SKILL.md`
 - Proje Claude uyumlu: `.claude/skills/<name>/SKILL.md`
 - Genel Claude uyumlu: `~/.claude/skills/<name>/SKILL.md`
 - Proje agent uyumlu: `.agents/skills/<name>/SKILL.md`
 - Genel agent uyumlu: `~/.agents/skills/<name>/SKILL.md`
+
+Not: OpenCode hem `skills` (cogul) hem de `skill` (tekil) dizin adlarini desteklerken, Claude ve agents yalnizca `skills` (cogul) destekler.
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/skills.mdx
+++ b/packages/web/src/content/docs/zh-cn/skills.mdx
@@ -13,12 +13,14 @@ description: "通过 SKILL.md 定义可复用的行为"
 为每个技能名称创建一个文件夹，并在其中放入 `SKILL.md`。
 OpenCode 会搜索以下位置：
 
-- 项目配置：`.opencode/skills/<name>/SKILL.md`
-- 全局配置：`~/.config/opencode/skills/<name>/SKILL.md`
+- 项目配置：`.opencode/skills/<name>/SKILL.md` 或 `.opencode/skill/<name>/SKILL.md`
+- 全局配置：`~/.config/opencode/skills/<name>/SKILL.md` 或 `~/.config/opencode/skill/<name>/SKILL.md`
 - 项目 Claude 兼容：`.claude/skills/<name>/SKILL.md`
 - 全局 Claude 兼容：`~/.claude/skills/<name>/SKILL.md`
 - 项目代理兼容：`.agents/skills/<name>/SKILL.md`
 - 全局代理兼容：`~/.agents/skills/<name>/SKILL.md`
+
+注意：OpenCode 同时支持 `skills`（复数）和 `skill`（单数）目录名称，而 Claude 和 agents 仅支持 `skills`（复数）。
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/skills.mdx
+++ b/packages/web/src/content/docs/zh-tw/skills.mdx
@@ -13,12 +13,14 @@ description: "透過 SKILL.md 定義可重複使用的行為"
 為每個技能名稱建立一個資料夾，並在其中放入 `SKILL.md`。
 OpenCode 會搜尋以下位置：
 
-- 專案設定：`.opencode/skills/<name>/SKILL.md`
-- 全域設定：`~/.config/opencode/skills/<name>/SKILL.md`
+- 專案設定：`.opencode/skills/<name>/SKILL.md` 或 `.opencode/skill/<name>/SKILL.md`
+- 全域設定：`~/.config/opencode/skills/<name>/SKILL.md` 或 `~/.config/opencode/skill/<name>/SKILL.md`
 - 專案 Claude 相容：`.claude/skills/<name>/SKILL.md`
 - 全域 Claude 相容：`~/.claude/skills/<name>/SKILL.md`
 - 專案代理相容：`.agents/skills/<name>/SKILL.md`
 - 全域代理相容：`~/.agents/skills/<name>/SKILL.md`
+
+注意：OpenCode 同時支援 `skills`（複數）和 `skill`（單數）目錄名稱，而 Claude 和 agents 僅支援 `skills`（複數）。
 
 ---
 


### PR DESCRIPTION
Update skills documentation across all languages to clarify that OpenCode supports both singular (skill) and plural (skills) directory names, while Claude and agents only support the plural form.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
test and review the code to make sure the skill and skills works both.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
