### PR TITLE
tweak(ui): fix padding bottom on the context tab

### DIFF
--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -267,14 +267,14 @@ export function SessionContextTab() {
 
   return (
     <ScrollView
-      class="@container h-full pb-10"
+      class="@container h-full"
       viewportRef={(el) => {
         scroll = el
         restoreScroll()
       }}
       onScroll={handleScroll}
     >
-      <div class="px-6 pt-4 flex flex-col gap-10">
+      <div class="px-6 pt-4 pb-10 flex flex-col gap-10">
         <div class="grid grid-cols-1 @[32rem]:grid-cols-2 gap-4">
           <For each={stats}>
             {(stat) => <Stat label={language.t(stat.label as Parameters<typeof language.t>[0])} value={stat.value()} />}


### PR DESCRIPTION
fix padding on the context tab from this issue: https://github.com/orgs/anomalyco/projects/4/views/3?pane=issue&itemId=163316823

<img width="1290" height="628" alt="CleanShot 2026-03-23 at 00 14 13@2x" src="https://github.com/user-attachments/assets/2b408cef-c417-4823-b9a4-2103eb975955" />
<img width="1268" height="578" alt="CleanShot 2026-03-23 at 00 14 18@2x" src="https://github.com/user-attachments/assets/c892277b-091d-48cf-af47-9770fec33f9e" />
