### PR TITLE
fix(cost): account for OpenRouter cache write tokens

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -272,6 +272,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
       providerMetadata[this.providerOptionsName].rejectedPredictionTokens =
         completionTokenDetails?.rejected_prediction_tokens
     }
+    if (responseBody.usage?.prompt_tokens_details?.cache_write_tokens != null) {
+      providerMetadata[this.providerOptionsName].usage = {
+        cacheWriteInputTokens: responseBody.usage?.prompt_tokens_details?.cache_write_tokens,
+      }
+    }
 
     return {
       content,
@@ -343,6 +348,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
       promptTokens: number | undefined
       promptTokensDetails: {
         cachedTokens: number | undefined
+        cacheWriteTokens: number | undefined
       }
       totalTokens: number | undefined
     } = {
@@ -355,6 +361,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
       promptTokens: undefined,
       promptTokensDetails: {
         cachedTokens: undefined,
+        cacheWriteTokens: undefined,
       },
       totalTokens: undefined,
     }
@@ -429,6 +436,9 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
               }
               if (prompt_tokens_details?.cached_tokens != null) {
                 usage.promptTokensDetails.cachedTokens = prompt_tokens_details?.cached_tokens
+              }
+              if (prompt_tokens_details?.cache_write_tokens != null) {
+                usage.promptTokensDetails.cacheWriteTokens = prompt_tokens_details?.cache_write_tokens
               }
             }
 
@@ -666,6 +676,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
               providerMetadata[providerOptionsName].rejectedPredictionTokens =
                 usage.completionTokensDetails.rejectedPredictionTokens
             }
+            if (usage.promptTokensDetails.cacheWriteTokens != null) {
+              providerMetadata[providerOptionsName].usage = {
+                cacheWriteInputTokens: usage.promptTokensDetails.cacheWriteTokens,
+              }
+            }
 
             controller.enqueue({
               type: "finish",
@@ -696,6 +711,7 @@ const openaiCompatibleTokenUsageSchema = z
     prompt_tokens_details: z
       .object({
         cached_tokens: z.number().nullish(),
+        cache_write_tokens: z.number().nullish(),
       })
       .nullish(),
     completion_tokens_details: z

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -810,6 +810,8 @@ export namespace Session {
           input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
           // @ts-expect-error
           input.metadata?.["venice"]?.["usage"]?.["cacheCreationInputTokens"] ??
+          // @ts-expect-error
+          input.metadata?.["openrouter"]?.["usage"]?.["cacheWriteInputTokens"] ??
           0) as number,
       )
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -278,6 +278,30 @@ describe("session.getUsage", () => {
     expect(result.tokens.cache.read).toBe(200)
   })
 
+  test("handles cache write tokens from usage payload", () => {
+    const model = createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/openai-compatible" })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 10_000,
+        outputTokens: 500,
+        totalTokens: 10_500,
+        cachedInputTokens: 2_000,
+      },
+      metadata: {
+        openrouter: {
+          usage: {
+            cacheWriteInputTokens: 1_500,
+          },
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(6_500)
+    expect(result.tokens.cache.read).toBe(2_000)
+    expect(result.tokens.cache.write).toBe(1_500)
+  })
+
   test("handles anthropic cache write metadata", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const result = Session.getUsage({


### PR DESCRIPTION
### Issue for this PR

Closes #18440

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes OpenRouter cost underestimation when cache write tokens are present. OpenAI-compatible responses can report `prompt_tokens_details.cache_write_tokens`, but we were not carrying that through for usage accounting.

Changes in this PR:
- parse `cache_write_tokens` in OpenAI-compatible provider paths (stream + non-stream)
- persist that value into provider metadata (`openrouter.usage.cacheWriteInputTokens`)
- include that metadata fallback in `Session.getUsage` so cache write tokens are counted in token/cost totals
- add regression coverage for the OpenRouter metadata path in `Session.getUsage` tests

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/compaction.test.ts`
- `cd packages/opencode && bun run typecheck`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR