### PR TITLE
docs(web): fix compaction agent name in Russian docs

### DIFF
--- a/packages/web/src/content/docs/ru/agents.mdx
+++ b/packages/web/src/content/docs/ru/agents.mdx
@@ -83,7 +83,7 @@ _Режим_: `subagent`
 
 ---
 
-### Использование Compact
+### Использование Compaction
 
 _Режим_: `primary`
 


### PR DESCRIPTION
### Issue for this PR

Closes #18770

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the Russian agents docs to use the correct built-in agent name, `Compaction`, instead of `Compact`.

### How did you verify your code works?

Confirmed the incorrect heading in `packages/web/src/content/docs/ru/agents.mdx` now reads `Использование Compaction` and reviewed the diff against `upstream/dev`.

### Screenshots / recordings

N/A - text-only docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR