### PR TITLE
fix: skip client system prompt for hidden agents during compaction

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -74,8 +74,10 @@ export namespace LLM {
         ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
         // any custom prompt passed into this call
         ...input.system,
-        // any custom prompt from last user message
-        ...(input.user.system ? [input.user.system] : []),
+        // Skip per-message system prompts for hidden agents (compaction, title, summary).
+        // These agents have their own dedicated prompts and must not be overridden by
+        // client-injected system prompts (e.g. Kiro's identity prompt).
+        ...(!input.agent.hidden && input.user.system ? [input.user.system] : []),
       ]
         .filter((x) => x)
         .join("\n"),


### PR DESCRIPTION
## Problem

When a client (e.g. Kiro) injects a custom system prompt via the per-message `system` field on `PromptInput`, it leaks into hidden agent calls (compaction, title, summary). During compaction, the model receives both the compaction summarizer prompt and the client's identity prompt (e.g. "You are Kiro, an AI assistant..."). The client's massive system prompt overwhelms the short compaction instructions, causing the model to respond as a fresh chat session instead of producing a summary.

**Observed behavior:** After compaction, the model says "I don't have any prior context about what we were working on" — all conversation context is lost.

## Root Cause

In `llm.ts`, the system prompt assembly unconditionally includes `input.user.system`:

```ts
...(input.user.system ? [input.user.system] : []),
```

The compaction agent passes the original user message (which carries the client's system prompt) to `LLM.stream()`. The client's system prompt gets joined with the compaction agent's own prompt, confusing the model.

## Fix

Skip `user.system` for hidden agents (compaction, title, summary). These agents have their own dedicated prompts and should never inherit client-injected system prompts.

```ts
...(!input.agent.hidden && input.user.system ? [input.user.system] : []),
```

One-line change in `packages/opencode/src/session/llm.ts`.