### PR TITLE
fix: stop tui stdout artifacts and clean up event listeners

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -3,7 +3,19 @@ import { Clipboard } from "@tui/util/clipboard"
 import { Selection } from "@tui/util/selection"
 import { MouseButton, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import {
+  Switch,
+  Match,
+  createEffect,
+  untrack,
+  ErrorBoundary,
+  createSignal,
+  onMount,
+  onCleanup,
+  batch,
+  Show,
+  on,
+} from "solid-js"
 import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./win32"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
@@ -255,10 +267,6 @@ function App() {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
-
-  createEffect(() => {
-    console.log(JSON.stringify(route.data))
-  })
 
   // Update terminal window title based on current route and session
   createEffect(() => {
@@ -677,11 +685,11 @@ function App() {
     },
   ])
 
-  sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
+  const offCommand = sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
     command.trigger(evt.properties.command)
   })
 
-  sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
+  const offToast = sdk.event.on(TuiEvent.ToastShow.type, (evt) => {
     toast.show({
       title: evt.properties.title,
       message: evt.properties.message,
@@ -690,14 +698,14 @@ function App() {
     })
   })
 
-  sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
+  const offSession = sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
     route.navigate({
       type: "session",
       sessionID: evt.properties.sessionID,
     })
   })
 
-  sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
+  const offDeleted = sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
       route.navigate({ type: "home" })
       toast.show({
@@ -707,7 +715,7 @@ function App() {
     }
   })
 
-  sdk.event.on(SessionApi.Event.Error.type, (evt) => {
+  const offError = sdk.event.on(SessionApi.Event.Error.type, (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
     const message = (() => {
@@ -729,13 +737,22 @@ function App() {
     })
   })
 
-  sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
+  const offUpdate = sdk.event.on(Installation.Event.UpdateAvailable.type, (evt) => {
     toast.show({
       variant: "info",
       title: "Update Available",
       message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
       duration: 10000,
     })
+  })
+
+  onCleanup(() => {
+    offCommand()
+    offToast()
+    offSession()
+    offDeleted()
+    offError()
+    offUpdate()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -111,11 +111,7 @@ function DialogWorkspaceCreate(props: { onSelect: (workspaceID: string) => Promi
     if (creating()) return
     setCreating(type)
 
-    const result = await sdk.client.experimental.workspace.create({ type, branch: null }).catch((err) => {
-      console.log(err)
-      return undefined
-    })
-    console.log(JSON.stringify(result, null, 2))
+    const result = await sdk.client.experimental.workspace.create({ type, branch: null }).catch(() => undefined)
     const workspace = result?.data
     if (!workspace) {
       setCreating(undefined)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -97,7 +97,7 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
-  sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
+  const offPrompt = sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     if (!input || input.isDestroyed) return
     input.insertText(evt.properties.text)
     setTimeout(() => {
@@ -108,6 +108,7 @@ export function Prompt(props: PromptProps) {
       renderer.requestRender()
     }, 0)
   })
+  onCleanup(offPrompt)
 
   createEffect(() => {
     if (props.disabled) input.cursorColor = theme.backgroundElement
@@ -548,10 +549,8 @@ export function Prompt(props: PromptProps) {
       })
 
       if (res.error) {
-        console.log("Creating a session failed:", res.error)
-
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          message: "Creating a session failed.",
           variant: "error",
         })
 

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -32,7 +32,6 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
         return store
       },
       navigate(route: Route) {
-        console.log("navigate", route)
         setStore(route)
       },
     }

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -356,7 +356,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const args = useArgs()
 
     async function bootstrap() {
-      console.log("bootstrapping")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
         .list({ start: start })

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,6 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, onMount } from "solid-js"
+import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { createSimpleContext } from "./helper"
 import { Glob } from "../../../../util/glob"
 import aura from "./theme/aura.json" with { type: "json" }
@@ -317,13 +317,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     onMount(init)
 
     function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
       renderer
         .getPalette({
           size: 16,
         })
         .then((colors) => {
-          console.log(colors.palette)
           if (!colors.palette[0]) {
             if (store.active === "system") {
               setStore(
@@ -347,9 +345,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
 
     const renderer = useRenderer()
-    process.on("SIGUSR2", async () => {
+    const reload = async () => {
       renderer.clearPaletteCache()
       init()
+    }
+    process.on("SIGUSR2", reload)
+    onCleanup(() => {
+      process.off("SIGUSR2", reload)
     })
 
     const values = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,6 +7,7 @@ import {
   For,
   Match,
   on,
+  onCleanup,
   onMount,
   Show,
   Switch,
@@ -215,7 +216,7 @@ export function Session() {
   })
 
   let lastSwitch: string | undefined = undefined
-  sdk.event.on("message.part.updated", (evt) => {
+  const offPart = sdk.event.on("message.part.updated", (evt) => {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
@@ -230,6 +231,7 @@ export function Session() {
       lastSwitch = part.id
     }
   })
+  onCleanup(offPart)
 
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -95,7 +95,6 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin" && which("osascript")) {
-      console.log("clipboard: using osascript")
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
         await Process.run(["osascript", "-e", `set the clipboard to "${escaped}"`], { nothrow: true })
@@ -104,7 +103,6 @@ export namespace Clipboard {
 
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && which("wl-copy")) {
-        console.log("clipboard: using wl-copy")
         return async (text: string) => {
           const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           if (!proc.stdin) return
@@ -114,7 +112,6 @@ export namespace Clipboard {
         }
       }
       if (which("xclip")) {
-        console.log("clipboard: using xclip")
         return async (text: string) => {
           const proc = Process.spawn(["xclip", "-selection", "clipboard"], {
             stdin: "pipe",
@@ -128,7 +125,6 @@ export namespace Clipboard {
         }
       }
       if (which("xsel")) {
-        console.log("clipboard: using xsel")
         return async (text: string) => {
           const proc = Process.spawn(["xsel", "--clipboard", "--input"], {
             stdin: "pipe",
@@ -144,7 +140,6 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Process.spawn(
@@ -169,7 +164,6 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
     return async (text: string) => {
       await clipboardy.write(text).catch(() => {})
     }


### PR DESCRIPTION
 ### Issue for this PR

  Closes #

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  This fixes two TUI problems that showed up together during longer sessions.

  First, there were a few `console.log(...)` calls left in the TUI layer. The TUI disables stdout interception, so those logs were being written directly into the terminal and could corrupt the screen output or make text look cut off.

  Second, some TUI event listeners were registered with `sdk.event.on(...)` but never cleaned up when components unmounted. After switching routes / remounting prompt and session views, listeners could accumulate and keep references alive longer than they should, which explains the memory growth.

  This PR:
  - removes the stray TUI `console.log(...)` calls
  - adds cleanup for TUI event subscriptions in app, session, and prompt components
  - unregisters the `SIGUSR2` theme reload handler on cleanup

  These changes work because they stop writing debug output into the live terminal buffer, and they ensure listeners do not survive past the lifecycle of the UI components that created them.

  ### How did you verify your code works?

  I verified this locally by:
  - running `bun install`
  - running `bun typecheck` from `packages/opencode`

  I also checked that the fix only touches the TUI files related to the rendering artifacts and event listener lifecycle.

  ### Screenshots / recordings

  I do not have a recording for this one. The issue is in terminal rendering / long-running TUI behavior rather than a simple static UI state.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR