### PR TITLE
fix: avoid external_directory prompt for global AGENTS.md

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -8,6 +8,10 @@ import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
 
 export namespace ConfigPaths {
+  export function globalDirectories() {
+    return [Global.Path.config, ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : [])]
+  }
+
   export async function projectFiles(name: string, directory: string, worktree: string) {
     const files: string[] = []
     for (const file of [`${name}.jsonc`, `${name}.json`]) {
@@ -20,8 +24,9 @@ export namespace ConfigPaths {
   }
 
   export async function directories(directory: string, worktree: string) {
+    const global = globalDirectories()
     return [
-      Global.Path.config,
+      global[0],
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? await Array.fromAsync(
             Filesystem.up({
@@ -38,7 +43,7 @@ export namespace ConfigPaths {
           stop: Global.Path.home,
         }),
       )),
-      ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
+      ...global.slice(1),
     ]
   }
 

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -1,6 +1,8 @@
 import path from "path"
 import type { Tool } from "./tool"
+import { ConfigPaths } from "../config/paths"
 import { Instance } from "../project/instance"
+import { Filesystem } from "../util/filesystem"
 
 type Kind = "file" | "directory"
 
@@ -9,12 +11,18 @@ type Options = {
   kind?: Kind
 }
 
+function internal(target: string) {
+  const file = path.isAbsolute(target) ? target : path.join(Instance.directory, target)
+  if (Instance.containsPath(file)) return true
+  return ConfigPaths.globalDirectories().some((dir) => Filesystem.contains(path.resolve(dir), file))
+}
+
 export async function assertExternalDirectory(ctx: Tool.Context, target?: string, options?: Options) {
   if (!target) return
 
   if (options?.bypass) return
 
-  if (Instance.containsPath(target)) return
+  if (internal(target)) return
 
   const kind = options?.kind ?? "file"
   const parentDir = kind === "directory" ? target : path.dirname(target)

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import { Global } from "../../src/global"
 import type { Tool } from "../../src/tool/tool"
 import { Instance } from "../../src/project/instance"
 import { assertExternalDirectory } from "../../src/tool/external-directory"
@@ -51,6 +52,59 @@ describe("tool.assertExternalDirectory", () => {
         await assertExternalDirectory(ctx, path.join("/tmp/project", "file.txt"))
       },
     })
+
+    expect(requests.length).toBe(0)
+  })
+
+  test("no-ops for AGENTS.md inside Global.Path.config", async () => {
+    const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+    const ctx: Tool.Context = {
+      ...baseCtx,
+      ask: async (req) => {
+        requests.push(req)
+      },
+    }
+
+    const prev = Global.Path.config
+    ;(Global.Path as { config: string }).config = "/tmp/opencode-config"
+
+    try {
+      await Instance.provide({
+        directory: "/tmp/project",
+        fn: async () => {
+          await assertExternalDirectory(ctx, path.join(Global.Path.config, "AGENTS.md"))
+        },
+      })
+    } finally {
+      ;(Global.Path as { config: string }).config = prev
+    }
+
+    expect(requests.length).toBe(0)
+  })
+
+  test("no-ops for AGENTS.md inside OPENCODE_CONFIG_DIR", async () => {
+    const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+    const ctx: Tool.Context = {
+      ...baseCtx,
+      ask: async (req) => {
+        requests.push(req)
+      },
+    }
+
+    const prev = process.env["OPENCODE_CONFIG_DIR"]
+    process.env["OPENCODE_CONFIG_DIR"] = "/tmp/opencode-profile"
+
+    try {
+      await Instance.provide({
+        directory: "/tmp/project",
+        fn: async () => {
+          await assertExternalDirectory(ctx, path.join(process.env["OPENCODE_CONFIG_DIR"]!, "AGENTS.md"))
+        },
+      })
+    } finally {
+      if (prev === undefined) delete process.env["OPENCODE_CONFIG_DIR"]
+      else process.env["OPENCODE_CONFIG_DIR"] = prev
+    }
 
     expect(requests.length).toBe(0)
   })


### PR DESCRIPTION
### Issue for this PR

Closes #13751

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a case where `~/.config/opencode/AGENTS.md` (and `OPENCODE_CONFIG_DIR/AGENTS.md`) could be treated as an external path and trigger an `external_directory` permission prompt.

The root cause was that the instruction/config system already knows about OpenCode's global config directories, but the external-directory permission check only trusted the current project/worktree. Because of that mismatch, AGENTS files inside OpenCode's own global config locations were incorrectly treated as external.

To fix it, I:
- added a shared helper for OpenCode global config directories in `ConfigPaths`
- updated `assertExternalDirectory()` to treat those config directories as internal/trusted paths
- added regression tests for both `Global.Path.config/AGENTS.md` and `OPENCODE_CONFIG_DIR/AGENTS.md`

This keeps the permission check strict for normal paths outside the project, while avoiding prompts for OpenCode's own config directories.

### How did you verify your code works?

I verified it locally with:

- `bun test test/tool/external-directory.test.ts`
- `bun typecheck`

I also added regression coverage to make sure:
- `Global.Path.config/AGENTS.md` does not trigger `external_directory`
- `OPENCODE_CONFIG_DIR/AGENTS.md` does not trigger `external_directory`
- regular external directories still go through the permission flow

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR