### PR TITLE
fix: inherit provider loaders for provider aliases

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -979,6 +979,10 @@ export namespace Config {
     .extend({
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
+      auth_provider: z
+        .string()
+        .optional()
+        .describe("Provider to inherit SDK and model loading behavior from"),
       models: z
         .record(
           z.string(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -55,6 +55,22 @@ import { ModelID, ProviderID } from "./schema"
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
+  function driver(cfg: Config.Info, id: string): string {
+    const seen = new Set<string>()
+    let current = id
+    while (true) {
+      if (seen.has(current)) return current
+      seen.add(current)
+      const next = cfg.provider?.[current]?.auth_provider
+      if (!next || next === current) return current
+      current = next
+    }
+  }
+
+  function aliases(cfg: Config.Info, source: string): string[] {
+    return Object.keys(cfg.provider ?? {}).filter((item) => item !== source && driver(cfg, item) === source)
+  }
+
   function shouldUseCopilotResponsesApi(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
     if (!match) return false
@@ -1069,18 +1085,26 @@ export namespace Provider {
 
     for (const plugin of await Plugin.list()) {
       if (!plugin.auth) continue
-      const providerID = ProviderID.make(plugin.auth.provider)
-      if (disabled.has(providerID)) continue
+      const loader = plugin.auth.loader
+      const source = plugin.auth.provider
 
-      const auth = await Auth.get(providerID)
-      if (!auth) continue
-      if (!plugin.auth.loader) continue
-
-      if (auth) {
-        const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
+      const load = async (id: string) => {
+        const providerID = ProviderID.make(id)
+        if (disabled.has(providerID)) return
+        const auth = await Auth.get(providerID)
+        if (!auth) return
+        if (!loader) return
+        const info = database[id]
+        if (!info) return
+        const options = await loader(() => Auth.get(providerID) as any, info)
         const opts = options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
+      }
+
+      await load(source)
+      for (const id of aliases(config, source)) {
+        await load(id)
       }
     }
 
@@ -1101,6 +1125,15 @@ export namespace Provider {
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
       }
+    }
+
+    for (const [id] of configProviders) {
+      const providerID = ProviderID.make(id)
+      if (disabled.has(providerID)) continue
+      const sourceID = ProviderID.make(driver(config, id))
+      if (sourceID === providerID) continue
+      if (modelLoaders[sourceID]) modelLoaders[providerID] = modelLoaders[sourceID]
+      if (varsLoaders[sourceID]) varsLoaders[providerID] = varsLoaders[sourceID]
     }
 
     // load config


### PR DESCRIPTION
### Issue for this PR

Closes #18486

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fix custom providers configured with `auth_provider` so they inherit the referenced provider's SDK options and model loader behavior.

Before this change, built-in auth/plugin loaders were only applied to the source provider id and there is no way to reuse built-in sdk auth/model-loading behavior.

This change applies plugin auth loaders to aliased providers and reuses model/vars loaders from the referenced provider, so config like this now works:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "my-github-copilot": {
      "name": "My GitHub Copilot",
      "auth_provider": "github-copilot",
      "npm": "@ai-sdk/github-copilot"
    }
  }
}
```

With this change, my-github-copilot behaves like a GitHub Copilot-backed provider for auth/model loading, while still keeping its own provider id and config entry instead of overriding github-copilot directly.

Without this fix, using a custom id here is limiting because the aliased provider does not inherit the built-in loader behavior.

### How did you verify your code works?

I cherry-picked this onto current upstream `dev`, verified the PR diff is limited to this fix, and ran `bun typecheck` from `packages/opencode`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR