### PR TITLE
fix(attach): read OPENCODE_SERVER_USERNAME instead of hardcoding opencode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -63,7 +63,8 @@ export const AttachCommand = cmd({
       const headers = (() => {
         const password = args.password ?? process.env.OPENCODE_SERVER_PASSWORD
         if (!password) return undefined
-        const auth = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
+        const username = process.env.OPENCODE_SERVER_USERNAME ?? "opencode"
+        const auth = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
         return { Authorization: auth }
       })()
       const config = await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Closes #18611

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode attach` builds the Basic auth header hardcoding `"opencode"` as the username:

```ts
const auth = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
```

This ignores `OPENCODE_SERVER_USERNAME`, so authentication fails when the server is configured with a non-default username. `opencode run` already reads the env var correctly (line 659 in `run.ts`). This PR applies the same pattern to `attach`.

### How did you verify your code works?

Code inspection — the fix mirrors the existing pattern in `run.ts` exactly.

### Screenshots / recordings

N/A — CLI-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
