### PR TITLE
feat(auth): show provider account identity after /connect

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -181,11 +181,24 @@ export function DialogConnectProvider(props: { provider: string }) {
   async function complete() {
     await globalSDK.client.global.dispose()
     dialog.close()
+
+    // Fetch identity to show which account was connected
+    let email: string | undefined
+    try {
+      const response = await fetch("/auth/identity")
+      if (response.ok) {
+        const identities = (await response.json()) as Record<string, string>
+        email = identities[props.provider]
+      }
+    } catch {}
+
     showToast({
       variant: "success",
       icon: "circle-check",
       title: language.t("provider.connect.toast.connected.title", { provider: provider().name }),
-      description: language.t("provider.connect.toast.connected.description", { provider: provider().name }),
+      description: email
+        ? language.t("provider.connect.toast.connected.description", { provider: provider().name }) + ` (${email})`
+        : language.t("provider.connect.toast.connected.description", { provider: provider().name }),
     })
   }
 

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -4,7 +4,7 @@ import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { Tag } from "@opencode-ai/ui/tag"
 import { showToast } from "@opencode-ai/ui/toast"
 import { popularProviders, useProviders } from "@/hooks/use-providers"
-import { createMemo, type Component, For, Show } from "solid-js"
+import { createMemo, createSignal, onMount, type Component, For, Show } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
@@ -33,6 +33,17 @@ export const SettingsProviders: Component = () => {
   const globalSDK = useGlobalSDK()
   const globalSync = useGlobalSync()
   const providers = useProviders()
+
+  const [identity, setIdentity] = createSignal<Record<string, string>>({})
+
+  onMount(async () => {
+    try {
+      const response = await fetch("/auth/identity")
+      if (response.ok) {
+        setIdentity(await response.json())
+      }
+    } catch {}
+  })
 
   const connected = createMemo(() => {
     return providers
@@ -153,6 +164,11 @@ export const SettingsProviders: Component = () => {
                       <ProviderIcon id={item.id} class="size-5 shrink-0 icon-strong-base" />
                       <span class="text-14-medium text-text-strong truncate">{item.name}</span>
                       <Tag>{type(item)}</Tag>
+                      <Show when={identity()[item.id]}>
+                        {(email) => (
+                          <span class="text-12-regular text-text-weak truncate">{email()}</span>
+                        )}
+                      </Show>
                     </div>
                     <Show
                       when={canDisconnect(item)}

--- a/packages/opencode/src/auth/effect.ts
+++ b/packages/opencode/src/auth/effect.ts
@@ -12,6 +12,7 @@ export class Oauth extends Schema.Class<Oauth>("OAuth")({
   expires: Schema.Number,
   accountId: Schema.optional(Schema.String),
   enterpriseUrl: Schema.optional(Schema.String),
+  email: Schema.optional(Schema.String),
 }) {}
 
 export class Api extends Schema.Class<Api>("ApiAuth")({

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -18,6 +18,7 @@ export namespace Auth {
       expires: z.number(),
       accountId: z.string().optional(),
       enterpriseUrl: z.string().optional(),
+      email: z.string().optional(),
     })
     .meta({ ref: "OAuth" })
 

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -253,6 +253,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                       expires: number
                       provider?: string
                       enterpriseUrl?: string
+                      email?: string
                     } = {
                       type: "success",
                       refresh: data.access_token,
@@ -263,6 +264,24 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                     if (deploymentType === "enterprise") {
                       result.enterpriseUrl = domain
                     }
+
+                    // Fetch GitHub user identity (best-effort)
+                    try {
+                      const apiBase = domain === "github.com"
+                        ? "https://api.github.com"
+                        : `https://${domain}/api/v3`
+                      const userResponse = await fetch(`${apiBase}/user`, {
+                        headers: {
+                          Authorization: `Bearer ${data.access_token}`,
+                          Accept: "application/json",
+                          "User-Agent": `opencode/${Installation.VERSION}`,
+                        },
+                      })
+                      if (userResponse.ok) {
+                        const user = (await userResponse.json()) as { login?: string; email?: string }
+                        result.email = user.login ?? user.email
+                      }
+                    } catch {}
 
                     return result
                   }

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -205,6 +205,7 @@ export namespace ProviderAuth {
             refresh: result.refresh,
             expires: result.expires,
             ...(result.accountId ? { accountId: result.accountId } : {}),
+            ...(result.email ? { email: result.email } : {}),
           })
         }
       })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -192,6 +192,34 @@ export namespace Server {
           return c.json(true)
         },
       )
+      .get(
+        "/auth/identity",
+        describeRoute({
+          summary: "Get provider identities",
+          description: "Get the email or username associated with each authenticated provider.",
+          operationId: "auth.identity",
+          responses: {
+            200: {
+              description: "Map of provider IDs to identity strings",
+              content: {
+                "application/json": {
+                  schema: resolver(z.record(z.string(), z.string())),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const all = await Auth.all()
+          const identity: Record<string, string> = {}
+          for (const [providerID, info] of Object.entries(all)) {
+            if (info.type === "oauth" && "email" in info && info.email) {
+              identity[providerID] = info.email
+            }
+          }
+          return c.json(identity)
+        },
+      )
       .use(async (c, next) => {
         if (c.req.path === "/log") return next()
         const rawWorkspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -123,6 +123,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
         | ({
             type: "success"
             provider?: string
+            email?: string
           } & (
             | {
                 refresh: string
@@ -143,6 +144,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
         | ({
             type: "success"
             provider?: string
+            email?: string
           } & (
             | {
                 refresh: string


### PR DESCRIPTION
### Issue for this PR

Closes #18125

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After `/connect` completes, there's no way to see which account was authenticated. With multiple accounts on the same provider, you're flying blind.

This adds optional `email` to the plugin `AuthOauthResult` callback return type. Providers can now return identity info after successful OAuth. The Copilot plugin uses this to fetch the GitHub username via `/user` (best-effort, wrapped in try/catch so it can't break auth).

A new `GET /auth/identity` endpoint returns a `{providerID: email}` map from stored auth data (credentials are never exposed). The settings providers list and the connect success toast use this to show which account is connected.

8 files, +83/-2 across 4 packages (plugin, opencode, app).

### How did you verify your code works?

- `bun turbo typecheck` passes all 13 packages (ran locally + CI confirms)
- Unit tests pass on Linux and Windows
- The 3 e2e failures are pre-existing flaky tests unrelated to auth (workspaces, multiline prompt, session model persistence)

### Screenshots / recordings

_No screenshots — identity display is a text label next to existing provider entries._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR