### PR TITLE
fix: Fix/auth to body provider dialogs

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -383,10 +383,11 @@ export function DialogConnectProvider(props: { provider: string }) {
       setFormStore("error", undefined)
       await globalSDK.client.auth.set({
         providerID: props.provider,
-        auth: {
-          type: "api",
-          key: apiKey,
-        },
+        body:{ 
+            type: "api",
+            key: apiKey,
+        }
+       
       })
       await complete()
     }

--- a/packages/app/src/components/dialog-custom-provider.tsx
+++ b/packages/app/src/components/dialog-custom-provider.tsx
@@ -131,7 +131,7 @@ export function DialogCustomProvider(props: Props) {
     const auth = result.key
       ? globalSDK.client.auth.set({
           providerID: result.providerID,
-          auth: {
+          body: {
             type: "api",
             key: result.key,
           },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -265,7 +265,7 @@ function ApiMethod(props: ApiMethodProps) {
         if (!value) return
         await sdk.client.auth.set({
           providerID: props.providerID,
-          auth: {
+          body: {
             type: "api",
             key: value,
           },


### PR DESCRIPTION


**Closes #18548** 

---

**Type of change:**
- [x] Bug fix

---

**What does this PR do?**
```
The `auth` property was being passed in three provider dialog components 
but the SDK type definition expects `body`. This caused TS2353 typecheck 
errors across the app, TUI and desktop packages.

Changed `auth` to `body` in:
- packages/app/src/components/dialog-connect-provider.tsx (line 386)
- packages/app/src/components/dialog-custom-provider.tsx (line 134)
- packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx (line 268)
```

---

**How did you verify your code works?**
```
Ran `bun turbo typecheck` before and after the fix.
Before: 3 TS2353 errors across 3 files
After: 0 errors, all 19 packages pass typecheck
```

---

**Checklist:**
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
