### PR TITLE
fix(account): handle pending console login polling

### DIFF
--- a/packages/opencode/src/account/effect.ts
+++ b/packages/opencode/src/account/effect.ts
@@ -148,6 +148,12 @@ export namespace AccountEffect {
           mapAccountServiceError("HTTP request failed"),
         )
 
+      const executeEffect = <E>(request: Effect.Effect<HttpClientRequest.HttpClientRequest, E>) =>
+        request.pipe(
+          Effect.flatMap((req) => http.execute(req)),
+          mapAccountServiceError("HTTP request failed"),
+        )
+
       const resolveToken = Effect.fnUntraced(function* (row: AccountRow) {
         const now = yield* Clock.currentTimeMillis
         if (row.token_expiry && row.token_expiry > now) return row.access_token
@@ -290,7 +296,7 @@ export namespace AccountEffect {
       })
 
       const poll = Effect.fn("Account.poll")(function* (input: Login) {
-        const response = yield* executeEffectOk(
+        const response = yield* executeEffect(
           HttpClientRequest.post(`${input.server}/auth/device/token`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.schemaBodyJson(DeviceTokenRequest)(

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -247,3 +247,134 @@ it.effect("poll returns pending when the server responds with authorization_pend
     expect(result._tag).toBe("PollPending")
   }),
 )
+
+it.effect("poll returns slow when the server responds with slow_down", () =>
+  Effect.gen(function* () {
+    const login = new Login({
+      code: DeviceCode.make("device-code"),
+      user: UserCode.make("user-code"),
+      url: "https://one.example.com/verify",
+      server: "https://one.example.com",
+      expiry: Duration.seconds(600),
+      interval: Duration.seconds(5),
+    })
+
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        req.url === "https://one.example.com/auth/device/token"
+          ? json(
+              req,
+              {
+                error: "slow_down",
+                error_description: "Polling too frequently, please slow down",
+              },
+              400,
+            )
+          : json(req, {}, 404),
+      ),
+    )
+
+    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+
+    expect(result._tag).toBe("PollSlow")
+  }),
+)
+
+it.effect("poll returns denied when the server responds with access_denied", () =>
+  Effect.gen(function* () {
+    const login = new Login({
+      code: DeviceCode.make("device-code"),
+      user: UserCode.make("user-code"),
+      url: "https://one.example.com/verify",
+      server: "https://one.example.com",
+      expiry: Duration.seconds(600),
+      interval: Duration.seconds(5),
+    })
+
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        req.url === "https://one.example.com/auth/device/token"
+          ? json(
+              req,
+              {
+                error: "access_denied",
+                error_description: "The authorization request was denied",
+              },
+              400,
+            )
+          : json(req, {}, 404),
+      ),
+    )
+
+    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+
+    expect(result._tag).toBe("PollDenied")
+  }),
+)
+
+it.effect("poll returns expired when the server responds with expired_token", () =>
+  Effect.gen(function* () {
+    const login = new Login({
+      code: DeviceCode.make("device-code"),
+      user: UserCode.make("user-code"),
+      url: "https://one.example.com/verify",
+      server: "https://one.example.com",
+      expiry: Duration.seconds(600),
+      interval: Duration.seconds(5),
+    })
+
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        req.url === "https://one.example.com/auth/device/token"
+          ? json(
+              req,
+              {
+                error: "expired_token",
+                error_description: "The device code has expired",
+              },
+              400,
+            )
+          : json(req, {}, 404),
+      ),
+    )
+
+    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+
+    expect(result._tag).toBe("PollExpired")
+  }),
+)
+
+it.effect("poll returns poll error for other OAuth errors", () =>
+  Effect.gen(function* () {
+    const login = new Login({
+      code: DeviceCode.make("device-code"),
+      user: UserCode.make("user-code"),
+      url: "https://one.example.com/verify",
+      server: "https://one.example.com",
+      expiry: Duration.seconds(600),
+      interval: Duration.seconds(5),
+    })
+
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        req.url === "https://one.example.com/auth/device/token"
+          ? json(
+              req,
+              {
+                error: "server_error",
+                error_description: "An unexpected error occurred",
+              },
+              400,
+            )
+          : json(req, {}, 404),
+      ),
+    )
+
+    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+
+    expect(result._tag).toBe("PollError")
+    if (result._tag === "PollError") {
+      expect(String(result.cause)).toContain("server_error")
+    }
+  }),
+)

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -34,6 +34,24 @@ const encodeOrg = Schema.encodeSync(Org)
 
 const org = (id: string, name: string) => encodeOrg(new Org({ id: OrgID.make(id), name }))
 
+const login = () =>
+  new Login({
+    code: DeviceCode.make("device-code"),
+    user: UserCode.make("user-code"),
+    url: "https://one.example.com/verify",
+    server: "https://one.example.com",
+    expiry: Duration.seconds(600),
+    interval: Duration.seconds(5),
+  })
+
+const deviceTokenClient = (body: unknown, status = 400) =>
+  HttpClient.make((req) =>
+    Effect.succeed(req.url === "https://one.example.com/auth/device/token" ? json(req, body, status) : json(req, {}, 404)),
+  )
+
+const poll = (body: unknown, status = 400) =>
+  AccountEffect.Service.use((s) => s.poll(login())).pipe(Effect.provide(live(deviceTokenClient(body, status))))
+
 it.effect("orgsByAccount groups orgs per account", () =>
   Effect.gen(function* () {
     yield* AccountRepo.use((r) =>
@@ -172,15 +190,6 @@ it.effect("config sends the selected org header", () =>
 
 it.effect("poll stores the account and first org on success", () =>
   Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
-    })
-
     const client = HttpClient.make((req) =>
       Effect.succeed(
         req.url === "https://one.example.com/auth/device/token"
@@ -198,7 +207,7 @@ it.effect("poll stores the account and first org on success", () =>
       ),
     )
 
-    const res = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+    const res = yield* AccountEffect.Service.use((s) => s.poll(login())).pipe(Effect.provide(live(client)))
 
     expect(res._tag).toBe("PollSuccess")
     if (res._tag === "PollSuccess") {
@@ -216,161 +225,54 @@ it.effect("poll stores the account and first org on success", () =>
   }),
 )
 
-it.effect("poll returns pending when the server responds with authorization_pending", () =>
-  Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
-    })
-
-    const client = HttpClient.make((req) =>
-      Effect.succeed(
-        req.url === "https://one.example.com/auth/device/token"
-          ? json(
-              req,
-              {
-                error: "authorization_pending",
-                error_description: "The authorization request is still pending",
-              },
-              400,
-            )
-          : json(req, {}, 404),
-      ),
-    )
-
-    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
-
-    expect(result._tag).toBe("PollPending")
-  }),
-)
-
-it.effect("poll returns slow when the server responds with slow_down", () =>
-  Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
-    })
-
-    const client = HttpClient.make((req) =>
-      Effect.succeed(
-        req.url === "https://one.example.com/auth/device/token"
-          ? json(
-              req,
-              {
-                error: "slow_down",
-                error_description: "Polling too frequently, please slow down",
-              },
-              400,
-            )
-          : json(req, {}, 404),
-      ),
-    )
-
-    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
-
-    expect(result._tag).toBe("PollSlow")
-  }),
-)
-
-it.effect("poll returns denied when the server responds with access_denied", () =>
-  Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
-    })
-
-    const client = HttpClient.make((req) =>
-      Effect.succeed(
-        req.url === "https://one.example.com/auth/device/token"
-          ? json(
-              req,
-              {
-                error: "access_denied",
-                error_description: "The authorization request was denied",
-              },
-              400,
-            )
-          : json(req, {}, 404),
-      ),
-    )
-
-    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
-
-    expect(result._tag).toBe("PollDenied")
-  }),
-)
-
-it.effect("poll returns expired when the server responds with expired_token", () =>
-  Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
-    })
-
-    const client = HttpClient.make((req) =>
-      Effect.succeed(
-        req.url === "https://one.example.com/auth/device/token"
-          ? json(
-              req,
-              {
-                error: "expired_token",
-                error_description: "The device code has expired",
-              },
-              400,
-            )
-          : json(req, {}, 404),
-      ),
-    )
-
-    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
-
-    expect(result._tag).toBe("PollExpired")
-  }),
-)
+for (const [name, body, expectedTag] of [
+  [
+    "pending",
+    {
+      error: "authorization_pending",
+      error_description: "The authorization request is still pending",
+    },
+    "PollPending",
+  ],
+  [
+    "slow",
+    {
+      error: "slow_down",
+      error_description: "Polling too frequently, please slow down",
+    },
+    "PollSlow",
+  ],
+  [
+    "denied",
+    {
+      error: "access_denied",
+      error_description: "The authorization request was denied",
+    },
+    "PollDenied",
+  ],
+  [
+    "expired",
+    {
+      error: "expired_token",
+      error_description: "The device code has expired",
+    },
+    "PollExpired",
+  ],
+] as const) {
+  it.effect(`poll returns ${name} for ${body.error}`, () =>
+    Effect.gen(function* () {
+      const result = yield* poll(body)
+      expect(result._tag).toBe(expectedTag)
+    }),
+  )
+}
 
 it.effect("poll returns poll error for other OAuth errors", () =>
   Effect.gen(function* () {
-    const login = new Login({
-      code: DeviceCode.make("device-code"),
-      user: UserCode.make("user-code"),
-      url: "https://one.example.com/verify",
-      server: "https://one.example.com",
-      expiry: Duration.seconds(600),
-      interval: Duration.seconds(5),
+    const result = yield* poll({
+      error: "server_error",
+      error_description: "An unexpected error occurred",
     })
-
-    const client = HttpClient.make((req) =>
-      Effect.succeed(
-        req.url === "https://one.example.com/auth/device/token"
-          ? json(
-              req,
-              {
-                error: "server_error",
-                error_description: "An unexpected error occurred",
-              },
-              400,
-            )
-          : json(req, {}, 404),
-      ),
-    )
-
-    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
 
     expect(result._tag).toBe("PollError")
     if (result._tag === "PollError") {

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -215,3 +215,35 @@ it.effect("poll stores the account and first org on success", () =>
     )
   }),
 )
+
+it.effect("poll returns pending when the server responds with authorization_pending", () =>
+  Effect.gen(function* () {
+    const login = new Login({
+      code: DeviceCode.make("device-code"),
+      user: UserCode.make("user-code"),
+      url: "https://one.example.com/verify",
+      server: "https://one.example.com",
+      expiry: Duration.seconds(600),
+      interval: Duration.seconds(5),
+    })
+
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        req.url === "https://one.example.com/auth/device/token"
+          ? json(
+              req,
+              {
+                error: "authorization_pending",
+                error_description: "The authorization request is still pending",
+              },
+              400,
+            )
+          : json(req, {}, 404),
+      ),
+    )
+
+    const result = yield* AccountEffect.Service.use((s) => s.poll(login)).pipe(Effect.provide(live(client)))
+
+    expect(result._tag).toBe("PollPending")
+  }),
+)


### PR DESCRIPTION
## Summary
- fix console device login polling to parse OAuth error responses from `/auth/device/token` instead of failing on normal 400 pending states
- add an account service test that reproduces `authorization_pending` and verifies the CLI keeps polling
- confirm the account test suite passes after the fix with `bun test test/account/*.test.ts`