### PR TITLE
fix(path): do not decode percent-encoding in raw filesystem paths

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -27,6 +27,17 @@ describe("file path helpers", () => {
     expect(stripQueryAndHash("a/b.ts")).toBe("a/b.ts")
   })
 
+  test("should NOT decode literal %20 in raw Windows path", () => {
+    const path = createPathHelpers(() => "D:\\First%20Second")
+    // Input is a raw path, not a file:// URL — %20 is a literal folder name character
+    expect(path.normalize("D:\\First%20Second\\file.txt")).toBe("file.txt")
+  })
+
+  test("should decode %20 in file:// URL path", () => {
+    const path = createPathHelpers(() => "/home/user/My Documents")
+    expect(path.normalize("file:///home/user/My%20Documents/file.txt")).toBe("file.txt")
+  })
+
   test("unquotes git escaped octal path strings", () => {
     expect(unquoteGitPath('"a/\\303\\251.txt"')).toBe("a/\u00e9.txt")
     expect(unquoteGitPath('"plain\\nname"')).toBe("plain\nname")

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -105,7 +105,14 @@ export function createPathHelpers(scope: () => string) {
   const normalize = (input: string) => {
     const root = scope()
 
-    let path = unquoteGitPath(decodeFilePath(stripQueryAndHash(stripFileProtocol(input))))
+    // Only decode percent-encoding for file:// URLs — raw filesystem paths may
+    // contain literal % characters (e.g. D:\First%20Second) that must be preserved.
+    const isUrl = input.startsWith("file://") || input.startsWith("file:\\\\")
+    let path = unquoteGitPath(
+      isUrl
+        ? decodeFilePath(stripQueryAndHash(stripFileProtocol(input)))
+        : stripQueryAndHash(stripFileProtocol(input)),
+    )
 
     // Separator-agnostic prefix stripping for Cygwin/native Windows compatibility
     // Only case-insensitive on Windows (drive letter or UNC paths)


### PR DESCRIPTION
## Summary

Fixes #18285.

When a project path contains a literal percent-encoded sequence in the directory name (e.g. `D:\First%20Second`), opencode was silently decoding `%20` to a space, resolving the path as `D:\First Second` — a different, non-existent directory.

## Root Cause

In `packages/app/src/context/file/path.ts`, the `normalize()` function always called `decodeFilePath()` (which runs `decodeURIComponent()`) on the raw input:

```ts
// Before: unconditional decode — breaks literal % in folder names
let path = unquoteGitPath(decodeFilePath(stripQueryAndHash(stripFileProtocol(input))))
```

`decodeFilePath` is only needed when the input is a `file://` URL (to convert `file:///home/user/My%20Docs` → `/home/user/My Docs`). Raw filesystem paths — Windows or Unix — may contain literal `%20` or other `%XX` sequences as part of the actual folder/file name. Decoding those is incorrect.

## Fix

Guard `decodeFilePath` behind an `isUrl` check:

```ts
// Only decode percent-encoding for file:// URLs — raw filesystem paths may
// contain literal % characters (e.g. D:\First%20Second) that must be preserved.
const isUrl = input.startsWith("file://") || input.startsWith("file:\\")
let path = unquoteGitPath(
  isUrl
    ? decodeFilePath(stripQueryAndHash(stripFileProtocol(input)))
    : stripQueryAndHash(stripFileProtocol(input)),
)
```

## Testing

Added 2 regression tests to `path.test.ts`:

1. **Literal `%20` in raw Windows path is preserved** — `D:\First%20Second\file.txt` normalizes correctly without decoding
2. **`%20` in `file://` URL is still decoded** — `file:///home/user/My%20Documents/file.txt` continues to work as before

All 39 existing tests pass.

## Notes

The typecheck pre-push hook fails on `@opencode-ai/enterprise` (`src/custom-elements.d.ts`) — this error exists on `dev` before this change and is unrelated to this fix.
