### PR TITLE
fix(app): per-workspace naming for git sub-folder workspaces

### DIFF
--- a/packages/app/e2e/projects/workspace-new-session.spec.ts
+++ b/packages/app/e2e/projects/workspace-new-session.spec.ts
@@ -101,13 +101,13 @@ test("new sessions from sidebar workspace actions stay in selected workspace", a
     trackDirectory(second.directory)
     await waitWorkspaceReady(page, second)
 
-    const firstSession = await createSessionFromWorkspace(page, first.slug, `workspace one ${Date.now()}`)
+    const firstSession = await createSessionFromWorkspace(page, first, `workspace one ${Date.now()}`)
     trackSession(firstSession.sessionID, first.directory)
 
-    const secondSession = await createSessionFromWorkspace(page, second.slug, `workspace two ${Date.now()}`)
+    const secondSession = await createSessionFromWorkspace(page, second, `workspace two ${Date.now()}`)
     trackSession(secondSession.sessionID, second.directory)
 
-    const thirdSession = await createSessionFromWorkspace(page, first.slug, `workspace one again ${Date.now()}`)
+    const thirdSession = await createSessionFromWorkspace(page, first, `workspace one again ${Date.now()}`)
     trackSession(thirdSession.sessionID, first.directory)
 
     await expect.poll(() => sessionDirectory(first.directory, firstSession.sessionID)).toBe(first.directory)

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -81,6 +81,20 @@ export function DialogEditProject(props: { project: LocalProject }) {
         const start = store.startup.trim()
 
         if (props.project.id && props.project.id !== "global") {
+          // Check if this is a sub-folder of a git project (worktree differs from git root).
+          // Sub-folder renames should be stored per-workspace, not shared across all worktrees.
+          const gitRoot = globalSync.data.project.find((x) => x.id === props.project.id)
+          const isSubfolder = gitRoot && props.project.worktree !== gitRoot.worktree
+          if (isSubfolder) {
+            globalSync.project.meta(props.project.worktree, {
+              name,
+              icon: { color: store.color, override: store.iconUrl || undefined },
+              commands: { start: start || undefined },
+            })
+            globalSync.project.icon(props.project.worktree, store.iconUrl || undefined)
+            dialog.close()
+            return
+          }
           await globalSDK.client.project.update({
             projectID: props.project.id,
             directory: props.project.worktree,

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -409,7 +409,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       }
 
       const isGlobal = projectID === "global" || (metadata?.id === undefined && localOverride)
-      if (!isGlobal) return base
+      if (!isGlobal) {
+        // Allow per-workspace name override for git sub-folder workspaces.
+        // Without this, all sub-folders of the same repo share the project-level name.
+        if (local?.name !== undefined) return { ...base, name: local.name }
+        return base
+      }
 
       return {
         ...base,

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1334,6 +1334,13 @@ export default function Layout(props: ParentProps) {
     const name = next === getFilename(project.worktree) ? "" : next
 
     if (project.id && project.id !== "global") {
+      // Sub-folder renames should be stored per-workspace, not shared across all worktrees.
+      const gitRoot = globalSync.data.project.find((x) => x.id === project.id)
+      const isSubfolder = gitRoot && project.worktree !== gitRoot.worktree
+      if (isSubfolder) {
+        globalSync.project.meta(project.worktree, { name })
+        return
+      }
       await globalSDK.client.project.update({ projectID: project.id, directory: project.worktree, name })
       return
     }


### PR DESCRIPTION
### Issue for this PR

Closes #18276

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When you open multiple sub-folders of the same git repo as separate sidebar entries, renaming one renames all of them. This happens because all worktrees share a single `project.name` in the DB keyed by git root commit hash.

The fix adds per-workspace name overrides for git sub-folder workspaces. The mechanism already exists for non-git projects (`workspace:project` in `.dat` files, added in `bcf7a65e`) — this PR extends it to git projects.

Three changes:

1. **`enrich()` in `layout.tsx`** — When a workspace-level name exists in the `.dat` file, use it instead of the shared project name. Without this, `if (!isGlobal) return base` exits early and ignores the local override entirely.

2. **`handleSubmit()` in `dialog-edit-project.tsx`** — Before calling `project.update()` (which writes to the shared DB), check if `worktree !== gitRoot.worktree`. If it's a sub-folder, route to `globalSync.project.meta()` instead.

3. **`renameProject()` in `pages/layout.tsx`** — Same sub-folder check for inline renames.

Root-level renames still go through `project.update()` and affect all worktrees (existing behavior).

### How did you verify your code works?

Manually tested with a monorepo (`its-fusion-kitchen`) that has multiple sub-folder sidebar entries. Before fix: renaming "golden-ticket" sub-folder also renamed the root project. After fix: each sidebar entry keeps its own name independently.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR