### PR TITLE
fix(tui): safe file reveal links (ref: opentui#864)

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-const childProcess = require("child_process")
-const fs = require("fs")
-const path = require("path")
-const os = require("os")
+import { spawnSync } from "child_process"
+import fs from "fs"
+import path from "path"
+import os from "os"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 function run(target) {
-  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+  const result = spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
   })
   if (result.error) {
@@ -149,6 +153,12 @@ const names = (() => {
 })()
 
 function findBinary(startDir) {
+  // Check dist folder for local development
+  const distCandidate = path.join(startDir, "..", "dist", base, "bin", binary)
+  if (fs.existsSync(distCandidate)) {
+    return distCandidate
+  }
+
   let current = startDir
   for (;;) {
     const modules = path.join(current, "node_modules")

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -117,6 +117,9 @@ export const McpListCommand = cmd({
             statusIcon = "✗"
             statusText = "needs client registration"
             hint = "\n    " + status.error
+          } else if (status.status === "connecting") {
+            statusIcon = "⋯"
+            statusText = "connecting"
           } else {
             statusIcon = "✗"
             statusText = "failed"

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -117,6 +117,9 @@ export function tui(input: {
 }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
+    const { provisionRevealHandler } = await import("@tui/util/reveal")
+    provisionRevealHandler()
+
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -99,7 +99,7 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
     timeout = setTimeout(() => {
       cleanup()
       resolve("dark")
-    }, 1000)
+    }, 100)
   })
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/todo-item.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/todo-item.tsx
@@ -18,15 +18,9 @@ export function TodoItem(props: TodoItemProps) {
       >
         [{props.status === "completed" ? "✓" : props.status === "in_progress" ? "•" : " "}]{" "}
       </text>
-      <text
-        flexGrow={1}
-        wrapMode="word"
-        style={{
-          fg: props.status === "in_progress" ? theme.warning : theme.textMuted,
-        }}
-      >
-        {props.content}
-      </text>
+      <box flexGrow={1}>
+        <text fg={props.status === "in_progress" ? theme.warning : theme.textMuted}>{props.content}</text>
+      </box>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -48,6 +48,7 @@ import type { SkillTool } from "@/tool/skill"
 import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useSDK } from "@tui/context/sdk"
 import { useCommandDialog } from "@tui/component/dialog-command"
+import type { DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
 import { Header } from "./header"
 import { parsePatch } from "diff"
@@ -104,6 +105,7 @@ const context = createContext<{
   showGenericToolOutput: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
+  tui: ReturnType<typeof useTuiConfig>
 }>()
 
 function use() {
@@ -116,6 +118,7 @@ export function Session() {
   const route = useRouteData("session")
   const { navigate } = useRoute()
   const sync = useSync()
+  const tuiConfig = useTuiConfig()
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
@@ -169,7 +172,7 @@ export function Session() {
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
 
   const scrollAcceleration = createMemo(() => {
-    const tui = sync.data.config.tui
+    const tui = tuiConfig
     if (tui?.scroll_acceleration?.enabled) {
       return new MacOSScrollAccel()
     }
@@ -327,6 +330,13 @@ export function Session() {
         type: "session",
         sessionID: children()[next].id,
       })
+    }
+  }
+
+  function childSessionHandler(func: (dialog: DialogContext) => void) {
+    return (dialog: DialogContext) => {
+      if (!session()?.parentID || dialog.stack.length > 0) return
+      func(dialog)
     }
   }
 
@@ -1031,6 +1041,7 @@ export function Session() {
         showGenericToolOutput,
         diffWrapMode,
         sync,
+        tui: tuiConfig,
       }}
     >
       <box flexDirection="row">
@@ -1226,7 +1237,6 @@ function UserMessage(props: {
   const local = useLocal()
   const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
-  const sync = useSync()
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
@@ -1956,6 +1966,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
   const { navigate } = useRoute()
   const local = useLocal()
   const sync = useSync()
+  const messages = createMemo(() => sync.data.message[props.metadata.sessionId ?? ""] ?? [])
 
   const tools = createMemo(() => {
     const sessionID = props.metadata.sessionId
@@ -1998,7 +2009,6 @@ function Task(props: ToolProps<typeof TaskTool>) {
   return (
     <InlineTool
       icon="│"
-      spinner={isRunning()}
       complete={props.input.description}
       pending="Delegating..."
       part={props.part}
@@ -2018,7 +2028,7 @@ function Edit(props: ToolProps<typeof EditTool>) {
   const { theme, syntax } = useTheme()
 
   const view = createMemo(() => {
-    const diffStyle = ctx.sync.data.config.tui?.diff_style
+    const diffStyle = ctx.tui?.diff_style
     if (diffStyle === "stacked") return "unified"
     // Default to "auto" behavior
     return ctx.width > 120 ? "split" : "unified"
@@ -2081,7 +2091,7 @@ function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
   const files = createMemo(() => props.metadata.files ?? [])
 
   const view = createMemo(() => {
-    const diffStyle = ctx.sync.data.config.tui?.diff_style
+    const diffStyle = ctx.tui?.diff_style
     if (diffStyle === "stacked") return "unified"
     return ctx.width > 120 ? "split" : "unified"
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -81,6 +81,8 @@ import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
+import { FilePathLink } from "../../ui/link"
+import { TextWithLinks } from "../../ui/text-with-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1455,6 +1457,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1728,7 +1731,7 @@ function InlineTool(props: {
 }
 
 function BlockTool(props: {
-  title: string
+  title: string | JSX.Element
   children: JSX.Element
   onClick?: () => void
   part?: ToolPart
@@ -1738,6 +1741,24 @@ function BlockTool(props: {
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+
+  // Wrap title in a fragment instead of text if it's already an element (like FilePathLink)
+  // to avoid nested text rendering issues which might break links
+  const titleContent = createMemo(() => {
+    if (typeof props.title === "string") {
+      return (
+        <text paddingLeft={3} fg={theme.textMuted}>
+          {props.title}
+        </text>
+      )
+    }
+    return (
+      <text paddingLeft={3} fg={theme.textMuted}>
+        {props.title}
+      </text>
+    )
+  })
+
   return (
     <box
       border={["left"]}
@@ -1756,15 +1777,10 @@ function BlockTool(props: {
         props.onClick?.()
       }}
     >
-      <Show
-        when={props.spinner}
-        fallback={
-          <text paddingLeft={3} fg={theme.textMuted}>
-            {props.title}
-          </text>
-        }
-      >
-        <Spinner color={theme.textMuted}>{props.title.replace(/^# /, "")}</Spinner>
+      <Show when={props.spinner} fallback={titleContent()}>
+        <Spinner color={theme.textMuted}>
+          {typeof props.title === "string" ? props.title.replace(/^# /, "") : ""}
+        </Spinner>
       </Show>
       {props.children}
       <Show when={error()}>
@@ -1824,7 +1840,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
           <box gap={1}>
             <text fg={theme.text}>$ {props.input.command}</text>
             <Show when={output()}>
-              <text fg={theme.text}>{limited()}</text>
+              <TextWithLinks text={limited()} fg={theme.text} />
             </Show>
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
@@ -1851,7 +1867,14 @@ function Write(props: ToolProps<typeof WriteTool>) {
   return (
     <Switch>
       <Match when={props.metadata.diagnostics !== undefined}>
-        <BlockTool title={"# Wrote " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool
+          title={
+            <>
+              # Wrote <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
+            </>
+          }
+          part={props.part}
+        >
           <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
             <code
               conceal={false}
@@ -1866,7 +1889,7 @@ function Write(props: ToolProps<typeof WriteTool>) {
       </Match>
       <Match when={true}>
         <InlineTool icon="←" pending="Preparing write..." complete={props.input.filePath} part={props.part}>
-          Write {normalizePath(props.input.filePath!)}
+          Write <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
         </InlineTool>
       </Match>
     </Switch>
@@ -1876,7 +1899,10 @@ function Write(props: ToolProps<typeof WriteTool>) {
 function Glob(props: ToolProps<typeof GlobTool>) {
   return (
     <InlineTool icon="✱" pending="Finding files..." complete={props.input.pattern} part={props.part}>
-      Glob "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      Glob "{props.input.pattern}"{" "}
+      <Show when={props.input.path}>
+        in <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>{" "}
+      </Show>
       <Show when={props.metadata.count}>
         ({props.metadata.count} {props.metadata.count === 1 ? "match" : "matches"})
       </Show>
@@ -1903,13 +1929,14 @@ function Read(props: ToolProps<typeof ReadTool>) {
         spinner={isRunning()}
         part={props.part}
       >
-        Read {normalizePath(props.input.filePath!)} {input(props.input, ["filePath"])}
+        Read <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>{" "}
+        {input(props.input, ["filePath"])}
       </InlineTool>
       <For each={loaded()}>
         {(filepath) => (
           <box paddingLeft={3}>
             <text paddingLeft={3} fg={theme.textMuted}>
-              ↳ Loaded {normalizePath(filepath)}
+              ↳ Loaded <FilePathLink path={filepath}>{normalizePath(filepath)}</FilePathLink>
             </text>
           </box>
         )}
@@ -1921,7 +1948,10 @@ function Read(props: ToolProps<typeof ReadTool>) {
 function Grep(props: ToolProps<typeof GrepTool>) {
   return (
     <InlineTool icon="✱" pending="Searching content..." complete={props.input.pattern} part={props.part}>
-      Grep "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      Grep "{props.input.pattern}"{" "}
+      <Show when={props.input.path}>
+        in <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>{" "}
+      </Show>
       <Show when={props.metadata.matches}>
         ({props.metadata.matches} {props.metadata.matches === 1 ? "match" : "matches"})
       </Show>
@@ -1930,23 +1960,21 @@ function Grep(props: ToolProps<typeof GrepTool>) {
 }
 
 function List(props: ToolProps<typeof ListTool>) {
-  const dir = createMemo(() => {
-    if (props.input.path) {
-      return normalizePath(props.input.path)
-    }
-    return ""
-  })
   return (
     <InlineTool icon="→" pending="Listing directory..." complete={props.input.path !== undefined} part={props.part}>
-      List {dir()}
+      List{" "}
+      <Show when={props.input.path}>
+        <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>
+      </Show>
     </InlineTool>
   )
 }
 
 function WebFetch(props: ToolProps<typeof WebFetchTool>) {
+  const url = () => (props.input as any).url
   return (
-    <InlineTool icon="%" pending="Fetching from the web..." complete={(props.input as any).url} part={props.part}>
-      WebFetch {(props.input as any).url}
+    <InlineTool icon="%" pending="Fetching from the web..." complete={url()} part={props.part}>
+      WebFetch <a href={url()}>{url()}</a>
     </InlineTool>
   )
 }
@@ -2057,7 +2085,15 @@ function Edit(props: ToolProps<typeof EditTool>) {
   return (
     <Switch>
       <Match when={props.metadata.diff !== undefined}>
-        <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool
+          title={
+            <>
+              {"← Edit "}
+              <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
+            </>
+          }
+          part={props.part}
+        >
           <box paddingLeft={1}>
             <diff
               diff={diffContent()}
@@ -2084,7 +2120,8 @@ function Edit(props: ToolProps<typeof EditTool>) {
       </Match>
       <Match when={true}>
         <InlineTool icon="←" pending="Preparing edit..." complete={props.input.filePath} part={props.part}>
-          Edit {normalizePath(props.input.filePath!)} {input({ replaceAll: props.input.replaceAll })}
+          Edit <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>{" "}
+          {input({ replaceAll: props.input.replaceAll })}
         </InlineTool>
       </Match>
     </Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,7 +7,6 @@ import {
   For,
   Match,
   on,
-  onMount,
   Show,
   Switch,
   useContext,
@@ -49,7 +48,6 @@ import type { SkillTool } from "@/tool/skill"
 import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useSDK } from "@tui/context/sdk"
 import { useCommandDialog } from "@tui/component/dialog-command"
-import type { DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
 import { Header } from "./header"
 import { parsePatch } from "diff"
@@ -79,10 +77,10 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { FilePathLink, Link } from "../../ui/link"
+import { TextWithLinks } from "../../ui/text-with-links"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
-import { FilePathLink } from "../../ui/link"
-import { TextWithLinks } from "../../ui/text-with-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -106,7 +104,6 @@ const context = createContext<{
   showGenericToolOutput: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
-  tui: ReturnType<typeof useTuiConfig>
 }>()
 
 function use() {
@@ -119,7 +116,6 @@ export function Session() {
   const route = useRouteData("session")
   const { navigate } = useRoute()
   const sync = useSync()
-  const tuiConfig = useTuiConfig()
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
@@ -173,7 +169,7 @@ export function Session() {
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
 
   const scrollAcceleration = createMemo(() => {
-    const tui = tuiConfig
+    const tui = sync.data.config.tui
     if (tui?.scroll_acceleration?.enabled) {
       return new MacOSScrollAccel()
     }
@@ -236,8 +232,6 @@ export function Session() {
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef
   const keybind = useKeybind()
-  const dialog = useDialog()
-  const renderer = useRenderer()
 
   // Allow exit when in child session (prompt is hidden)
   const exit = useExit()
@@ -323,37 +317,16 @@ export function Session() {
 
   const local = useLocal()
 
-  function moveFirstChild() {
-    if (children().length === 1) return
-    const next = children().find((x) => !!x.parentID)
-    if (next) {
-      navigate({
-        type: "session",
-        sessionID: next.id,
-      })
-    }
-  }
-
   function moveChild(direction: number) {
     if (children().length === 1) return
-
-    const sessions = children().filter((x) => !!x.parentID)
-    let next = sessions.findIndex((x) => x.id === session()?.id) + direction
-
-    if (next >= sessions.length) next = 0
-    if (next < 0) next = sessions.length - 1
-    if (sessions[next]) {
+    let next = children().findIndex((x) => x.id === session()?.id) + direction
+    if (next >= children().length) next = 0
+    if (next < 0) next = children().length - 1
+    if (children()[next]) {
       navigate({
         type: "session",
-        sessionID: sessions[next].id,
+        sessionID: children()[next].id,
       })
-    }
-  }
-
-  function childSessionHandler(func: (dialog: DialogContext) => void) {
-    return (dialog: DialogContext) => {
-      if (!session()?.parentID || dialog.stack.length > 0) return
-      func(dialog)
     }
   }
 
@@ -926,13 +899,24 @@ export function Session() {
       },
     },
     {
-      title: "Go to child session",
-      value: "session.child.first",
-      keybind: "session_child_first",
+      title: "Next child session",
+      value: "session.child.next",
+      keybind: "session_child_cycle",
       category: "Session",
       hidden: true,
       onSelect: (dialog) => {
-        moveFirstChild()
+        moveChild(1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous child session",
+      value: "session.child.previous",
+      keybind: "session_child_cycle_reverse",
+      category: "Session",
+      hidden: true,
+      onSelect: (dialog) => {
+        moveChild(-1)
         dialog.clear()
       },
     },
@@ -1027,6 +1011,9 @@ export function Session() {
     }
   })
 
+  const dialog = useDialog()
+  const renderer = useRenderer()
+
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
 
@@ -1044,7 +1031,6 @@ export function Session() {
         showGenericToolOutput,
         diffWrapMode,
         sync,
-        tui: tuiConfig,
       }}
     >
       <box flexDirection="row">
@@ -1344,8 +1330,6 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     return props.message.time.completed - user.time.created
   })
 
-  const keybind = useKeybind()
-
   return (
     <>
       <For each={props.parts}>
@@ -1363,14 +1347,6 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           )
         }}
       </For>
-      <Show when={props.parts.some((x) => x.type === "tool" && x.tool === "task")}>
-        <box paddingTop={1} paddingLeft={3}>
-          <text fg={theme.text}>
-            {keybind.print("session_child_first")}
-            <span style={{ fg: theme.textMuted }}> view subagents</span>
-          </text>
-        </box>
-      </Show>
       <Show when={props.message.error && props.message.error.name !== "MessageAbortedError"}>
         <box
           border={["left"]}
@@ -1643,7 +1619,6 @@ function InlineTool(props: {
   iconColor?: RGBA
   complete: any
   pending: string
-  spinner?: boolean
   children: JSX.Element
   part: ToolPart
   onClick?: () => void
@@ -1711,18 +1686,11 @@ function InlineTool(props: {
         }
       }}
     >
-      <Switch>
-        <Match when={props.spinner}>
-          <Spinner color={fg()} children={props.children} />
-        </Match>
-        <Match when={true}>
-          <text paddingLeft={3} fg={fg()} attributes={denied() ? TextAttributes.STRIKETHROUGH : undefined}>
-            <Show fallback={<>~ {props.pending}</>} when={props.complete}>
-              <span style={{ fg: props.iconColor }}>{props.icon}</span> {props.children}
-            </Show>
-          </text>
-        </Match>
-      </Switch>
+      <text paddingLeft={3} fg={fg()} attributes={denied() ? TextAttributes.STRIKETHROUGH : undefined}>
+        <Show fallback={<>~ {props.pending}</>} when={props.complete}>
+          <span style={{ fg: props.iconColor }}>{props.icon}</span> {props.children}
+        </Show>
+      </text>
       <Show when={error() && !denied()}>
         <text fg={theme.error}>{error()}</text>
       </Show>
@@ -1742,23 +1710,6 @@ function BlockTool(props: {
   const [hover, setHover] = createSignal(false)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
 
-  // Wrap title in a fragment instead of text if it's already an element (like FilePathLink)
-  // to avoid nested text rendering issues which might break links
-  const titleContent = createMemo(() => {
-    if (typeof props.title === "string") {
-      return (
-        <text paddingLeft={3} fg={theme.textMuted}>
-          {props.title}
-        </text>
-      )
-    }
-    return (
-      <text paddingLeft={3} fg={theme.textMuted}>
-        {props.title}
-      </text>
-    )
-  })
-
   return (
     <box
       border={["left"]}
@@ -1777,9 +1728,16 @@ function BlockTool(props: {
         props.onClick?.()
       }}
     >
-      <Show when={props.spinner} fallback={titleContent()}>
+      <Show
+        when={props.spinner}
+        fallback={
+          <text paddingLeft={3} fg={theme.textMuted}>
+            {props.title}
+          </text>
+        }
+      >
         <Spinner color={theme.textMuted}>
-          {typeof props.title === "string" ? props.title.replace(/^# /, "") : ""}
+          {typeof props.title === "string" ? props.title.replace(/^# /, "") : props.title}
         </Spinner>
       </Show>
       {props.children}
@@ -1912,7 +1870,6 @@ function Glob(props: ToolProps<typeof GlobTool>) {
 
 function Read(props: ToolProps<typeof ReadTool>) {
   const { theme } = useTheme()
-  const isRunning = createMemo(() => props.part.state.status === "running")
   const loaded = createMemo(() => {
     if (props.part.state.status !== "completed") return []
     if (props.part.state.time.compacted) return []
@@ -1922,13 +1879,7 @@ function Read(props: ToolProps<typeof ReadTool>) {
   })
   return (
     <>
-      <InlineTool
-        icon="→"
-        pending="Reading file..."
-        complete={props.input.filePath}
-        spinner={isRunning()}
-        part={props.part}
-      >
+      <InlineTool icon="→" pending="Reading file..." complete={props.input.filePath} part={props.part}>
         Read <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>{" "}
         {input(props.input, ["filePath"])}
       </InlineTool>
@@ -1971,7 +1922,7 @@ function List(props: ToolProps<typeof ListTool>) {
 }
 
 function WebFetch(props: ToolProps<typeof WebFetchTool>) {
-  const url = () => (props.input as any).url
+  const url = () => (props.input as any).url as string
   return (
     <InlineTool icon="%" pending="Fetching from the web..." complete={url()} part={props.part}>
       WebFetch <a href={url()}>{url()}</a>
@@ -2006,22 +1957,17 @@ function Task(props: ToolProps<typeof TaskTool>) {
   const local = useLocal()
   const sync = useSync()
 
-  onMount(() => {
-    if (props.metadata.sessionId && !sync.data.message[props.metadata.sessionId]?.length)
-      sync.session.sync(props.metadata.sessionId)
-  })
-
-  const messages = createMemo(() => sync.data.message[props.metadata.sessionId ?? ""] ?? [])
-
   const tools = createMemo(() => {
-    return messages().flatMap((msg) =>
+    const sessionID = props.metadata.sessionId
+    const msgs = sync.data.message[sessionID ?? ""] ?? []
+    return msgs.flatMap((msg) =>
       (sync.data.part[msg.id] ?? [])
         .filter((part): part is ToolPart => part.type === "tool")
         .map((part) => ({ tool: part.tool, state: part.state })),
     )
   })
 
-  const current = createMemo(() => tools().findLast((x) => (x.state as any).title))
+  const current = createMemo(() => tools().findLast((x) => x.state.status !== "pending"))
 
   const isRunning = createMemo(() => props.part.state.status === "running")
 
@@ -2072,7 +2018,7 @@ function Edit(props: ToolProps<typeof EditTool>) {
   const { theme, syntax } = useTheme()
 
   const view = createMemo(() => {
-    const diffStyle = ctx.tui.diff_style
+    const diffStyle = ctx.sync.data.config.tui?.diff_style
     if (diffStyle === "stacked") return "unified"
     // Default to "auto" behavior
     return ctx.width > 120 ? "split" : "unified"
@@ -2135,7 +2081,7 @@ function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
   const files = createMemo(() => props.metadata.files ?? [])
 
   const view = createMemo(() => {
-    const diffStyle = ctx.tui.diff_style
+    const diffStyle = ctx.sync.data.config.tui?.diff_style
     if (diffStyle === "stacked") return "unified"
     return ctx.width > 120 ? "split" : "unified"
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1870,7 +1870,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
           <box gap={1}>
             <text fg={theme.text}>$ {props.input.command}</text>
             <Show when={output()}>
-              <TextWithLinks text={limited()} fg={theme.text} />
+              <TextWithLinks text={contextualOutput()} fg={theme.text} />
             </Show>
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -28,7 +28,15 @@ import {
   RGBA,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
+import type {
+  AssistantMessage,
+  Part,
+  ToolPart,
+  UserMessage,
+  TextPart,
+  ReasoningPart,
+  FilePart,
+} from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
 import { Locale } from "@/util/locale"
 import type { Tool } from "@/tool/tool"
@@ -82,6 +90,7 @@ import { FilePathLink, Link } from "../../ui/link"
 import { TextWithLinks } from "../../ui/text-with-links"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
+import { preprocessMarkdownLinks } from "../../ui/preprocess-markdown-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1226,6 +1235,21 @@ const MIME_BADGE: Record<string, string> = {
   "application/x-directory": "dir",
 }
 
+function processUserMessageText(text: string | undefined, files: FilePart[]): string {
+  if (!text) return ""
+
+  let processed = text
+  for (const file of files) {
+    if (file.source?.type === "file" && file.source.path) {
+      const filename = file.source.path.split("/").pop() || file.source.path
+      const regex = new RegExp(`@${filename}\\b`, "g")
+      processed = processed.replace(regex, file.source.path)
+    }
+  }
+
+  return preprocessMarkdownLinks(processed)
+}
+
 function UserMessage(props: {
   message: UserMessage
   parts: Part[]
@@ -1237,7 +1261,8 @@ function UserMessage(props: {
   const local = useLocal()
   const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
-  const { theme } = useTheme()
+  const sync = useSync()
+  const { theme, syntax } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
@@ -1270,7 +1295,13 @@ function UserMessage(props: {
             backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
             flexShrink={0}
           >
-            <text fg={theme.text}>{text()?.text}</text>
+            <code
+              filetype="markdown"
+              drawUnstyledText={false}
+              syntaxStyle={syntax()}
+              content={processUserMessageText(text()?.text, files())}
+              fg={theme.text}
+            />
             <Show when={files().length}>
               <box flexDirection="row" paddingBottom={metadataVisible() ? 1 : 0} paddingTop={1} gap={1} flexWrap="wrap">
                 <For each={files()}>
@@ -1368,7 +1399,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           customBorderChars={SplitBorder.customBorderChars}
           borderColor={theme.error}
         >
-          <text fg={theme.textMuted}>{props.message.error?.data.message}</text>
+          <text fg={theme.textMuted}>{String(props.message.error?.data.message || "")}</text>
         </box>
       </Show>
       <Switch>
@@ -1415,6 +1446,11 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
     return props.part.text.replace("[REDACTED]", "").trim()
   })
+
+  const processedContent = createMemo(() => {
+    return preprocessMarkdownLinks("_Thinking:_ " + content())
+  })
+
   return (
     <Show when={content() && ctx.showThinking()}>
       <box
@@ -1431,7 +1467,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
           drawUnstyledText={false}
           streaming={true}
           syntaxStyle={subtleSyntax()}
-          content={"_Thinking:_ " + content()}
+          content={processedContent()}
           conceal={ctx.conceal()}
           fg={theme.textMuted}
         />
@@ -1444,6 +1480,10 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
   const ctx = use()
   const { theme, syntax } = useTheme()
 
+  const processedContent = createMemo(() => {
+    return preprocessMarkdownLinks(props.part.text.trim())
+  })
+
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1452,7 +1492,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
             <markdown
               syntaxStyle={syntax()}
               streaming={true}
-              content={props.part.text.trim()}
+              content={processedContent()}
               conceal={ctx.conceal()}
               fg={theme.markdownText}
               bg={theme.background}
@@ -1464,7 +1504,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={processedContent()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />
@@ -1766,9 +1806,31 @@ function Bash(props: ToolProps<typeof BashTool>) {
   const [expanded, setExpanded] = createSignal(false)
   const lines = createMemo(() => output().split("\n"))
   const overflow = createMemo(() => lines().length > 10)
-  const limited = createMemo(() => {
-    if (expanded() || !overflow()) return output()
-    return [...lines().slice(0, 10), "…"].join("\n")
+
+  const contextualOutput = createMemo(() => {
+    const text = expanded() || !overflow() ? output() : [...lines().slice(0, 10), "…"].join("\n")
+
+    const command = props.input.command || ""
+    const lsMatch = command.match(/\bls\b.*?\s+([^\s]+\/?)$/)
+    const cdMatch = command.match(/\bcd\s+([^\s]+)/)
+    const directory = lsMatch?.[1] || cdMatch?.[1] || ""
+
+    if (directory && (command.includes("ls") || command.includes("dir"))) {
+      return text
+        .split("\n")
+        .map((line) => {
+          const fileMatch = line.match(/^[-drwx@]+\s+\d+\s+\w+\s+\w+\s+[\d,]+\s+\w+\s+\d+\s+[\d:]+\s+(.+)$/)
+          if (fileMatch && fileMatch[1] && fileMatch[1] !== "." && fileMatch[1] !== "..") {
+            const filename = fileMatch[1]
+            const fullPath = directory.endsWith("/") ? directory + filename : directory + "/" + filename
+            return line.replace(filename, fullPath)
+          }
+          return line
+        })
+        .join("\n")
+    }
+
+    return text
   })
 
   const workdirDisplay = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -90,7 +90,6 @@ import { FilePathLink, Link } from "../../ui/link"
 import { TextWithLinks } from "../../ui/text-with-links"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
-import { preprocessMarkdownLinks } from "../../ui/preprocess-markdown-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1247,7 +1246,7 @@ function processUserMessageText(text: string | undefined, files: FilePart[]): st
     }
   }
 
-  return preprocessMarkdownLinks(processed)
+  return processed
 }
 
 function UserMessage(props: {
@@ -1448,7 +1447,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
   })
 
   const processedContent = createMemo(() => {
-    return preprocessMarkdownLinks("_Thinking:_ " + content())
+    return "_Thinking:_ " + content()
   })
 
   return (
@@ -1481,7 +1480,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
   const { theme, syntax } = useTheme()
 
   const processedContent = createMemo(() => {
-    return preprocessMarkdownLinks(props.part.text.trim())
+    return props.part.text.trim()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "solid-js"
 import type { RGBA } from "@opentui/core"
-import open from "open"
+import path from "path"
 
 export interface LinkProps {
   href: string
@@ -8,21 +8,30 @@ export interface LinkProps {
   fg?: RGBA
 }
 
-/**
- * Link component that renders clickable hyperlinks.
- * Clicking anywhere on the link text opens the URL in the default browser.
- */
 export function Link(props: LinkProps) {
   const displayText = props.children ?? props.href
 
   return (
-    <text
-      fg={props.fg}
-      onMouseUp={() => {
-        open(props.href).catch(() => {})
-      }}
-    >
+    <a href={props.href} style={{ fg: props.fg }}>
       {displayText}
-    </text>
+    </a>
+  )
+}
+
+export interface FilePathLinkProps {
+  path: string
+  children?: JSX.Element | string
+  fg?: RGBA
+}
+
+export function FilePathLink(props: FilePathLinkProps) {
+  const displayText = props.children ?? props.path
+  const absolutePath = path.isAbsolute(props.path) ? props.path : path.resolve(process.cwd(), props.path)
+  const fileUrl = `file://${absolutePath}`
+
+  return (
+    <a href={fileUrl} style={{ fg: props.fg }}>
+      {displayText}
+    </a>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "solid-js"
 import type { RGBA } from "@opentui/core"
 import path from "path"
+import { revealScheme } from "@tui/util/reveal"
 
 export interface LinkProps {
   href: string
@@ -9,11 +10,11 @@ export interface LinkProps {
 }
 
 export function Link(props: LinkProps) {
-  const displayText = props.children ?? props.href
+  const display = props.children ?? props.href
 
   return (
     <a href={props.href} style={{ fg: props.fg }}>
-      {displayText}
+      {display}
     </a>
   )
 }
@@ -25,13 +26,12 @@ export interface FilePathLinkProps {
 }
 
 export function FilePathLink(props: FilePathLinkProps) {
-  const displayText = props.children ?? props.path
-  const absolutePath = path.isAbsolute(props.path) ? props.path : path.resolve(process.cwd(), props.path)
-  const fileUrl = `file://${absolutePath}`
+  const display = props.children ?? props.path
+  const absolute = path.isAbsolute(props.path) ? props.path : path.resolve(process.cwd(), props.path)
 
   return (
-    <a href={fileUrl} style={{ fg: props.fg }}>
-      {displayText}
+    <a href={revealScheme(absolute)} style={{ fg: props.fg }}>
+      {display}
     </a>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/preprocess-markdown-links.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/preprocess-markdown-links.ts
@@ -1,0 +1,108 @@
+import { homedir } from "os"
+import * as path from "path"
+
+// Enhanced regex to better match file paths, including:
+// - Paths starting with ~ (like ~/.claude/CLAUDE.md)
+// - Paths ending with common file extensions (.md, .txt, .js, etc.)
+// - Relative paths with file extensions
+// - URLs
+const PATH_REGEX =
+  /((?:https?:\/\/[^\s"'()<>]+)|(?:[A-Za-z]:[\\\/](?:[^\\\/\s"'()<>:*?]+[\\\/])*[^\\\/\s"'()<>:*?]*)|(?:\/|~|\.\.?\/)[^\s"'()<>]+(?::\d+(?::\d+)?)?|(?:[\w.-]+\/[^\s"'()<>]*)|(?:[a-zA-Z][\w.-]*\.\w{2,})|(?:~\/[^\s"'()<>]+)|(?:\b[A-Za-z][\w.-]*\.(?:md|txt|js|ts|jsx|tsx|py|rb|go|rs|java|cpp|c|h|hpp|css|html|xml|json|yaml|yml|toml|ini|conf|config|sh|bash|zsh|fish|ps1|psm1|bat|cmd)\b))/g
+
+export function preprocessMarkdownLinks(text: string): string {
+  const toolPatterns = [
+    /\bWrote\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bRead\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bEdit\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bCreated\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bUpdated\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bDeleted\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bFound\s+in\s+([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+    /\bFile:\s*([^\s\[\]]+(?:\.[a-zA-Z0-9]+)?)/g,
+  ]
+
+  let processedText = text
+  for (const pattern of toolPatterns) {
+    processedText = processedText.replace(pattern, (match, path) => {
+      if (match.includes("[") || match.includes("]")) return match
+      if (path.startsWith("http://") || path.startsWith("https://")) return match
+      const keyword = match.substring(0, match.indexOf(path)).trim()
+      return `${keyword} \`${path}\``
+    })
+  }
+
+  const protectedRanges: Array<{ start: number; end: number }> = []
+
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g
+  let match
+  while ((match = linkRegex.exec(processedText)) !== null) {
+    protectedRanges.push({ start: match.index, end: match.index + match[0].length })
+  }
+
+  const codeBlockRegex = /```[\s\S]*?```/g
+  while ((match = codeBlockRegex.exec(processedText)) !== null) {
+    protectedRanges.push({ start: match.index, end: match.index + match[0].length })
+  }
+
+  const inlineCodeRegex = /`[^`]+`/g
+  while ((match = inlineCodeRegex.exec(processedText)) !== null) {
+    protectedRanges.push({ start: match.index, end: match.index + match[0].length })
+  }
+
+  protectedRanges.sort((a, b) => a.start - b.start)
+
+  let result = ""
+  let lastIndex = 0
+
+  PATH_REGEX.lastIndex = 0
+  while ((match = PATH_REGEX.exec(processedText)) !== null) {
+    const matchStart = match.index
+    const matchEnd = match.index + match[0].length
+
+    const isProtected = protectedRanges.some(
+      (range) =>
+        (matchStart >= range.start && matchStart < range.end) || (matchEnd > range.start && matchEnd <= range.end),
+    )
+
+    if (isProtected) continue
+
+    let pathMatch = match[0]
+
+    if (pathMatch.startsWith("http")) continue
+
+    if (/^[a-zA-Z]+\.(com|org|net|io|dev|app|ai|co)$/.test(pathMatch)) continue
+
+    if (pathMatch.includes("*") && !pathMatch.endsWith("/*")) continue
+
+    const isWildcardDir = pathMatch.endsWith("/*")
+    if (isWildcardDir) {
+      pathMatch = pathMatch.slice(0, -2)
+    }
+
+    result += processedText.slice(lastIndex, matchStart)
+
+    let href = pathMatch
+
+    if (pathMatch.startsWith("~")) {
+      href = pathMatch.replace(/^~/, homedir())
+    } else if (
+      pathMatch.startsWith("./") ||
+      pathMatch.startsWith("../") ||
+      (!pathMatch.startsWith("/") && !pathMatch.match(/^[A-Za-z]:[\\\/]/))
+    ) {
+      href = path.resolve(process.cwd(), pathMatch)
+    }
+
+    href = path.normalize(href)
+
+    const fileUrl = `file://${href.startsWith("/") ? "" : "/"}${href.replace(/\\/g, "/")}`
+
+    result += `[${pathMatch}](${fileUrl})`
+
+    lastIndex = matchEnd
+  }
+
+  result += processedText.slice(lastIndex)
+
+  return result
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/text-with-links.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/text-with-links.tsx
@@ -1,0 +1,99 @@
+import { For, createMemo } from "solid-js"
+import { FilePathLink, Link } from "./link"
+import type { RGBA } from "@opentui/core"
+import { useTheme } from "@tui/context/theme"
+
+const PATH_REGEX =
+  /((?:https?:\/\/[^\s"'()<>]+)|(?:\/|~|\.\.?\/)[^\s"'()<>]+|(?:[\w.-]+\/[^\s"'()<>]*)|(?:[a-zA-Z][\w.-]*\.\w{2,})|(?:[\w.-]+[*@/])|(?:\*\*[^*]+\*\*)|(?:_[^_]+_)|(?:`[^`]+`))/g
+
+export function TextWithLinks(props: { text: string; fg?: RGBA }) {
+  const { theme } = useTheme()
+
+  const parts = createMemo(() => {
+    const text = props.text
+    const result = []
+    let lastIndex = 0
+    let match
+
+    PATH_REGEX.lastIndex = 0
+    while ((match = PATH_REGEX.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        result.push({ type: "text", content: text.slice(lastIndex, match.index) })
+      }
+
+      let content = match[0]
+
+      // Handle Markdown formatting
+      if (content.startsWith("**") && content.endsWith("**")) {
+        result.push({ type: "bold", content: content.slice(2, -2) })
+      } else if (content.startsWith("_") && content.endsWith("_")) {
+        // TUI might not support italic widely, but we can try or use another style
+        result.push({ type: "italic", content: content.slice(1, -1) })
+      } else if (content.startsWith("`") && content.endsWith("`")) {
+        // For code spans, we strip backticks.
+        // Optionally we could check if the code content is a file path?
+        // Let's just treat it as styled text for now to be safe.
+        result.push({ type: "code", content: content.slice(1, -1) })
+      } else {
+        // Trim trailing punctuation usually found at end of sentences or in lists
+        const suffixMatch = content.match(/[.,:;`'"})\]>]+$/)
+        const suffix = suffixMatch ? suffixMatch[0] : ""
+        content = content.substring(0, content.length - suffix.length)
+
+        if (content.length < 2) {
+          result.push({ type: "text", content: match[0] })
+        } else {
+          const isUrl = content.startsWith("http")
+          result.push({
+            type: isUrl ? "url" : "path",
+            content: content,
+          })
+          if (suffix) {
+            result.push({ type: "text", content: suffix })
+          }
+        }
+      }
+
+      lastIndex = PATH_REGEX.lastIndex
+    }
+
+    if (lastIndex < text.length) {
+      result.push({ type: "text", content: text.slice(lastIndex) })
+    }
+
+    return result
+  })
+
+  return (
+    <text fg={props.fg}>
+      <For each={parts()}>
+        {(part) => {
+          if (part.type === "url") {
+            return (
+              <Link href={part.content} fg={props.fg}>
+                {part.content}
+              </Link>
+            )
+          }
+          if (part.type === "path") {
+            return (
+              <FilePathLink path={part.content} fg={props.fg}>
+                {part.content}
+              </FilePathLink>
+            )
+          }
+          if (part.type === "bold") {
+            return <span style={{ bold: true }}>{part.content}</span>
+          }
+          if (part.type === "italic") {
+            return <span style={{ italic: true }}>{part.content}</span>
+          }
+          if (part.type === "code") {
+            return <span style={{ bg: theme.backgroundElement }}>{part.content}</span>
+          }
+          return part.content
+        }}
+      </For>
+    </text>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/util/reveal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/reveal.ts
@@ -1,0 +1,40 @@
+import { execSync, exec } from "child_process"
+import { existsSync } from "fs"
+import path from "path"
+import os from "os"
+
+const APP_PATH = path.join(os.homedir(), "Applications", "OpenCodeReveal.app")
+const SCHEME = "opencode-reveal"
+
+let provisioned: boolean | undefined
+
+export function revealScheme(absolute: string) {
+  if (process.platform !== "darwin") return `file://${absolute}`
+  if (provisioned === undefined) provisioned = existsSync(APP_PATH)
+  if (!provisioned) return `file://${absolute}`
+  return `${SCHEME}://${absolute}`
+}
+
+export function provisionRevealHandler() {
+  if (process.platform !== "darwin") return
+  if (existsSync(APP_PATH)) {
+    provisioned = true
+    return
+  }
+  try {
+    execSync(
+      `osacompile -o ${JSON.stringify(APP_PATH)} -e 'on open location input' -e 'set filePath to text 21 thru -1 of input' -e 'do shell script "open -R " & quoted form of filePath' -e 'end open location'`,
+      { stdio: "ignore" },
+    )
+    execSync(
+      `defaults write ${JSON.stringify(APP_PATH + "/Contents/Info")} CFBundleURLTypes -array '{ CFBundleURLName = "OpenCode Reveal"; CFBundleURLSchemes = ("${SCHEME}"); }'`,
+      { stdio: "ignore" },
+    )
+    exec(
+      `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f ${JSON.stringify(APP_PATH)}`,
+    )
+    provisioned = true
+  } catch {
+    provisioned = false
+  }
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1074,6 +1074,10 @@ export namespace Config {
         .describe(
           "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
         ),
+      notifications: z
+        .boolean()
+        .optional()
+        .describe("Send desktop notifications when sessions complete (macOS only). Defaults to true."),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
       enabled_providers: z
         .array(z.string())

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -154,6 +154,8 @@ export namespace Config {
 
       deps.push(
         iife(async () => {
+          const exists = existsSync(path.join(dir, "node_modules"))
+          if (exists) return
           const shouldInstall = await needsInstall(dir)
           if (shouldInstall) await installDependencies(dir)
         }),

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,3 +1,4 @@
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = "true"
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -103,6 +103,13 @@ export namespace MCP {
         .meta({
           ref: "MCPStatusNeedsClientRegistration",
         }),
+      z
+        .object({
+          status: z.literal("connecting"),
+        })
+        .meta({
+          ref: "MCPStatusConnecting",
+        }),
     ])
     .meta({
       ref: "MCPStatus",
@@ -186,7 +193,7 @@ export namespace MCP {
       const clients: Record<string, MCPClient> = {}
       const status: Record<string, Status> = {}
 
-      await Promise.all(
+      Promise.all(
         Object.entries(config).map(async ([key, mcp]) => {
           if (!isMcpConfigured(mcp)) {
             log.error("Ignoring MCP config entry without type", { key })
@@ -199,6 +206,9 @@ export namespace MCP {
             return
           }
 
+          status[key] = { status: "connecting" }
+          Bus.publish(ToolsChanged, { server: key })
+
           const result = await create(key, mcp).catch(() => undefined)
           if (!result) return
 
@@ -206,9 +216,12 @@ export namespace MCP {
 
           if (result.mcpClient) {
             clients[key] = result.mcpClient
+            Bus.publish(ToolsChanged, { server: key })
           }
         }),
-      )
+      ).catch((error) => {
+        log.error("Unexpected error in MCP background connection", { error })
+      })
       return {
         status,
         clients,

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -124,11 +124,39 @@ export namespace MCP {
     })
   }
 
+  function coerceJsonStrings(args: Record<string, unknown>, schema: JSONSchema7): Record<string, unknown> {
+    const properties = schema.properties ?? {}
+    const result: Record<string, unknown> = { ...args }
+
+    for (const [key, value] of Object.entries(args)) {
+      if (typeof value !== "string") continue
+
+      const propSchema = properties[key]
+      if (!propSchema || typeof propSchema === "boolean") continue
+
+      const expectedType = propSchema.type
+      if (!expectedType) continue
+
+      const isArrayOrObject = expectedType === "array" || expectedType === "object"
+      if (!isArrayOrObject) continue
+
+      const trimmed = value.trim()
+      const looksLikeJson =
+        (trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))
+      if (!looksLikeJson) continue
+
+      try {
+        result[key] = JSON.parse(value)
+      } catch {}
+    }
+
+    return result
+  }
+
   // Convert MCP tool definition to AI SDK Tool type
   async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
-    // Spread first, then override type to ensure it's always "object"
     const schema: JSONSchema7 = {
       ...(inputSchema as JSONSchema7),
       type: "object",
@@ -140,10 +168,11 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
+        const coerced = coerceJsonStrings(args as Record<string, unknown>, schema)
         return client.callTool(
           {
             name: mcpTool.name,
-            arguments: (args || {}) as Record<string, unknown>,
+            arguments: coerced,
           },
           CallToolResultSchema,
           {

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -17,7 +17,7 @@ export namespace Notification {
     Bus.subscribe(SessionStatus.Event.Idle, async (event) => {
       const config = await Config.get()
       // Default to true if not explicitly set to false
-      if (config.notifications === false) return
+      if (Reflect.get(config, "notifications") === false) return
 
       try {
         await sendCompletionNotification(event.properties.sessionID)

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -1,6 +1,7 @@
 import { Bus } from "@/bus"
 import { SessionStatus } from "@/session/status"
 import { Session } from "@/session"
+import { SessionID } from "@/session/schema"
 import { Log } from "@/util/log"
 import { Config } from "@/config/config"
 
@@ -27,13 +28,12 @@ export namespace Notification {
   }
 
   async function sendCompletionNotification(sessionID: string) {
-    const session = await Session.get(sessionID)
+    const id = SessionID.make(sessionID)
+    const session = await Session.get(id)
     if (!session) return
 
-    const messagesWithParts = await Session.messages({ sessionID, limit: 10 })
-    const lastAssistant = messagesWithParts
-      .filter((m) => m.info.role === "assistant")
-      .pop()
+    const messagesWithParts = await Session.messages({ sessionID: id, limit: 10 })
+    const lastAssistant = messagesWithParts.filter((m) => m.info.role === "assistant").pop()
 
     // Build notification content
     const title = session.title || "OpenCode"
@@ -79,10 +79,13 @@ export namespace Notification {
 
     try {
       // Get window name, session name, window index, and pane ID
-      const proc = Bun.spawn(["tmux", "display-message", "-p", "#{window_name}\t#{session_name}\t#{window_index}\t#{pane_id}"], {
-        stdout: "pipe",
-        stderr: "ignore",
-      })
+      const proc = Bun.spawn(
+        ["tmux", "display-message", "-p", "#{window_name}\t#{session_name}\t#{window_index}\t#{pane_id}"],
+        {
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      )
       const output = await new Response(proc.stdout).text()
       await proc.exited
       const [windowName, sessionName, windowIndex, pane] = output.trim().split("\t")

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -1,0 +1,189 @@
+import { Bus } from "@/bus"
+import { SessionStatus } from "@/session/status"
+import { Session } from "@/session"
+import { Log } from "@/util/log"
+import { Config } from "@/config/config"
+
+const log = Log.create({ name: "notification" })
+
+export namespace Notification {
+  let initialized = false
+
+  export async function init() {
+    if (initialized) return
+    initialized = true
+
+    Bus.subscribe(SessionStatus.Event.Idle, async (event) => {
+      const config = await Config.get()
+      // Default to true if not explicitly set to false
+      if (config.notifications === false) return
+
+      try {
+        await sendCompletionNotification(event.properties.sessionID)
+      } catch (err) {
+        log.error("failed to send notification", { error: err })
+      }
+    })
+  }
+
+  async function sendCompletionNotification(sessionID: string) {
+    const session = await Session.get(sessionID)
+    if (!session) return
+
+    const messagesWithParts = await Session.messages({ sessionID, limit: 10 })
+    const lastAssistant = messagesWithParts
+      .filter((m) => m.info.role === "assistant")
+      .pop()
+
+    // Build notification content
+    const title = session.title || "OpenCode"
+    let message = "Session completed"
+
+    if (lastAssistant) {
+      // Get a summary from the last assistant message
+      const textPart = lastAssistant.parts.find((p) => p.type === "text")
+      if (textPart && textPart.type === "text") {
+        // Truncate to first 100 chars
+        const text = textPart.text.slice(0, 100)
+        message = text.length < textPart.text.length ? text + "..." : text
+      }
+    }
+
+    // Get tmux info if available
+    const tmux = await getTmuxInfo()
+    if (tmux?.windowName) {
+      message = `[${tmux.windowName}] ${message}`
+    }
+
+    // Build URL if share is available
+    const url = session.share?.url
+
+    await sendMacOSNotification({
+      title,
+      message,
+      url,
+      sessionID,
+      tmux,
+    })
+  }
+
+  interface TmuxInfo {
+    windowName?: string
+    pane?: string // e.g., "%123"
+    sessionName?: string
+    windowIndex?: string
+  }
+
+  async function getTmuxInfo(): Promise<TmuxInfo | undefined> {
+    if (!process.env["TMUX"]) return undefined
+
+    try {
+      // Get window name, session name, window index, and pane ID
+      const proc = Bun.spawn(["tmux", "display-message", "-p", "#{window_name}\t#{session_name}\t#{window_index}\t#{pane_id}"], {
+        stdout: "pipe",
+        stderr: "ignore",
+      })
+      const output = await new Response(proc.stdout).text()
+      await proc.exited
+      const [windowName, sessionName, windowIndex, pane] = output.trim().split("\t")
+      return {
+        windowName: windowName || undefined,
+        sessionName: sessionName || undefined,
+        windowIndex: windowIndex || undefined,
+        pane: pane || process.env["TMUX_PANE"],
+      }
+    } catch {
+      return undefined
+    }
+  }
+
+  async function getTerminalBundleId(): Promise<string> {
+    // Check common terminal emulators by looking at parent process or known env vars
+    const termProgram = process.env["TERM_PROGRAM"]
+
+    switch (termProgram) {
+      case "ghostty":
+        return "com.mitchellh.ghostty"
+      case "iTerm.app":
+        return "com.googlecode.iterm2"
+      case "Apple_Terminal":
+        return "com.apple.Terminal"
+      case "WezTerm":
+        return "com.github.wez.wezterm"
+      case "Alacritty":
+        return "org.alacritty"
+      case "kitty":
+        return "net.kovidgoyal.kitty"
+      default:
+        // Fallback: try to detect from TERM_PROGRAM_VERSION or default to Terminal
+        if (process.env["GHOSTTY_RESOURCES_DIR"]) return "com.mitchellh.ghostty"
+        if (process.env["ITERM_SESSION_ID"]) return "com.googlecode.iterm2"
+        if (process.env["KITTY_WINDOW_ID"]) return "net.kovidgoyal.kitty"
+        if (process.env["WEZTERM_PANE"]) return "com.github.wez.wezterm"
+        return "com.apple.Terminal"
+    }
+  }
+
+  async function sendMacOSNotification(opts: {
+    title: string
+    message: string
+    url?: string
+    sessionID: string
+    tmux?: TmuxInfo
+  }) {
+    if (process.platform !== "darwin") return
+
+    const terminalBundleId = await getTerminalBundleId()
+
+    // Try terminal-notifier first (better UX with click actions)
+    const terminalNotifierArgs = [
+      "-title",
+      opts.title,
+      "-message",
+      opts.message,
+      "-group",
+      `opencode-${opts.sessionID}`,
+    ]
+
+    // Build click action: activate terminal and optionally switch tmux window
+    if (opts.tmux?.sessionName && opts.tmux?.windowIndex) {
+      // Use -execute to run tmux select-window, then activate terminal
+      const tmuxCmd = `tmux select-window -t '${opts.tmux.sessionName}:${opts.tmux.windowIndex}' 2>/dev/null; open -a '${terminalBundleId}'`
+      terminalNotifierArgs.push("-execute", tmuxCmd)
+    } else {
+      // Just activate the terminal
+      terminalNotifierArgs.push("-activate", terminalBundleId)
+    }
+
+    // Add subtitle with share URL if available
+    if (opts.url) {
+      terminalNotifierArgs.push("-subtitle", opts.url)
+    }
+
+    try {
+      const proc = Bun.spawn(["terminal-notifier", ...terminalNotifierArgs], {
+        stdout: "ignore",
+        stderr: "pipe",
+      })
+      await proc.exited
+      if (proc.exitCode === 0) return
+    } catch {
+      // terminal-notifier not available, fall back to osascript
+    }
+
+    // Fallback to osascript (no click action support)
+    const escapedTitle = opts.title.replace(/"/g, '\\"')
+    const escapedMessage = opts.message.replace(/"/g, '\\"')
+    const script = `display notification "${escapedMessage}" with title "${escapedTitle}"`
+
+    try {
+      const proc = Bun.spawn(["osascript", "-e", script], {
+        stdout: "ignore",
+        stderr: "ignore",
+      })
+      await proc.exited
+    } catch (err) {
+      log.error("osascript notification failed", { error: err })
+    }
+  }
+}

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { Notification } from "@/notification"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -22,6 +23,7 @@ export async function InstanceBootstrap() {
   FileWatcher.init()
   Vcs.init()
   Snapshot.init()
+  await Notification.init()
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -8,6 +8,7 @@ export namespace ProviderError {
   // https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
   const OVERFLOW_PATTERNS = [
     /prompt is too long/i, // Anthropic
+    /extra usage is required for long context/i, // Anthropic (billing tier context limit)
     /input is too long for requested model/i, // Amazon Bedrock
     /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
     /input token count.*exceeds the maximum/i, // Google (Gemini)

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -121,7 +121,8 @@ export namespace ProviderError {
     const responseBody = JSON.stringify(body)
     if (body.type !== "error") return
 
-    switch (body?.error?.code) {
+    const code = body?.error?.code ?? body?.error?.type
+    switch (code) {
       case "context_length_exceeded":
         return {
           type: "context_overflow",
@@ -149,6 +150,15 @@ export namespace ProviderError {
           isRetryable: false,
           responseBody,
         }
+    }
+
+    const msg = typeof body?.error?.message === "string" ? body.error.message : responseBody
+    if (isOverflow(msg)) {
+      return {
+        type: "context_overflow",
+        message: msg,
+        responseBody,
+      }
     }
   }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -782,13 +782,19 @@ export namespace MessageV2 {
 
     const tools = Object.fromEntries(Array.from(toolNames).map((toolName) => [toolName, { toModelOutput }]))
 
-    return convertToModelMessages(
-      result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
-      {
-        //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
-        tools,
-      },
-    )
+    const filtered = result.filter((msg) => msg.parts.some((part) => part.type !== "step-start"))
+    if (filtered.length > 0 && filtered[filtered.length - 1].role === "assistant") {
+      filtered.push({
+        id: MessageID.ascending(),
+        role: "user",
+        parts: [{ type: "text", text: "Continue." }],
+      })
+    }
+
+    return convertToModelMessages(filtered, {
+      //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
+      tools,
+    })
   }
 
   export const page = fn(

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -3,11 +3,46 @@ import { Tool } from "./tool"
 import { Question } from "../question"
 import DESCRIPTION from "./question.txt"
 
+const parseIfString = (val: unknown) => {
+  if (typeof val === "string") {
+    try {
+      return JSON.parse(val)
+    } catch {
+      return val
+    }
+  }
+  return val
+}
+
 export const QuestionTool = Tool.define("question", {
   description: DESCRIPTION,
   parameters: z.object({
-    questions: z.array(Question.Info.omit({ custom: true })).describe("Questions to ask"),
+    questions: z.preprocess(parseIfString, z.array(Question.Info.omit({ custom: true }))).describe("Questions to ask"),
   }),
+  formatValidationError(error: z.ZodError) {
+    const err = error as any
+    const questionsError = err.errors.find((e: any) => e.path[0] === "questions" && e.code === "invalid_type")
+    if (questionsError && questionsError.message.includes("expected array, received string")) {
+      return `The question tool received stringified JSON instead of a proper array. Please provide the questions parameter as a JSON array, not as a string. Example: {"questions": [{"question": "What approach?", "header": "Approach", "options": [{"label": "Option A", "description": "Description A"}]}]}`
+    }
+
+    const messages = err.errors.map((e: any) => {
+      if (e.path.length === 0 && e.code === "invalid_type") {
+        return "The tool arguments must be a JSON object with a 'questions' property"
+      }
+      if (e.path[0] === "questions" && e.code === "invalid_type") {
+        return "The 'questions' parameter must be an array of question objects"
+      }
+      if (e.path[1] !== undefined && typeof e.path[1] === "number") {
+        const field = e.path[2]
+        const index = e.path[1]
+        return `Question at index ${index}: ${field} ${e.message}`
+      }
+      return `${e.path.join(".")}: ${e.message}`
+    })
+
+    return messages.join("; ")
+  },
   async execute(params, ctx) {
     const answers = await Question.ask({
       sessionID: ctx.sessionID,

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -16,15 +16,17 @@ export const TodoWriteTool = Tool.define("todowrite", {
       metadata: {},
     })
 
+    const todosArray = Array.isArray(params.todos) ? params.todos : []
+
     await Todo.update({
       sessionID: ctx.sessionID,
-      todos: params.todos,
+      todos: todosArray,
     })
     return {
-      title: `${params.todos.filter((x) => x.status !== "completed").length} todos`,
-      output: JSON.stringify(params.todos, null, 2),
+      title: `${todosArray.filter((x) => x.status !== "completed").length} todos`,
+      output: JSON.stringify(todosArray, null, 2),
       metadata: {
-        todos: params.todos,
+        todos: todosArray,
       },
     }
   },
@@ -42,12 +44,13 @@ export const TodoReadTool = Tool.define("todoread", {
     })
 
     const todos = await Todo.get(ctx.sessionID)
+    const todosArray = Array.isArray(todos) ? todos : []
     return {
-      title: `${todos.filter((x) => x.status !== "completed").length} todos`,
+      title: `${todosArray.filter((x) => x.status !== "completed").length} todos`,
       metadata: {
-        todos,
+        todos: todosArray,
       },
-      output: JSON.stringify(todos, null, 2),
+      output: JSON.stringify(todosArray, null, 2),
     }
   },
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1873,12 +1873,17 @@ export type McpStatusNeedsClientRegistration = {
   error: string
 }
 
+export type McpStatusConnecting = {
+  status: "connecting"
+}
+
 export type McpStatus =
   | McpStatusConnected
   | McpStatusDisabled
   | McpStatusFailed
   | McpStatusNeedsAuth
   | McpStatusNeedsClientRegistration
+  | McpStatusConnecting
 
 export type Path = {
   home: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11959,6 +11959,16 @@
         },
         "required": ["status", "error"]
       },
+      "MCPStatusConnecting": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "connecting"
+          }
+        },
+        "required": ["status"]
+      },
       "MCPStatus": {
         "anyOf": [
           {
@@ -11975,6 +11985,9 @@
           },
           {
             "$ref": "#/components/schemas/MCPStatusNeedsClientRegistration"
+          },
+          {
+            "$ref": "#/components/schemas/MCPStatusConnecting"
           }
         ]
       },

--- a/scripts/rebuild-custom.sh
+++ b/scripts/rebuild-custom.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rebuild custom-build branch from latest upstream/dev + unmerged PR branches.
+# Usage: ./scripts/rebuild-custom.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Configuration ---
+# PR branches to merge on top of upstream/dev.
+# Order matters: dependencies first, features last.
+PR_BRANCHES=(
+  fork/fix/tool-json-coercion
+  fork/fix/prefill-guard
+  fork/fix/suppress-browserslist-warning
+  fork/fix/todo-tool-array-handling
+  fork/fix/user-message-file-references
+  fork/feat/mcp-lazy-load
+  fork/feat/macos-notifications
+  fork/feat/osc8-clickable-links
+  fork/feat/tui-clickable-links
+)
+
+BACKUP="backup/custom-build-$(date +%Y%m%d-%H%M%S)"
+
+echo "==> Fetching upstream and fork..."
+git fetch upstream dev --quiet
+git fetch fork --quiet
+
+echo "==> Backing up current custom-build to $BACKUP"
+git branch "$BACKUP" custom-build 2>/dev/null || true
+
+echo "==> Updating fork dev from upstream..."
+git update-ref refs/heads/dev upstream/dev
+git push fork dev --quiet 2>/dev/null || echo "    (push skipped or failed, continuing)"
+
+echo "==> Rebuilding custom-build from upstream/dev..."
+git checkout -B custom-build upstream/dev --quiet
+
+MERGED=()
+SKIPPED=()
+FAILED=()
+
+for branch in "${PR_BRANCHES[@]}"; do
+  # Skip branches already merged upstream
+  if git merge-base --is-ancestor "$branch" upstream/dev 2>/dev/null; then
+    SKIPPED+=("$branch (merged upstream)")
+    continue
+  fi
+
+  # Check branch exists
+  if ! git rev-parse "$branch" &>/dev/null; then
+    SKIPPED+=("$branch (not found)")
+    continue
+  fi
+
+  echo "==> Merging $branch..."
+  if git merge "$branch" --no-edit --quiet 2>/dev/null; then
+    MERGED+=("$branch")
+  else
+    echo "    CONFLICT merging $branch — aborting this merge"
+    git merge --abort
+    FAILED+=("$branch")
+  fi
+done
+
+echo ""
+echo "=== Rebuild Summary ==="
+echo "Base: upstream/dev ($(git rev-parse --short upstream/dev))"
+echo ""
+
+if [ ${#MERGED[@]} -gt 0 ]; then
+  echo "Merged (${#MERGED[@]}):"
+  for b in "${MERGED[@]}"; do echo "  ✓ $b"; done
+fi
+
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+  echo "Skipped (${#SKIPPED[@]}):"
+  for b in "${SKIPPED[@]}"; do echo "  - $b"; done
+fi
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "FAILED (${#FAILED[@]}):"
+  for b in "${FAILED[@]}"; do echo "  ✗ $b"; done
+  echo ""
+  echo "Fix conflicts manually: git merge <branch>"
+fi
+
+echo ""
+echo "Backup: $BACKUP"
+echo "Run 'bun install' and rebuild when ready."


### PR DESCRIPTION
## Context

**Not intended for merge** — tracking branch for personal custom-build. Linked from [anomalyco/opentui#864](https://github.com/anomalyco/opentui/issues/864) as a concrete example of the workaround.

## Problem

`<a href="file:///path">` hyperlinks rendered via OSC8 **execute** the target file when clicked. For executable files (`.sh`, binaries), this is a security risk. The desired behavior is to **reveal the file in the system file manager** (Finder on macOS).

opentui currently provides no way to intercept or override link click behavior (#864, blocked on #650).

## Workaround

### Safe file reveal (macOS)

- **`opencode-reveal://` URL scheme** — a tiny AppleScript app (`~/Applications/OpenCodeReveal.app`) is auto-provisioned at TUI startup on macOS. It handles `opencode-reveal:///path` URLs by running `open -R /path` (reveal in Finder without executing).
- **`FilePathLink`** uses `opencode-reveal://` on macOS, falls back to `file://` elsewhere.
- **`Link`** unchanged — `<a href="https://...">` opens in browser via OSC8 (safe).

### Other fixes in this branch

- **Remove `preprocessMarkdownLinks`** — was producing visible `(file:///...)` URLs in assistant text that neither the `<markdown>` nor `<code>` renderer could turn into clickable hyperlinks.
- **`parseStreamError` overflow detection** — check `body.error.type` (Anthropic format) in addition to `body.error.code`, and fall through to `OVERFLOW_PATTERNS` matching on the error message. Catches Anthropic billing-tier long context errors as context overflow for compaction instead of infinite retries.

## Files changed

| File | Change |
|------|--------|
| `src/cli/cmd/tui/util/reveal.ts` | New — reveal handler provisioning + scheme helper |
| `src/cli/cmd/tui/ui/link.tsx` | `FilePathLink` uses `revealScheme()` instead of `file://` |
| `src/cli/cmd/tui/app.tsx` | Call `provisionRevealHandler()` at startup |
| `src/cli/cmd/tui/routes/session/index.tsx` | Remove `preprocessMarkdownLinks` calls + import |
| `src/provider/error.ts` | `parseStreamError` handles Anthropic error format |

## Proper fix

Tracked in [anomalyco/opentui#864](https://github.com/anomalyco/opentui/issues/864). Once opentui supports a link click callback or `onMouseUp`/`preventDefault` on `<a>` elements (#650), the `opencode-reveal://` workaround can be replaced with a cross-platform click handler:

```ts
// future: when opentui #650 lands
<a href={url} onMouseUp={(e) => {
  e.preventDefault()
  revealInFileManager(path) // open -R (mac) / explorer /select, (win) / xdg-open (linux)
}}>
```