### PR TITLE
fix(app): restore keyboard project switching in open sidebar

### DIFF
--- a/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from "../fixtures"
-import { cleanupSession, closeSidebar, hoverSessionItem } from "../actions"
+import {
+  cleanupSession,
+  cleanupTestProject,
+  closeSidebar,
+  createTestProject,
+  hoverSessionItem,
+  waitSession,
+} from "../actions"
 import { projectSwitchSelector } from "../selectors"
+import { dirSlug } from "../utils"
 
 test("collapsed sidebar popover stays open when archiving a session", async ({ page, slug, sdk, gotoSession }) => {
   const stamp = Date.now()
@@ -35,5 +43,32 @@ test("collapsed sidebar popover stays open when archiving a session", async ({ p
   } finally {
     await cleanupSession({ sdk, sessionID: one.id })
     await cleanupSession({ sdk, sessionID: two.id })
+  }
+})
+
+test("collapsed sidebar project switch activates on enter", async ({ page, withProject }) => {
+  await page.setViewportSize({ width: 1400, height: 800 })
+
+  const other = await createTestProject()
+  const slug = dirSlug(other)
+
+  try {
+    await withProject(
+      async () => {
+        await closeSidebar(page)
+
+        const project = page.locator(projectSwitchSelector(slug)).first()
+
+        await expect(project).toBeVisible()
+        await project.focus()
+        await expect(project).toBeFocused()
+
+        await page.keyboard.press("Enter")
+        await waitSession(page, { directory: other })
+      },
+      { extra: [other] },
+    )
+  } finally {
+    await cleanupTestProject(other)
   }
 })

--- a/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from "../fixtures"
 import {
+  defocus,
   cleanupSession,
   cleanupTestProject,
   closeSidebar,
   createTestProject,
   hoverSessionItem,
+  openSidebar,
   waitSession,
 } from "../actions"
 import { projectSwitchSelector } from "../selectors"
@@ -46,7 +48,7 @@ test("collapsed sidebar popover stays open when archiving a session", async ({ p
   }
 })
 
-test("collapsed sidebar project switch activates on enter", async ({ page, withProject }) => {
+test("open sidebar project switch activates on first tabbed enter", async ({ page, withProject }) => {
   await page.setViewportSize({ width: 1400, height: 800 })
 
   const other = await createTestProject()
@@ -55,13 +57,23 @@ test("collapsed sidebar project switch activates on enter", async ({ page, withP
   try {
     await withProject(
       async () => {
-        await closeSidebar(page)
+        await openSidebar(page)
+        await defocus(page)
 
         const project = page.locator(projectSwitchSelector(slug)).first()
 
         await expect(project).toBeVisible()
-        await project.focus()
-        await expect(project).toBeFocused()
+
+        let hit = false
+        for (let i = 0; i < 20; i++) {
+          hit = await project.evaluate((el) => {
+            return el.matches(":focus") || !!el.parentElement?.matches(":focus")
+          })
+          if (hit) break
+          await page.keyboard.press("Tab")
+        }
+
+        expect(hit).toBe(true)
 
         await page.keyboard.press("Enter")
         await waitSession(page, { directory: other })

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -76,15 +76,6 @@ const ProjectTile = (props: {
 }): JSX.Element => {
   const notification = useNotification()
   const layout = useLayout()
-  const open = () => {
-    if (props.selected()) {
-      props.setSuppressHover(true)
-      layout.sidebar.toggle()
-      return
-    }
-    props.setSuppressHover(false)
-    props.navigateToProject(props.project.worktree)
-  }
   const unseenCount = createMemo(() =>
     props.dirs().reduce((total, directory) => total + notification.project.unseenCount(directory), 0),
   )
@@ -138,13 +129,15 @@ const ProjectTile = (props: {
           if (props.suppressHover()) return
           props.onProjectFocus(props.project.worktree)
         }}
-        onKeyDown={(event: KeyboardEvent) => {
-          if (event.key !== "Enter") return
-          event.preventDefault()
-          event.stopPropagation()
-          open()
+        onClick={() => {
+          if (props.selected()) {
+            props.setSuppressHover(true)
+            layout.sidebar.toggle()
+            return
+          }
+          props.setSuppressHover(false)
+          props.navigateToProject(props.project.worktree)
         }}
-        onClick={open}
         onBlur={() => props.setOpen(false)}
       >
         <ProjectIcon project={props.project} notify />

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -76,6 +76,15 @@ const ProjectTile = (props: {
 }): JSX.Element => {
   const notification = useNotification()
   const layout = useLayout()
+  const open = () => {
+    if (props.selected()) {
+      props.setSuppressHover(true)
+      layout.sidebar.toggle()
+      return
+    }
+    props.setSuppressHover(false)
+    props.navigateToProject(props.project.worktree)
+  }
   const unseenCount = createMemo(() =>
     props.dirs().reduce((total, directory) => total + notification.project.unseenCount(directory), 0),
   )
@@ -129,15 +138,13 @@ const ProjectTile = (props: {
           if (props.suppressHover()) return
           props.onProjectFocus(props.project.worktree)
         }}
-        onClick={() => {
-          if (props.selected()) {
-            props.setSuppressHover(true)
-            layout.sidebar.toggle()
-            return
-          }
-          props.setSuppressHover(false)
-          props.navigateToProject(props.project.worktree)
+        onKeyDown={(event: KeyboardEvent) => {
+          if (event.key !== "Enter") return
+          event.preventDefault()
+          event.stopPropagation()
+          open()
         }}
+        onClick={open}
         onBlur={() => props.setOpen(false)}
       >
         <ProjectIcon project={props.project} notify />

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -13,7 +13,7 @@ export function HoverCard(props: HoverCardProps) {
 
   return (
     <Kobalte gutter={4} {...rest}>
-      <Kobalte.Trigger as="div" data-slot="hover-card-trigger">
+      <Kobalte.Trigger as="div" data-slot="hover-card-trigger" tabIndex={-1}>
         {local.trigger}
       </Kobalte.Trigger>
       <Kobalte.Portal mount={local.mount}>


### PR DESCRIPTION
## Summary
- fix the open-sidebar keyboard regression where the hover-card wrapper inserted an extra tab stop before the actual project button
- keep `HoverCard.Trigger` wrappers out of the tab order so `Tab` lands on the real interactive child and `Enter` activates it normally
- add an e2e regression for the first tabbed `Enter` path in the open sidebar project list

## Root Cause
- Kobalte's `HoverCard.Trigger` is implemented via `LinkRoot`
- when rendered as a non-`a` element, it gets `tabIndex=0`
- our `@opencode-ai/ui/hover-card` wrapper rendered the trigger as a `div`, so the wrapper itself became focusable and intercepted keyboard tab order before the nested project button

## Verification
- ran `bun typecheck` in `packages/app`
- ran `bun typecheck` in `packages/ui`
- ran `bun test:e2e -- -g \"open sidebar project switch activates on first tabbed enter\"` in `packages/app` (blocked locally because the backend at `127.0.0.1:4096` was unavailable)