### PR TITLE
fix(ci): add concurrency control to prevent race in hash updates

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -17,6 +17,10 @@ on:
       - "patches/**"
       - ".github/workflows/nix-hashes.yml"
 
+concurrency:
+  group: nix-hashes-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Native runners required: bun install cross-compilation flags (--os/--cpu)
   # do not produce byte-identical node_modules as native installs.


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Multiple concurrent workflow runs on the same branch can race to commit  hashes.json. When an older commit's run finishes after a newer commit's run, stale hashes overwrite correct ones.
Add concurrency group per-branch with cancel-in-progress to ensure only the latest commit's hashes are computed and committed.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
Can't verify, I have no access to CI but it's a simple enough fix

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._