### PR TITLE
feat(opencode): add OPENCODE_AUTH_PATH override for auth credential file

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -63,7 +63,6 @@ export namespace Auth {
       const decode = Schema.decodeUnknownOption(Info)
 
       const all = Effect.fn("Auth.all")(function* () {
-      const all = Effect.fn("Auth.all")(function* () {
         const data = (yield* fsys.readJson(file()).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
         return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
       })

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,17 +1,22 @@
 import path from "path"
 import { Effect, Layer, Record, Result, Schema, Context } from "effect"
 import { makeRuntime } from "@/effect/run-service"
+import { Flag } from "@/flag/flag"
 import { zod } from "@/util/effect-zod"
 import { Global } from "../global"
 import { AppFileSystem } from "../filesystem"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
-const file = path.join(Global.Path.data, "auth.json")
-
 const fail = (message: string) => (cause: unknown) => new Auth.AuthError({ message, cause })
 
 export namespace Auth {
+  export function file() {
+    if (!Flag.OPENCODE_AUTH_PATH) return path.join(Global.Path.data, "auth.json")
+    if (path.isAbsolute(Flag.OPENCODE_AUTH_PATH)) return Flag.OPENCODE_AUTH_PATH
+    return path.join(Global.Path.data, Flag.OPENCODE_AUTH_PATH)
+  }
+
   export class Oauth extends Schema.Class<Oauth>("OAuth")({
     type: Schema.Literal("oauth"),
     refresh: Schema.String,
@@ -58,7 +63,8 @@ export namespace Auth {
       const decode = Schema.decodeUnknownOption(Info)
 
       const all = Effect.fn("Auth.all")(function* () {
-        const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
+      const all = Effect.fn("Auth.all")(function* () {
+        const data = (yield* fsys.readJson(file()).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
         return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
       })
 
@@ -72,7 +78,7 @@ export namespace Auth {
         if (norm !== key) delete data[key]
         delete data[norm + "/"]
         yield* fsys
-          .writeJson(file, { ...data, [norm]: info }, 0o600)
+          .writeJson(file(), { ...data, [norm]: info }, 0o600)
           .pipe(Effect.mapError(fail("Failed to write auth data")))
       })
 
@@ -81,7 +87,7 @@ export namespace Auth {
         const data = yield* all()
         delete data[key]
         delete data[norm]
-        yield* fsys.writeJson(file, data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))
+        yield* fsys.writeJson(file(), data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))
       })
 
       return Service.of({ get, all, set, remove })

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -4,10 +4,8 @@ import * as prompts from "@clack/prompts"
 import { UI } from "../ui"
 import { ModelsDev } from "../../provider/models"
 import { map, pipe, sortBy, values } from "remeda"
-import path from "path"
 import os from "os"
 import { Config } from "../../config/config"
-import { Global } from "../../global"
 import { Plugin } from "../../plugin"
 import { Instance } from "../../project/instance"
 import type { Hooks } from "@opencode-ai/plugin"
@@ -211,7 +209,7 @@ export const ProvidersListCommand = cmd({
   describe: "list providers and credentials",
   async handler(_args) {
     UI.empty()
-    const authPath = path.join(Global.Path.data, "auth.json")
+    const authPath = Auth.file()
     const homedir = os.homedir()
     const displayPath = authPath.startsWith(homedir) ? authPath.replace(homedir, "~") : authPath
     prompts.intro(`Credentials ${UI.Style.TEXT_DIM}${displayPath}`)

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -79,6 +79,7 @@ export namespace Flag {
   export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"]
   export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"]
   export const OPENCODE_DISABLE_EMBEDDED_WEB_UI = truthy("OPENCODE_DISABLE_EMBEDDED_WEB_UI")
+  export declare const OPENCODE_AUTH_PATH: string | undefined
   export const OPENCODE_DB = process.env["OPENCODE_DB"]
   export const OPENCODE_DISABLE_CHANNEL_DB = truthy("OPENCODE_DISABLE_CHANNEL_DB")
   export const OPENCODE_SKIP_MIGRATIONS = truthy("OPENCODE_SKIP_MIGRATIONS")
@@ -142,6 +143,17 @@ Object.defineProperty(Flag, "OPENCODE_PURE", {
 Object.defineProperty(Flag, "OPENCODE_PLUGIN_META_FILE", {
   get() {
     return process.env["OPENCODE_PLUGIN_META_FILE"]
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_AUTH_PATH
+// This must be evaluated at access time, not module load time,
+// because tests and external tooling may set this env var at runtime
+Object.defineProperty(Flag, "OPENCODE_AUTH_PATH", {
+  get() {
+    return process.env["OPENCODE_AUTH_PATH"]
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "bun:test"
+import path from "path"
 import { Auth } from "../../src/auth"
+import { Global } from "../../src/global"
 
 test("set normalizes trailing slashes in keys", async () => {
   await Auth.set("https://example.com/", {
@@ -55,4 +57,33 @@ test("set and remove are no-ops on keys without trailing slashes", async () => {
   await Auth.remove("anthropic")
   const after = await Auth.all()
   expect(after["anthropic"]).toBeUndefined()
+})
+
+test("file resolves OPENCODE_AUTH_PATH relative to data dir", () => {
+  const prev = process.env.OPENCODE_AUTH_PATH
+  process.env.OPENCODE_AUTH_PATH = "custom-auth.json"
+  try {
+    expect(Auth.file()).toBe(path.join(Global.Path.data, "custom-auth.json"))
+  } finally {
+    if (prev === undefined) {
+      delete process.env.OPENCODE_AUTH_PATH
+      return
+    }
+    process.env.OPENCODE_AUTH_PATH = prev
+  }
+})
+
+test("file keeps OPENCODE_AUTH_PATH absolute", () => {
+  const prev = process.env.OPENCODE_AUTH_PATH
+  const auth = path.join(Global.Path.data, "auth-alt.json")
+  process.env.OPENCODE_AUTH_PATH = auth
+  try {
+    expect(Auth.file()).toBe(auth)
+  } finally {
+    if (prev === undefined) {
+      delete process.env.OPENCODE_AUTH_PATH
+      return
+    }
+    process.env.OPENCODE_AUTH_PATH = prev
+  }
 })

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -119,7 +119,7 @@ opencode auth [command]
 
 #### login
 
-OpenCode is powered by the provider list at [Models.dev](https://models.dev), so you can use `opencode auth login` to configure API keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`.
+OpenCode is powered by the provider list at [Models.dev](https://models.dev), so you can use `opencode auth login` to configure API keys for any provider you'd like to use. By default this is stored in `~/.local/share/opencode/auth.json` and can be overridden with `OPENCODE_AUTH_PATH`.
 
 ```bash
 opencode auth login
@@ -131,7 +131,7 @@ When OpenCode starts up it loads the providers from the credentials file. And if
 
 #### list
 
-Lists all the authenticated providers as stored in the credentials file.
+Lists all the authenticated providers as stored in the credentials file, and shows any active provider environment variables.
 
 ```bash
 opencode auth list
@@ -558,6 +558,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
 | `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
 | `OPENCODE_CONFIG`                     | string  | Path to config file                               |
+| `OPENCODE_AUTH_PATH`                  | string  | Customize auth credential file path               |
 | `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
 | `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
 | `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |


### PR DESCRIPTION
### Issue for this PR

Closes #18562

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds support for `OPENCODE_AUTH_PATH` so auth credentials are not hardcoded to `~/.local/share/opencode/auth.json`.

- Adds `Auth.file()` resolution logic:
  - default path when unset
  - absolute path passthrough
  - relative path resolved under OpenCode data dir
- Uses resolved path for auth read/write operations
- Updates `opencode auth list` to print the resolved credentials path
- Documents the new env var and auth storage behavior in CLI docs

### How did you verify your code works?

- Added auth tests for relative and absolute `OPENCODE_AUTH_PATH` path resolution.
- Manually validated diff to ensure all auth read/write call sites now use `Auth.file()` and list output no longer uses hardcoded path.

### Screenshots / recordings

N/A (CLI/docs change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR