### PR TITLE
feat(opencode): add remote TUI directory switching

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -19,6 +19,7 @@ import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
+import { DialogChangeDirectory } from "@tui/component/dialog-change-directory"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { DialogWorkspaceList } from "@tui/component/dialog-workspace-list"
 import { KeybindProvider } from "@tui/context/keybind"
@@ -370,6 +371,18 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogSessionList />)
+      },
+    },
+    {
+      title: "Change directory",
+      value: "directory.change",
+      category: "Workspace",
+      slash: {
+        name: "changedirectory",
+        aliases: ["cd"],
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogChangeDirectory />)
       },
     },
     ...(Flag.OPENCODE_EXPERIMENTAL_WORKSPACES

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-change-directory.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-change-directory.tsx
@@ -1,0 +1,28 @@
+import { useDialog } from "@tui/ui/dialog"
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
+import { useRoute } from "@tui/context/route"
+import { useSync } from "@tui/context/sync"
+import { useSDK } from "../context/sdk"
+
+export function DialogChangeDirectory() {
+  const dialog = useDialog()
+  const route = useRoute()
+  const sync = useSync()
+  const sdk = useSDK()
+
+  return (
+    <DialogPrompt
+      title="Change Directory"
+      value={sync.data.path.directory || sdk.directory || "/"}
+      placeholder="/path/to/project"
+      onConfirm={(value) => {
+        const dir = value.trim().replace(/\/+$/g, "") || "/"
+        dialog.clear()
+        sdk.setDirectory(dir)
+        route.navigate({ type: "home" })
+        void sync.bootstrap()
+      }}
+      onCancel={() => dialog.clear()}
+    />
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -5,6 +5,7 @@ import { batch, onCleanup, onMount } from "solid-js"
 
 export type EventSource = {
   on: (handler: (event: Event) => void) => () => void
+  setDirectory?: (directory: string) => void
   setWorkspace?: (workspaceID?: string) => void
 }
 
@@ -18,6 +19,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     events?: EventSource
   }) => {
     const abort = new AbortController()
+    let directory = props.directory
     let workspaceID: string | undefined
     let sse: AbortController | undefined
 
@@ -25,7 +27,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       return createOpencodeClient({
         baseUrl: props.url,
         signal: abort.signal,
-        directory: props.directory,
+        directory,
         fetch: props.fetch,
         headers: props.headers,
         experimental_workspaceID: workspaceID,
@@ -109,9 +111,19 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       get client() {
         return sdk
       },
-      directory: props.directory,
+      get directory() {
+        return directory
+      },
       event: emitter,
       fetch: props.fetch ?? fetch,
+      setDirectory(next: string) {
+        if (directory === next) return
+        directory = next
+        workspaceID = undefined
+        sdk = createSDK()
+        props.events?.setDirectory?.(next)
+        if (!props.events) startSSE()
+      },
       setWorkspace(next?: string) {
         if (workspaceID === next) return
         workspaceID = next

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -42,6 +42,9 @@ function createWorkerFetch(client: RpcClient): typeof fetch {
 function createEventSource(client: RpcClient): EventSource {
   return {
     on: (handler) => client.on<Event>("event", handler),
+    setDirectory: (directory) => {
+      void client.call("setDirectory", { directory })
+    },
     setWorkspace: (workspaceID) => {
       void client.call("setWorkspace", { workspaceID })
     },

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -44,6 +44,11 @@ const eventStream = {
   abort: undefined as AbortController | undefined,
 }
 
+const state = {
+  directory: process.cwd(),
+  workspaceID: undefined as string | undefined,
+}
+
 const startEventStream = (input: { directory: string; workspaceID?: string }) => {
   if (eventStream.abort) eventStream.abort.abort()
   const abort = new AbortController()
@@ -96,7 +101,7 @@ const startEventStream = (input: { directory: string; workspaceID?: string }) =>
   })
 }
 
-startEventStream({ directory: process.cwd() })
+startEventStream({ directory: state.directory })
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {
@@ -136,8 +141,14 @@ export const rpc = {
     Config.global.reset()
     await Instance.disposeAll()
   },
+  async setDirectory(input: { directory: string }) {
+    state.directory = input.directory
+    state.workspaceID = undefined
+    startEventStream({ directory: state.directory })
+  },
   async setWorkspace(input: { workspaceID?: string }) {
-    startEventStream({ directory: process.cwd(), workspaceID: input.workspaceID })
+    state.workspaceID = input.workspaceID
+    startEventStream({ directory: state.directory, workspaceID: state.workspaceID })
   },
   async shutdown() {
     Log.Default.info("worker shutting down")


### PR DESCRIPTION
### Issue for this PR

Closes #18119

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a small `/changedirectory` command for the remote TUI flow.

When the TUI is attached to a remote server, it should not stay tied to the startup cwd forever, otherwise switching remote project context is awkward. This change lets the TUI reload itself against a new remote directory, clears the active workspace selection, and returns to the home screen.

### How did you verify your code works?

I tested it by attaching to a remote OpenCode server, running `/changedirectory`, entering a different remote directory, and confirming the TUI returned to home and reloaded against the new path.

### Screenshots / recordings
<img width="1040" height="921" alt="屏幕截图 2026-03-19 020712" src="https://github.com/user-attachments/assets/caa11bc1-0cfd-43a5-a539-540501c95889" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
