### PR TITLE
fix(core): switch /event route to effect and implement queue

### DIFF
--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -1,0 +1,91 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import { streamSSE } from "hono/streaming"
+import { Effect, Queue, Stream } from "effect"
+import { Log } from "@/util/log"
+import { BusEvent } from "@/bus/bus-event"
+import { Bus } from "@/bus"
+import { lazy } from "../../util/lazy"
+
+const log = Log.create({ service: "server" })
+
+export const EventRoutes = lazy(() =>
+  new Hono().get(
+    "/event",
+    describeRoute({
+      summary: "Subscribe to events",
+      description: "Get events",
+      operationId: "event.subscribe",
+      responses: {
+        200: {
+          description: "Event stream",
+          content: {
+            "text/event-stream": {
+              schema: resolver(BusEvent.payloads()),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      log.info("event connected")
+      c.header("X-Accel-Buffering", "no")
+      c.header("X-Content-Type-Options", "nosniff")
+      return streamSSE(c, async (stream) => {
+        await Effect.runPromise(
+          Stream.callback<string>((q) =>
+            Effect.acquireRelease(
+              Effect.sync(() => {
+                stream.onAbort(() => {
+                  Queue.endUnsafe(q)
+                })
+
+                Queue.offerUnsafe(
+                  q,
+                  JSON.stringify({
+                    type: "server.connected",
+                    properties: {},
+                  }),
+                )
+
+                const unsub = Bus.subscribeAll((event) => {
+                  Queue.offerUnsafe(q, JSON.stringify(event))
+                  if (event.type === Bus.InstanceDisposed.type) {
+                    Queue.endUnsafe(q)
+                  }
+                })
+
+                // Send heartbeat every 10s to prevent stalled proxy streams.
+                const heartbeat = setInterval(() => {
+                  Queue.offerUnsafe(
+                    q,
+                    JSON.stringify({
+                      type: "server.heartbeat",
+                      properties: {},
+                    }),
+                  )
+                }, 10_000)
+
+                return { heartbeat, unsub }
+              }),
+              (x) =>
+                Effect.sync(() => {
+                  clearInterval(x.heartbeat)
+                  x.unsub()
+                  Queue.endUnsafe(q)
+                  log.info("event disconnected")
+                }),
+            ),
+          ).pipe(
+            Stream.runForEach((data) =>
+              Effect.tryPromise({
+                try: () => stream.writeSSE({ data }),
+                catch: () => {},
+              }),
+            ),
+          ),
+        )
+      })
+    },
+  ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,10 +1,7 @@
-import { BusEvent } from "@/bus/bus-event"
-import { Bus } from "@/bus"
 import { Log } from "../util/log"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono } from "hono"
 import { cors } from "hono/cors"
-import { streamSSE } from "hono/streaming"
 import { proxy } from "hono/proxy"
 import { basicAuth } from "hono/basic-auth"
 import z from "zod"
@@ -34,6 +31,7 @@ import { FileRoutes } from "./routes/file"
 import { ConfigRoutes } from "./routes/config"
 import { ExperimentalRoutes } from "./routes/experimental"
 import { ProviderRoutes } from "./routes/provider"
+import { EventRoutes } from "./routes/event"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { NotFoundError } from "../storage/db"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
@@ -251,6 +249,7 @@ export namespace Server {
       .route("/question", QuestionRoutes())
       .route("/provider", ProviderRoutes())
       .route("/", FileRoutes())
+      .route("/", EventRoutes())
       .route("/mcp", McpRoutes())
       .route("/tui", TuiRoutes())
       .post(
@@ -496,64 +495,6 @@ export namespace Server {
         }),
         async (c) => {
           return c.json(await Format.status())
-        },
-      )
-      .get(
-        "/event",
-        describeRoute({
-          summary: "Subscribe to events",
-          description: "Get events",
-          operationId: "event.subscribe",
-          responses: {
-            200: {
-              description: "Event stream",
-              content: {
-                "text/event-stream": {
-                  schema: resolver(BusEvent.payloads()),
-                },
-              },
-            },
-          },
-        }),
-        async (c) => {
-          log.info("event connected")
-          c.header("X-Accel-Buffering", "no")
-          c.header("X-Content-Type-Options", "nosniff")
-          return streamSSE(c, async (stream) => {
-            stream.writeSSE({
-              data: JSON.stringify({
-                type: "server.connected",
-                properties: {},
-              }),
-            })
-            const unsub = Bus.subscribeAll(async (event) => {
-              await stream.writeSSE({
-                data: JSON.stringify(event),
-              })
-              if (event.type === Bus.InstanceDisposed.type) {
-                stream.close()
-              }
-            })
-
-            // Send heartbeat every 10s to prevent stalled proxy streams.
-            const heartbeat = setInterval(() => {
-              stream.writeSSE({
-                data: JSON.stringify({
-                  type: "server.heartbeat",
-                  properties: {},
-                }),
-              })
-            }, 10_000)
-
-            await new Promise<void>((resolve) => {
-              stream.onAbort(() => {
-                clearInterval(heartbeat)
-                unsub()
-                resolve()
-                log.info("event disconnected")
-              })
-            })
-          })
         },
       )
       .all("/*", async (c) => {


### PR DESCRIPTION
* Moves the `/event` route into it's own file
* Reimplements it with effect
* The reason to do this is to handle event processing more explicitly. Previously, it was doing `await stream.writeSSE` inside of a callback to `Bus.subscribeAll`. The `Bus` abstraction allows you to do `await Bus.publish` and it will actually wait for all listeners to finish processing, and since a listener is writing to SSE, it will block until the event is written to SSE
* However, that's a little strange, and is unpredictable because multiple paths could be publishing events through the bus. So it _looks_ like it's writing events to SSE in order, but that's not actually guaranteed
* We aren't able to actually allow waiting when publishing events anymore. With the new sync system, it will handle emitting a lot of events internally
* We still should queue writing events to SSE. This PR does that by using effect's queue mechanism, pushing events as they come onto the queue and then sequentially processing them