### PR TITLE
chore(app): QOL: don't sign commits during e2e tests

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -183,6 +183,7 @@ export async function createTestProject() {
 
   execSync("git init", { cwd: root, stdio: "ignore" })
   execSync("git config core.fsmonitor false", { cwd: root, stdio: "ignore" })
+  execSync("git config commit.gpgsign false", { cwd: root, stdio: "ignore" })
   execSync("git add -A", { cwd: root, stdio: "ignore" })
   execSync('git -c user.name="e2e" -c user.email="e2e@example.com" commit -m "init" --allow-empty', {
     cwd: root,


### PR DESCRIPTION
### Issue for this PR

Closes #18295

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement (QOL for local dev/test)
- [ ] Documentation

### What does this PR do?

When I try to run e2e tests locally I get spammed by `pinentry-touchid` because I have git configured globally to sign commits. This simple one-line change disables commit signing for repositories used during e2e tests, preventing `pinentry-touchid` from ruining my day.

### How did you verify your code works?

I ran e2e tests with the change in place.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
