### PR TITLE
fix(tui): fix `--prompt` auto-submit race condition

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import { createEffect, createMemo, Match, on, onMount, Show, Switch } from "solid-js"
+import { createEffect, createMemo, createSignal, Match, on, onMount, Show, Switch } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { useKeybind } from "@tui/context/keybind"
 import { Logo } from "../component/logo"
@@ -78,6 +78,7 @@ export function Home() {
   let prompt: PromptRef
   const args = useArgs()
   const local = useLocal()
+  const [pendingAutoSubmit, setPendingAutoSubmit] = createSignal(false)
   onMount(() => {
     if (once) return
     if (route.initialPrompt) {
@@ -86,17 +87,17 @@ export function Home() {
     } else if (args.prompt) {
       prompt.set({ input: args.prompt, parts: [] })
       once = true
+      setPendingAutoSubmit(true)
     }
   })
 
   // Wait for sync and model store to be ready before auto-submitting --prompt
   createEffect(
     on(
-      () => sync.ready && local.model.ready,
+      () => sync.ready && local.model.ready && pendingAutoSubmit(),
       (ready) => {
         if (!ready) return
-        if (!args.prompt) return
-        if (prompt.current?.input !== args.prompt) return
+        setPendingAutoSubmit(false)
         prompt.submit()
       },
     ),


### PR DESCRIPTION
### Issue for this PR

Closes #17608
Closes #18190

### Type of change

- [x] Bug fix

### What does this PR do?

The `--prompt` flag stopped working in v1.2.25 after #7476 ([`b312928`](https://github.com/anomalyco/opencode/commit/b312928e9f9149aaacf1cbb9af96399c1672c334)) moved `prompt.submit()` into a `createEffect` with a text-comparison guard.

The guard (`prompt.current?.input !== args.prompt`) is untracked by `on()`, so if the value doesn't match at the exact moment that readiness transitions, the submission is silently skipped and never retried.

This replaces the text comparison with a `createSignal` that coordinates between `onMount` (sets prompt) and the effect (submits).

### How did you verify your code works?

```
cd packages/opencode
bun dev -- --prompt "hello"

# see failure
# apply patch

bun dev -- --prompt "hello"
# success
```

### Screenshots / recordings

https://github.com/user-attachments/assets/b9bfb60f-d502-4d59-b186-bd0c137dc5bd

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

