### PR TITLE
fix: discourage _noop tool call during LiteLLM compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -174,6 +174,7 @@ export namespace SessionCompaction {
     const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
 Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
 The summary that you construct will be used so that another agent can read it and continue the work.
+Do not call any tools. Respond only with the summary text.
 
 When constructing the summary, try to stick to this template:
 ---

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -176,11 +176,19 @@ export namespace LLM {
       input.model.providerID.toLowerCase().includes("litellm") ||
       input.model.api.id.toLowerCase().includes("litellm")
 
+    // LiteLLM/Bedrock rejects requests where the message history contains tool
+    // calls but no tools param is present. When there are no active tools (e.g.
+    // during compaction), inject a stub tool to satisfy the validation requirement.
+    // The stub description explicitly tells the model not to call it.
     if (isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
       tools["_noop"] = tool({
-        description:
-          "Placeholder for LiteLLM/Anthropic proxy compatibility - required when message history contains tool calls but no active tools are needed",
-        inputSchema: jsonSchema({ type: "object", properties: {} }),
+        description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            reason: { type: "string", description: "Unused" },
+          },
+        }),
         execute: async () => ({ output: "", title: "", metadata: {} }),
       })
     }


### PR DESCRIPTION
### Issue for this PR

Closes #14368
Closes #18053

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When compaction runs with no active tools, LiteLLM/Bedrock rejects the request if the message history contains tool calls but the `tools` param is absent. The existing fix injected a `_noop` stub. The model would call the stub instead of generating a summary — producing the post-compaction amnesia. This PR changes the stubs description to explicitly say it must never be called, and adds a "Do not call any tools" instruction to the compaction prompt so the model is discouraged from invoking it via both the tool definition and the prompt.

### How did you verify your code works?

Ran `bun typecheck` from `packages/opencode/` — no errors. I also ran opencode locally with the fix applied and triggered compaction in a live session (the session in which this PR was created). The session successfully compacted and retained context across the compaction boundary, which was not possible before the fix.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR