### PR TITLE
fix: add formatter import-stripping warning to edit tool description

### DIFF
--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -8,3 +8,4 @@ Usage:
 - The edit will FAIL if `oldString` is not found in the file with an error "oldString not found in content".
 - The edit will FAIL if `oldString` is found multiple times in the file with an error "Found multiple matches for oldString. Provide more surrounding lines in oldString to identify the correct match." Either provide a larger string with more surrounding context to make it unique or use `replaceAll` to change every instance of `oldString`. 
 - Use `replaceAll` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+- Language-specific formatters may run after every edit. Some formatters (e.g. ruff, eslint) automatically remove unused imports. To avoid import stripping, always add the code that uses a symbol first, then add the import for it in a separate edit. Never add an import as the only change if the symbol is not yet used in the file.


### PR DESCRIPTION
### Issue for this PR

Closes #11359

### Type of change

- [x] Bug fix

### What does this PR do?

Adds a hint to the edit tool description warning the agent that language-specific formatters (e.g. ruff, eslint) may automatically remove unused imports after each edit. The hint instructs the agent to:

1. Add code that **uses** a symbol first
2. Add the **import** in a separate edit afterward

This prevents the frustrating loop where the agent adds imports → formatter strips them → agent re-adds → formatter strips again.

### How did you verify your code works?

- Typecheck passes (all 12 packages)
- Change is a single line addition to a `.txt` description file — no runtime behavior change
- The fix matches the exact suggestion from the issue author

### Screenshots / recordings

N/A — text-only change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR