### PR TITLE
fix: update stale account url/email on re-login

### DIFF
--- a/packages/opencode/src/account/repo.ts
+++ b/packages/opencode/src/account/repo.ts
@@ -136,6 +136,8 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
             .onConflictDoUpdate({
               target: AccountTable.id,
               set: {
+                email: input.email,
+                url: input.url,
                 access_token: input.accessToken,
                 refresh_token: input.refreshToken,
                 token_expiry: input.expiry,


### PR DESCRIPTION
## Summary

- `persistAccount()` upsert only updated tokens on conflict, leaving stale `email` and `url` values from previous environments
- This caused re-login against a new server to keep using the old server URL for token refresh, leading to 400 errors
- Now updates all server-owned fields (`email`, `url`, tokens, expiry) on conflict

## Test plan

- [ ] Log in with an account that has a stale URL in the DB
- [ ] Verify the account row's `url` and `email` are updated after re-login
- [ ] Verify token refresh uses the new URL