### PR TITLE
feat(plugin): expose native skill discovery via PluginInput.skills

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -16,6 +16,7 @@ import { makeRuntime } from "@/effect/run-service"
 import { errorMessage } from "@/util/error"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
+import { Skill } from "../skill"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -129,6 +130,11 @@ export namespace Plugin {
               return Server.url ?? new URL("http://localhost:4096")
             },
             $: Bun.$,
+            skills: {
+              all: () => Skill.all(),
+              get: (name: string) => Skill.get(name),
+              dirs: () => Skill.dirs(),
+            },
           }
 
           for (const plugin of INTERNAL_PLUGINS) {

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, test, expect } from "bun:test"
 import { Skill } from "../../src/skill"
+import { Plugin } from "../../src/plugin"
+import { ToolRegistry } from "../../src/tool/registry"
 import { Instance } from "../../src/project/instance"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { SessionID, MessageID } from "../../src/session/schema"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
@@ -24,6 +28,17 @@ description: A global skill from ~/.claude/skills for testing.
 This skill is loaded from the global home directory.
 `,
   )
+}
+
+const toolCtx = {
+  sessionID: SessionID.make("ses_test-plugin-skill"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
 }
 
 test("discovers skills from .opencode/skill/ directory", async () => {
@@ -387,6 +402,279 @@ description: A skill in the .opencode/skills directory.
     fn: async () => {
       const dirs = await Skill.dirs()
       expect(dirs.length).toBe(4)
+    },
+  })
+})
+
+test("discovers skills from config.skills.paths", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const configSkillDir = path.join(dir, "config-skills", "config-skill")
+      await Bun.write(
+        path.join(configSkillDir, "SKILL.md"),
+        `---
+name: config-skill
+description: A skill registered via config.skills.paths.
+---
+
+# Config Skill
+`,
+      )
+    },
+  })
+
+  // Write config after tmpdir is created
+  const configSkillsPath = path.join(tmp.path, "config-skills")
+  await Bun.write(
+    path.join(tmp.path, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      skills: {
+        paths: [configSkillsPath],
+      },
+    }),
+  )
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      const configSkill = skills.find((s) => s.name === "config-skill")
+      expect(configSkill).toBeDefined()
+      expect(configSkill!.description).toBe("A skill registered via config.skills.paths.")
+    },
+  })
+})
+
+test("Skill.get() returns skill from config.skills.paths", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const configSkillDir = path.join(dir, "config-skills", "get-test-skill")
+      await Bun.write(
+        path.join(configSkillDir, "SKILL.md"),
+        `---
+name: get-test-skill
+description: Skill for get() test.
+---
+
+# Get Test Skill
+`,
+      )
+    },
+  })
+
+  const configSkillsPath = path.join(tmp.path, "config-skills")
+  await Bun.write(
+    path.join(tmp.path, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      skills: {
+        paths: [configSkillsPath],
+      },
+    }),
+  )
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skill = await Skill.get("get-test-skill")
+      expect(skill).toBeDefined()
+      expect(skill!.name).toBe("get-test-skill")
+      expect(skill!.description).toBe("Skill for get() test.")
+    },
+  })
+})
+
+test("Skill.dirs() includes config.skills.paths directories", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const configSkillDir = path.join(dir, "config-skills", "dirs-test-skill")
+      await Bun.write(
+        path.join(configSkillDir, "SKILL.md"),
+        `---
+name: dirs-test-skill
+description: Skill for dirs() test.
+---
+
+# Dirs Test Skill
+`,
+      )
+    },
+  })
+
+  const configSkillsPath = path.join(tmp.path, "config-skills")
+  await Bun.write(
+    path.join(tmp.path, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      skills: {
+        paths: [configSkillsPath],
+      },
+    }),
+  )
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const dirs = await Skill.dirs()
+      const configSkillDir = path.join(tmp.path, "config-skills", "dirs-test-skill")
+      expect(dirs).toContain(configSkillDir)
+    },
+  })
+})
+
+test("Skill.get() returns undefined for missing skills", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skill = await Skill.get("nonexistent-skill")
+      expect(skill).toBeUndefined()
+    },
+  })
+})
+
+test("backward compatibility: existing opencode and claude skill loading still works with config.skills.paths", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const opencodeSkillDir = path.join(dir, ".opencode", "skill", "opencode-skill")
+      const claudeSkillDir = path.join(dir, ".claude", "skills", "claude-skill")
+      const configSkillDir = path.join(dir, "config-skills", "config-skill")
+      await Bun.write(
+        path.join(opencodeSkillDir, "SKILL.md"),
+        `---
+name: opencode-skill
+description: Skill in .opencode/skill directory.
+---
+
+# OpenCode Skill
+`,
+      )
+      await Bun.write(
+        path.join(claudeSkillDir, "SKILL.md"),
+        `---
+name: claude-skill
+description: Skill in .claude/skills directory.
+---
+
+# Claude Skill
+`,
+      )
+      await Bun.write(
+        path.join(configSkillDir, "SKILL.md"),
+        `---
+name: config-skill
+description: Skill in config.skills.paths.
+---
+
+# Config Skill
+`,
+      )
+    },
+  })
+
+  const configSkillsPath = path.join(tmp.path, "config-skills")
+  await Bun.write(
+    path.join(tmp.path, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      skills: {
+        paths: [configSkillsPath],
+      },
+    }),
+  )
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills.length).toBe(3)
+      expect(skills.find((s) => s.name === "opencode-skill")).toBeDefined()
+      expect(skills.find((s) => s.name === "claude-skill")).toBeDefined()
+      expect(skills.find((s) => s.name === "config-skill")).toBeDefined()
+    },
+  })
+})
+
+
+test("PluginInput.skills works in plugin tool execute after config hooks populate skills.paths", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const pluginDir = path.join(dir, ".opencode", "plugin")
+      const configSkillDir = path.join(dir, "plugin-config-skills", "plugin-config-skill")
+      await fs.mkdir(pluginDir, { recursive: true })
+      await Bun.write(
+        path.join(configSkillDir, "SKILL.md"),
+        `---
+name: plugin-config-skill
+description: A skill registered by a plugin config hook.
+---
+
+# Plugin Config Skill
+`,
+      )
+      await Bun.write(
+        path.join(pluginDir, "plugin-skill-check.ts"),
+        [
+          'import { tool } from "@opencode-ai/plugin"',
+          '',
+          'export default async (input) => ({',
+          '  config: async (config) => {',
+          '    config.skills ??= {}',
+          '    config.skills.paths ??= []',
+          '    config.skills.paths.push("./plugin-config-skills")',
+          '  },',
+          '  tool: {',
+          '    "plugin-skill-check": tool({',
+          '      description: "Checks PluginInput.skills access",',
+          '      args: {},',
+          '      execute: async () => {',
+          '        const skill = await input.skills.get("plugin-config-skill")',
+          '        const dirs = await input.skills.dirs()',
+          '        const all = await input.skills.all()',
+          '        return JSON.stringify({',
+          '          name: skill?.name,',
+          '          description: skill?.description,',
+          '          dirs,',
+          '          count: all.length,',
+          '        })',
+          '      },',
+          '    }),',
+          '  },',
+          '})',
+          '',
+        ].join("\n"),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Plugin.init()
+      const tools = await ToolRegistry.tools({
+        providerID: ProviderID.opencode,
+        modelID: ModelID.make("gpt-5"),
+      })
+      const pluginTool = tools.find((tool) => tool.id === "plugin-skill-check")
+      expect(pluginTool).toBeDefined()
+      const result = await pluginTool!.execute({}, toolCtx)
+      const parsed = JSON.parse(result.output) as {
+        name?: string
+        description?: string
+        dirs: string[]
+        count: number
+      }
+      expect(parsed.name).toBe("plugin-config-skill")
+      expect(parsed.description).toBe("A skill registered by a plugin config hook.")
+      expect(parsed.count).toBeGreaterThanOrEqual(1)
+      expect(parsed.dirs).toContain(path.join(tmp.path, "plugin-config-skills", "plugin-config-skill"))
     },
   })
 })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,13 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type SkillInfo = {
+  name: string
+  description: string
+  location: string
+  content: string
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -30,6 +37,11 @@ export type PluginInput = {
   worktree: string
   serverUrl: URL
   $: BunShell
+  skills: {
+    all(): Promise<SkillInfo[]>
+    get(name: string): Promise<SkillInfo | undefined>
+    dirs(): Promise<string[]>
+  }
 }
 
 export type PluginOptions = Record<string, unknown>


### PR DESCRIPTION
### Issue for this PR

Closes #18688

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `skills` accessor to `PluginInput` so plugins that override the native `skill` tool can discover skills registered by other plugins via `config.skills.paths`.

The native `Skill` module already reads `config.skills.paths` and discovers those skills. But `PluginInput` didn't expose this, so replacement skill tools (like oh-my-opencode's) had no way to access natively-registered skills.

The fix adds three lazy, async methods to `PluginInput.skills`:
- `all()` — returns all discovered skills (including from `config.skills.paths`)
- `get(name)` — finds a single skill by name
- `dirs()` — returns skill directories

These delegate to the existing `Skill` module's exported functions (`Skill.all()`, `Skill.get()`, `Skill.dirs()`), which use lazy loading via `ensure()`. No eager discovery happens at plugin init time — skills are loaded on first access, by which time config hooks have already run.

Changes:
- **`packages/plugin/src/index.ts`**: Added `SkillInfo` type and `skills` property to `PluginInput`
- **`packages/opencode/src/plugin/index.ts`**: Wired `skills` accessor to native `Skill` module
- **`packages/opencode/test/skill/skill.test.ts`**: 7 new tests

### How did you verify your code works?

- 17/17 skill tests pass (7 new tests covering config.skills.paths discovery, get/dirs/missing, backward compat, and full plugin integration)
- 1413 pass / 0 fail full test suite (1 pre-existing failure in write permissions test, unrelated)
- TypeScript compilation clean (`bunx tsc --noEmit`)

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR