### PR TITLE
fix(app): show friendly local plugin names in status popover

### DIFF
--- a/packages/app/src/utils/plugin-spec.test.ts
+++ b/packages/app/src/utils/plugin-spec.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { pluginSpec } from "./plugin-spec"
+
+describe("pluginSpec", () => {
+  test("parses npm package with version", () => {
+    expect(pluginSpec("oh-my-opencode@2.4.3")).toEqual({
+      name: "oh-my-opencode",
+      version: "2.4.3",
+    })
+  })
+
+  test("parses scoped npm package with version", () => {
+    expect(pluginSpec("@scope/plugin@1.0.0")).toEqual({
+      name: "@scope/plugin",
+      version: "1.0.0",
+    })
+  })
+
+  test("defaults npm package to latest when version is missing", () => {
+    expect(pluginSpec("@scope/plugin")).toEqual({
+      name: "@scope/plugin",
+      version: "latest",
+    })
+  })
+
+  test("parses file plugin and keeps raw specifier", () => {
+    expect(pluginSpec("file:///project/.opencode/plugins/custom-plugin.ts")).toEqual({
+      name: "custom-plugin",
+      raw: "file:///project/.opencode/plugins/custom-plugin.ts",
+    })
+  })
+
+  test("uses parent directory name when filename is index", () => {
+    expect(pluginSpec("file:///project/.opencode/plugins/my-plugin/index.js")).toEqual({
+      name: "my-plugin",
+      raw: "file:///project/.opencode/plugins/my-plugin/index.js",
+    })
+  })
+})

--- a/packages/app/src/utils/plugin-spec.ts
+++ b/packages/app/src/utils/plugin-spec.ts
@@ -1,0 +1,39 @@
+export type PluginSpec = {
+  name: string
+  version?: string
+  raw?: string
+}
+
+function fileName(value: string) {
+  try {
+    const path = decodeURIComponent(new URL(value).pathname)
+    const parts = path.split("/").filter(Boolean)
+    const file = parts[parts.length - 1] ?? path
+    const base = file.replace(/\.[^.]+$/, "")
+    if (base === "index" && parts.length > 1) {
+      return parts[parts.length - 2]
+    }
+    return base || value
+  } catch {
+    return value
+  }
+}
+
+function pkgName(value: string): PluginSpec {
+  const at = value.lastIndexOf("@")
+  if (at <= 0) return { name: value, version: "latest" }
+  return {
+    name: value.slice(0, at),
+    version: value.slice(at + 1),
+  }
+}
+
+export function pluginSpec(value: string): PluginSpec {
+  if (value.startsWith("file://")) {
+    return {
+      name: fileName(value),
+      raw: value,
+    }
+  }
+  return pkgName(value)
+}


### PR DESCRIPTION
### Issue for this PR

Closes #12478

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes unreadable plugin names in the Status popover when plugins are configured with local `file://` specifiers.

Changes included:
- parser utility to extract friendly display names from plugin specifiers
- Status popover plugin row now shows readable names for local plugins (filename or parent folder for `index.*`)
- keeps raw specifier visible (muted/truncated with full value on hover) for traceability

Why this works: users get understandable plugin labels without losing access to the exact configured source path.

### How did you verify your code works?

- `cd packages/app && bun run typecheck`
- `cd packages/app && bun test src/utils/plugin-spec.test.ts`
- Playwright visual verification of status popover tabs (dark theme)

### Screenshots / recordings

![servers dark](https://files.catbox.moe/xae3a6.png)
![plugins dark friendly names](https://files.catbox.moe/wkgukz.png)
![plugins flow dark](https://files.catbox.moe/120bwr.gif)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR