### PR TITLE
feat(desktop): expand deep links and normalize project paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ nix run nixpkgs#opencode           # or github:anomalyco/opencode for latest dev
 
 OpenCode is also available as a desktop application. Download directly from the [releases page](https://github.com/anomalyco/opencode/releases) or [opencode.ai/download](https://opencode.ai/download).
 
+OpenCode Desktop also supports `opencode://` deep links for opening a specific project or starting a new session. See the [Desktop guide](https://opencode.ai/docs/desktop).
+
 | Platform              | Download                              |
 | --------------------- | ------------------------------------- |
 | macOS (Apple Silicon) | `opencode-desktop-darwin-aarch64.dmg` |

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ nix run nixpkgs#opencode           # or github:anomalyco/opencode for latest dev
 
 OpenCode is also available as a desktop application. Download directly from the [releases page](https://github.com/anomalyco/opencode/releases) or [opencode.ai/download](https://opencode.ai/download).
 
-OpenCode Desktop also supports `opencode://` deep links for opening a specific project or starting a new session. See the [Desktop guide](https://opencode.ai/docs/desktop).
-
 | Platform              | Download                              |
 | --------------------- | ------------------------------------- |
 | macOS (Apple Silicon) | `opencode-desktop-darwin-aarch64.dmg` |

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { projectIndex } from "./server"
+
+describe("projectIndex", () => {
+  test("matches path variants for the same workspace", () => {
+    expect(projectIndex([{ worktree: "C:/Users/Alice/code/demo" }], "C:\\Users\\Alice\\code\\demo\\")).toBe(0)
+    expect(projectIndex([{ worktree: "/tmp/demo" }], "/tmp/demo///")).toBe(0)
+  })
+
+  test("returns -1 for a different workspace", () => {
+    expect(projectIndex([{ worktree: "/tmp/demo" }], "/tmp/other")).toBe(-1)
+  })
+})

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -3,6 +3,7 @@ import { type Accessor, batch, createEffect, createMemo, onCleanup } from "solid
 import { createStore } from "solid-js/store"
 import { Persist, persisted } from "@/utils/persist"
 import { useCheckServerHealth } from "@/utils/server-health"
+import { workspaceKey } from "@/utils/workspace-key"
 
 type StoredProject = { worktree: string; expanded: boolean }
 type StoredServer = string | ServerConnection.HttpBase | ServerConnection.Http
@@ -13,6 +14,11 @@ export function normalizeServerUrl(input: string) {
   if (!trimmed) return
   const withProtocol = /^https?:\/\//.test(trimmed) ? trimmed : `http://${trimmed}`
   return withProtocol.replace(/\/+$/, "")
+}
+
+export const projectIndex = (list: Array<{ worktree: string }>, directory: string) => {
+  const key = workspaceKey(directory)
+  return list.findIndex((item) => workspaceKey(item.worktree) === key)
 }
 
 export function serverName(conn?: ServerConnection.Any, ignoreDisplayName = false) {
@@ -241,7 +247,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          if (current.find((x) => x.worktree === directory)) return
+          if (projectIndex(current, directory) !== -1) return
           setStore("projects", key, [{ worktree: directory, expanded: true }, ...current])
         },
         close(directory: string) {
@@ -251,28 +257,28 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           setStore(
             "projects",
             key,
-            current.filter((x) => x.worktree !== directory),
+            current.filter((x) => workspaceKey(x.worktree) !== workspaceKey(directory)),
           )
         },
         expand(directory: string) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const index = current.findIndex((x) => x.worktree === directory)
+          const index = projectIndex(current, directory)
           if (index !== -1) setStore("projects", key, index, "expanded", true)
         },
         collapse(directory: string) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const index = current.findIndex((x) => x.worktree === directory)
+          const index = projectIndex(current, directory)
           if (index !== -1) setStore("projects", key, index, "expanded", false)
         },
         move(directory: string, toIndex: number) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const fromIndex = current.findIndex((x) => x.worktree === directory)
+          const fromIndex = projectIndex(current, directory)
           if (fromIndex === -1 || fromIndex === toIndex) return
           const result = [...current]
           const [item] = result.splice(fromIndex, 1)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -76,12 +76,7 @@ import {
   sortedRootSessions,
   workspaceKey,
 } from "./layout/helpers"
-import {
-  collectNewSessionDeepLinks,
-  collectOpenProjectDeepLinks,
-  deepLinkEvent,
-  drainPendingDeepLinks,
-} from "./layout/deep-links"
+import { collectDeepLinks, deepLinkEvent, drainPendingDeepLinks } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
   LocalWorkspace,
@@ -1308,20 +1303,49 @@ export default function Layout(props: ParentProps) {
   }
 
   const handleDeepLinks = (urls: string[]) => {
-    if (!server.isLocal()) return
+    for (const link of collectDeepLinks(urls)) {
+      if (link.type === "settings") {
+        openSettings()
+        continue
+      }
 
-    for (const directory of collectOpenProjectDeepLinks(urls)) {
-      openProject(directory)
-    }
+      if (link.type === "server") {
+        openServer()
+        continue
+      }
 
-    for (const link of collectNewSessionDeepLinks(urls)) {
+      if (link.type === "provider") {
+        connectProvider()
+        continue
+      }
+
+      if (link.type === "edit-project") {
+        editProject(link.directory)
+        continue
+      }
+
+      if (!server.isLocal()) continue
+
+      if (link.type === "open-project") {
+        openProject(link.directory)
+        continue
+      }
+
+      if (link.type === "new-session") {
+        openProject(link.directory, false)
+        const slug = base64Encode(link.directory)
+        if (link.prompt) {
+          setSessionHandoff(slug, { prompt: link.prompt })
+        }
+        const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
+        navigateWithSidebarReset(href)
+        continue
+      }
+
       openProject(link.directory, false)
       const slug = base64Encode(link.directory)
-      if (link.prompt) {
-        setSessionHandoff(slug, { prompt: link.prompt })
-      }
-      const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
-      navigateWithSidebarReset(href)
+      const hash = link.message ? `#message-${link.message}` : ""
+      navigateWithSidebarReset(`/${slug}/session/${link.id}${hash}`)
     }
   }
 
@@ -1394,6 +1418,18 @@ export default function Layout(props: ParentProps) {
   }
 
   const showEditProjectDialog = (project: LocalProject) => dialog.show(() => <DialogEditProject project={project} />)
+
+  const editProject = (directory: string) => {
+    const key = workspaceKey(directory)
+    const project = layout.projects
+      .list()
+      .find(
+        (item) =>
+          workspaceKey(item.worktree) === key || item.sandboxes?.some((sandbox) => workspaceKey(sandbox) === key),
+      )
+    if (!project) return
+    showEditProjectDialog(project)
+  }
 
   async function chooseProject() {
     function resolve(result: string | string[] | null) {

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -1,5 +1,14 @@
 export const deepLinkEvent = "opencode:deep-link"
 
+export type DeepLink =
+  | { type: "open-project"; directory: string }
+  | { type: "new-session"; directory: string; prompt?: string }
+  | { type: "open-session"; directory: string; id: string; message?: string }
+  | { type: "edit-project"; directory: string }
+  | { type: "settings" }
+  | { type: "server" }
+  | { type: "provider" }
+
 const parseUrl = (input: string) => {
   if (!input.startsWith("opencode://")) return
   if (typeof URL.canParse === "function" && !URL.canParse(input)) return
@@ -13,28 +22,40 @@ const parseUrl = (input: string) => {
 export const parseDeepLink = (input: string) => {
   const url = parseUrl(input)
   if (!url) return
-  if (url.hostname !== "open-project") return
-  const directory = url.searchParams.get("directory")
-  if (!directory) return
-  return directory
+  const directory = url.searchParams.get("directory") || undefined
+
+  if (url.hostname === "open-project") {
+    if (!directory) return
+    return { type: "open-project", directory } satisfies DeepLink
+  }
+
+  if (url.hostname === "new-session") {
+    if (!directory) return
+    const prompt = url.searchParams.get("prompt") || undefined
+    if (!prompt) return { type: "new-session", directory } satisfies DeepLink
+    return { type: "new-session", directory, prompt } satisfies DeepLink
+  }
+
+  if (url.hostname === "open-session") {
+    if (!directory) return
+    const id = url.searchParams.get("id") || undefined
+    if (!id) return
+    const message = url.searchParams.get("message") || undefined
+    if (!message) return { type: "open-session", directory, id } satisfies DeepLink
+    return { type: "open-session", directory, id, message } satisfies DeepLink
+  }
+
+  if (url.hostname === "edit-project") {
+    if (!directory) return
+    return { type: "edit-project", directory } satisfies DeepLink
+  }
+
+  if (url.hostname === "settings") return { type: "settings" } satisfies DeepLink
+  if (url.hostname === "server") return { type: "server" } satisfies DeepLink
+  if (url.hostname === "provider") return { type: "provider" } satisfies DeepLink
 }
 
-export const parseNewSessionDeepLink = (input: string) => {
-  const url = parseUrl(input)
-  if (!url) return
-  if (url.hostname !== "new-session") return
-  const directory = url.searchParams.get("directory")
-  if (!directory) return
-  const prompt = url.searchParams.get("prompt") || undefined
-  if (!prompt) return { directory }
-  return { directory, prompt }
-}
-
-export const collectOpenProjectDeepLinks = (urls: string[]) =>
-  urls.map(parseDeepLink).filter((directory): directory is string => !!directory)
-
-export const collectNewSessionDeepLinks = (urls: string[]) =>
-  urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
+export const collectDeepLinks = (urls: string[]) => urls.map(parseDeepLink).filter((link): link is DeepLink => !!link)
 
 type OpenCodeWindow = Window & {
   __OPENCODE__?: {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import {
-  collectNewSessionDeepLinks,
-  collectOpenProjectDeepLinks,
-  drainPendingDeepLinks,
-  parseDeepLink,
-  parseNewSessionDeepLink,
-} from "./deep-links"
+import { collectDeepLinks, drainPendingDeepLinks, parseDeepLink } from "./deep-links"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import {
   displayName,
@@ -29,7 +23,10 @@ const session = (input: Partial<Session> & Pick<Session, "id" | "directory">) =>
 
 describe("layout deep links", () => {
   test("parses open-project deep links", () => {
-    expect(parseDeepLink("opencode://open-project?directory=/tmp/demo")).toBe("/tmp/demo")
+    expect(parseDeepLink("opencode://open-project?directory=/tmp/demo")).toEqual({
+      type: "open-project",
+      directory: "/tmp/demo",
+    })
   })
 
   test("ignores non-project deep links", () => {
@@ -46,7 +43,10 @@ describe("layout deep links", () => {
     const original = Object.getOwnPropertyDescriptor(URL, "canParse")
     Object.defineProperty(URL, "canParse", { configurable: true, value: undefined })
     try {
-      expect(parseDeepLink("opencode://open-project?directory=/tmp/demo")).toBe("/tmp/demo")
+      expect(parseDeepLink("opencode://open-project?directory=/tmp/demo")).toEqual({
+        type: "open-project",
+        directory: "/tmp/demo",
+      })
     } finally {
       if (original) Object.defineProperty(URL, "canParse", original)
       if (!original) Reflect.deleteProperty(URL, "canParse")
@@ -58,35 +58,74 @@ describe("layout deep links", () => {
     expect(parseDeepLink("opencode://open-project?directory=")).toBeUndefined()
   })
 
-  test("collects only valid open-project directories", () => {
-    const result = collectOpenProjectDeepLinks([
-      "opencode://open-project?directory=/a",
-      "opencode://other?directory=/b",
-      "opencode://open-project?directory=/c",
-    ])
-    expect(result).toEqual(["/a", "/c"])
-  })
-
   test("parses new-session deep links with optional prompt", () => {
-    expect(parseNewSessionDeepLink("opencode://new-session?directory=/tmp/demo")).toEqual({ directory: "/tmp/demo" })
-    expect(parseNewSessionDeepLink("opencode://new-session?directory=/tmp/demo&prompt=hello%20world")).toEqual({
+    expect(parseDeepLink("opencode://new-session?directory=/tmp/demo")).toEqual({
+      type: "new-session",
+      directory: "/tmp/demo",
+    })
+    expect(parseDeepLink("opencode://new-session?directory=/tmp/demo&prompt=hello%20world")).toEqual({
+      type: "new-session",
       directory: "/tmp/demo",
       prompt: "hello world",
     })
   })
 
-  test("ignores new-session deep links without directory", () => {
-    expect(parseNewSessionDeepLink("opencode://new-session")).toBeUndefined()
-    expect(parseNewSessionDeepLink("opencode://new-session?directory=")).toBeUndefined()
+  test("parses open-session deep links with optional message", () => {
+    expect(parseDeepLink("opencode://open-session?directory=/tmp/demo&id=session-1")).toEqual({
+      type: "open-session",
+      directory: "/tmp/demo",
+      id: "session-1",
+    })
+    expect(parseDeepLink("opencode://open-session?directory=/tmp/demo&id=session-1&message=msg-1")).toEqual({
+      type: "open-session",
+      directory: "/tmp/demo",
+      id: "session-1",
+      message: "msg-1",
+    })
   })
 
-  test("collects only valid new-session deep links", () => {
-    const result = collectNewSessionDeepLinks([
-      "opencode://new-session?directory=/a",
-      "opencode://open-project?directory=/b",
+  test("parses desktop dialog deep links", () => {
+    expect(parseDeepLink("opencode://settings")).toEqual({ type: "settings" })
+    expect(parseDeepLink("opencode://server")).toEqual({ type: "server" })
+    expect(parseDeepLink("opencode://provider")).toEqual({ type: "provider" })
+    expect(parseDeepLink("opencode://edit-project?directory=/tmp/demo")).toEqual({
+      type: "edit-project",
+      directory: "/tmp/demo",
+    })
+  })
+
+  test("ignores new-session deep links without directory", () => {
+    expect(parseDeepLink("opencode://new-session")).toBeUndefined()
+    expect(parseDeepLink("opencode://new-session?directory=")).toBeUndefined()
+  })
+
+  test("ignores open-session deep links without required params", () => {
+    expect(parseDeepLink("opencode://open-session")).toBeUndefined()
+    expect(parseDeepLink("opencode://open-session?directory=/tmp/demo")).toBeUndefined()
+    expect(parseDeepLink("opencode://open-session?id=session-1")).toBeUndefined()
+  })
+
+  test("ignores edit-project deep links without directory", () => {
+    expect(parseDeepLink("opencode://edit-project")).toBeUndefined()
+    expect(parseDeepLink("opencode://edit-project?directory=")).toBeUndefined()
+  })
+
+  test("collects only valid deep links", () => {
+    const result = collectDeepLinks([
+      "opencode://open-project?directory=/a",
+      "opencode://other?directory=/b",
       "opencode://new-session?directory=/c&prompt=ship%20it",
+      "opencode://open-session?directory=/d&id=session-1&message=msg-1",
+      "opencode://settings",
+      "opencode://edit-project?directory=/e",
     ])
-    expect(result).toEqual([{ directory: "/a" }, { directory: "/c", prompt: "ship it" }])
+    expect(result).toEqual([
+      { type: "open-project", directory: "/a" },
+      { type: "new-session", directory: "/c", prompt: "ship it" },
+      { type: "open-session", directory: "/d", id: "session-1", message: "msg-1" },
+      { type: "settings" },
+      { type: "edit-project", directory: "/e" },
+    ])
   })
 
   test("drains global deep links once", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -2,6 +2,8 @@ import { getFilename } from "@opencode-ai/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import { workspaceKey } from "@/utils/workspace-key"
 
+export { workspaceKey }
+
 type SessionStore = {
   session?: Session[]
   path: { directory: string }

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -1,17 +1,10 @@
 import { getFilename } from "@opencode-ai/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
+import { workspaceKey } from "@/utils/workspace-key"
 
 type SessionStore = {
   session?: Session[]
   path: { directory: string }
-}
-
-export const workspaceKey = (directory: string) => {
-  const value = directory.replaceAll("\\", "/")
-  const drive = value.match(/^([A-Za-z]:)\/+$/)
-  if (drive) return `${drive[1]}/`
-  if (/^\/+$/i.test(value)) return "/"
-  return value.replace(/\/+$/, "")
 }
 
 function sortSessions(now: number) {

--- a/packages/app/src/utils/workspace-key.test.ts
+++ b/packages/app/src/utils/workspace-key.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { workspaceKey } from "./workspace-key"
+
+describe("workspaceKey", () => {
+  test("normalizes trailing slash and backslash variants", () => {
+    expect(workspaceKey("/tmp/demo///")).toBe("/tmp/demo")
+    expect(workspaceKey("C:\\tmp\\demo\\\\")).toBe("C:/tmp/demo")
+  })
+
+  test("preserves root directories", () => {
+    expect(workspaceKey("/")).toBe("/")
+    expect(workspaceKey("///")).toBe("/")
+    expect(workspaceKey("C:\\")).toBe("C:/")
+    expect(workspaceKey("C://")).toBe("C:/")
+    expect(workspaceKey("C:///")).toBe("C:/")
+  })
+})

--- a/packages/app/src/utils/workspace-key.ts
+++ b/packages/app/src/utils/workspace-key.ts
@@ -1,0 +1,7 @@
+export const workspaceKey = (directory: string) => {
+  const value = directory.replaceAll("\\", "/")
+  const drive = value.match(/^([A-Za-z]:)\/+$/)
+  if (drive) return `${drive[1]}/`
+  if (/^\/+$/i.test(value)) return "/"
+  return value.replace(/\/+$/, "")
+}

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -224,7 +224,7 @@ export default defineConfig({
             "zh-CN": "使用",
             "zh-TW": "使用",
           },
-          items: ["go", "tui", "cli", "web", "ide", "zen", "share", "github", "gitlab"],
+          items: ["go", "tui", "cli", "web", "desktop", "ide", "zen", "share", "github", "gitlab"],
         },
 
         {

--- a/packages/web/src/content/docs/desktop.mdx
+++ b/packages/web/src/content/docs/desktop.mdx
@@ -1,0 +1,50 @@
+---
+title: Desktop
+description: Use OpenCode Desktop and open projects with deep links.
+---
+
+OpenCode Desktop supports `opencode://` links for opening a specific local project.
+
+## Open from links
+
+Supported links:
+
+- `opencode://open-project?directory=<absolute-path>`
+- `opencode://new-session?directory=<absolute-path>&prompt=<optional prompt>`
+
+Notes:
+
+- `directory` must be an absolute path.
+- Query values should be URL-encoded.
+- `new-session` opens the project and routes to a new session page.
+- If `prompt` is present, it prefills the composer.
+
+Examples:
+
+```text
+# macOS / Linux
+opencode://open-project?directory=%2FUsers%2Falice%2Fcode%2Fmy-app
+opencode://new-session?directory=%2FUsers%2Falice%2Fcode%2Fmy-app&prompt=Review%20the%20auth%20flow
+
+# Windows
+opencode://open-project?directory=C%3A%2FUsers%2FAlice%2Fcode%2Fmy-app
+opencode://new-session?directory=C%3A%2FUsers%2FAlice%2Fcode%2Fmy-app&prompt=Summarize%20the%20build%20setup
+```
+
+## Troubleshooting
+
+### Deep links do nothing
+
+OpenCode Desktop only handles `opencode://` links while it is using its built-in local server mode.
+
+If a deep link does nothing:
+
+1. Open the server picker from the Home screen.
+2. In **Default server**, click **Clear** so Desktop goes back to its local sidecar server.
+3. Retry the link.
+
+Other things to check:
+
+- `directory` must be an absolute path.
+- Query values such as `directory` and `prompt` should be URL-encoded.
+- If `OpenCode`, `OpenCode Beta`, or `OpenCode Dev` are all installed, your OS may send `opencode://` links to whichever app most recently claimed the protocol handler.

--- a/packages/web/src/content/docs/desktop.mdx
+++ b/packages/web/src/content/docs/desktop.mdx
@@ -1,41 +1,65 @@
 ---
 title: Desktop
-description: Use OpenCode Desktop and open projects with deep links.
+description: Use OpenCode Desktop shortcuts, dialogs, and project deep links.
 ---
 
-OpenCode Desktop supports `opencode://` links for opening a specific local project.
+OpenCode Desktop supports `opencode://` links for opening projects, jumping back into sessions, and opening desktop-specific dialogs.
 
-## Open from links
+## Deep links
 
-Supported links:
+### Project links
 
 - `opencode://open-project?directory=<absolute-path>`
 - `opencode://new-session?directory=<absolute-path>&prompt=<optional prompt>`
+- `opencode://open-session?directory=<absolute-path>&id=<session-id>&message=<optional message-id>`
 
-Notes:
+These links require Desktop to be using its built-in local server mode.
 
-- `directory` must be an absolute path.
+- Use an absolute path for `directory`.
 - Query values should be URL-encoded.
-- `new-session` opens the project and routes to a new session page.
+- `open-project` opens the project and resumes the last or latest session when one is available.
+- If no session exists, `open-project` falls back to the new session page.
+- `new-session` opens the project and routes directly to a new session page.
 - If `prompt` is present, it prefills the composer.
+- `open-session` routes to an existing session.
+- If `message` is present, Desktop scrolls to `#message-<message-id>` after opening the session.
 
-Examples:
+### Desktop dialogs
+
+- `opencode://edit-project?directory=<project-or-workspace-path>`
+- `opencode://settings`
+- `opencode://server`
+- `opencode://provider`
+
+These links work even when Desktop is connected to a remote server.
+
+- `edit-project` opens the same project editor shown from the project right-click menu.
+- `directory` can be the project root or one of its workspaces.
+- `edit-project` only works when Desktop already knows that project or workspace path.
+
+### Examples
 
 ```text
 # macOS / Linux
 opencode://open-project?directory=%2FUsers%2Falice%2Fcode%2Fmy-app
 opencode://new-session?directory=%2FUsers%2Falice%2Fcode%2Fmy-app&prompt=Review%20the%20auth%20flow
+opencode://open-session?directory=%2FUsers%2Falice%2Fcode%2Fmy-app&id=session_123&message=msg_456
+opencode://edit-project?directory=%2FUsers%2Falice%2Fcode%2Fmy-app
+opencode://settings
+opencode://server
+opencode://provider
 
 # Windows
 opencode://open-project?directory=C%3A%2FUsers%2FAlice%2Fcode%2Fmy-app
 opencode://new-session?directory=C%3A%2FUsers%2FAlice%2Fcode%2Fmy-app&prompt=Summarize%20the%20build%20setup
+opencode://open-session?directory=C%3A%2FUsers%2FAlice%2Fcode%2Fmy-app&id=session_123
 ```
 
 ## Troubleshooting
 
 ### Deep links do nothing
 
-OpenCode Desktop only handles `opencode://` links while it is using its built-in local server mode.
+Project and session deep links require OpenCode Desktop to be using its built-in local server mode. Desktop dialog links like `settings`, `server`, `provider`, and `edit-project` also work when connected to a remote server.
 
 If a deep link does nothing:
 
@@ -45,6 +69,6 @@ If a deep link does nothing:
 
 Other things to check:
 
-- `directory` must be an absolute path.
-- Query values such as `directory` and `prompt` should be URL-encoded.
+- Use an absolute path for `directory` in project and session links.
+- Query values such as `directory`, `prompt`, `id`, and `message` should be URL-encoded when needed.
 - If `OpenCode`, `OpenCode Beta`, or `OpenCode Dev` are all installed, your OS may send `opencode://` links to whichever app most recently claimed the protocol handler.

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -197,6 +197,12 @@ used.
 You are now ready to use OpenCode to work on your project. Feel free to ask it
 anything!
 
+---
+
+### Desktop app
+
+Use the [Desktop guide](/docs/desktop) for desktop-specific behavior, including `opencode://` deep links for opening a project or starting a new session.
+
 If you are new to using an AI coding agent, here are some examples that might
 help.
 

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -201,7 +201,7 @@ anything!
 
 ### Desktop app
 
-Use the [Desktop guide](/docs/desktop) for desktop-specific behavior, including `opencode://` deep links for opening a project or starting a new session.
+Use the [Desktop guide](/docs/desktop) for desktop-specific behavior, including `opencode://` deep links. Project and session links use Desktop's built-in local server, while dialog links also work when connected to a remote server.
 
 If you are new to using an AI coding agent, here are some examples that might
 help.

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -119,6 +119,10 @@ If you have `OPENCODE_PORT` set in your environment, the desktop app will try to
 
 - Unset `OPENCODE_PORT` (or pick a free port) and restart.
 
+### Fix deep links
+
+See the [Desktop guide](/docs/desktop#deep-links-do-nothing) for desktop deep-link formats and the most common reasons `opencode://` links do not open as expected.
+
 ---
 
 ### Linux: Wayland / X11 issues

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -121,7 +121,7 @@ If you have `OPENCODE_PORT` set in your environment, the desktop app will try to
 
 ### Fix deep links
 
-See the [Desktop guide](/docs/desktop#deep-links-do-nothing) for desktop deep-link formats and the most common reasons `opencode://` links do not open as expected.
+See the [Desktop guide](/docs/desktop#deep-links-do-nothing) for desktop deep-link formats and the most common reasons `opencode://` links do not open as expected. `open-project`, `new-session`, and `open-session` require the built-in local server, while `settings`, `server`, `provider`, and `edit-project` also work when connected to a remote server.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #6232

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This expands Desktop deep-link support beyond the existing `open-project` and `new-session` links.

It adds support for:
- `opencode://open-session`
- `opencode://edit-project`
- `opencode://settings`
- `opencode://server`
- `opencode://provider`

The session and project links still require Desktop's built-in local server. The dialog links work even when Desktop is connected to a remote server.

This PR also fixes project matching in desktop state by normalizing workspace paths before comparing them. That avoids duplicate or mismatched project entries when the same path is opened with different separators or trailing slashes, which is relevant to #11666.

I also updated the Desktop docs and related doc links so they describe the wider deep-link surface and the local-server vs remote-server behavior correctly.

### How did you verify your code works?

- Ran `bun test src/utils/workspace-key.test.ts` in `packages/app`
- Ran `bun test src/context/server.test.ts` in `packages/app`
- Ran `git diff --check`

I did not run full app/web typecheck or build because this worktree still has missing-dependency environment issues unrelated to this change.

### Screenshots / recordings

Not included. This changes deep-link handling and docs, but I did not capture UI recordings in this environment.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR