### PR TITLE
fix: persist MCP server enabled/disabled state to config (fixes #18664)

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -589,6 +589,16 @@ export namespace MCP {
       }
       s.clients[name] = result.mcpClient
     }
+
+    // Persist enabled state to config so it survives app restart
+    await Config.update({
+      mcp: {
+        [name]: {
+          ...mcp,
+          enabled: true,
+        },
+      },
+    })
   }
 
   export async function disconnect(name: string) {
@@ -601,6 +611,20 @@ export namespace MCP {
       delete s.clients[name]
     }
     s.status[name] = { status: "disabled" }
+
+    // Persist disabled state to config so it survives app restart
+    const cfg = await Config.get()
+    const mcp = cfg.mcp?.[name]
+    if (mcp && isMcpConfigured(mcp)) {
+      await Config.update({
+        mcp: {
+          [name]: {
+            ...mcp,
+            enabled: false,
+          },
+        },
+      })
+    }
   }
 
   export async function tools() {


### PR DESCRIPTION
## Summary

Fixes #18664 - MCP server settings now persist correctly across app restarts on Mac desktop.

---

## Problem

Users toggle MCP servers off in Mac desktop app settings, but after restart the servers turn back on. Settings don't persist.

**Reported in #18664:**
> "MCP server cannot keep off in Mac desktop app"

---

## Root Cause

**`MCP.connect()` and `MCP.disconnect()` update in-memory state only:**

```typescript
// connect() - updates memory
const result = await create(name, { ...mcp, enabled: true })
s.status[name] = result.status
s.clients[name] = result.mcpClient
// ❌ Never writes enabled: true to config.json

// disconnect() - updates memory  
s.status[name] = { status: "disabled" }
// ❌ Never writes enabled: false to config.json
```

**On app restart:**
1. `state()` reads config from disk
2. Config still has old `enabled` value (or no value = defaults to enabled)
3. User's toggle is lost

---

## Solution

**Persist `enabled` field to config after state changes:**

### `connect()` - Added config persistence
```typescript
export async function connect(name: string) {
  // ... existing logic ...
  
  const s = await state()
  s.status[name] = result.status
  if (result.mcpClient) {
    s.clients[name] = result.mcpClient
  }

  // ✅ NEW: Persist enabled state to config
  await Config.update({
    mcp: {
      [name]: {
        ...mcp,
        enabled: true,
      },
    },
  })
}
```

### `disconnect()` - Added config persistence
```typescript
export async function disconnect(name: string) {
  const s = await state()
  const client = s.clients[name]
  if (client) {
    await client.close().catch((error) => {
      log.error("Failed to close MCP client", { name, error })
    })
    delete s.clients[name]
  }
  s.status[name] = { status: "disabled" }

  // ✅ NEW: Persist disabled state to config
  const cfg = await Config.get()
  const mcp = cfg.mcp?.[name]
  if (mcp && isMcpConfigured(mcp)) {
    await Config.update({
      mcp: {
        [name]: {
          ...mcp,
          enabled: false,
        },
      },
    })
  }
}
```

---

## Testing

**Manual test:**
1. Open OpenCode Mac desktop app
2. Open MCP settings (Cmd+K → "Toggle MCPs")
3. Toggle an MCP server OFF (switch to disabled)
4. Quit OpenCode completely
5. Restart OpenCode
6. Open MCP settings again
7. ✅ Verify server stays OFF

**Expected behavior:**
- Server remains disabled after restart
- `enabled: false` written to `config.json`

**Reverse test:**
1. Toggle MCP server ON
2. Quit and restart
3. ✅ Verify server stays ON

---

## Changes

**File:** `packages/opencode/src/mcp/index.ts`
- `connect()`: +7 lines (config persistence)
- `disconnect()`: +11 lines (config persistence with validation)

**Total:** 18 lines added

---

## Backward Compatibility

✅ **Fully backward compatible**

- Existing configs without `enabled` field work (defaults to enabled)
- Configs with `enabled: true/false` continue working
- No breaking changes to API
- No schema changes required

---

## Platform Impact

**Affected:** Mac desktop app (primary reported issue)

**Also fixes:** Any platform where config persistence is expected
- Linux desktop
- Windows desktop  
- CLI (if MCP toggle is used)

---

## Why This Matters

**User frustration:**
- Users have to re-toggle MCPs every session
- No feedback that setting won't persist
- Breaks user trust in settings persistence

**Now:**
- Toggle once, stays forever
- Settings survive app restart
- Matches expected behavior

---

## Implementation Notes

**Used existing `Config.update()` API:**
- Already handles merging with existing config
- Properly writes to `config.json`
- Disposes instance to reload config

**Safety in `disconnect()`:**
- Checks `isMcpConfigured(mcp)` before update
- Prevents writing invalid config
- Graceful if config entry missing

---

## Checklist

- [x] Identified root cause (memory-only state)
- [x] Fixed `connect()` to persist `enabled: true`
- [x] Fixed `disconnect()` to persist `enabled: false`  
- [x] Used existing `Config.update()` API
- [x] Backward compatible (no breaking changes)
- [x] Clear commit message
- [x] Fixes #18664

---

Ready for review! This is a targeted fix - only adds config persistence to the two functions that change MCP enabled state.