### PR TITLE
fix(cli): read OPENCODE_SERVER_USERNAME in attach command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -63,7 +63,8 @@ export const AttachCommand = cmd({
       const headers = (() => {
         const password = args.password ?? process.env.OPENCODE_SERVER_PASSWORD
         if (!password) return undefined
-        const auth = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
+        const username = process.env.OPENCODE_SERVER_USERNAME ?? "opencode"
+        const auth = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
         return { Authorization: auth }
       })()
       const config = await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Closes #18611

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode attach` hardcodes `"opencode"` as the Basic auth username, ignoring the `OPENCODE_SERVER_USERNAME` environment variable. This causes silent authentication failure when the server is configured with a custom username.

The fix reads `process.env.OPENCODE_SERVER_USERNAME` with `"opencode"` as fallback, matching the existing pattern in `run.ts`, `worker.ts`, and `plugin/index.ts`.

### How did you verify your code works?

- Typecheck passes (all packages)
- Pattern is identical to the existing implementation in `run.ts:659`, `worker.ts:154`, and `plugin/index.ts:65`
- Single line change with no runtime behavior difference for default username users

### Screenshots / recordings

N/A — 1-line code change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR