### PR TITLE
fix(plan): resolve model from agent config in plan tools

### DIFF
--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -5,15 +5,21 @@ import { Question } from "../question"
 import { Session } from "../session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "../provider/provider"
+import { Agent } from "../agent/agent"
 import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
-async function getLastModel(sessionID: SessionID) {
+async function lastModel(sessionID: SessionID) {
   for await (const item of MessageV2.stream(sessionID)) {
     if (item.info.role === "user" && item.info.model) return item.info.model
   }
   return Provider.defaultModel()
+}
+
+async function resolveModel(agentName: string, sessionID: SessionID) {
+  const info = await Agent.get(agentName)
+  return info?.model ?? (await lastModel(sessionID))
 }
 
 export const PlanExitTool = Tool.define("plan_exit", {
@@ -41,7 +47,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
     const answer = answers[0]?.[0]
     if (answer === "No") throw new Question.RejectedError()
 
-    const model = await getLastModel(ctx.sessionID)
+    const model = await resolveModel("build", ctx.sessionID)
 
     const userMsg: MessageV2.User = {
       id: MessageID.ascending(),
@@ -99,7 +105,7 @@ export const PlanEnterTool = Tool.define("plan_enter", {
 
     if (answer === "No") throw new Question.RejectedError()
 
-    const model = await getLastModel(ctx.sessionID)
+    const model = await resolveModel("plan", ctx.sessionID)
 
     const userMsg: MessageV2.User = {
       id: MessageID.ascending(),

--- a/packages/opencode/test/tool/plan.test.ts
+++ b/packages/opencode/test/tool/plan.test.ts
@@ -1,0 +1,113 @@
+import { test, expect, spyOn, beforeEach, afterEach } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID } from "../../src/session/schema"
+import * as QuestionModule from "../../src/question"
+import { PlanExitTool } from "../../src/tool/plan"
+
+const ctx = (sessionID: string) => ({
+  sessionID: sessionID as any,
+  messageID: MessageID.ascending(),
+  callID: "test-call",
+  agent: "plan",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: async () => {},
+  ask: async () => {},
+})
+
+async function seedPlanMessage(sessionID: string, model: { providerID: string; modelID: string }) {
+  const msg: MessageV2.User = {
+    id: MessageID.ascending(),
+    sessionID: sessionID as any,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "plan",
+    model: model as any,
+  }
+  await Session.updateMessage(msg)
+  await Session.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID: sessionID as any,
+    type: "text",
+    text: "make a plan",
+  } as any)
+}
+
+let askSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  askSpy = spyOn(QuestionModule.Question, "ask").mockResolvedValue([["Yes"]])
+})
+
+afterEach(() => {
+  askSpy.mockRestore()
+})
+
+test("plan_exit uses agent.build.model from config when set", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    config: {
+      agent: {
+        build: {
+          model: "openai/gpt-4o",
+        },
+      },
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      await seedPlanMessage(session.id, { providerID: "anthropic", modelID: "claude-3-5-sonnet" })
+
+      const tool = await PlanExitTool.init()
+      await tool.execute({}, ctx(session.id))
+
+      let buildMsg: MessageV2.User | undefined
+      for await (const item of MessageV2.stream(session.id as any)) {
+        if (item.info.role === "user" && item.info.agent === "build") {
+          buildMsg = item.info as MessageV2.User
+        }
+      }
+
+      expect(buildMsg).toBeDefined()
+      expect(String(buildMsg!.model.providerID)).toBe("openai")
+      expect(String(buildMsg!.model.modelID)).toBe("gpt-4o")
+
+      await Session.remove(session.id)
+    },
+  })
+})
+
+test("plan_exit falls back to last session model when agent.build.model is not configured", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const session = await Session.create({})
+      await seedPlanMessage(session.id, { providerID: "anthropic", modelID: "claude-3-5-sonnet" })
+
+      const tool = await PlanExitTool.init()
+      await tool.execute({}, ctx(session.id))
+
+      let buildMsg: MessageV2.User | undefined
+      for await (const item of MessageV2.stream(session.id as any)) {
+        if (item.info.role === "user" && item.info.agent === "build") {
+          buildMsg = item.info as MessageV2.User
+        }
+      }
+
+      expect(buildMsg).toBeDefined()
+      expect(String(buildMsg!.model.providerID)).toBe("anthropic")
+      expect(String(buildMsg!.model.modelID)).toBe("claude-3-5-sonnet")
+
+      await Session.remove(session.id)
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #9296

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a user configures a specific model for the `build` or `plan` agent (e.g. `agent.build.model = "openai/gpt-4o"`), the plan tools were ignoring it. Both `PlanExitTool` and `PlanEnterTool` were always falling back to the last model seen in the session history via `getLastModel`, so the build agent would inherit the plan agent's model instead of its own configured one.

This PR adds a `resolveModel` helper that calls `Agent.get(agentName)` first and uses the configured model if present, only falling back to the last session model when none is set. `PlanExitTool` resolves for the `build` agent and `PlanEnterTool` for the `plan` agent.

### How did you verify your code works?

Added two tests in `packages/opencode/test/tool/plan.test.ts`:
- One verifies that when `agent.build.model` is configured, the message written by `PlanExitTool` uses that model.
- One verifies that when no model is configured, it falls back to the last session model.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR