### PR TITLE
docs: add @pnz1990/open-krode to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -49,7 +49,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
-| [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [@pnz1990/open-krode](https://github.com/pnz1990/open-krode)                                       | kro RGD DAG visualization and live instance observability with browser UI, YAML inspection, and a specialized krode agent |
+| [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                                                  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #18314

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [@pnz1990/open-krode](https://github.com/pnz1990/open-krode) to the ecosystem plugins table. It is an OpenCode plugin that adds a `krode` agent for visualizing kro ResourceGraphDefinitions as DAGs and watching live CR instances in a browser UI with node/YAML inspection and 5s auto-refresh.

### How did you verify your code works?

Docs-only change — one row added to the markdown table.

### Screenshots / recordings

N/A — documentation change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR