### PR TITLE
fix(nix): pass NODE_EXTRA_CA_CERTS through to bun in node_modules build

### DIFF
--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -47,6 +47,11 @@ stdenvNoCC.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
+    # Bridge NIX_SSL_CERT_FILE (already in impureEnvVars) to NODE_EXTRA_CA_CERTS
+    # so bun trusts custom CA bundles (e.g. corporate TLS inspection proxies)
+    if [ -n "''${NIX_SSL_CERT_FILE:-}" ]; then
+      export NODE_EXTRA_CA_CERTS="$NIX_SSL_CERT_FILE"
+    fi
     export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
     bun install \
       --cpu="${bunCpu}" \

--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -47,8 +47,6 @@ stdenvNoCC.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
-    # Bridge NIX_SSL_CERT_FILE (already in impureEnvVars) to NODE_EXTRA_CA_CERTS
-    # so bun trusts custom CA bundles (e.g. corporate TLS inspection proxies)
     if [ -n "''${NIX_SSL_CERT_FILE:-}" ]; then
       export NODE_EXTRA_CA_CERTS="$NIX_SSL_CERT_FILE"
     fi


### PR DESCRIPTION
### Issue for this PR

Closes #18407

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `NODE_EXTRA_CA_CERTS` to `impureEnvVars` in the node_modules fixed-output derivation

Corporate environments with TLS inspection proxies inject their own CA certificates into the chain. This causes bun to fail with `SELF_SIGNED_CERT_IN_CHAIN` when fetching GitHub tarballs (e.g. `ghostty-web`) during the nix build.

`lib.fetchers.proxyImpureEnvVars` already includes `NIX_SSL_CERT_FILE`, but bun ignores that and only reads `NODE_EXTRA_CA_CERTS`. Without it in `impureEnvVars`, there's no way to pass a custom CA bundle through to bun in the sandboxed build.

### How did you verify your code works?

No longer see self signed cert error when building my nix flake against my local opencode repo with this change.

```
    opencode = {
      url = "path:/Users/**/src/opencode";
      inputs.nixpkgs.follows = "nixpkgs";
    };
```

### Screenshots / recordings

```
error: Cannot build '/nix/store/gkas8rz3acaf0ki1yxgh2p5g5vsn33yg-opencode-node_modules-1.2.27-dirty.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/p4f478rz4w49p6jlywsrkgw4kbmnz427-opencode-node_modules-1.2.27-dirty
       Last 11 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/n45409qd16qldkr02dn2f8rq4wj7bd73-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: buildPhase
       > bun install v1.3.10 (30e609e0)
       > Resolving dependencies
       > Resolved, downloaded and extracted [434]
       > error: SELF_SIGNED_CERT_IN_CHAIN downloading tarball ghostty-web@github:anomalyco/ghostty-web#main
       > error: ghostty-web@github:anomalyco/ghostty-web#main failed to resolve
```
old error that is gone

===
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._