### PR TITLE
fix(app): prevent crash when model context is undefined during project switch

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1499,12 +1499,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           style={control()}
                           onClick={() => dialog.show(() => <DialogSelectModelUnpaid model={local.model} />)}
                         >
-                          <Show when={local.model.current()?.provider?.id}>
-                            <ProviderIcon
-                              id={local.model.current()!.provider.id}
-                              class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                              style={{ "will-change": "opacity", transform: "translateZ(0)" }}
-                            />
+                          <Show when={local.model.current()?.provider?.id} keyed>
+                            {(id) => (
+                              <ProviderIcon
+                                id={id}
+                                class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
+                                style={{ "will-change": "opacity", transform: "translateZ(0)" }}
+                              />
+                            )}
                           </Show>
                           <span class="truncate">
                             {local.model.current()?.name ?? language.t("dialog.model.select.title")}
@@ -1531,12 +1533,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           "data-action": "prompt-model",
                         }}
                       >
-                        <Show when={local.model.current()?.provider?.id}>
-                          <ProviderIcon
-                            id={local.model.current()!.provider.id}
-                            class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
-                            style={{ "will-change": "opacity", transform: "translateZ(0)" }}
-                          />
+                        <Show when={local.model.current()?.provider?.id} keyed>
+                          {(id) => (
+                            <ProviderIcon
+                              id={id}
+                              class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
+                              style={{ "will-change": "opacity", transform: "translateZ(0)" }}
+                            />
+                          )}
                         </Show>
                         <span class="truncate">
                           {local.model.current()?.name ?? language.t("dialog.model.select.title")}


### PR DESCRIPTION
### Issue for this PR

Closes #18491

### Type of change

- [x] Bug fix

### What does this PR do?

`prompt-input.tsx` uses `<Show when={local.model.current()}>` to guard `ProviderIcon` rendering, but the inner block accesses `current()!.provider.id` with a non-null assertion. During project switch transitions, Solid can re-evaluate reactive expressions while `current()` is transiently `undefined`, causing:

```
TypeError: Cannot read properties of undefined (reading 'provider')
```

The fix replaces the non-null assertion with Solid's `keyed` callback pattern on the `<Show>` component. The `keyed` callback safely captures the truthy value from the `when` condition, so `provider.id` is always defined inside the callback body.

Two `<Show>` sites in the file were affected and both are fixed.

### How did you verify your code works?

- `bun run typecheck` passes across all 12 packages
- Manually verified: open web UI, select a model, switch projects in sidebar — no crash, provider icon renders correctly

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR