### PR TITLE
fix: include cache bin directory in which() lookups

### DIFF
--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -18,7 +18,7 @@ export namespace Global {
       return process.env.OPENCODE_TEST_HOME || os.homedir()
     },
     data,
-    bin: path.join(data, "bin"),
+    bin: path.join(cache, "bin"),
     log: path.join(data, "log"),
     cache,
     config,

--- a/packages/opencode/src/util/which.ts
+++ b/packages/opencode/src/util/which.ts
@@ -1,9 +1,13 @@
 import whichPkg from "which"
+import path from "path"
+import { Global } from "../global"
 
 export function which(cmd: string, env?: NodeJS.ProcessEnv) {
+  const base = env?.PATH ?? env?.Path ?? process.env.PATH ?? process.env.Path ?? ""
+  const full = base ? base + path.delimiter + Global.Path.bin : Global.Path.bin
   const result = whichPkg.sync(cmd, {
     nothrow: true,
-    path: env?.PATH ?? env?.Path ?? process.env.PATH ?? process.env.Path,
+    path: full,
     pathExt: env?.PATHEXT ?? env?.PathExt ?? process.env.PATHEXT ?? process.env.PathExt,
   })
   return typeof result === "string" ? result : null


### PR DESCRIPTION
## Summary
- Move `Global.Path.bin` from data directory to cache directory
- Append `Global.Path.bin` to PATH in `which()` so tools installed via npm in the cache are discoverable