### PR TITLE
feat: add /btw background session command

### DIFF
--- a/.opencode/command/btw.md
+++ b/.opencode/command/btw.md
@@ -1,0 +1,13 @@
+---
+description: ask in background or append a todo
+---
+
+Background helper.
+
+Usage:
+
+- `/btw ask <question>` to start a background child session and post the result back here later.
+- `/btw todo <text>` to append a todo to the current session immediately.
+- `/btw status` to list child background tasks for the current session.
+
+If no subcommand is provided, treat the remaining text as `ask`.

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -54,6 +54,7 @@ export namespace ModelsDev {
       context: z.number(),
       input: z.number().optional(),
       output: z.number(),
+      tools: z.number().optional(),
     }),
     modalities: z
       .object({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -809,6 +809,7 @@ export namespace Provider {
         context: z.number(),
         input: z.number().optional(),
         output: z.number(),
+        tools: z.number().optional(),
       }),
       status: z.enum(["alpha", "beta", "deprecated", "active"]),
       options: z.record(z.string(), z.any()),
@@ -835,6 +836,10 @@ export namespace Provider {
       ref: "Provider",
     })
   export type Info = z.infer<typeof Info>
+
+  const TOOL_LIMITS: Record<string, number> = {
+    xai: 200,
+  }
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     const m: Model = {
@@ -872,6 +877,7 @@ export namespace Provider {
         context: model.limit.context,
         input: model.limit.input,
         output: model.limit.output,
+        tools: model.limit.tools,
       },
       capabilities: {
         temperature: model.temperature,
@@ -896,6 +902,11 @@ export namespace Provider {
       },
       release_date: model.release_date,
       variants: {},
+    }
+
+    if (!m.limit.tools) {
+      const cap = TOOL_LIMITS[provider.id]
+      if (cap) m.limit.tools = cap
     }
 
     m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
@@ -1026,6 +1037,7 @@ export namespace Provider {
           limit: {
             context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
             output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+            tools: model.limit?.tools ?? existingModel?.limit?.tools,
           },
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
           family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -185,6 +185,18 @@ export namespace LLM {
       })
     }
 
+    const all = Object.keys(tools).filter((x) => x !== "invalid")
+    const cap = input.model.limit.tools
+    let active = all
+    if (cap && all.length > cap) {
+      l.warn("capping tools", {
+        total: all.length,
+        limit: cap,
+        dropped: all.length - cap,
+      })
+      active = all.slice(0, cap)
+    }
+
     // Wire up toolExecutor for DWS workflow models so that tool calls
     // from the workflow service are executed via opencode's tool system
     // and results sent back over the WebSocket.
@@ -244,7 +256,7 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+      activeTools: active,
       tools,
       toolChoice: input.toolChoice,
       maxOutputTokens,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -684,7 +684,7 @@ export namespace MessageV2 {
           parts: [],
         }
         for (const part of msg.parts) {
-          if (part.type === "text")
+          if (part.type === "text" && !part.synthetic)
             assistantMessage.parts.push({
               type: "text",
               text: part.text,
@@ -756,7 +756,7 @@ export namespace MessageV2 {
           }
         }
         if (assistantMessage.parts.length > 0) {
-          result.push(assistantMessage)
+          if (assistantMessage.parts.length > 0) result.push(assistantMessage)
           // Inject pending media as a user message for providers that don't support
           // media (images, PDFs) in tool results
           if (media.length > 0) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -49,6 +49,7 @@ import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import { Todo } from "./todo"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1773,6 +1774,210 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
   const placeholderRegex = /\$(\d+)/g
   const quoteTrimRegex = /^["']|["']$/g
+
+  function text(parts: MessageV2.Part[]) {
+    return parts.findLast((part) => part.type === "text")?.text.trim() ?? ""
+  }
+
+  function label(prefix: string, value: string) {
+    const next = value.trim() || prefix
+    return next.length > 80 ? next.slice(0, 77) + "..." : next
+  }
+
+  async function idle(sessionID: SessionID) {
+    while (SessionStatus.get(sessionID).type !== "idle") {
+      await Bun.sleep(50)
+    }
+  }
+
+  async function post(input: {
+    sessionID: SessionID
+    agent: string
+    model: { providerID: ProviderID; modelID: ModelID }
+    title: string
+    text: string
+    wait?: boolean
+  }) {
+    if (input.wait) await idle(input.sessionID)
+    const user: MessageV2.User = {
+      id: MessageID.ascending(),
+      sessionID: input.sessionID,
+      role: "user",
+      time: {
+        created: Date.now(),
+      },
+      agent: input.agent,
+      model: input.model,
+    }
+    await Session.updateMessage(user)
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: user.id,
+      sessionID: input.sessionID,
+      type: "text",
+      text: input.title,
+      synthetic: true,
+    } satisfies MessageV2.TextPart)
+
+    const assistant: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      sessionID: input.sessionID,
+      parentID: user.id,
+      mode: input.agent,
+      agent: input.agent,
+      cost: 0,
+      path: {
+        cwd: Instance.directory,
+        root: Instance.worktree,
+      },
+      time: {
+        created: Date.now(),
+        completed: Date.now(),
+      },
+      role: "assistant",
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: input.model.modelID,
+      providerID: input.model.providerID,
+    }
+    await Session.updateMessage(assistant)
+    const part = {
+      id: PartID.ascending(),
+      messageID: assistant.id,
+      sessionID: input.sessionID,
+      type: "text",
+      text: input.text,
+      synthetic: true,
+    } satisfies MessageV2.TextPart
+    await Session.updatePart(part)
+    return {
+      info: assistant,
+      parts: [part],
+    }
+  }
+
+  async function update(input: { part: MessageV2.TextPart; text: string; wait?: boolean }) {
+    if (input.wait) await idle(input.part.sessionID)
+    input.part.text = [input.part.text, input.text].filter(Boolean).join("\n\n")
+    await Session.updatePart(input.part)
+  }
+
+  async function status(sessionID: SessionID) {
+    const kids = await Session.children(sessionID)
+    if (kids.length === 0) return "No background tasks yet."
+
+    const lines = await Promise.all(
+      kids.map(async (child) => {
+        const state = SessionStatus.get(child.id)
+        if (state.type === "busy") return `- ${child.title} (\`${child.id}\`) - running`
+        if (state.type === "retry") return `- ${child.title} (\`${child.id}\`) - retry ${state.attempt}`
+
+        const msgs = await Session.messages({ sessionID: child.id, limit: 3 })
+        const assistant = msgs.find((msg) => msg.info.role === "assistant")
+        const value = assistant ? text(assistant.parts) || "completed" : "idle"
+        return `- ${child.title} (\`${child.id}\`) - ${value}`
+      }),
+    )
+
+    return lines.join("\n")
+  }
+
+  export async function commandBtw(input: {
+    sessionID: SessionID
+    agent: string
+    model: { providerID: ProviderID; modelID: ModelID }
+    arguments: string
+    variant?: string
+    parts?: CommandInput["parts"]
+    run?: (input: PromptInput) => Promise<MessageV2.WithParts>
+  }) {
+    const run = input.run ?? prompt
+    const args = input.arguments.trim()
+    if (args === "status") {
+      return post({
+        sessionID: input.sessionID,
+        agent: input.agent,
+        model: input.model,
+        title: "Background status",
+        text: await status(input.sessionID),
+      })
+    }
+
+    const todo = args.startsWith("todo ") ? args.slice(5).trim() : ""
+    if (todo) {
+      Todo.append({
+        sessionID: input.sessionID,
+        todo: { content: todo, status: "pending", priority: "medium" },
+      })
+      return post({
+        sessionID: input.sessionID,
+        agent: input.agent,
+        model: input.model,
+        title: `Background note: ${label("todo", todo)}`,
+        text: `Added todo: ${todo}`,
+      })
+    }
+
+    const query = args.startsWith("ask ") ? args.slice(4).trim() : args
+    if (!query) {
+      return post({
+        sessionID: input.sessionID,
+        agent: input.agent,
+        model: input.model,
+        title: "Background helper",
+        text: "Usage: `/btw ask <question>`, `/btw todo <text>`, or `/btw status`.",
+      })
+    }
+
+    const parent = await Session.get(input.sessionID)
+    const child = await Session.create({
+      parentID: input.sessionID,
+      workspaceID: parent.workspaceID,
+      title: `BTW: ${label("background task", query)}`,
+    })
+
+    const note = await post({
+      sessionID: input.sessionID,
+      agent: input.agent,
+      model: input.model,
+      title: `Background task: ${label("ask", query)}`,
+      text: `Started background task in child session \`${child.id}\`. I'll post the result here when it finishes.`,
+    })
+
+    void run({
+      sessionID: child.id,
+      model: input.model,
+      agent: input.agent,
+      variant: input.variant,
+      parts: [
+        {
+          type: "text",
+          text: query,
+        },
+        ...(input.parts ?? []),
+      ],
+    })
+      .then((result) =>
+        update({
+          part: note.parts[0] as MessageV2.TextPart,
+          text: `Child session \`${child.id}\` completed.\n\n${text(result.parts) || "(no text output)"}`,
+          wait: true,
+        }),
+      )
+      .catch((err) =>
+        update({
+          part: note.parts[0] as MessageV2.TextPart,
+          text: `Child session \`${child.id}\` failed: ${err instanceof Error ? err.message : String(err)}`,
+          wait: true,
+        }),
+      )
+
+    return note
+  }
   /**
    * Regular expression to match @ file references in text
    * Matches @ followed by file paths, excluding commas, periods at end of sentences, and backticks
@@ -1867,6 +2072,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         error: error.toObject(),
       })
       throw error
+    }
+
+    if (input.command === "btw") {
+      return commandBtw({
+        sessionID: input.sessionID,
+        agent: agent.name,
+        model: taskModel,
+        arguments: input.arguments,
+        variant: input.variant,
+        parts: input.parts,
+      })
     }
 
     const templateParts = await resolvePromptParts(template)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1785,7 +1785,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   }
 
   async function idle(sessionID: SessionID) {
-    while (SessionStatus.get(sessionID).type !== "idle") {
+    while ((await SessionStatus.get(sessionID)).type !== "idle") {
       await Bun.sleep(50)
     }
   }
@@ -1872,7 +1872,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const lines = await Promise.all(
       kids.map(async (child) => {
-        const state = SessionStatus.get(child.id)
+        const state = await SessionStatus.get(child.id)
         if (state.type === "busy") return `- ${child.title} (\`${child.id}\`) - running`
         if (state.type === "retry") return `- ${child.title} (\`${child.id}\`) - retry ${state.attempt}`
 

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -4,6 +4,7 @@ import { SessionID } from "./schema"
 import z from "zod"
 import { Database, eq, asc } from "../storage/db"
 import { TodoTable } from "./session.sql"
+import { max } from "drizzle-orm"
 
 export namespace Todo {
   export const Info = z
@@ -53,5 +54,28 @@ export namespace Todo {
       status: row.status,
       priority: row.priority,
     }))
+  }
+
+  export function append(input: { sessionID: SessionID; todo: Info }) {
+    Database.transaction((db) => {
+      const row = db
+        .select({ position: max(TodoTable.position) })
+        .from(TodoTable)
+        .where(eq(TodoTable.session_id, input.sessionID))
+        .get()
+      db.insert(TodoTable)
+        .values({
+          session_id: input.sessionID,
+          content: input.todo.content,
+          status: input.todo.status,
+          priority: input.todo.priority,
+          position: (row?.position ?? -1) + 1,
+        })
+        .run()
+    })
+    Bus.publish(Event.Updated, {
+      sessionID: input.sessionID,
+      todos: get(input.sessionID),
+    })
   }
 }

--- a/packages/opencode/test/session/btw.test.ts
+++ b/packages/opencode/test/session/btw.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { PartID, MessageID, SessionID } from "../../src/session/schema"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionStatus } from "../../src/session/status"
+import { Todo } from "../../src/session/todo"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+const model = {
+  providerID: ProviderID.make("openai"),
+  modelID: ModelID.make("gpt-5.2"),
+}
+
+async function parts(sessionID: SessionID) {
+  const msgs = await Session.messages({ sessionID })
+  return msgs.flatMap((msg) => msg.parts.filter((part) => part.type === "text").map((part) => part.text))
+}
+
+async function wait(check: () => Promise<boolean>) {
+  for (let i = 0; i < 20; i++) {
+    if (await check()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("timed out waiting for background result")
+}
+
+describe("session.prompt /btw", () => {
+  test("appends todos immediately", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const result = await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "todo follow up on logs",
+        })
+
+        await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "todo file a note",
+        })
+
+        expect(result.info.role).toBe("assistant")
+        expect(Todo.get(session.id)).toEqual([
+          {
+            content: "follow up on logs",
+            status: "pending",
+            priority: "medium",
+          },
+          {
+            content: "file a note",
+            status: "pending",
+            priority: "medium",
+          },
+        ])
+        expect(await parts(session.id)).toContain("Added todo: follow up on logs")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("creates a child session and reports completion back to parent", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const result = await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "ask what changed?",
+          run: async (input) => ({
+            info: {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              parentID: MessageID.ascending(),
+              mode: input.agent ?? "build",
+              agent: input.agent ?? "build",
+              cost: 0,
+              path: {
+                cwd: Instance.directory,
+                root: Instance.worktree,
+              },
+              time: {
+                created: Date.now(),
+                completed: Date.now(),
+              },
+              role: "assistant",
+              tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+              modelID: input.model?.modelID ?? model.modelID,
+              providerID: input.model?.providerID ?? model.providerID,
+            } satisfies MessageV2.Assistant,
+            parts: [
+              {
+                id: PartID.ascending(),
+                messageID: MessageID.ascending(),
+                sessionID: input.sessionID,
+                type: "text",
+                text: "background answer",
+              } satisfies MessageV2.TextPart,
+            ],
+          }),
+        })
+
+        expect(result.info.role).toBe("assistant")
+        await wait(
+          async () =>
+            (await Session.children(session.id)).length === 1 &&
+            (await parts(session.id)).some((item) => item.includes("background answer")),
+        )
+
+        const kids = await Session.children(session.id)
+        expect(kids).toHaveLength(1)
+        const msgs = await Session.messages({ sessionID: session.id })
+        expect(msgs.filter((msg) => msg.info.role === "assistant")).toHaveLength(1)
+        const text = await parts(session.id)
+        expect(text.some((item) => item.includes("Started background task in child session"))).toBe(true)
+        expect(text.some((item) => item.includes("background answer"))).toBe(true)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("reports background child status", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        let done = false
+
+        await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "ask first",
+          run: async (input) => {
+            SessionStatus.set(input.sessionID, { type: "busy" })
+            while (!done) await Bun.sleep(5)
+            SessionStatus.set(input.sessionID, { type: "idle" })
+            return {
+              info: {
+                id: MessageID.ascending(),
+                sessionID: input.sessionID,
+                parentID: MessageID.ascending(),
+                mode: input.agent ?? "build",
+                agent: input.agent ?? "build",
+                cost: 0,
+                path: {
+                  cwd: Instance.directory,
+                  root: Instance.worktree,
+                },
+                time: {
+                  created: Date.now(),
+                  completed: Date.now(),
+                },
+                role: "assistant",
+                tokens: {
+                  input: 0,
+                  output: 0,
+                  reasoning: 0,
+                  cache: { read: 0, write: 0 },
+                },
+                modelID: input.model?.modelID ?? model.modelID,
+                providerID: input.model?.providerID ?? model.providerID,
+              } satisfies MessageV2.Assistant,
+              parts: [
+                {
+                  id: PartID.ascending(),
+                  messageID: MessageID.ascending(),
+                  sessionID: input.sessionID,
+                  type: "text",
+                  text: "done later",
+                } satisfies MessageV2.TextPart,
+              ],
+            }
+          },
+        })
+
+        await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "ask second",
+          run: async (input) => {
+            const info = {
+              id: MessageID.ascending(),
+              sessionID: input.sessionID,
+              parentID: MessageID.ascending(),
+              mode: input.agent ?? "build",
+              agent: input.agent ?? "build",
+              cost: 0,
+              path: {
+                cwd: Instance.directory,
+                root: Instance.worktree,
+              },
+              time: {
+                created: Date.now(),
+                completed: Date.now(),
+              },
+              role: "assistant",
+              tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+              modelID: input.model?.modelID ?? model.modelID,
+              providerID: input.model?.providerID ?? model.providerID,
+            } satisfies MessageV2.Assistant
+            const part = {
+              id: PartID.ascending(),
+              messageID: info.id,
+              sessionID: input.sessionID,
+              type: "text",
+              text: "finished already",
+            } satisfies MessageV2.TextPart
+            await Session.updateMessage(info)
+            await Session.updatePart(part)
+            return {
+              info,
+              parts: [part],
+            }
+          },
+        })
+
+        await wait(async () => (await Session.children(session.id)).length === 2)
+        const result = await SessionPrompt.commandBtw({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          arguments: "status",
+        })
+
+        const value = result.parts.find((part) => part.type === "text")
+        expect(value?.text.includes("running")).toBe(true)
+        expect(value?.text.includes("finished already")).toBe(true)
+
+        done = true
+        await wait(async () => (await parts(session.id)).some((item) => item.includes("done later")))
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -154,7 +154,7 @@ describe("session.message-v2.toModelMessage", () => {
     expect(MessageV2.toModelMessages(input, model)).toStrictEqual([])
   })
 
-  test("includes synthetic text parts", () => {
+  test("keeps synthetic user text but drops synthetic assistant text", () => {
     const messageID = "m-user"
 
     const input: MessageV2.WithParts[] = [
@@ -186,10 +186,6 @@ describe("session.message-v2.toModelMessage", () => {
       {
         role: "user",
         content: [{ type: "text", text: "hello" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "assistant" }],
       },
     ])
   })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1177,6 +1177,7 @@ export type ProviderConfig = {
         context: number
         input?: number
         output: number
+        tools?: number
       }
       modalities?: {
         input: Array<"text" | "audio" | "image" | "video" | "pdf">
@@ -1598,6 +1599,7 @@ export type Model = {
     context: number
     input?: number
     output: number
+    tools?: number
   }
   status: "alpha" | "beta" | "deprecated" | "active"
   options: {
@@ -3950,6 +3952,7 @@ export type ProviderListResponses = {
             context: number
             input?: number
             output: number
+            tools?: number
           }
           modalities?: {
             input: Array<"text" | "audio" | "image" | "video" | "pdf">

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4531,6 +4531,9 @@
                                     },
                                     "output": {
                                       "type": "number"
+                                    },
+                                    "tools": {
+                                      "type": "number"
                                     }
                                   },
                                   "required": ["context", "output"]
@@ -10091,6 +10094,9 @@
                     },
                     "output": {
                       "type": "number"
+                    },
+                    "tools": {
+                      "type": "number"
                     }
                   },
                   "required": ["context", "output"]
@@ -11021,6 +11027,9 @@
                 "type": "number"
               },
               "output": {
+                "type": "number"
+              },
+              "tools": {
                 "type": "number"
               }
             },


### PR DESCRIPTION
### Issue for this PR

Closes #16992
Supersedes #17198

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This rebases the original `/btw` implementation from #17198 onto current `dev`.

I resolved the merge conflict in `packages/opencode/src/session/llm.ts` and fixed `/btw` after rebase by awaiting `SessionStatus.get()`, which is now async on current `dev`.

There are no intended behavior changes beyond making the branch mergeable and keeping the original `/btw` behavior working on current `dev`.

Credit to @brendandebeasi for the original implementation in #17198.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/session/btw.test.ts test/session/message-v2.test.ts`

### Screenshots / recordings

_N/A - backend/CLI command, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR