### PR TITLE
fix(ui): stop auto close of sidebar on resize

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2368,14 +2368,12 @@ export default function Layout(props: ParentProps) {
                     size={layout.sidebar.width()}
                     min={244}
                     max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}
-                    collapseThreshold={244}
                     onResize={(w) => {
                       setState("sizing", true)
                       if (sizet !== undefined) clearTimeout(sizet)
                       sizet = window.setTimeout(() => setState("sizing", false), 120)
                       layout.sidebar.resize(w)
                     }}
-                    onCollapse={layout.sidebar.close}
                   />
                 </div>
               </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the desktop sidebar was resized down to its minimum width and the user continued dragging, the `ResizeHandle` would treat that as a collapse gesture and call `layout.sidebar.close()`. This PR removes the sidebar's collapse-on-drag wiring by not passing `collapseThreshold`/`onCollapse` for the sidebar handle, so resizing clamps at the minimum width but never closes the sidebar.

### How did you verify your code works?

- `bun test` (packages/app)
- `bun typecheck` (packages/app)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR