### PR TITLE
fix(tui): set fg before content to prevent white text in unstyled code blocks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1439,13 +1439,13 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
         borderColor={theme.backgroundElement}
       >
         <code
+          fg={theme.textMuted}
           filetype="markdown"
           drawUnstyledText={false}
           streaming={true}
           syntaxStyle={subtleSyntax()}
-          content={"_Thinking:_ " + content()}
           conceal={ctx.conceal()}
-          fg={theme.textMuted}
+          content={"_Thinking:_ " + content()}
         />
       </box>
     </Show>
@@ -1461,23 +1461,23 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
               fg={theme.markdownText}
               bg={theme.background}
+              syntaxStyle={syntax()}
+              streaming={true}
+              conceal={ctx.conceal()}
+              content={props.part.text.trim()}
             />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code
+              fg={theme.text}
               filetype="markdown"
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
               conceal={ctx.conceal()}
-              fg={theme.text}
+              content={props.part.text.trim()}
             />
           </Match>
         </Switch>
@@ -1854,8 +1854,8 @@ function Write(props: ToolProps<typeof WriteTool>) {
         <BlockTool title={"# Wrote " + normalizePath(props.input.filePath!)} part={props.part}>
           <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
             <code
-              conceal={false}
               fg={theme.text}
+              conceal={false}
               filetype={filetype(props.input.filePath!)}
               syntaxStyle={syntax()}
               content={code()}
@@ -2060,6 +2060,7 @@ function Edit(props: ToolProps<typeof EditTool>) {
         <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
           <box paddingLeft={1}>
             <diff
+              fg={theme.text}
               diff={diffContent()}
               view={view()}
               filetype={ft()}
@@ -2067,7 +2068,6 @@ function Edit(props: ToolProps<typeof EditTool>) {
               showLineNumbers={true}
               width="100%"
               wrapMode={ctx.diffWrapMode()}
-              fg={theme.text}
               addedBg={theme.diffAddedBg}
               removedBg={theme.diffRemovedBg}
               contextBg={theme.diffContextBg}
@@ -2107,6 +2107,7 @@ function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
     return (
       <box paddingLeft={1}>
         <diff
+          fg={theme.text}
           diff={p.diff}
           view={view()}
           filetype={filetype(p.filePath)}
@@ -2114,7 +2115,6 @@ function ApplyPatch(props: ToolProps<typeof ApplyPatchTool>) {
           showLineNumbers={true}
           width="100%"
           wrapMode={ctx.diffWrapMode()}
-          fg={theme.text}
           addedBg={theme.diffAddedBg}
           removedBg={theme.diffRemovedBg}
           contextBg={theme.diffContextBg}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -76,6 +76,7 @@ function EditBody(props: { request: PermissionRequest }) {
           }}
         >
           <diff
+            fg={theme.text}
             diff={diff()}
             view={view()}
             filetype={ft()}
@@ -83,7 +84,6 @@ function EditBody(props: { request: PermissionRequest }) {
             showLineNumbers={true}
             width="100%"
             wrapMode="word"
-            fg={theme.text}
             addedBg={theme.diffAddedBg}
             removedBg={theme.diffRemovedBg}
             contextBg={theme.diffContextBg}


### PR DESCRIPTION
Some terminals default to white text when no foreground color is set. Moving fg props before content ensures the default foreground color is applied before text rendering triggers, fixing readability on light themes.

### Issue for this PR

Closes #16470
Fixes #17323
Fixes #17617
Fixes #17349
Fixes #17148

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In some terminals, text inside code blocks without a language specifier renders as white, making it unreadable on light backgrounds. The `@opentui/solid` reconciler sets JSX props as independent reactive effects — when `content` fires before `fg`, the text buffer renders with the hardcoded white default foreground (`RGBA(1,1,1,1)`) from `TextBufferRenderable` instead of the theme color.
This moves `fg` before `content` on all `<code>`, `<markdown>`, and `<diff>` components in `session/index.tsx` and `session/permission.tsx` so that `_defaultFg` is set on the text buffer before any text rendering is triggered. No props are added, removed, or changed in value — strictly a reordering fix.

### How did you verify your code works?

- `bun typecheck` passes cleanly
- `bun test` — 1416 pass, 8 skip, 3 pre-existing timeout flakes in unrelated subsystems (file search, OAuth browser)
- Verified locally with `bun dev` on a light-background terminal that unstyled code blocks now use the theme text color

### Screenshots / recordings

Using MacOS default terminal.

**Before:**
<img width="714" height="572" alt="image" src="https://github.com/user-attachments/assets/90bcafbb-9675-40df-adf0-980b5fbf9819" />

**After:**
<img width="793" height="496" alt="image" src="https://github.com/user-attachments/assets/ad82d892-16d5-4653-bc8b-2b742224c8a5" />




### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
