### PR TITLE
fix(server): log named error details

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -62,7 +62,7 @@ export namespace Server {
         log.error("failed", {
           error: err,
           message: msg,
-          stack,
+          stack: stack ? JSON.stringify(stack) : undefined,
           named,
         })
         if (err instanceof NamedError) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -56,8 +56,14 @@ export namespace Server {
     const app = new Hono()
     return app
       .onError((err, c) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        const stack = err instanceof Error ? err.stack : undefined
+        const named = err instanceof NamedError ? err.toObject() : undefined
         log.error("failed", {
           error: err,
+          message: msg,
+          stack,
+          named,
         })
         if (err instanceof NamedError) {
           let status: ContentfulStatusCode


### PR DESCRIPTION
## Summary
- include explicit error message, stack, and serialized named error payloads in the server onError logger
- make worktree reset and remove failures show their full backend message in CI and e2e logs instead of only the error name

## Testing
- bun typecheck