### PR TITLE
feat(vscode): sync IDE context into the TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -41,6 +41,7 @@ import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { TuiConfigProvider } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
+import { IdeContextProvider, useIdeContext } from "./context/ide-context"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -148,27 +149,29 @@ export function tui(input: {
                           headers={input.headers}
                           events={input.events}
                         >
-                          <SyncProvider>
-                            <ThemeProvider mode={mode}>
-                              <LocalProvider>
-                                <KeybindProvider>
-                                  <PromptStashProvider>
-                                    <DialogProvider>
-                                      <CommandProvider>
-                                        <FrecencyProvider>
-                                          <PromptHistoryProvider>
-                                            <PromptRefProvider>
-                                              <App />
-                                            </PromptRefProvider>
-                                          </PromptHistoryProvider>
-                                        </FrecencyProvider>
-                                      </CommandProvider>
-                                    </DialogProvider>
-                                  </PromptStashProvider>
-                                </KeybindProvider>
-                              </LocalProvider>
-                            </ThemeProvider>
-                          </SyncProvider>
+                          <IdeContextProvider>
+                            <SyncProvider>
+                              <ThemeProvider mode={mode}>
+                                <LocalProvider>
+                                  <KeybindProvider>
+                                    <PromptStashProvider>
+                                      <DialogProvider>
+                                        <CommandProvider>
+                                          <FrecencyProvider>
+                                            <PromptHistoryProvider>
+                                              <PromptRefProvider>
+                                                <App />
+                                              </PromptRefProvider>
+                                            </PromptHistoryProvider>
+                                          </FrecencyProvider>
+                                        </CommandProvider>
+                                      </DialogProvider>
+                                    </PromptStashProvider>
+                                  </KeybindProvider>
+                                </LocalProvider>
+                              </ThemeProvider>
+                            </SyncProvider>
+                          </IdeContextProvider>
                         </SDKProvider>
                       </TuiConfigProvider>
                     </RouteProvider>
@@ -695,6 +698,11 @@ function App() {
       type: "session",
       sessionID: evt.properties.sessionID,
     })
+  })
+
+  const ideContext = useIdeContext()
+  sdk.event.on(TuiEvent.ContextSync.type, (evt) => {
+    ideContext.setFiles(evt.properties.files)
   })
 
   sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -35,6 +35,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { useIdeContext } from "../../context/ide-context"
 
 export type PromptProps = {
   sessionID?: string
@@ -72,6 +73,24 @@ export function Prompt(props: PromptProps) {
   const sync = useSync()
   const dialog = useDialog()
   const toast = useToast()
+  const ideContext = useIdeContext()
+
+  const ideContextBar = createMemo(() => {
+    const files = ideContext.files()
+    if (files.length === 0) return ""
+    const active = files.find((f) => f.active)
+    const others = files.filter((f) => !f.active).length
+    if (active) {
+      const name = path.basename(active.path)
+      const sel = active.selection ? `#L${active.selection.startLine}-${active.selection.endLine}` : ""
+      const more = others > 0 ? ` · ${others} more` : ""
+      return `📄 ${name}${sel}${more}`
+    }
+    const first = files[0]
+    const name = path.basename(first.path)
+    const sel = first.selection ? `#L${first.selection.startLine}-${first.selection.endLine}` : ""
+    return `📄 ${name}${sel}`
+  })
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
   const history = usePromptHistory()
   const stash = usePromptStash()
@@ -832,6 +851,11 @@ export function Prompt(props: PromptProps) {
             backgroundColor={theme.backgroundElement}
             flexGrow={1}
           >
+            <Show when={ideContext.files().length > 0}>
+              <box flexShrink={0} paddingBottom={1}>
+                <text fg={theme.text}>{ideContextBar()}</text>
+              </box>
+            </Show>
             <textarea
               placeholder={placeholderText()}
               textColor={keybind.leader ? theme.textMuted : theme.text}

--- a/packages/opencode/src/cli/cmd/tui/context/ide-context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/ide-context.tsx
@@ -1,0 +1,21 @@
+import { createSignal } from "solid-js"
+import { createSimpleContext } from "./helper"
+
+export type IdeContextFile = {
+  path: string
+  selection?: { startLine: number; endLine: number }
+  active: boolean
+}
+
+export const { use: useIdeContext, provider: IdeContextProvider } = createSimpleContext({
+  name: "IdeContext",
+  init: () => {
+    const [files, setFiles] = createSignal<IdeContextFile[]>([])
+
+    return {
+      files,
+      setFiles,
+      clear: () => setFiles([]),
+    }
+  },
+})

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -3,8 +3,15 @@ import { Bus } from "@/bus"
 import { SessionID } from "@/session/schema"
 import z from "zod"
 
+const IdeContextFile = z.object({
+  path: z.string(),
+  selection: z.object({ startLine: z.number(), endLine: z.number() }).optional(),
+  active: z.boolean(),
+})
+
 export const TuiEvent = {
   PromptAppend: BusEvent.define("tui.prompt.append", z.object({ text: z.string() })),
+  ContextSync: BusEvent.define("tui.context.sync", z.object({ files: IdeContextFile.array() })),
   CommandExecute: BusEvent.define(
     "tui.command.execute",
     z.object({

--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -102,6 +102,30 @@ export const TuiRoutes = lazy(() =>
       },
     )
     .post(
+      "/context/sync",
+      describeRoute({
+        summary: "Sync IDE context",
+        description: "Sync IDE context from VSCode or other editors",
+        operationId: "tui.contextSync",
+        responses: {
+          200: {
+            description: "Context synced successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", TuiEvent.ContextSync.properties),
+      async (c) => {
+        await Bus.publish(TuiEvent.ContextSync, c.req.valid("json"))
+        return c.json(true)
+      },
+    )
+    .post(
       "/open-help",
       describeRoute({
         summary: "Open help dialog",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -21,6 +21,7 @@ import type {
   ConfigUpdateResponses,
   EventSubscribeResponses,
   EventTuiCommandExecute,
+  EventTuiContextSync,
   EventTuiPromptAppend,
   EventTuiSessionSelect,
   EventTuiToastShow,
@@ -158,6 +159,8 @@ import type {
   TuiAppendPromptErrors,
   TuiAppendPromptResponses,
   TuiClearPromptResponses,
+  TuiContextSyncErrors,
+  TuiContextSyncResponses,
   TuiControlNextResponses,
   TuiControlResponseResponses,
   TuiExecuteCommandErrors,
@@ -3260,6 +3263,50 @@ export class Tui extends HeyApiClient {
   }
 
   /**
+   * Sync IDE context
+   *
+   * Sync IDE context from VSCode or other editors
+   */
+  public contextSync<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      files?: Array<{
+        path: string
+        selection?: {
+          startLine: number
+          endLine: number
+        }
+        active: boolean
+      }>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "files" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<TuiContextSyncResponses, TuiContextSyncErrors, ThrowOnError>({
+      url: "/tui/context/sync",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * Open help dialog
    *
    * Open the help dialog in the TUI to display user assistance information.
@@ -3528,7 +3575,12 @@ export class Tui extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+      body?:
+        | EventTuiPromptAppend
+        | EventTuiContextSync
+        | EventTuiCommandExecute
+        | EventTuiToastShow
+        | EventTuiSessionSelect
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -723,6 +723,20 @@ export type EventTuiPromptAppend = {
   }
 }
 
+export type EventTuiContextSync = {
+  type: "tui.context.sync"
+  properties: {
+    files: Array<{
+      path: string
+      selection?: {
+        startLine: number
+        endLine: number
+      }
+      active: boolean
+    }>
+  }
+}
+
 export type EventTuiCommandExecute = {
   type: "tui.command.execute"
   properties: {
@@ -983,6 +997,7 @@ export type Event =
   | EventFileWatcherUpdated
   | EventTodoUpdated
   | EventTuiPromptAppend
+  | EventTuiContextSync
   | EventTuiCommandExecute
   | EventTuiToastShow
   | EventTuiSessionSelect
@@ -4518,6 +4533,43 @@ export type TuiAppendPromptResponses = {
 
 export type TuiAppendPromptResponse = TuiAppendPromptResponses[keyof TuiAppendPromptResponses]
 
+export type TuiContextSyncData = {
+  body?: {
+    files: Array<{
+      path: string
+      selection?: {
+        startLine: number
+        endLine: number
+      }
+      active: boolean
+    }>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/tui/context/sync"
+}
+
+export type TuiContextSyncErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type TuiContextSyncError = TuiContextSyncErrors[keyof TuiContextSyncErrors]
+
+export type TuiContextSyncResponses = {
+  /**
+   * Context synced successfully
+   */
+  200: boolean
+}
+
+export type TuiContextSyncResponse = TuiContextSyncResponses[keyof TuiContextSyncResponses]
+
 export type TuiOpenHelpData = {
   body?: never
   path?: never
@@ -4690,7 +4742,7 @@ export type TuiShowToastResponses = {
 export type TuiShowToastResponse = TuiShowToastResponses[keyof TuiShowToastResponses]
 
 export type TuiPublishData = {
-  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+  body?: EventTuiPromptAppend | EventTuiContextSync | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
   path?: never
   query?: {
     directory?: string

--- a/sdks/vscode/eslint.config.mjs
+++ b/sdks/vscode/eslint.config.mjs
@@ -28,7 +28,7 @@ export default [
       curly: "warn",
       eqeqeq: "warn",
       "no-throw-literal": "warn",
-      semi: "warn",
+      semi: ["warn", "never"],
     },
   },
 ]

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -20,9 +20,29 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:opencode.openTerminal",
+    "onCommand:opencode.openNewTerminal",
+    "onCommand:opencode.syncContext",
+    "onCommand:opencode.addFilepathToTerminal"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "opencode",
+      "properties": {
+        "opencode.context.autoSync": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically sync file context to opencode when files or selections change. Enabled by default."
+        },
+        "opencode.context.includeInactiveFiles": {
+          "type": "boolean",
+          "default": true,
+          "description": "Include open inactive files in the IDE context. Enabled by default."
+        }
+      }
+    },
     "commands": [
       {
         "command": "opencode.openTerminal",
@@ -43,6 +63,10 @@
       {
         "command": "opencode.addFilepathToTerminal",
         "title": "Add Filepath to Terminal"
+      },
+      {
+        "command": "opencode.syncContext",
+        "title": "Sync IDE Context"
       }
     ],
     "menus": {
@@ -71,8 +95,8 @@
         "linux": "ctrl+shift+escape"
       },
       {
-        "command": "opencode.addFilepathToTerminal",
-        "title": "opencode: Insert At-Mentioned",
+        "command": "opencode.syncContext",
+        "title": "Sync IDE Context",
         "key": "cmd+alt+k",
         "mac": "cmd+alt+k",
         "win": "ctrl+alt+K",

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,137 +1,334 @@
-// This method is called when your extension is deactivated
-export function deactivate() {}
-
+import { existsSync } from "node:fs"
+import * as path from "node:path"
 import * as vscode from "vscode"
 
 const TERMINAL_NAME = "opencode"
+const output = vscode.window.createOutputChannel("opencode")
 
-export function activate(context: vscode.ExtensionContext) {
-  let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
-    await openTerminal()
-  })
+type Sel = {
+  startLine: number
+  endLine: number
+}
 
-  let openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
-    // An opencode terminal already exists => focus it
-    const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME)
-    if (existingTerminal) {
-      existingTerminal.show()
-      return
+type Item = {
+  path: string
+  active: boolean
+  selection?: Sel
+}
+
+class Files {
+  private map = new Map<string, Item>()
+  private active: string | undefined
+  private readonly change = new vscode.EventEmitter<void>()
+  readonly onDidChange = this.change.event
+
+  constructor(ctx: vscode.ExtensionContext) {
+    ctx.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (!editor) {
+          return
+        }
+        this.upsert(editor)
+        this.setActive(editor.document.uri.fsPath)
+        this.emit()
+      }),
+      vscode.window.onDidChangeTextEditorSelection((event) => {
+        this.upsert(event.textEditor)
+        if (event.textEditor.document.uri.fsPath === this.active) {
+          this.setActive(event.textEditor.document.uri.fsPath)
+        }
+        this.emit()
+      }),
+      vscode.window.onDidChangeVisibleTextEditors((editors) => {
+        editors.forEach((editor) => this.upsert(editor))
+        this.prune()
+        this.emit()
+      }),
+      vscode.workspace.onDidCloseTextDocument((doc) => {
+        this.map.delete(doc.uri.fsPath)
+        if (this.active === doc.uri.fsPath) {
+          this.active = undefined
+        }
+        this.prune()
+        this.emit()
+      }),
+    )
+
+    vscode.window.visibleTextEditors.forEach((editor) => this.upsert(editor))
+    if (vscode.window.activeTextEditor) {
+      this.upsert(vscode.window.activeTextEditor)
+      this.setActive(vscode.window.activeTextEditor.document.uri.fsPath)
     }
+    this.prune()
+  }
 
-    await openTerminal()
-  })
-
-  let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
-    const fileRef = getActiveFile()
-    if (!fileRef) {
-      return
+  snapshot(include: boolean) {
+    const files: Item[] = []
+    const active = this.getActive()
+    if (active) {
+      files.push(active)
     }
-
-    const terminal = vscode.window.activeTerminal
-    if (!terminal) {
-      return
+    if (include) {
+      files.push(...this.getOpen())
     }
+    return files
+  }
 
-    if (terminal.name === TERMINAL_NAME) {
-      // @ts-ignore
-      const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
-      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef, false)
-      terminal.show()
+  getActive() {
+    if (!this.active) {
+      return undefined
     }
-  })
-
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
-
-  async function openTerminal() {
-    // Create a new terminal in split screen
-    const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
-    const terminal = vscode.window.createTerminal({
-      name: TERMINAL_NAME,
-      iconPath: {
-        light: vscode.Uri.file(context.asAbsolutePath("images/button-dark.svg")),
-        dark: vscode.Uri.file(context.asAbsolutePath("images/button-light.svg")),
-      },
-      location: {
-        viewColumn: vscode.ViewColumn.Beside,
-        preserveFocus: false,
-      },
-      env: {
-        _EXTENSION_OPENCODE_PORT: port.toString(),
-        OPENCODE_CALLER: "vscode",
-      },
-    })
-
-    terminal.show()
-    terminal.sendText(`opencode --port ${port}`)
-
-    const fileRef = getActiveFile()
-    if (!fileRef) {
-      return
+    const item = this.map.get(this.active)
+    if (!item) {
+      return undefined
     }
+    return { ...item, active: true }
+  }
 
-    // Wait for the terminal to be ready
-    let tries = 10
-    let connected = false
-    do {
-      await new Promise((resolve) => setTimeout(resolve, 200))
-      try {
-        await fetch(`http://localhost:${port}/app`)
-        connected = true
-        break
-      } catch (e) {}
+  getOpen() {
+    return Array.from(this.tabs())
+      .filter((file) => file !== this.active)
+      .flatMap((file) => {
+        const item = this.map.get(file)
+        if (item) {
+          return [{ ...item, active: false }]
+        }
 
-      tries--
-    } while (tries > 0)
+        const rel = this.rel(vscode.Uri.file(file))
+        if (!rel) {
+          return []
+        }
 
-    // If connected, append the prompt to the terminal
-    if (connected) {
-      await appendPrompt(port, `In ${fileRef}`)
-      terminal.show()
+        return [{ path: rel, active: false }]
+      })
+  }
+
+  private emit() {
+    this.change.fire()
+  }
+
+  private setActive(file: string) {
+    this.active = file
+    for (const [key, item] of this.map.entries()) {
+      item.active = key === file
     }
   }
 
-  async function appendPrompt(port: number, text: string) {
-    await fetch(`http://localhost:${port}/tui/append-prompt`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ text }),
-    })
-  }
-
-  function getActiveFile() {
-    const activeEditor = vscode.window.activeTextEditor
-    if (!activeEditor) {
-      return
-    }
-
-    const document = activeEditor.document
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
-    if (!workspaceFolder) {
-      return
-    }
-
-    // Get the relative path from workspace root
-    const relativePath = vscode.workspace.asRelativePath(document.uri)
-    let filepathWithAt = `@${relativePath}`
-
-    // Check if there's a selection and add line numbers
-    const selection = activeEditor.selection
-    if (!selection.isEmpty) {
-      // Convert to 1-based line numbers
-      const startLine = selection.start.line + 1
-      const endLine = selection.end.line + 1
-
-      if (startLine === endLine) {
-        // Single line selection
-        filepathWithAt += `#L${startLine}`
-      } else {
-        // Multi-line selection
-        filepathWithAt += `#L${startLine}-${endLine}`
+  private prune() {
+    const tabs = this.tabs()
+    for (const [file] of this.map.entries()) {
+      if (file === this.active) {
+        continue
+      }
+      if (!tabs.has(file)) {
+        this.map.delete(file)
       }
     }
-
-    return filepathWithAt
   }
+
+  private tabs() {
+    const tabs = new Set<string>()
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        if (tab.input instanceof vscode.TabInputText) {
+          tabs.add(tab.input.uri.fsPath)
+        }
+      }
+    }
+    return tabs
+  }
+
+  private upsert(editor: vscode.TextEditor) {
+    const rel = this.rel(editor.document.uri)
+    if (!rel) {
+      return
+    }
+    this.map.set(editor.document.uri.fsPath, {
+      path: rel,
+      active: editor.document.uri.fsPath === this.active,
+      selection: this.selection(editor.selection),
+    })
+  }
+
+  private rel(uri: vscode.Uri) {
+    const folder = vscode.workspace.getWorkspaceFolder(uri)
+    if (!folder) {
+      return undefined
+    }
+    return vscode.workspace.asRelativePath(uri)
+  }
+
+  private selection(sel: vscode.Selection) {
+    if (sel.isEmpty) {
+      return undefined
+    }
+    return {
+      startLine: Math.min(sel.anchor.line, sel.active.line) + 1,
+      endLine: Math.max(sel.anchor.line, sel.active.line) + 1,
+    }
+  }
+}
+
+let files: Files
+let sync: vscode.Disposable | undefined
+
+export function activate(ctx: vscode.ExtensionContext) {
+  files = new Files(ctx)
+
+  ctx.subscriptions.push(
+    output,
+    vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
+      await open(ctx)
+    }),
+    vscode.commands.registerCommand("opencode.openTerminal", async () => {
+      const existing = terminal()
+      if (existing) {
+        existing.show()
+        return
+      }
+      await open(ctx)
+    }),
+    vscode.commands.registerCommand("opencode.syncContext", async () => {
+      await push()
+    }),
+    vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
+      const editor = vscode.window.activeTextEditor
+      const term = terminal()
+      if (!editor || !term) {
+        return
+      }
+
+      const file = vscode.workspace.asRelativePath(editor.document.uri)
+      const sel = editor.selection.isEmpty
+        ? ""
+        : `#L${Math.min(editor.selection.anchor.line, editor.selection.active.line) + 1}-${Math.max(editor.selection.anchor.line, editor.selection.active.line) + 1}`
+
+      term.show()
+      term.sendText(`@${file}${sel}`, false)
+    }),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (!event.affectsConfiguration("opencode.context.autoSync")) {
+        return
+      }
+      watch()
+    }),
+  )
+
+  watch()
+}
+
+export function deactivate() {
+  sync?.dispose()
+}
+
+function watch() {
+  sync?.dispose()
+  if (!cfg("context.autoSync", false)) {
+    sync = undefined
+    return
+  }
+  sync = files.onDidChange(() => {
+    void push()
+  })
+}
+
+function cfg<T extends boolean>(key: string, fallback: T) {
+  return vscode.workspace.getConfiguration("opencode").get<T>(key, fallback)
+}
+
+function terminal() {
+  return vscode.window.terminals.find((item) => item.name === TERMINAL_NAME)
+}
+
+function payload() {
+  return files.snapshot(cfg("context.includeInactiveFiles", false))
+}
+
+function log(files: Item[], kind: string) {
+  output.appendLine(
+    `${kind}: ${files.map((file) => `${file.path}${file.selection ? `#L${file.selection.startLine}-${file.selection.endLine}` : ""}${file.active ? " [active]" : ""}`).join(", ") || "<none>"}`,
+  )
+}
+
+async function push() {
+  const term = terminal()
+  if (!term) {
+    return
+  }
+  const port = (term.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
+  if (!port) {
+    return
+  }
+  const body = payload()
+  log(body, "sync")
+  try {
+    await fetch(`http://localhost:${port}/tui/context/sync`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ files: body }),
+    })
+  } catch (err) {
+    output.appendLine(`sync error: ${String(err)}`)
+  }
+}
+
+async function open(ctx: vscode.ExtensionContext) {
+  const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
+  const body = payload()
+  log(body, "open")
+
+  const term = vscode.window.createTerminal({
+    name: TERMINAL_NAME,
+    iconPath: {
+      light: vscode.Uri.file(path.join(ctx.extensionPath, "images", "button-dark.svg")),
+      dark: vscode.Uri.file(path.join(ctx.extensionPath, "images", "button-light.svg")),
+    },
+    location: { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false },
+    env: {
+      _EXTENSION_OPENCODE_PORT: String(port),
+      OPENCODE_CALLER: "vscode",
+      PATH: `/Users/ravshan/.local/bin:/usr/local/bin:/usr/bin:/bin:${process.env.PATH || ""}`,
+    },
+  })
+
+  term.show()
+  term.sendText(`${binary(ctx)} --port ${port}`)
+
+  let tries = 10
+  let ready = false
+  while (tries > 0) {
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    try {
+      await fetch(`http://localhost:${port}/app`)
+      ready = true
+      break
+    } catch {}
+    tries -= 1
+  }
+
+  if (!ready) {
+    return
+  }
+
+  try {
+    await fetch(`http://localhost:${port}/tui/context/sync`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ files: body }),
+    })
+  } catch (err) {
+    output.appendLine(`open error: ${String(err)}`)
+  }
+}
+
+function binary(ctx: vscode.ExtensionContext) {
+  const plat = process.platform
+  const arch = process.arch
+  const dir = `${plat === "darwin" ? "opencode-darwin" : plat === "linux" ? "opencode-linux" : "opencode-windows"}-${arch}`
+  const exe = plat === "win32" ? "opencode.exe" : "opencode"
+  const local = path.join(ctx.extensionPath, "..", "..", "packages", "opencode", "dist", dir, "bin", exe)
+  if (existsSync(local)) {
+    return local
+  }
+  return exe
 }


### PR DESCRIPTION
### Issue for this PR

Closes #3096
Closes #3472

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds an IDE-context sync path between the VS Code extension and the TUI. The extension now sends the active file plus open inactive files, keeps them synced by default, and the TUI shows the active file with a compact inactive-file count above the prompt.

It also restores the filepath insert command and renames the VS Code setting from `includeOpenFiles` to `includeInactiveFiles`, which matches the actual behavior better.

### How did you verify your code works?

- built `packages/opencode`
- ran `bun run compile` in `sdks/vscode`
- tested the VS Code flow locally: opening opencode sends the active file and inactive open files, switching focus no longer drops the active file, and the prompt bar renders the IDE context safely

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR