### PR TITLE
feat(api): add POST /session/:sessionID/todo endpoint for plugin todo management

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -173,7 +173,7 @@ export const SessionRoutes = lazy(() =>
       validator(
         "param",
         z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
+          sessionID: Session.get.schema,
         }),
       ),
       async (c) => {
@@ -187,13 +187,13 @@ export const SessionRoutes = lazy(() =>
       describeRoute({
         summary: "Update session todos",
         description: "Update the todo list for a specific session. This triggers a todo.updated event that refreshes the TUI sidebar.",
-        operationId: "session.todo.update",
+        operationId: "session.todoUpdate",
         responses: {
           200: {
             description: "Todos updated successfully",
             content: {
               "application/json": {
-                schema: resolver(z.boolean()),
+                schema: resolver(Todo.Info.array()),
               },
             },
           },
@@ -203,7 +203,7 @@ export const SessionRoutes = lazy(() =>
       validator(
         "param",
         z.object({
-          sessionID: z.string().meta({ description: "Session ID" }),
+          sessionID: Session.get.schema,
         }),
       ),
       validator("json", z.object({ todos: z.array(Todo.Info) })),
@@ -211,7 +211,7 @@ export const SessionRoutes = lazy(() =>
         const sessionID = c.req.valid("param").sessionID
         const { todos } = c.req.valid("json")
         await Todo.update({ sessionID, todos })
-        return c.json(true)
+        return c.json(todos)
       },
     )
     .post(

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -183,6 +183,38 @@ export const SessionRoutes = lazy(() =>
       },
     )
     .post(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Update session todos",
+        description: "Update the todo list for a specific session. This triggers a todo.updated event that refreshes the TUI sidebar.",
+        operationId: "session.todo.update",
+        responses: {
+          200: {
+            description: "Todos updated successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator("json", z.object({ todos: z.array(Todo.Info) })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const { todos } = c.req.valid("json")
+        await Todo.update({ sessionID, todos })
+        return c.json(true)
+      },
+    )
+    .post(
       "/",
       describeRoute({
         summary: "Create session",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -133,6 +133,8 @@ import type {
   SessionSummarizeResponses,
   SessionTodoErrors,
   SessionTodoResponses,
+  SessionTodoUpdateErrors,
+  SessionTodoUpdateResponses,
   SessionUnrevertErrors,
   SessionUnrevertResponses,
   SessionUnshareErrors,
@@ -141,6 +143,7 @@ import type {
   SessionUpdateResponses,
   SubtaskPartInput,
   TextPartInput,
+  Todo,
   ToolIdsErrors,
   ToolIdsResponses,
   ToolListErrors,
@@ -1178,6 +1181,43 @@ export class Session extends HeyApiClient {
       url: "/session/{sessionID}/todo",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Update session todos
+   *
+   * Update the todo list for a specific session. This triggers a todo.updated event that refreshes the TUI sidebar.
+   */
+  public todoUpdate<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      todos?: Array<Todo>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "body", key: "todos" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionTodoUpdateResponses, SessionTodoUpdateErrors, ThrowOnError>({
+      url: "/session/{sessionID}/todo",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3065,9 +3065,6 @@ export type SessionChildrenResponse = SessionChildrenResponses[keyof SessionChil
 export type SessionTodoData = {
   body?: never
   path: {
-    /**
-     * Session ID
-     */
     sessionID: string
   }
   query?: {
@@ -3097,6 +3094,41 @@ export type SessionTodoResponses = {
 }
 
 export type SessionTodoResponse = SessionTodoResponses[keyof SessionTodoResponses]
+
+export type SessionTodoUpdateData = {
+  body?: {
+    todos: Array<Todo>
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/todo"
+}
+
+export type SessionTodoUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionTodoUpdateError = SessionTodoUpdateErrors[keyof SessionTodoUpdateErrors]
+
+export type SessionTodoUpdateResponses = {
+  /**
+   * Todos updated successfully
+   */
+  200: Array<Todo>
+}
+
+export type SessionTodoUpdateResponse = SessionTodoUpdateResponses[keyof SessionTodoUpdateResponses]
 
 export type SessionInitData = {
   body?: {


### PR DESCRIPTION
## Summary

Adds a `POST /session/:sessionID/todo` endpoint that allows plugins and external callers to write todo items to a session's TUI sidebar.

## Problem

The existing `TodoWriteTool` lets the LLM agent update todos during its own session, but there is no HTTP API for **plugins** to write todos programmatically. Plugins receive the SDK client and server URL at init time, but the SDK only exposes `session.todo()` (GET) -- there is no way to write.

This matters for plugins that manage their own task tracking and want it to appear in the TUI sidebar. For example, a verification plugin that tracks checklist progress across multiple tasks needs to update the sidebar from its own lifecycle code, not through the LLM's tool calls.

### Why an HTTP endpoint (and not another approach)

| Alternative | Why it does not work |
|---|---|
| **Plugin custom tool calling `Todo.update()` directly** | Plugin tools run from user-space code loaded via `import()`. They cannot access `Todo` from the core `opencode` package -- it is not in their dependency graph. `PluginToolContext` does not expose `Todo` or `Bus`. |
| **Hooks API** (`tool.execute.after`, `chat.message`, etc.) | Hooks are reactive -- they fire in response to LLM activity. Plugins need to write todos **proactively** from their own lifecycle code (event handlers, timers, external triggers). No hook provides this. |
| **Publishing `Todo.Event.Updated` on the Bus directly** | The Bus is internal to the core package. Even if a plugin could publish to it, skipping `Storage.write()` would mean todos are lost on refresh. |
| **Extending `PluginInput` with a `todo` capability** | Would require adding every internal module to the plugin context. The established pattern is: routes -> SDK generation -> SDK client. This endpoint follows that pattern. |

The HTTP endpoint is the canonical pattern in this codebase -- all other plugin interactions (sessions, messages, permissions, TUI control) go through the SDK client over HTTP.

## Changes

### `packages/opencode/src/server/routes/session.ts`

New endpoint:

```
POST /session/:sessionID/todo
Body: { "todos": [{ "id": string, "content": string, "status": string, "priority": string }] }
Response: 200 -> Todo[] (the written todos)
Errors: 400 (bad request), 404 (session not found)
```

Implementation:
- Validates `sessionID` using `Session.get.schema` (same as all other session routes -- rejects nonexistent sessions)
- Validates request body against `Todo.Info.array()` (reuses the existing zod schema)
- Calls `Todo.update({ sessionID, todos })` which writes to storage and publishes `todo.updated` on the bus
- Returns the written todo array (matches the pattern of other mutating endpoints like `session.update`)

Also fixed the existing `GET /:sessionID/todo` endpoint to use `Session.get.schema` instead of a bare `z.string()` for the `sessionID` param -- consistency with all other session routes.

### `packages/sdk/js/src/v2/gen/{sdk,types}.gen.ts`

Regenerated SDK. Adds:
- `Session.todoUpdate({ sessionID, todos })` -- typed method on the Session class
- `SessionTodoUpdateData`, `SessionTodoUpdateErrors`, `SessionTodoUpdateResponses` types

The `operationId` is `session.todoUpdate` (not `session.todo.update`) to produce a flat method on `Session` rather than a nested subclass.

## Usage

```typescript
// From a plugin
const plugin: Plugin = async ({ client }) => {
  await client.session.todoUpdate({
    sessionID: "ses_abc123",
    todos: [
      { id: "1", content: "Run tests", status: "in_progress", priority: "high" },
      { id: "2", content: "Update docs", status: "pending", priority: "medium" },
    ],
  })
}
```

## Testing

- `bun tsc --noEmit` passes in both `packages/opencode` and `packages/sdk/js`
- `turbo typecheck` passes across all 12 packages (run via pre-push hook)
