### PR TITLE
fix(tui): surface sub-agent provider errors in parent task flow

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -40,6 +40,7 @@ export const TaskTool = Tool.define(
     const run = Effect.fn("TaskTool.execute")(function* (params: z.infer<typeof parameters>, ctx: Tool.Context) {
       const cfg = yield* config.get()
 
+      // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
         yield* ctx.ask({
           permission: id,
@@ -121,6 +122,14 @@ export const TaskTool = Tool.define(
         ops.cancel(nextSession.id)
       }
 
+      function getSubagentFailureMessage(result: MessageV2.WithParts) {
+        const info = result.info
+        if (info.role !== "assistant" || !info.error) return
+        if (info.error.name === "MessageAbortedError") return
+        const detail = info.error.data.message?.trim()
+        return detail ? `Sub-agent failed: ${detail}` : "Sub-agent failed"
+      }
+
       return yield* Effect.acquireUseRelease(
         Effect.sync(() => {
           ctx.abort.addEventListener("abort", cancel)
@@ -143,6 +152,9 @@ export const TaskTool = Tool.define(
               },
               parts,
             })
+
+            const failure = getSubagentFailureMessage(result)
+            if (failure) return yield* Effect.fail(new Error(failure))
 
             return {
               title: params.description,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -64,19 +64,19 @@ const seed = Effect.fn("TaskToolTest.seed")(function* (title = "Pinned") {
   return { chat, assistant }
 })
 
-function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void; text?: string }): TaskPromptOps {
+function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void; text?: string; error?: MessageV2.ErrorInfo }): TaskPromptOps {
   return {
     cancel() {},
     resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
     prompt: (input) =>
       Effect.sync(() => {
         opts?.onPrompt?.(input)
-        return reply(input, opts?.text ?? "done")
+        return reply(input, opts?.text ?? "done", opts?.error)
       }),
   }
 }
 
-function reply(input: SessionPrompt.PromptInput, text: string): MessageV2.WithParts {
+function reply(input: SessionPrompt.PromptInput, text: string, error?: MessageV2.ErrorInfo): MessageV2.WithParts {
   const id = MessageID.ascending()
   return {
     info: {
@@ -93,6 +93,7 @@ function reply(input: SessionPrompt.PromptInput, text: string): MessageV2.WithPa
       providerID: input.model?.providerID ?? ref.providerID,
       time: { created: Date.now() },
       finish: "stop",
+      ...(error ? { error } : {}),
     },
     parts: [
       {
@@ -379,6 +380,58 @@ describe("tool.task", () => {
           },
           experimental: {
             primary_tools: ["bash", "read"],
+          },
+        },
+      },
+    ),
+  )
+
+  it.live("execute throws when subagent ends with provider error", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const { chat, assistant } = yield* seed()
+          const tool = yield* TaskTool
+          const def = yield* tool.init()
+          const error = new MessageV2.APIError({
+            message: "You are rate-limited",
+            isRetryable: false,
+            statusCode: 429,
+          }).toObject()
+          const promptOps = stubOps({ error })
+
+          const result = yield* Effect.either(
+            def.execute(
+              {
+                description: "Check provider state",
+                prompt: "Inspect provider state",
+                subagent_type: "general",
+              },
+              {
+                sessionID: chat.id,
+                messageID: assistant.id,
+                agent: "build",
+                abort: new AbortController().signal,
+                extra: { promptOps },
+                messages: [],
+                metadata: () => Effect.void,
+                ask: () => Effect.void,
+              },
+            ),
+          )
+
+          if (result._tag === "Right") {
+            throw new Error("Expected error but got success")
+          }
+          const failure = result.left
+          expect(failure.message).toContain("Sub-agent failed: You are rate-limited")
+        }),
+      {
+        config: {
+          agent: {
+            general: {
+              mode: "subagent",
+            },
           },
         },
       },


### PR DESCRIPTION
### Issue for this PR

Closes #17583

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This ensures sub-agent provider failures are visible in the parent task flow. The `task` tool previously returned normally even when the sub-agent ended with an assistant API error, which made the parent flow appear successful with no clear failure signal.

Now the task tool surfaces non-abort sub-agent assistant errors as tool failures (`Sub-agent failed: ...`). This makes rate-limit/provider failures visible in the primary flow instead of being silently swallowed.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/task.test.ts`
- `cd packages/opencode && bun run typecheck`
- Added regression test for a mocked sub-agent 429/API error propagation path

### Screenshots / recordings

_Not a UI layout change. TUI behavior change validated by test coverage._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Related: #5204