### PR TITLE
fix: preserve plugin metadata and title in fromPlugin wrapper

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -35,6 +35,11 @@ import { makeRunPromise } from "@/effect/run-service"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
+  const plain = (x: unknown): x is Record<string, any> =>
+    !!x &&
+    typeof x === "object" &&
+    !Array.isArray(x) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(x))
 
   type State = {
     custom: Tool.Info[]
@@ -65,17 +70,33 @@ export namespace ToolRegistry {
                 parameters: z.object(def.args),
                 description: def.description,
                 execute: async (args, toolCtx) => {
+                  let title: string | undefined
+                  let meta: Record<string, any> | undefined
                   const pluginCtx = {
                     ...toolCtx,
                     directory: ctx.directory,
                     worktree: ctx.worktree,
+                    metadata(input: { title?: string; metadata?: Record<string, any> }) {
+                      if (input.title !== undefined) title = input.title
+                      if (input.metadata !== undefined) meta = plain(input.metadata) ? input.metadata : {}
+                      toolCtx.metadata(input)
+                    },
                   } as unknown as PluginToolContext
-                  const result = await def.execute(args as any, pluginCtx)
-                  const out = await Truncate.output(result, {}, initCtx?.agent)
+                  const result = (await def.execute(args as any, pluginCtx)) as unknown
+                  const item = plain(result) ? result : undefined
+                  const text = item && typeof item.output === "string" ? item.output : typeof result === "string" ? result : undefined
+                  if (text === undefined) throw new Error(`Plugin tool ${id} must return a string or an object with string output`)
+                  const out = await Truncate.output(text, {}, initCtx?.agent)
+                  const info = item && typeof item.title === "string" ? item.title : title ?? ""
+                  const data = item && plain(item.metadata) ? item.metadata : meta ?? {}
                   return {
-                    title: "",
-                    output: out.truncated ? out.content : result,
-                    metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+                    title: info,
+                    output: out.content,
+                    metadata: {
+                      ...data,
+                      truncated: out.truncated,
+                      ...(out.truncated && { outputPath: out.outputPath }),
+                    },
                   }
                 },
               }),

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -4,6 +4,19 @@ import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { MessageID, SessionID } from "../../src/session/schema"
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "call_test",
+  agent: "test",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
 
 afterEach(async () => {
   await Instance.disposeAll()
@@ -120,6 +133,137 @@ describe("tool.registry", () => {
       fn: async () => {
         const ids = await ToolRegistry.ids()
         expect(ids).toContain("cowsay")
+      },
+    })
+  })
+
+  test("preserves metadata set via context.metadata()", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolsDir = path.join(opencodeDir, "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "hello.ts"),
+          [
+            "export default {",
+            "  description: 'hello tool',",
+            "  args: {},",
+            "  execute: async (_args: {}, ctx: any) => {",
+            "    ctx.metadata({ title: 'ctx title', metadata: { foo: 'bar' } })",
+            "    return 'x'.repeat(60 * 1024)",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = (
+          await ToolRegistry.tools({ providerID: ProviderID.make("test"), modelID: ModelID.make("test") })
+        ).find((x) => x.id === "hello")
+        expect(tool).toBeDefined()
+        if (!tool) return
+
+        const result = await tool.execute({}, ctx)
+        expect(result.title).toBe("ctx title")
+        expect(result.metadata.foo).toBe("bar")
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.metadata.outputPath).toBeDefined()
+      },
+    })
+  })
+
+  test("preserves string plugin results", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolsDir = path.join(opencodeDir, "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "hello.ts"),
+          [
+            "export default {",
+            "  description: 'hello tool',",
+            "  args: {},",
+            "  execute: async () => 'hello world',",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = (
+          await ToolRegistry.tools({ providerID: ProviderID.make("test"), modelID: ModelID.make("test") })
+        ).find((x) => x.id === "hello")
+        expect(tool).toBeDefined()
+        if (!tool) return
+
+        const result = await tool.execute({}, ctx)
+        expect(result.title).toBe("")
+        expect(result.output).toBe("hello world")
+        expect(result.metadata.truncated).toBe(false)
+        expect("outputPath" in result.metadata).toBe(false)
+      },
+    })
+  })
+
+  test("preserves structured plugin results", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolsDir = path.join(opencodeDir, "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(toolsDir, "hello.ts"),
+          [
+            "export default {",
+            "  description: 'hello tool',",
+            "  args: {},",
+            "  execute: async () => ({",
+            "    title: 'result title',",
+            "    metadata: { foo: 'bar' },",
+            "    output: 'hello world',",
+            "  }) as any,",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = (
+          await ToolRegistry.tools({ providerID: ProviderID.make("test"), modelID: ModelID.make("test") })
+        ).find((x) => x.id === "hello")
+        expect(tool).toBeDefined()
+        if (!tool) return
+
+        const result = await tool.execute({}, ctx)
+        expect(result.title).toBe("result title")
+        expect(result.output).toBe("hello world")
+        expect(result.metadata.foo).toBe("bar")
+        expect(result.metadata.truncated).toBe(false)
+        expect("outputPath" in result.metadata).toBe(false)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #12527

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes plugin tool result handling in `fromPlugin()` so metadata and title set during execution are preserved in the final tool result.

Previously, the wrapper rebuilt the final result with only truncation metadata, which caused metadata set via `context.metadata()` to be lost. It also treated plugin results as plain strings and dropped structured fields like `title` and `metadata`.

This change:
- preserves the last `context.metadata()` title/metadata as fallback state
- supports structured plugin results with `output`, `title`, and `metadata`
- keeps the legacy string return path for existing plugin tools
- merges truncation metadata on top of plugin metadata, matching built-in tool behavior

### How did you verify your code works?

I verified this locally with:

- `cd ~/opencode-12527/packages/opencode`
- `bun test test/tool/registry.test.ts`
- `bun run typecheck`

I also added regression coverage for:
- preserving metadata set via `context.metadata()`
- preserving structured plugin results
- preserving legacy string plugin results

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR