### PR TITLE
fix(permission): use absolute paths for external file permission matching

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -172,7 +172,11 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
     }))
 
     // Check permissions if needed
-    const relativePaths = fileChanges.map((c) => path.relative(Instance.worktree, c.filePath).replaceAll("\\", "/"))
+    const relativePaths = fileChanges.map((c) =>
+      Instance.containsPath(c.filePath)
+        ? path.relative(Instance.worktree, c.filePath).replaceAll("\\", "/")
+        : c.filePath.replaceAll("\\", "/"),
+    )
     await ctx.ask({
       permission: "edit",
       patterns: relativePaths,

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -63,7 +63,7 @@ export const EditTool = Tool.define("edit", {
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
         await ctx.ask({
           permission: "edit",
-          patterns: [path.relative(Instance.worktree, filePath)],
+          patterns: [Instance.containsPath(filePath) ? path.relative(Instance.worktree, filePath) : filePath],
           always: ["*"],
           metadata: {
             filepath: filePath,
@@ -99,7 +99,7 @@ export const EditTool = Tool.define("edit", {
       )
       await ctx.ask({
         permission: "edit",
-        patterns: [path.relative(Instance.worktree, filePath)],
+        patterns: [Instance.containsPath(filePath) ? path.relative(Instance.worktree, filePath) : filePath],
         always: ["*"],
         metadata: {
           filepath: filePath,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -33,7 +33,7 @@ export const WriteTool = Tool.define("write", {
     const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
     await ctx.ask({
       permission: "edit",
-      patterns: [path.relative(Instance.worktree, filepath)],
+      patterns: [Instance.containsPath(filepath) ? path.relative(Instance.worktree, filepath) : filepath],
       always: ["*"],
       metadata: {
         filepath,


### PR DESCRIPTION
### Issue for this PR

Closes #18441

### Type of change

- [x] Bug fix

### What does this PR do?

The `edit`, `write`, and `apply_patch` tools send permission check patterns as **relative paths** from the worktree (e.g. `../../.config/opencode/file.txt`). Meanwhile, user-defined permission rules in config are expanded to **absolute paths** (e.g. `/Users/x/.config/opencode/**` after `~/` expansion in `Permission.fromConfig()`).

`Wildcard.match()` compares these two different formats and never matches, so edit/write rules for external files silently fall through to the default `{ permission: "*", pattern: "*", action: "allow" }` rule — bypassing any user-specified `"ask"` or `"deny"` restrictions.

The fix checks whether the target file is inside the worktree via `Instance.containsPath()`:
- **Internal files**: keep relative paths (preserves existing behavior and matches relative config patterns like `"src/**"`)
- **External files**: use absolute paths (correctly matches expanded config rules like `"/Users/x/.config/**"`)

This is consistent with how `assertExternalDirectory()` already sends absolute glob patterns for the `external_directory` permission check.

### How did you verify your code works?

- `bun run typecheck` passes (all 13 packages)
- Traced the permission evaluation flow: with this fix, an external file path like `/Users/x/.config/opencode/settings.json` now correctly matches a config rule `{ "edit": { "~/.config/opencode/**": "ask" } }` (expanded to `/Users/x/.config/opencode/**`)
- Internal files (inside worktree) remain unchanged — relative paths still match relative config patterns

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR