### PR TITLE
fix(app): prevent scroll jump during history backfill

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -132,13 +132,11 @@ function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
       fn()
       return
     }
-    const beforeTop = el.scrollTop
-    const beforeHeight = el.scrollHeight
+    const height = el.scrollHeight
     fn()
     requestAnimationFrame(() => {
-      const delta = el.scrollHeight - beforeHeight
-      if (!delta) return
-      el.scrollTop = beforeTop + delta
+      const delta = el.scrollHeight - height
+      if (delta) el.scrollTop += delta
     })
   }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #17996

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When scrolling up quickly through chat history, the viewport jumps because `preserveScroll` captures `scrollTop` before the DOM update but restores it inside `requestAnimationFrame`. Native scroll events that fire between the capture and the rAF callback make the captured value stale, so the viewport snaps to a wrong position.

This change switches from absolute scroll restoration (`scrollTop = beforeTop + delta`) to relative adjustment (`scrollTop += delta`). Reading `scrollTop` at rAF time instead of capture time keeps the value fresh regardless of user scrolling in the interim.

### How did you verify your code works?

- Playwright test with synthetic scrollable container — confirmed 0px visual shift with both `overflow-anchor: auto` and `overflow-anchor: none`
- Manual QA in headed Chromium connected to a live sidecar with real session data — injected a scroll monitor overlay that tracked every `scrollHeight` change and flagged jumps above 80px threshold. 0 jumps detected across multiple backfill cycles.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR