### PR TITLE
tui: keep patch tool counts visible with long filenames

### DIFF
--- a/packages/ui/src/components/basic-tool.css
+++ b/packages/ui/src/components/basic-tool.css
@@ -8,7 +8,9 @@
   justify-content: flex-start;
 
   [data-slot="basic-tool-tool-trigger-content"] {
-    width: auto;
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
     display: flex;
     align-items: center;
     align-self: stretch;
@@ -49,17 +51,19 @@
   }
 
   [data-slot="basic-tool-tool-info"] {
-    flex: 0 1 auto;
+    flex: 1 1 auto;
     min-width: 0;
     font-size: 14px;
   }
 
   [data-slot="basic-tool-tool-info-structured"] {
-    width: auto;
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 0;
     display: flex;
     align-items: center;
     gap: 8px;
-    justify-content: flex-start;
+    justify-content: space-between;
   }
 
   [data-slot="basic-tool-tool-info-main"] {

--- a/packages/ui/src/components/basic-tool.css
+++ b/packages/ui/src/components/basic-tool.css
@@ -8,8 +8,9 @@
   justify-content: flex-start;
 
   [data-slot="basic-tool-tool-trigger-content"] {
-    flex: 1 1 auto;
-    width: 100%;
+    flex: 0 1 auto;
+    width: auto;
+    max-width: calc(100% - 24px);
     min-width: 0;
     display: flex;
     align-items: center;
@@ -51,19 +52,21 @@
   }
 
   [data-slot="basic-tool-tool-info"] {
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
+    max-width: 100%;
     font-size: 14px;
   }
 
   [data-slot="basic-tool-tool-info-structured"] {
-    flex: 1 1 auto;
-    width: 100%;
+    flex: 0 1 auto;
+    width: auto;
+    max-width: 100%;
     min-width: 0;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 8px;
-    justify-content: space-between;
+    justify-content: flex-start;
   }
 
   [data-slot="basic-tool-tool-info-main"] {
@@ -154,5 +157,11 @@
     line-height: var(--line-height-large);
     letter-spacing: var(--letter-spacing-normal);
     color: var(--text-base);
+  }
+
+  [data-slot="basic-tool-tool-action"] {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
   }
 }

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -174,7 +174,9 @@ export function BasicTool(props: BasicToolProps) {
                           </Show>
                         </Show>
                       </div>
-                      <Show when={!pending() && trigger().action}>{trigger().action}</Show>
+                      <Show when={!pending() && trigger().action}>
+                        <span data-slot="basic-tool-tool-action">{trigger().action}</span>
+                      </Show>
                     </div>
                   )}
                 </Match>

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -424,7 +424,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
 
   [data-slot="message-part-title-area"] {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -436,10 +436,11 @@
   }
 
   [data-slot="message-part-title"] {
-    flex-shrink: 0;
+    flex: 1 1 auto;
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
     font-family: var(--font-family-sans);
     font-size: 14px;
     font-style: normal;
@@ -466,12 +467,17 @@
   }
 
   [data-slot="message-part-title-text"] {
+    flex-shrink: 0;
     text-transform: capitalize;
     color: var(--text-strong);
   }
 
   [data-slot="message-part-title-filename"] {
     /* No text-transform - preserve original filename casing */
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-weight: var(--font-weight-regular);
   }
 
@@ -501,6 +507,7 @@
     gap: 16px;
     align-items: center;
     justify-content: flex-end;
+    flex-shrink: 0;
   }
 }
 
@@ -1183,6 +1190,7 @@
     display: flex;
     flex-grow: 1;
     min-width: 0;
+    overflow: hidden;
   }
 
   [data-slot="apply-patch-directory"] {
@@ -1196,7 +1204,11 @@
 
   [data-slot="apply-patch-filename"] {
     color: var(--text-strong);
-    flex-shrink: 0;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   [data-slot="apply-patch-trigger-actions"] {


### PR DESCRIPTION

<img width="1150" height="382" alt="CleanShot 2026-03-22 at 23 23 31@2x" src="https://github.com/user-attachments/assets/ba05044e-864b-4a87-a500-fa4afef901dc" />

Files with long names now truncate gracefully with ellipsis instead of pushing other elements out of view. Tool info sections better utilize available space with improved flex layout handling.

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Long patch tool filenames could consume the full width of the header row, which pushed the diff count and collapse chevron out of view. This update lets the filename and tool subtitle shrink correctly inside their flex containers, so users can still see the change count and expand or collapse the section even when a file path is unusually long.

This works because the relevant header containers now allow their contents to shrink with `min-width: 0` and flex growth applied at the right levels, while the count and chevron remain non-shrinking elements on the trailing edge.

### How did you verify your code works?

Ran `bun typecheck` in `packages/ui`.

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR