### PR TITLE
fix(app): namespace lastProjectSession by server origin

### DIFF
--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -223,6 +223,9 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
       get key() {
         return state.active
       },
+      get origin() {
+        return origin()
+      },
       get name() {
         return serverName(current())
       },

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -93,10 +93,27 @@ import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from 
 import { SidebarContent } from "./layout/sidebar-shell"
 
 export default function Layout(props: ParentProps) {
+  type SessionRoute = { directory: string; id: string; at: number }
+
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+
+  // Migrate lastProjectSession from flat { [dir]: route } to per-origin { [origin]: { [dir]: route } }
+  const migrateLayoutPage = (value: unknown) => {
+    if (!isRecord(value)) return value
+    const lps = value.lastProjectSession
+    if (!isRecord(lps)) return value
+    // Already migrated if the values are origin-keyed records of records
+    const firstValue = Object.values(lps)[0]
+    if (firstValue !== undefined && isRecord(firstValue) && !("id" in firstValue)) return value
+    // Wrap existing flat entries under "local" origin
+    return { ...value, lastProjectSession: { local: lps } }
+  }
+
   const [store, setStore, , ready] = persisted(
-    Persist.global("layout.page", ["layout.page.v1"]),
+    { ...Persist.global("layout.page", ["layout.page.v1"]), migrate: migrateLayoutPage },
     createStore({
-      lastProjectSession: {} as { [directory: string]: { directory: string; id: string; at: number } },
+      lastProjectSession: {} as { [origin: string]: { [directory: string]: SessionRoute } },
       activeProject: undefined as string | undefined,
       activeWorkspace: undefined as string | undefined,
       workspaceOrder: {} as Record<string, string[]>,
@@ -106,6 +123,9 @@ export default function Layout(props: ParentProps) {
       gettingStartedDismissed: false,
     }),
   )
+
+  // Accessors for per-origin lastProjectSession
+  const originSessions = () => store.lastProjectSession[server.origin] ?? {}
 
   const pageReady = createMemo(() => ready())
 
@@ -1187,14 +1207,19 @@ export default function Layout(props: ParentProps) {
   }
 
   function rememberSessionRoute(directory: string, id: string, root = activeProjectRoot(directory)) {
-    setStore("lastProjectSession", root, { directory, id, at: Date.now() })
+    const key = server.origin
+    if (!key) return root
+    setStore("lastProjectSession", key, root, { directory, id, at: Date.now() })
     return root
   }
 
   function clearLastProjectSession(root: string) {
-    if (!store.lastProjectSession[root]) return
+    const key = server.origin
+    if (!key) return
+    if (!store.lastProjectSession[key]?.[root]) return
     setStore(
       "lastProjectSession",
+      key,
       produce((draft) => {
         delete draft[root]
       }),
@@ -1233,11 +1258,12 @@ export default function Layout(props: ParentProps) {
       dirs = effectiveWorkspaceOrder(root, [root, ...listed], store.workspaceOrder[root])
       return canOpen(target)
     }
+    const originKey = server.origin
     const openSession = async (target: { directory: string; id: string }) => {
       if (!canOpen(target.directory)) return false
       const [data] = globalSync.child(target.directory, { bootstrap: false })
       if (data.session.some((item) => item.id === target.id)) {
-        setStore("lastProjectSession", root, { directory: target.directory, id: target.id, at: Date.now() })
+        if (originKey) setStore("lastProjectSession", originKey, root, { directory: target.directory, id: target.id, at: Date.now() })
         navigateWithSidebarReset(`/${base64Encode(target.directory)}/session/${target.id}`)
         return true
       }
@@ -1247,12 +1273,12 @@ export default function Layout(props: ParentProps) {
         .catch(() => undefined)
       if (!resolved?.directory) return false
       if (!canOpen(resolved.directory)) return false
-      setStore("lastProjectSession", root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
+      if (originKey) setStore("lastProjectSession", originKey, root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
       navigateWithSidebarReset(`/${base64Encode(resolved.directory)}/session/${resolved.id}`)
       return true
     }
 
-    const projectSession = store.lastProjectSession[root]
+    const projectSession = originSessions()[root]
     if (projectSession?.id) {
       await refreshDirs(projectSession.directory)
       const opened = await openSession(projectSession)
@@ -1439,7 +1465,7 @@ export default function Layout(props: ParentProps) {
 
     if (!result) return
 
-    if (workspaceKey(store.lastProjectSession[root]?.directory ?? "") === workspaceKey(directory)) {
+    if (workspaceKey(originSessions()[root]?.directory ?? "") === workspaceKey(directory)) {
       clearLastProjectSession(root)
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #18302

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenCode Desktop connects to multiple servers (local sidecar + remote `opencode serve`), `lastProjectSession` is stored as a flat record keyed by directory path. Session IDs from one server persist after switching to another server, causing the Desktop to poll for sessions that only exist on the previous server — resulting in a "Session not found" error loop every ~4 seconds with audible chimes and red notification badges.

The fix namespaces `lastProjectSession` by server origin, matching the pattern already used by `store.projects[origin]` in `server.tsx`.

**`server.tsx`**: Expose the `origin` getter (derived from `projectsKey(state.active)`) so `pages/layout.tsx` can use it. Follows the existing `key` and `name` getter pattern.

**`pages/layout.tsx`**: Change `lastProjectSession` from `{ [directory]: route }` to `{ [origin]: { [directory]: route } }`. All reads go through a new `originSessions()` helper. All writes include `server.origin` as the first key. Migration wraps existing flat entries under the `"local"` origin key so no session history is lost.

The migration detects old vs new format by checking if the first value has an `id` field (old flat format) vs being a nested record (new namespaced format). This is idempotent — re-running migration on already-migrated data is a no-op.

### How did you verify your code works?

- Traced all 8 read/write sites for `lastProjectSession` across `rememberSessionRoute`, `clearLastProjectSession`, `syncSessionRoute`, `navigateToProject`, `deleteWorkspace`, and the route-change effect
- Verified migration preserves existing session restore data under the "local" origin
- Confirmed `server.origin` uses the same `projectsKey()` logic that already namespaces `store.projects` correctly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR