### PR TITLE
docs: add opencode-dir to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -18,6 +18,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                               | Description                                                                                       |
 | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
+| [opencode-dir](https://github.com/adiled/opencode-dir)                                             | Change directory, move sessions, and other directory based operations for OpenCode sessions |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |


### PR DESCRIPTION
### Issue for this PR

N/A — ecosystem listing addition

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add opencode-dir to the community plugins list. Change directory, move sessions, and other directory based operations for OpenCode sessions.

### How did you verify your code works?

- Plugin installed via npm: works
- /cd and /mv appear in autocomplete: yes
- /mv successfully rewrites session to new directory: yes

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR