### PR TITLE
fix(install): guide users to reload shell config after PATH update

### DIFF
--- a/install
+++ b/install
@@ -435,6 +435,10 @@ if [[ "$no_modify_path" != "true" ]]; then
                 print_message info "  export PATH=$INSTALL_DIR:\$PATH"
             ;;
         esac
+        if [[ -n "$config_file" && "$current_shell" != "fish" ]]; then
+            print_message info "${MUTED}To use opencode in this session, reload your shell config:${NC}"
+            print_message info "  source $config_file"
+        fi
     fi
 fi
 


### PR DESCRIPTION
### Issue for this PR

Closes #18624

### Type of change

- [x] Bug fix

### What does this PR do?

After adding `opencode` to `$PATH` in the shell rc file (`.bashrc`, `.zshrc`, etc.), the install script did not tell the user they need to reload their shell config for the change to take effect in the current session. This caused `command not found` errors immediately after install.

The fix adds a single print after the PATH entry is written:

```
To use opencode in this session, reload your shell config:
  source ~/.zshrc
```

This only shows when the PATH was actually modified (not when it was already present, not in fish since `fish_add_path` applies immediately, and not in GitHub Actions).

### How did you verify your code works?

Code inspection — the message is printed only inside the `elif [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]` block, after a PATH entry is added, with the exact config file path that was modified.

### Screenshots / recordings

N/A — install script change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
