### PR TITLE
fix(app): open inline comments directly on touch devices

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createMemo, Match, on, onCleanup, Switch } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
+import { createMediaQuery } from "@solid-primitives/media"
 import type { FileSearchHandle } from "@opencode-ai/ui/file"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
 import { cloneSelectedLineRange, previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
@@ -56,6 +57,7 @@ export function FileTabContent(props: { tab: string }) {
   const file = useFile()
   const comments = useComments()
   const language = useLanguage()
+  const touch = createMediaQuery("(hover: none), (pointer: coarse)")
   const prompt = usePrompt()
   const fileComponent = useFileComponent()
   const { sessionKey, tabs, view } = useSessionLayout()
@@ -398,7 +400,7 @@ export function FileTabContent(props: { tab: string }) {
           cacheKey: cacheKey(),
         }}
         enableLineSelection
-        enableHoverUtility
+        enableHoverUtility={!touch()}
         selectedLines={activeSelection()}
         commentedLines={commentedLines()}
         onRendered={() => {
@@ -406,12 +408,16 @@ export function FileTabContent(props: { tab: string }) {
         }}
         annotations={commentsUi.annotations()}
         renderAnnotation={commentsUi.renderAnnotation}
-        renderHoverUtility={commentsUi.renderHoverUtility}
+        renderHoverUtility={touch() ? undefined : commentsUi.renderHoverUtility}
         onLineSelected={(range: SelectedLineRange | null) => {
           commentsUi.onLineSelected(range)
         }}
         onLineNumberSelectionEnd={commentsUi.onLineNumberSelectionEnd}
         onLineSelectionEnd={(range: SelectedLineRange | null) => {
+          if (touch() && range) {
+            commentsUi.onLineNumberSelectionEnd(range)
+            return
+          }
           commentsUi.onLineSelectionEnd(range)
         }}
         search={search}


### PR DESCRIPTION
### Issue for this PR

Closes #17598

### Type of change

- [x] Bug fix

### What does this PR do?

Inline comments were only discoverable through the hover affordance in the file view, which does not work well on touch devices like iPad.

This change keeps the desktop hover flow unchanged and makes touch devices open the inline comment draft directly after a line selection.

### How did you verify your code works?

1. Ran bun typecheck in app
2. Verified desktop behavior is unchanged: inline comment entry still appears on hover
3. Verified on touch devices that selecting a line opens the inline comment draft directly
4. Confirmed existing inline comment interactions still work after opening the draft

### Screenshots / recordings

Before

https://github.com/user-attachments/assets/6b6171ca-b34f-446f-9dd6-de440e738b25

After

https://github.com/user-attachments/assets/9cfc7e18-908f-4683-b819-b0eabcb2d212

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
