### PR TITLE
fix(tui): prevent subagent sessions from overwriting the selected agent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -154,13 +154,13 @@ export function Prompt(props: PromptProps) {
   createEffect(() => {
     const sessionID = props.sessionID
     const msg = lastUserMessage()
+    const info = sessionID ? sync.session.get(sessionID) : undefined
 
     if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
+      if (!sessionID || !msg || !info || info.parentID) return
 
       syncedSessionID = sessionID
 
-      // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
       if (msg.agent && isPrimaryAgent) {
         local.agent.set(msg.agent)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -219,6 +219,7 @@ export function Session() {
     const part = evt.properties.part
     if (part.type !== "tool") return
     if (part.sessionID !== route.sessionID) return
+    if (session()?.parentID) return
     if (part.state.status !== "completed") return
     if (part.id === lastSwitch) return
 


### PR DESCRIPTION
## Summary

Fixes #18404

Prevent child/subagent sessions from mutating the globally selected primary agent in the TUI.

This change gates both:
- prompt-state restore
- tool-driven plan/build agent switching

to root sessions only (`!session.parentID`).

As a result, subagent sessions no longer overwrite the selected primary agent after tool activity, while existing root-session behavior remains unchanged.

## Testing

- Verified the change is limited to:
  - `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
  - `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`
- CI `bun typecheck` currently fails in unrelated `packages/app` files:
  - `src/components/dialog-connect-provider.tsx`
  - `src/components/dialog-custom-provider.tsx`
- Local Bun/tsgo validation was unavailable in the original shell used for development