### PR TITLE
feat: add hard stop on max steps

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -42,6 +42,7 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      stopOnMaxSteps: z.boolean().optional(),
     })
     .meta({
       ref: "Agent",
@@ -227,6 +228,7 @@ export namespace Agent {
       item.hidden = value.hidden ?? item.hidden
       item.name = value.name ?? item.name
       item.steps = value.steps ?? item.steps
+      item.stopOnMaxSteps = value.stopOnMaxSteps ?? item.stopOnMaxSteps
       item.options = mergeDeep(item.options, value.options ?? {})
       item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -718,6 +718,10 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Maximum number of agentic iterations before forcing text-only response"),
+      stopOnMaxSteps: z
+        .boolean()
+        .optional()
+        .describe("End the session immediately after the final allowed step instead of forcing a text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),
       permission: Permission.optional(),
     })
@@ -735,6 +739,7 @@ export namespace Config {
         "hidden",
         "color",
         "steps",
+        "stopOnMaxSteps",
         "maxSteps",
         "options",
         "permission",
@@ -768,6 +773,7 @@ export namespace Config {
         options?: Record<string, unknown>
         permission?: Permission
         steps?: number
+        stopOnMaxSteps?: boolean
       }
     })
     .meta({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -559,6 +559,7 @@ export namespace SessionPrompt {
       const agent = await Agent.get(lastUser.agent)
       const maxSteps = agent.steps ?? Infinity
       const isLastStep = step >= maxSteps
+      const shouldStopOnMaxSteps = isLastStep && agent.stopOnMaxSteps === true
       msgs = await insertReminders({
         messages: msgs,
         agent,
@@ -664,7 +665,7 @@ export namespace SessionPrompt {
         system,
         messages: [
           ...MessageV2.toModelMessages(msgs, model),
-          ...(isLastStep
+          ...(isLastStep && !shouldStopOnMaxSteps
             ? [
                 {
                   role: "assistant" as const,
@@ -700,6 +701,14 @@ export namespace SessionPrompt {
           await Session.updateMessage(processor.message)
           break
         }
+      }
+
+      if (shouldStopOnMaxSteps) {
+        if (!modelFinished && !processor.message.error) {
+          processor.message.finish = "step-limit"
+          await Session.updateMessage(processor.message)
+        }
+        break
       }
 
       if (result === "stop") break

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,14 +1,25 @@
 import path from "path"
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { fileURLToPath } from "url"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import * as LLMModule from "../../src/session/llm"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
+
+type MockStreamInput = Parameters<typeof LLMModule.LLM.stream>[0]
+
+const usage = {
+  inputTokens: 10,
+  outputTokens: 4,
+  totalTokens: 14,
+  reasoningTokens: 0,
+  cachedInputTokens: 0,
+}
 
 describe("session.prompt missing file", () => {
   test("does not fail the prompt when a file part is missing", async () => {
@@ -105,6 +116,133 @@ describe("session.prompt missing file", () => {
       },
     })
   })
+})
+
+describe("session.prompt max steps", () => {
+  let streamSpy: ReturnType<typeof spyOn>
+  let previousOpenAIKey: string | undefined
+
+  function hasWrapUpPrompt(input: MockStreamInput) {
+    return input.messages.some(
+      (message: MockStreamInput["messages"][number]) =>
+        message.role === "assistant" &&
+        typeof message.content === "string" &&
+        message.content.includes("Tools are disabled until next user input"),
+    )
+  }
+
+  beforeEach(() => {
+    previousOpenAIKey = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = "test-openai-key"
+    streamSpy = spyOn(LLMModule.LLM, "stream")
+  })
+
+  afterEach(() => {
+    streamSpy.mockRestore()
+    if (previousOpenAIKey === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = previousOpenAIKey
+  })
+
+  test("injects the max-steps wrap-up prompt by default", async () => {
+    streamSpy.mockImplementationOnce(async (input: MockStreamInput) => {
+      expect(hasWrapUpPrompt(input)).toBe(true)
+
+      return ({
+        fullStream: (async function* () {
+          yield { type: "start-step" as const }
+          yield { type: "text-start" as const }
+          yield { type: "text-delta" as const, text: "Wrapped up." }
+          yield { type: "text-end" as const }
+          yield {
+            type: "finish-step" as const,
+            finishReason: "stop",
+            usage,
+            providerMetadata: {},
+          }
+        })(),
+      } as unknown) as Awaited<ReturnType<typeof LLMModule.LLM.stream>>
+    })
+
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+            steps: 1,
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "Max steps default" })
+        const result = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          parts: [{ type: "text", text: "Do one step and stop." }],
+        })
+
+        expect(streamSpy).toHaveBeenCalledTimes(1)
+        expect(result.info.role).toBe("assistant")
+        if (result.info.role === "assistant") {
+          expect(result.info.finish).toBe("stop")
+        }
+      },
+    })
+  })
+
+  test("stops immediately at the step limit when stopOnMaxSteps is enabled", async () => {
+    streamSpy.mockImplementation(async (input: MockStreamInput) => {
+      expect(hasWrapUpPrompt(input)).toBe(false)
+
+      return ({
+        fullStream: (async function* () {
+          yield { type: "start-step" as const }
+          yield {
+            type: "finish-step" as const,
+            finishReason: "tool-calls",
+            usage,
+            providerMetadata: {},
+          }
+        })(),
+      } as unknown) as Awaited<ReturnType<typeof LLMModule.LLM.stream>>
+    })
+
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+            steps: 1,
+            stopOnMaxSteps: true,
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "Max steps hard stop" })
+        const result = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          parts: [{ type: "text", text: "Do one step and hard stop." }],
+        })
+
+        expect(streamSpy).toHaveBeenCalledTimes(1)
+        expect(result.info.role).toBe("assistant")
+        if (result.info.role === "assistant") {
+          expect(result.info.finish).toBe("step-limit")
+        }
+        expect(result.parts.some((part) => part.type === "step-finish")).toBe(true)
+      },
+    })
+  }, 10000)
 })
 
 describe("session.prompt special characters", () => {

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -301,6 +301,19 @@ If this is not set, the agent will continue to iterate until the model chooses t
 
 When the limit is reached, the agent receives a special system prompt instructing it to respond with a summarization of its work and recommended remaining tasks.
 
+If you want the session to end immediately after the last allowed step instead of producing that text-only wrap-up, set `stopOnMaxSteps` to `true`.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "build": {
+      "steps": 3,
+      "stopOnMaxSteps": true
+    }
+  }
+}
+```
+
 :::caution
 The legacy `maxSteps` field is deprecated. Use `steps` instead.
 :::


### PR DESCRIPTION
## Summary
- add an opt-in \ agent setting that ends the session immediately after the last allowed step
- keep the existing max-step wrap-up behavior as the default when the flag is not enabled
- add prompt-loop tests covering both the default wrap-up path and the new hard-stop path

## Testing
- bun run typecheck
- bun test test/session/prompt.test.ts -t "session.prompt max steps"