### PR TITLE
fix(file): guard against EISDIR when .gitignore/.ignore is a directory

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -611,11 +611,11 @@ export namespace File {
           if (Instance.project.vcs === "git") {
             const ig = ignore()
             const gitignore = path.join(Instance.project.worktree, ".gitignore")
-            if (await Filesystem.exists(gitignore)) {
+            if (await Filesystem.exists(gitignore) && !(await Filesystem.isDir(gitignore))) {
               ig.add(await Filesystem.readText(gitignore))
             }
             const ignoreFile = path.join(Instance.project.worktree, ".ignore")
-            if (await Filesystem.exists(ignoreFile)) {
+            if (await Filesystem.exists(ignoreFile) && !(await Filesystem.isDir(ignoreFile))) {
               ig.add(await Filesystem.readText(ignoreFile))
             }
             ignored = ig.ignores.bind(ig)


### PR DESCRIPTION
## Summary

- Add `isDir` check before reading `.gitignore` and `.ignore` in `File.list()`
- Prevents EISDIR crash when these paths are directories instead of files

## Root Cause

`Filesystem.exists()` returns `true` for both files and directories, but `Filesystem.readText()` throws `EISDIR: illegal operation on a directory, read` when the path is a directory. The `File.list()` function didn't distinguish between files and directories before attempting to read `.gitignore` and `.ignore`, causing the entire file listing to fail with an unhandled error.

## Test plan

- [ ] `opencode debug file list .` works in a project with normal `.gitignore`
- [ ] `opencode debug file list .` works in a project where `.gitignore` is a directory (edge case)
- [ ] Desktop app file modification panel displays files correctly

Closes #18449