### PR TITLE
fix: set Server.url after Bun.serve() to reflect actual bound port

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -540,7 +540,6 @@ export namespace Server {
     mdnsDomain?: string
     cors?: string[]
   }) {
-    url = new URL(`http://${opts.hostname}:${opts.port}`)
     const app = createApp(opts)
     const args = {
       hostname: opts.hostname,
@@ -557,6 +556,11 @@ export namespace Server {
     }
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
+    // Set url after Bun.serve() resolves so server.port reflects the actual
+    // bound port. When opts.port === 0, Bun picks an available port and the
+    // pre-bind value would leave url.port === "0", breaking ctx.serverUrl for
+    // plugins.
+    url = new URL(`http://${opts.hostname}:${server.port}`)
 
     const shouldPublishMDNS =
       opts.mdns &&


### PR DESCRIPTION
## Problem

When OpenCode is launched with `--port 0` (or when port 4096 is unavailable and the fallback random port is used), `ctx.serverUrl` in the plugin API always reports `http://localhost:0` — an unusable URL.

This makes it impossible for plugins to communicate back to the running OpenCode server without resorting to OS-level workarounds.

## Root Cause

In `Server.listen()`, `Server.url` was assigned **before** `Bun.serve()` was called:

```ts
// Before this fix
url = new URL(`http://${opts.hostname}:${opts.port}`)  // port is still 0 here
const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
// server.port now has the real port, but url was never updated
```

`Bun.serve()` returns a server object with `.port` set to the actual bound port, but `Server.url` was never updated to reflect it.

The module-level `Server.url` is what plugins receive via `ctx.serverUrl` (see `plugin/index.ts`):

```ts
get serverUrl(): URL {
  return Server.url ?? new URL("http://localhost:4096")
}
```

So plugins always got `http://localhost:0` when `--port 0` was used.

Note: the `listen()` fallback logic (`tryServe(4096) ?? tryServe(0)`) means this bug also affects any user where port 4096 is already taken — even without explicit `--port 0`.

## Fix

Move the `url` assignment to after `Bun.serve()` resolves, using `server.port`:

```ts
const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
url = new URL(`http://${opts.hostname}:${server.port}`)  // ← actual bound port
```

## Impact

Any plugin using `ctx.serverUrl` to talk back to the server silently received a broken URL. As a concrete example, [`@mspiegel31/opencode-cmux`](https://github.com/mspiegel31/opencode-cmux) — a plugin that calls `opencode attach <url>` to open subagent TUI panes — currently works around this with `lsof` to discover the real port from the process's TCP sockets. That workaround is macOS-only and fragile; this fix makes it unnecessary.