### PR TITLE
fix: reject pending callbacks in cancel to prevent hanging

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -82,6 +82,15 @@ export namespace SessionPrompt {
     },
     async (current) => {
       for (const item of Object.values(current)) {
+        // Reject all pending callbacks to prevent callers from hanging
+        const cancelError = new DOMException("Session cancelled", "AbortError")
+        for (const callback of item.callbacks) {
+          try {
+            callback.reject(cancelError)
+          } catch (e) {
+            log.error("failed to reject callback during dispose", { error: e })
+          }
+        }
         item.abort.abort()
       }
     },
@@ -264,6 +273,15 @@ export namespace SessionPrompt {
     if (!match) {
       SessionStatus.set(sessionID, { type: "idle" })
       return
+    }
+    // Reject all pending callbacks to prevent callers from hanging
+    const cancelError = new DOMException("Session cancelled", "AbortError")
+    for (const callback of match.callbacks) {
+      try {
+        callback.reject(cancelError)
+      } catch (e) {
+        log.error("failed to reject callback during cancel", { error: e, sessionID })
+      }
     }
     match.abort.abort()
     delete s[sessionID]


### PR DESCRIPTION
### Issue for this PR

Closes [#18378](https://github.com/anomalyco/opencode/issues/18378)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a bug where pending callbacks in the session state were not being rejected when a session was cancelled or disposed, causing callers to hang indefinitely.

When `SessionPrompt.cancel()` was called (due to an error, abort, or session disposal), it would:

1. Abort the AbortController
2. Delete the session state entry
3. Set the session status to idle
   However, it did **not** reject the callbacks array containing pending Promise resolve/reject handlers. This meant that any caller waiting for the session to complete (via the `loop()` function's callback mechanism) would hang forever.

This PR ensures all pending callbacks are rejected with an `AbortError` before the session state is cleaned up in two places:

1. `cancel()` function - when a session is explicitly cancelled
2. State dispose handler - when the instance is being disposed

### How did you verify your code works?

- Built the project with `bun run script/build.ts --single`
- Verified the built binary runs correctly with `--version`
- Tested in a high-concurrency scenario with 20+ parallel subagent invocations
- Confirmed that previously hanging subagents now properly reject and propagate errors

### Screenshots / recordings

Not included (backend logic fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR