### PR TITLE
fix(acp): return global sessions in unstable_listSessions

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -39,6 +39,7 @@ import { ModelID, ProviderID } from "../provider/schema"
 import { Agent as AgentModule } from "../agent/agent"
 import { Installation } from "@/installation"
 import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session"
 import { Config } from "@/config/config"
 import { Todo } from "@/session/todo"
 import { z } from "zod"
@@ -670,20 +671,9 @@ export namespace ACP {
       try {
         const cursor = params.cursor ? Number(params.cursor) : undefined
         const limit = 100
-
-        const sessions = await this.sdk.session
-          .list(
-            {
-              directory: params.cwd ?? undefined,
-              roots: true,
-            },
-            { throwOnError: true },
-          )
-          .then((x) => x.data ?? [])
-
-        const sorted = sessions.toSorted((a, b) => b.time.updated - a.time.updated)
-        const filtered = cursor ? sorted.filter((s) => s.time.updated < cursor) : sorted
-        const page = filtered.slice(0, limit)
+        const list = [...Session.listGlobal({ roots: true, cursor, limit: limit + 1 })]
+        const more = list.length > limit
+        const page = more ? list.slice(0, limit) : list
 
         const entries: SessionInfo[] = page.map((session) => ({
           sessionId: session.id,
@@ -693,7 +683,7 @@ export namespace ACP {
         }))
 
         const last = page[page.length - 1]
-        const next = filtered.length > limit && last ? String(last.time.updated) : undefined
+        const next = more && last ? String(last.time.updated) : undefined
 
         const response: ListSessionsResponse = {
           sessions: entries,


### PR DESCRIPTION
### Issue for this PR

Closes #18575

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ACP.unstable_listSessions` was using `sdk.session.list({ directory: params.cwd, roots: true })`, which scopes results to the current project directory. That means ACP only returned sessions for the active project instead of returning the global session list described in the issue.

This PR changes `unstable_listSessions` to use `Session.listGlobal({ roots: true, cursor, limit: limit + 1 })` instead.

Why this works:
- `Session.listGlobal(...)` is the existing global session enumeration path already used elsewhere in the codebase.
- It removes the accidental project-level filtering caused by passing `params.cwd` as `directory`.
- It preserves the existing ACP response shape and pagination behavior:
  - still returns root sessions only
  - still uses the same `SessionInfo` field mapping
  - still computes `nextCursor` from the last returned session's `time.updated`

This change is intentionally minimal and only touches `packages/opencode/src/acp/agent.ts`.

### How did you verify your code works?

I verified the fix by:
- tracing the old implementation in `packages/opencode/src/acp/agent.ts`
- confirming that `sdk.session.list(...)` was project-scoped because it used `directory: params.cwd`
- checking the existing global enumeration implementation in `packages/opencode/src/session/index.ts`
- comparing the usage pattern with `packages/opencode/src/server/routes/experimental.ts`

I also attempted to run local checks, but my local environment is missing required tooling/dependencies:
- `bun typecheck` failed because `tsgo` is not installed in the current environment
- `bun test test/server/global-session-list.test.ts` failed because local dependencies such as `zod` and `drizzle-orm/bun-sqlite/migrator` were not available

So I was able to verify the code path and the fix logically in the repository, but I could not complete a full local automated test run in the current machine state.

### Screenshots / recordings

N/A

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR