### PR TITLE
fix: add error logging to empty catch blocks in cleanup operations

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -229,7 +229,10 @@ export namespace MCP {
         for (const dpid of await descendants(pid)) {
           try {
             process.kill(dpid, "SIGTERM")
-          } catch {}
+          } catch (err) {
+            // Process may have already exited, which is fine
+            log.debug("Failed to kill descendant process", { pid: dpid, error: err })
+          }
         }
       }
 

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -96,13 +96,14 @@ export namespace Pty {
       for (const session of sessions.values()) {
         try {
           session.process.kill()
-        } catch {}
+        } catch (err) {
+          // Process may have already exited
+          log.debug("Failed to kill PTY process", { error: err })
+        }
         for (const [key, ws] of session.subscribers.entries()) {
           try {
             if (ws.data === key) ws.close()
-          } catch {
-            // ignore
-          }
+          } catch {}
         }
       }
       sessions.clear()
@@ -229,7 +230,10 @@ export namespace Pty {
     log.info("removing session", { id })
     try {
       session.process.kill()
-    } catch {}
+    } catch (err) {
+      // Process may have already exited
+      log.debug("Failed to kill PTY process during removal", { id, error: err })
+    }
     for (const [key, ws] of session.subscribers.entries()) {
       try {
         if (ws.data === key) ws.close()

--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -37,7 +37,9 @@ export namespace MDNS {
       if (bonjour) {
         try {
           bonjour.destroy()
-        } catch {}
+        } catch (destroyErr) {
+          log.debug("Failed to destroy bonjour instance", { error: destroyErr })
+        }
       }
       bonjour = undefined
       currentPort = undefined


### PR DESCRIPTION
### Issue for this PR

Closes #18239

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes empty catch blocks in cleanup operations that were silently hiding errors.

**The problem**: Several catch blocks were empty, making it impossible to debug when cleanup operations failed (e.g., killing processes, destroying services).

**The fix**: Added debug-level logging to 4 empty catch blocks:
- `packages/opencode/src/mcp/index.ts` - Log when killing MCP descendant processes fails
- `packages/opencode/src/pty/index.ts` - Log when killing PTY processes fails (2 locations)
- `packages/opencode/src/server/mdns.ts` - Log when destroying bonjour instance fails

**Why it works**: These are cleanup operations where failures are often expected (e.g., process already exited). The debug logs don't change the error handling behavior - errors are still gracefully ignored - but now developers can see what's happening during troubleshooting.

### How did you verify your code works?

- Verified the code compiles and type checks correctly
- Confirmed log messages include relevant context (PIDs, error details)
- These are debug-level logs, so they don't affect normal operation
- The changes are simple additions with no behavioral changes to the error handling logic

### Screenshots / recordings

_Not applicable - this is a logging improvement with no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR