### PR TITLE
fix(file): guard against EISDIR when .gitignore/.ignore is a directory

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -611,11 +611,11 @@ export namespace File {
           if (Instance.project.vcs === "git") {
             const ig = ignore()
             const gitignore = path.join(Instance.project.worktree, ".gitignore")
-            if (await Filesystem.exists(gitignore)) {
+            if (await Filesystem.exists(gitignore) && !(await Filesystem.isDir(gitignore))) {
               ig.add(await Filesystem.readText(gitignore))
             }
             const ignoreFile = path.join(Instance.project.worktree, ".ignore")
-            if (await Filesystem.exists(ignoreFile)) {
+            if (await Filesystem.exists(ignoreFile) && !(await Filesystem.isDir(ignoreFile))) {
               ig.add(await Filesystem.readText(ignoreFile))
             }
             ignored = ig.ignores.bind(ig)


### PR DESCRIPTION
### Issue for this PR

Closes #18449

### Type of change

- [x] Bug fix

### What does this PR do?

`File.list()` reads `.gitignore` and `.ignore` after checking `Filesystem.exists()`, but `exists()` returns `true` for directories too. When either path is a directory instead of a file, `Filesystem.readText()` throws:

```
EISDIR: illegal operation on a directory, read
```

This crashes the entire file listing in the desktop app's file modification panel.

The fix adds an `isDir` guard (using `Filesystem.stat()`) before each `readText()` call. If the path is a directory, it's skipped silently — matching the existing behavior for missing files.

### How did you verify your code works?

- `bun run typecheck` passes across all 12 packages
- `opencode debug file list .` works in a project with normal `.gitignore`
- Tested with `.gitignore` as a directory — file listing completes without error

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR