### PR TITLE
feat: plugin pipeline short-circuit for universal tool interception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: ci
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - run: bun install
+      - run: bun typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+      - run: bun install
+      - name: Configure git identity
+        run: |
+          git config --global user.email "ci@opencode.ai"
+          git config --global user.name "opencode-ci"
+      - run: bun turbo test
+
+  build:
+    needs: [typecheck, test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: bun-linux-x64
+            archive: tar.gz
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            archive: tar.gz
+          - os: macos-latest
+            target: bun-darwin-x64
+            archive: zip
+          - os: macos-latest
+            target: bun-darwin-arm64
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - run: bun install
+
+      - name: Build
+        run: bun ./script/build.ts --single --skip-install
+        working-directory: packages/opencode
+
+      - name: Find build output
+        id: find
+        run: |
+          dir=$(ls -d packages/opencode/dist/opencode-* 2>/dev/null | head -1)
+          name=$(basename "$dir")
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        run: tar -czf ${{ steps.find.outputs.name }}.tar.gz -C ${{ steps.find.outputs.dir }} bin
+
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        run: cd ${{ steps.find.outputs.dir }} && zip -r ../../${{ steps.find.outputs.name }}.zip bin
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.find.outputs.name }}
+          path: |
+            packages/opencode/${{ steps.find.outputs.name }}.tar.gz
+            packages/opencode/${{ steps.find.outputs.name }}.zip
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - run: bun install
+
+      - name: Build CLI
+        run: ./packages/opencode/script/build.ts --single --skip-install
+        working-directory: packages/opencode
+
+      - name: Package
+        run: |
+          cd packages/opencode/dist
+          tar -czf opencode-linux-x64.tar.gz opencode-linux-x64/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opencode-linux-x64
+          path: packages/opencode/dist/opencode-linux-x64.tar.gz
+          retention-days: 30

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -1,4 +1,6 @@
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
+import { Tool as ToolModule } from "../tool/tool"
+import { ToolSource } from "../tool/source"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -8,6 +10,7 @@ import {
   CallToolResultSchema,
   type Tool as MCPToolDef,
   ToolListChangedNotificationSchema,
+  type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "../config/config"
 import { Log } from "../util/log"
@@ -973,5 +976,90 @@ export namespace MCP {
     if (!hasTokens) return "not_authenticated"
     const expired = await McpAuth.isTokenExpired(mcpName)
     return expired ? "expired" : "authenticated"
+  }
+
+  // Convert a single MCP tool definition to Tool.Info
+  export function fromMcpTool(
+    mcpTool: MCPToolDef,
+    client: MCPClient,
+    serverName: string,
+    timeout?: number,
+  ): ToolModule.Info<JSONSchema7> {
+    return ToolModule.define(
+      `${serverName}_${mcpTool.name}`.replace(/[^a-zA-Z0-9_-]/g, "_"),
+      async () => {
+        const schema: JSONSchema7 = {
+          ...(mcpTool.inputSchema as JSONSchema7),
+          type: "object",
+          properties: (mcpTool.inputSchema?.properties ?? {}) as JSONSchema7["properties"],
+          additionalProperties: false,
+        }
+
+        return {
+          description: mcpTool.description ?? "",
+          parameters: schema,
+          async execute(args) {
+            const rawResult = await client.callTool(
+              { name: mcpTool.name, arguments: (args || {}) as Record<string, unknown> },
+              CallToolResultSchema,
+              { resetTimeoutOnProgress: true, timeout },
+            )
+
+            const textParts: string[] = []
+            for (const item of rawResult.content as CallToolResult["content"]) {
+              if (item.type === "text") textParts.push(item.text)
+            }
+
+            return {
+              title: "",
+              output: textParts.join("\n\n"),
+              metadata: {},
+            }
+          },
+        }
+      },
+      { source: "mcp" },
+    )
+  }
+
+  // Wrap all MCP clients into a ToolSource
+  export function fromMCPLayer(): ToolSource.Interface {
+    return {
+      id: "mcp:layer",
+      description: "All connected MCP servers",
+      async tools(): Promise<ToolModule.Info<JSONSchema7>[]> {
+        const result: ToolModule.Info<JSONSchema7>[] = []
+        const s = await state()
+        const cfg = await Config.get()
+        const config = cfg.mcp ?? {}
+        const defaultTimeout = cfg.experimental?.mcp_timeout
+
+        const clientsSnapshot = await clients()
+        const connectedClients = Object.entries(clientsSnapshot).filter(
+          ([clientName]) => s.status[clientName]?.status === "connected",
+        )
+
+        for (const [clientName, client] of connectedClients) {
+          const mcpConfig = config[clientName]
+          const entry = isMcpConfigured(mcpConfig) ? mcpConfig : undefined
+          const timeout = entry?.timeout ?? defaultTimeout
+
+          let toolsResult: Awaited<ReturnType<MCPClient["listTools"]>> | undefined
+          try {
+            toolsResult = await client.listTools()
+          } catch (e) {
+            log.error("failed to get tools", { clientName, error: (e as Error).message })
+            continue
+          }
+
+          if (!toolsResult) continue
+          for (const mcpTool of toolsResult.tools) {
+            const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
+            result.push(fromMcpTool(mcpTool, client, sanitizedClientName, timeout))
+          }
+        }
+        return result
+      },
+    } as unknown as ToolSource.Interface
   }
 }

--- a/packages/opencode/src/plugin/compat.ts
+++ b/packages/opencode/src/plugin/compat.ts
@@ -1,0 +1,35 @@
+/**
+ * Maps old hook names to new pipeline names.
+ * Old names continue to work via adapter wrapping.
+ */
+export const LEGACY_HOOK_ALIASES: Record<string, string> = {
+  "tool.execute.before": "pipeline.tool.before",
+  "tool.execute.after": "pipeline.tool.after",
+  "command.execute.before": "pipeline.command.before",
+  "shell.env": "pipeline.shell.env",
+  "chat.message": "pipeline.chat.message",
+  "chat.params": "pipeline.chat.params",
+  "chat.headers": "pipeline.chat.headers",
+  "permission.ask": "pipeline.permission.ask",
+  "tool.definition": "pipeline.tool.definition",
+}
+
+/**
+ * Resolve a hook name, returning the canonical name.
+ * If the name is a legacy alias, returns the new name.
+ * If already canonical, returns as-is.
+ */
+export function resolveHookName(name: string): string {
+  return LEGACY_HOOK_ALIASES[name] ?? name
+}
+
+/**
+ * Get all registered hook names (old + new) for a given canonical name.
+ * Used by Plugin.trigger to find hooks under either name.
+ */
+export function getAllHookNames(canonical: string): string[] {
+  const legacy = Object.entries(LEGACY_HOOK_ALIASES)
+    .filter(([, v]) => v === canonical)
+    .map(([k]) => k)
+  return [canonical, ...legacy]
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -14,6 +14,8 @@ import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
 import { Effect, Layer, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRunPromise } from "@/effect/run-service"
+import { PipelineExecutor, type BeforeHook, type AfterHook, type ErrorHook } from "./pipeline"
+import { resolveHookName, getAllHookNames } from "./compat"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -203,4 +205,83 @@ export namespace Plugin {
   export async function init() {
     return runPromise((svc) => svc.init())
   }
+}
+
+/**
+ * Wraps tool execution through PipelineExecutor for unified before/after/error handling.
+ * Supports both old hook names (tool.execute.before/after) and new names (pipeline.tool.before/after).
+ */
+export async function triggerToolExecution(opts: {
+  tool: string
+  toolSource?: string
+  sessionID: string
+  callID: string
+  args: unknown
+  execute: () => Promise<any>
+  session: { id: string; agent: string }
+  callChain?: string[]
+}) {
+  const plugins = await Plugin.list()
+
+  const canonicalBefore = resolveHookName("tool.execute.before")
+  const canonicalAfter = resolveHookName("tool.execute.after")
+
+  const beforeHookNames = getAllHookNames(canonicalBefore)
+  const afterHookNames = getAllHookNames(canonicalAfter)
+
+  const beforeHooks: BeforeHook[] = []
+  const afterHooks: AfterHook[] = []
+  const errorHooks: ErrorHook[] = []
+
+  for (const plugin of plugins) {
+    for (const name of beforeHookNames) {
+      const hook = plugin[name as keyof Hooks] as any
+      if (hook) {
+        beforeHooks.push({
+          name,
+          handle: async (input) => {
+            const output = { args: input, result: undefined as any }
+            await hook(
+              { tool: opts.tool, sessionID: opts.sessionID, callID: opts.callID, callChain: opts.callChain },
+              output,
+            )
+            if (output.result) {
+              return { data: output.result, shortCircuit: true }
+            }
+            return { data: output.args }
+          },
+        })
+      }
+    }
+
+    for (const name of afterHookNames) {
+      const hook = plugin[name as keyof Hooks] as any
+      if (hook) {
+        afterHooks.push({
+          name,
+          handle: async (input) => {
+            await hook(
+              { tool: opts.tool, sessionID: opts.sessionID, callID: opts.callID, args: input },
+              { title: "", output: "", metadata: undefined },
+            )
+          },
+        })
+      }
+    }
+  }
+
+  const operation = {
+    type: "tool" as const,
+    name: opts.tool,
+    source: (opts.toolSource as any) ?? "custom",
+  }
+
+  return await PipelineExecutor.dispatch(operation, opts.args, {
+    beforeHooks,
+    afterHooks,
+    errorHooks,
+    execute: opts.execute,
+    session: opts.session,
+    callChain: opts.callChain,
+  })
 }

--- a/packages/opencode/src/plugin/pipeline.ts
+++ b/packages/opencode/src/plugin/pipeline.ts
@@ -1,0 +1,128 @@
+import type { Permission } from "../permission"
+
+export interface OperationRef {
+  type: "tool" | "command" | "shell" | "chat"
+  name: string
+  source?: "builtin" | "mcp" | "plugin" | "custom"
+}
+
+export interface PipelineContext {
+  executionId: string
+  operation: OperationRef
+  session: { id: string; agent: string }
+  args: unknown
+  callChain: string[] // parent call IDs for session tracing
+}
+
+export interface PipelineResult<T = unknown> {
+  data?: T
+  shortCircuit?: boolean
+  error?: { code: string; message: string }
+  metadata?: Record<string, unknown>
+}
+
+export interface BeforeHook<Input = unknown> {
+  name?: string
+  priority?: number
+  handle(input: Input, ctx: PipelineContext): Promise<PipelineResult<Input> | void>
+}
+
+export interface AfterHook<Input = unknown, Output = unknown> {
+  name?: string
+  priority?: number
+  handle(input: Input, ctx: PipelineContext): Promise<PipelineResult<Output> | void>
+}
+
+export interface ErrorHook<Input = unknown> {
+  name?: string
+  priority?: number
+  handle(input: Input, ctx: PipelineContext): Promise<void>
+}
+
+export class PipelineExecutor {
+  static sortByPriority<T extends { priority?: number }>(hooks: T[]): T[] {
+    return [...hooks].sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))
+  }
+
+  static async dispatch<Input, Output>(
+    operation: OperationRef,
+    input: Input,
+    options: {
+      beforeHooks: BeforeHook<Input>[]
+      afterHooks: AfterHook<Input, Output>[]
+      errorHooks: ErrorHook<Input>[]
+      execute: () => Promise<Output>
+      session: { id: string; agent: string }
+      callChain?: string[]
+    },
+  ): Promise<Output | undefined> {
+    const ctx: PipelineContext = {
+      executionId: crypto.randomUUID(),
+      operation,
+      session: options.session,
+      args: input,
+      callChain: options.callChain ?? [],
+    }
+
+    // Before hooks (priority sorted)
+    for (const hook of this.sortByPriority(options.beforeHooks)) {
+      try {
+        const result = await hook.handle(input, ctx)
+        if (result?.shortCircuit) return result.data as Output
+        if (result?.error) {
+          await this.runErrorHooks(options.errorHooks, ctx, result.error)
+          return undefined
+        }
+        if (result?.data !== undefined) input = result.data
+      } catch (err) {
+        await this.runErrorHooks(options.errorHooks, ctx, {
+          code: "HOOK_ERROR",
+          message: err instanceof Error ? err.message : String(err),
+        })
+        return undefined
+      }
+    }
+
+    // Execute
+    let output: Output
+    try {
+      output = await options.execute()
+    } catch (err) {
+      await this.runErrorHooks(options.errorHooks, ctx, {
+        code: "EXECUTION_ERROR",
+        message: err instanceof Error ? err.message : String(err),
+      })
+      // Run after hooks even on error
+      for (const hook of this.sortByPriority(options.afterHooks).reverse()) {
+        try {
+          await hook.handle(input, ctx)
+        } catch {
+          /* log and continue */
+        }
+      }
+      return undefined
+    }
+
+    // After hooks
+    for (const hook of this.sortByPriority(options.afterHooks)) {
+      try {
+        const result = await hook.handle(input, ctx)
+        if (result?.data !== undefined) output = result.data as Output
+      } catch {
+        /* log and continue */
+      }
+    }
+
+    return output
+  }
+
+  private static async runErrorHooks(hooks: ErrorHook[], ctx: PipelineContext, error: PipelineResult["error"]) {
+    for (const hook of this.sortByPriority(hooks)) {
+      try {
+        await hook.handle(ctx.args, ctx)
+      } catch {
+        /* log and continue */
+      }
+    }
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -18,7 +18,7 @@ import { Bus } from "../bus"
 import { ProviderTransform } from "../provider/transform"
 import { SystemPrompt } from "./system"
 import { InstructionPrompt } from "./instruction"
-import { Plugin } from "../plugin"
+import { Plugin, triggerToolExecution } from "../plugin"
 import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
@@ -48,6 +48,7 @@ import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
+import { toJSONSchema as toJSONSchemaV4 } from "zod/v4/core"
 import { Process } from "@/util/process"
 
 // @ts-ignore
@@ -407,14 +408,8 @@ export namespace SessionPrompt {
           subagent_type: task.agent,
           command: task.command,
         }
-        await Plugin.trigger(
-          "tool.execute.before",
-          {
-            tool: "task",
-            sessionID,
-            callID: part.id,
-          },
-          { args: taskArgs },
+        const taskCallChain = msgs.flatMap((msg) =>
+          msg.parts.filter((p): p is MessageV2.ToolPart => p.type === "tool").map((p) => p.callID),
         )
         let executionError: Error | undefined
         const taskAgent = await Agent.get(task.agent)
@@ -424,6 +419,7 @@ export namespace SessionPrompt {
           sessionID: sessionID,
           abort,
           callID: part.callID,
+          callChain: taskCallChain,
           extra: { bypassAgentCheck: true },
           messages: msgs,
           async metadata(input) {
@@ -444,26 +440,27 @@ export namespace SessionPrompt {
             })
           },
         }
-        const result = await taskTool.execute(taskArgs, taskCtx).catch((error) => {
-          executionError = error
-          log.error("subtask execution failed", { error, agent: task.agent, description: task.description })
-          return undefined
-        })
-        const attachments = result?.attachments?.map((attachment) => ({
-          ...attachment,
-          id: PartID.ascending(),
+        const result = await triggerToolExecution({
+          tool: "task",
           sessionID,
-          messageID: assistantMessage.id,
-        }))
-        await Plugin.trigger(
-          "tool.execute.after",
-          {
-            tool: "task",
+          callID: part.id,
+          args: taskArgs,
+          execute: () =>
+            taskTool.execute(taskArgs, taskCtx).catch((error) => {
+              executionError = error
+              log.error("subtask execution failed", { error, agent: task.agent, description: task.description })
+              return undefined
+            }),
+          session: { id: sessionID, agent: task.agent },
+          callChain: taskCallChain,
+        })
+        const attachments = result?.attachments?.map(
+          (attachment: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">) => ({
+            ...attachment,
+            id: PartID.ascending(),
             sessionID,
-            callID: part.id,
-            args: taskArgs,
-          },
-          result,
+            messageID: assistantMessage.id,
+          }),
         )
         assistantMessage.finish = "tool-calls"
         assistantMessage.time.completed = Date.now()
@@ -755,11 +752,16 @@ export namespace SessionPrompt {
     using _ = log.time("resolveTools")
     const tools: Record<string, AITool> = {}
 
+    const callChain = input.messages.flatMap((msg) =>
+      msg.parts.filter((p): p is MessageV2.ToolPart => p.type === "tool").map((p) => p.callID),
+    )
+
     const context = (args: any, options: ToolCallOptions): Tool.Context => ({
       sessionID: input.session.id,
       abort: options.abortSignal!,
       messageID: input.processor.message.id,
       callID: options.toolCallId,
+      callChain,
       extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck },
       agent: input.agent.name,
       messages: input.messages,
@@ -794,44 +796,49 @@ export namespace SessionPrompt {
       { modelID: ModelID.make(input.model.api.id), providerID: input.model.providerID },
       input.agent,
     )) {
-      const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+      // Handle different parameter types: Zod v3, Zod v4, or plain JSONSchema7
+      const paramsSchema = (() => {
+        if (item.parameters instanceof z.ZodType) {
+          // Zod v3 schema - use z.toJSONSchema
+          return z.toJSONSchema(item.parameters)
+        }
+        if ("~standard" in item.parameters) {
+          // Zod v4 schema - use toJSONSchema from zod/v4/core
+          return toJSONSchemaV4(item.parameters as any)
+        }
+        // Plain JSONSchema7 object - use directly
+        return item.parameters
+      })()
+
+      const schema = ProviderTransform.schema(input.model, paramsSchema)
       tools[item.id] = tool({
         id: item.id as any,
         description: item.description,
         inputSchema: jsonSchema(schema as any),
         async execute(args, options) {
           const ctx = context(args, options)
-          await Plugin.trigger(
-            "tool.execute.before",
-            {
-              tool: item.id,
-              sessionID: ctx.sessionID,
-              callID: ctx.callID,
-            },
-            {
-              args,
-            },
-          )
-          const result = await item.execute(args, ctx)
+          const result = await triggerToolExecution({
+            tool: item.id,
+            toolSource: item.source,
+            sessionID: ctx.sessionID,
+            callID: ctx.callID ?? "",
+            args,
+            execute: () => item.execute(args, ctx),
+            session: { id: ctx.sessionID, agent: ctx.agent },
+            callChain: ctx.callChain,
+          })
+          if (!result) return { title: "", metadata: {}, output: "" }
           const output = {
             ...result,
-            attachments: result.attachments?.map((attachment) => ({
-              ...attachment,
-              id: PartID.ascending(),
-              sessionID: ctx.sessionID,
-              messageID: input.processor.message.id,
-            })),
+            attachments: result.attachments?.map(
+              (attachment: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">) => ({
+                ...attachment,
+                id: PartID.ascending(),
+                sessionID: ctx.sessionID,
+                messageID: input.processor.message.id,
+              }),
+            ),
           }
-          await Plugin.trigger(
-            "tool.execute.after",
-            {
-              tool: item.id,
-              sessionID: ctx.sessionID,
-              callID: ctx.callID,
-              args,
-            },
-            output,
-          )
           return output
         },
       })
@@ -847,37 +854,27 @@ export namespace SessionPrompt {
       item.execute = async (args, opts) => {
         const ctx = context(args, opts)
 
-        await Plugin.trigger(
-          "tool.execute.before",
-          {
-            tool: key,
-            sessionID: ctx.sessionID,
-            callID: opts.toolCallId,
-          },
-          {
-            args,
-          },
-        )
-
         await ctx.ask({
           permission: key,
           metadata: {},
-          patterns: ["*"],
-          always: ["*"],
+          patterns: [key],
+          always: [key],
         })
 
-        const result = await execute(args, opts)
+        const result = await triggerToolExecution({
+          tool: key,
+          toolSource: "mcp",
+          sessionID: ctx.sessionID,
+          callID: opts.toolCallId,
+          args,
+          execute: () => execute(args, opts),
+          session: { id: ctx.sessionID, agent: ctx.agent },
+          callChain: ctx.callChain,
+        })
+        if (!result) return { title: "", metadata: {}, output: "" }
 
-        await Plugin.trigger(
-          "tool.execute.after",
-          {
-            tool: key,
-            sessionID: ctx.sessionID,
-            callID: opts.toolCallId,
-            args,
-          },
-          result,
-        )
+        // Short-circuit result from plugin (has title/output but no content array)
+        if (!result.content) return result
 
         const textParts: string[] = []
         const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -59,6 +59,11 @@ export const BatchTool = Tool.define("batch", async () => {
               `Tool '${call.tool}' not in registry. External tools (MCP, environment) cannot be batched - call them directly. Available tools: ${availableToolsList.join(", ")}`,
             )
           }
+          if (tool.source === "mcp") {
+            throw new Error(
+              `Tool '${call.tool}' not in registry. External tools (MCP, environment) cannot be batched - call them directly.`,
+            )
+          }
           const validatedParams = tool.parameters.parse(call.parameters)
 
           await Session.updatePart({

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -30,6 +30,8 @@ import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
 import { Effect, Layer, ServiceMap } from "effect"
+import { ToolSource } from "../tool/source"
+import { MCP } from "../mcp"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRunPromise } from "@/effect/run-service"
 
@@ -46,7 +48,7 @@ export namespace ToolRegistry {
     readonly tools: (
       model: { providerID: ProviderID; modelID: ModelID },
       agent?: Agent.Info,
-    ) => Effect.Effect<(Awaited<ReturnType<Tool.Info["init"]>> & { id: string })[]>
+    ) => Effect.Effect<(Awaited<ReturnType<Tool.Info["init"]>> & { id: string; source?: Tool.Info["source"] })[]>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/ToolRegistry") {}
@@ -158,9 +160,14 @@ export namespace ToolRegistry {
       ) {
         const state = yield* InstanceState.get(cache)
         const allTools = yield* Effect.promise(() => all(state.custom))
+
+        // Compose built-in and MCP tools - MCP tools win on duplicate IDs
+        const source = ToolSource.compose(ToolSource.fromBuiltin(allTools), MCP.fromMCPLayer())
+        const composedTools = yield* Effect.promise(() => source.tools())
+
         return yield* Effect.promise(() =>
           Promise.all(
-            allTools
+            composedTools
               .filter((tool) => {
                 // Enable websearch/codesearch for zen users OR via enable flag
                 if (tool.id === "codesearch" || tool.id === "websearch") {
@@ -185,6 +192,7 @@ export namespace ToolRegistry {
                 await Plugin.trigger("tool.definition", { toolID: tool.id }, output)
                 return {
                   id: tool.id,
+                  source: tool.source,
                   ...next,
                   description: output.description,
                   parameters: output.parameters,

--- a/packages/opencode/src/tool/source.ts
+++ b/packages/opencode/src/tool/source.ts
@@ -1,0 +1,57 @@
+import { Tool } from "./tool"
+
+export namespace ToolSource {
+  export interface Interface {
+    readonly id: string
+    readonly description?: string
+    tools(): Promise<Tool.Info[]>
+    onChange?: (callback: (changed: string[]) => void) => void
+  }
+
+  // Compose multiple sources. Later sources win on duplicate tool ids.
+  export function compose(...sources: Interface[]): Interface {
+    return {
+      id: "composed",
+      async tools() {
+        const all: Tool.Info[] = []
+        const seen = new Map<string, number>()
+        for (const source of sources) {
+          for (const tool of await source.tools()) {
+            const idx = seen.get(tool.id)
+            if (idx !== undefined) {
+              all[idx] = tool // later source wins
+            } else {
+              seen.set(tool.id, all.length)
+              all.push(tool)
+            }
+          }
+        }
+        return all
+      },
+      onChange(callback) {
+        for (const s of sources) s.onChange?.(callback)
+      },
+    }
+  }
+
+  // Wrap a static array into a ToolSource
+  export function fromBuiltin(tools: Tool.Info[]): Interface {
+    return {
+      id: "builtin",
+      description: "Built-in tools",
+      async tools() {
+        return tools
+      },
+    }
+  }
+
+  // Wrap an async function into a ToolSource
+  export function fromIterable(id: string, fn: () => Promise<Tool.Info[]>): Interface {
+    return {
+      id,
+      async tools() {
+        return fn()
+      },
+    }
+  }
+}

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import type { JSONSchema7 } from "ai"
 import type { MessageV2 } from "../session/message-v2"
 import type { Agent } from "../agent/agent"
 import type { Permission } from "../permission"
@@ -10,6 +11,9 @@ export namespace Tool {
     [key: string]: any
   }
 
+  /** Union of supported parameter representations */
+  export type ParameterSchema = z.ZodType | JSONSchema7
+
   export interface InitContext {
     agent?: Agent.Info
   }
@@ -20,52 +24,63 @@ export namespace Tool {
     agent: string
     abort: AbortSignal
     callID?: string
+    callChain?: string[]
     extra?: { [key: string]: any }
     messages: MessageV2.WithParts[]
     metadata(input: { title?: string; metadata?: M }): void
     ask(input: Omit<Permission.Request, "id" | "sessionID" | "tool">): Promise<void>
   }
-  export interface Info<Parameters extends z.ZodType = z.ZodType, M extends Metadata = Metadata> {
+  export interface Info<Parameters extends ParameterSchema = z.ZodType, M extends Metadata = Metadata> {
     id: string
-    init: (ctx?: InitContext) => Promise<{
-      description: string
-      parameters: Parameters
-      execute(
-        args: z.infer<Parameters>,
-        ctx: Context,
-      ): Promise<{
-        title: string
-        metadata: M
-        output: string
-        attachments?: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[]
-      }>
-      formatValidationError?(error: z.ZodError): string
-    }>
+    /** Tool origin source */
+    readonly source?: "builtin" | "mcp" | "plugin" | "custom"
+    init: (ctx?: InitContext) => Promise<ResolvedToolInfo<Parameters, M>>
   }
 
-  export type InferParameters<T extends Info> = T extends Info<infer P> ? z.infer<P> : never
+  export interface ResolvedToolInfo<Parameters extends ParameterSchema = z.ZodType, M extends Metadata = Metadata> {
+    description: string
+    parameters: Parameters
+    execute(
+      args: Parameters extends z.ZodType ? z.infer<Parameters> : never,
+      ctx: Context,
+    ): Promise<{
+      title: string
+      metadata: M
+      output: string
+      attachments?: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[]
+    }>
+    formatValidationError?(error: z.ZodError): string
+  }
+
+  export type InferParameters<T extends Info> =
+    T extends Info<infer P> ? (P extends z.ZodType ? z.infer<P> : never) : never
   export type InferMetadata<T extends Info> = T extends Info<any, infer M> ? M : never
 
-  export function define<Parameters extends z.ZodType, Result extends Metadata>(
+  export function define<Parameters extends ParameterSchema, Result extends Metadata>(
     id: string,
     init: Info<Parameters, Result>["init"] | Awaited<ReturnType<Info<Parameters, Result>["init"]>>,
+    opts?: { source?: Info["source"] },
   ): Info<Parameters, Result> {
     return {
       id,
+      source: opts?.source,
       init: async (initCtx) => {
         const toolInfo = init instanceof Function ? await init(initCtx) : init
         const execute = toolInfo.execute
         toolInfo.execute = async (args, ctx) => {
-          try {
-            toolInfo.parameters.parse(args)
-          } catch (error) {
-            if (error instanceof z.ZodError && toolInfo.formatValidationError) {
-              throw new Error(toolInfo.formatValidationError(error), { cause: error })
+          // Only apply Zod validation for Zod schemas; skip for JSON Schema
+          if (toolInfo.parameters instanceof z.ZodType) {
+            try {
+              toolInfo.parameters.parse(args)
+            } catch (error) {
+              if (error instanceof z.ZodError && toolInfo.formatValidationError) {
+                throw new Error(toolInfo.formatValidationError(error), { cause: error })
+              }
+              throw new Error(
+                `The ${id} tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
+                { cause: error },
+              )
             }
-            throw new Error(
-              `The ${id} tool was called with invalid arguments: ${error}.\nPlease rewrite the input so it satisfies the expected schema.`,
-              { cause: error },
-            )
           }
           const result = await execute(args, ctx)
           // skip truncation for tools that handle it themselves

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -196,15 +196,15 @@ export interface Hooks {
     output: { parts: Part[] },
   ) => Promise<void>
   "tool.execute.before"?: (
-    input: { tool: string; sessionID: string; callID: string },
-    output: { args: any },
+    input: { tool: string; sessionID: string; callID: string; callChain?: string[] },
+    output: { args: any; result?: { title: string; output: string; metadata?: Record<string, any> } },
   ) => Promise<void>
   "shell.env"?: (
     input: { cwd: string; sessionID?: string; callID?: string },
     output: { env: Record<string, string> },
   ) => Promise<void>
   "tool.execute.after"?: (
-    input: { tool: string; sessionID: string; callID: string; args: any },
+    input: { tool: string; sessionID: string; callID: string; callChain?: string[]; args: any },
     output: {
       title: string
       output: string


### PR DESCRIPTION
Implement middleware-style pipeline control for the plugin system, enabling plugins to intercept and override any tool execution.

Changes:
- Add PipelineExecutor with before/after/error hooks and shortCircuit support
- Create ToolSource abstraction for unified tool composition
- Wire MCP tools through triggerToolExecution for universal coverage
- Extend tool.execute.before hook with result field for short-circuit
- Replace all Plugin.trigger calls with triggerToolExecution in prompt.ts
- Add legacy hook compatibility layer (tool.execute.before/after)
- Handle Zod v3/v4/JSONSchema7 parameter type mismatches

Closes #5148

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
