### PR TITLE
fix(opencode): use themed TUI overlay dimmers

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { Global } from "@/global"
 import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
+import { overlayColor } from "../../ui/overlay"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
@@ -1205,7 +1206,7 @@ export function Session() {
                 right={0}
                 bottom={0}
                 alignItems="flex-end"
-                backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
+                backgroundColor={overlayColor(theme, 70 / 255)}
               >
                 <Sidebar sessionID={route.sessionID} />
               </box>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -1,11 +1,12 @@
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { batch, createContext, Show, useContext, type JSX, type ParentProps } from "solid-js"
 import { useTheme } from "@tui/context/theme"
-import { MouseButton, Renderable, RGBA } from "@opentui/core"
+import { MouseButton, Renderable } from "@opentui/core"
 import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { Flag } from "@/flag/flag"
 import { Selection } from "@tui/util/selection"
+import { overlayColor } from "./overlay"
 
 export function Dialog(
   props: ParentProps<{
@@ -38,7 +39,7 @@ export function Dialog(
       paddingTop={dimensions().height / 4}
       left={0}
       top={0}
-      backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
+      backgroundColor={overlayColor(theme)}
     >
       <box
         onMouseUp={(e) => {

--- a/packages/opencode/src/cli/cmd/tui/ui/overlay.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/overlay.ts
@@ -1,0 +1,17 @@
+import { RGBA } from "@opentui/core"
+
+type OverlayTheme = {
+  background: RGBA
+  backgroundPanel: RGBA
+  backgroundMenu: RGBA
+}
+
+export function overlayColor(theme: OverlayTheme, alpha = 150 / 255) {
+  const base =
+    theme.backgroundMenu.a > 0
+      ? theme.backgroundMenu
+      : theme.backgroundPanel.a > 0
+        ? theme.backgroundPanel
+        : theme.background
+  return RGBA.fromValues(base.r, base.g, base.b, alpha)
+}

--- a/packages/opencode/test/cli/tui/overlay.test.ts
+++ b/packages/opencode/test/cli/tui/overlay.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { overlayColor } from "../../../src/cli/cmd/tui/ui/overlay"
+
+const ints = (color: RGBA) => ({
+  r: Math.round(color.r * 255),
+  g: Math.round(color.g * 255),
+  b: Math.round(color.b * 255),
+  a: Math.round(color.a * 255),
+})
+
+test("uses backgroundMenu color for overlays when available", () => {
+  const color = overlayColor({
+    background: RGBA.fromInts(255, 255, 255),
+    backgroundPanel: RGBA.fromInts(240, 240, 240),
+    backgroundMenu: RGBA.fromInts(230, 220, 210),
+  })
+
+  expect(ints(color)).toEqual({
+    r: 230,
+    g: 220,
+    b: 210,
+    a: 150,
+  })
+})
+
+test("falls back to backgroundPanel when backgroundMenu is transparent", () => {
+  const color = overlayColor({
+    background: RGBA.fromInts(255, 255, 255),
+    backgroundPanel: RGBA.fromInts(235, 235, 235),
+    backgroundMenu: RGBA.fromInts(0, 0, 0, 0),
+  })
+
+  expect(ints(color)).toEqual({
+    r: 235,
+    g: 235,
+    b: 235,
+    a: 150,
+  })
+})
+
+test("supports custom overlay opacity", () => {
+  const color = overlayColor(
+    {
+      background: RGBA.fromInts(255, 255, 255),
+      backgroundPanel: RGBA.fromInts(235, 235, 235),
+      backgroundMenu: RGBA.fromInts(230, 220, 210),
+    },
+    70 / 255,
+  )
+
+  expect(ints(color).a).toBe(70)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #13363

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes TUI dialogs and overlay dimmers using a hardcoded translucent black backdrop, which looks wrong on light terminals when using the system theme.

The current code hardcodes black overlay colors for the dialog backdrop and the narrow-screen session sidebar overlay. This change replaces those hardcoded colors with a shared theme-aware overlay helper that derives the overlay color from the current TUI theme, while preserving the existing dimmer opacity.

That keeps dark terminals dark, but avoids black-looking overlays on light terminals.

### How did you verify your code works?

I added a focused test for the overlay color helper and ran:

`bun test test/cli/tui/overlay.test.ts`

I also ran:

`bun run typecheck`

And I verified the branch push passed the repo pre-push hook, including:

`bun turbo typecheck`

### Screenshots / recordings

Not included. This is a small TUI overlay color fix and I verified it through targeted tests and typecheck.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
