### PR TITLE
fix(acp): use global session list in unstable_listSessions

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -671,19 +671,22 @@ export namespace ACP {
         const cursor = params.cursor ? Number(params.cursor) : undefined
         const limit = 100
 
-        const sessions = await this.sdk.session
+        // Use global session list so sessions from all projects are returned,
+        // not just the current project scoped by Instance.project.id
+        const sessions = await this.sdk.experimental.session
           .list(
             {
               directory: params.cwd ?? undefined,
               roots: true,
+              cursor,
+              limit: limit + 1,
             },
             { throwOnError: true },
           )
           .then((x) => x.data ?? [])
 
-        const sorted = sessions.toSorted((a, b) => b.time.updated - a.time.updated)
-        const filtered = cursor ? sorted.filter((s) => s.time.updated < cursor) : sorted
-        const page = filtered.slice(0, limit)
+        const hasMore = sessions.length > limit
+        const page = hasMore ? sessions.slice(0, limit) : sessions
 
         const entries: SessionInfo[] = page.map((session) => ({
           sessionId: session.id,
@@ -693,7 +696,7 @@ export namespace ACP {
         }))
 
         const last = page[page.length - 1]
-        const next = filtered.length > limit && last ? String(last.time.updated) : undefined
+        const next = hasMore && last ? String(last.time.updated) : undefined
 
         const response: ListSessionsResponse = {
           sessions: entries,

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -671,8 +671,6 @@ export namespace ACP {
         const cursor = params.cursor ? Number(params.cursor) : undefined
         const limit = 100
 
-        // Use global session list so sessions from all projects are returned,
-        // not just the current project scoped by Instance.project.id
         const sessions = await this.sdk.experimental.session
           .list(
             {


### PR DESCRIPTION
### Issue for this PR

Closes #18575
Closes #16137

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`unstable_listSessions` called `sdk.session.list()` which queries sessions scoped to `Instance.project.id`. When ACP runs from `/` or a non-git directory (e.g. registry mode in Zed), the project resolves to `"global"` and sessions from git-backed projects are invisible.

Switched to `sdk.experimental.session.list()` which calls `Session.listGlobal()` — a SQLite query across all projects with no project scoping. Also moved sorting, cursor, and limit to the server side instead of doing it in-memory since the experimental endpoint already handles these in SQL.

### How did you verify your code works?

- Typecheck passes across all 13 packages
- Traced the call chain: `sdk.experimental.session.list()` → `GET /experimental/session` → `Session.listGlobal()` which queries `SessionTable` without project ID filtering

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR