### PR TITLE
fix(session): prevent assistant-last message array from reaching provider APIs

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -782,13 +782,19 @@ export namespace MessageV2 {
 
     const tools = Object.fromEntries(Array.from(toolNames).map((toolName) => [toolName, { toModelOutput }]))
 
-    return convertToModelMessages(
-      result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
-      {
-        //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
-        tools,
-      },
-    )
+    const filtered = result.filter((msg) => msg.parts.some((part) => part.type !== "step-start"))
+    if (filtered.length > 0 && filtered[filtered.length - 1].role === "assistant") {
+      filtered.push({
+        id: MessageID.ascending(),
+        role: "user",
+        parts: [{ type: "text", text: "Continue." }],
+      })
+    }
+
+    return convertToModelMessages(filtered, {
+      //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
+      tools,
+    })
   }
 
   export const page = fn(


### PR DESCRIPTION
## Summary
- Fixes \"This model does not support assistant message prefill\" errors that occur when the model message array ends with an assistant message
- Adds a guard in `toModelMessages` that appends a synthetic user message when the filtered array ends with an assistant role

## Problem
After compaction, error recovery, or when filtered-out user messages leave an assistant message at the tail of the model message array, some providers and the AI SDK reject the conversation. This manifests as:

```
AI_APICallError: This model does not support assistant message prefill. 
The conversation must end with a user message.
```

Observed with `anthropic/claude-opus-4-6` where the error comes from the AI SDK's message validation before reaching the Anthropic API.

## Solution
Added a guard at the end of `toModelMessages()` in `message-v2.ts` that detects when the filtered message array ends with an assistant role and appends a synthetic `"Continue."` user message to satisfy provider requirements.

This complements the existing synthetic user message injection in `prompt.ts` (line 506) which handles the task/command case but doesn't cover all edge cases (compaction, error recovery, etc.).

## Related
- Existing workaround in `prompt.ts:505-528` for task command case
- Affects all providers that don't support assistant prefill