### PR TITLE
effectify Pty service

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -163,7 +163,7 @@ Still open and likely worth migrating:
 
 - [x] `Plugin`
 - [ ] `ToolRegistry`
-- [x] `Pty`
+- [ ] `Pty`
 - [ ] `Worktree`
 - [ ] `Bus`
 - [x] `Command`

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -163,7 +163,7 @@ Still open and likely worth migrating:
 
 - [x] `Plugin`
 - [ ] `ToolRegistry`
-- [ ] `Pty`
+- [x] `Pty`
 - [ ] `Worktree`
 - [ ] `Bus`
 - [x] `Command`

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -1,13 +1,16 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
+import { InstanceState } from "@/effect/instance-state"
+import { makeRunPromise, memoMap } from "@/effect/run-service"
+import { Instance } from "@/project/instance"
 import { type IPty } from "bun-pty"
 import z from "zod"
 import { Log } from "../util/log"
-import { Instance } from "../project/instance"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
 import { PtyID } from "./schema"
+import { Effect, Layer, ManagedRuntime, ServiceMap } from "effect"
 
 export namespace Pty {
   const log = Log.create({ service: "pty" })
@@ -23,7 +26,20 @@ export namespace Pty {
     close: (code?: number, reason?: string) => void
   }
 
-  // WebSocket control frame: 0x00 + UTF-8 JSON.
+  type Active = {
+    info: Info
+    process: IPty
+    buffer: string
+    bufferCursor: number
+    cursor: number
+    subscribers: Map<unknown, Socket>
+  }
+
+  type State = {
+    dir: string
+    sessions: Map<PtyID, Active>
+  }
+
   const meta = (cursor: number) => {
     const json = JSON.stringify({ cursor })
     const bytes = encoder.encode(json)
@@ -81,241 +97,310 @@ export namespace Pty {
     Deleted: BusEvent.define("pty.deleted", z.object({ id: PtyID.zod })),
   }
 
-  interface ActiveSession {
-    info: Info
-    process: IPty
-    buffer: string
-    bufferCursor: number
-    cursor: number
-    subscribers: Map<unknown, Socket>
+  export interface Interface {
+    readonly list: () => Effect.Effect<Info[]>
+    readonly get: (id: PtyID) => Effect.Effect<Info | undefined>
+    readonly create: (input: CreateInput) => Effect.Effect<Info>
+    readonly update: (id: PtyID, input: UpdateInput) => Effect.Effect<Info | undefined>
+    readonly remove: (id: PtyID) => Effect.Effect<void>
+    readonly resize: (id: PtyID, cols: number, rows: number) => Effect.Effect<void>
+    readonly write: (id: PtyID, data: string) => Effect.Effect<void>
+    readonly connect: (
+      id: PtyID,
+      ws: Socket,
+      cursor?: number,
+    ) => Effect.Effect<{ onMessage: (message: string | ArrayBuffer) => void; onClose: () => void } | undefined>
   }
 
-  const state = Instance.state(
-    () => new Map<PtyID, ActiveSession>(),
-    async (sessions) => {
-      for (const session of sessions.values()) {
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Pty") {}
+
+  export const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const cache = yield* InstanceState.make<State>(
+        Effect.fn("Pty.state")(function* (ctx) {
+          const state = {
+            dir: ctx.directory,
+            sessions: new Map<PtyID, Active>(),
+          }
+
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              for (const session of state.sessions.values()) {
+                try {
+                  session.process.kill()
+                } catch {}
+                for (const [key, ws] of session.subscribers.entries()) {
+                  try {
+                    if (ws.data === key) ws.close()
+                  } catch {}
+                }
+              }
+              state.sessions.clear()
+            }),
+          )
+
+          return state
+        }),
+      )
+
+      const drop = Effect.fn("Pty.drop")(function* (id: PtyID) {
+        const state = yield* InstanceState.get(cache)
+        const session = state.sessions.get(id)
+        if (!session) return
+        state.sessions.delete(id)
+        log.info("removing session", { id })
         try {
           session.process.kill()
         } catch {}
         for (const [key, ws] of session.subscribers.entries()) {
           try {
             if (ws.data === key) ws.close()
+          } catch {}
+        }
+        session.subscribers.clear()
+        void Bus.publish(Event.Deleted, { id: session.info.id })
+      })
+
+      const list = Effect.fn("Pty.list")(function* () {
+        const state = yield* InstanceState.get(cache)
+        return Array.from(state.sessions.values()).map((session) => session.info)
+      })
+
+      const get = Effect.fn("Pty.get")(function* (id: PtyID) {
+        const state = yield* InstanceState.get(cache)
+        return state.sessions.get(id)?.info
+      })
+
+      const create = Effect.fn("Pty.create")(function* (input: CreateInput) {
+        const state = yield* InstanceState.get(cache)
+        return yield* Effect.promise(async () => {
+          const id = PtyID.ascending()
+          const command = input.command || Shell.preferred()
+          const args = input.args || []
+          if (command.endsWith("sh")) {
+            args.push("-l")
+          }
+
+          const cwd = input.cwd || state.dir
+          const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
+          const env = {
+            ...process.env,
+            ...input.env,
+            ...shellEnv.env,
+            TERM: "xterm-256color",
+            OPENCODE_TERMINAL: "1",
+          } as Record<string, string>
+
+          if (process.platform === "win32") {
+            env.LC_ALL = "C.UTF-8"
+            env.LC_CTYPE = "C.UTF-8"
+            env.LANG = "C.UTF-8"
+          }
+          log.info("creating session", { id, cmd: command, args, cwd })
+
+          const spawn = await pty()
+          const proc = spawn(command, args, {
+            name: "xterm-256color",
+            cwd,
+            env,
+          })
+
+          const info = {
+            id,
+            title: input.title || `Terminal ${id.slice(-4)}`,
+            command,
+            args,
+            cwd,
+            status: "running",
+            pid: proc.pid,
+          } as const
+          const session: Active = {
+            info,
+            process: proc,
+            buffer: "",
+            bufferCursor: 0,
+            cursor: 0,
+            subscribers: new Map(),
+          }
+          state.sessions.set(id, session)
+          proc.onData(
+            Instance.bind((chunk) => {
+              session.cursor += chunk.length
+
+              for (const [key, ws] of session.subscribers.entries()) {
+                if (ws.readyState !== 1) {
+                  session.subscribers.delete(key)
+                  continue
+                }
+                if (ws.data !== key) {
+                  session.subscribers.delete(key)
+                  continue
+                }
+                try {
+                  ws.send(chunk)
+                } catch {
+                  session.subscribers.delete(key)
+                }
+              }
+
+              session.buffer += chunk
+              if (session.buffer.length <= BUFFER_LIMIT) return
+              const excess = session.buffer.length - BUFFER_LIMIT
+              session.buffer = session.buffer.slice(excess)
+              session.bufferCursor += excess
+            }),
+          )
+          proc.onExit(
+            Instance.bind(({ exitCode }) => {
+              if (session.info.status === "exited") return
+              log.info("session exited", { id, exitCode })
+              session.info.status = "exited"
+              void Bus.publish(Event.Exited, { id, exitCode })
+              void runPromise((svc) => svc.remove(id))
+            }),
+          )
+          await Bus.publish(Event.Created, { info })
+          return info
+        })
+      })
+
+      const update = Effect.fn("Pty.update")(function* (id: PtyID, input: UpdateInput) {
+        const state = yield* InstanceState.get(cache)
+        const session = state.sessions.get(id)
+        if (!session) return
+        if (input.title) {
+          session.info.title = input.title
+        }
+        if (input.size) {
+          session.process.resize(input.size.cols, input.size.rows)
+        }
+        yield* Effect.promise(() => Bus.publish(Event.Updated, { info: session.info }))
+        return session.info
+      })
+
+      const remove = Effect.fn("Pty.remove")(function* (id: PtyID) {
+        yield* drop(id)
+      })
+
+      const resize = Effect.fn("Pty.resize")(function* (id: PtyID, cols: number, rows: number) {
+        const state = yield* InstanceState.get(cache)
+        const session = state.sessions.get(id)
+        if (session && session.info.status === "running") {
+          session.process.resize(cols, rows)
+        }
+      })
+
+      const write = Effect.fn("Pty.write")(function* (id: PtyID, data: string) {
+        const state = yield* InstanceState.get(cache)
+        const session = state.sessions.get(id)
+        if (session && session.info.status === "running") {
+          session.process.write(data)
+        }
+      })
+
+      const connect = Effect.fn("Pty.connect")(function* (id: PtyID, ws: Socket, cursor?: number) {
+        const state = yield* InstanceState.get(cache)
+        const session = state.sessions.get(id)
+        if (!session) {
+          ws.close()
+          return
+        }
+        log.info("client connected to session", { id })
+
+        const key = ws.data && typeof ws.data === "object" ? ws.data : ws
+        session.subscribers.delete(key)
+        session.subscribers.set(key, ws)
+
+        const cleanup = () => {
+          session.subscribers.delete(key)
+        }
+
+        const start = session.bufferCursor
+        const end = session.cursor
+        const from =
+          cursor === -1 ? end : typeof cursor === "number" && Number.isSafeInteger(cursor) ? Math.max(0, cursor) : 0
+
+        const data = (() => {
+          if (!session.buffer) return ""
+          if (from >= end) return ""
+          const offset = Math.max(0, from - start)
+          if (offset >= session.buffer.length) return ""
+          return session.buffer.slice(offset)
+        })()
+
+        if (data) {
+          try {
+            for (let i = 0; i < data.length; i += BUFFER_CHUNK) {
+              ws.send(data.slice(i, i + BUFFER_CHUNK))
+            }
           } catch {
-            // ignore
+            cleanup()
+            ws.close()
+            return
           }
         }
-      }
-      sessions.clear()
-    },
+
+        try {
+          ws.send(meta(end))
+        } catch {
+          cleanup()
+          ws.close()
+          return
+        }
+
+        return {
+          onMessage: (message: string | ArrayBuffer) => {
+            session.process.write(String(message))
+          },
+          onClose: () => {
+            log.info("client disconnected from session", { id })
+            cleanup()
+          },
+        }
+      })
+
+      return Service.of({ list, get, create, update, remove, resize, write, connect })
+    }),
   )
 
+  const runPromise = makeRunPromise(Service, layer)
+  let rt: ManagedRuntime.ManagedRuntime<Service, never> | undefined
+
+  function runSync<A, E>(effect: Effect.Effect<A, E, Service>) {
+    rt ??= ManagedRuntime.make(layer, { memoMap })
+    return rt.runSync(effect)
+  }
+
   export function list() {
-    return Array.from(state().values()).map((s) => s.info)
+    return runSync(Service.use((svc) => svc.list()))
   }
 
   export function get(id: PtyID) {
-    return state().get(id)?.info
-  }
-
-  export async function create(input: CreateInput) {
-    const id = PtyID.ascending()
-    const command = input.command || Shell.preferred()
-    const args = input.args || []
-    if (command.endsWith("sh")) {
-      args.push("-l")
-    }
-
-    const cwd = input.cwd || Instance.directory
-    const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
-    const env = {
-      ...process.env,
-      ...input.env,
-      ...shellEnv.env,
-      TERM: "xterm-256color",
-      OPENCODE_TERMINAL: "1",
-    } as Record<string, string>
-
-    if (process.platform === "win32") {
-      env.LC_ALL = "C.UTF-8"
-      env.LC_CTYPE = "C.UTF-8"
-      env.LANG = "C.UTF-8"
-    }
-    log.info("creating session", { id, cmd: command, args, cwd })
-
-    const spawn = await pty()
-    const ptyProcess = spawn(command, args, {
-      name: "xterm-256color",
-      cwd,
-      env,
-    })
-
-    const info = {
-      id,
-      title: input.title || `Terminal ${id.slice(-4)}`,
-      command,
-      args,
-      cwd,
-      status: "running",
-      pid: ptyProcess.pid,
-    } as const
-    const session: ActiveSession = {
-      info,
-      process: ptyProcess,
-      buffer: "",
-      bufferCursor: 0,
-      cursor: 0,
-      subscribers: new Map(),
-    }
-    state().set(id, session)
-    ptyProcess.onData(
-      Instance.bind((chunk) => {
-        session.cursor += chunk.length
-
-        for (const [key, ws] of session.subscribers.entries()) {
-          if (ws.readyState !== 1) {
-            session.subscribers.delete(key)
-            continue
-          }
-
-          if (ws.data !== key) {
-            session.subscribers.delete(key)
-            continue
-          }
-
-          try {
-            ws.send(chunk)
-          } catch {
-            session.subscribers.delete(key)
-          }
-        }
-
-        session.buffer += chunk
-        if (session.buffer.length <= BUFFER_LIMIT) return
-        const excess = session.buffer.length - BUFFER_LIMIT
-        session.buffer = session.buffer.slice(excess)
-        session.bufferCursor += excess
-      }),
-    )
-    ptyProcess.onExit(
-      Instance.bind(({ exitCode }) => {
-        if (session.info.status === "exited") return
-        log.info("session exited", { id, exitCode })
-        session.info.status = "exited"
-        Bus.publish(Event.Exited, { id, exitCode })
-        remove(id)
-      }),
-    )
-    Bus.publish(Event.Created, { info })
-    return info
-  }
-
-  export async function update(id: PtyID, input: UpdateInput) {
-    const session = state().get(id)
-    if (!session) return
-    if (input.title) {
-      session.info.title = input.title
-    }
-    if (input.size) {
-      session.process.resize(input.size.cols, input.size.rows)
-    }
-    Bus.publish(Event.Updated, { info: session.info })
-    return session.info
-  }
-
-  export async function remove(id: PtyID) {
-    const session = state().get(id)
-    if (!session) return
-    state().delete(id)
-    log.info("removing session", { id })
-    try {
-      session.process.kill()
-    } catch {}
-    for (const [key, ws] of session.subscribers.entries()) {
-      try {
-        if (ws.data === key) ws.close()
-      } catch {
-        // ignore
-      }
-    }
-    session.subscribers.clear()
-    Bus.publish(Event.Deleted, { id: session.info.id })
+    return runSync(Service.use((svc) => svc.get(id)))
   }
 
   export function resize(id: PtyID, cols: number, rows: number) {
-    const session = state().get(id)
-    if (session && session.info.status === "running") {
-      session.process.resize(cols, rows)
-    }
+    runSync(Service.use((svc) => svc.resize(id, cols, rows)))
   }
 
   export function write(id: PtyID, data: string) {
-    const session = state().get(id)
-    if (session && session.info.status === "running") {
-      session.process.write(data)
-    }
+    runSync(Service.use((svc) => svc.write(id, data)))
   }
 
   export function connect(id: PtyID, ws: Socket, cursor?: number) {
-    const session = state().get(id)
-    if (!session) {
-      ws.close()
-      return
-    }
-    log.info("client connected to session", { id })
+    return runSync(Service.use((svc) => svc.connect(id, ws, cursor)))
+  }
 
-    // Use ws.data as the unique key for this connection lifecycle.
-    // If ws.data is undefined, fallback to ws object.
-    const connectionKey = ws.data && typeof ws.data === "object" ? ws.data : ws
+  export async function create(input: CreateInput) {
+    return runPromise((svc) => svc.create(input))
+  }
 
-    // Optionally cleanup if the key somehow exists
-    session.subscribers.delete(connectionKey)
-    session.subscribers.set(connectionKey, ws)
+  export async function update(id: PtyID, input: UpdateInput) {
+    return runPromise((svc) => svc.update(id, input))
+  }
 
-    const cleanup = () => {
-      session.subscribers.delete(connectionKey)
-    }
-
-    const start = session.bufferCursor
-    const end = session.cursor
-
-    const from =
-      cursor === -1 ? end : typeof cursor === "number" && Number.isSafeInteger(cursor) ? Math.max(0, cursor) : 0
-
-    const data = (() => {
-      if (!session.buffer) return ""
-      if (from >= end) return ""
-      const offset = Math.max(0, from - start)
-      if (offset >= session.buffer.length) return ""
-      return session.buffer.slice(offset)
-    })()
-
-    if (data) {
-      try {
-        for (let i = 0; i < data.length; i += BUFFER_CHUNK) {
-          ws.send(data.slice(i, i + BUFFER_CHUNK))
-        }
-      } catch {
-        cleanup()
-        ws.close()
-        return
-      }
-    }
-
-    try {
-      ws.send(meta(end))
-    } catch {
-      cleanup()
-      ws.close()
-      return
-    }
-    return {
-      onMessage: (message: string | ArrayBuffer) => {
-        session.process.write(String(message))
-      },
-      onClose: () => {
-        log.info("client disconnected from session", { id })
-        cleanup()
-      },
-    }
+  export async function remove(id: PtyID) {
+    return runPromise((svc) => svc.remove(id))
   }
 }

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -1,7 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRunPromise, memoMap } from "@/effect/run-service"
+import { makeRunPromise } from "@/effect/run-service"
 import { Instance } from "@/project/instance"
 import { type IPty } from "bun-pty"
 import z from "zod"
@@ -10,7 +10,7 @@ import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
 import { Plugin } from "@/plugin"
 import { PtyID } from "./schema"
-import { Effect, Layer, ManagedRuntime, ServiceMap } from "effect"
+import { Effect, Layer, ServiceMap } from "effect"
 
 export namespace Pty {
   const log = Log.create({ service: "pty" })
@@ -40,6 +40,7 @@ export namespace Pty {
     sessions: Map<PtyID, Active>
   }
 
+  // WebSocket control frame: 0x00 + UTF-8 JSON.
   const meta = (cursor: number) => {
     const json = JSON.stringify({ cursor })
     const bytes = encoder.encode(json)
@@ -308,7 +309,10 @@ export namespace Pty {
         }
         log.info("client connected to session", { id })
 
+        // Use ws.data as the unique key for this connection lifecycle.
+        // If ws.data is undefined, fallback to ws object.
         const key = ws.data && typeof ws.data === "object" ? ws.data : ws
+        // Optionally cleanup if the key somehow exists
         session.subscribers.delete(key)
         session.subscribers.set(key, ws)
 
@@ -365,31 +369,25 @@ export namespace Pty {
   )
 
   const runPromise = makeRunPromise(Service, layer)
-  let rt: ManagedRuntime.ManagedRuntime<Service, never> | undefined
 
-  function runSync<A, E>(effect: Effect.Effect<A, E, Service>) {
-    rt ??= ManagedRuntime.make(layer, { memoMap })
-    return rt.runSync(effect)
+  export async function list() {
+    return runPromise((svc) => svc.list())
   }
 
-  export function list() {
-    return runSync(Service.use((svc) => svc.list()))
+  export async function get(id: PtyID) {
+    return runPromise((svc) => svc.get(id))
   }
 
-  export function get(id: PtyID) {
-    return runSync(Service.use((svc) => svc.get(id)))
+  export async function resize(id: PtyID, cols: number, rows: number) {
+    return runPromise((svc) => svc.resize(id, cols, rows))
   }
 
-  export function resize(id: PtyID, cols: number, rows: number) {
-    runSync(Service.use((svc) => svc.resize(id, cols, rows)))
+  export async function write(id: PtyID, data: string) {
+    return runPromise((svc) => svc.write(id, data))
   }
 
-  export function write(id: PtyID, data: string) {
-    runSync(Service.use((svc) => svc.write(id, data)))
-  }
-
-  export function connect(id: PtyID, ws: Socket, cursor?: number) {
-    return runSync(Service.use((svc) => svc.connect(id, ws, cursor)))
+  export async function connect(id: PtyID, ws: Socket, cursor?: number) {
+    return runPromise((svc) => svc.connect(id, ws, cursor))
   }
 
   export async function create(input: CreateInput) {

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -118,6 +118,18 @@ export namespace Pty {
   export const layer = Layer.effect(
     Service,
     Effect.gen(function* () {
+      function teardown(session: Active) {
+        try {
+          session.process.kill()
+        } catch {}
+        for (const [key, ws] of session.subscribers.entries()) {
+          try {
+            if (ws.data === key) ws.close()
+          } catch {}
+        }
+        session.subscribers.clear()
+      }
+
       const cache = yield* InstanceState.make<State>(
         Effect.fn("Pty.state")(function* (ctx) {
           const state = {
@@ -128,14 +140,7 @@ export namespace Pty {
           yield* Effect.addFinalizer(() =>
             Effect.sync(() => {
               for (const session of state.sessions.values()) {
-                try {
-                  session.process.kill()
-                } catch {}
-                for (const [key, ws] of session.subscribers.entries()) {
-                  try {
-                    if (ws.data === key) ws.close()
-                  } catch {}
-                }
+                teardown(session)
               }
               state.sessions.clear()
             }),
@@ -145,21 +150,13 @@ export namespace Pty {
         }),
       )
 
-      const drop = Effect.fn("Pty.drop")(function* (id: PtyID) {
+      const remove = Effect.fn("Pty.remove")(function* (id: PtyID) {
         const state = yield* InstanceState.get(cache)
         const session = state.sessions.get(id)
         if (!session) return
         state.sessions.delete(id)
         log.info("removing session", { id })
-        try {
-          session.process.kill()
-        } catch {}
-        for (const [key, ws] of session.subscribers.entries()) {
-          try {
-            if (ws.data === key) ws.close()
-          } catch {}
-        }
-        session.subscribers.clear()
+        teardown(session)
         void Bus.publish(Event.Deleted, { id: session.info.id })
       })
 
@@ -258,7 +255,7 @@ export namespace Pty {
               log.info("session exited", { id, exitCode })
               session.info.status = "exited"
               void Bus.publish(Event.Exited, { id, exitCode })
-              void runPromise((svc) => svc.remove(id))
+              Effect.runFork(remove(id))
             }),
           )
           await Bus.publish(Event.Created, { info })
@@ -278,10 +275,6 @@ export namespace Pty {
         }
         yield* Effect.promise(() => Bus.publish(Event.Updated, { info: session.info }))
         return session.info
-      })
-
-      const remove = Effect.fn("Pty.remove")(function* (id: PtyID) {
-        yield* drop(id)
       })
 
       const resize = Effect.fn("Pty.resize")(function* (id: PtyID, cols: number, rows: number) {

--- a/packages/opencode/src/server/routes/pty.ts
+++ b/packages/opencode/src/server/routes/pty.ts
@@ -28,7 +28,7 @@ export const PtyRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(Pty.list())
+        return c.json(await Pty.list())
       },
     )
     .post(
@@ -75,7 +75,7 @@ export const PtyRoutes = lazy(() =>
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
       async (c) => {
-        const info = Pty.get(c.req.valid("param").ptyID)
+        const info = await Pty.get(c.req.valid("param").ptyID)
         if (!info) {
           throw new NotFoundError({ message: "Session not found" })
         }
@@ -150,7 +150,7 @@ export const PtyRoutes = lazy(() =>
         },
       }),
       validator("param", z.object({ ptyID: PtyID.zod })),
-      upgradeWebSocket((c) => {
+      upgradeWebSocket(async (c) => {
         const id = PtyID.zod.parse(c.req.param("ptyID"))
         const cursor = (() => {
           const value = c.req.query("cursor")
@@ -159,8 +159,8 @@ export const PtyRoutes = lazy(() =>
           if (!Number.isSafeInteger(parsed) || parsed < -1) return
           return parsed
         })()
-        let handler: ReturnType<typeof Pty.connect>
-        if (!Pty.get(id)) throw new Error("Session not found")
+        let handler: Awaited<ReturnType<typeof Pty.connect>>
+        if (!(await Pty.get(id))) throw new Error("Session not found")
 
         type Socket = {
           readyState: number
@@ -177,13 +177,13 @@ export const PtyRoutes = lazy(() =>
         }
 
         return {
-          onOpen(_event, ws) {
+          async onOpen(_event, ws) {
             const socket = ws.raw
             if (!isSocket(socket)) {
               ws.close()
               return
             }
-            handler = Pty.connect(id, socket, cursor)
+            handler = await Pty.connect(id, socket, cursor)
           },
           onMessage(event) {
             if (typeof event.data !== "string") return

--- a/packages/opencode/src/server/routes/pty.ts
+++ b/packages/opencode/src/server/routes/pty.ts
@@ -176,6 +176,9 @@ export const PtyRoutes = lazy(() =>
           return typeof (value as { readyState?: unknown }).readyState === "number"
         }
 
+        const pending: string[] = []
+        let ready = false
+
         return {
           async onOpen(_event, ws) {
             const socket = ws.raw
@@ -184,9 +187,16 @@ export const PtyRoutes = lazy(() =>
               return
             }
             handler = await Pty.connect(id, socket, cursor)
+            ready = true
+            for (const msg of pending) handler?.onMessage(msg)
+            pending.length = 0
           },
           onMessage(event) {
             if (typeof event.data !== "string") return
+            if (!ready) {
+              pending.push(event.data)
+              return
+            }
             handler?.onMessage(event.data)
           },
           onClose() {


### PR DESCRIPTION
## Summary
- migrate `Pty` to the current Effect service pattern using `InstanceState` and `makeRunPromise`
- keep session creation, websocket connection, and terminal lifecycle behavior scoped per instance
- publish this as a fresh rebased draft branch so the original PR stays available for reference