### PR TITLE
fix: treat Anthropic long context billing error as context overflow

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -8,6 +8,7 @@ export namespace ProviderError {
   // https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
   const OVERFLOW_PATTERNS = [
     /prompt is too long/i, // Anthropic
+    /extra usage is required for long context/i, // Anthropic (billing tier context limit)
     /input is too long for requested model/i, // Amazon Bedrock
     /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
     /input token count.*exceeds the maximum/i, // Google (Gemini)


### PR DESCRIPTION
### Issue for this PR

Closes #18684

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic returns `"Extra usage is required for long context requests"` when the prompt exceeds the billing tier's context limit. This error was not matched by any existing overflow pattern, so `parseAPICallError` classified it as a generic retryable API error.

The result: opencode retries indefinitely (observed up to attempt #7 with 2-minute backoff delays), never compacts, and eventually corrupts session state.

The fix adds the pattern to `OVERFLOW_PATTERNS` so the error is classified as `context_overflow`. This triggers compaction, which reduces the prompt to fit within the standard context window — the same recovery path used for all other "prompt too long" errors.

One-line change in `packages/opencode/src/provider/error.ts`.

### How did you verify your code works?

- Confirmed the regex matches the exact Anthropic error string `"Extra usage is required for long context requests"`
- Verified `bun typecheck` passes cleanly
- Verified the pattern sits alongside the existing Anthropic overflow pattern (`/prompt is too long/i`)

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR