### PR TITLE
fix(opencode): reduce memory usage during prompting with lazy boundary scan and context windowing

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -921,10 +921,113 @@ export namespace MessageV2 {
     return result
   }
 
+  // ── Lightweight conversation loading ──────────────────────────────────
+  //
+  // filterCompactedLazy avoids materializing the full WithParts[] array.
+  // Phase 1: scan message *info only* (no parts) newest→oldest to find
+  //          the compaction boundary and collect message IDs.
+  // Phase 2: load parts only for messages after the boundary.
+  //
+  // For a 7,000-message session with no compaction this still loads all
+  // parts, but for compacted sessions it skips everything before the
+  // summary — which is the common case for long-running sessions.
+
+  /** Scan info-only (no parts) newest→oldest. Returns message rows from
+   *  the compaction boundary forward, in oldest-first order. */
+  async function scanBoundary(sessionID: SessionID) {
+    const size = 50
+    let before: string | undefined
+    const rows: (typeof MessageTable.$inferSelect)[] = []
+    const completed = new Set<string>()
+
+    while (true) {
+      const cursor_before = before ? cursor.decode(before) : undefined
+      const where = cursor_before
+        ? and(eq(MessageTable.session_id, sessionID), older(cursor_before))
+        : eq(MessageTable.session_id, sessionID)
+      const batch = Database.use((db) =>
+        db
+          .select()
+          .from(MessageTable)
+          .where(where)
+          .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
+          .limit(size + 1)
+          .all(),
+      )
+      if (batch.length === 0) break
+      const more = batch.length > size
+      const page = more ? batch.slice(0, size) : batch
+
+      let found = false
+      for (const row of page) {
+        rows.push(row)
+        const msg = info(row)
+        if (
+          msg.role === "assistant" &&
+          (msg as Assistant).summary &&
+          (msg as Assistant).finish &&
+          !(msg as Assistant).error
+        )
+          completed.add(msg.parentID)
+        if (msg.role === "user" && completed.has(msg.id)) {
+          // Potential boundary — need to check parts for compaction type.
+          // Only load parts for THIS message to check.
+          const partRows = Database.use((db) =>
+            db.select().from(PartTable).where(eq(PartTable.message_id, row.id)).all(),
+          )
+          if (partRows.some((p) => (p.data as any).type === "compaction")) {
+            found = true
+            break
+          }
+        }
+      }
+      if (found || !more) break
+      const tail = page.at(-1)!
+      before = cursor.encode({ id: tail.id, time: tail.time_created })
+    }
+    rows.reverse()
+    return rows
+  }
+
+  /** Load conversation from compaction boundary forward, with full parts.
+   *  For compacted sessions: two-pass (info scan → selective hydrate) is
+   *  much cheaper. For uncompacted sessions: falls back to the original
+   *  single-pass filterCompacted(stream()) to avoid the extra info scan. */
+  export async function filterCompactedLazy(sessionID: SessionID) {
+    // Quick probe: check newest 50 message infos for any compaction summary.
+    // One DB query, no parts loaded.
+    const probe = Database.use((db) =>
+      db
+        .select()
+        .from(MessageTable)
+        .where(eq(MessageTable.session_id, sessionID))
+        .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
+        .limit(50)
+        .all(),
+    )
+    const compacted = probe.some((row) => {
+      const msg = info(row)
+      return (
+        msg.role === "assistant" && (msg as Assistant).summary && (msg as Assistant).finish && !(msg as Assistant).error
+      )
+    })
+    if (!compacted) {
+      // No recent compaction summary — fall back to single-pass which
+      // loads parts alongside info (avoids 155+ wasted info-only queries
+      // for uncompacted sessions).
+      return filterCompacted(stream(sessionID))
+    }
+    // Compacted session: two-pass is efficient — scan info to find boundary,
+    // then hydrate only messages after it.
+    const rows = await scanBoundary(sessionID)
+    return hydrate(rows)
+  }
+
   export function fromError(
     e: unknown,
     ctx: { providerID: ProviderID; aborted?: boolean },
   ): NonNullable<Assistant["error"]> {
+
     switch (true) {
       case e instanceof DOMException && e.name === "AbortError":
         return new MessageV2.AbortedError(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1337,12 +1337,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           let structured: unknown | undefined
           let step = 0
           const session = yield* sessions.get(sessionID)
+          // filterCompactedLazy scans message info without loading parts to find
+          // the compaction boundary, then hydrates parts only for messages after
+          // it. For a 7K-message session with compaction at message #100, this
+          // loads ~100 messages' parts instead of all 7K.
+          let msgs = yield* Effect.promise(() => MessageV2.filterCompactedLazy(sessionID))
+          let needsFullReload = false
 
           while (true) {
+            if (needsFullReload) {
+              msgs = yield* Effect.promise(() => MessageV2.filterCompactedLazy(sessionID))
+              needsFullReload = false
+            }
             yield* status.set(sessionID, { type: "busy" })
             log.info("loop", { step, sessionID })
-
-            let msgs = yield* Effect.promise(() => MessageV2.filterCompacted(MessageV2.stream(sessionID)))
 
             let lastUser: MessageV2.User | undefined
             let lastAssistant: MessageV2.Assistant | undefined
@@ -1382,6 +1390,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             if (task?.type === "subtask") {
               yield* handleSubtask({ task, model, lastUser, sessionID, session, msgs })
+              needsFullReload = true
               continue
             }
 
@@ -1394,6 +1403,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 overflow: task.overflow,
               })
               if (result === "stop") break
+              needsFullReload = true
               continue
             }
 
@@ -1403,6 +1413,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
             ) {
               yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+              needsFullReload = true
               continue
             }
 
@@ -1486,12 +1497,30 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
                 yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
+                // Context-window windowing: only convert messages that fit in the
+                // LLM context window to ModelMessage format. This avoids creating
+                // ~300MB of wrapper objects for messages the provider will discard.
+                const budget = (model.limit.input || model.limit.context || 200_000) * 4 // chars
+                let used = 0
+                let windowStart = msgs.length
+                for (let i = msgs.length - 1; i >= 0; i--) {
+                  for (const part of msgs[i].parts) {
+                    if (part.type === "text") used += part.text.length
+                    else if (part.type === "tool" && part.state.status === "completed")
+                      used += (part.state.output?.length ?? 0) + JSON.stringify(part.state.input).length
+                    else if (part.type === "reasoning") used += part.text.length
+                  }
+                  if (used > budget) break
+                  windowStart = i
+                }
+                const window = windowStart > 0 ? msgs.slice(windowStart) : msgs
+
                 const [skills, env, instructions, modelMsgs] = yield* Effect.promise(() =>
                   Promise.all([
                     SystemPrompt.skills(agent),
                     SystemPrompt.environment(model),
                     InstructionPrompt.system(),
-                    MessageV2.toModelMessages(msgs, model),
+                    MessageV2.toModelMessages(window, model),
                   ]),
                 )
                 const system = [...env, ...(skills ? [skills] : []), ...instructions]
@@ -1537,6 +1566,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     auto: true,
                     overflow: !handle.message.finish,
                   })
+                  needsFullReload = true
+                } else {
+                  // Normal tool-call continuation: fetch the latest page to pick up
+                  // new assistant messages and tool results, then merge with the
+                  // cached history to avoid reloading the entire conversation.
+                  const fresh = yield* Effect.promise(() => MessageV2.page({ sessionID, limit: 200 }))
+                  const existing = new Map(msgs.map((m) => [m.info.id, m]))
+                  for (const msg of fresh.items) existing.set(msg.info.id, msg)
+                  msgs = Array.from(existing.values()).sort((a, b) =>
+                    a.info.id < b.info.id ? -1 : a.info.id > b.info.id ? 1 : 0,
+                  )
                 }
                 return "continue" as const
               }),


### PR DESCRIPTION
### Issue for this PR

Closes #18136

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two targeted optimizations to reduce peak RSS during prompting from ~4-8GB down to ~1.2GB:

**1. Lazy compaction boundary scan (`filterCompactedLazy`)**

The prompt loop calls `filterCompacted(stream(sessionID))` which streams ALL messages newest→oldest, loading parts for every message. For compacted sessions, most of those parts are discarded once the boundary is found.

New approach: probe the newest 50 message infos (1 DB query, no parts). If a compaction summary is detected, use a two-phase scan — info-only scan to find the boundary, then hydrate parts only for messages after it. If no compaction summary is found, fall back to the original single-pass `filterCompacted(stream())` to avoid wasted info-only queries.

**2. Context-window message windowing**

`toModelMessages` was called with ALL messages (e.g., 7,704 for a long session), creating ModelMessage wrapper objects for every one. These flow through 4-5 copy layers (`toModelMessages` → `convertToModelMessages` → `ProviderTransform.message` → `convertToLanguageModelPrompt`), each creating ~60MB of wrapper objects.

Now the prompt loop estimates which messages from the tail fit in the LLM context window (`model.limit.context × 4 chars/token`) and only passes those to `toModelMessages`. For a 7,704-message session where ~200 fit, this cuts the conversion pipeline from ~300MB to ~10MB.

**3. Prompt loop caching**

The conversation is loaded once before the loop. On normal tool-call iterations, only the latest 200-message page is fetched and merged into the cache. Full reload only happens after compaction.

### How did you verify your code works?

- Monitored RSS with `/proc/<PID>/status` every 30s during active prompting
- Before: peak 4.8GB, idle 1GB
- After: peak 1.2GB, idle ~580MB
- All session tests pass (118 pass, 4 skip, 0 fail)
- Tested with both compacted and uncompacted sessions

### Screenshots / recordings

Memory monitoring (30s intervals) after fix:
```
time,rss_mb,hwm_mb
20:46:02,942,1236    ← active prompting
20:48:02,1020,1236   ← peak during tool calls
20:50:02,606,1236    ← settled after activity
20:55:32,568,1236    ← stable idle
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR