### PR TITLE
fix(app): fall back to icon.url in sidebar avatar

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -44,7 +44,9 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
         <Avatar
           fallback={name()}
           src={
-            props.project.id === OPENCODE_PROJECT_ID ? "https://opencode.ai/favicon.svg" : props.project.icon?.override
+            props.project.id === OPENCODE_PROJECT_ID
+              ? "https://opencode.ai/favicon.svg"
+              : props.project.icon?.override || props.project.icon?.url
           }
           {...getAvatarColors(props.project.icon?.color)}
           class="size-full rounded"


### PR DESCRIPTION
### Issue for this PR

Closes #18746

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Project.discover()` saves the found favicon into `icon.url`, but the sidebar avatar only checks `icon.override`. So discovered favicons never render — you just see the letter fallback.

This adds `icon.url` as a fallback when `override` is absent.

### How did you verify your code works?

Put a `favicon.png` in a project root with `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY=true`, opened the project in web — icon now shows up in the sidebar instead of the default letter.

### Screenshots / recordings

_No UI layout changes, just the icon source resolution._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR