### PR TITLE
Add opencode-bar entry to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -59,6 +59,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
+| [opencode-bar](https://github.com/kargnas/opencode-bar)                                          | macOS menu bar app for OpenCode usage and subscription tracking |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent  |


### PR DESCRIPTION
### What does this PR do?
Adds opencode-bar to the Projects list on the Ecosystem docs page so users can discover the app.

### How did you verify your code works?
Checked the updated table entry renders correctly in the markdown file.