### PR TITLE
fix(opencode): add short agent summaries for picker

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -26,6 +26,7 @@ export namespace Agent {
     .object({
       name: z.string(),
       description: z.string().optional(),
+      summary: z.string().optional(),
       mode: z.enum(["subagent", "primary", "all"]),
       native: z.boolean().optional(),
       hidden: z.boolean().optional(),
@@ -221,6 +222,7 @@ export namespace Agent {
       item.variant = value.variant ?? item.variant
       item.prompt = value.prompt ?? item.prompt
       item.description = value.description ?? item.description
+      item.summary = value.summary ?? item.summary
       item.temperature = value.temperature ?? item.temperature
       item.topP = value.top_p ?? item.topP
       item.mode = value.mode ?? item.mode
@@ -317,6 +319,7 @@ export namespace Agent {
       model: language,
       schema: z.object({
         identifier: z.string(),
+        summary: z.string(),
         whenToUse: z.string(),
         systemPrompt: z.string(),
       }),

--- a/packages/opencode/src/agent/generate.txt
+++ b/packages/opencode/src/agent/generate.txt
@@ -59,6 +59,7 @@ When a user describes what they want an agent to do, you will:
 Your output must be a valid JSON object with exactly these fields:
 {
 "identifier": "A unique, descriptive identifier using lowercase letters, numbers, and hyphens (e.g., 'code-reviewer', 'api-docs-writer', 'test-generator')",
+"summary": "A short one-line summary for agent pickers and lists. Keep it under 80 characters and describe the agent's core specialty without examples.",
 "whenToUse": "A precise, actionable description starting with 'Use this agent when...' that clearly defines the triggering conditions and use cases. Ensure you include examples as described above.",
 "systemPrompt": "The complete system prompt that will govern the agent's behavior, written in second person ('You are...', 'You will...') and structured for maximum clarity and effectiveness"
 }

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -187,10 +187,12 @@ const AgentCreateCommand = cmd({
         // Build frontmatter
         const frontmatter: {
           description: string
+          summary: string
           mode: AgentMode
           tools?: Record<string, boolean>
         } = {
           description: generated.whenToUse,
+          summary: generated.summary,
           mode,
         }
         if (Object.keys(tools).length > 0) {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -12,7 +12,7 @@ export function DialogAgent() {
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "native" : (item.summary ?? item.description),
       }
     }),
   )

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -722,6 +722,7 @@ export namespace Config {
       tools: z.record(z.string(), z.boolean()).optional().describe("@deprecated Use 'permission' field instead"),
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
+      summary: z.string().optional().describe("Short summary used when listing agents in the UI"),
       mode: z.enum(["subagent", "primary", "all"]).optional(),
       hidden: z
         .boolean()
@@ -752,6 +753,7 @@ export namespace Config {
         "variant",
         "prompt",
         "description",
+        "summary",
         "temperature",
         "top_p",
         "mode",

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -130,6 +130,7 @@ test("custom agent from config creates new agent", async () => {
         my_custom_agent: {
           model: "openai/gpt-4",
           description: "My custom agent",
+          summary: "Short custom summary",
           temperature: 0.5,
           top_p: 0.9,
         },
@@ -144,10 +145,33 @@ test("custom agent from config creates new agent", async () => {
       expect(String(custom?.model?.providerID)).toBe("openai")
       expect(String(custom?.model?.modelID)).toBe("gpt-4")
       expect(custom?.description).toBe("My custom agent")
+      expect(custom?.summary).toBe("Short custom summary")
       expect(custom?.temperature).toBe(0.5)
       expect(custom?.topP).toBe(0.9)
       expect(custom?.native).toBe(false)
       expect(custom?.mode).toBe("all")
+    },
+  })
+})
+
+test("custom agent summary overrides native display summary without changing description", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        build: {
+          description: "Longer description used for routing build tasks",
+          summary: "Short build summary",
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await Agent.get("build")
+      expect(build).toBeDefined()
+      expect(build?.description).toBe("Longer description used for routing build tasks")
+      expect(build?.summary).toBe("Short build summary")
     },
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1092,6 +1092,10 @@ export type AgentConfig = {
    * Description of when to use the agent
    */
   description?: string
+  /**
+   * Short summary used when listing agents in the UI
+   */
+  summary?: string
   mode?: "subagent" | "primary" | "all"
   /**
    * Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)
@@ -1906,6 +1910,7 @@ export type Command = {
 export type Agent = {
   name: string
   description?: string
+  summary?: string
   mode: "subagent" | "primary" | "all"
   native?: boolean
   hidden?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10002,6 +10002,10 @@
             "description": "Description of when to use the agent",
             "type": "string"
           },
+          "summary": {
+            "description": "Short summary used when listing agents in the UI",
+            "type": "string"
+          },
           "mode": {
             "type": "string",
             "enum": ["subagent", "primary", "all"]
@@ -12056,6 +12060,9 @@
             "type": "string"
           },
           "description": {
+            "type": "string"
+          },
+          "summary": {
             "type": "string"
           },
           "mode": {


### PR DESCRIPTION
### Issue for this PR

Closes #4825

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the `/agent` picker using the long agent `description` field directly.

`opencode agent create` currently writes a long `description` because that field is used for agent routing guidance. The TUI picker was also showing that same text, which makes custom agents hard to read.

This change adds an optional short `summary` field for agents, generates it during `opencode agent create`, and makes the TUI agent picker prefer `summary` over `description`. The long `description` is still preserved for routing behavior, while the picker gets a shorter display string.

I also regenerated the OpenAPI/SDK types because the agent schema changed.

### How did you verify your code works?

I tested the agent config/runtime path locally with:

`bun test test/agent/agent.test.ts`

That passed with 38 tests passing.

I also verified the branch push passed the repo pre-push hook, including:

`bun turbo typecheck`

### Screenshots / recordings

Not included. This is a small TUI text/display change and I verified it through tests and typecheck.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
