### PR TITLE
feat: added /auth command to re-authenticate with custom provider

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -54,4 +54,46 @@ export namespace Auth {
   export async function remove(key: string) {
     return runPromise((service) => service.remove(key))
   }
+
+  export async function urls(): Promise<string[]> {
+    const data = await all()
+    return Object.entries(data)
+      .filter(([, value]) => value.type === "wellknown")
+      .map(([key]) => key)
+  }
+
+  const WellKnownConfig = z.object({
+    auth: z.object({
+      command: z.array(z.string()),
+      env: z.string(),
+    }),
+  })
+
+  export async function wellknown(url: string) {
+    const normalized = url.replace(/\/+$/, "")
+    const response = await fetch(`${normalized}/.well-known/opencode`)
+    if (!response.ok) {
+      throw new Error(`failed to fetch well-known config from ${normalized}: ${response.status}`)
+    }
+    const parsed = WellKnownConfig.safeParse(await response.json())
+    if (!parsed.success) {
+      throw new Error(`invalid well-known config from ${normalized}: ${parsed.error.message}`)
+    }
+    const proc = Bun.spawn({
+      cmd: parsed.data.auth.command,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const exit = await proc.exited
+    if (exit !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      throw new Error(`auth command failed with exit code ${exit}${stderr ? ": " + stderr.trim() : ""}`)
+    }
+    const token = await new Response(proc.stdout).text()
+    await set(normalized, {
+      type: "wellknown",
+      key: parsed.data.auth.env,
+      token: token.trim(),
+    })
+  }
 }

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -11,8 +11,6 @@ import { Global } from "../../global"
 import { Plugin } from "../../plugin"
 import { Instance } from "../../project/instance"
 import type { Hooks } from "@opencode-ai/plugin"
-import { Process } from "../../util/process"
-import { text } from "node:stream/consumers"
 
 type PluginAuth = NonNullable<Hooks["auth"]>
 
@@ -277,29 +275,12 @@ export const ProvidersLoginCommand = cmd({
         UI.empty()
         prompts.intro("Add credential")
         if (args.url) {
-          const url = args.url.replace(/\/+$/, "")
-          const wellknown = await fetch(`${url}/.well-known/opencode`).then((x) => x.json() as any)
-          prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
-          const proc = Process.spawn(wellknown.auth.command, {
-            stdout: "pipe",
-          })
-          if (!proc.stdout) {
-            prompts.log.error("Failed")
-            prompts.outro("Done")
-            return
-          }
-          const [exit, token] = await Promise.all([proc.exited, text(proc.stdout)])
-          if (exit !== 0) {
-            prompts.log.error("Failed")
-            prompts.outro("Done")
-            return
-          }
-          await Auth.set(url, {
-            type: "wellknown",
-            key: wellknown.auth.env,
-            token: token.trim(),
-          })
-          prompts.log.success("Logged into " + url)
+          const result = await Auth.wellknown(args.url).then(
+            () => true as const,
+            (e) => e,
+          )
+          if (result === true) prompts.log.success("Logged into " + args.url)
+          else prompts.log.error(result instanceof Error ? result.message : "Failed")
           prompts.outro("Done")
           return
         }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -9,6 +9,7 @@ import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
+import { DialogSelect } from "@tui/ui/dialog-select"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { SyncProvider, useSync } from "@tui/context/sync"
 import { LocalProvider, useLocal } from "@tui/context/local"
@@ -356,6 +357,19 @@ function App() {
     ),
   )
 
+  async function authenticate(url: string) {
+    toast.show({ message: "Authenticating...", variant: "info" })
+    const { error } = await sdk.client.auth.wellknown.refresh({ url })
+    if (error) {
+      toast.show({ message: "Authentication failed", variant: "error", duration: 4000 })
+      return false
+    }
+    await sdk.client.instance.dispose()
+    await sync.bootstrap()
+    toast.show({ message: "Authenticated with " + url, variant: "success", duration: 3000 })
+    return true
+  }
+
   const connected = useConnected()
   command.register(() => [
     {
@@ -527,6 +541,45 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogProviderList />)
+      },
+      category: "Provider",
+    },
+    {
+      title: "Re-authenticate",
+      value: "auth.login",
+      slash: {
+        name: "auth",
+      },
+      async onSelect() {
+        const result = await sdk.client.auth.wellknown.list()
+        const urls = result.data
+        if (!urls || urls.length === 0) {
+          toast.show({
+            message: "No well-known auth entries found. Use /auth <url> to add one.",
+            variant: "warning",
+            duration: 4000,
+          })
+          dialog.clear()
+          return
+        }
+        if (urls.length === 1) {
+          await authenticate(urls[0])
+          dialog.clear()
+          return
+        }
+        dialog.replace(() => (
+          <DialogSelect
+            title="Select provider to re-authenticate"
+            options={urls.map((url) => ({
+              title: url,
+              value: url,
+            }))}
+            onSelect={async (option) => {
+              await authenticate(option.value)
+              dialog.clear()
+            }}
+          />
+        ))
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -583,6 +583,29 @@ export function Prompt(props: PromptProps) {
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
 
+    // Handle /auth and /auth <url> commands
+    if (inputText === "/auth" || inputText.startsWith("/auth ")) {
+      const url = inputText.slice("/auth".length).trim()
+      input.extmarks.clear()
+      setStore("prompt", { input: "", parts: [] })
+      setStore("extmarkToPartIndex", new Map())
+      input.clear()
+      if (!url) {
+        command.trigger("auth.login")
+        return
+      }
+      toast.show({ message: "Authenticating...", variant: "info" })
+      const { error } = await sdk.client.auth.wellknown.refresh({ url })
+      if (error) {
+        toast.show({ message: "Authentication failed", variant: "error", duration: 4000 })
+        return
+      }
+      await sdk.client.instance.dispose()
+      await sync.bootstrap()
+      toast.show({ message: "Authenticated with " + url, variant: "success", duration: 3000 })
+      return
+    }
+
     // Capture mode before it gets reset
     const currentMode = store.mode
     const variant = local.model.variant.current()

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -192,6 +192,57 @@ export namespace Server {
           return c.json(true)
         },
       )
+      .get(
+        "/auth/wellknown",
+        describeRoute({
+          summary: "List well-known auth URLs",
+          description: "Get a list of all well-known authentication URLs stored in credentials.",
+          operationId: "auth.wellknown.list",
+          responses: {
+            200: {
+              description: "List of well-known URLs",
+              content: {
+                "application/json": {
+                  schema: resolver(z.array(z.string())),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          return c.json(await Auth.urls())
+        },
+      )
+      .post(
+        "/auth/wellknown",
+        describeRoute({
+          summary: "Authenticate with well-known URL",
+          description:
+            "Fetch a well-known config from the given URL, run its auth command, and store the resulting token.",
+          operationId: "auth.wellknown.refresh",
+          responses: {
+            200: {
+              description: "Successfully authenticated",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            url: z.string(),
+          }),
+        ),
+        async (c) => {
+          await Auth.wellknown(c.req.valid("json").url)
+          return c.json(true)
+        },
+      )
       .use(async (c, next) => {
         if (c.req.path === "/log") return next()
         const rawWorkspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -13,6 +13,9 @@ import type {
   AuthRemoveResponses,
   AuthSetErrors,
   AuthSetResponses,
+  AuthWellknownListResponses,
+  AuthWellknownRefreshErrors,
+  AuthWellknownRefreshResponses,
   CommandListResponses,
   Config as Config3,
   ConfigGetResponses,
@@ -309,6 +312,48 @@ export class Global extends HeyApiClient {
   }
 }
 
+export class Wellknown extends HeyApiClient {
+  /**
+   * List well-known auth URLs
+   *
+   * Get a list of all well-known authentication URLs stored in credentials.
+   */
+  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<AuthWellknownListResponses, unknown, ThrowOnError>({
+      url: "/auth/wellknown",
+      ...options,
+    })
+  }
+
+  /**
+   * Authenticate with well-known URL
+   *
+   * Fetch a well-known config from the given URL, run its auth command, and store the resulting token.
+   */
+  public refresh<ThrowOnError extends boolean = false>(
+    parameters?: {
+      url?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "body", key: "url" }] }])
+    return (options?.client ?? this.client).post<
+      AuthWellknownRefreshResponses,
+      AuthWellknownRefreshErrors,
+      ThrowOnError
+    >({
+      url: "/auth/wellknown",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Auth extends HeyApiClient {
   /**
    * Remove auth credentials
@@ -362,6 +407,11 @@ export class Auth extends HeyApiClient {
         ...params.headers,
       },
     })
+  }
+
+  private _wellknown?: Wellknown
+  get wellknown(): Wellknown {
+    return (this._wellknown ??= new Wellknown({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2084,6 +2084,49 @@ export type AuthSetResponses = {
 
 export type AuthSetResponse = AuthSetResponses[keyof AuthSetResponses]
 
+export type AuthWellknownListData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/auth/wellknown"
+}
+
+export type AuthWellknownListResponses = {
+  /**
+   * List of well-known URLs
+   */
+  200: Array<string>
+}
+
+export type AuthWellknownListResponse = AuthWellknownListResponses[keyof AuthWellknownListResponses]
+
+export type AuthWellknownRefreshData = {
+  body?: {
+    url: string
+  }
+  path?: never
+  query?: never
+  url: "/auth/wellknown"
+}
+
+export type AuthWellknownRefreshErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type AuthWellknownRefreshError = AuthWellknownRefreshErrors[keyof AuthWellknownRefreshErrors]
+
+export type AuthWellknownRefreshResponses = {
+  /**
+   * Successfully authenticated
+   */
+  200: boolean
+}
+
+export type AuthWellknownRefreshResponse = AuthWellknownRefreshResponses[keyof AuthWellknownRefreshResponses]
+
 export type ProjectListData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a well-known auth token (e.g. a JWT from an enterprise provider like `opencode.example.com`) expires mid-session, you currently have to quit `opencode`, run `opencode auth login <url>` in your shell, and restart - losing your session context. This adds a `/auth` slash command so you can re-authenticate without leaving the TUI.

### How it works:
- `/auth` with no args looks up existing well-known entries from `auth.json`. If there's one, it re-runs the auth flow automatically. If there are multiple, it shows a picker. If there are none, it tells you to use `/auth <url>`.
- `/auth <url> `authenticates with the given well-known URL (new or existing) by fetching its `.well-known/opencode` config, running the auth command, and storing the token.
- After re-auth, the instance is disposed and re-bootstrapped (same pattern as `/connect`) so the new token takes effect immediately.

I also extracted the inline well-known auth logic from the CLI opencode auth login command into a shared `Auth.wellknown()` function so both the CLI and TUI use the same code path. The well-known config response is now validated with a Zod schema instead of as any, and stderr is captured on auth command failure for better error messages.

### How did you verify your code works?

- `bun run typecheck` passes clean
- `bun test` - 756 pass, 0 fail
- Tested bun dev launches the TUI with `/auth` available in the command palette

### Screenshots / recordings

<img width="810" height="575" alt="image" src="https://github.com/user-attachments/assets/83179c17-f387-4f4f-b2c3-3a4c91b935f2" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

