### PR TITLE
refactor: replace Bun.sleep with node:timers/promises sleep

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -9,6 +9,7 @@ import { useToast } from "../ui/toast"
 import { useKeybind } from "../context/keybind"
 import { DialogSessionList } from "./workspace/dialog-session-list"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { setTimeout as sleep } from "node:timers/promises"
 
 async function openWorkspace(input: {
   dialog: ReturnType<typeof useDialog>
@@ -56,7 +57,7 @@ async function openWorkspace(input: {
       return
     }
     if (result.response.status >= 500 && result.response.status < 600) {
-      await Bun.sleep(1000)
+      await sleep(1000)
       continue
     }
     if (!result.data) {

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { setTimeout as sleep } from "node:timers/promises"
 import { fn } from "@/util/fn"
 import { Database, eq } from "@/storage/db"
 import { Project } from "@/project/project"
@@ -117,7 +118,7 @@ export namespace Workspace {
       const adaptor = await getAdaptor(space.type)
       const res = await adaptor.fetch(space, "/event", { method: "GET", signal: stop }).catch(() => undefined)
       if (!res || !res.ok || !res.body) {
-        await Bun.sleep(1000)
+        await sleep(1000)
         continue
       }
       await parseSSE(res.body, stop, (event) => {
@@ -127,7 +128,7 @@ export namespace Workspace {
         })
       })
       // Wait 250ms and retry if SSE connection fails
-      await Bun.sleep(250)
+      await sleep(250)
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace all `Bun.sleep()` calls with portable `sleep` from `node:timers/promises` in two files
- Removes dependency on Bun-specific APIs where a Node.js standard equivalent exists