### PR TITLE
fix(opencode): preserve readonly subagent restrictions across compaction

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -177,8 +177,14 @@ export namespace SessionPrompt {
       })
     }
     if (permissions.length > 0) {
-      session.permission = permissions
-      await Session.setPermission({ sessionID: session.id, permission: permissions })
+      const next = [
+        ...(session.permission ?? []).filter(
+          (item) => !permissions.some((rule) => rule.permission === item.permission && rule.pattern === item.pattern),
+        ),
+        ...permissions,
+      ]
+      session.permission = next
+      await Session.setPermission({ sessionID: session.id, permission: next })
     }
 
     if (input.noReply === true) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -30,6 +30,14 @@ const resolveWasm = (asset: string) => {
   return fileURLToPath(url)
 }
 
+function trim(input: string) {
+  return input.replace(/^['"]|['"]$/g, "")
+}
+
+function redirect(input: string) {
+  return /(^|[^<])>>?|&>|>&|<>/.test(input)
+}
+
 const parser = lazy(async () => {
   const { Parser } = await import("web-tree-sitter")
   const { default: treeWasm } = await import("web-tree-sitter/tree-sitter.wasm" as string, {
@@ -89,6 +97,7 @@ export const BashTool = Tool.define("bash", async () => {
       if (!Instance.containsPath(cwd)) directories.add(cwd)
       const patterns = new Set<string>()
       const always = new Set<string>()
+      const edits = new Set<string>()
 
       for (const node of tree.rootNode.descendantsOfType("command")) {
         if (!node) continue
@@ -110,6 +119,20 @@ export const BashTool = Tool.define("bash", async () => {
             continue
           }
           command.push(child.text)
+        }
+
+        if (node.parent?.type === "redirected_statement" && redirect(commandText)) {
+          edits.add("*")
+        }
+        if (command[0] === "sed" && command.includes("-i")) {
+          const arg = command.at(-1)
+          if (!arg || arg.startsWith("-")) {
+            edits.add("*")
+          } else {
+            const file = path.resolve(cwd, trim(arg))
+            if (!Instance.containsPath(file)) edits.add("*")
+            else edits.add(path.relative(Instance.worktree, file))
+          }
         }
 
         // not an exhaustive list, but covers most common cases
@@ -146,6 +169,15 @@ export const BashTool = Tool.define("bash", async () => {
           permission: "external_directory",
           patterns: globs,
           always: globs,
+          metadata: {},
+        })
+      }
+
+      if (edits.size > 0) {
+        await ctx.ask({
+          permission: "edit",
+          patterns: Array.from(edits),
+          always: ["*"],
           metadata: {},
         })
       }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -46,6 +46,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
       const config = await Config.get()
+      const caller = await Agent.get(ctx.agent)
 
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
@@ -62,8 +63,41 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const agent = await Agent.get(params.subagent_type)
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+      if (!caller) throw new Error(`Unknown agent type: ${ctx.agent}`)
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
+      const parent = await Session.get(ctx.sessionID)
+      const rules = Permission.merge(caller.permission, parent.permission ?? [])
+      const perm = [
+        {
+          permission: "todowrite" as const,
+          pattern: "*" as const,
+          action: "deny" as const,
+        },
+        {
+          permission: "todoread" as const,
+          pattern: "*" as const,
+          action: "deny" as const,
+        },
+        ...(hasTaskPermission
+          ? []
+          : [
+              {
+                permission: "task" as const,
+                pattern: "*" as const,
+                action: "deny" as const,
+              },
+            ]),
+        ...(Permission.evaluate("edit", "*", rules).action === "deny"
+          ? [
+              {
+                permission: "edit" as const,
+                pattern: "*" as const,
+                action: "deny" as const,
+              },
+            ]
+          : []),
+      ]
 
       const session = await iife(async () => {
         if (params.task_id) {
@@ -75,25 +109,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
           permission: [
-            {
-              permission: "todowrite",
-              pattern: "*",
-              action: "deny",
-            },
-            {
-              permission: "todoread",
-              pattern: "*",
-              action: "deny",
-            },
-            ...(hasTaskPermission
-              ? []
-              : [
-                  {
-                    permission: "task" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
+            ...perm,
             ...(config.experimental?.primary_tools?.map((t) => ({
               pattern: "*",
               action: "allow" as const,
@@ -102,6 +118,28 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           ],
         })
       })
+      const curr = session.permission ?? []
+      const next = [
+        ...curr.filter(
+          (item) => !perm.some((rule) => rule.permission === item.permission && rule.pattern === item.pattern),
+        ),
+        ...perm,
+      ]
+      const same =
+        next.length === curr.length &&
+        next.every(
+          (rule, i) =>
+            rule.permission === curr[i]?.permission &&
+            rule.pattern === curr[i]?.pattern &&
+            rule.action === curr[i]?.action,
+        )
+      if (!same) {
+        session.permission = next
+        await Session.setPermission({
+          sessionID: session.id,
+          permission: next,
+        })
+      }
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -148,6 +148,52 @@ describe("session.prompt special characters", () => {
   })
 })
 
+describe("session.prompt permissions", () => {
+  test("merges legacy tool permissions into existing session rules", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({
+          permission: [
+            {
+              permission: "edit",
+              pattern: "*",
+              action: "deny",
+            },
+          ],
+        })
+
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          tools: {
+            task: false,
+          },
+          parts: [{ type: "text", text: "hello" }],
+        })
+
+        const next = await Session.get(session.id)
+
+        expect(next.permission).toContainEqual({
+          permission: "edit",
+          pattern: "*",
+          action: "deny",
+        })
+        expect(next.permission).toContainEqual({
+          permission: "task",
+          pattern: "*",
+          action: "deny",
+        })
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})
+
 describe("session.prompt agent variant", () => {
   test("applies agent variant only when using agent model", async () => {
     const prev = process.env.OPENAI_API_KEY

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -285,8 +285,37 @@ describe("tool.bash permissions", () => {
         }
         await bash.execute({ command: "cat > /tmp/output.txt", description: "Redirect ls output" }, testCtx)
         const bashReq = requests.find((r) => r.permission === "bash")
+        const editReq = requests.find((r) => r.permission === "edit")
         expect(bashReq).toBeDefined()
+        expect(editReq).toBeDefined()
+        expect(editReq!.patterns).toContain("*")
         expect(bashReq!.patterns).toContain("cat > /tmp/output.txt")
+      },
+    })
+  })
+
+  test("asks for edit permission when sed writes in place", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.txt"), "a\n")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute({ command: "sed -i 's/a/b/' a.txt", description: "Edit file in place" }, testCtx)
+        const editReq = requests.find((r) => r.permission === "edit")
+        expect(editReq).toBeDefined()
+        expect(editReq!.patterns).toContain("a.txt")
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #18213

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a case where readonly restrictions on plan-mode subagents could be lost after compaction.

The main issue was that when a child task session was created or resumed, the effective readonly `edit` restriction from the parent context was not being persisted into the child session. On top of that, the legacy `tools` path in `SessionPrompt.prompt()` could replace the existing session permission rules entirely, which removed inherited restrictions.

This PR fixes that by:
- persisting the parent readonly `edit` restriction into child subagent sessions in `TaskTool`, including resumed `task_id` sessions
- changing `SessionPrompt.prompt()` to merge tool-derived permissions into the existing session rules instead of replacing the whole ruleset
- requiring `edit` permission for the shell write paths used in this issue (`cat > ...` / output redirection and `sed -i`), so those writes cannot bypass readonly mode after compaction

I kept the shell-side change narrow to the repro path instead of expanding the general bash permission model.

### How did you verify your code works?

I verified the change by:
- tracing the repro path through `task.ts`, `prompt.ts`, `compaction.ts`, `message-v2.ts`, and `bash.ts`
- checking that `git diff --check` passes
- adding regression tests for:
  - merging legacy tool permissions without wiping existing session permissions
  - requiring `edit` permission for output redirection
  - requiring `edit` permission for `sed -i`

I also verified this in CI after updating the branch: unit tests, e2e tests, typecheck, and nix-eval are now passing.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR