### PR TITLE
app: only show context tooltip from session header button

### DIFF
--- a/packages/app/e2e/prompt/context.spec.ts
+++ b/packages/app/e2e/prompt/context.spec.ts
@@ -93,3 +93,23 @@ test("context panel can open file picker from context actions", async ({ page, s
     await expect(dialog).toHaveCount(0)
   })
 })
+
+test("context tooltip only appears from the session header trigger", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, `e2e context tooltip ${Date.now()}`, async (session) => {
+    await seedContextSession({ sessionID: session.id, sdk })
+    await gotoSession(session.id)
+
+    const trigger = contextButton(page)
+    await expect(trigger).toBeVisible()
+    await trigger.click()
+
+    const tab = page.getByRole("tab", { name: "Context" })
+    await expect(tab).toBeVisible()
+
+    await tab.locator('[data-component="progress-circle"]').hover()
+    await expect(page.locator('[data-component="tooltip"]')).toHaveCount(0)
+
+    await trigger.hover()
+    await expect(page.locator('[data-component="tooltip"]')).toBeVisible()
+  })
+})

--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -101,10 +101,10 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
 
   return (
     <Show when={params.id}>
-      <Tooltip value={tooltipValue()} placement={props.placement ?? "top"}>
-        <Switch>
-          <Match when={variant() === "indicator"}>{circle()}</Match>
-          <Match when={true}>
+      <Switch>
+        <Match when={variant() === "indicator"}>{circle()}</Match>
+        <Match when={true}>
+          <Tooltip value={tooltipValue()} placement={props.placement ?? "top"}>
             <Button
               type="button"
               variant="ghost"
@@ -114,9 +114,9 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
             >
               {circle()}
             </Button>
-          </Match>
-        </Switch>
-      </Tooltip>
+          </Tooltip>
+        </Match>
+      </Switch>
     </Show>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the Context tab is already open, hovering the usage indicator inside that tab shows the same high level context tooltip as the session header button. From a user perspective that feels like duplicate UI in the panel they already opened, and it makes the tab itself look like it has extra behavior when it should just label the open panel.

This keeps the tooltip on the session header button, where users expect to peek at context usage before opening the panel, and removes it from the passive indicator rendered inside the open Context tab. I also added a regression test that covers both hover paths so this stays limited to the intended trigger.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Added a focused e2e regression test for the tooltip behavior in `packages/app/e2e/prompt/context.spec.ts`

### Screenshots / recordings

_Not included._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR