### PR TITLE
fix(path): do not decode percent-encoding in raw filesystem paths

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -27,6 +27,17 @@ describe("file path helpers", () => {
     expect(stripQueryAndHash("a/b.ts")).toBe("a/b.ts")
   })
 
+  test("should NOT decode literal %20 in raw Windows path", () => {
+    const path = createPathHelpers(() => "D:\\First%20Second")
+    // Input is a raw path, not a file:// URL — %20 is a literal folder name character
+    expect(path.normalize("D:\\First%20Second\\file.txt")).toBe("file.txt")
+  })
+
+  test("should decode %20 in file:// URL path", () => {
+    const path = createPathHelpers(() => "/home/user/My Documents")
+    expect(path.normalize("file:///home/user/My%20Documents/file.txt")).toBe("file.txt")
+  })
+
   test("unquotes git escaped octal path strings", () => {
     expect(unquoteGitPath('"a/\\303\\251.txt"')).toBe("a/\u00e9.txt")
     expect(unquoteGitPath('"plain\\nname"')).toBe("plain\nname")

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -105,7 +105,14 @@ export function createPathHelpers(scope: () => string) {
   const normalize = (input: string) => {
     const root = scope()
 
-    let path = unquoteGitPath(decodeFilePath(stripQueryAndHash(stripFileProtocol(input))))
+    // Only decode percent-encoding for file:// URLs — raw filesystem paths may
+    // contain literal % characters (e.g. D:\First%20Second) that must be preserved.
+    const isUrl = input.startsWith("file://") || input.startsWith("file:\\\\")
+    let path = unquoteGitPath(
+      isUrl
+        ? decodeFilePath(stripQueryAndHash(stripFileProtocol(input)))
+        : stripQueryAndHash(stripFileProtocol(input)),
+    )
 
     // Separator-agnostic prefix stripping for Cygwin/native Windows compatibility
     // Only case-insensitive on Windows (drive letter or UNC paths)


### PR DESCRIPTION
### Issue for this PR

Closes #18285

### Type of change

- [x] Bug fix

### What does this PR do?

`normalize()` was calling `decodeURIComponent()` on all paths unconditionally. If a directory name contains a literal `%20` (e.g. `D:\First%20Second`), the function silently converts it to a space and resolves a path that doesn't exist.

The fix is simple: only call `decodeFilePath` when the input is a `file://` URL. Raw filesystem paths (Windows or Unix) may contain literal `%` characters that are part of the name and must not be decoded.

### How did you verify your code works?

Added two regression tests:
- one that verifies literal `%20` in a raw path is preserved
- one that verifies `%20` in a `file://` URL is still decoded correctly

Both pass. Existing tests unchanged.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
