### PR TITLE
fix: preserve oauth metadata for provider auth

### DIFF
--- a/packages/opencode/src/auth/effect.ts
+++ b/packages/opencode/src/auth/effect.ts
@@ -2,31 +2,11 @@ import path from "path"
 import { Effect, Layer, Record, Result, Schema, ServiceMap } from "effect"
 import { Global } from "../global"
 import { Filesystem } from "../util/filesystem"
+import * as AuthSchema from "./schema"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
-export class Oauth extends Schema.Class<Oauth>("OAuth")({
-  type: Schema.Literal("oauth"),
-  refresh: Schema.String,
-  access: Schema.String,
-  expires: Schema.Number,
-  accountId: Schema.optional(Schema.String),
-  enterpriseUrl: Schema.optional(Schema.String),
-}) {}
-
-export class Api extends Schema.Class<Api>("ApiAuth")({
-  type: Schema.Literal("api"),
-  key: Schema.String,
-}) {}
-
-export class WellKnown extends Schema.Class<WellKnown>("WellKnownAuth")({
-  type: Schema.Literal("wellknown"),
-  key: Schema.String,
-  token: Schema.String,
-}) {}
-
-export const Info = Schema.Union([Oauth, Api, WellKnown])
-export type Info = Schema.Schema.Type<typeof Info>
+export type Info = AuthSchema.Info
 
 export class AuthError extends Schema.TaggedErrorClass<AuthError>()("AuthError", {
   message: Schema.String,
@@ -50,13 +30,14 @@ export namespace AuthEffect {
   export const layer = Layer.effect(
     Service,
     Effect.gen(function* () {
-      const decode = Schema.decodeUnknownOption(Info)
-
       const all = Effect.fn("Auth.all")(() =>
         Effect.tryPromise({
           try: async () => {
             const data = await Filesystem.readJson<Record<string, unknown>>(file).catch(() => ({}))
-            return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
+            return Record.filterMap(data, (value) => {
+              const parsed = AuthSchema.Info.safeParse(value)
+              return parsed.success ? Result.succeed(parsed.data) : Result.failVoid
+            })
           },
           catch: fail("Failed to read auth data"),
         }),

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
-import z from "zod"
 import { runtime } from "@/effect/runtime"
 import * as S from "./effect"
+import * as Schema from "./schema"
 
 export { OAUTH_DUMMY_KEY } from "./effect"
 
@@ -10,34 +10,11 @@ function runPromise<A>(f: (service: S.AuthEffect.Interface) => Effect.Effect<A, 
 }
 
 export namespace Auth {
-  export const Oauth = z
-    .object({
-      type: z.literal("oauth"),
-      refresh: z.string(),
-      access: z.string(),
-      expires: z.number(),
-      accountId: z.string().optional(),
-      enterpriseUrl: z.string().optional(),
-    })
-    .meta({ ref: "OAuth" })
-
-  export const Api = z
-    .object({
-      type: z.literal("api"),
-      key: z.string(),
-    })
-    .meta({ ref: "ApiAuth" })
-
-  export const WellKnown = z
-    .object({
-      type: z.literal("wellknown"),
-      key: z.string(),
-      token: z.string(),
-    })
-    .meta({ ref: "WellKnownAuth" })
-
-  export const Info = z.discriminatedUnion("type", [Oauth, Api, WellKnown]).meta({ ref: "Auth" })
-  export type Info = z.infer<typeof Info>
+  export const Oauth = Schema.Oauth
+  export const Api = Schema.Api
+  export const WellKnown = Schema.WellKnown
+  export const Info = Schema.Info
+  export type Info = Schema.Info
 
   export async function get(providerID: string) {
     return runPromise((service) => service.get(providerID))

--- a/packages/opencode/src/auth/schema.ts
+++ b/packages/opencode/src/auth/schema.ts
@@ -1,0 +1,35 @@
+import z from "zod"
+
+export const Oauth = z
+  .object({
+    type: z.literal("oauth"),
+    refresh: z.string(),
+    access: z.string(),
+    expires: z.number(),
+    accountId: z.string().optional(),
+    enterpriseUrl: z.string().optional(),
+  })
+  .catchall(z.unknown())
+  .meta({ ref: "OAuth" })
+
+export const Api = z
+  .object({
+    type: z.literal("api"),
+    key: z.string(),
+  })
+  .meta({ ref: "ApiAuth" })
+
+export const WellKnown = z
+  .object({
+    type: z.literal("wellknown"),
+    key: z.string(),
+    token: z.string(),
+  })
+  .meta({ ref: "WellKnownAuth" })
+
+export const Info = z.discriminatedUnion("type", [Oauth, Api, WellKnown]).meta({ ref: "Auth" })
+
+export type Oauth = z.infer<typeof Oauth>
+export type Api = z.infer<typeof Api>
+export type WellKnown = z.infer<typeof WellKnown>
+export type Info = z.infer<typeof Info>

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -4,7 +4,7 @@ import * as Auth from "@/auth/effect"
 import { runPromiseInstance } from "@/effect/runtime"
 import { fn } from "@/util/fn"
 import { ProviderID } from "./schema"
-import { Array as Arr, Effect, Layer, Record, Result, ServiceMap, Struct } from "effect"
+import { Array as Arr, Effect, Layer, Record, Result, ServiceMap } from "effect"
 import z from "zod"
 
 export namespace ProviderAuth {
@@ -118,7 +118,8 @@ export namespace ProviderAuth {
           ),
         )
       })
-      const pending = new Map<ProviderID, AuthOuathResult>()
+      const pending = new Map<string, AuthOuathResult>()
+      const key = (providerID: ProviderID, method: number) => `${providerID}:${method}`
 
       const methods = Effect.fn("ProviderAuth.methods")(function* () {
         return Record.map(hooks, (item) =>
@@ -167,7 +168,7 @@ export namespace ProviderAuth {
         }
 
         const result = yield* Effect.promise(() => method.authorize(input.inputs))
-        pending.set(input.providerID, result)
+        pending.set(key(input.providerID, input.method), result)
         return {
           url: result.url,
           method: result.method,
@@ -180,31 +181,35 @@ export namespace ProviderAuth {
         method: number
         code?: string
       }) {
-        const match = pending.get(input.providerID)
+        const id = key(input.providerID, input.method)
+        const match = pending.get(id)
         if (!match) return yield* Effect.fail(new OauthMissing({ providerID: input.providerID }))
         if (match.method === "code" && !input.code) {
           return yield* Effect.fail(new OauthCodeMissing({ providerID: input.providerID }))
         }
+        pending.delete(id)
 
         const result = yield* Effect.promise(() =>
           match.method === "code" ? match.callback(input.code!) : match.callback(),
         )
         if (!result || result.type !== "success") return yield* Effect.fail(new OauthCallbackFailed({}))
+        const save = result.provider ? ProviderID.make(result.provider) : input.providerID
 
         if ("key" in result) {
-          yield* auth.set(input.providerID, {
+          yield* auth.set(save, {
             type: "api",
             key: result.key,
           })
         }
 
         if ("refresh" in result) {
-          yield* auth.set(input.providerID, {
+          const { type: _, provider: __, refresh, access, expires, ...extra } = result
+          yield* auth.set(save, {
             type: "oauth",
-            access: result.access,
-            refresh: result.refresh,
-            expires: result.expires,
-            ...(result.accountId ? { accountId: result.accountId } : {}),
+            access,
+            refresh,
+            expires,
+            ...extra,
           })
         }
       })

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -56,3 +56,23 @@ test("set and remove are no-ops on keys without trailing slashes", async () => {
   const after = await Auth.all()
   expect(after["anthropic"]).toBeUndefined()
 })
+
+test("oauth auth preserves plugin metadata", async () => {
+  await Auth.set("anthropic", {
+    type: "oauth",
+    refresh: "refresh",
+    access: "access",
+    expires: 123,
+    userAgent: "claude-code/2.1.76",
+    billingHeader: "x-anthropic-billing-header: cc_version=2.1.76.4dc; cc_entrypoint=cli; cch=00000;",
+  })
+
+  const auth = await Auth.get("anthropic")
+  expect(auth).toBeDefined()
+  expect(auth?.type).toBe("oauth")
+  if (auth?.type !== "oauth") return
+  expect(auth.userAgent).toBe("claude-code/2.1.76")
+  expect(auth.billingHeader).toBe(
+    "x-anthropic-billing-header: cc_version=2.1.76.4dc; cc_entrypoint=cli; cch=00000;",
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes provider OAuth logins dropping plugin-supplied OAuth metadata during the server callback flow.

The provider auth path only persisted a small hard-coded subset of OAuth fields (access, refresh, expires, accountId). That worked for existing built-in flows, but it broke providers or plugins that need to persist additional OAuth fields
after login. In practice this caused subscription-based OAuth logins, including Anthropic/Claude Pro/Max, to stop working correctly after authentication completed.

This PR changes the auth schema and provider callback handling so OAuth credentials keep any additional plugin-supplied fields instead of silently discarding them. It also respects result.provider when saving auth and keys pending OAuth
callbacks by providerID + method so flows do not collide as easily.

Why this works: the actual login flow was succeeding, but the stored auth payload was incomplete after callback. By preserving the full successful OAuth result, downstream provider code can still access the fields it needs on later
requests.

### How did you verify your code works?

I verified this locally by:

- running bun install
- running bun test test/auth/auth.test.ts in packages/opencode
- running bun typecheck in packages/opencode

I also reproduced the Anthropic login flow manually and confirmed it worked again after this change.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR