### PR TITLE
fix(acp): session/set_mode now activates agent's configured model

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -46,7 +46,13 @@ import { LoadAPIKeyError } from "ai"
 import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
 
-type ModeOption = { id: string; name: string; description?: string }
+type ModeOption = {
+  id: string
+  name: string
+  description?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+}
 type ModelOption = { modelId: string; name: string }
 
 const DEFAULT_VARIANT_VALUE = "default"
@@ -1125,6 +1131,8 @@ export namespace ACP {
           id: agent.name,
           name: agent.name,
           description: agent.description,
+          model: agent.model,
+          variant: agent.variant,
         }))
     }
 
@@ -1279,10 +1287,19 @@ export namespace ACP {
     async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse | void> {
       const session = this.sessionManager.get(params.sessionId)
       const availableModes = await this.loadAvailableModes(session.cwd)
-      if (!availableModes.some((mode) => mode.id === params.modeId)) {
+      const selectedMode = availableModes.find((mode) => mode.id === params.modeId)
+      if (!selectedMode) {
         throw new Error(`Agent not found: ${params.modeId}`)
       }
       this.sessionManager.setMode(params.sessionId, params.modeId)
+
+      if (selectedMode.model) {
+        this.sessionManager.setModel(session.id, {
+          providerID: ProviderID.make(selectedMode.model.providerID),
+          modelID: ModelID.make(selectedMode.model.modelID),
+        })
+        this.sessionManager.setVariant(session.id, selectedMode.variant)
+      }
     }
 
     async prompt(params: PromptRequest) {

--- a/packages/opencode/test/acp/set-session-mode.test.ts
+++ b/packages/opencode/test/acp/set-session-mode.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test"
+import { ACP } from "../../src/acp/agent"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+function createFakeAgent(agents: any[] = []) {
+  const calls = {
+    eventSubscribe: 0,
+    sessionCreate: 0,
+  }
+
+  const connection = {
+    async sessionUpdate() {},
+    async requestPermission() {
+      return { outcome: { outcome: "selected", optionId: "once" } }
+    },
+  } as unknown as AgentSideConnection
+
+  const sdk = {
+    global: {
+      event: async (opts?: { signal?: AbortSignal }) => {
+        calls.eventSubscribe++
+        const stream = async function* () {
+          await new Promise(() => {})
+        }
+        return { stream: stream() }
+      },
+    },
+    session: {
+      create: async () => {
+        calls.sessionCreate++
+        return {
+          data: {
+            id: `ses_${calls.sessionCreate}`,
+            time: { created: new Date().toISOString() },
+          },
+        }
+      },
+      get: async () => ({
+        data: { id: "ses_1", time: { created: new Date().toISOString() } },
+      }),
+      messages: async () => ({ data: [] }),
+    },
+    config: {
+      providers: async () => ({
+        data: {
+          providers: [
+            {
+              id: "test-provider",
+              name: "Test Provider",
+              models: {
+                "model-a": { id: "model-a", name: "Model A" },
+                "model-b": { id: "model-b", name: "Model B" },
+              },
+            },
+          ],
+        },
+      }),
+    },
+    app: {
+      agents: async () => ({ data: agents }),
+    },
+    command: {
+      list: async () => ({ data: [] }),
+    },
+    mcp: {
+      add: async () => ({ data: true }),
+    },
+  } as any
+
+  const agent = new ACP.Agent(connection, {
+    sdk,
+    defaultModel: { providerID: "test-provider", modelID: "model-a" },
+  } as any)
+
+  const stop = () => {
+    ;(agent as any).eventAbort.abort()
+  }
+
+  const sessionManager = () => (agent as any).sessionManager
+
+  return { agent, stop, sdk, sessionManager }
+}
+
+describe("acp.agent setSessionMode", () => {
+  test("updates session model when selected mode has a configured model", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop, sessionManager } = createFakeAgent([
+          { name: "build", description: "default", mode: "primary" },
+          {
+            name: "custom",
+            description: "custom agent",
+            mode: "primary",
+            model: { providerID: "test-provider", modelID: "model-b" },
+            variant: "high",
+          },
+        ])
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        const before = sessionManager().getModel(sessionId)
+        expect(before.providerID).toBe("test-provider")
+        expect(before.modelID).toBe("model-a")
+
+        await agent.setSessionMode({ sessionId, modeId: "custom" })
+
+        const after = sessionManager().getModel(sessionId)
+        expect(after.providerID).toBe("test-provider")
+        expect(after.modelID).toBe("model-b")
+        expect(sessionManager().getVariant(sessionId)).toBe("high")
+
+        stop()
+      },
+    })
+  })
+
+  test("does not change session model when selected mode has no configured model", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop, sessionManager } = createFakeAgent([
+          { name: "build", description: "default", mode: "primary" },
+          { name: "plan", description: "plan mode", mode: "primary" },
+        ])
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        await agent.setSessionMode({ sessionId, modeId: "plan" })
+
+        const after = sessionManager().getModel(sessionId)
+        expect(after.providerID).toBe("test-provider")
+        expect(after.modelID).toBe("model-a")
+
+        stop()
+      },
+    })
+  })
+
+  test("throws when mode does not exist", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop } = createFakeAgent([
+          { name: "build", description: "default", mode: "primary" },
+        ])
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        expect(agent.setSessionMode({ sessionId, modeId: "nonexistent" })).rejects.toThrow("Agent not found")
+
+        stop()
+      },
+    })
+  })
+
+  test("switching modes updates model each time", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop, sessionManager } = createFakeAgent([
+          {
+            name: "agent-a",
+            description: "agent a",
+            mode: "primary",
+            model: { providerID: "test-provider", modelID: "model-a" },
+          },
+          {
+            name: "agent-b",
+            description: "agent b",
+            mode: "primary",
+            model: { providerID: "test-provider", modelID: "model-b" },
+          },
+        ])
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        await agent.setSessionMode({ sessionId, modeId: "agent-b" })
+        expect(sessionManager().getModel(sessionId).modelID).toBe("model-b")
+
+        await agent.setSessionMode({ sessionId, modeId: "agent-a" })
+        expect(sessionManager().getModel(sessionId).modelID).toBe("model-a")
+
+        stop()
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #18620

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session/set_mode` only updated `session.modeId` but never called `setModel()`/`setVariant()`, so the session kept using the default or previously configured model instead of the one configured for the selected agent.

The root cause is twofold:

1. `loadAvailableModes()` stripped `model` and `variant` from agent configs when building the mode list, so `setSessionMode()` had no model data available.
2. `setSessionMode()` only called `this.sessionManager.setMode()` without updating the model.

The fix extends `ModeOption` to carry `model` and `variant`, passes them through in `loadAvailableModes()`, and adds the `setModel()`/`setVariant()` calls in `setSessionMode()` when the selected agent has a configured model.

Ref #7099

### How did you verify your code works?

1. Added 4 unit tests in `packages/opencode/test/acp/set-session-mode.test.ts` — all pass
2. Built the binary and manually verified that switching agents via ACP now activates the configured model

### Screenshots / recordings

_N/A — backend/protocol change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR