### PR TITLE
feat(core): add reasoning variant toggle for GLM models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -340,13 +340,35 @@ export namespace ProviderTransform {
     if (
       id.includes("deepseek") ||
       id.includes("minimax") ||
-      id.includes("glm") ||
       id.includes("mistral") ||
       id.includes("kimi") ||
       // TODO: Remove this after models.dev data is fixed to use "kimi-k2.5" instead of "k2p5"
       id.includes("k2p5")
     )
       return {}
+
+    // GLM models: allow toggling thinking on/off
+    if (id.includes("glm")) {
+      if (model.api.npm === "@ai-sdk/openai-compatible") {
+        if (["zai", "zhipuai"].includes(model.providerID)) {
+          return {
+            none: { thinking: { type: "disabled" } },
+            high: { thinking: { type: "enabled", clear_thinking: false } },
+          }
+        }
+        return {
+          none: { reasoning: { enabled: false } },
+          high: { reasoning: { enabled: true } },
+        }
+      }
+      if (model.api.npm === "@openrouter/ai-sdk-provider") {
+        return {
+          none: { reasoning: { enabled: false } },
+          high: { reasoning: { enabled: true } },
+        }
+      }
+      return {}
+    }
 
     // see: https://docs.x.ai/docs/guides/reasoning#control-how-hard-the-model-thinks
     if (id.includes("grok") && id.includes("grok-3-mini")) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1799,14 +1799,65 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
-  test("glm returns empty object", () => {
+  test("glm on zai returns thinking toggle variants", () => {
     const model = createMockModel({
-      id: "glm/glm-4",
-      providerID: "glm",
+      id: "zai/glm-5",
+      providerID: "zai",
       api: {
-        id: "glm-4",
-        url: "https://api.glm.com",
+        id: "glm-5",
+        url: "https://open.z.ai/api",
         npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { thinking: { type: "disabled" } },
+      high: { thinking: { type: "enabled", clear_thinking: false } },
+    })
+  })
+
+  test("glm on openai-compatible (non-zai) returns reasoning toggle variants", () => {
+    const model = createMockModel({
+      id: "openrouter/z-ai/glm-5",
+      providerID: "openrouter",
+      api: {
+        id: "z-ai/glm-5",
+        url: "https://openrouter.ai/api/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { reasoning: { enabled: false } },
+      high: { reasoning: { enabled: true } },
+    })
+  })
+
+  test("glm on openrouter provider returns reasoning toggle variants", () => {
+    const model = createMockModel({
+      id: "openrouter/z-ai/glm-5",
+      providerID: "openrouter",
+      api: {
+        id: "z-ai/glm-5",
+        url: "https://openrouter.ai/api/v1",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      none: { reasoning: { enabled: false } },
+      high: { reasoning: { enabled: true } },
+    })
+  })
+
+  test("glm without matching npm returns empty object", () => {
+    const model = createMockModel({
+      id: "custom/glm-5",
+      providerID: "custom",
+      api: {
+        id: "glm-5",
+        url: "https://custom.api.com",
+        npm: "@ai-sdk/anthropic",
       },
     })
     const result = ProviderTransform.variants(model)


### PR DESCRIPTION
### Issue for this PR

Closes #18598

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GLM models were excluded from reasoning variants in `ProviderTransform.variants()`, which meant users could not toggle thinking mode on/off at runtime — only via static config before starting a session.

This PR removes GLM from the exclusion list and adds `none`/`high` variants with the correct parameter format per provider:
- **Z.AI/Zhipu directly**: `thinking: { type: "enabled"/"disabled" }` (native API format)
- **OpenRouter / openai-compatible**: `reasoning: { enabled: true/false }`

Users just need `"reasoning": true` in their model config to get the variant selector. The code handles the provider-specific format automatically.

### How did you verify your code works?

- All 121 existing transform tests pass, including 4 new tests covering GLM variants for Z.AI, OpenRouter (both SDK flavors), and unknown providers
- Manually tested with GLM-5 via OpenRouter: confirmed `none` disables thinking output, `high` enables it, switching works mid-session

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR