### PR TITLE
feat(tui): add unified Git section to sidebar with branch and modified files

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -211,26 +211,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </For>
               </Show>
             </box>
-            <Show when={todo().length > 0 && todo().some((t) => t.status !== "completed")}>
-              <box>
-                <box
-                  flexDirection="row"
-                  gap={1}
-                  onMouseDown={() => todo().length > 2 && setExpanded("todo", !expanded.todo)}
-                >
-                  <Show when={todo().length > 2}>
-                    <text fg={theme.text}>{expanded.todo ? "▼" : "▶"}</text>
-                  </Show>
-                  <text fg={theme.text}>
-                    <b>Todo</b>
-                  </text>
-                </box>
-                <Show when={todo().length <= 2 || expanded.todo}>
-                  <For each={todo()}>{(todo) => <TodoItem status={todo.status} content={todo.content} />}</For>
-                </Show>
-              </box>
-            </Show>
-            <Show when={diff().length > 0}>
+            <Show when={sync.data.vcs?.branch || diff().length > 0}>
               <box>
                 <box
                   flexDirection="row"
@@ -241,11 +222,19 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                     <text fg={theme.text}>{expanded.diff ? "▼" : "▶"}</text>
                   </Show>
                   <text fg={theme.text}>
-                    <b>Modified Files</b>
+                    <b>Git</b>
                   </text>
                 </box>
-                <Show when={diff().length <= 2 || expanded.diff}>
-                  <For each={diff() || []}>
+                <Show when={sync.data.vcs?.branch}>
+                  <text fg={theme.textMuted}> {sync.data.vcs!.branch}</text>
+                </Show>
+                <Show when={diff().length > 0}>
+                  <text fg={theme.textMuted}>
+                    {diff().length} modified file{diff().length > 1 ? "s" : ""}
+                  </text>
+                </Show>
+                <Show when={diff().length > 0 && (diff().length <= 2 || expanded.diff)}>
+                  <For each={diff()}>
                     {(item) => {
                       return (
                         <box flexDirection="row" gap={1} justifyContent="space-between">
@@ -264,6 +253,25 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                       )
                     }}
                   </For>
+                </Show>
+              </box>
+            </Show>
+            <Show when={todo().length > 0 && todo().some((t) => t.status !== "completed")}>
+              <box>
+                <box
+                  flexDirection="row"
+                  gap={1}
+                  onMouseDown={() => todo().length > 2 && setExpanded("todo", !expanded.todo)}
+                >
+                  <Show when={todo().length > 2}>
+                    <text fg={theme.text}>{expanded.todo ? "▼" : "▶"}</text>
+                  </Show>
+                  <text fg={theme.text}>
+                    <b>Todo</b>
+                  </text>
+                </box>
+                <Show when={todo().length <= 2 || expanded.todo}>
+                  <For each={todo()}>{(todo) => <TodoItem status={todo.status} content={todo.content} />}</For>
                 </Show>
               </box>
             </Show>
@@ -304,17 +312,18 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               </box>
             </box>
           </Show>
-          <box>
-            <text>
-              <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
-              <span style={{ fg: theme.text }}>{directory().split("/").at(-1)?.split(":")[0]}</span>
-            </text>
-            <Show when={sync.data.vcs?.branch}>
-              <text fg={theme.textMuted}>
-                 {sync.data.vcs!.branch}
+          <Show when={sync.data.vcs?.branch}>
+            <box>
+              <text fg={theme.text}>
+                <b>Git</b>
               </text>
-            </Show>
-          </box>
+              <text fg={theme.textMuted}> {sync.data.vcs!.branch}</text>
+            </box>
+          </Show>
+          <text>
+            <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
+            <span style={{ fg: theme.text }}>{directory().split("/").at(-1)?.split(":")[0]}</span>
+          </text>
           <text fg={theme.textMuted}>
             <span style={{ fg: theme.success }}>•</span> <b>Open</b>
             <span style={{ fg: theme.text }}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -8,6 +8,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
 import { Installation } from "@/installation"
 import { useKeybind } from "../../context/keybind"
+
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
@@ -303,10 +304,17 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               </box>
             </box>
           </Show>
-          <text>
-            <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
-            <span style={{ fg: theme.text }}>{directory().split("/").at(-1)}</span>
-          </text>
+          <box>
+            <text>
+              <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
+              <span style={{ fg: theme.text }}>{directory().split("/").at(-1)?.split(":")[0]}</span>
+            </text>
+            <Show when={sync.data.vcs?.branch}>
+              <text fg={theme.textMuted}>
+                 {sync.data.vcs!.branch}
+              </text>
+            </Show>
+          </box>
           <text fg={theme.textMuted}>
             <span style={{ fg: theme.success }}>•</span> <b>Open</b>
             <span style={{ fg: theme.text }}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -312,14 +312,6 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               </box>
             </box>
           </Show>
-          <Show when={sync.data.vcs?.branch}>
-            <box>
-              <text fg={theme.text}>
-                <b>Git</b>
-              </text>
-              <text fg={theme.textMuted}> {sync.data.vcs!.branch}</text>
-            </box>
-          </Show>
           <text>
             <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
             <span style={{ fg: theme.text }}>{directory().split("/").at(-1)?.split(":")[0]}</span>


### PR DESCRIPTION
## Description

Adds a **Git** section to the TUI sidebar (after LSP), consolidating branch info and modified files into a single collapsible group — matching the style of existing sections (Context, MCP, LSP, Todo).

Previously the branch was concatenated to the folder path as `project:branch` and modified files were a separate "Modified Files" section. Now they live under one **Git** header.

Closes #18167

### Impacted files

- `packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx`

## How to Test

1. Open a project that is a git repo
2. Look at the TUI sidebar — after LSP, a **Git** section should appear:
   ```
   Git
    main
    2 modified files
     sidebar.tsx            +8 -4
     vcs.ts                 +2 -1
   ```
3. The file list is collapsible when there are more than 2 modified files
4. Switch branches — the branch name updates reactively
5. Open a non-git project — the Git section should not appear