### PR TITLE
feat: App - Support setting base URL during build

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -588,6 +588,7 @@ export function AppInterface(props: {
             <Show when={useSettings().general.newLayoutDesigns().toString()} keyed>
               <Dynamic
                 component={props.router ?? Router}
+                base={import.meta.env.BASE_URL.replace(/\/$/, "") || undefined}
                 root={(routerProps) => (
                   <TabsProvider>
                     <PermissionProvider>

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -97,13 +97,14 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
-  let serverBaseUrl = import.meta.env.VITE_OPENCODE_SERVER_BASE_URL ?? ""
-  // Normalizing slashes. Add starting slash if needed, remove trailing slash. Default value will be empty string.
-  serverBaseUrl = ("/" + serverBaseUrl.replace(/^\//, "")).replace(/\/$/, "")
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
-  if (import.meta.env.DEV)
-    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}${serverBaseUrl}`
-  return location.origin + serverBaseUrl
+  const url = new URL(
+    import.meta.env.DEV
+      ? `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
+      : location.origin,
+  )
+  url.pathname = import.meta.env.VITE_OPENCODE_SERVER_BASE_URL ?? ""
+  return url.href
 }
 
 const getDefaultUrl = () => {

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -104,7 +104,9 @@ const getCurrentUrl = () => {
       : location.origin,
   )
   url.pathname = import.meta.env.VITE_OPENCODE_SERVER_BASE_URL ?? ""
-  return url.href
+  // Stripping the trailing slash since some consumer code is sensitive to it.
+  // For example, ~18 tests (e.g. e2e/regression/legacy-new-session.spec.ts) fail on "http://127.0.0.1:4096/", but succeed on "http://127.0.0.1:4096".
+  return url.href.replace(/\/$/, "")
 }
 
 const getDefaultUrl = () => {

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -97,10 +97,13 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
+  let serverBaseUrl = import.meta.env.VITE_OPENCODE_SERVER_BASE_URL ?? ""
+  // Normalizing slashes. Add starting slash if needed, remove trailing slash. Default value will be empty string.
+  serverBaseUrl = ("/" + serverBaseUrl.replace(/^\//, "")).replace(/\/$/, "")
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
-    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
-  return location.origin
+    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}${serverBaseUrl}`
+  return location.origin + serverBaseUrl
 }
 
 const getDefaultUrl = () => {

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,4 +1,5 @@
 interface ImportMetaEnv {
+  readonly BASE_URL: string
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
   readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -20,6 +20,7 @@ const sentry =
     : false
 
 export default defineConfig({
+  base: process.env.VITE_BASE_URL || "/",
   plugins: [desktopPlugin, sentry] as any,
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
This is needed to host OpenCode app under under some URL prefix. Usage: Set `VITE_BASE_URL` env var during build. This automatically sets the `base` in Vite config. It's also used in routers.
See https://vite.dev/config/shared-options#base

### Issue for this PR

Issue: https://github.com/anomalyco/opencode/issues/7624

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This change is needed to host OpenCode app under under some URL prefix.
This tiny PR makes it possible to build OpenCode Web App with VITE_BASE_URL="/subdir/" and have it run under `http://<host>:<port>/subdir/` instead of root (`http://<host>:<port>/`).

Set `VITE_BASE_URL` env var during build. This automatically sets the `base` in Vite config. Vite generates correct URLs in `index.html`.
`import.meta.env.BASE_URL` is also used in routers. See https://vite.dev/config/shared-options#base
You can also set `VITE_OPENCODE_SERVER_BASE_URL` to specify the base URL prefix for the server.


### How did you verify your code works?

```
% VITE_BASE_URL="/XXX" VITE_OPENCODE_SERVER_BASE_URL="/" bun dev
$ vite
(!) "base" option should start with a slash.

  VITE v7.1.4  ready in 320 ms

  ➜  Local:   http://localhost:3000/XXX
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
