### PR TITLE
feat: add IDE selection sync API

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/opencode/src/ide/index.ts
+++ b/packages/opencode/src/ide/index.ts
@@ -13,6 +13,15 @@ const SUPPORTED_IDES = [
   { name: "VSCodium" as const, cmd: "codium" },
 ]
 
+export type EditorSelection = {
+  file: string
+  startLine: number
+  startColumn: number
+  endLine: number
+  endColumn: number
+  text?: string
+}
+
 export namespace Ide {
   const log = Log.create({ service: "ide" })
 
@@ -21,6 +30,17 @@ export namespace Ide {
       "ide.installed",
       z.object({
         ide: z.string(),
+      }),
+    ),
+    SelectionChanged: BusEvent.define(
+      "ide.selection.changed",
+      z.object({
+        file: z.string(),
+        startLine: z.number(),
+        startColumn: z.number(),
+        endLine: z.number(),
+        endColumn: z.number(),
+        text: z.string().optional(),
       }),
     ),
   }
@@ -70,5 +90,21 @@ export namespace Ide {
     if (stdout.includes("already installed")) {
       throw new AlreadyInstalledError({})
     }
+  }
+
+  export async function publishSelection(selection: EditorSelection) {
+    log.info("selection changed", {
+      file: selection.file,
+      startLine: selection.startLine,
+      endLine: selection.endLine,
+    })
+    await Bus.publish(Event.SelectionChanged, {
+      file: selection.file,
+      startLine: selection.startLine,
+      startColumn: selection.startColumn,
+      endLine: selection.endLine,
+      endColumn: selection.endColumn,
+      text: selection.text,
+    })
   }
 }

--- a/packages/opencode/src/server/routes/ide.ts
+++ b/packages/opencode/src/server/routes/ide.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { Ide, type EditorSelection } from "@/ide"
+import { lazy } from "@/util/lazy"
+
+const SelectionSchema = z.object({
+  file: z.string().describe("Absolute path to the file"),
+  startLine: z.number().int().min(1).describe("Start line number (1-indexed)"),
+  startColumn: z.number().int().min(1).describe("Start column number (1-indexed)"),
+  endLine: z.number().int().min(1).describe("End line number (1-indexed)"),
+  endColumn: z.number().int().min(1).describe("End column number (1-indexed)"),
+  text: z.string().optional().describe("Selected text content"),
+})
+
+export const IdeRoutes = lazy(() =>
+  new Hono()
+    .post(
+      "/selection",
+      describeRoute({
+        summary: "Publish editor selection",
+        description:
+          "Receive editor selection changes from IDE extensions. This allows the IDE to sync selected code ranges to opencode.",
+        operationId: "ide.selection",
+        responses: {
+          200: {
+            description: "Selection published successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ success: z.boolean() })),
+              },
+            },
+          },
+          400: {
+            description: "Invalid selection data",
+          },
+        },
+      }),
+      validator("json", SelectionSchema),
+      async (c) => {
+        const selection = c.req.valid("json") as EditorSelection
+        await Ide.publishSelection(selection)
+        return c.json({ success: true })
+      },
+    )
+    .post(
+      "/selection/batch",
+      describeRoute({
+        summary: "Publish multiple editor selections",
+        description: "Receive multiple selection changes at once (e.g., multi-cursor selections)",
+        operationId: "ide.selection.batch",
+        responses: {
+          200: {
+            description: "Selections published successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ success: z.boolean(), count: z.number() })),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ selections: z.array(SelectionSchema) })),
+      async (c) => {
+        const { selections } = c.req.valid("json")
+        for (const selection of selections as EditorSelection[]) {
+          await Ide.publishSelection(selection)
+        }
+        return c.json({ success: true, count: selections.length })
+      },
+    ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,6 +42,7 @@ import { Filesystem } from "@/util/filesystem"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
+import { IdeRoutes } from "./routes/ide"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 
@@ -252,6 +253,7 @@ export namespace Server {
       .route("/", EventRoutes())
       .route("/mcp", McpRoutes())
       .route("/tui", TuiRoutes())
+      .route("/ide", IdeRoutes())
       .post(
         "/instance/dispose",
         describeRoute({


### PR DESCRIPTION
## Summary

Add support for syncing editor selection from IDE extensions to opencode.

### Changes

- Add `ide.selection.changed` BusEvent for selection changes
- Add `POST /ide/selection` endpoint to receive selection from IDE
- Add `POST /ide/selection/batch` endpoint for multi-cursor selections
- Fix `custom-elements.d.ts` files that contained invalid path strings

### API

**POST /ide/selection**

```json
{
  "file": "/path/to/file.ts",
  "startLine": 1,
  "startColumn": 1,
  "endLine": 10,
  "endColumn": 5,
  "text": "selected text (optional)"
}
```

**POST /ide/selection/batch**

```json
{
  "selections": [
    { "file": "...", "startLine": 1, ... },
    { "file": "...", "startLine": 5, ... }
  ]
}
```

### VSCode Extension Usage

In the VSCode extension, listen for selection changes and POST to the opencode server:

```typescript
vscode.window.onDidChangeTextEditorSelection((e) => {
  const editor = e.textEditor
  const selection = editor.selection
  const file = editor.document.uri.fsPath
  
  fetch('http://localhost:4096/ide/selection', {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({
      file,
      startLine: selection.start.line + 1,
      startColumn: selection.start.character + 1,
      endLine: selection.end.line + 1,
      endColumn: selection.end.character + 1,
      text: editor.document.getText(selection)
    })
  })
})
```

### Events

The selection is published as a BusEvent `ide.selection.changed` which can be subscribed via SSE at `/event`.