### PR TITLE
feat(tui): add syntax highlighting for kotlin, hcl, lua, toml

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -102,6 +102,14 @@ export default {
       },
     },
     {
+      filetype: "kotlin",
+      wasm: "https://github.com/fwcd/tree-sitter-kotlin/releases/download/0.3.8/tree-sitter-kotlin.wasm",
+      queries: {
+        highlights: ["https://raw.githubusercontent.com/fwcd/tree-sitter-kotlin/0.3.8/queries/highlights.scm"],
+        locals: ["https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/master/queries/kotlin/locals.scm"],
+      },
+    },
+    {
       filetype: "ruby",
       wasm: "https://github.com/tree-sitter/tree-sitter-ruby/releases/download/v0.23.1/tree-sitter-ruby.wasm",
       queries: {
@@ -159,6 +167,15 @@ export default {
       // },
     },
     {
+      filetype: "hcl",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-hcl/releases/download/v1.2.0/tree-sitter-hcl.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/master/queries/hcl/highlights.scm",
+        ],
+      },
+    },
+    {
       filetype: "json",
       wasm: "https://github.com/tree-sitter/tree-sitter-json/releases/download/v0.24.8/tree-sitter-json.wasm",
       queries: {
@@ -204,6 +221,16 @@ export default {
       },
     },
     {
+      filetype: "lua",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-lua/releases/download/v0.5.0/tree-sitter-lua.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-lua/v0.5.0/queries/highlights.scm",
+        ],
+        locals: ["https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-lua/v0.5.0/queries/locals.scm"],
+      },
+    },
+    {
       filetype: "ocaml",
       wasm: "https://github.com/tree-sitter/tree-sitter-ocaml/releases/download/v0.24.2/tree-sitter-ocaml.wasm",
       queries: {
@@ -233,6 +260,15 @@ export default {
         ],
         locals: [
           "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/swift/locals.scm",
+        ],
+      },
+    },
+    {
+      filetype: "toml",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-toml/releases/download/v0.7.0/tree-sitter-toml.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/master/queries/toml/highlights.scm",
         ],
       },
     },


### PR DESCRIPTION
### Issue for this PR

Closes #18197

### Type of change

- [x] New feature

### What does this PR do?

Adds Tree-sitter parser support for syntax highlighting in the TUI for kotlin, hcl, lua, and toml. Each language now has proper syntax highlighting when used in fenced code blocks and in diffs.

- **kotlin**: fwcd/tree-sitter-kotlin
- **hcl**: tree-sitter-grammars/tree-sitter-hcl 
- **lua**: tree-sitter-grammars/tree-sitter-lua 
- **toml**: tree-sitter-grammars/tree-sitter-toml 

Wasm binaries are from official tree-sitter releases, queries from nvim-treesitter.

### How did you verify your code works?

Tested kotlin, hcl, lua, and toml fenced code blocks in the TUI after restart. Typecheck passes (`bun typecheck`).

### Screenshots / recordings

#### Before

<img width="322" height="548" alt="before-fix-opencode" src="https://github.com/user-attachments/assets/76e6ef64-eda2-4cb1-a692-573fb8f33a72" />

#### After

<img width="322" height="525" alt="after-fix-opencode" src="https://github.com/user-attachments/assets/65cb73d7-264d-4645-b541-280509592b48" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR