### PR TITLE
fix(app): prevent crash when model context is undefined during project switch

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1499,12 +1499,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           style={control()}
                           onClick={() => dialog.show(() => <DialogSelectModelUnpaid model={local.model} />)}
                         >
-                          <Show when={local.model.current()?.provider?.id}>
-                            <ProviderIcon
-                              id={local.model.current()!.provider.id}
-                              class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                              style={{ "will-change": "opacity", transform: "translateZ(0)" }}
-                            />
+                          <Show when={local.model.current()?.provider?.id} keyed>
+                            {(id) => (
+                              <ProviderIcon
+                                id={id}
+                                class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
+                                style={{ "will-change": "opacity", transform: "translateZ(0)" }}
+                              />
+                            )}
                           </Show>
                           <span class="truncate">
                             {local.model.current()?.name ?? language.t("dialog.model.select.title")}
@@ -1531,12 +1533,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           "data-action": "prompt-model",
                         }}
                       >
-                        <Show when={local.model.current()?.provider?.id}>
-                          <ProviderIcon
-                            id={local.model.current()!.provider.id}
-                            class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                            style={{ "will-change": "opacity", transform: "translateZ(0)" }}
-                          />
+                        <Show when={local.model.current()?.provider?.id} keyed>
+                          {(id) => (
+                            <ProviderIcon
+                              id={id}
+                              class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
+                              style={{ "will-change": "opacity", transform: "translateZ(0)" }}
+                            />
+                          )}
                         </Show>
                         <span class="truncate">
                           {local.model.current()?.name ?? language.t("dialog.model.select.title")}


### PR DESCRIPTION
## Summary

- Replace non-null assertion (`current()!.provider.id`) with Solid's `keyed` callback pattern in `ProviderIcon` rendering
- Prevents `TypeError: Cannot read properties of undefined (reading 'provider')` crash when switching projects in web/desktop UI

## Root Cause

In `prompt-input.tsx`, `<Show when={...}>` guards the render, but Solid can evaluate reactive access while `local.model.current()` is transiently `undefined` during project switch transitions. The `!` non-null assertion then throws.

The `keyed` callback pattern safely captures the truthy value from the `when` condition, so the `id` is always defined inside the callback.

## Test plan

- [ ] Open web UI, select a model, click a different project in the sidebar — no crash
- [ ] Verify provider icon still renders correctly when model is available

Closes #18491