### PR TITLE
feat: add offline mode to disable non-essential outbound connections

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -1,4 +1,5 @@
 import type { Argv } from "yargs"
+import { withOfflineOption } from "../network"
 import path from "path"
 import { pathToFileURL } from "url"
 import { UI } from "../ui"
@@ -222,7 +223,7 @@ export const RunCommand = cmd({
   command: "run [message..]",
   describe: "run opencode with a message",
   builder: (yargs: Argv) => {
-    return yargs
+    return withOfflineOption(yargs
       .positional("message", {
         describe: "message to send",
         type: "string",
@@ -301,9 +302,11 @@ export const RunCommand = cmd({
         type: "boolean",
         describe: "show thinking blocks",
         default: false,
-      })
+      }),
+    )
   },
   handler: async (args) => {
+    if (args.offline) process.env["OPENCODE_OFFLINE"] = "true"
     let message = [...args.message, ...(args["--"] || [])]
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,6 +1,6 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { withNetworkOptions, withOfflineOption, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import { Workspace } from "../../control-plane/workspace"
 import { Project } from "../../project/project"
@@ -8,9 +8,10 @@ import { Installation } from "../../installation"
 
 export const ServeCommand = cmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) => withOfflineOption(withNetworkOptions(yargs)),
   describe: "starts a headless opencode server",
   handler: async (args) => {
+    if (args.offline) process.env["OPENCODE_OFFLINE"] = "true"
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "url"
 import { UI } from "@/cli/ui"
 import { Log } from "@/util/log"
 import { withTimeout } from "@/util/timeout"
-import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
+import { withNetworkOptions, withOfflineOption, resolveNetworkOptions } from "@/cli/network"
 import { Filesystem } from "@/util/filesystem"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
@@ -66,39 +66,42 @@ export const TuiThreadCommand = cmd({
   command: "$0 [project]",
   describe: "start opencode tui",
   builder: (yargs) =>
-    withNetworkOptions(yargs)
-      .positional("project", {
-        type: "string",
-        describe: "path to start opencode in",
-      })
-      .option("model", {
-        type: "string",
-        alias: ["m"],
-        describe: "model to use in the format of provider/model",
-      })
-      .option("continue", {
-        alias: ["c"],
-        describe: "continue the last session",
-        type: "boolean",
-      })
-      .option("session", {
-        alias: ["s"],
-        type: "string",
-        describe: "session id to continue",
-      })
-      .option("fork", {
-        type: "boolean",
-        describe: "fork the session when continuing (use with --continue or --session)",
-      })
-      .option("prompt", {
-        type: "string",
-        describe: "prompt to use",
-      })
-      .option("agent", {
-        type: "string",
-        describe: "agent to use",
-      }),
+    withOfflineOption(
+      withNetworkOptions(yargs)
+        .positional("project", {
+          type: "string",
+          describe: "path to start opencode in",
+        })
+        .option("model", {
+          type: "string",
+          alias: ["m"],
+          describe: "model to use in the format of provider/model",
+        })
+        .option("continue", {
+          alias: ["c"],
+          describe: "continue the last session",
+          type: "boolean",
+        })
+        .option("session", {
+          alias: ["s"],
+          type: "string",
+          describe: "session id to continue",
+        })
+        .option("fork", {
+          type: "boolean",
+          describe: "fork the session when continuing (use with --continue or --session)",
+        })
+        .option("prompt", {
+          type: "string",
+          describe: "prompt to use",
+        })
+        .option("agent", {
+          type: "string",
+          describe: "agent to use",
+        }),
+    ),
   handler: async (args) => {
+    if (args.offline) process.env["OPENCODE_OFFLINE"] = "true"
     // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
     // (Important when running under `bun run` wrappers on Windows.)
     const unguard = win32InstallCtrlCGuard()

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -36,6 +36,15 @@ export function withNetworkOptions<T>(yargs: Argv<T>) {
   return yargs.options(options)
 }
 
+export function withOfflineOption<T>(yargs: Argv<T>) {
+  return yargs.option("offline", {
+    type: "boolean" as const,
+    describe:
+      "disable non-essential outbound connections (auto-update, session sharing, app proxy). Equivalent to OPENCODE_OFFLINE=true",
+    default: false,
+  })
+}
+
 export async function resolveNetworkOptions(args: NetworkOptions) {
   const config = await Config.global()
   const portExplicitlySet = process.argv.includes("--port")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -248,6 +248,17 @@ export namespace Config {
       result.share = "auto"
     }
 
+    // Apply offline mode: set env var so all dynamic Flag getters pick it up at runtime
+    if (result.offline) {
+      process.env["OPENCODE_OFFLINE"] = "true"
+    }
+    // When offline, force share to disabled so the UI hides the /share command.
+    // Check both result.offline (config file) and Flag.OPENCODE_OFFLINE (env var / --offline flag)
+    // to avoid relying on the getter picking up the just-set env var above.
+    if (result.offline || Flag.OPENCODE_OFFLINE) {
+      result.share = "disabled"
+    }
+
     // Apply flag overrides for compaction settings
     if (Flag.OPENCODE_DISABLE_AUTOCOMPACT) {
       result.compaction = { ...result.compaction, auto: false }
@@ -1040,6 +1051,12 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       logLevel: Log.Level.optional().describe("Log level"),
+      offline: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, disables non-essential outbound connections (auto-update, session sharing, app proxy). Equivalent to setting OPENCODE_OFFLINE=true. Essential connections (LLM providers, models.dev model catalog) are not affected.",
+        ),
       server: Server.optional().describe("Server configuration for opencode serve and web commands"),
       command: z
         .record(z.string(), Command)

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -17,7 +17,7 @@ export namespace Flag {
   export declare const OPENCODE_TUI_CONFIG: string | undefined
   export declare const OPENCODE_CONFIG_DIR: string | undefined
   export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"]
-  export const OPENCODE_DISABLE_AUTOUPDATE = truthy("OPENCODE_DISABLE_AUTOUPDATE")
+  export declare const OPENCODE_DISABLE_AUTOUPDATE: boolean
   export const OPENCODE_DISABLE_PRUNE = truthy("OPENCODE_DISABLE_PRUNE")
   export const OPENCODE_DISABLE_TERMINAL_TITLE = truthy("OPENCODE_DISABLE_TERMINAL_TITLE")
   export const OPENCODE_PERMISSION = process.env["OPENCODE_PERMISSION"]
@@ -26,6 +26,16 @@ export namespace Flag {
   export const OPENCODE_ENABLE_EXPERIMENTAL_MODELS = truthy("OPENCODE_ENABLE_EXPERIMENTAL_MODELS")
   export const OPENCODE_DISABLE_AUTOCOMPACT = truthy("OPENCODE_DISABLE_AUTOCOMPACT")
   export const OPENCODE_DISABLE_MODELS_FETCH = truthy("OPENCODE_DISABLE_MODELS_FETCH")
+  // Offline mode: disables non-essential outbound connections (autoupdate, sharing, app proxy).
+  // models.dev and Exa search are intentionally excluded — models.dev is essential metadata;
+  // Exa is user-initiated and already gated by a permission prompt.
+  // Individual granular flags still work independently; this is a single kill switch.
+  // Declared as getters (not plain constants) because flag.ts is imported before the CLI
+  // handler or config loading runs, so process.env.OPENCODE_OFFLINE isn't set yet at
+  // module evaluation time.
+  export declare const OPENCODE_OFFLINE: boolean
+  export declare const OPENCODE_DISABLE_SHARE: boolean
+  export declare const OPENCODE_DISABLE_APP_PROXY: boolean
   export const OPENCODE_DISABLE_CLAUDE_CODE = truthy("OPENCODE_DISABLE_CLAUDE_CODE")
   export const OPENCODE_DISABLE_CLAUDE_CODE_PROMPT =
     OPENCODE_DISABLE_CLAUDE_CODE || truthy("OPENCODE_DISABLE_CLAUDE_CODE_PROMPT")
@@ -120,6 +130,40 @@ Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
 Object.defineProperty(Flag, "OPENCODE_CLIENT", {
   get() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Offline mode — getters instead of constants because flag.ts loads before the CLI handler
+// or config sets process.env.OPENCODE_OFFLINE.
+Object.defineProperty(Flag, "OPENCODE_OFFLINE", {
+  get() {
+    return truthy("OPENCODE_OFFLINE")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+Object.defineProperty(Flag, "OPENCODE_DISABLE_AUTOUPDATE", {
+  get() {
+    return truthy("OPENCODE_OFFLINE") || truthy("OPENCODE_DISABLE_AUTOUPDATE")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+Object.defineProperty(Flag, "OPENCODE_DISABLE_SHARE", {
+  get() {
+    return truthy("OPENCODE_OFFLINE") || truthy("OPENCODE_DISABLE_SHARE")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+Object.defineProperty(Flag, "OPENCODE_DISABLE_APP_PROXY", {
+  get() {
+    return truthy("OPENCODE_OFFLINE") || truthy("OPENCODE_DISABLE_APP_PROXY")
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -556,6 +556,9 @@ export namespace Server {
         },
       )
       .all("/*", async (c) => {
+        if (Flag.OPENCODE_DISABLE_APP_PROXY) {
+          return c.json({ error: "App proxy is disabled" }, 503)
+        }
         const path = c.req.path
 
         const response = await proxy(`https://app.opencode.ai${path}`, {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -10,6 +10,7 @@ import { Database, eq } from "@/storage/db"
 import { SessionShareTable } from "./share.sql"
 import { Log } from "@/util/log"
 import type * as SDK from "@opencode-ai/sdk/v2"
+import { Flag } from "@/flag/flag"
 
 export namespace ShareNext {
   const log = Log.create({ service: "share-next" })
@@ -61,10 +62,8 @@ export namespace ShareNext {
     return { headers, api: consoleApi, baseUrl: active.url }
   }
 
-  const disabled = process.env["OPENCODE_DISABLE_SHARE"] === "true" || process.env["OPENCODE_DISABLE_SHARE"] === "1"
-
   export async function init() {
-    if (disabled) return
+    if (Flag.OPENCODE_DISABLE_SHARE) return
     Bus.subscribe(Session.Event.Updated, async (evt) => {
       await sync(evt.properties.info.id, [
         {
@@ -112,7 +111,7 @@ export namespace ShareNext {
   }
 
   export async function create(sessionID: SessionID) {
-    if (disabled) return { id: "", url: "", secret: "" }
+    if (Flag.OPENCODE_DISABLE_SHARE) return { id: "", url: "", secret: "" }
     log.info("creating share", { sessionID })
     const req = await request()
     const response = await fetch(`${req.baseUrl}${req.api.create}`, {
@@ -189,7 +188,7 @@ export namespace ShareNext {
 
   const queue = new Map<string, { timeout: NodeJS.Timeout; data: Map<string, Data> }>()
   async function sync(sessionID: SessionID, data: Data[]) {
-    if (disabled) return
+    if (Flag.OPENCODE_DISABLE_SHARE) return
     const existing = queue.get(sessionID)
     if (existing) {
       for (const item of data) {
@@ -228,7 +227,7 @@ export namespace ShareNext {
   }
 
   export async function remove(sessionID: SessionID) {
-    if (disabled) return
+    if (Flag.OPENCODE_DISABLE_SHARE) return
     log.info("removing share", { sessionID })
     const share = get(sessionID)
     if (!share) return

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -2,7 +2,6 @@ import z from "zod"
 import { Tool } from "./tool"
 import DESCRIPTION from "./websearch.txt"
 import { abortAfterAny } from "../util/abort"
-
 const API_CONFIG = {
   BASE_URL: "https://mcp.exa.ai",
   ENDPOINTS: {
@@ -63,6 +62,7 @@ export const WebSearchTool = Tool.define("websearch", async () => {
         .describe("Maximum characters for context string optimized for LLMs (default: 10000)"),
     }),
     async execute(params, ctx) {
+
       await ctx.ask({
         permission: "websearch",
         patterns: [params.query],

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -96,6 +96,7 @@ describe("tui thread", () => {
       session: undefined,
       continue: false,
       fork: false,
+      offline: false,
       port: 0,
       hostname: "127.0.0.1",
       mdns: false,

--- a/packages/opencode/test/flag/offline.test.ts
+++ b/packages/opencode/test/flag/offline.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+
+describe("offline flag", () => {
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    savedEnv = {
+      OPENCODE_OFFLINE: process.env["OPENCODE_OFFLINE"],
+      OPENCODE_DISABLE_AUTOUPDATE: process.env["OPENCODE_DISABLE_AUTOUPDATE"],
+      OPENCODE_DISABLE_SHARE: process.env["OPENCODE_DISABLE_SHARE"],
+      OPENCODE_DISABLE_APP_PROXY: process.env["OPENCODE_DISABLE_APP_PROXY"],
+    }
+    delete process.env["OPENCODE_OFFLINE"]
+    delete process.env["OPENCODE_DISABLE_AUTOUPDATE"]
+    delete process.env["OPENCODE_DISABLE_SHARE"]
+    delete process.env["OPENCODE_DISABLE_APP_PROXY"]
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  test("OPENCODE_OFFLINE=true enables all offline flags", async () => {
+    process.env["OPENCODE_OFFLINE"] = "true"
+    const { Flag } = await import("../../src/flag/flag")
+    expect(Flag.OPENCODE_OFFLINE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_SHARE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_APP_PROXY).toBe(true)
+  })
+
+  test("OPENCODE_OFFLINE=1 enables all offline flags", async () => {
+    process.env["OPENCODE_OFFLINE"] = "1"
+    const { Flag } = await import("../../src/flag/flag")
+    expect(Flag.OPENCODE_OFFLINE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_SHARE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_APP_PROXY).toBe(true)
+  })
+
+  test("without OPENCODE_OFFLINE, flags are false by default", async () => {
+    const { Flag } = await import("../../src/flag/flag")
+    expect(Flag.OPENCODE_OFFLINE).toBe(false)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(false)
+    expect(Flag.OPENCODE_DISABLE_SHARE).toBe(false)
+    expect(Flag.OPENCODE_DISABLE_APP_PROXY).toBe(false)
+  })
+
+  test("granular flags work independently without OPENCODE_OFFLINE", async () => {
+    process.env["OPENCODE_DISABLE_AUTOUPDATE"] = "true"
+    process.env["OPENCODE_DISABLE_SHARE"] = "true"
+    const { Flag } = await import("../../src/flag/flag")
+    expect(Flag.OPENCODE_OFFLINE).toBe(false)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_SHARE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_APP_PROXY).toBe(false)
+  })
+
+  test("flags are dynamic — setting env at runtime changes their value", async () => {
+    const { Flag } = await import("../../src/flag/flag")
+    expect(Flag.OPENCODE_OFFLINE).toBe(false)
+    process.env["OPENCODE_OFFLINE"] = "true"
+    expect(Flag.OPENCODE_OFFLINE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(true)
+    expect(Flag.OPENCODE_DISABLE_SHARE).toBe(true)
+    delete process.env["OPENCODE_OFFLINE"]
+    expect(Flag.OPENCODE_OFFLINE).toBe(false)
+    expect(Flag.OPENCODE_DISABLE_AUTOUPDATE).toBe(false)
+  })
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -457,6 +457,41 @@ Notice that this only works if it was not installed using a package manager such
 
 ---
 
+### Offline mode
+
+You can disable all non-essential outbound connections with the `offline` option. This is useful in air-gapped or privacy-sensitive environments.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "offline": true
+}
+```
+
+You can also set it via environment variable or CLI flag:
+
+```bash
+# Environment variable
+OPENCODE_OFFLINE=true opencode
+
+# CLI flag
+opencode --offline
+opencode run --offline "fix the tests"
+opencode serve --offline
+```
+
+When offline mode is enabled:
+
+- Auto-update checks (`opencode.ai/install`) are skipped
+- Session sharing (`opncd.ai`) is disabled and the `/share` command is hidden
+- The web UI proxy (`app.opencode.ai`) returns an error
+
+Essential connections are not affected — your configured LLM provider and the `models.dev` model catalog continue to work normally. Exa web/code search is also unaffected since it is user-initiated and already gated by a permission prompt.
+
+For finer-grained control, you can use the individual environment variables: `OPENCODE_DISABLE_AUTOUPDATE`, `OPENCODE_DISABLE_SHARE`, and `OPENCODE_DISABLE_APP_PROXY`.
+
+---
+
 ### Formatters
 
 You can configure code formatters through the `formatter` option.


### PR DESCRIPTION
### Issue for this PR

Closes #18233

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a single "kill switch" for non-essential outbound connections, useful in privacy-sensitive or restricted-network environments.

Three equivalent ways to enable it:

```jsonc
// opencode.json
{ "offline": true }
```

```bash
OPENCODE_OFFLINE=true opencode
opencode --offline
opencode run --offline "fix the tests"
opencode serve --offline
```

When enabled, the following are disabled:

| Connection | Effect |
|---|---|
| `opencode.ai/install` auto-update check | Skipped |
| `opncd.ai` session sharing | Disabled; `/share` command hidden in TUI |
| `app.opencode.ai` web UI proxy | Returns 503 |

Intentionally **not** affected: `models.dev` (essential model metadata) and Exa search (user-initiated, already gated by a permission prompt).

The existing granular flags (`OPENCODE_DISABLE_AUTOUPDATE`, `OPENCODE_DISABLE_SHARE`, `OPENCODE_DISABLE_APP_PROXY`) continue to work independently — `OPENCODE_OFFLINE` is a superset that implies all of them.

**Implementation note:** offline flags are implemented as `Object.defineProperty` getters rather than plain constants, because `flag.ts` is imported before the CLI handler or config loading has a chance to set `OPENCODE_OFFLINE` in the environment.

Inspired by the [rolandcode fork](https://github.com/standardnguyen/rolandcode?tab=readme-ov-file#whats-removed), which patches these out entirely — this PR adds a first-class opt-in instead.

### How did you verify your code works?

- Added `test/flag/offline.test.ts` — 5 tests covering: env var activation, granular flag independence, `OPENCODE_OFFLINE` as superset, and dynamic runtime behavior (getters pick up env changes after module load)
- Updated `test/cli/tui/thread.test.ts` to include `offline: false` in the expected args shape
- `bun test` — all tests pass
- `bun typecheck` — no errors

### Screenshots / recordings

Not applicable — no UI changes (the `/share` command disappearing from the TUI when offline is the only visual effect, and it's a removal rather than something screenshot-worthy).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR