### PR TITLE
fix(app): prefer cmd+k for command palette

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -175,9 +175,9 @@ export async function runTerminal(page: Page, input: { cmd: string; token: strin
   await expect.poll(() => terminalHas(page, { term, token: input.token }), { timeout }).toBe(true)
 }
 
-export async function openPalette(page: Page) {
+export async function openPalette(page: Page, key = "K") {
   await defocus(page)
-  await page.keyboard.press(`${modKey}+P`)
+  await page.keyboard.press(`${modKey}+${key}`)
 
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()

--- a/packages/app/e2e/app/palette.spec.ts
+++ b/packages/app/e2e/app/palette.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { openPalette } from "../actions"
+import { closeDialog, openPalette } from "../actions"
 
 test("search palette opens and closes", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -7,5 +7,14 @@ test("search palette opens and closes", async ({ page, gotoSession }) => {
   const dialog = await openPalette(page)
 
   await page.keyboard.press("Escape")
+  await expect(dialog).toHaveCount(0)
+})
+
+test("search palette also opens with cmd+p", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const dialog = await openPalette(page, "P")
+
+  await closeDialog(page, dialog)
   await expect(dialog).toHaveCount(0)
 })

--- a/packages/app/e2e/settings/settings-keybinds.spec.ts
+++ b/packages/app/e2e/settings/settings-keybinds.spec.ts
@@ -241,7 +241,7 @@ test("changing file open keybind works", async ({ page, gotoSession }) => {
   await expect(keybindButton).toBeVisible()
 
   const initialKeybind = await keybindButton.textContent()
-  expect(initialKeybind).toContain("P")
+  expect(initialKeybind).toContain("K")
 
   await keybindButton.click()
   await expect(keybindButton).toHaveText(/press/i)

--- a/packages/app/src/context/command-keybind.test.ts
+++ b/packages/app/src/context/command-keybind.test.ts
@@ -40,4 +40,11 @@ describe("command keybind helpers", () => {
     expect(display.includes("Alt") || display.includes("⌥")).toBe(true)
     expect(formatKeybind("none")).toBe("")
   })
+
+  test("formatKeybind prefers the first combo", () => {
+    const display = formatKeybind("mod+k,mod+p")
+
+    expect(display.includes("K") || display.includes("k")).toBe(true)
+    expect(display.includes("P") || display.includes("p")).toBe(false)
+  })
 })

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -255,7 +255,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         id: "file.open",
         title: language.t("command.file.open"),
         description: language.t("palette.search.placeholder"),
-        keybind: "mod+p",
+        keybind: "mod+k,mod+p",
         slash: "open",
         onSelect: () => dialog.show(() => <DialogSelectFile onOpenFile={showAllFiles} />),
       }),


### PR DESCRIPTION
## summary
- make the session search affordance show `Cmd+K` by making it the primary keybind for the command palette
- keep `Cmd+P` working as a secondary shortcut so existing muscle memory still works
- update e2e and keybind coverage for the new primary shortcut and legacy alias

## testing
- bun test:e2e -- app/palette.spec.ts
- bun test:e2e -- settings/settings-keybinds.spec.ts -g \"changing command palette keybind works\"