### PR TITLE
ci: upload playwright artifacts for flaky retries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,13 +97,31 @@ jobs:
         run: bunx playwright install chromium
 
       - name: Run app e2e tests
+        id: e2e
         run: bun --cwd packages/app test:e2e:local
         env:
           CI: true
         timeout-minutes: 30
 
+      - name: Detect Playwright flakes
+        id: playwright-status
+        if: always()
+        run: |
+          node <<'EOF'
+          const fs = require("fs")
+          const file = "packages/app/e2e/playwright-report/results.json"
+          if (!fs.existsSync(file)) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, "flaky=false\nflaky_count=0\n")
+            process.exit(0)
+          }
+
+          const report = JSON.parse(fs.readFileSync(file, "utf8"))
+          const count = Number(report?.stats?.flaky ?? report?.suitesSummary?.flaky ?? 0)
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `flaky=${count > 0}\nflaky_count=${count}\n`)
+          EOF
+
       - name: Upload Playwright artifacts
-        if: failure()
+        if: failure() || steps.playwright-status.outputs.flaky == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers,
-  reporter: [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]],
+  reporter: [
+    ["html", { outputFolder: "e2e/playwright-report", open: "never" }],
+    ["json", { outputFile: "e2e/playwright-report/results.json" }],
+    ["line"],
+  ],
   webServer: {
     command,
     url: baseURL,


### PR DESCRIPTION
## Summary
- add a Playwright JSON report so CI can detect when retries converted a failure into a flaky pass
- upload Playwright traces, test results, and the HTML report when the e2e job fails or when flaky retries are detected
- keep artifact retention and paths unchanged so failed retry attempts stay downloadable from the same workflow run

## Testing
- bun typecheck