### PR TITLE
fix(bundler): rewrite namespace re-exports for Bun bundler compatibility

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -1,40 +1,43 @@
 import { runPromiseInstance } from "@/effect/runtime"
-import { File as S } from "./service"
+import * as Mod from "./service"
+
+const init = () => {
+  return runPromiseInstance(Mod.File.Service.use((svc) => svc.init()))
+}
+
+const status = async () => {
+  return runPromiseInstance(Mod.File.Service.use((svc) => svc.status()))
+}
+
+const read = async (file: string): Promise<File.Content> => {
+  return runPromiseInstance(Mod.File.Service.use((svc) => svc.read(file)))
+}
+
+const list = async (dir?: string) => {
+  return runPromiseInstance(Mod.File.Service.use((svc) => svc.list(dir)))
+}
+
+const search = async (input: { query: string; limit?: number; dirs?: boolean; type?: "file" | "directory" }) => {
+  return runPromiseInstance(Mod.File.Service.use((svc) => svc.search(input)))
+}
+
+export const File = {
+  Info: Mod.File.Info,
+  Node: Mod.File.Node,
+  Content: Mod.File.Content,
+  Event: Mod.File.Event,
+  Service: Mod.File.Service,
+  layer: Mod.File.layer,
+  init,
+  status,
+  read,
+  list,
+  search,
+}
 
 export namespace File {
-  export const Info = S.Info
-  export type Info = S.Info
-
-  export const Node = S.Node
-  export type Node = S.Node
-
-  export const Content = S.Content
-  export type Content = S.Content
-
-  export const Event = S.Event
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-
-  export function init() {
-    return runPromiseInstance(S.Service.use((svc) => svc.init()))
-  }
-
-  export async function status() {
-    return runPromiseInstance(S.Service.use((svc) => svc.status()))
-  }
-
-  export async function read(file: string): Promise<Content> {
-    return runPromiseInstance(S.Service.use((svc) => svc.read(file)))
-  }
-
-  export async function list(dir?: string) {
-    return runPromiseInstance(S.Service.use((svc) => svc.list(dir)))
-  }
-
-  export async function search(input: { query: string; limit?: number; dirs?: boolean; type?: "file" | "directory" }) {
-    return runPromiseInstance(S.Service.use((svc) => svc.search(input)))
-  }
+  export type Info = Mod.File.Info
+  export type Node = Mod.File.Node
+  export type Content = Mod.File.Content
+  export type Interface = Mod.File.Interface
 }

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -1,28 +1,33 @@
 import { runPromiseInstance } from "@/effect/runtime"
 import type { SessionID } from "@/session/schema"
-import { FileTime as S } from "./time-service"
+import * as Mod from "./time-service"
+
+const read = (sessionID: SessionID, file: string) => {
+  return runPromiseInstance(Mod.FileTime.Service.use((s) => s.read(sessionID, file)))
+}
+
+const get = (sessionID: SessionID, file: string) => {
+  return runPromiseInstance(Mod.FileTime.Service.use((s) => s.get(sessionID, file)))
+}
+
+const assert = async (sessionID: SessionID, filepath: string) => {
+  return runPromiseInstance(Mod.FileTime.Service.use((s) => s.assert(sessionID, filepath)))
+}
+
+const withLock = async <T>(filepath: string, fn: () => Promise<T>): Promise<T> => {
+  return runPromiseInstance(Mod.FileTime.Service.use((s) => s.withLock(filepath, fn)))
+}
+
+export const FileTime = {
+  Service: Mod.FileTime.Service,
+  layer: Mod.FileTime.layer,
+  read,
+  get,
+  assert,
+  withLock,
+}
 
 export namespace FileTime {
-  export type Stamp = S.Stamp
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-
-  export function read(sessionID: SessionID, file: string) {
-    return runPromiseInstance(S.Service.use((s) => s.read(sessionID, file)))
-  }
-
-  export function get(sessionID: SessionID, file: string) {
-    return runPromiseInstance(S.Service.use((s) => s.get(sessionID, file)))
-  }
-
-  export async function assert(sessionID: SessionID, filepath: string) {
-    return runPromiseInstance(S.Service.use((s) => s.assert(sessionID, filepath)))
-  }
-
-  export async function withLock<T>(filepath: string, fn: () => Promise<T>): Promise<T> {
-    return runPromiseInstance(S.Service.use((s) => s.withLock(filepath, fn)))
-  }
+  export type Stamp = Mod.FileTime.Stamp
+  export type Interface = Mod.FileTime.Interface
 }

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -1,16 +1,18 @@
 import { runPromiseInstance } from "@/effect/runtime"
-import { Format as S } from "./service"
+import * as Mod from "./service"
+
+const status = async () => {
+  return runPromiseInstance(Mod.Format.Service.use((s) => s.status()))
+}
+
+export const Format = {
+  Status: Mod.Format.Status,
+  Service: Mod.Format.Service,
+  layer: Mod.Format.layer,
+  status,
+}
 
 export namespace Format {
-  export const Status = S.Status
-  export type Status = S.Status
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-
-  export async function status() {
-    return runPromiseInstance(S.Service.use((s) => s.status()))
-  }
+  export type Status = Mod.Format.Status
+  export type Interface = Mod.Format.Interface
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -1,52 +1,51 @@
 import { runPromiseInstance } from "@/effect/runtime"
 import { fn } from "@/util/fn"
 import z from "zod"
-import { Permission as S } from "./service"
+import * as Mod from "./service"
+
+const list = async (): Promise<Mod.Permission.Request[]> => {
+  return runPromiseInstance(Mod.Permission.Service.use((s) => s.list()))
+}
+
+export const PermissionNext = {
+  Action: Mod.Permission.Action,
+  Rule: Mod.Permission.Rule,
+  Ruleset: Mod.Permission.Ruleset,
+  Request: Mod.Permission.Request,
+  Reply: Mod.Permission.Reply,
+  Approval: Mod.Permission.Approval,
+  Event: Mod.Permission.Event,
+  RejectedError: Mod.Permission.RejectedError,
+  CorrectedError: Mod.Permission.CorrectedError,
+  DeniedError: Mod.Permission.DeniedError,
+  AskInput: Mod.Permission.AskInput,
+  ReplyInput: Mod.Permission.ReplyInput,
+  Service: Mod.Permission.Service,
+  layer: Mod.Permission.layer,
+  evaluate: Mod.Permission.evaluate,
+  fromConfig: Mod.Permission.fromConfig,
+  merge: Mod.Permission.merge,
+  disabled: Mod.Permission.disabled,
+  ask: fn(
+    Mod.Permission.AskInput,
+    async (input: z.infer<typeof Mod.Permission.AskInput>): Promise<void> =>
+      runPromiseInstance(Mod.Permission.Service.use((s) => s.ask(input))),
+  ),
+  reply: fn(
+    Mod.Permission.ReplyInput,
+    async (input: z.infer<typeof Mod.Permission.ReplyInput>): Promise<void> =>
+      runPromiseInstance(Mod.Permission.Service.use((s) => s.reply(input))),
+  ),
+  list,
+}
 
 export namespace PermissionNext {
-  export const Action = S.Action
-  export type Action = S.Action
-
-  export const Rule = S.Rule
-  export type Rule = S.Rule
-
-  export const Ruleset = S.Ruleset
-  export type Ruleset = S.Ruleset
-
-  export const Request = S.Request
-  export type Request = S.Request
-
-  export const Reply = S.Reply
-  export type Reply = S.Reply
-
-  export const Approval = S.Approval
-  export type Approval = z.infer<typeof S.Approval>
-
-  export const Event = S.Event
-
-  export const RejectedError = S.RejectedError
-  export const CorrectedError = S.CorrectedError
-  export const DeniedError = S.DeniedError
-  export type Error = S.Error
-
-  export const AskInput = S.AskInput
-  export const ReplyInput = S.ReplyInput
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-
-  export const evaluate = S.evaluate
-  export const fromConfig = S.fromConfig
-  export const merge = S.merge
-  export const disabled = S.disabled
-
-  export const ask = fn(S.AskInput, async (input) => runPromiseInstance(S.Service.use((s) => s.ask(input))))
-
-  export const reply = fn(S.ReplyInput, async (input) => runPromiseInstance(S.Service.use((s) => s.reply(input))))
-
-  export async function list() {
-    return runPromiseInstance(S.Service.use((s) => s.list()))
-  }
+  export type Action = Mod.Permission.Action
+  export type Rule = Mod.Permission.Rule
+  export type Ruleset = Mod.Permission.Ruleset
+  export type Request = Mod.Permission.Request
+  export type Reply = Mod.Permission.Reply
+  export type Approval = z.infer<typeof Mod.Permission.Approval>
+  export type Error = Mod.Permission.Error
+  export type Interface = Mod.Permission.Interface
 }

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -2,47 +2,49 @@ import { runPromiseInstance } from "@/effect/runtime"
 import { fn } from "@/util/fn"
 import { ProviderID } from "./schema"
 import z from "zod"
-import { ProviderAuth as S } from "./auth-service"
+import * as Mod from "./auth-service"
+
+const methods = async () => {
+  return runPromiseInstance(Mod.ProviderAuth.Service.use((svc) => svc.methods()))
+}
+
+const authorize = fn(
+  z.object({
+    providerID: ProviderID.zod,
+    method: z.number(),
+    inputs: z.record(z.string(), z.string()).optional(),
+  }),
+  async (input): Promise<ProviderAuth.Authorization | undefined> =>
+    runPromiseInstance(Mod.ProviderAuth.Service.use((svc) => svc.authorize(input))),
+)
+
+const callback = fn(
+  z.object({
+    providerID: ProviderID.zod,
+    method: z.number(),
+    code: z.string().optional(),
+  }),
+  async (input) => runPromiseInstance(Mod.ProviderAuth.Service.use((svc) => svc.callback(input))),
+)
+
+export const ProviderAuth = {
+  Method: Mod.ProviderAuth.Method,
+  Authorization: Mod.ProviderAuth.Authorization,
+  OauthMissing: Mod.ProviderAuth.OauthMissing,
+  OauthCodeMissing: Mod.ProviderAuth.OauthCodeMissing,
+  OauthCallbackFailed: Mod.ProviderAuth.OauthCallbackFailed,
+  ValidationFailed: Mod.ProviderAuth.ValidationFailed,
+  Service: Mod.ProviderAuth.Service,
+  layer: Mod.ProviderAuth.layer,
+  defaultLayer: Mod.ProviderAuth.defaultLayer,
+  methods,
+  authorize,
+  callback,
+}
 
 export namespace ProviderAuth {
-  export const Method = S.Method
-  export type Method = S.Method
-
-  export const Authorization = S.Authorization
-  export type Authorization = S.Authorization
-
-  export const OauthMissing = S.OauthMissing
-  export const OauthCodeMissing = S.OauthCodeMissing
-  export const OauthCallbackFailed = S.OauthCallbackFailed
-  export const ValidationFailed = S.ValidationFailed
-  export type Error = S.Error
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-  export const defaultLayer = S.defaultLayer
-
-  export async function methods() {
-    return runPromiseInstance(S.Service.use((svc) => svc.methods()))
-  }
-
-  export const authorize = fn(
-    z.object({
-      providerID: ProviderID.zod,
-      method: z.number(),
-      inputs: z.record(z.string(), z.string()).optional(),
-    }),
-    async (input): Promise<Authorization | undefined> =>
-      runPromiseInstance(S.Service.use((svc) => svc.authorize(input))),
-  )
-
-  export const callback = fn(
-    z.object({
-      providerID: ProviderID.zod,
-      method: z.number(),
-      code: z.string().optional(),
-    }),
-    async (input) => runPromiseInstance(S.Service.use((svc) => svc.callback(input))),
-  )
+  export type Method = Mod.ProviderAuth.Method
+  export type Authorization = Mod.ProviderAuth.Authorization
+  export type Error = Mod.ProviderAuth.Error
+  export type Interface = Mod.ProviderAuth.Interface
 }

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -1,49 +1,49 @@
 import { runPromiseInstance } from "@/effect/runtime"
 import type { MessageID, SessionID } from "@/session/schema"
 import type { QuestionID } from "./schema"
-import { Question as S } from "./service"
+import * as Q from "./service"
+
+const ask = async (input: {
+  sessionID: SessionID
+  questions: Question.Info[]
+  tool?: { messageID: MessageID; callID: string }
+}): Promise<Question.Answer[]> => {
+  return runPromiseInstance(Q.Question.Service.use((s) => s.ask(input)))
+}
+
+const reply = async (input: { requestID: QuestionID; answers: Question.Answer[] }) => {
+  return runPromiseInstance(Q.Question.Service.use((s) => s.reply(input)))
+}
+
+const reject = async (requestID: QuestionID) => {
+  return runPromiseInstance(Q.Question.Service.use((s) => s.reject(requestID)))
+}
+
+const list = async () => {
+  return runPromiseInstance(Q.Question.Service.use((s) => s.list()))
+}
+
+export const Question = {
+  Option: Q.Question.Option,
+  Info: Q.Question.Info,
+  Request: Q.Question.Request,
+  Answer: Q.Question.Answer,
+  Reply: Q.Question.Reply,
+  Event: Q.Question.Event,
+  RejectedError: Q.Question.RejectedError,
+  Service: Q.Question.Service,
+  layer: Q.Question.layer,
+  ask,
+  reply,
+  reject,
+  list,
+}
 
 export namespace Question {
-  export const Option = S.Option
-  export type Option = S.Option
-
-  export const Info = S.Info
-  export type Info = S.Info
-
-  export const Request = S.Request
-  export type Request = S.Request
-
-  export const Answer = S.Answer
-  export type Answer = S.Answer
-
-  export const Reply = S.Reply
-  export type Reply = S.Reply
-
-  export const Event = S.Event
-  export const RejectedError = S.RejectedError
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-
-  export async function ask(input: {
-    sessionID: SessionID
-    questions: Info[]
-    tool?: { messageID: MessageID; callID: string }
-  }): Promise<Answer[]> {
-    return runPromiseInstance(S.Service.use((s) => s.ask(input)))
-  }
-
-  export async function reply(input: { requestID: QuestionID; answers: Answer[] }) {
-    return runPromiseInstance(S.Service.use((s) => s.reply(input)))
-  }
-
-  export async function reject(requestID: QuestionID) {
-    return runPromiseInstance(S.Service.use((s) => s.reject(requestID)))
-  }
-
-  export async function list() {
-    return runPromiseInstance(S.Service.use((s) => s.list()))
-  }
+  export type Option = Q.Question.Option
+  export type Info = Q.Question.Info
+  export type Request = Q.Question.Request
+  export type Answer = Q.Question.Answer
+  export type Reply = Q.Question.Reply
+  export type Interface = Q.Question.Interface
 }

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -1,35 +1,38 @@
 import { runPromiseInstance } from "@/effect/runtime"
 import type { Agent } from "@/agent/agent"
-import { Skill as S } from "./service"
+import * as Mod from "./service"
+
+const get = async (name: string) => {
+  return runPromiseInstance(Mod.Skill.Service.use((skill) => skill.get(name)))
+}
+
+const all = async () => {
+  return runPromiseInstance(Mod.Skill.Service.use((skill) => skill.all()))
+}
+
+const dirs = async () => {
+  return runPromiseInstance(Mod.Skill.Service.use((skill) => skill.dirs()))
+}
+
+const available = async (agent?: Agent.Info) => {
+  return runPromiseInstance(Mod.Skill.Service.use((skill) => skill.available(agent)))
+}
+
+export const Skill = {
+  Info: Mod.Skill.Info,
+  InvalidError: Mod.Skill.InvalidError,
+  NameMismatchError: Mod.Skill.NameMismatchError,
+  Service: Mod.Skill.Service,
+  layer: Mod.Skill.layer,
+  defaultLayer: Mod.Skill.defaultLayer,
+  fmt: Mod.Skill.fmt,
+  get,
+  all,
+  dirs,
+  available,
+}
 
 export namespace Skill {
-  export const Info = S.Info
-  export type Info = S.Info
-
-  export const InvalidError = S.InvalidError
-  export const NameMismatchError = S.NameMismatchError
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-  export const defaultLayer = S.defaultLayer
-
-  export const fmt = S.fmt
-
-  export async function get(name: string) {
-    return runPromiseInstance(S.Service.use((skill) => skill.get(name)))
-  }
-
-  export async function all() {
-    return runPromiseInstance(S.Service.use((skill) => skill.all()))
-  }
-
-  export async function dirs() {
-    return runPromiseInstance(S.Service.use((skill) => skill.dirs()))
-  }
-
-  export async function available(agent?: Agent.Info) {
-    return runPromiseInstance(S.Service.use((skill) => skill.available(agent)))
-  }
+  export type Info = Mod.Skill.Info
+  export type Interface = Mod.Skill.Interface
 }

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -1,44 +1,51 @@
 import { runPromiseInstance } from "@/effect/runtime"
-import { Snapshot as S } from "./service"
+import * as Snap from "./service"
+
+const cleanup = async () => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.cleanup()))
+}
+
+const track = async () => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.track()))
+}
+
+const patch = async (hash: string) => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.patch(hash)))
+}
+
+const restore = async (snapshot: string) => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.restore(snapshot)))
+}
+
+const revert = async (patches: Snapshot.Patch[]) => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.revert(patches)))
+}
+
+const diff = async (hash: string) => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.diff(hash)))
+}
+
+const diffFull = async (from: string, to: string) => {
+  return runPromiseInstance(Snap.Snapshot.Service.use((svc) => svc.diffFull(from, to)))
+}
+
+export const Snapshot = {
+  Patch: Snap.Snapshot.Patch,
+  FileDiff: Snap.Snapshot.FileDiff,
+  Service: Snap.Snapshot.Service,
+  layer: Snap.Snapshot.layer,
+  defaultLayer: Snap.Snapshot.defaultLayer,
+  cleanup,
+  track,
+  patch,
+  restore,
+  revert,
+  diff,
+  diffFull,
+}
 
 export namespace Snapshot {
-  export const Patch = S.Patch
-  export type Patch = S.Patch
-
-  export const FileDiff = S.FileDiff
-  export type FileDiff = S.FileDiff
-
-  export type Interface = S.Interface
-
-  export const Service = S.Service
-  export const layer = S.layer
-  export const defaultLayer = S.defaultLayer
-
-  export async function cleanup() {
-    return runPromiseInstance(S.Service.use((svc) => svc.cleanup()))
-  }
-
-  export async function track() {
-    return runPromiseInstance(S.Service.use((svc) => svc.track()))
-  }
-
-  export async function patch(hash: string) {
-    return runPromiseInstance(S.Service.use((svc) => svc.patch(hash)))
-  }
-
-  export async function restore(snapshot: string) {
-    return runPromiseInstance(S.Service.use((svc) => svc.restore(snapshot)))
-  }
-
-  export async function revert(patches: Patch[]) {
-    return runPromiseInstance(S.Service.use((svc) => svc.revert(patches)))
-  }
-
-  export async function diff(hash: string) {
-    return runPromiseInstance(S.Service.use((svc) => svc.diff(hash)))
-  }
-
-  export async function diffFull(from: string, to: string) {
-    return runPromiseInstance(S.Service.use((svc) => svc.diffFull(from, to)))
-  }
+  export type Patch = Snap.Snapshot.Patch
+  export type FileDiff = Snap.Snapshot.FileDiff
+  export type Interface = Snap.Snapshot.Interface
 }

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -1,18 +1,20 @@
 import type { Agent } from "../agent/agent"
 import { runtime } from "@/effect/runtime"
-import { Truncate as S } from "./truncate-effect"
+import * as Mod from "./truncate-effect"
+
+const output = async (text: string, options: Truncate.Options = {}, agent?: Agent.Info): Promise<Truncate.Result> => {
+  return runtime.runPromise(Mod.Truncate.Service.use((s) => s.output(text, options, agent)))
+}
+
+export const Truncate = {
+  MAX_LINES: Mod.Truncate.MAX_LINES,
+  MAX_BYTES: Mod.Truncate.MAX_BYTES,
+  DIR: Mod.Truncate.DIR,
+  GLOB: Mod.Truncate.GLOB,
+  output,
+}
 
 export namespace Truncate {
-  export const MAX_LINES = S.MAX_LINES
-  export const MAX_BYTES = S.MAX_BYTES
-  export const DIR = S.DIR
-  export const GLOB = S.GLOB
-
-  export type Result = S.Result
-
-  export type Options = S.Options
-
-  export async function output(text: string, options: Options = {}, agent?: Agent.Info): Promise<Result> {
-    return runtime.runPromise(S.Service.use((s) => s.output(text, options, agent)))
-  }
+  export type Result = Mod.Truncate.Result
+  export type Options = Mod.Truncate.Options
 }


### PR DESCRIPTION
### Issue for this PR

Closes #18525

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rewrites 9 facade/index files that re-export values from service modules inside TypeScript namespaces. Bun's bundler transpiles namespace re-exports like `export const FileDiff = S.FileDiff` into self-referential assignments (`Snapshot.FileDiff = Snapshot.FileDiff`) which evaluate to `undefined` when circular imports delay module initialization.

The fix splits each file into:
- A plain `export const X = { ... }` object literal with value exports (eagerly initialized with correct references)
- A separate `export namespace X { ... }` block with type-only exports (erased at runtime)

This preserves the identical public API surface while ensuring Bun's bundler emits correct initialization code regardless of module evaluation order.

**Files changed:** `src/snapshot/index.ts`, `src/question/index.ts`, `src/provider/auth.ts`, `src/file/index.ts`, `src/file/time.ts`, `src/skill/skill.ts`, `src/tool/truncate.ts`, `src/permission/index.ts`, `src/format/index.ts`

### How did you verify your code works?

1. `bun typecheck` — passes clean (`tsgo --noEmit`)
2. `bun run build --single` — builds successfully
3. Bundled binary `opencode serve` — starts and listens without TypeError (previously crashed with `Snapshot2.FileDiff.array` and `ProviderAuth2.Authorization.optional` errors)
4. Bundled binary `opencode run "echo test"` — creates session, runs LLM prompt loop, executes tools successfully

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR