### PR TITLE
feat: live IDE context awareness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1902,7 +1902,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
@@ -3028,7 +3028,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -29,6 +29,7 @@ import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
 import type { Workspace } from "@opencode-ai/sdk/v2"
+import type { Ide } from "@/ide"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -72,6 +73,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         [key: string]: McpResource
       }
       formatter: FormatterStatus[]
+      /** Current editor context from the IDE MCP server (active file, selection, etc.) */
+      ide_context: Ide.EditorContext
       vcs: VcsInfo | undefined
       path: Path
       workspaceList: Workspace[]
@@ -100,6 +103,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       mcp: {},
       mcp_resource: {},
       formatter: [],
+      ide_context: {},
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
       workspaceList: [],
@@ -342,6 +346,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
         case "lsp.updated": {
           sdk.client.lsp.status().then((x) => setStore("lsp", x.data!))
+          break
+        }
+
+        case "ide.context.updated": {
+          setStore("ide_context", reconcile(event.properties))
           break
         }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -32,6 +32,7 @@ import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
 import { Locale } from "@/util/locale"
+import type { Ide } from "@/ide"
 import type { Tool } from "@/tool/tool"
 import type { ReadTool } from "@/tool/read"
 import type { WriteTool } from "@/tool/write"
@@ -213,6 +214,33 @@ export function Session() {
       prompt.set(route.initialPrompt)
     }
   })
+
+  // Map from message ID to the editor context at submission time.
+  // Snapshot of IDE context at the time each user message was sent, used to
+  // display a badge in message history. Stored in a separate map rather than
+  // on the persisted Message schema to avoid bloating every message on disk
+  // with display-only data. Ephemeral — lost on TUI restart, which is fine.
+  const messageContextMap = new Map<string, Ide.EditorContext>()
+
+  // Track only the message array length so this effect doesn't rerun on
+  // every streaming token or part update — only when a new message is added.
+  createEffect(
+    on(
+      () => (sync.data.message[route.sessionID] ?? []).length,
+      () => {
+        const msgs = sync.data.message[route.sessionID] ?? []
+        for (const msg of msgs) {
+          if (msg.role === "user" && !messageContextMap.has(msg.id)) {
+            // Snapshot the current IDE context at the time this message first appears
+            const ctx = { ...sync.data.ide_context }
+            if (ctx.selection) {
+              messageContextMap.set(msg.id, ctx)
+            }
+          }
+        }
+      },
+    ),
+  )
 
   let lastSwitch: string | undefined = undefined
   sdk.event.on("message.part.updated", (evt) => {
@@ -1152,6 +1180,7 @@ export function Session() {
                         message={message as UserMessage}
                         parts={sync.data.part[message.id] ?? []}
                         pending={pending()}
+                        editorContext={messageContextMap.get(message.id)}
                       />
                     </Match>
                     <Match when={message.role === "assistant"}>
@@ -1233,6 +1262,8 @@ function UserMessage(props: {
   onMouseUp: () => void
   index: number
   pending?: string
+  /** Snapshot of IDE editor context at the time this message was submitted */
+  editorContext?: Ide.EditorContext
 }) {
   const ctx = use()
   const local = useLocal()
@@ -1291,6 +1322,15 @@ function UserMessage(props: {
                   }}
                 </For>
               </box>
+            </Show>
+            <Show when={props.editorContext?.selection}>
+              {(sel) => (
+                <text fg={theme.textMuted}>
+                  {"\u2702"} Selected {sel().end.line - sel().start.line + 1}{" "}
+                  {sel().end.line === sel().start.line ? "line" : "lines"} from{" "}
+                  {props.editorContext?.uri ? path.basename(props.editorContext.uri) : "unknown"}
+                </text>
+              )}
             </Show>
             <Show
               when={queued()}
@@ -1465,8 +1505,6 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               streaming={true}
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
-              fg={theme.markdownText}
-              bg={theme.background}
             />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -210,6 +210,24 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </For>
               </Show>
             </box>
+            {/* Editor context — shown when the IDE MCP server is connected */}
+            <Show when={sync.data.ide_context.uri}>
+              {(uri) => (
+                <box flexDirection="column" gap={0}>
+                  <text fg={theme.text}>
+                    <b>Editor</b>
+                  </text>
+                  <text fg={theme.textMuted}>{path.basename(uri())}</text>
+                  <Show when={sync.data.ide_context.selection}>
+                    {(sel) => (
+                      <text fg={theme.textMuted}>
+                        Lines {sel().start.line + 1}-{sel().end.line + 1} selected
+                      </text>
+                    )}
+                  </Show>
+                </box>
+              )}
+            </Show>
             <Show when={todo().length > 0 && todo().some((t) => t.status !== "completed")}>
               <box>
                 <box

--- a/packages/opencode/src/ide/index.ts
+++ b/packages/opencode/src/ide/index.ts
@@ -4,6 +4,13 @@ import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
 import { Log } from "../util/log"
 import { Process } from "@/util/process"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+import { Installation } from "../installation"
+import fs from "fs/promises"
+import path from "path"
+import { Instance } from "../project/instance"
 
 const SUPPORTED_IDES = [
   { name: "Windsurf" as const, cmd: "windsurf" },
@@ -16,11 +23,31 @@ const SUPPORTED_IDES = [
 export namespace Ide {
   const log = Log.create({ service: "ide" })
 
+  /**
+   * Key used to register the IDE MCP client in the MCP state. Referenced by
+   * mcp/index.ts (to store the client).
+   */
+  export const IDE_CLIENT_KEY = "vscode"
+
   export const Event = {
     Installed: BusEvent.define(
       "ide.installed",
       z.object({
         ide: z.string(),
+      }),
+    ),
+    /** Fired when the IDE editor context changes (active file, selection). */
+    ContextUpdated: BusEvent.define(
+      "ide.context.updated",
+      z.object({
+        uri: z.string().optional(),
+        selection: z
+          .object({
+            start: z.object({ line: z.number(), column: z.number() }),
+            end: z.object({ line: z.number(), column: z.number() }),
+            text: z.string(),
+          })
+          .optional(),
       }),
     ),
   }
@@ -70,5 +97,277 @@ export namespace Ide {
     if (stdout.includes("already installed")) {
       throw new AlreadyInstalledError({})
     }
+  }
+
+  /**
+   * Schema for the JSON lock file written by the VS Code extension's MCP server.
+   * Using Zod instead of a bare `as` cast so malformed lock files are caught at
+   * parse time rather than causing mysterious failures downstream.
+   */
+  const LockFileSchema = z.object({
+    pid: z.number(),
+    workspaceFolders: z.array(z.string()),
+    authToken: z.string(),
+  })
+
+  /**
+   * Returned by `discover()` when a live IDE MCP server is found.
+   * Contains everything the CLI needs to connect to the server.
+   */
+  export interface DiscoveryResult {
+    port: number
+    authToken: string
+    workspaceFolders: string[]
+  }
+
+  /**
+   * Check whether a process with the given pid is currently running.
+   *
+   * We use `process.kill(pid, 0)` which sends signal 0 — this performs the
+   * kernel permission/existence check without actually delivering a signal.
+   * It throws ESRCH if the process doesn't exist, and EPERM if the process
+   * exists but we don't have permission to signal it (which still means it's
+   * alive).
+   */
+  export function isProcessRunning(pid: number): boolean {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch (err: unknown) {
+      // EPERM means the process exists but we can't signal it — still alive
+      return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "EPERM"
+    }
+  }
+
+  /**
+   * Discover a running IDE MCP server by reading the lock file it created.
+   *
+   * The VS Code extension writes `{ideDir}/{port}.lock` containing the server's
+   * pid, auth token, and workspace folders.  This function:
+   *
+   * 1. Reads `OPENCODE_MCP_PORT` from the environment.  When the CLI is
+   *    launched from within the extension, the extension sets this var to the
+   *    port its MCP server is listening on.  Without it there is nothing to
+   *    discover, so we return null immediately.
+   *
+   * 2. Reads and parses the corresponding lock file.  A missing or malformed
+   *    file means the server never started (or was from a different run), so
+   *    we return null.
+   *
+   * 3. Verifies the pid recorded in the lock file is still alive.  If the
+   *    extension process died the lock file is stale, so we delete it and
+   *    return null.
+   *
+   * 4. On success, returns the port, auth token, and workspace folders needed
+   *    to connect to the MCP server.
+   *
+   * @param ideDir - Directory to look for `{port}.lock` files in.
+   *                 Normally `{xdgData}/opencode/ide/` in production; callers
+   *                 pass a temp dir in tests so the filesystem stays clean.
+   */
+  export async function discover(ideDir: string): Promise<DiscoveryResult | null> {
+    const portStr = process.env["OPENCODE_MCP_PORT"]
+    if (!portStr) {
+      log.debug("discover: OPENCODE_MCP_PORT not set, skipping IDE MCP discovery")
+      return null
+    }
+
+    const port = Number(portStr)
+    if (!Number.isFinite(port)) {
+      log.warn("discover: OPENCODE_MCP_PORT is not a valid number", { portStr })
+      return null
+    }
+    const lockFilePath = path.join(ideDir, `${port}.lock`)
+
+    // Clean up any stale .tmp files left behind if the extension crashed
+    // between writeFileSync and renameSync during lock file creation.
+    const tmpPath = lockFilePath + ".tmp"
+    await fs.unlink(tmpPath).catch(() => {})
+
+    // Read the lock file — if it doesn't exist the server isn't running
+    const raw = await fs.readFile(lockFilePath, "utf-8").catch(() => null)
+    if (raw === null) {
+      log.debug("discover: lock file not found", { lockFilePath })
+      return null
+    }
+
+    // Parse and validate the lock file against the expected schema.
+    // A parse or validation failure means a corrupt/incompatible file.
+    const parsed = (() => {
+      try {
+        return JSON.parse(raw)
+      } catch {
+        return null
+      }
+    })()
+    const validated = LockFileSchema.safeParse(parsed)
+    if (!validated.success) {
+      log.warn("discover: lock file is malformed", { lockFilePath, error: validated.error.message })
+      return null
+    }
+    const lockFile = validated.data
+
+    // Check that the IDE process is still alive; clean up the stale file if not
+    if (!isProcessRunning(lockFile.pid)) {
+      log.debug("discover: stale lock file (pid not running), removing", {
+        lockFilePath,
+        pid: lockFile.pid,
+      })
+      await fs.unlink(lockFilePath).catch(() => {})
+      return null
+    }
+
+    log.info("discover: found live IDE MCP server", {
+      port,
+      pid: lockFile.pid,
+      workspaceFolders: lockFile.workspaceFolders,
+    })
+
+    return {
+      port,
+      authToken: lockFile.authToken,
+      workspaceFolders: lockFile.workspaceFolders,
+    }
+  }
+
+  /**
+   * Connects an MCP client to the IDE's MCP server using discovery info.
+   * Bypasses the config-driven MCP.create() flow since the IDE server is
+   * auto-discovered, not user-configured.
+   *
+   * The IDE extension's MCP server uses Bearer token auth — the token is
+   * written into the lock file at startup and must be sent with every request.
+   */
+  export async function connectIde(info: DiscoveryResult): Promise<Client> {
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${info.port}`), {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${info.authToken}`,
+        },
+      },
+    })
+    const client = new Client({
+      name: "opencode",
+      version: Installation.VERSION,
+    })
+    await client.connect(transport)
+    return client
+  }
+
+  /**
+   * The current state of the editor, returned as a JSON payload by the
+   * `editor://context` MCP resource. This type definition must be kept in sync
+   *  with `EditorContext` defined in `sdks/vscode/src/mcp-server.ts`.
+   */
+  export interface EditorContext {
+    /**
+     * URI of the focused editor document, if any (e.g. `file:///path/to/file.ts`,
+     * `git:///path?ref=HEAD`, `output:channel-name`). All URI schemes are
+     * included so that non-file contexts like diff views and output panels are
+     * visible to the consumer.
+     */
+    uri?: string
+
+    /**
+     * The highlighted text selection, if any. Absent when there is no active
+     * editor or the selection is empty (i.e. just a cursor with no highlighted
+     * text).
+     */
+    selection?: {
+      /** Line and column position of the first selected character (inclusive). */
+      start: { line: number; column: number }
+      /** Line and column position after the last selected character (exclusive). */
+      end: { line: number; column: number }
+      /** The selected text content. */
+      text: string
+    }
+  }
+
+  /** The MCP resource URI that the IDE extension exposes for editor context. */
+  const EDITOR_CONTEXT_URI = "editor://context"
+
+  /** Per-instance editor context, updated in real time by the IDE extension. */
+  const state = Instance.state(() => ({ context: {} as EditorContext }))
+
+  /** Returns the current editor context snapshot. */
+  export function editorContext(): EditorContext {
+    return state().context
+  }
+
+  /**
+   * Reads the initial editor context and subscribes to live updates.
+   * Called once after the IDE MCP client connects. On each resource-updated
+   * notification for editor://context, re-reads the resource and updates
+   * the stored state.
+   *
+   * Assumes a single IDE connection at a time. If reconnection is needed
+   * (e.g. VS Code restarts), the caller must create a new client and call
+   * this function again — it will replace the onclose and notification
+   * handlers on the new client.
+   */
+  export async function subscribeToContext(client: Client): Promise<void> {
+    // Read initial state
+    await refreshContext(client)
+
+    // Subscribe to updates (MCP protocol requirement before receiving
+    // notifications for a specific resource). Non-fatal — we degrade
+    // gracefully to "no live updates" while keeping the initial snapshot.
+    await client.subscribeResource({ uri: EDITOR_CONTEXT_URI }).catch((err) => {
+      log.debug("failed to subscribe to editor context updates", { error: err })
+    })
+
+    // Handle resource-updated notifications. Note: setNotificationHandler
+    // registers a single handler per schema — calling it again on the same
+    // client for ResourceUpdatedNotificationSchema would replace this handler.
+    // Safe to call once on each new client after reconnection, but must not
+    // be called twice on the same client.
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, async (notification) => {
+      if (notification.params.uri === EDITOR_CONTEXT_URI) {
+        await refreshContext(client)
+      }
+    })
+
+    // Clear stored context when the IDE disconnects so stale data is never
+    // attached to prompts or shown in the TUI sidebar.
+    client.onclose = () => {
+      state().context = {}
+      Bus.publish(Ide.Event.ContextUpdated, state().context).catch((err) =>
+        log.debug("failed to publish context cleared event", { error: err }),
+      )
+    }
+  }
+
+  /**
+   * Reads the editor://context resource from the IDE MCP server and updates
+   * the in-memory state. Publishes a bus event so the TUI can react.
+   */
+  async function refreshContext(client: Client): Promise<void> {
+    const result = await client.readResource({ uri: EDITOR_CONTEXT_URI }).catch((err) => {
+      log.debug("failed to read editor context", { error: err })
+      return null
+    })
+    if (!result) return
+
+    const first = result.contents[0]
+    const text = first && "text" in first ? first.text : undefined
+    if (typeof text !== "string") return
+
+    const parsed = (() => {
+      try {
+        return JSON.parse(text)
+      } catch {
+        return null
+      }
+    })()
+    // Validate against the same Zod schema used for the bus event so
+    // malformed data from the IDE extension is rejected at the boundary.
+    const validated = Ide.Event.ContextUpdated.properties.safeParse(parsed)
+    if (!validated.success) {
+      log.debug("editor context failed validation", { error: validated.error.message })
+      return
+    }
+    state().context = validated.data
+    // Publish bus event so the TUI sync layer can pick it up
+    await Bus.publish(Ide.Event.ContextUpdated, state().context)
   }
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -24,6 +24,9 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import path from "path"
+import { Global } from "../global"
+import { Ide } from "../ide"
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -209,6 +212,37 @@ export namespace MCP {
           }
         }),
       )
+      // Auto-discover IDE MCP server (VS Code extension).
+      // The extension writes a lock file containing its port and auth token when
+      // it starts; `Ide.discover` reads that file and validates the process is
+      // still running.  If discovery succeeds we connect directly — bypassing
+      // the config-driven create() flow — and register the client as "vscode".
+      const ideDir = path.join(Global.Path.data, "ide")
+      const ideInfo = await Ide.discover(ideDir)
+      if (ideInfo) {
+        await Ide.connectIde(ideInfo)
+          .then(async (ideClient) => {
+            // Close existing client if present to prevent memory leaks
+            const existingClient = clients[Ide.IDE_CLIENT_KEY]
+            if (existingClient) {
+              await existingClient.close().catch((error) => {
+                log.error("Failed to close existing IDE MCP client", { error })
+              })
+            }
+            clients[Ide.IDE_CLIENT_KEY] = ideClient
+            status[Ide.IDE_CLIENT_KEY] = { status: "connected" }
+            // Start receiving live editor context updates
+            await Ide.subscribeToContext(ideClient)
+          })
+          .catch((error) => {
+            log.error("failed to connect to IDE MCP server", { error })
+            status[Ide.IDE_CLIENT_KEY] = {
+              status: "failed" as const,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          })
+      }
+
       return {
         status,
         clients,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -13,6 +13,7 @@ import type { Provider } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
+import { Ide } from "../ide"
 
 export namespace SystemPrompt {
   export function provider(model: Provider.Model) {
@@ -27,7 +28,7 @@ export namespace SystemPrompt {
 
   export async function environment(model: Provider.Model) {
     const project = Instance.project
-    return [
+    const result = [
       [
         `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
         `Here is some useful information about the environment you are running in:`,
@@ -48,8 +49,11 @@ export namespace SystemPrompt {
             : ""
         }`,
         `</directories>`,
+        ...getIdeContext(),
       ].join("\n"),
     ]
+
+    return result
   }
 
   export async function skills(agent: Agent.Info) {
@@ -64,5 +68,28 @@ export namespace SystemPrompt {
       // version of them here and a less verbose version in tool description, rather than vice versa.
       Skill.fmt(list, { verbose: true }),
     ].join("\n")
+  }
+
+  /**
+   * Returns a human-readable description of the current IDE editor context
+   * (active file and selection) for inclusion in the system prompt.
+   * Reads from the in-memory state maintained by `Ide.subscribeToContext()`,
+   * so this never makes a network call.
+   */
+  export function getIdeContext(): string[] {
+    const ctx = Ide.editorContext()
+    if (!ctx.uri) return []
+
+    return [
+      `<ide-context>`,
+      `  The user has ${ctx.uri} open in their IDE.`,
+      ...(ctx.selection
+        ? [
+            `  They have ${ctx.selection.start.line === ctx.selection.end.line ? `line ${ctx.selection.start.line + 1}` : `lines ${ctx.selection.start.line + 1}-${ctx.selection.end.line + 1}`} selected:`,
+            ctx.selection.text,
+          ]
+        : []),
+      `</ide-context>`,
+    ]
   }
 }

--- a/packages/opencode/test/ide/discovery.test.ts
+++ b/packages/opencode/test/ide/discovery.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for IDE MCP server discovery via lock files.
+ *
+ * Exercises `Ide.discover()` and `Ide.isProcessRunning()` using temporary
+ * lock files and the current process PID. No real VS Code or MCP server is
+ * involved — the tests validate the lock file parsing, stale-pid cleanup,
+ * and error handling paths.
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import fs from "fs"
+import path from "path"
+import os from "os"
+import { Ide } from "../../src/ide"
+
+describe("Ide.discover", () => {
+  let tmpDir: string
+  const original = { ...process.env }
+
+  beforeEach(() => {
+    // Create a fresh temp directory for each test so lock files don't bleed over
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-ide-discovery-"))
+  })
+
+  afterEach(() => {
+    // Restore env vars so tests don't interfere with each other
+    Object.keys(process.env).forEach((key) => {
+      delete process.env[key]
+    })
+    Object.assign(process.env, original)
+
+    // Clean up the temp directory
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test("returns null when OPENCODE_MCP_PORT is not set", async () => {
+    delete process.env["OPENCODE_MCP_PORT"]
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null when lock file is missing", async () => {
+    process.env["OPENCODE_MCP_PORT"] = "9876"
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null and cleans up when lock file has dead pid", async () => {
+    const port = 9877
+    process.env["OPENCODE_MCP_PORT"] = String(port)
+
+    // pid 999999999 should never exist in practice
+    const lockFilePath = path.join(tmpDir, `${port}.lock`)
+    fs.writeFileSync(
+      lockFilePath,
+      JSON.stringify({ pid: 999999999, workspaceFolders: ["/some/path"], authToken: "test-token" }),
+    )
+
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+
+    // The stale lock file should be cleaned up
+    expect(fs.existsSync(lockFilePath)).toBe(false)
+  })
+
+  test("returns null when OPENCODE_MCP_PORT is not a number", async () => {
+    process.env["OPENCODE_MCP_PORT"] = "not-a-number"
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null when lock file contains invalid JSON", async () => {
+    const port = 9879
+    process.env["OPENCODE_MCP_PORT"] = String(port)
+    const lockFilePath = path.join(tmpDir, `${port}.lock`)
+    fs.writeFileSync(lockFilePath, "{not-valid-json")
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns null when lock file has wrong shape", async () => {
+    const port = 9880
+    process.env["OPENCODE_MCP_PORT"] = String(port)
+    const lockFilePath = path.join(tmpDir, `${port}.lock`)
+    // pid should be a number, not a string
+    fs.writeFileSync(lockFilePath, JSON.stringify({ pid: "not-a-number", authToken: 123 }))
+    const result = await Ide.discover(tmpDir)
+    expect(result).toBeNull()
+  })
+
+  test("returns connection info when lock file is valid", async () => {
+    const port = 9878
+    process.env["OPENCODE_MCP_PORT"] = String(port)
+
+    const lockFilePath = path.join(tmpDir, `${port}.lock`)
+    fs.writeFileSync(
+      lockFilePath,
+      JSON.stringify({
+        pid: process.pid, // use the current process pid — guaranteed to be alive
+        workspaceFolders: ["/workspace/myproject"],
+        authToken: "my-auth-token",
+      }),
+    )
+
+    const result = await Ide.discover(tmpDir)
+    expect(result).not.toBeNull()
+    expect(result?.port).toBe(port)
+    expect(result?.authToken).toBe("my-auth-token")
+    expect(result?.workspaceFolders).toEqual(["/workspace/myproject"])
+  })
+})

--- a/packages/opencode/test/ide/editor-context.test.ts
+++ b/packages/opencode/test/ide/editor-context.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for the IDE editor context pipeline: subscribing to context updates,
+ * handling error conditions, schema validation, and system prompt formatting.
+ *
+ * Uses a fake MCP client — the real server is tested separately in
+ * sdks/vscode/test/mcp-server.test.ts.
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from "bun:test"
+import { Ide } from "../../src/ide/index.js"
+import { Instance } from "../../src/project/instance"
+import { SystemPrompt } from "../../src/session/system"
+import { tmpdir } from "../fixture/fixture"
+
+// ---------------------------------------------------------------------------
+// Fake MCP Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fake of the MCP SDK Client, implementing only the methods that
+ * subscribeToContext uses. Returns canned responses rather than making real
+ * network calls. Avoids importing the real Client class, which can be
+ * replaced by mock.module() in other test files (Bun shares the module
+ * cache across test files with no isolation).
+ */
+function createFakeClient(opts: {
+  /** JSON object or raw string to return from readResource for editor://context. */
+  context: Record<string, unknown> | string
+  /** If true, readResource throws instead of returning data. */
+  failRead?: boolean
+}) {
+  let notificationHandler: ((notification: { params: { uri: string } }) => Promise<void>) | undefined
+  let onclose: (() => void) | undefined
+
+  return {
+    /** Returns canned resource contents, or throws if failRead is set. */
+    async readResource(_params: { uri: string }) {
+      if (opts.failRead) throw new Error("simulated read failure")
+      const text = typeof opts.context === "string" ? opts.context : JSON.stringify(opts.context)
+      return {
+        contents: [
+          {
+            uri: "editor://context",
+            mimeType: "application/json",
+            text,
+          },
+        ],
+      }
+    },
+
+    /** No-op — accepts the subscription without tracking it. */
+    async subscribeResource(_params: { uri: string }) {},
+
+    /** Captures the notification handler so tests can trigger it. */
+    setNotificationHandler(_schema: unknown, handler: (notification: { params: { uri: string } }) => Promise<void>) {
+      notificationHandler = handler
+    },
+
+    /** Setter for the disconnect callback. */
+    set onclose(handler: (() => void) | undefined) {
+      onclose = handler
+    },
+
+    // -- Test helpers (not part of the real Client interface) --
+
+    /** Simulate a resource-updated notification from the server. */
+    async sendNotification(uri: string) {
+      if (notificationHandler) {
+        await notificationHandler({ params: { uri } })
+      }
+    },
+
+    /** Simulate a disconnect. */
+    triggerClose() {
+      if (onclose) onclose()
+    },
+
+    /** Update the context that readResource returns (for mid-test changes). */
+    setContext(context: Record<string, unknown> | string) {
+      opts.context = context
+    },
+
+    /** Toggle whether readResource throws. */
+    setFailRead(fail: boolean) {
+      opts.failRead = fail
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("subscribeToContext", () => {
+  // subscribeToContext uses Instance.state() internally, which requires an
+  // active Instance context (AsyncLocalStorage). We create a temp directory
+  // per test and hold onto the cleanup handle.
+  let tmp: Awaited<ReturnType<typeof tmpdir>>
+
+  beforeEach(async () => {
+    tmp = await tmpdir({ git: true })
+  })
+
+  afterEach(async () => {
+    await tmp[Symbol.asyncDispose]()
+  })
+
+  test("reads initial context and updates on notification", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(Ide.editorContext()).toEqual({})
+
+        const client = createFakeClient({
+          context: { uri: "/initial/file.ts" },
+        })
+
+        await Ide.subscribeToContext(client as any)
+
+        // Initial state was read.
+        expect(Ide.editorContext().uri).toBe("/initial/file.ts")
+
+        // Simulate the server-side file change + notification.
+        client.setContext({ uri: "/updated/file.ts" })
+        await client.sendNotification("editor://context")
+
+        expect(Ide.editorContext().uri).toBe("/updated/file.ts")
+      },
+    })
+  })
+
+  test("clears context when client disconnects", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({
+          context: { uri: "/some/file.ts" },
+        })
+
+        await Ide.subscribeToContext(client as any)
+        expect(Ide.editorContext().uri).toBe("/some/file.ts")
+
+        client.triggerClose()
+
+        expect(Ide.editorContext()).toEqual({})
+      },
+    })
+  })
+
+  test("ignores notifications for unrelated URIs", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({
+          context: { uri: "/initial/file.ts" },
+        })
+
+        await Ide.subscribeToContext(client as any)
+        expect(Ide.editorContext().uri).toBe("/initial/file.ts")
+
+        // Change the context the mock would return, but send a notification
+        // for a different URI — subscribeToContext should ignore it.
+        client.setContext({ uri: "/should-not-update.ts" })
+        await client.sendNotification("editor://other")
+
+        expect(Ide.editorContext().uri).toBe("/initial/file.ts")
+      },
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Context shapes — verify all valid EditorContext variants round-trip
+  // -------------------------------------------------------------------------
+
+  test("handles empty context (no active editor)", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({ context: {} })
+        await Ide.subscribeToContext(client as any)
+
+        const ctx = Ide.editorContext()
+        expect(ctx).toEqual({})
+        expect(ctx.uri).toBeUndefined()
+        expect(ctx.selection).toBeUndefined()
+      },
+    })
+  })
+
+  test("handles context with uri and selection", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({
+          context: {
+            uri: "file:///workspace/src/app.tsx",
+            selection: {
+              start: { line: 10, column: 0 },
+              end: { line: 15, column: 42 },
+              text: "const x = 1",
+            },
+          },
+        })
+        await Ide.subscribeToContext(client as any)
+
+        const ctx = Ide.editorContext()
+        expect(ctx.uri).toBe("file:///workspace/src/app.tsx")
+        expect(ctx.selection).toBeDefined()
+        expect(ctx.selection!.text).toBe("const x = 1")
+        expect(ctx.selection!.start.line).toBe(10)
+        expect(ctx.selection!.end.column).toBe(42)
+      },
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // refreshContext error handling — malformed data must not crash or corrupt
+  // -------------------------------------------------------------------------
+
+  test("survives readResource failure without corrupting state", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // First, establish valid state.
+        const client = createFakeClient({ context: { uri: "/good/file.ts" } })
+        await Ide.subscribeToContext(client as any)
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+
+        // Now make readResource fail and trigger a notification.
+        client.setFailRead(true)
+        await client.sendNotification("editor://context")
+
+        // State should be unchanged — the failed read is swallowed.
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+      },
+    })
+  })
+
+  test("survives malformed JSON without corrupting state", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({ context: { uri: "/good/file.ts" } })
+        await Ide.subscribeToContext(client as any)
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+
+        // Return invalid JSON from the resource.
+        client.setContext("{not-valid-json" as any)
+        await client.sendNotification("editor://context")
+
+        // State should be unchanged.
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+      },
+    })
+  })
+
+  test("survives schema validation failure without corrupting state", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({ context: { uri: "/good/file.ts" } })
+        await Ide.subscribeToContext(client as any)
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+
+        // Return valid JSON that doesn't match the EditorContext schema
+        // (selection missing required fields).
+        client.setContext({ uri: 123, selection: "not-an-object" } as any)
+        await client.sendNotification("editor://context")
+
+        // State should be unchanged.
+        expect(Ide.editorContext().uri).toBe("/good/file.ts")
+      },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// EditorContext schema — contract between VS Code extension and CLI
+// ---------------------------------------------------------------------------
+
+describe("EditorContext schema", () => {
+  const schema = Ide.Event.ContextUpdated.properties
+
+  test("accepts empty object (no active editor)", () => {
+    const result = schema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts uri only", () => {
+    const result = schema.safeParse({ uri: "file:///workspace/index.ts" })
+    expect(result.success).toBe(true)
+    expect(result.data!.uri).toBe("file:///workspace/index.ts")
+  })
+
+  test("accepts uri with selection", () => {
+    const result = schema.safeParse({
+      uri: "git:///workspace/index.ts?ref=HEAD",
+      selection: {
+        start: { line: 0, column: 0 },
+        end: { line: 5, column: 10 },
+        text: "hello",
+      },
+    })
+    expect(result.success).toBe(true)
+    expect(result.data!.selection!.text).toBe("hello")
+  })
+
+  test("rejects uri with wrong type", () => {
+    const result = schema.safeParse({ uri: 42 })
+    expect(result.success).toBe(false)
+  })
+
+  test("rejects selection missing required fields", () => {
+    const result = schema.safeParse({
+      uri: "file:///foo",
+      selection: { start: { line: 0, column: 0 } },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test("strips unknown fields", () => {
+    const result = schema.safeParse({ uri: "file:///foo", extra: "field" })
+    expect(result.success).toBe(true)
+    expect((result.data as any).extra).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getIdeContext — system prompt formatting
+// ---------------------------------------------------------------------------
+
+describe("getIdeContext", () => {
+  let tmp: Awaited<ReturnType<typeof tmpdir>>
+
+  beforeEach(async () => {
+    tmp = await tmpdir({ git: true })
+  })
+
+  afterEach(async () => {
+    await tmp[Symbol.asyncDispose]()
+  })
+
+  test("returns empty array when no editor is active", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // Default state — no IDE connected.
+        expect(SystemPrompt.getIdeContext()).toEqual([])
+      },
+    })
+  })
+
+  test("returns empty array for empty context (connected but no open file)", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({ context: {} })
+        await Ide.subscribeToContext(client as any)
+
+        expect(SystemPrompt.getIdeContext()).toEqual([])
+      },
+    })
+  })
+
+  test("formats uri-only context", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({ context: { uri: "file:///workspace/app.ts" } })
+        await Ide.subscribeToContext(client as any)
+
+        const result = SystemPrompt.getIdeContext().join("\n")
+        expect(result).toContain("<ide-context>")
+        expect(result).toContain("file:///workspace/app.ts")
+        expect(result).toContain("</ide-context>")
+      },
+    })
+  })
+
+  test("formats context with selection and 1-indexed lines", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({
+          context: {
+            uri: "file:///workspace/app.ts",
+            selection: {
+              start: { line: 0, column: 0 },
+              end: { line: 1, column: 11 },
+              text: "const x = 1\nconst y = 2",
+            },
+          },
+        })
+        await Ide.subscribeToContext(client as any)
+
+        const result = SystemPrompt.getIdeContext().join("\n")
+        // Lines are 0-indexed from VS Code, displayed as 1-indexed.
+        expect(result).toContain("<ide-context>")
+        expect(result).toContain("lines 1-2 selected:")
+        expect(result).toContain("const x = 1\nconst y = 2")
+        expect(result).toContain("file:///workspace/app.ts")
+        expect(result).toContain("</ide-context>")
+      },
+    })
+  })
+
+  test("uses singular 'line' for single-line selection", async () => {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const client = createFakeClient({
+          context: {
+            uri: "file:///workspace/app.ts",
+            selection: {
+              start: { line: 4, column: 0 },
+              end: { line: 4, column: 15 },
+              text: "const x = 'hi'",
+            },
+          },
+        })
+        await Ide.subscribeToContext(client as any)
+
+        const result = SystemPrompt.getIdeContext().join("\n")
+        expect(result).toContain("line 5 selected:")
+        expect(result).not.toContain("lines")
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -607,6 +607,31 @@ export type EventSessionIdle = {
   }
 }
 
+export type EventIdeInstalled = {
+  type: "ide.installed"
+  properties: {
+    ide: string
+  }
+}
+
+export type EventIdeContextUpdated = {
+  type: "ide.context.updated"
+  properties: {
+    uri?: string
+    selection?: {
+      start: {
+        line: number
+        column: number
+      }
+      end: {
+        line: number
+        column: number
+      }
+      text: string
+    }
+  }
+}
+
 export type QuestionOption = {
   /**
    * Display text (1-5 words, concise)
@@ -976,6 +1001,8 @@ export type Event =
   | EventPermissionReplied
   | EventSessionStatus
   | EventSessionIdle
+  | EventIdeInstalled
+  | EventIdeContextUpdated
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8782,6 +8782,76 @@
         },
         "required": ["type", "properties"]
       },
+      "Event.ide.installed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "ide.installed"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "ide": {
+                "type": "string"
+              }
+            },
+            "required": ["ide"]
+          }
+        },
+        "required": ["type", "properties"]
+      },
+      "Event.ide.context.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "ide.context.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "uri": {
+                "type": "string"
+              },
+              "selection": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "object",
+                    "properties": {
+                      "line": {
+                        "type": "number"
+                      },
+                      "column": {
+                        "type": "number"
+                      }
+                    },
+                    "required": ["line", "column"]
+                  },
+                  "end": {
+                    "type": "object",
+                    "properties": {
+                      "line": {
+                        "type": "number"
+                      },
+                      "column": {
+                        "type": "number"
+                      }
+                    },
+                    "required": ["line", "column"]
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                },
+                "required": ["start", "end", "text"]
+              }
+            }
+          }
+        },
+        "required": ["type", "properties"]
+      },
       "QuestionOption": {
         "type": "object",
         "properties": {
@@ -9738,6 +9808,12 @@
           },
           {
             "$ref": "#/components/schemas/Event.session.idle"
+          },
+          {
+            "$ref": "#/components/schemas/Event.ide.installed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.ide.context.updated"
           },
           {
             "$ref": "#/components/schemas/Event.question.asked"

--- a/sdks/vscode/.gitignore
+++ b/sdks/vscode/.gitignore
@@ -1,1 +1,3 @@
 dist
+out
+.vscode-test

--- a/sdks/vscode/bun.lock
+++ b/sdks/vscode/bun.lock
@@ -1,9 +1,12 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-agent",
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "1.25.2",
+        "@types/bun": "^1.3.11",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
         "@types/vscode": "^1.94.0",
@@ -11,9 +14,11 @@
         "@typescript-eslint/parser": "^8.31.1",
         "@vscode/test-cli": "^0.0.11",
         "@vscode/test-electron": "^2.5.2",
+        "bun-types": "^1.3.11",
         "esbuild": "^0.25.3",
         "eslint": "^9.25.1",
         "typescript": "^5.8.3",
+        "xdg-basedir": "^5.1.0",
       },
     },
   },
@@ -90,6 +95,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.3", "", { "dependencies": { "@eslint/core": "^0.15.1", "levn": "^0.4.1" } }, "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
@@ -108,6 +115,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -115,6 +124,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -152,13 +163,17 @@
 
     "@vscode/test-electron": ["@vscode/test-electron@2.5.2", "", { "dependencies": { "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "jszip": "^3.10.1", "ora": "^8.1.0", "semver": "^7.6.2" } }, "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -172,13 +187,23 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browser-stdout": ["browser-stdout@1.3.1", "", {}, "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="],
 
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c8": ["c8@9.1.0", "", { "dependencies": { "@bcoe/v8-coverage": "^0.2.3", "@istanbuljs/schema": "^0.1.3", "find-up": "^5.0.0", "foreground-child": "^3.1.1", "istanbul-lib-coverage": "^3.2.0", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.1.6", "test-exclude": "^6.0.0", "v8-to-istanbul": "^9.0.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1" }, "bin": { "c8": "bin/c8.js" } }, "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -200,9 +225,19 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -212,17 +247,33 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.18.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.25.8", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.8", "@esbuild/android-arm": "0.25.8", "@esbuild/android-arm64": "0.25.8", "@esbuild/android-x64": "0.25.8", "@esbuild/darwin-arm64": "0.25.8", "@esbuild/darwin-x64": "0.25.8", "@esbuild/freebsd-arm64": "0.25.8", "@esbuild/freebsd-x64": "0.25.8", "@esbuild/linux-arm": "0.25.8", "@esbuild/linux-arm64": "0.25.8", "@esbuild/linux-ia32": "0.25.8", "@esbuild/linux-loong64": "0.25.8", "@esbuild/linux-mips64el": "0.25.8", "@esbuild/linux-ppc64": "0.25.8", "@esbuild/linux-riscv64": "0.25.8", "@esbuild/linux-s390x": "0.25.8", "@esbuild/linux-x64": "0.25.8", "@esbuild/netbsd-arm64": "0.25.8", "@esbuild/netbsd-x64": "0.25.8", "@esbuild/openbsd-arm64": "0.25.8", "@esbuild/openbsd-x64": "0.25.8", "@esbuild/openharmony-arm64": "0.25.8", "@esbuild/sunos-x64": "0.25.8", "@esbuild/win32-arm64": "0.25.8", "@esbuild/win32-ia32": "0.25.8", "@esbuild/win32-x64": "0.25.8" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -242,6 +293,16 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -250,11 +311,15 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -266,13 +331,23 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
@@ -280,19 +355,31 @@
 
     "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -305,6 +392,8 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -320,6 +409,8 @@
 
     "is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
@@ -334,11 +425,15 @@
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -360,9 +455,19 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
@@ -376,7 +481,15 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -396,6 +509,8 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -404,19 +519,31 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -424,27 +551,49 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
@@ -468,19 +617,27 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -494,6 +651,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -504,9 +663,15 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@eslint/eslintrc/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -518,17 +683,23 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "eslint/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -543,6 +714,10 @@
     "ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -560,6 +735,8 @@
 
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -567,6 +744,8 @@
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -20,7 +20,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -94,15 +96,19 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.94.0",
+    "@modelcontextprotocol/sdk": "1.25.2",
+    "@types/bun": "^1.3.11",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@types/vscode": "^1.94.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
-    "eslint": "^9.25.1",
-    "esbuild": "^0.25.3",
-    "typescript": "^5.8.3",
     "@vscode/test-cli": "^0.0.11",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^2.5.2",
+    "bun-types": "^1.3.11",
+    "esbuild": "^0.25.3",
+    "eslint": "^9.25.1",
+    "typescript": "^5.8.3",
+    "xdg-basedir": "^5.1.0"
   }
 }

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -2,15 +2,20 @@
 export function deactivate() {}
 
 import * as vscode from "vscode"
+import * as fs from "fs"
+import * as path from "path"
+import * as crypto from "crypto"
+import { createMcpServer } from "./mcp-server"
+import { vscodeEditorState } from "./vscode-editor-state"
 
 const TERMINAL_NAME = "opencode"
 
-export function activate(context: vscode.ExtensionContext) {
-  let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
+export async function activate(context: vscode.ExtensionContext) {
+  const openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
     await openTerminal()
   })
 
-  let openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
+  const openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
     // An opencode terminal already exists => focus it
     const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME)
     if (existingTerminal) {
@@ -21,7 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
     await openTerminal()
   })
 
-  let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
+  const addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
     const fileRef = getActiveFile()
     if (!fileRef) {
       return
@@ -40,7 +45,106 @@ export function activate(context: vscode.ExtensionContext) {
     }
   })
 
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
+  context.subscriptions.push(openNewTerminalDisposable, openTerminalDisposable, addFilepathDisposable)
+
+  // --- MCP Server for IDE Context Awareness ---
+  // Wrapped in try/catch so that a failure to start the MCP server (e.g. socket
+  // bind error, missing xdg-basedir) does not take down the terminal commands
+  // registered above — those should keep working regardless.
+  try {
+    // The editor state function reads live state from
+    // vscode.window.activeTextEditor each time it is called, so the
+    // editor://context resource always returns up-to-date context.
+    const editorState = vscodeEditorState
+
+    // Generate a per-session secret so that only the opencode process that reads
+    // the lock file can authenticate with the MCP server.
+    const authToken = crypto.randomUUID()
+
+    const version = context.extension.packageJSON.version ?? "0.0.0"
+
+    // Use xdg-basedir (the same package the opencode CLI uses) so lock file paths
+    // are always in the same location regardless of which process writes them.
+    // Dynamic import is required because xdg-basedir is an ESM-only package;
+    // TypeScript in Node16 module mode rejects static imports of ESM from CJS.
+    const { xdgData } = await import("xdg-basedir")
+    if (!xdgData) {
+      console.error("opencode: xdg-basedir returned no data directory; MCP server not started")
+      return
+    }
+    const ideDir = path.join(xdgData, "opencode", "ide")
+    fs.mkdirSync(ideDir, { recursive: true })
+
+    // Start the MCP HTTP server. It binds to 127.0.0.1 on an OS-assigned
+    // ephemeral port so there is no risk of port conflicts.
+    const mcpHandle = await createMcpServer(editorState, version, authToken)
+    const lockFilePath = path.join(ideDir, `${mcpHandle.port}.lock`)
+
+    // environmentVariableCollection persists across VS Code restarts, so terminals
+    // opened before this activation would otherwise inherit a stale port from the
+    // previous session. clear() ensures they get only the current port.
+    const envCollection = context.environmentVariableCollection
+    envCollection.clear()
+    envCollection.replace("OPENCODE_MCP_PORT", mcpHandle.port.toString())
+
+    // Write the lock file atomically: write to a .tmp file first, then rename
+    // into place. This guarantees readers never observe a partially-written file.
+    const lockContent = JSON.stringify({
+      pid: process.pid,
+      workspaceFolders: (vscode.workspace.workspaceFolders ?? []).map((f) => f.uri.fsPath),
+      authToken,
+    })
+    const tmpPath = lockFilePath + ".tmp"
+    // mode 0o600: owner-only read/write. The lock file contains the auth token,
+    // so on shared machines we don't want other users to be able to read it.
+    fs.writeFileSync(tmpPath, lockContent, { mode: 0o600 })
+    fs.renameSync(tmpPath, lockFilePath)
+
+    // --- Editor change notifications ---
+    // Fire resource-updated notifications when the user switches files or
+    // changes their selection. This lets the CLI update its UI in real time
+    // without polling. Both listeners are debounced to avoid flooding the
+    // MCP transport during rapid cursor movement or repeated file switches.
+
+    // How long to wait after the last editor event before sending a notification.
+    // Low enough to feel responsive, high enough to batch rapid cursor movement
+    // (key repeat fires events every ~30ms).
+    const EDITOR_NOTIFY_DEBOUNCE_MS = 150
+
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined
+    function notifyDebounced() {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(() => {
+        mcpHandle.notifyContextChanged().catch(() => {})
+      }, EDITOR_NOTIFY_DEBOUNCE_MS)
+    }
+
+    context.subscriptions.push(
+      vscode.window.onDidChangeActiveTextEditor(() => notifyDebounced()),
+      vscode.window.onDidChangeTextEditorSelection(() => notifyDebounced()),
+      {
+        dispose() {
+          if (debounceTimer) clearTimeout(debounceTimer)
+        },
+      },
+    )
+
+    // Clean up the MCP server and its lock file when the extension deactivates
+    // (e.g. VS Code is closed, the workspace changes, or the extension is
+    // disabled). Without this the lock file would linger and mislead the CLI.
+    context.subscriptions.push({
+      dispose() {
+        // close() is async but VS Code's dispose is sync. Attach .catch() to
+        // prevent an unhandled rejection if shutdown fails.
+        mcpHandle.close().catch(() => {})
+        try {
+          fs.unlinkSync(lockFilePath)
+        } catch {}
+      },
+    })
+  } catch (err) {
+    console.error("opencode: MCP server failed to start", err)
+  }
 
   async function openTerminal() {
     // Create a new terminal in split screen

--- a/sdks/vscode/src/mcp-server.ts
+++ b/sdks/vscode/src/mcp-server.ts
@@ -1,0 +1,315 @@
+/**
+ * mcp-server.ts
+ *
+ * Implements a lightweight MCP (Model Context Protocol) HTTP server that runs
+ * inside the VS Code extension process. It exposes an `editor://context`
+ * resource that lets opencode query the editor's active file and selection
+ * without having to go through the VS Code extension host command API — the
+ * CLI can just make a plain HTTP request instead.
+ *
+ * Clients can subscribe to resource-update notifications so they are informed
+ * whenever the editor context changes (e.g. active file switch, selection
+ * change). The extension calls `notifyContextChanged()` to broadcast these
+ * updates to all connected sessions.
+ *
+ * The server binds to 127.0.0.1 on an OS-assigned ephemeral port (port 0) so
+ * it never conflicts with other services. Bearer-token auth guards every
+ * request so that only the opencode process that spawned the extension can
+ * talk to it.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import http from "http"
+import { randomUUID } from "crypto"
+
+// ---------------------------------------------------------------------------
+// EditorContext — the shape of the `editor://context` resource payload
+// ---------------------------------------------------------------------------
+
+/**
+ * The current state of the editor, returned as a JSON payload by the
+ * `editor://context` MCP resource. This type definition must be kept in sync
+ * with `EditorContext` defined in `packages/opencode/src/ide/index.ts`.
+ */
+export interface EditorContext {
+  /**
+   * URI of the focused editor document, if any (e.g. `file:///path/to/file.ts`,
+   * `git:///path?ref=HEAD`, `output:channel-name`). All URI schemes are
+   * included so that non-file contexts like diff views and output panels are
+   * visible to the consumer.
+   */
+  uri?: string
+
+  /**
+   * The highlighted text selection, if any. Absent when there is no active
+   * editor or the selection is empty (i.e. just a cursor with no highlighted
+   * text).
+   */
+  selection?: {
+    /** Line and column position of the first selected character (inclusive). */
+    start: { line: number; column: number }
+    /** Line and column position after the last selected character (exclusive). */
+    end: { line: number; column: number }
+    /** The selected text content. */
+    text: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EditorState — abstraction over the IDE for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current editor context. Having this as a replaceable function
+ * lets tests inject a fake without spinning up a real VS Code host.
+ */
+export type EditorState = () => EditorContext
+
+// ---------------------------------------------------------------------------
+// McpServerHandle — port, notification broadcast, and graceful shutdown
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle returned by `createMcpServer`. Callers use `port` to tell the
+ * opencode CLI where to connect, `notifyContextChanged()` to broadcast
+ * resource-update notifications, and `close()` when the extension deactivates
+ * so the HTTP server is shut down cleanly.
+ */
+export interface McpServerHandle {
+  /** The actual TCP port the server is listening on (OS-assigned). */
+  port: number
+
+  /**
+   * Notify all connected MCP clients that the `editor://context` resource has
+   * changed. Clients that have subscribed to resource updates will receive a
+   * `notifications/resources/updated` message. Errors on individual sessions
+   * are silently swallowed so one broken connection doesn't affect others.
+   */
+  notifyContextChanged(): Promise<void>
+
+  /** Shuts down the HTTP server and all active MCP sessions. */
+  close(): Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// createMcpServer
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates and starts an MCP HTTP server bound to 127.0.0.1 on a random
+ * OS-assigned port.
+ *
+ * Protocol summary
+ * ----------------
+ * - Every request must carry `Authorization: Bearer <authToken>` or it gets
+ *   a 401 response.
+ * - POST /  → creates a new MCP session (StreamableHTTPServerTransport).
+ * - GET  /  with `mcp-session-id` header → streams events for an existing
+ *   session (SSE).
+ * - DELETE / with `mcp-session-id` header → closes an existing session.
+ *
+ * Each session is independent; sessions are stored in a simple in-memory map
+ * keyed by the session ID that the transport generates.
+ *
+ * @param editorState  Source of VS Code editor information.
+ * @param version      VS Code extension version, reported in MCP server info
+ *                     during initialization (informational, used for debugging).
+ * @param authToken    Secret token that clients must supply as a Bearer token.
+ */
+export async function createMcpServer(
+  editorState: EditorState,
+  version: string,
+  authToken: string,
+): Promise<McpServerHandle> {
+  type Session = {
+    /** Handles HTTP request/response routing and SSE streaming for one connected client. */
+    transport: StreamableHTTPServerTransport
+
+    /**
+     * Registers the `editor://context` resource and sends notifications over
+     * the transport. Each session needs its own McpServer because the SDK only
+     * allows one transport per McpServer instance.
+     */
+    server: McpServer
+  }
+
+  // All active sessions, keyed by the session ID that the transport generates.
+  // Entries are added on POST (initialization) and removed when the transport closes.
+  const sessions = new Map<string, Session>()
+
+  // ---------------------------------------------------------------------------
+  // MCP server + resource registration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Creates a fresh McpServer instance and registers the `editor://context`
+   * resource. We create one McpServer per session because McpServer is
+   * stateful (it owns the transport connection lifecycle). Re-using a single
+   * McpServer across sessions is not supported by the SDK.
+   */
+  function createSessionServer(): McpServer {
+    const mcp = new McpServer(
+      { name: "opencode-vscode", version },
+      { capabilities: { resources: { subscribe: true } } },
+    )
+
+    // The MCP SDK (v1.25.2) does not automatically register handlers for
+    // resources/subscribe and resources/unsubscribe, even when the server
+    // declares `subscribe: true` in its capabilities. Without these, clients
+    // get a MethodNotFound error when they try to subscribe.
+    //
+    // A more fully-featured MCP server would track which resources each client
+    // subscribes to and only notify those clients. Here we no-op because
+    // there's only one resource (`editor://context`) and we broadcast to all
+    // sessions anyway.
+    //
+    // Remove/update these if a future SDK version handles subscribe natively,
+    // or if we add more resources.
+    mcp.server.setRequestHandler(SubscribeRequestSchema, async () => ({}))
+    mcp.server.setRequestHandler(UnsubscribeRequestSchema, async () => ({}))
+
+    /**
+     * `editor://context` — the sole resource exposed by this server.
+     *
+     * Returns the current editor context as JSON (active document URI and
+     * text selection). Calls the `editorState` function each time so the
+     * result is always up-to-date.
+     */
+    mcp.registerResource(
+      "editorContext",
+      "editor://context",
+      {
+        description: "Current editor state: active file path and text selection",
+        mimeType: "application/json",
+      },
+      async (resourceUri) => ({
+        contents: [
+          {
+            uri: resourceUri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(editorState()),
+          },
+        ],
+      }),
+    )
+
+    return mcp
+  }
+
+  // ---------------------------------------------------------------------------
+  // HTTP server
+  // ---------------------------------------------------------------------------
+
+  const httpServer = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    // ------------------------------------------------------------------
+    // Auth check. Binding to 127.0.0.1 means the port is not reachable
+    // from other machines, but any process running locally (e.g. under a
+    // different user account) can connect. A shared secret (Bearer token)
+    // ensures that only the opencode CLI that discovered the lock file can
+    // talk to this server.
+    // ------------------------------------------------------------------
+    const authHeader = req.headers["authorization"] ?? ""
+    const expectedHeader = `Bearer ${authToken}`
+    if (authHeader !== expectedHeader) {
+      res.writeHead(401, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ error: "Unauthorized" }))
+      return
+    }
+
+    const sessionId = req.headers["mcp-session-id"] as string | undefined
+    const method = req.method?.toUpperCase()
+
+    if (method === "POST") {
+      // ------------------------------------------------------------------
+      // POST — either continue an existing session or start a new one. The
+      // first POST has no session ID and triggers session creation. Subsequent
+      // POSTs include an `mcp-session-id` header and must be routed to the
+      // existing transport. Today the only follow-up POST is `initialized` (the
+      // client reads resources over GET/SSE), but the spec allows arbitrary
+      // RPCs over POST, so we handle routing for correctness.
+      // ------------------------------------------------------------------
+      if (sessionId && sessions.has(sessionId)) {
+        await sessions.get(sessionId)!.transport.handleRequest(req, res)
+        return
+      }
+
+      const mcp = createSessionServer()
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          sessions.set(id, { transport, server: mcp })
+        },
+      })
+
+      // Clean up when the transport closes. If `notifyContextChanged()` races
+      // with this cleanup, the deleted session may still receive a notification
+      // attempt — the .catch(() => {}) in `notifyContextChanged` handles that
+      // safely.
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          sessions.delete(transport.sessionId)
+        }
+      }
+
+      await mcp.connect(transport)
+      await transport.handleRequest(req, res)
+    } else if ((method === "GET" || method === "DELETE") && sessionId) {
+      // ------------------------------------------------------------------
+      // GET / DELETE with a session ID — route to the existing session.
+      // ------------------------------------------------------------------
+      const session = sessions.get(sessionId)
+      if (!session) {
+        res.writeHead(400, { "Content-Type": "application/json" })
+        res.end(JSON.stringify({ error: "Unknown session ID" }))
+        return
+      }
+      await session.transport.handleRequest(req, res)
+    } else {
+      res.writeHead(400, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ error: "Bad request" }))
+    }
+  })
+
+  // Bind to loopback only — this server should never be reachable from outside
+  // the local machine.
+  await new Promise<void>((resolve, reject) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve())
+    httpServer.once("error", reject)
+  })
+
+  // address() returns null if not listening, a string if bound to a Unix
+  // socket, or AddressInfo for TCP. We always bind to TCP above.
+  const address = httpServer.address()
+  if (!address || typeof address === "string") {
+    throw new Error("Unexpected server address format")
+  }
+  const port = address.port
+
+  // ---------------------------------------------------------------------------
+  // Construct and return the handle
+  // ---------------------------------------------------------------------------
+  return {
+    port,
+    async notifyContextChanged() {
+      // Broadcast a resource-update notification to every active session.
+      // Errors are swallowed per-session so one broken connection doesn't
+      // prevent the rest from being notified.
+      for (const { server } of sessions.values()) {
+        server.server.sendResourceUpdated({ uri: "editor://context" }).catch(() => {})
+      }
+    },
+    async close() {
+      // Close all active sessions first so clients get a clean disconnect.
+      await Promise.all([...sessions.values()].map((s) => s.transport.close()))
+      sessions.clear()
+
+      // Then shut down the HTTP server.
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err: Error | undefined) => (err ? reject(err) : resolve()))
+      })
+    },
+  }
+}

--- a/sdks/vscode/src/vscode-editor-state.ts
+++ b/sdks/vscode/src/vscode-editor-state.ts
@@ -1,0 +1,38 @@
+/**
+ * vscode-editor-state.ts
+ *
+ * Production `EditorState` implementation that reads live state from VS Code's
+ * `window.activeTextEditor`. This file is the only place in the MCP-server
+ * subsystem that imports the `vscode` module, which keeps the rest of the
+ * server code testable under Bun (where the `vscode` module is not available).
+ */
+
+import * as vscode from "vscode"
+import type { EditorContext, EditorState } from "./mcp-server"
+
+/**
+ * Returns a snapshot of the current editor context by reading from
+ * `vscode.window.activeTextEditor`. Passed to `createMcpServer` when
+ * the extension activates.
+ */
+export const vscodeEditorState: EditorState = (): EditorContext => {
+  const editor = vscode.window.activeTextEditor
+  if (!editor) return {}
+
+  const result: EditorContext = {
+    uri: editor.document.uri.toString(),
+  }
+
+  const sel = editor.selection
+  // isEmpty means start === end (no text highlighted). We omit the selection
+  // entirely so callers don't have to special-case zero-length selections.
+  if (!sel.isEmpty) {
+    result.selection = {
+      start: { line: sel.start.line, column: sel.start.character },
+      end: { line: sel.end.line, column: sel.end.character },
+      text: editor.document.getText(sel),
+    }
+  }
+
+  return result
+}

--- a/sdks/vscode/test/mcp-server.test.ts
+++ b/sdks/vscode/test/mcp-server.test.ts
@@ -1,0 +1,235 @@
+/**
+ * mcp-server.test.ts
+ *
+ * Tests for the MCP HTTP server created by `createMcpServer`. These tests
+ * exercise the `editor://context` resource, authentication, session routing,
+ * and server lifecycle using a fake `EditorState` — no VS Code host needed.
+ *
+ * Run with: cd sdks/vscode && bun test
+ */
+
+import { describe, test, expect, afterEach } from "bun:test"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { createMcpServer, type McpServerHandle } from "../src/mcp-server"
+import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Connects an MCP client to a test server, completing the `initialize`
+ * handshake. The returned client is ready for resource reads.
+ *
+ * @param port      TCP port the test server is listening on.
+ * @param authToken Bearer token expected by the server.
+ */
+async function connectClient(port: number, authToken: string): Promise<Client> {
+  const client = new Client({ name: "test", version: "1.0.0" })
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}`), {
+    requestInit: { headers: { Authorization: `Bearer ${authToken}` } },
+  })
+  await client.connect(transport)
+  return client
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createMcpServer", () => {
+  /** Shared auth token used across most tests. */
+  const authToken = "test-token"
+
+  /** Handles cleaned up in afterEach so every test starts fresh. */
+  let handle: McpServerHandle | null = null
+  let client: Client | null = null
+
+  afterEach(async () => {
+    await client?.close()
+    await handle?.close()
+    client = null
+    handle = null
+  })
+
+  // -------------------------------------------------------------------------
+  // editor://context resource
+  // -------------------------------------------------------------------------
+
+  describe("editor://context resource", () => {
+    test("returns file path and selection", async () => {
+      handle = await createMcpServer(
+        () => ({
+          uri: "/workspace/src/index.ts",
+          selection: {
+            start: { line: 10, column: 0 },
+            end: { line: 15, column: 22 },
+            text: "selected code",
+          },
+        }),
+        "1.0.0",
+        authToken,
+      )
+      client = await connectClient(handle.port, authToken)
+
+      const result = await client.readResource({
+        uri: "editor://context",
+      })
+      const parsed = JSON.parse((result.contents[0] as { text: string }).text)
+
+      expect(parsed.uri).toBe("/workspace/src/index.ts")
+      expect(parsed.selection.text).toBe("selected code")
+      expect(parsed.selection.start.line).toBe(10)
+      expect(parsed.selection.end.line).toBe(15)
+    })
+
+    test("returns file path without selection when nothing selected", async () => {
+      handle = await createMcpServer(
+        () => ({ uri: "/workspace/src/index.ts" }),
+        "1.0.0",
+        authToken,
+      )
+      client = await connectClient(handle.port, authToken)
+
+      const result = await client.readResource({
+        uri: "editor://context",
+      })
+      const parsed = JSON.parse((result.contents[0] as { text: string }).text)
+
+      expect(parsed.uri).toBe("/workspace/src/index.ts")
+      expect(parsed.selection).toBeUndefined()
+    })
+
+    test("returns empty object when no editor is open", async () => {
+      handle = await createMcpServer(() => ({}), "1.0.0", authToken)
+      client = await connectClient(handle.port, authToken)
+
+      const result = await client.readResource({
+        uri: "editor://context",
+      })
+      const parsed = JSON.parse((result.contents[0] as { text: string }).text)
+
+      expect(parsed).toEqual({})
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  describe("authentication", () => {
+    test("rejects requests with wrong token", async () => {
+      handle = await createMcpServer(() => ({}), "1.0.0", authToken)
+
+      const badClient = new Client({ name: "test", version: "1.0.0" })
+      const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${handle.port}`), {
+        requestInit: {
+          headers: { Authorization: "Bearer wrong-token" },
+        },
+      })
+      await expect(badClient.connect(transport)).rejects.toThrow()
+    })
+
+    test("rejects requests with no token", async () => {
+      handle = await createMcpServer(() => ({}), "1.0.0", authToken)
+
+      const badClient = new Client({ name: "test", version: "1.0.0" })
+      const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${handle.port}`))
+      await expect(badClient.connect(transport)).rejects.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Session routing
+  // -------------------------------------------------------------------------
+
+  describe("session routing", () => {
+    test("multiple resource reads on same client work", async () => {
+      handle = await createMcpServer(
+        () => ({ uri: "/workspace/file.ts" }),
+        "1.0.0",
+        authToken,
+      )
+      client = await connectClient(handle.port, authToken)
+
+      // First read
+      const r1 = await client.readResource({ uri: "editor://context" })
+      const p1 = JSON.parse((r1.contents[0] as { text: string }).text)
+      expect(p1.uri).toBe("/workspace/file.ts")
+
+      // Second read on the same session — verifies session routing works.
+      const r2 = await client.readResource({ uri: "editor://context" })
+      const p2 = JSON.parse((r2.contents[0] as { text: string }).text)
+      expect(p2.uri).toBe("/workspace/file.ts")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Notifications
+  // -------------------------------------------------------------------------
+
+  describe("notifyContextChanged", () => {
+    test("broadcasts resource-updated to all connected clients", async () => {
+      handle = await createMcpServer(
+        () => ({ uri: "/workspace/file.ts" }),
+        "1.0.0",
+        authToken,
+      )
+
+      // Connect two independent clients to the same server, each getting
+      // its own MCP session.
+      const client1 = await connectClient(handle.port, authToken)
+      const client2 = await connectClient(handle.port, authToken)
+
+      // Subscribe both clients to the resource.
+      await client1.subscribeResource({ uri: "editor://context" })
+      await client2.subscribeResource({ uri: "editor://context" })
+
+      // Set up notification promises with timeout guards so the test fails
+      // clearly instead of hanging if a notification never arrives.
+      function awaitNotification(c: Client): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+          const timer = setTimeout(() => reject(new Error("notification did not arrive within 5s")), 5000)
+          c.setNotificationHandler(ResourceUpdatedNotificationSchema, (n) => {
+            clearTimeout(timer)
+            resolve(n.params.uri)
+          })
+        })
+      }
+
+      const p1 = awaitNotification(client1)
+      const p2 = awaitNotification(client2)
+
+      // Trigger a broadcast — both clients should receive the notification.
+      await handle.notifyContextChanged()
+
+      expect(await p1).toBe("editor://context")
+      expect(await p2).toBe("editor://context")
+
+      await client1.close()
+      await client2.close()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("lifecycle", () => {
+    test("close() shuts down cleanly", async () => {
+      handle = await createMcpServer(() => ({}), "1.0.0", authToken)
+      const port = handle.port
+      await handle.close()
+      handle = null
+
+      // After close, the server should no longer accept connections.
+      await expect(fetch(`http://127.0.0.1:${port}`)).rejects.toThrow()
+    })
+
+    test("server binds to 127.0.0.1", async () => {
+      handle = await createMcpServer(() => ({}), "1.0.0", authToken)
+      expect(handle.port).toBeGreaterThan(0)
+    })
+  })
+})

--- a/sdks/vscode/tsconfig.json
+++ b/sdks/vscode/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "exclude": ["test"],
   "compilerOptions": {
     "module": "Node16",
     "target": "ES2022",
@@ -6,6 +7,7 @@
     "sourceMap": true,
     "rootDir": "src",
     "typeRoots": ["./node_modules/@types"],
+    "types": ["node"],
     "strict": true /* enable all strict type-checking options */,
     "skipLibCheck": true
     /* Additional Checks */

--- a/sdks/vscode/tsconfig.test.json
+++ b/sdks/vscode/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src", "test"],
+  "exclude": []
+}


### PR DESCRIPTION
### Issue for this PR

Closes #3472

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

I just want to say here: I realize this is a pretty large PR for a feature that hasn't had any design review yet whatsoever. I worked on this very impulsively, and I want to apologize up front for not following the process in CONTRIBUTING.md. I'm happy to split this up for ease of review and make any changes needed to satisfy the maintainers' design requirements. Thanks in advance for taking the time to consider this!

### What does this PR do?

The VS Code extension claims "Context Awareness" (https://opencode.ai/docs/ide) but doesn't actually share live editor state with opencode. When users select text in VS Code and refer to it in a prompt, the agent has no idea what they're looking at. There's no indication in the TUI that the IDE is connected or what file/selection is active.

This PR adds a minimal MCP server to the VS Code extension that exposes the editor's active file and selection as an `editor://context` resource with live push updates. The CLI auto-discovers the server via a lock file protocol, subscribes to context changes, and surfaces the information in three places:

1. **System prompt** — the agent always knows what file the user has open and what text is selected
2. **TUI sidebar** — "Editor" section showing active filename and selected line range, updating in real time as the user navigates
3. **Message history** — `✂ Selected N lines from filename` badge below user messages that had an active selection at submission time

### How did you verify your code works?

- Extension tests: `cd sdks/vscode && bun test`
- CLI IDE tests: `cd packages/opencode && bun test test/ide/`
- Manual end-to-end: testing: ran the VS Code's "Extension Development Host" and opencode, selected text and confirmed the selection was available to opencode, and updated live with user interaction. Note that our MCP is hidden from the `/mcps` list.

### Screenshots / recordings

<img width="1500" height="1022" alt="image" src="https://github.com/user-attachments/assets/d27f8141-396f-4905-9eaa-5867826aebba" />

https://github.com/user-attachments/assets/31428a83-ea2d-4f88-bf29-dc3a3591a425

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

