### PR TITLE
feat: Add per-turn show/hide thinking in session timeline

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -460,14 +460,14 @@ function index<T extends { id: string }>(items: readonly T[]) {
   return new Map(items.map((item) => [item.id, item] as const))
 }
 
-function renderable(part: PartType, showReasoningSummaries = true) {
+function renderable(part: PartType, showReasoning = false) {
   if (part.type === "tool") {
     if (HIDDEN_TOOLS.has(part.tool)) return false
     if (part.tool === "question") return part.state.status !== "pending" && part.state.status !== "running"
     return true
   }
   if (part.type === "text") return !!part.text?.trim()
-  if (part.type === "reasoning") return showReasoningSummaries && !!part.text?.trim()
+  if (part.type === "reasoning") return showReasoning && !!part.text?.trim()
   return !!PART_MAPPING[part.type]
 }
 
@@ -486,7 +486,7 @@ export function AssistantParts(props: {
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
   working?: boolean
-  showReasoningSummaries?: boolean
+  showReasoning?: boolean
   shellToolDefaultOpen?: boolean
   editToolDefaultOpen?: boolean
 }) {
@@ -506,7 +506,7 @@ export function AssistantParts(props: {
       groupParts(
         props.messages.flatMap((message) =>
           list(data.store.part?.[message.id], emptyParts)
-            .filter((part) => renderable(part, props.showReasoningSummaries ?? true))
+            .filter((part) => renderable(part, props.showReasoning ?? false))
             .map((part) => ({
               messageID: message.id,
               part,

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -62,6 +62,38 @@
     }
   }
 
+  [data-slot="session-turn-thinking-toggle"] {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+  }
+
+  [data-slot="session-turn-thinking-toggle-button"] {
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    color: var(--text-weak);
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  [data-slot="session-turn-thinking-toggle-button"]:hover {
+    color: var(--text-base);
+  }
+
+  [data-slot="session-turn-thinking-toggle-button"]:focus-visible {
+    outline: 1px solid var(--border-selected);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+
   [data-component="text-reveal"].session-turn-thinking-heading {
     flex: 1 1 auto;
     min-width: 0;

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -87,17 +87,14 @@ function list<T>(value: T[] | undefined | null, fallback: T[]) {
 
 const hidden = new Set(["todowrite", "todoread"])
 
-function partState(part: PartType, showReasoningSummaries: boolean) {
+function partState(part: PartType) {
   if (part.type === "tool") {
     if (hidden.has(part.tool)) return
     if (part.tool === "question" && (part.state.status === "pending" || part.state.status === "running")) return
     return "visible" as const
   }
   if (part.type === "text") return part.text?.trim() ? ("visible" as const) : undefined
-  if (part.type === "reasoning") {
-    if (showReasoningSummaries && part.text?.trim()) return "visible" as const
-    return
-  }
+  if (part.type === "reasoning") return
   if (PART_MAPPING[part.type]) return "visible" as const
   return
 }
@@ -244,9 +241,11 @@ export function SessionTurn(
   const [state, setState] = createStore({
     open: false,
     expanded: [] as string[],
+    thinking: false,
   })
   const open = () => state.open
   const expanded = () => state.expanded
+  const thinking = () => state.thinking
 
   createEffect(
     on(
@@ -321,6 +320,26 @@ export function SessionTurn(
   const working = createMemo(() => status().type !== "idle" && active())
   const showReasoningSummaries = createMemo(() => props.showReasoningSummaries ?? true)
 
+  const reasoning = createMemo(() =>
+    assistantMessages()
+      .flatMap((message) => list(data.store.part?.[message.id], emptyParts))
+      .filter((part): part is PartType & { type: "reasoning"; text: string } => part.type === "reasoning")
+      .filter((part) => !!part.text?.trim()),
+  )
+  const hasReasoning = createMemo(() => reasoning().length > 0)
+
+  createEffect(
+    on(
+      hasReasoning,
+      (value) => {
+        if (value) return
+        if (!thinking()) return
+        setState("thinking", false)
+      },
+      { defer: true },
+    ),
+  )
+
   const assistantCopyPartID = createMemo(() => {
     if (working()) return null
     return showAssistantCopyPartID() ?? null
@@ -343,23 +362,21 @@ export function SessionTurn(
   const assistantVisible = createMemo(() =>
     assistantMessages().reduce((count, message) => {
       const parts = list(data.store.part?.[message.id], emptyParts)
-      return count + parts.filter((part) => partState(part, showReasoningSummaries()) === "visible").length
+      return count + parts.filter((part) => partState(part) === "visible").length
     }, 0),
   )
   const assistantTailVisible = createMemo(() =>
     assistantMessages()
       .flatMap((message) => list(data.store.part?.[message.id], emptyParts))
       .flatMap((part) => {
-        if (partState(part, showReasoningSummaries()) !== "visible") return []
+        if (partState(part) !== "visible") return []
         if (part.type === "text") return ["text" as const]
         return ["other" as const]
       })
       .at(-1),
   )
   const reasoningHeading = createMemo(() =>
-    assistantMessages()
-      .flatMap((message) => list(data.store.part?.[message.id], emptyParts))
-      .filter((part): part is PartType & { type: "reasoning"; text: string } => part.type === "reasoning")
+    reasoning()
       .map((part) => heading(part.text))
       .filter((text): text is string => !!text)
       .at(-1),
@@ -408,16 +425,27 @@ export function SessionTurn(
                     showAssistantCopyPartID={assistantCopyPartID()}
                     turnDurationMs={turnDurationMs()}
                     working={working()}
-                    showReasoningSummaries={showReasoningSummaries()}
+                    showReasoning={thinking()}
                     shellToolDefaultOpen={props.shellToolDefaultOpen}
                     editToolDefaultOpen={props.editToolDefaultOpen}
                   />
                 </div>
               </Show>
+              <Show when={hasReasoning()}>
+                <div data-slot="session-turn-thinking-toggle">
+                  <button
+                    type="button"
+                    data-slot="session-turn-thinking-toggle-button"
+                    onClick={() => setState("thinking", !thinking())}
+                  >
+                    {thinking() ? i18n.t("ui.sessionTurn.steps.hide") : i18n.t("ui.sessionTurn.steps.show")}
+                  </button>
+                </div>
+              </Show>
               <Show when={showThinking()}>
                 <div data-slot="session-turn-thinking">
                   <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} />
-                  <Show when={!showReasoningSummaries()}>
+                  <Show when={!showReasoningSummaries() && !thinking()}>
                     <TextReveal
                       text={reasoningHeading()}
                       class="session-turn-thinking-heading"


### PR DESCRIPTION
## Summary
- add per-turn thinking visibility state to SessionTurn (collapsed by default)
- add Show steps / Hide steps toggle when a turn has reasoning parts
- decouple reasoning-part rendering from global showReasoningSummaries by adding explicit showReasoning flow in AssistantParts
- keep existing global setting intact and continue using it for thinking status/preview behavior
- add styling for the inline thinking toggle row/button

## Behavior
- reasoning content is hidden by default per turn
- expanding/collapsing affects only the current turn
- no toggle is shown when a turn has no reasoning parts
- streaming status row remains in place while the turn is active

## Validation
- Could not run un typecheck in packages/ui / packages/app in this environment because un is not installed (un: The term 'bun' is not recognized).
