### PR TITLE
fix(core): disable chunk timeout by default

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -47,8 +47,6 @@ import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
 
-const DEFAULT_CHUNK_TIMEOUT = 300_000
-
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
@@ -1130,7 +1128,7 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
-      const chunkTimeout = options["chunkTimeout"] || DEFAULT_CHUNK_TIMEOUT
+      const chunkTimeout = options["chunkTimeout"]
       delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {


### PR DESCRIPTION
Fixes these issues:

* https://github.com/anomalyco/opencode/issues/17307
* https://github.com/anomalyco/opencode/issues/17318
* https://github.com/anomalyco/opencode/issues/17574
* https://github.com/anomalyco/opencode/issues/17578

We are removing the default chunk timeout for now, you can still turn it on in the config if you want this feature. In the future we may re-introduce this for specific models that we know are safe to apply this, but this is causing too many small issues across the board right now.