### PR TITLE
fix(opencode): respect configured model input limits

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -983,6 +983,7 @@ export namespace Config {
         .record(
           z.string(),
           ModelsDev.Model.partial().extend({
+            limit: ModelsDev.Model.shape.limit.partial().optional(),
             variants: z
               .record(
                 z.string(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -932,6 +932,7 @@ export namespace Provider {
           options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
           limit: {
             context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
+            input: model.limit?.input ?? existingModel?.limit?.input,
             output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
           },
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -452,6 +452,83 @@ test("provider with baseURL from config", async () => {
   })
 })
 
+test("custom model preserves configured input limit", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            custom: {
+              name: "Custom Provider",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              options: {
+                apiKey: "test-key",
+              },
+              models: {
+                sample: {
+                  name: "Sample",
+                  tool_call: true,
+                  limit: {
+                    context: 128_000,
+                    input: 64_000,
+                    output: 4096,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers["custom"].models["sample"]
+      expect(model.limit.input).toBe(64_000)
+    },
+  })
+})
+
+test("model override can replace input limit", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              options: {
+                apiKey: "test-key",
+              },
+              models: {
+                "gpt-5.4": {
+                  limit: {
+                    input: 922_000,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers["openai"].models["gpt-5.4"]
+      expect(model.limit.input).toBe(922_000)
+    },
+  })
+})
+
 test("model cost defaults to zero when not specified", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #16298
Refs #16308

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It keeps `provider.models.<model>.limit.input` when building provider config overrides and allows config files to override just `limit.input` without restating `context` and `output`.

That fixes the long-context OpenAI case where users want to raise the client-side compaction threshold for models like `gpt-5.4`.

### How did you verify your code works?

- Added provider tests that verify custom models keep configured `limit.input`
- Added a regression test that verifies an `openai` model override can set only `limit.input`
- Ran `bun test test/provider/provider.test.ts`
- Ran `bun typecheck` in `packages/opencode`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR