### PR TITLE
fix(acp): listSessions returns sessions from all projects, not just current

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -671,7 +671,7 @@ export namespace ACP {
         const cursor = params.cursor ? Number(params.cursor) : undefined
         const limit = 100
 
-        const sessions = await this.sdk.session
+        const sessions = await this.sdk.experimental.session
           .list(
             {
               directory: params.cwd ?? undefined,


### PR DESCRIPTION
### Issue for this PR

N/A — discovered while building [openplexer](https://github.com/remorses/openplexer) (ACP client that syncs sessions to Notion).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`unstable_listSessions` in the ACP agent calls `this.sdk.session.list()` which hits `GET /session` — the per-project route. That route's handler calls `Session.list()` which always filters by `Instance.project`, so ACP clients only ever see sessions from the single project where `opencode acp` was started.

Switched to `this.sdk.experimental.session.list()` which hits `GET /experimental/session`. That route calls `Session.listGlobal()` with no project filter, returning sessions across all projects.

One-line change: `this.sdk.session` → `this.sdk.experimental.session`. Parameters stay the same.

### How did you verify your code works?

- CI passes (typecheck, unit tests, e2e)
- Ran ACP smoke test gist locally — ACP protocol flow (initialize → listSessions) completes without errors

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR