### PR TITLE
fix(session): stabilize single-message prompt prefix for llama cache reuse

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -655,9 +655,10 @@ export namespace SessionPrompt {
       // Build system prompt, adding structured output instruction if needed
       const skills = await SystemPrompt.skills(agent)
       const system = [
-        ...(await SystemPrompt.environment(model)),
-        ...(skills ? [skills] : []),
         ...(await InstructionPrompt.system()),
+        // Put the most stable instructions first to maximize prompt-cache reuse.
+        ...(await SystemPrompt.environment(model, session.time.created)),
+        ...(skills ? [skills] : []),
       ]
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -25,7 +25,7 @@ export namespace SystemPrompt {
     return [PROMPT_DEFAULT]
   }
 
-  export async function environment(model: Provider.Model) {
+  export async function environment(model: Provider.Model, sessionCreatedAt: number) {
     const project = Instance.project
     return [
       [
@@ -36,7 +36,8 @@ export namespace SystemPrompt {
         `  Workspace root folder: ${Instance.worktree}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Today's date: ${new Date().toDateString()}`,
+        // Keep the session day stable so long-lived sessions do not churn the prompt at midnight.
+        `  Today's date: ${new Date(sessionCreatedAt).toDateString()}`,
         `</env>`,
         `<directories>`,
         `  ${

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -6,6 +6,30 @@ import { SystemPrompt } from "../../src/session/system"
 import { tmpdir } from "../fixture/fixture"
 
 describe("session.system", () => {
+  test("environment uses the session creation day", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const environment = await SystemPrompt.environment(
+          {
+            providerID: "openai",
+            api: {
+              id: "gpt-5.2",
+            },
+          } as any,
+          Date.UTC(2026, 2, 22, 23, 59, 59),
+        )
+
+        expect(environment).toHaveLength(1)
+        expect(environment[0]).toContain("Today's date: Sun Mar 22 2026")
+      },
+    })
+  })
+
   test("skills output is sorted by name and stable across calls", async () => {
     await using tmp = await tmpdir({
       git: true,


### PR DESCRIPTION
[ai-agent-generated] This description was generated by an AI agent at the explicit request of GitHub user `henry701`. Human review is required.

### Issue for this PR

Related: #14743, #14203

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This is a narrow follow-up to #14743, not a replacement for it.

I traced a real llama.cpp prompt-cache miss to one specific source of churn inside the single-message system preamble. A restored slot was used successfully, but only about 2,151 of 28,491 tokens were reusable on the next turn because the prefix diverged before the conversation history. The concrete early diff was the session date rolling from `Sun Mar 22 2026` to `Mon Mar 23 2026`, followed by the appended next user turn.

This PR keeps the change set small and compatible with llama.cpp / Qwen-style templates:
- Pins `Today's date` to `session.time.created` so the session day does not roll at midnight.
- Moves `InstructionPrompt.system()` ahead of runtime environment and skill context inside the same system prompt.
- Does not introduce multiple system messages or rely on provider-specific prompt splitting.

Why this shape:
- The #14743 thread already documents that multiple system messages can break llama.cpp / Qwen templates unless providers opt out via `splitSystemPrompt: false`.
- This patch targets the same prefix-stability problem while staying in the existing single-system-message shape.
- The current `dev` tree already includes additional runtime preamble content such as `Workspace root folder` and the skills block, so moving that runtime context later still improves the byte-stable head of the prompt.

### How did you verify your code works?

I could not complete local runtime validation in this environment because this checkout now declares `bun@1.3.11` and this machine currently has `bun 1.2.9`, which fails to resolve the repo's `catalog:` workspace setup.

I still verified the change in three ways:
- Reconstructed the saved slot prompt and confirmed that restore was succeeding.
- Reconstructed the later live request and confirmed the early prefix diff was the date line plus the appended next user turn.
- Added focused coverage in `packages/opencode/test/session/system.test.ts` for the session-created date behavior.

### Screenshots / recordings

N/A. This is a backend prompt-shaping change.

### Future follow-up

This PR only addresses one narrow source of prefix churn. The broader plan that is likely to improve prompt caching further is:
- Keep the head of the prompt byte-stable across turns.
- Append compact, revisioned diffs for changed skills, commands, tools, or runtime context at the end of the prompt, immediately before the next user message, instead of regenerating those manifests at the head.
- Snapshot per-session runtime context where safe, while keeping model-specific and agent-specific state live when it must stay live.
- Continue the broader cache work in #14743 for providers that can safely use split system blocks.

Several other harnesses already use this append-only delta pattern because it preserves the cached prefix while still exposing updated tool and skill context.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
