### PR TITLE
fix(server): bypass auth for frontend static paths

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -50,6 +50,21 @@ import { lazy } from "@/util/lazy"
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
 
+function web(path: string, method: string) {
+  if (method !== "GET" && method !== "HEAD") return false
+  if (
+    path === "/" ||
+    path === "/index.html" ||
+    path === "/site.webmanifest" ||
+    path === "/favicon.ico" ||
+    path === "/robots.txt" ||
+    path === "/oc-theme-preload.js"
+  )
+    return true
+  if (path.startsWith("/assets/")) return true
+  return false
+}
+
 export namespace Server {
   const log = Log.create({ service: "server" })
 
@@ -81,6 +96,7 @@ export namespace Server {
         // Allow CORS preflight requests to succeed without auth.
         // Browser clients sending Authorization headers will preflight with OPTIONS.
         if (c.req.method === "OPTIONS") return next()
+        if (web(c.req.path, c.req.method)) return next()
         const password = Flag.OPENCODE_SERVER_PASSWORD
         if (!password) return next()
         const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"


### PR DESCRIPTION

### Issue for this PR

- fix: #12447
- fix: #9206
- fix: #18189

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR bypasses HTTP basic auth for frontend static routes required to bootstrap OpenCode Web correctly when `OPENCODE_SERVER_PASSWORD` is enabled.

With basic auth enabled, browsers may request static assets/manifests in ways that do not consistently include credentials (e.g. module/crossorigin behavior), causing bootstrap failures and repeated auth prompts.

- Add a `web(path, method)` guard for frontend static requests.
- Allow unauthenticated `GET/HEAD` for:
  - `/`
  - `/index.html`
  - `/site.webmanifest`
  - `/favicon.ico`
  - `/robots.txt`
  - `/oc-theme-preload.js`
  - `/assets/*`
- Keep auth protection for non-static API routes.

### How did you verify your code works?

none, it is simple

### Screenshots / recordings

none

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


