### PR TITLE
fix(app): submit button not working in line-comment

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -217,17 +217,6 @@ export function FileTabContent(props: { tab: string }) {
         onDelete={controls.remove}
       />
     ),
-    onDraftPopoverFocusOut: (e: FocusEvent) => {
-      const current = e.currentTarget as HTMLDivElement
-      const target = e.relatedTarget
-      if (target instanceof Node && current.contains(target)) return
-
-      setTimeout(() => {
-        if (!document.activeElement || !current.contains(document.activeElement)) {
-          setNote("commenting", null)
-        }
-      }, 0)
-    },
   })
 
   createEffect(() => {

--- a/packages/ui/src/components/line-comment-annotations.tsx
+++ b/packages/ui/src/components/line-comment-annotations.tsx
@@ -61,7 +61,6 @@ type LineCommentControllerProps<T extends LineCommentShape> = {
   onDelete?: (comment: T) => void
   renderCommentActions?: (comment: T, controls: { edit: VoidFunction; remove: VoidFunction }) => JSX.Element
   editSubmitLabel?: string
-  onDraftPopoverFocusOut?: JSX.EventHandlerUnion<HTMLDivElement, FocusEvent>
   getHoverSelectedRange?: Accessor<SelectedLineRange | null>
   cancelDraftOnCommentToggle?: boolean
   clearSelectionOnSelectionEndNull?: boolean
@@ -88,7 +87,6 @@ type DraftProps = {
   onInput: (value: string) => void
   onCancel: VoidFunction
   onSubmit: (value: string) => void
-  onPopoverFocusOut?: JSX.EventHandlerUnion<HTMLDivElement, FocusEvent>
   cancelLabel?: string
   submitLabel?: string
 }
@@ -145,7 +143,6 @@ export function createLineCommentAnnotationRenderer<T>(props: {
               onInput={view().editor!.onInput}
               onCancel={view().editor!.onCancel}
               onSubmit={view().editor!.onSubmit}
-              onPopoverFocusOut={view().editor!.onPopoverFocusOut}
               cancelLabel={view().editor!.cancelLabel}
               submitLabel={view().editor!.submitLabel}
             />
@@ -166,7 +163,6 @@ export function createLineCommentAnnotationRenderer<T>(props: {
           onInput={view().onInput}
           onCancel={view().onCancel}
           onSubmit={view().onSubmit}
-          onPopoverFocusOut={view().onPopoverFocusOut}
         />
       )
     }, host)
@@ -421,7 +417,6 @@ export function createLineCommentController<T extends LineCommentShape>(
         props.onSubmit({ comment, selection: cloneSelectedLineRange(range) })
         note.cancelDraft()
       },
-      onPopoverFocusOut: props.onDraftPopoverFocusOut,
     }),
   })
 

--- a/packages/ui/src/components/line-comment-styles.ts
+++ b/packages/ui/src/components/line-comment-styles.ts
@@ -14,9 +14,14 @@ export const lineCommentStyles = `
   position: relative;
   right: auto;
   display: flex;
-  width: 100%;
+  width: calc(100% - 4rem);
   min-width: 0;
+  max-width: 600px;
   align-items: flex-start;
+}
+
+[data-component="session-review"] [data-component="line-comment"][data-inline] {
+  width: 100%;
 }
 
 [data-component="line-comment"][data-open] {
@@ -182,9 +187,14 @@ export const lineCommentStyles = `
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  row-gap: 4px;
   padding-left: 8px;
   min-width: 0;
+}
+
+[data-component="line-comment"] [data-slot="line-comment-action-buttons"] {
+  display: flex;
+  gap: 8px;
 }
 
 [data-component="line-comment"] [data-slot="line-comment-editor-label"] {

--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -38,7 +38,6 @@ export type LineCommentAnchorProps = {
   buttonLabel?: string
   onClick?: JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent>
   onMouseEnter?: JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent>
-  onPopoverFocusOut?: JSX.EventHandlerUnion<HTMLDivElement, FocusEvent>
   class?: string
   popoverClass?: string
   children?: JSX.Element
@@ -98,7 +97,6 @@ export const LineCommentAnchor = (props: LineCommentAnchorProps) => {
                   [props.popoverClass ?? ""]: !!props.popoverClass,
                 }}
                 on:mousedown={(e) => e.stopPropagation()}
-                on:focusout={props.onPopoverFocusOut as any}
               >
                 {props.children}
               </div>
@@ -115,7 +113,6 @@ export const LineCommentAnchor = (props: LineCommentAnchorProps) => {
           on:mousedown={(e) => e.stopPropagation()}
           on:click={props.onClick as any}
           on:mouseenter={props.onMouseEnter as any}
-          on:focusout={props.onPopoverFocusOut as any}
         >
           {props.children}
         </div>
@@ -233,7 +230,7 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
   })
 
   return (
-    <LineCommentAnchor {...rest} open={true} variant="editor" hideButton={props.inline} onClick={() => focus()}>
+    <LineCommentAnchor {...rest} open={true} variant="editor" hideButton={props.inline}>
       <div data-slot="line-comment-editor">
         <textarea
           ref={(el) => {
@@ -273,7 +270,7 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
           <Show
             when={!props.inline}
             fallback={
-              <>
+              <div data-slot="line-comment-action-buttons">
                 <button
                   type="button"
                   data-slot="line-comment-action"
@@ -293,15 +290,17 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
                 >
                   {split.submitLabel ?? i18n.t("ui.lineComment.submit")}
                 </button>
-              </>
+              </div>
             }
           >
-            <Button size="small" variant="ghost" onClick={split.onCancel}>
-              {split.cancelLabel ?? i18n.t("ui.common.cancel")}
-            </Button>
-            <Button size="small" variant="primary" disabled={text().trim().length === 0} onClick={submit}>
-              {split.submitLabel ?? i18n.t("ui.lineComment.submit")}
-            </Button>
+            <div data-slot="line-comment-action-buttons">
+              <Button size="small" variant="ghost" onClick={split.onCancel}>
+                {split.cancelLabel ?? i18n.t("ui.common.cancel")}
+              </Button>
+              <Button size="small" variant="primary" disabled={text().trim().length === 0} onClick={submit}>
+                {split.submitLabel ?? i18n.t("ui.lineComment.submit")}
+              </Button>
+            </div>
           </Show>
         </div>
       </div>


### PR DESCRIPTION
### Issue for this PR

- Fixes #11947 
- May resolve #11502 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Remove the `onDraftPopoverFocusOut` callback chain in `packages/app/src/pages/session/file-tabs.tsx` and related components (`line-comment.tsx` and `line-comment-annotations.tsx` in `packages/ui/src/components`).
- Modify the CSS of the comment editor component so that its width within the file tab won't get to large, which results in UI overflow.

To be short, this PR mainly addresses the unfinished work in PR #17948, which only resolved the issue in Review tab, but the problem still exists in the file tab.

#### Problem

When viewing a file in the file tab (the file viewer, not the dedicated Review tab), clicking the "Comment" (submit) button inside the inline comment editor popover does nothing. The only way to submit a comment is by pressing Enter.

<details>
<summary>Root Cause & Explanations (click for more details)</summary>

The `onDraftPopoverFocusOut` callback (file-tabs.tsx:220) was designed to close the draft when focus leaves the popover div.

https://github.com/anomalyco/opencode/blob/2c056c90dabed3d2c273981079fe76957ab05d73/packages/app/src/pages/session/file-tabs.tsx#L220-L230

However, how the focus moves when user clicks differs across browsers and platforms. macOS's GUI habitually **does not give the focus to the button** when it's clicked. This means that in WebKit (which is also the WebView being used in OpenCode Desktop on macOS), clicking the comments button does not transfer focus to it. Instead, the entire popup loses focus. This causes `current.contains(document.activeElement)` to be false, triggering `setNote("commenting", null)`, leading to a bug.

On Chromium, while focus does transfer to the button when clicked, a recent PR (#17948) added a `preventDefault` event to the button's mousedown event. This means that even in Chromium-based browsers, clicking this button no longer transfers focus to it.

Therefore, in the current situation, the `onDraftPopoverFocusOut` function is purely a bug, hindering normal functionality without contributing anything positive.
</details>

### How did you verify your code works?

I built and ran the modified application and ensured that all functions worked correctly.

Screen recording below can be compared with recording within #18377 to demonstrate the proposed fix.

**Explanation to potential concerns**: 
Even if `onDraftPopoverFocusOut` is removed, users can still close the window by clicking on other lines, pressing Escape, or clicking the Cancel button.  
This change does not result in significant UI/UX changes or functional breakdown; on the contrary, it improves the UI/UX of the feature.

### Screenshots / recordings

Recording: the submit button now works well

https://github.com/user-attachments/assets/c2aa65f6-bd5e-4f6e-b26d-b4fe38c98b39

Screenshot: before this PR, the editor was too wide, making itself overflows.

<img width="1900" height="1103" alt="before" src="https://github.com/user-attachments/assets/eb7d34cd-7d46-43e7-a0c1-daae5c1a83a8" />

Screenshot: if this PR gets merged, the comments editor will display normally both in review tab and file tab

<img width="1902" height="1106" alt="after" src="https://github.com/user-attachments/assets/cefb6e6a-b23d-46ba-b00e-2cb81a6a451c" />
<img width="1899" height="1099" alt="after-2" src="https://github.com/user-attachments/assets/ff421dee-5114-4410-956c-efd0e7e569fd" />
<img width="1905" height="1103" alt="after-3" src="https://github.com/user-attachments/assets/82d7c714-db4b-4016-8717-9550aba90a6a" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
