### PR TITLE
feat(app): add 'open pull request' command

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -46,6 +46,7 @@ const COMMON_COMMAND_IDS = [
   "session.next",
   "terminal.toggle",
   "review.toggle",
+  "project.pullRequest.open",
 ] as const
 
 const uniqueEntries = (items: Entry[]) => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -158,7 +158,7 @@ export async function bootstrapDirectory(input: {
     input.sdk.vcs.get().then((x) => {
       const next = x.data ?? input.store.vcs
       input.setStore("vcs", next)
-      if (next?.branch) input.vcsCache.setStore("value", next)
+      input.vcsCache.setStore("value", next?.branch ? { branch: next.branch } : undefined)
     }),
     input.sdk.permission.list().then((x) => {
       const grouped = groupBySession(

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -498,7 +498,10 @@ describe("applyDirectoryEvent", () => {
     const [cacheStore, setCacheStore] = createStore({ value: undefined as State["vcs"] })
 
     applyDirectoryEvent({
-      event: { type: "vcs.branch.updated", properties: { branch: "feature/test" } },
+      event: {
+        type: "vcs.branch.updated",
+        properties: { branch: "feature/test", pull_request_url: "https://github.com/acme/repo/pull/1" },
+      },
       store,
       setStore,
       push() {},
@@ -511,8 +514,13 @@ describe("applyDirectoryEvent", () => {
       },
     })
 
-    expect(store.vcs).toEqual({ branch: "feature/test" })
-    expect(cacheStore.value).toEqual({ branch: "feature/test" })
+    expect(store.vcs).toEqual({
+      branch: "feature/test",
+      pull_request_url: "https://github.com/acme/repo/pull/1",
+    })
+    expect(cacheStore.value).toEqual({
+      branch: "feature/test",
+    })
   })
 
   test("routes disposal and lsp events to side-effect handlers", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -268,11 +268,16 @@ export function applyDirectoryEvent(input: {
       break
     }
     case "vcs.branch.updated": {
-      const props = event.properties as { branch: string }
-      if (input.store.vcs?.branch === props.branch) break
-      const next = { branch: props.branch }
+      const props = event.properties as { branch?: string; pull_request_url?: string }
+      if (input.store.vcs?.branch === props.branch && input.store.vcs?.pull_request_url === props.pull_request_url) {
+        break
+      }
+      const next = {
+        branch: props.branch,
+        pull_request_url: props.pull_request_url,
+      }
       input.setStore("vcs", next)
-      if (input.vcsCache) input.vcsCache.setStore("value", next)
+      if (input.vcsCache) input.vcsCache.setStore("value", next.branch ? { branch: next.branch } : undefined)
       break
     }
     case "permission.asked": {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -23,6 +23,8 @@ export const dict = {
 
   "command.sidebar.toggle": "Toggle sidebar",
   "command.project.open": "Open project",
+  "command.project.pullRequest.open": "Open pull request",
+  "command.project.pullRequest.open.description": "Open the current pull request in your browser",
   "command.provider.connect": "Connect provider",
   "command.server.switch": "Switch server",
   "command.settings.open": "Open settings",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -138,6 +138,11 @@ export default function Layout(props: ParentProps) {
   }
   const colorSchemeLabel = (scheme: ColorScheme) => language.t(colorSchemeKey[scheme])
   const currentDir = createMemo(() => decode64(params.dir) ?? "")
+  const currentVcs = createMemo(() => {
+    const dir = currentDir()
+    if (!dir) return
+    return globalSync.child(dir, { bootstrap: false })[0].vcs
+  })
 
   const [state, setState] = createStore({
     autoselect: !initialDirectory,
@@ -986,6 +991,18 @@ export default function Layout(props: ParentProps) {
         category: language.t("command.category.project"),
         keybind: "mod+o",
         onSelect: () => chooseProject(),
+      },
+      {
+        id: "project.pullRequest.open",
+        title: language.t("command.project.pullRequest.open"),
+        description: language.t("command.project.pullRequest.open.description"),
+        category: language.t("command.category.project"),
+        disabled: !currentVcs()?.pull_request_url,
+        onSelect: () => {
+          const url = currentVcs()?.pull_request_url
+          if (!url) return
+          platform.openLink(url)
+        },
       },
       {
         id: "provider.connect",

--- a/packages/opencode/src/project/pull-request.ts
+++ b/packages/opencode/src/project/pull-request.ts
@@ -1,0 +1,58 @@
+import { Process } from "@/util/process"
+import { git } from "@/util/git"
+
+export async function pull(dir: string, branch?: string) {
+  if (!branch || branch === "HEAD") return
+
+  const remote = await git(["remote", "get-url", "origin"], { cwd: dir })
+  if (remote.exitCode !== 0) return
+
+  const host = parse(remote.text())
+  if (!host) return
+  if (host.includes("github")) return github(dir)
+  if (host.includes("gitlab")) return gitlab(dir)
+}
+
+async function github(dir: string) {
+  const out = await Process.text(["gh", "pr", "view", "--json", "url", "--jq", ".url"], {
+    cwd: dir,
+    nothrow: true,
+    stdin: "ignore",
+  })
+  if (out.code !== 0) return
+
+  const url = out.text.trim()
+  if (!url) return
+  return url
+}
+
+async function gitlab(dir: string) {
+  const out = await Process.text(["glab", "mr", "view", "--json", "web_url"], {
+    cwd: dir,
+    nothrow: true,
+    stdin: "ignore",
+  })
+  if (out.code !== 0 || !out.text.trim()) return
+
+  const data = JSON.parse(out.text) as { web_url?: string }
+  if (!data.web_url) return
+  return data.web_url
+}
+
+function parse(input: string) {
+  const text = input.trim().toLowerCase()
+  if (!text) return
+
+  if (text.startsWith("http://") || text.startsWith("https://") || text.startsWith("ssh://")) {
+    const head = text
+      .replace(/^https?:\/\//, "")
+      .replace(/^ssh:\/\//, "")
+      .split("/")[0]
+    return head.split("@")[1] ?? head
+  }
+
+  const at = text.indexOf("@")
+  const colon = text.indexOf(":")
+  if (at === -1 || colon <= at) return
+  return text.slice(at + 1, colon)
+}

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -6,6 +6,7 @@ import { FileWatcher } from "@/file/watcher"
 import { Log } from "@/util/log"
 import { git } from "@/util/git"
 import { Instance } from "./instance"
+import { pull } from "./pull-request"
 import z from "zod"
 
 export namespace Vcs {
@@ -16,13 +17,15 @@ export namespace Vcs {
       "vcs.branch.updated",
       z.object({
         branch: z.string().optional(),
+        pull_request_url: z.string().optional(),
       }),
     ),
   }
 
   export const Info = z
     .object({
-      branch: z.string(),
+      branch: z.string().optional(),
+      pull_request_url: z.string().optional(),
     })
     .meta({
       ref: "VcsInfo",
@@ -30,7 +33,7 @@ export namespace Vcs {
   export type Info = z.infer<typeof Info>
 
   export interface Interface {
-    readonly branch: () => Effect.Effect<string | undefined>
+    readonly get: () => Effect.Effect<Info>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Vcs") {}
@@ -39,20 +42,22 @@ export namespace Vcs {
     Service,
     Effect.gen(function* () {
       const instance = yield* InstanceContext
-      let currentBranch: string | undefined
+      let info: Info = {}
 
       if (instance.project.vcs === "git") {
-        const getCurrentBranch = async () => {
+        const getInfo = async () => {
           const result = await git(["rev-parse", "--abbrev-ref", "HEAD"], {
             cwd: instance.project.worktree,
           })
-          if (result.exitCode !== 0) return undefined
-          const text = result.text().trim()
-          return text || undefined
+          const branch = result.exitCode === 0 ? result.text().trim() || undefined : undefined
+          return {
+            branch,
+            pull_request_url: await pull(instance.project.worktree, branch),
+          }
         }
 
-        currentBranch = yield* Effect.promise(() => getCurrentBranch())
-        log.info("initialized", { branch: currentBranch })
+        info = yield* Effect.promise(() => getInfo())
+        log.info("initialized", info)
 
         yield* Effect.acquireRelease(
           Effect.sync(() =>
@@ -60,11 +65,11 @@ export namespace Vcs {
               FileWatcher.Event.Updated,
               Instance.bind(async (evt) => {
                 if (!evt.properties.file.endsWith("HEAD")) return
-                const next = await getCurrentBranch()
-                if (next !== currentBranch) {
-                  log.info("branch changed", { from: currentBranch, to: next })
-                  currentBranch = next
-                  Bus.publish(Event.BranchUpdated, { branch: next })
+                const next = await getInfo()
+                if (next.branch !== info.branch || next.pull_request_url !== info.pull_request_url) {
+                  log.info("updated", { from: info, to: next })
+                  info = next
+                  Bus.publish(Event.BranchUpdated, next)
                 }
               }),
             ),
@@ -74,8 +79,8 @@ export namespace Vcs {
       }
 
       return Service.of({
-        branch: Effect.fn("Vcs.branch")(function* () {
-          return currentBranch
+        get: Effect.fn("Vcs.get")(function* () {
+          return info
         }),
       })
     }),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -332,10 +332,7 @@ export namespace Server {
           },
         }),
         async (c) => {
-          const branch = await runPromiseInstance(Vcs.Service.use((s) => s.branch()))
-          return c.json({
-            branch,
-          })
+          return c.json(await runPromiseInstance(Vcs.Service.use((s) => s.get())))
         },
       )
       .get(

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -69,22 +69,22 @@ function nextBranchUpdate(directory: string, timeout = 10_000) {
 describeVcs("Vcs", () => {
   afterEach(() => Instance.disposeAll())
 
-  test("branch() returns current branch name", async () => {
+  test("get() returns current branch name", async () => {
     await using tmp = await tmpdir({ git: true })
 
     await withVcs(tmp.path, async (rt) => {
-      const branch = await rt.runPromise(Vcs.Service.use((s) => s.branch()))
-      expect(branch).toBeDefined()
-      expect(typeof branch).toBe("string")
+      const info = await rt.runPromise(Vcs.Service.use((s) => s.get()))
+      expect(info.branch).toBeDefined()
+      expect(typeof info.branch).toBe("string")
     })
   })
 
-  test("branch() returns undefined for non-git directories", async () => {
+  test("get() returns empty info for non-git directories", async () => {
     await using tmp = await tmpdir()
 
     await withVcs(tmp.path, async (rt) => {
-      const branch = await rt.runPromise(Vcs.Service.use((s) => s.branch()))
-      expect(branch).toBeUndefined()
+      const info = await rt.runPromise(Vcs.Service.use((s) => s.get()))
+      expect(info).toEqual({})
     })
   })
 
@@ -104,7 +104,7 @@ describeVcs("Vcs", () => {
     })
   })
 
-  test("branch() reflects the new branch after HEAD change", async () => {
+  test("get() reflects the new branch after HEAD change", async () => {
     await using tmp = await tmpdir({ git: true })
     const branch = `test-${Math.random().toString(36).slice(2)}`
     await $`git branch ${branch}`.cwd(tmp.path).quiet()
@@ -116,8 +116,8 @@ describeVcs("Vcs", () => {
       await fs.writeFile(head, `ref: refs/heads/${branch}\n`)
 
       await pending
-      const current = await rt.runPromise(Vcs.Service.use((s) => s.branch()))
-      expect(current).toBe(branch)
+      const current = await rt.runPromise(Vcs.Service.use((s) => s.get()))
+      expect(current.branch).toBe(branch)
     })
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -102,6 +102,7 @@ export type EventVcsBranchUpdated = {
   type: "vcs.branch.updated"
   properties: {
     branch?: string
+    pull_request_url?: string
   }
 }
 
@@ -1889,7 +1890,8 @@ export type Path = {
 }
 
 export type VcsInfo = {
-  branch: string
+  branch?: string
+  pull_request_url?: string
 }
 
 export type Command = {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds pull request awareness to project VCS state and exposes an "Open pull request" command in the app when the current branch has an associated GitHub PR or GitLab MR.

On the backend, VCS info now returns both the current branch and an optional `pull_request_url` by resolving the repo host and querying `gh pr view` or `glab mr view`. On the frontend, that URL flows through the SDK and directory sync state so the command appears deterministically in the `Cmd/Ctrl+P` palette and opens immediately without doing remote lookup at selection time.

### How did you verify your code works?

Ran:
- `bun ./script/build.ts` in `packages/sdk/js`
- `bun typecheck` in `packages/opencode`
- `bun test src/context/global-sync/event-reducer.test.ts` in `packages/app`
- `bun test test/project/vcs.test.ts` in `packages/opencode`
- `git diff --check`

### Screenshots / recordings

_Not included; this is a small command/state change with no screenshot captured yet._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._