### PR TITLE
fix(config): write PATCH /config to opencode.json instead of config.json

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1347,10 +1347,18 @@ export namespace Config {
   }
 
   export async function update(config: Info) {
-    const filepath = path.join(Instance.directory, "config.json")
+    const filepath = projectConfigFile()
     const existing = await loadFile(filepath)
     await Filesystem.writeJson(filepath, mergeDeep(existing, config))
     await Instance.dispose()
+  }
+
+  function projectConfigFile() {
+    const candidates = ["opencode.jsonc", "opencode.json"].map((file) => path.join(Instance.directory, file))
+    for (const file of candidates) {
+      if (existsSync(file)) return file
+    }
+    return candidates[1]
   }
 
   function globalConfigFile() {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -685,7 +685,7 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await Config.update(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "opencode.json"))
       expect(writtenConfig.model).toBe("updated/model")
     },
   })


### PR DESCRIPTION
### Issue for this PR

Closes #4194

### Type of change

- [x] Bug fix

### What does this PR do?

`Config.update()` (used by `PATCH /config`) was writing to `config.json` in the project root. However, the config loader reads from `opencode.jsonc` / `opencode.json` — it never reads `config.json` at the project level.

This means any config change via the API (desktop app, web UI, or direct API call) would silently disappear on the next restart.

The fix adds a `projectConfigFile()` helper (mirroring the existing `globalConfigFile()` pattern) that checks for an existing `opencode.jsonc` first, then falls back to `opencode.json`.

### How did you verify your code works?

- Typecheck passes (12/12 packages)
- Verified the config loader reads `opencode.jsonc` / `opencode.json` (lines 119-122 in config.ts)
- Confirmed `globalConfigFile()` uses the same pattern and works correctly for the global case

### Screenshots / recordings

N/A

### Checklist

- [x] Code follows project conventions
- [x] Single concern per PR
- [x] Linked to issue
- [x] Typecheck passes