### PR TITLE
feat: add provider racing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode",
@@ -1887,7 +1887,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 

--- a/packages/console/app/vite.config.ts
+++ b/packages/console/app/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       cloudflare: {
         nodeCompat: true,
       },
-    }),
+    }) as PluginOption,
   ],
   server: {
     allowedHosts: true,

--- a/packages/enterprise/vite.config.ts
+++ b/packages/enterprise/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     nitro({
       ...nitroConfig,
       baseURL: process.env.OPENCODE_BASE_URL,
-    }),
+    }) as PluginOption,
   ],
   server: {
     host: "0.0.0.0",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -79,6 +79,7 @@
     "@ai-sdk/xai": "2.0.51",
     "@aws-sdk/credential-providers": "3.993.0",
     "@clack/prompts": "1.0.0-alpha.1",
+    "@effect/platform-node": "4.0.0-beta.31",
     "@gitlab/gitlab-ai-provider": "3.6.0",
     "@gitlab/opencode-gitlab-auth": "1.3.3",
     "@hono/standard-validator": "0.1.5",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -971,6 +971,13 @@ export namespace Config {
               )
               .optional()
               .describe("Variant-specific configuration"),
+            race: z
+              .array(z.record(z.string(), z.any()))
+              .optional()
+              .describe(
+                "Race multiple provider configurations in parallel. Each entry is a providerOptions override " +
+                  "(e.g. OpenRouter provider routing). The first stream to produce output wins; others are aborted.",
+              ),
           }),
         )
         .optional(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -728,6 +728,13 @@ export namespace Provider {
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),
       variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+      race: z
+        .array(z.record(z.string(), z.any()))
+        .optional()
+        .describe(
+          "Race multiple provider configurations in parallel. Each entry is a providerOptions override " +
+            "(e.g. OpenRouter provider routing). The first stream to produce output wins; others are aborted.",
+        ),
     })
     .meta({
       ref: "Model",
@@ -952,6 +959,7 @@ export namespace Provider {
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
           variants: {},
+          race: model.race ?? existingModel?.race,
         }
         const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
         parsedModel.variants = mapValues(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -169,13 +169,8 @@ export namespace LLM {
       })
     }
 
-    return streamText({
-      onError(error) {
-        l.error("stream error", {
-          error,
-        })
-      },
-      async experimental_repairToolCall(failed) {
+    const sharedStreamParams = {
+      async experimental_repairToolCall(failed: any) {
         const lower = failed.toolCall.toolName.toLowerCase()
         if (lower !== failed.toolCall.toolName && tools[lower]) {
           l.info("repairing tool call", {
@@ -199,12 +194,10 @@ export namespace LLM {
       temperature: params.temperature,
       topP: params.topP,
       topK: params.topK,
-      providerOptions: ProviderTransform.providerOptions(input.model, params.options),
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
       tools,
       toolChoice: input.toolChoice,
       maxOutputTokens,
-      abortSignal: input.abort,
       headers: {
         ...(input.model.providerID.startsWith("opencode")
           ? {
@@ -235,9 +228,8 @@ export namespace LLM {
         model: language,
         middleware: [
           {
-            async transformParams(args) {
+            async transformParams(args: any) {
               if (args.type === "stream") {
-                // @ts-expect-error
                 args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
               }
               return args.params
@@ -252,7 +244,101 @@ export namespace LLM {
           sessionId: input.sessionID,
         },
       },
+    }
+
+    // If model has race configs, fire parallel streams and return the first to produce output
+    const raceConfigs = input.model.race
+    if (raceConfigs && raceConfigs.length > 1) {
+      return raceStreams(l, input, sharedStreamParams, raceConfigs, params.options)
+    }
+
+    return streamText({
+      ...sharedStreamParams,
+      onError(error) {
+        l.error("stream error", { error })
+      },
+      abortSignal: input.abort,
+      providerOptions: ProviderTransform.providerOptions(input.model, params.options),
     })
+  }
+
+  /**
+   * Race multiple streamText calls with different providerOptions.
+   * Each entry in `raceConfigs` is merged into the base providerOptions.
+   * The first stream to emit a text chunk wins; all others are aborted.
+   */
+  async function raceStreams(
+    l: ReturnType<typeof log.clone>,
+    input: StreamInput,
+    sharedParams: Record<string, any>,
+    raceConfigs: Record<string, any>[],
+    baseOptions: Record<string, any>,
+  ): Promise<StreamOutput> {
+    const controllers: AbortController[] = []
+    const lanes: { label: string; stream: StreamOutput; controller: AbortController }[] = []
+
+    for (let i = 0; i < raceConfigs.length; i++) {
+      const controller = new AbortController()
+      controllers.push(controller)
+
+      // Link to parent abort signal so all lanes stop if the session is cancelled
+      if (input.abort.aborted) {
+        controller.abort()
+      } else {
+        input.abort.addEventListener("abort", () => controller.abort(), { once: true })
+      }
+
+      const laneOptions = mergeDeep(baseOptions, raceConfigs[i])
+      const label = `lane-${i}`
+      l.info("race: starting lane", { lane: label, providerOverride: raceConfigs[i] })
+
+      const result = streamText({
+        ...(sharedParams as any),
+        abortSignal: controller.signal,
+        providerOptions: ProviderTransform.providerOptions(input.model, laneOptions),
+        onError(error: any) {
+          l.error("race: stream error", { lane: label, error })
+        },
+      })
+
+      lanes.push({ label, stream: result, controller })
+    }
+
+    // Race: the first lane to produce a text chunk wins
+    const winnerIndex = await Promise.race(
+      lanes.map(
+        (lane, i) =>
+          new Promise<number>(async (resolve, reject) => {
+            try {
+              for await (const part of lane.stream.fullStream) {
+                if (part.type === "text-delta" || part.type === "tool-call") {
+                  resolve(i)
+                  return
+                }
+              }
+              // Stream ended without text — still counts as "finished"
+              resolve(i)
+            } catch (err: any) {
+              // If this lane was aborted because another won, don't reject
+              if (err.name === "AbortError") return
+              reject(err)
+            }
+          }),
+      ),
+    )
+
+    const winner = lanes[winnerIndex]
+    l.info("race: winner", { lane: winner.label })
+
+    // Abort all other lanes
+    for (let i = 0; i < lanes.length; i++) {
+      if (i !== winnerIndex) {
+        l.info("race: aborting loser", { lane: lanes[i].label })
+        lanes[i].controller.abort()
+      }
+    }
+
+    return winner.stream
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {


### PR DESCRIPTION
Summary:
- add a race config for model definitions so multiple provider routes can stream in parallel
- return the first lane that produces output and abort the rest
- preserve the existing provider-routing config surface while making OpenRouter latency less unpredictable

Testing:
- bun run typecheck