### PR TITLE
docs: fix GitHub workflow indentation

### DIFF
--- a/packages/web/src/content/docs/ar/github.mdx
+++ b/packages/web/src/content/docs/ar/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **تخزين مفاتيح API ضمن secrets**

--- a/packages/web/src/content/docs/bs/github.mdx
+++ b/packages/web/src/content/docs/bs/github.mdx
@@ -61,13 +61,13 @@ Ili ga možete postaviti ručno.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **Sačuvaj API ključeve u tajne**

--- a/packages/web/src/content/docs/da/github.mdx
+++ b/packages/web/src/content/docs/da/github.mdx
@@ -64,13 +64,13 @@ Eller du kan indstille det manuelt.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Opbevar API-nøglerne i hemmeligheder**

--- a/packages/web/src/content/docs/de/github.mdx
+++ b/packages/web/src/content/docs/de/github.mdx
@@ -64,13 +64,13 @@ Oder Sie können es manuell einrichten.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Speichern Sie die API-Schlüssel in Secrets**

--- a/packages/web/src/content/docs/es/github.mdx
+++ b/packages/web/src/content/docs/es/github.mdx
@@ -64,13 +64,13 @@ O puede configurarlo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Guarda las claves API en secretos**

--- a/packages/web/src/content/docs/fr/github.mdx
+++ b/packages/web/src/content/docs/fr/github.mdx
@@ -64,13 +64,13 @@ Ajoutez le fichier de workflow suivant à `.github/workflows/opencode.yml` dans 
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **Stockez les clés API dans les secrets**

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -64,13 +64,13 @@ Or you can set it up manually.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Store the API keys in secrets**

--- a/packages/web/src/content/docs/it/github.mdx
+++ b/packages/web/src/content/docs/it/github.mdx
@@ -64,13 +64,13 @@ In alternativa, puoi configurarlo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Salva le API key nei secret**

--- a/packages/web/src/content/docs/ja/github.mdx
+++ b/packages/web/src/content/docs/ja/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
 ```
 
 3. **API キーをシークレットに保存する**

--- a/packages/web/src/content/docs/ko/github.mdx
+++ b/packages/web/src/content/docs/ko/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Store the API keys in secrets**

--- a/packages/web/src/content/docs/nb/github.mdx
+++ b/packages/web/src/content/docs/nb/github.mdx
@@ -64,13 +64,13 @@ Eller du kan sette den opp manuelt.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Lagre API-nøklene i hemmeligheter**

--- a/packages/web/src/content/docs/pl/github.mdx
+++ b/packages/web/src/content/docs/pl/github.mdx
@@ -64,13 +64,13 @@ Można też uszkodzić to rozwiązanie.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Przechowuj klucze API w tajemnicy**

--- a/packages/web/src/content/docs/pt-br/github.mdx
+++ b/packages/web/src/content/docs/pt-br/github.mdx
@@ -64,13 +64,13 @@ Ou você pode configurá-lo manualmente.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Armazene as chaves de API em segredos**
@@ -139,15 +139,15 @@ jobs:
         with:
           persist-credentials: false
 
-       - name: Run OpenCode
-         uses: anomalyco/opencode/github@latest
-         env:
-           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-         with:
-           model: anthropic/claude-sonnet-4-20250514
-           prompt: |
-             Revise a base de código para quaisquer comentários TODO e crie um resumo.
-             Se encontrar problemas que valham a pena resolver, abra um issue para rastreá-los.
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          prompt: |
+            Revise a base de código para quaisquer comentários TODO e crie um resumo.
+            Se encontrar problemas que valham a pena resolver, abra um issue para rastreá-los.
 ```
 
 Para eventos agendados, a entrada `prompt` é **obrigatória** uma vez que não há comentário para extrair instruções. Fluxos de trabalho agendados são executados sem um contexto de usuário para verificação de permissões, então o fluxo de trabalho deve conceder `contents: write` e `pull-requests: write` se você espera que o opencode crie branches ou PRs.
@@ -177,18 +177,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-       - uses: anomalyco/opencode/github@latest
-         env:
-           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           model: anthropic/claude-sonnet-4-20250514
-           use_github_token: true
-           prompt: |
-             Revise este pull request:
-             - Verifique problemas de qualidade de código
-             - Procure por potenciais bugs
-             - Sugira melhorias
+      - uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          use_github_token: true
+          prompt: |
+            Revise este pull request:
+            - Verifique problemas de qualidade de código
+            - Procure por potenciais bugs
+            - Sugira melhorias
 ```
 
 Para eventos de `pull_request`, se nenhum `prompt` for fornecido, o opencode padrão será revisar o pull request.
@@ -233,15 +233,15 @@ jobs:
         with:
           persist-credentials: false
 
-       - uses: anomalyco/opencode/github@latest
-         if: steps.check.outputs.result == 'true'
-         env:
-           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-         with:
-           model: anthropic/claude-sonnet-4-20250514
-           prompt: |
-             Revise este issue. Se houver uma correção clara ou docs relevantes:
-             - Forneça links de documentação
+      - uses: anomalyco/opencode/github@latest
+        if: steps.check.outputs.result == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          prompt: |
+            Revise este issue. Se houver uma correção clara ou docs relevantes:
+            - Forneça links de documentação
              - Adicione orientação sobre tratamento de erros para exemplos de código
              Caso contrário, não comente.
 ```

--- a/packages/web/src/content/docs/ru/github.mdx
+++ b/packages/web/src/content/docs/ru/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **Храните ключи API в секрете**

--- a/packages/web/src/content/docs/th/github.mdx
+++ b/packages/web/src/content/docs/th/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **เก็บคีย์ API เป็นความลับ**

--- a/packages/web/src/content/docs/tr/github.mdx
+++ b/packages/web/src/content/docs/tr/github.mdx
@@ -64,13 +64,13 @@ Veya manuel olarak ayarlayabilirsiniz.
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **API anahtarlarını gizli olarak saklayın**

--- a/packages/web/src/content/docs/zh-cn/github.mdx
+++ b/packages/web/src/content/docs/zh-cn/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **将 API 密钥存储到 Secrets 中**

--- a/packages/web/src/content/docs/zh-tw/github.mdx
+++ b/packages/web/src/content/docs/zh-tw/github.mdx
@@ -64,13 +64,13 @@ opencode github install
               persist-credentials: false
 
           - name: Run OpenCode
-           uses: anomalyco/opencode/github@latest
-           env:
-             ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-           with:
-             model: anthropic/claude-sonnet-4-20250514
-             # share: true
-             # github_token: xxxx
+            uses: anomalyco/opencode/github@latest
+            env:
+              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+            with:
+              model: anthropic/claude-sonnet-4-20250514
+              # share: true
+              # github_token: xxxx
    ```
 
 3. **將 API 金鑰儲存到 Secrets 中**


### PR DESCRIPTION
## Summary
Fix invalid YAML indentation in the GitHub workflow docs examples.

## Root cause
Several workflow snippets had step fields aligned one space too far left, which makes the copied YAML invalid. The same drift existed in the localized docs copies, with extra broken examples in `pt-br`.

## Changes
- align `uses`, `env`, `with`, and prompt blocks under the affected workflow steps in the English docs page
- apply the same indentation fix to every localized `github.mdx` copy
- fix the remaining malformed `pt-br` review and issue workflow examples

## Verification
- `git diff --check`
- `node -` structural audit over all `packages/web/src/content/docs/**/github.mdx` workflow snippets (18 files)

Closes #18717
