### PR TITLE
Add custom type for OpenCode agent server

### DIFF
--- a/packages/web/src/content/docs/fr/acp.mdx
+++ b/packages/web/src/content/docs/fr/acp.mdx
@@ -31,6 +31,7 @@ Ajoutez à votre configuration [Zed](https://zed.dev) (`~/.config/zed/settings.j
 {
   "agent_servers": {
     "OpenCode": {
+      "type": "custom",
       "command": "opencode",
       "args": ["acp"]
     }


### PR DESCRIPTION
When installing opencode locally using brew, to bind it to zed it needs a mandatory type prop. "Custom" works well in my installation.

### Issue for this PR
When I tried copy/paste the snippet, zed threw a warning for the missing "type" prop.

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
it indicates a prop to add in zed's settings.json file.

### How did you verify your code works?

On macos, using zed and opencode installed via brew.


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
