### PR TITLE
fix(core): restore SIGHUP exit handler (#16057)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -53,6 +53,7 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
         message: store,
       },
     )
+    process.on("SIGHUP", () => exit())
     return exit
   },
 })

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -47,11 +47,6 @@ process.on("uncaughtException", (e) => {
   })
 })
 
-// Ensure the process exits on terminal hangup (eg. closing the terminal tab).
-// Without this, long-running commands like `serve` block on a never-resolving
-// promise and survive as orphaned processes.
-process.on("SIGHUP", () => process.exit())
-
 let cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -47,6 +47,11 @@ process.on("uncaughtException", (e) => {
   })
 })
 
+// Ensure the process exits on terminal hangup (eg. closing the terminal tab).
+// Without this, long-running commands like `serve` block on a never-resolving
+// promise and survive as orphaned processes.
+process.on("SIGHUP", () => process.exit())
+
 let cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")


### PR DESCRIPTION
## Summary

This restores the SIGHUP handler that was previously reverted in commit a73ac650e. The handler ensures the process exits on terminal hangup (eg. closing the terminal tab), preventing long-running commands like `serve` from becoming orphaned processes.

## Changes

- Added `process.on("SIGHUP", () => process.exit())` to `packages/opencode/src/index.ts`

## Why this matters

Without this handler, long-running commands like `serve` can block on a never-resolving promise and survive as orphaned processes after the terminal closes.