### PR TITLE
feat(app): import global commands from files and folders

### DIFF
--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -8,6 +8,7 @@ import { SettingsGeneral } from "./settings-general"
 import { SettingsKeybinds } from "./settings-keybinds"
 import { SettingsProviders } from "./settings-providers"
 import { SettingsModels } from "./settings-models"
+import { SettingsCommands } from "./settings-commands"
 
 export const DialogSettings: Component = () => {
   const language = useLanguage()
@@ -45,6 +46,10 @@ export const DialogSettings: Component = () => {
                       <Icon name="models" />
                       {language.t("settings.models.title")}
                     </Tabs.Trigger>
+                    <Tabs.Trigger value="commands">
+                      <Icon name="brain" />
+                      {language.t("settings.commands.title")}
+                    </Tabs.Trigger>
                   </div>
                 </div>
               </div>
@@ -66,6 +71,9 @@ export const DialogSettings: Component = () => {
         </Tabs.Content>
         <Tabs.Content value="models" class="no-scrollbar">
           <SettingsModels />
+        </Tabs.Content>
+        <Tabs.Content value="commands" class="no-scrollbar">
+          <SettingsCommands />
         </Tabs.Content>
       </Tabs>
     </Dialog>

--- a/packages/app/src/components/settings-commands.tsx
+++ b/packages/app/src/components/settings-commands.tsx
@@ -51,21 +51,22 @@ export const SettingsCommands: Component = () => {
   const platform = usePlatform()
   const globalSync = useGlobalSync()
   const [store, setStore] = createStore({ loading: false })
+  const canImport = createMemo(() => Boolean(platform.openFilePickerDialog && platform.readTextFile))
 
   const list = createMemo(() => {
     return Object.keys(globalSync.data.config.command ?? {}).sort((a, b) => a.localeCompare(b))
   })
 
   const add = async () => {
-    if (!platform.openFilePickerDialog || !platform.readTextFile) return
+    if (!canImport()) return
 
-    const pick = await platform.openFilePickerDialog({ multiple: true, title: "Choose markdown command files" })
+    const pick = await platform.openFilePickerDialog!({ multiple: true, title: "Choose command markdown files" })
     if (!pick) return
     const paths = Array.isArray(pick) ? pick : [pick]
 
     const files = paths.filter((item) => item.toLowerCase().endsWith(".md"))
     if (files.length === 0) {
-      showToast({ title: language.t("common.requestFailed"), description: "Select one or more .md files." })
+      showToast({ title: language.t("common.requestFailed"), description: "Pick one or more .md files." })
       return
     }
 
@@ -79,7 +80,7 @@ export const SettingsCommands: Component = () => {
       for (const file of files) {
         const key = name(file)
         if (!key) continue
-        const parsed = parse(await platform.readTextFile(file))
+        const parsed = parse(await platform.readTextFile!(file))
         if (!parsed.template) continue
         next[key] = parsed
       }
@@ -89,12 +90,13 @@ export const SettingsCommands: Component = () => {
         return
       }
 
-      await globalSync.updateConfig({ command: next })
+      const curr = globalSync.data.config.command ?? {}
+      await globalSync.updateConfig({ command: { ...curr, ...next } })
       showToast({
         variant: "success",
         icon: "circle-check",
         title: "Commands imported",
-        description: `${Object.keys(next).length} command${Object.keys(next).length > 1 ? "s" : ""} added globally.`,
+        description: `${Object.keys(next).length} command${Object.keys(next).length > 1 ? "s" : ""} saved in global config.`,
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -119,9 +121,14 @@ export const SettingsCommands: Component = () => {
           <div class="bg-surface-raised-base px-4 rounded-lg">
             <div class="flex items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base">
               <div class="text-14-regular text-text-weak">
-                Import markdown files to use as slash commands in every project.
+                Import `.md` files and use them as slash commands in every project.
               </div>
-              <Button size="large" variant="secondary" onClick={() => void add()} disabled={store.loading}>
+              <Button
+                size="large"
+                variant="secondary"
+                onClick={() => void add()}
+                disabled={store.loading || !canImport()}
+              >
                 {store.loading
                   ? `${language.t("common.loading")}${language.t("common.loading.ellipsis")}`
                   : "Import .md"}
@@ -144,13 +151,13 @@ export const SettingsCommands: Component = () => {
         </div>
 
         <div class="text-12-regular text-text-weak max-w-[640px]">
-          Imported commands are stored in your global OpenCode config, so they are available in all projects.
+          Imported commands are stored in your global OpenCode config and shared across all projects.
         </div>
       </div>
 
-      <Show when={!platform.openFilePickerDialog || !platform.readTextFile}>
+      <Show when={!canImport()}>
         <div class="max-w-[720px] text-12-regular text-text-weak mt-6">
-          Command file import is only available in the desktop app.
+          Command import is available in the desktop app.
         </div>
       </Show>
     </div>

--- a/packages/app/src/components/settings-commands.tsx
+++ b/packages/app/src/components/settings-commands.tsx
@@ -51,56 +51,73 @@ export const SettingsCommands: Component = () => {
   const platform = usePlatform()
   const globalSync = useGlobalSync()
   const [store, setStore] = createStore({ loading: false })
-  const canImport = createMemo(() => Boolean(platform.openFilePickerDialog && platform.readTextFile))
+  const files = createMemo(() => Boolean(platform.openFilePickerDialog && platform.readTextFile))
+  const dirs = createMemo(() => Boolean(platform.openDirectoryPickerDialog && platform.readMarkdownFiles))
 
   const list = createMemo(() => {
     return Object.keys(globalSync.data.config.command ?? {}).sort((a, b) => a.localeCompare(b))
   })
 
-  const add = async () => {
-    if (!canImport()) return
-
-    const pick = await platform.openFilePickerDialog!({ multiple: true, title: "Choose command markdown files" })
-    if (!pick) return
-    const paths = Array.isArray(pick) ? pick : [pick]
-
-    const files = paths.filter((item) => item.toLowerCase().endsWith(".md"))
-    if (files.length === 0) {
-      showToast({ title: language.t("common.requestFailed"), description: "Pick one or more .md files." })
-      return
-    }
-
+  const apply = async (input: Array<{ path: string; text: string }>) => {
     const next: Record<
       string,
       { template: string; description?: string; agent?: string; model?: string; subtask?: boolean }
     > = {}
+    for (const item of input) {
+      const key = name(item.path)
+      if (!key) continue
+      const parsed = parse(item.text)
+      if (!parsed.template) continue
+      next[key] = parsed
+    }
+    if (Object.keys(next).length === 0) {
+      showToast({ title: language.t("common.requestFailed"), description: "No valid commands were imported." })
+      return
+    }
+    const curr = globalSync.data.config.command ?? {}
+    await globalSync.updateConfig({ command: { ...curr, ...next } })
+    showToast({
+      variant: "success",
+      icon: "circle-check",
+      title: "Commands imported",
+      description: `${Object.keys(next).length} command${Object.keys(next).length > 1 ? "s" : ""} saved in global config.`,
+    })
+  }
+
+  const file = async () => {
+    if (!files()) return
+    const pick = await platform.openFilePickerDialog!({ multiple: true, title: "Choose command markdown files" })
+    if (!pick) return
+    const paths = (Array.isArray(pick) ? pick : [pick]).filter((item) => item.toLowerCase().endsWith(".md"))
+    if (paths.length === 0) {
+      showToast({ title: language.t("common.requestFailed"), description: "Pick one or more .md files." })
+      return
+    }
     setStore("loading", true)
-
     try {
-      for (const file of files) {
-        const key = name(file)
-        if (!key) continue
-        const parsed = parse(await platform.readTextFile!(file))
-        if (!parsed.template) continue
-        next[key] = parsed
-      }
-
-      if (Object.keys(next).length === 0) {
-        showToast({ title: language.t("common.requestFailed"), description: "No valid commands were imported." })
-        return
-      }
-
-      const curr = globalSync.data.config.command ?? {}
-      await globalSync.updateConfig({ command: { ...curr, ...next } })
-      showToast({
-        variant: "success",
-        icon: "circle-check",
-        title: "Commands imported",
-        description: `${Object.keys(next).length} command${Object.keys(next).length > 1 ? "s" : ""} saved in global config.`,
-      })
+      await apply(await Promise.all(paths.map(async (path) => ({ path, text: await platform.readTextFile!(path) }))))
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      showToast({ title: language.t("common.requestFailed"), description: message })
+      const msg = err instanceof Error ? err.message : String(err)
+      showToast({ title: language.t("common.requestFailed"), description: msg })
+    } finally {
+      setStore("loading", false)
+    }
+  }
+
+  const dir = async () => {
+    if (!dirs()) return
+    const pick = await platform.openDirectoryPickerDialog!({
+      multiple: true,
+      title: "Choose folders with command files",
+    })
+    if (!pick) return
+    const paths = Array.isArray(pick) ? pick : [pick]
+    setStore("loading", true)
+    try {
+      await apply(await platform.readMarkdownFiles!(paths))
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      showToast({ title: language.t("common.requestFailed"), description: msg })
     } finally {
       setStore("loading", false)
     }
@@ -121,18 +138,32 @@ export const SettingsCommands: Component = () => {
           <div class="bg-surface-raised-base px-4 rounded-lg">
             <div class="flex items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base">
               <div class="text-14-regular text-text-weak">
-                Import `.md` files and use them as slash commands in every project.
+                Import `.md` files or folders and use them as slash commands in every project.
               </div>
-              <Button
-                size="large"
-                variant="secondary"
-                onClick={() => void add()}
-                disabled={store.loading || !canImport()}
-              >
-                {store.loading
-                  ? `${language.t("common.loading")}${language.t("common.loading.ellipsis")}`
-                  : "Import .md"}
-              </Button>
+              <div class="flex items-center gap-2 shrink-0">
+                <div onClick={() => (store.loading || !files() ? undefined : void file())}>
+                  <Button
+                    size="large"
+                    variant="secondary"
+                    class={store.loading || !files() ? "opacity-50 pointer-events-none" : undefined}
+                  >
+                    {store.loading
+                      ? `${language.t("common.loading")}${language.t("common.loading.ellipsis")}`
+                      : "Import files"}
+                  </Button>
+                </div>
+                <div onClick={() => (store.loading || !dirs() ? undefined : void dir())}>
+                  <Button
+                    size="large"
+                    variant="secondary"
+                    class={store.loading || !dirs() ? "opacity-50 pointer-events-none" : undefined}
+                  >
+                    {store.loading
+                      ? `${language.t("common.loading")}${language.t("common.loading.ellipsis")}`
+                      : "Import folders"}
+                  </Button>
+                </div>
+              </div>
             </div>
 
             <Show
@@ -155,7 +186,7 @@ export const SettingsCommands: Component = () => {
         </div>
       </div>
 
-      <Show when={!canImport()}>
+      <Show when={!files() && !dirs()}>
         <div class="max-w-[720px] text-12-regular text-text-weak mt-6">
           Command import is available in the desktop app.
         </div>

--- a/packages/app/src/components/settings-commands.tsx
+++ b/packages/app/src/components/settings-commands.tsx
@@ -1,16 +1,158 @@
-import { Component } from "solid-js"
+import { showToast } from "@opencode-ai/ui/toast"
+import { Button } from "@opencode-ai/ui/button"
+import { getFilename } from "@opencode-ai/util/path"
+import { Component, For, Show, createMemo } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+
+function clean(input: string) {
+  const quoted = (input.startsWith('"') && input.endsWith('"')) || (input.startsWith("'") && input.endsWith("'"))
+  if (!quoted) return input
+  return input.slice(1, -1)
+}
+
+function parse(markdown: string) {
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/)
+  if (!match) return { template: markdown.trim() }
+
+  const meta = {
+    description: undefined as string | undefined,
+    agent: undefined as string | undefined,
+    model: undefined as string | undefined,
+    subtask: undefined as boolean | undefined,
+  }
+
+  for (const line of match[1].split(/\r?\n/)) {
+    const item = line.match(/^\s*([a-z_]+)\s*:\s*(.*?)\s*$/)
+    if (!item) continue
+    const key = item[1]
+    const val = clean(item[2])
+    if (key === "description") meta.description = val
+    if (key === "agent") meta.agent = val
+    if (key === "model") meta.model = val
+    if (key === "subtask") meta.subtask = val === "true"
+  }
+
+  return {
+    ...meta,
+    template: match[2].trim(),
+  }
+}
+
+function name(path: string) {
+  const file = getFilename(path).replace(/\.md$/i, "").trim()
+  return file.replace(/\s+/g, "-")
+}
 
 export const SettingsCommands: Component = () => {
-  // TODO: Replace this placeholder with full commands settings controls.
   const language = useLanguage()
+  const platform = usePlatform()
+  const globalSync = useGlobalSync()
+  const [store, setStore] = createStore({ loading: false })
+
+  const list = createMemo(() => {
+    return Object.keys(globalSync.data.config.command ?? {}).sort((a, b) => a.localeCompare(b))
+  })
+
+  const add = async () => {
+    if (!platform.openFilePickerDialog || !platform.readTextFile) return
+
+    const pick = await platform.openFilePickerDialog({ multiple: true, title: "Choose markdown command files" })
+    if (!pick) return
+    const paths = Array.isArray(pick) ? pick : [pick]
+
+    const files = paths.filter((item) => item.toLowerCase().endsWith(".md"))
+    if (files.length === 0) {
+      showToast({ title: language.t("common.requestFailed"), description: "Select one or more .md files." })
+      return
+    }
+
+    const next: Record<
+      string,
+      { template: string; description?: string; agent?: string; model?: string; subtask?: boolean }
+    > = {}
+    setStore("loading", true)
+
+    try {
+      for (const file of files) {
+        const key = name(file)
+        if (!key) continue
+        const parsed = parse(await platform.readTextFile(file))
+        if (!parsed.template) continue
+        next[key] = parsed
+      }
+
+      if (Object.keys(next).length === 0) {
+        showToast({ title: language.t("common.requestFailed"), description: "No valid commands were imported." })
+        return
+      }
+
+      await globalSync.updateConfig({ command: next })
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: "Commands imported",
+        description: `${Object.keys(next).length} command${Object.keys(next).length > 1 ? "s" : ""} added globally.`,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      showToast({ title: language.t("common.requestFailed"), description: message })
+    } finally {
+      setStore("loading", false)
+    }
+  }
 
   return (
-    <div class="flex flex-col h-full overflow-y-auto">
-      <div class="flex flex-col gap-6 p-6 max-w-[600px]">
-        <h2 class="text-16-medium text-text-strong">{language.t("settings.commands.title")}</h2>
-        <p class="text-14-regular text-text-weak">{language.t("settings.commands.description")}</p>
+    <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
+      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
+        <div class="flex flex-col gap-3 pt-6 pb-8 max-w-[720px]">
+          <h2 class="text-16-medium text-text-strong">{language.t("settings.commands.title")}</h2>
+          <p class="text-14-regular text-text-weak">{language.t("settings.commands.description")}</p>
+        </div>
       </div>
+
+      <div class="flex flex-col gap-8 max-w-[720px]">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-14-medium text-text-strong pb-2">Global command files</h3>
+          <div class="bg-surface-raised-base px-4 rounded-lg">
+            <div class="flex items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base">
+              <div class="text-14-regular text-text-weak">
+                Import markdown files to use as slash commands in every project.
+              </div>
+              <Button size="large" variant="secondary" onClick={() => void add()} disabled={store.loading}>
+                {store.loading
+                  ? `${language.t("common.loading")}${language.t("common.loading.ellipsis")}`
+                  : "Import .md"}
+              </Button>
+            </div>
+
+            <Show
+              when={list().length > 0}
+              fallback={<div class="py-4 text-14-regular text-text-weak">No global commands configured yet.</div>}
+            >
+              <For each={list()}>
+                {(item) => (
+                  <div class="min-h-12 py-3 border-b border-border-weak-base last:border-none">
+                    <div class="text-14-medium text-text-strong">/{item}</div>
+                  </div>
+                )}
+              </For>
+            </Show>
+          </div>
+        </div>
+
+        <div class="text-12-regular text-text-weak max-w-[640px]">
+          Imported commands are stored in your global OpenCode config, so they are available in all projects.
+        </div>
+      </div>
+
+      <Show when={!platform.openFilePickerDialog || !platform.readTextFile}>
+        <div class="max-w-[720px] text-12-regular text-text-weak mt-6">
+          Command file import is only available in the desktop app.
+        </div>
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -81,6 +81,9 @@ export type Platform = {
   /** Read UTF-8 text file content (desktop only) */
   readTextFile?(path: string): Promise<string>
 
+  /** Read markdown files from files/folders (desktop only) */
+  readMarkdownFiles?(paths: string[]): Promise<Array<{ path: string; text: string }>>
+
   /** Webview zoom level (desktop only) */
   webviewZoom?: Accessor<number>
 

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -78,6 +78,9 @@ export type Platform = {
   /** Parse markdown to HTML using native parser (desktop only, returns unprocessed code blocks) */
   parseMarkdown?(markdown: string): Promise<string>
 
+  /** Read UTF-8 text file content (desktop only) */
+  readTextFile?(path: string): Promise<string>
+
   /** Webview zoom level (desktop only) */
   webviewZoom?: Accessor<number>
 

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -17,9 +17,10 @@ use futures::{
     future::{self, Shared},
 };
 use std::{
+    collections::HashSet,
     env,
     net::TcpListener,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     sync::{Arc, Mutex},
     time::Duration,
@@ -44,6 +45,12 @@ struct ServerReadyData {
     username: Option<String>,
     password: Option<String>,
     is_sidecar: bool,
+}
+
+#[derive(Clone, serde::Serialize, specta::Type, Debug)]
+struct MarkdownFile {
+    path: String,
+    text: String,
 }
 
 #[derive(Clone, Copy, serde::Serialize, specta::Type, Debug)]
@@ -214,6 +221,61 @@ async fn read_text_file(path: String) -> Result<String, String> {
     tokio::fs::read_to_string(path)
         .await
         .map_err(|e| format!("Failed to read file: {e}"))
+}
+
+fn add_markdown(path: &Path, seen: &mut HashSet<PathBuf>, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    let full = path
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path {}: {e}", path.display()))?;
+    if !seen.insert(full.clone()) {
+        return Ok(());
+    }
+
+    if full.is_file() {
+        if full
+            .extension()
+            .and_then(|v| v.to_str())
+            .is_some_and(|v| v.eq_ignore_ascii_case("md"))
+        {
+            out.push(full);
+        }
+        return Ok(());
+    }
+
+    if !full.is_dir() {
+        return Ok(());
+    }
+
+    for item in std::fs::read_dir(&full).map_err(|e| format!("Failed to read dir {}: {e}", full.display()))? {
+        let item = item.map_err(|e| format!("Failed to read dir entry in {}: {e}", full.display()))?;
+        add_markdown(&item.path(), seen, out)?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+async fn read_markdown_files(paths: Vec<String>) -> Result<Vec<MarkdownFile>, String> {
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+
+    for path in paths {
+        add_markdown(Path::new(&path), &mut seen, &mut files)?;
+    }
+
+    let mut out = Vec::new();
+    for path in files {
+        let text = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|e| format!("Failed to read file {}: {e}", path.display()))?;
+        out.push(MarkdownFile {
+            path: path.to_string_lossy().to_string(),
+            text,
+        });
+    }
+
+    Ok(out)
 }
 
 #[cfg(target_os = "macos")]
@@ -409,6 +471,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             set_display_backend,
             markdown::parse_markdown_command,
             read_text_file,
+            read_markdown_files,
             check_app_exists,
             wsl_path,
             resolve_app_path,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -208,6 +208,14 @@ fn open_path(_app: AppHandle, path: String, app_name: Option<String>) -> Result<
         .map_err(|e| format!("Failed to open path: {e}"))
 }
 
+#[tauri::command]
+#[specta::specta]
+async fn read_text_file(path: String) -> Result<String, String> {
+    tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))
+}
+
 #[cfg(target_os = "macos")]
 fn check_macos_app(app_name: &str) -> bool {
     // Check common installation locations
@@ -400,6 +408,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             get_display_backend,
             set_display_backend,
             markdown::parse_markdown_command,
+            read_text_file,
             check_app_exists,
             wsl_path,
             resolve_app_path,

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -16,6 +16,7 @@ export const commands = {
 	setDisplayBackend: (backend: LinuxDisplayBackend) => __TAURI_INVOKE<null>("set_display_backend", { backend }),
 	parseMarkdownCommand: (markdown: string) => __TAURI_INVOKE<string>("parse_markdown_command", { markdown }),
 	readTextFile: (path: string) => __TAURI_INVOKE<string>("read_text_file", { path }),
+	readMarkdownFiles: (paths: string[]) => __TAURI_INVOKE<MarkdownFile[]>("read_markdown_files", { paths }),
 	checkAppExists: (appName: string) => __TAURI_INVOKE<boolean>("check_app_exists", { appName }),
 	wslPath: (path: string, mode: "windows" | "linux" | null) => __TAURI_INVOKE<string>("wsl_path", { path, mode }),
 	resolveAppPath: (appName: string) => __TAURI_INVOKE<string | null>("resolve_app_path", { appName }),
@@ -34,6 +35,11 @@ export type InitStep = { phase: "server_waiting" } | { phase: "sqlite_waiting" }
 export type LinuxDisplayBackend = "wayland" | "auto";
 
 export type LoadingWindowComplete = null;
+
+export type MarkdownFile = {
+		path: string,
+		text: string,
+	};
 
 export type ServerReadyData = {
 		url: string,
@@ -66,3 +72,4 @@ function makeEvent<T>(name: string) {
 
     return Object.assign(fn, base);
 }
+

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -15,6 +15,7 @@ export const commands = {
 	getDisplayBackend: () => __TAURI_INVOKE<"wayland" | "auto" | null>("get_display_backend"),
 	setDisplayBackend: (backend: LinuxDisplayBackend) => __TAURI_INVOKE<null>("set_display_backend", { backend }),
 	parseMarkdownCommand: (markdown: string) => __TAURI_INVOKE<string>("parse_markdown_command", { markdown }),
+	readTextFile: (path: string) => __TAURI_INVOKE<string>("read_text_file", { path }),
 	checkAppExists: (appName: string) => __TAURI_INVOKE<boolean>("check_app_exists", { appName }),
 	wslPath: (path: string, mode: "windows" | "linux" | null) => __TAURI_INVOKE<string>("wsl_path", { path, mode }),
 	resolveAppPath: (appName: string) => __TAURI_INVOKE<string | null>("resolve_app_path", { appName }),
@@ -65,4 +66,3 @@ function makeEvent<T>(name: string) {
 
     return Object.assign(fn, base);
 }
-

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -370,6 +370,8 @@ const createPlatform = (): Platform => {
 
     readTextFile: (path: string) => commands.readTextFile(path),
 
+    readMarkdownFiles: (paths: string[]) => commands.readMarkdownFiles(paths),
+
     webviewZoom,
 
     checkAppExists: async (appName: string) => {

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -368,6 +368,8 @@ const createPlatform = (): Platform => {
 
     parseMarkdown: (markdown: string) => commands.parseMarkdownCommand(markdown),
 
+    readTextFile: (path: string) => commands.readTextFile(path),
+
     webviewZoom,
 
     checkAppExists: async (appName: string) => {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a real Commands settings tab in desktop that imports global slash commands from either selected `.md` files or selected folders. Folder imports recurse to discover markdown files, parse frontmatter/body, then save commands to global config.

Also fixes import behavior to merge with existing `command` config instead of overwriting it, so previously configured global commands are preserved.

### How did you verify your code works?

- `bun run typecheck` (in `packages/desktop`)
- `cargo check` (in `packages/desktop/src-tauri`)
- `cargo test test_export_types --lib` (in `packages/desktop/src-tauri`)

### Screenshots / recordings

Included screenshot in discussion showing Commands settings with import actions.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR