### PR TITLE
feat: auto discover models from custom providers

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -977,6 +977,7 @@ export namespace Config {
 
   export const Provider = ModelsDev.Provider.partial()
     .extend({
+      discover: z.boolean().optional().describe("Auto-discover models from this provider (default: false)"),
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
       models: z

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -946,6 +946,73 @@ export namespace Provider {
         )
         parsed.models[modelID] = parsedModel
       }
+
+      if (provider.discover) {
+        const npm = provider.npm ?? modelsDev[providerID]?.npm ?? "@ai-sdk/openai-compatible"
+        const baseURL = provider.options?.baseURL ?? provider.api ?? modelsDev[providerID]?.api
+        if ((npm === "@ai-sdk/openai-compatible" || npm === "@ai-sdk/openai" || npm === "openai") && baseURL) {
+          try {
+            const url = new URL(baseURL.replace(/\/$/, "") + "/models")
+            let apiKey = provider.options?.apiKey
+            if (!apiKey) {
+              const envVars = provider.env ?? existing?.env ?? []
+              for (const e of envVars) {
+                const val = Env.get(e)
+                if (val) {
+                  apiKey = val
+                  break
+                }
+              }
+            }
+            if (!apiKey) {
+              const auth = await Auth.get(providerID)
+              if (auth && auth.type === "api") apiKey = auth.key
+            }
+
+            const res = await fetch(url.href, {
+              headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+              signal: AbortSignal.timeout(5000),
+            })
+            if (res.ok) {
+              const data = (await res.json()) as { data: any[] }
+              if (data && Array.isArray(data.data)) {
+                for (const m of data.data) {
+                  if (!m.id) continue
+                  const modelID = m.id
+                  if (!parsed.models[modelID]) {
+                    parsed.models[modelID] = {
+                      id: ModelID.make(modelID),
+                      name: modelID,
+                      providerID: ProviderID.make(providerID),
+                      api: { id: modelID, npm, url: baseURL },
+                      status: "active",
+                      capabilities: {
+                        temperature: true,
+                        reasoning: false,
+                        attachment: false,
+                        toolcall: true,
+                        input: { text: true, audio: false, image: false, video: false, pdf: false },
+                        output: { text: true, audio: false, image: false, video: false, pdf: false },
+                        interleaved: false,
+                      },
+                      limit: { context: 128000, output: 4096 },
+                      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+                      options: {},
+                      variants: {},
+                      headers: {},
+                      family: "",
+                      release_date: "",
+                    }
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            log.warn("failed to discover models", { providerID, error: e })
+          }
+        }
+      }
+
       database[providerID] = parsed
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `discover` field to the Provider configuration to allow auto-discovering models for custom providers using the `/v1/models` endpoint for `@ai-sdk/openai-compatible` providers (e.g., Ollama, vLLM).

During initialization, the provider checks the endpoint and dynamically populates the available models that are not already explicitly configured by the user. Discovered models default to reasonable settings (e.g. 128K context window, standard tool support enabled) making it extremely simple to set up a local provider without listing all models manually.

### How did you verify your code works?

Tested locally by configuring an openai-compatible provider with `discover: true` and validating that models fetched from the `/v1/models` endpoint successfully populate the configuration list.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR