### PR TITLE
fix(lsp): fixes Dockerfile LSP failing to load Dockerfile file

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -175,6 +175,15 @@ export namespace LSP {
     })
   }
 
+  export const matchesExtension = (file: string, extensions: string[]): boolean => {
+    if (extensions.length === 0) return true
+
+    const { ext, base } = path.parse(file)
+    const target = (ext || base).toLowerCase()
+
+    return extensions.some((e) => e.toLowerCase() === target)
+  }
+
   async function getClients(file: string) {
     const s = await state()
 
@@ -228,7 +237,7 @@ export namespace LSP {
     }
 
     for (const server of Object.values(s.servers)) {
-      if (server.extensions.length && !server.extensions.includes(extension)) continue
+      if (!matchesExtension(file, server.extensions)) continue
 
       const root = await server.root(file)
       if (!root) continue
@@ -269,9 +278,8 @@ export namespace LSP {
 
   export async function hasClients(file: string) {
     const s = await state()
-    const extension = path.parse(file).ext || file
     for (const server of Object.values(s.servers)) {
-      if (server.extensions.length && !server.extensions.includes(extension)) continue
+      if (!matchesExtension(file, server.extensions)) continue
       const root = await server.root(file)
       if (!root) continue
       if (s.broken.has(root + server.id)) continue

--- a/packages/opencode/test/lsp/matches-extension.test.ts
+++ b/packages/opencode/test/lsp/matches-extension.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { LSP } from "../../src/lsp/index"
+
+describe("LSP.matchesExtension", () => {
+  describe("files with extensions", () => {
+    test("matches exact extension", () => {
+      expect(LSP.matchesExtension("file.dockerfile", [".dockerfile", "Dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("file.sh", [".sh", ".bash"])).toBe(true)
+    })
+
+    test("matches case-insensitive extension", () => {
+      expect(LSP.matchesExtension("file.Dockerfile", [".dockerfile", "Dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("file.DOCKERFILE", [".dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("file.dockerfile", [".Dockerfile"])).toBe(true)
+    })
+
+    test("does not match different extension", () => {
+      expect(LSP.matchesExtension("file.txt", [".dockerfile"])).toBe(false)
+      expect(LSP.matchesExtension("file.sh", [".dockerfile"])).toBe(false)
+    })
+  })
+
+  describe("files without extensions (like Dockerfile)", () => {
+    test("matches basename exactly", () => {
+      expect(LSP.matchesExtension("Dockerfile", [".dockerfile", "Dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("Makefile", ["Makefile"])).toBe(true)
+    })
+
+    test("matches basename case-insensitively", () => {
+      expect(LSP.matchesExtension("dockerfile", [".dockerfile", "Dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("DOCKERFILE", ["Dockerfile"])).toBe(true)
+    })
+
+    test("does not match different basename", () => {
+      expect(LSP.matchesExtension("README", ["Dockerfile"])).toBe(false)
+    })
+  })
+
+  describe("empty extensions array", () => {
+    test("returns true for any file", () => {
+      expect(LSP.matchesExtension("Dockerfile", [])).toBe(true)
+      expect(LSP.matchesExtension("file.dockerfile", [])).toBe(true)
+      expect(LSP.matchesExtension("anything", [])).toBe(true)
+    })
+  })
+
+  describe("files with dots in name", () => {
+    test("handles files like app.Dockerfile", () => {
+      expect(LSP.matchesExtension("app.Dockerfile", [".dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("app.Dockerfile", ["Dockerfile"])).toBe(false)
+    })
+
+    test("handles files with multiple dots", () => {
+      expect(LSP.matchesExtension("file.tar.gz", [".gz"])).toBe(true)
+      expect(LSP.matchesExtension("file.tar.gz", [".tar"])).toBe(false)
+      expect(LSP.matchesExtension("file.tar.bz2", [".bz2"])).toBe(true)
+    })
+  })
+
+  describe("extension without leading dot", () => {
+    test("matches file with extension when extension has no dot", () => {
+      expect(LSP.matchesExtension("file.dockerfile", ["dockerfile"])).toBe(false)
+      expect(LSP.matchesExtension("Dockerfile", ["dockerfile"])).toBe(true)
+    })
+
+    test("mixed dot and no-dot extensions", () => {
+      expect(LSP.matchesExtension("file.sh", ["sh", ".bash"])).toBe(false)
+      expect(LSP.matchesExtension("file.bash", ["sh", ".bash"])).toBe(true)
+    })
+  })
+
+  describe("absolute paths", () => {
+    test("matches extension in absolute path", () => {
+      expect(LSP.matchesExtension("/path/to/Dockerfile", ["Dockerfile"])).toBe(true)
+      expect(LSP.matchesExtension("/path/to/file.sh", [".sh"])).toBe(true)
+      expect(LSP.matchesExtension("/path/to/file.txt", [".sh"])).toBe(false)
+    })
+  })
+
+  describe("multiple extensions", () => {
+    test("returns true if any extension matches", () => {
+      expect(LSP.matchesExtension("file.rb", [".js", ".ts", ".rb"])).toBe(true)
+      expect(LSP.matchesExtension("file.go", [".js", ".ts", ".rb"])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR
Closes #18558

### Type of change
- [x] Bug fix

### What does this PR do?

Fixes LSP extension matching for files named exactly `Dockerfile` (without a file extension) and adds case-insensitive extension matching.

The old code used case-sensitive `Array.includes()` which failed for:
- `Dockerfile` (no extension, basename fallback didn't match due to case)
- `file.Dockerfile` (case mismatch with `.dockerfile` extension)

The new `matchesExtension` function handles:
1. Case-insensitive extension matching (`.Dockerfile` matches `.dockerfile`)
2. Files without extensions matching basenames (`Dockerfile` matches `Dockerfile` extension)

### How did you verify your code works?

- Added unit tests covering various edge cases
- All tests pass
- Manually tested with actual Dockerfile files:
  - `Dockerfile` - LSP spawns and initializes correctly
  - `file.dockerfile` - continues to work  
  - `something.Dockerfile` - case-insensitive matching works

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### TLDR
I have tested and **now** Dockerfile LSP works! (Before this PR it didn't!)