### PR TITLE
fix(app): only navigate prompt history when input is empty

### DIFF
--- a/packages/app/e2e/prompt/prompt-history.spec.ts
+++ b/packages/app/e2e/prompt/prompt-history.spec.ts
@@ -108,7 +108,10 @@ test("prompt history restores unsent draft with arrow navigation", async ({ page
     await page.keyboard.type(draft)
     await wait(page, draft)
 
-    await edge(page, "start")
+    // Clear the draft before navigating history (ArrowUp only works when prompt is empty)
+    await prompt.fill("")
+    await wait(page, "")
+
     await page.keyboard.press("ArrowUp")
     await wait(page, second)
 
@@ -119,7 +122,7 @@ test("prompt history restores unsent draft with arrow navigation", async ({ page
     await wait(page, second)
 
     await page.keyboard.press("ArrowDown")
-    await wait(page, draft)
+    await wait(page, "")
   })
 })
 

--- a/packages/app/src/components/prompt-input/history.test.ts
+++ b/packages/app/src/components/prompt-input/history.test.ts
@@ -126,7 +126,7 @@ describe("prompt-input history", () => {
   test("canNavigateHistoryAtCursor only allows prompt boundaries", () => {
     const value = "a\nb\nc"
 
-    expect(canNavigateHistoryAtCursor("up", value, 0)).toBe(true)
+    expect(canNavigateHistoryAtCursor("up", value, 0)).toBe(false)
     expect(canNavigateHistoryAtCursor("down", value, 0)).toBe(false)
 
     expect(canNavigateHistoryAtCursor("up", value, 2)).toBe(false)
@@ -135,10 +135,13 @@ describe("prompt-input history", () => {
     expect(canNavigateHistoryAtCursor("up", value, 5)).toBe(false)
     expect(canNavigateHistoryAtCursor("down", value, 5)).toBe(true)
 
-    expect(canNavigateHistoryAtCursor("up", "abc", 0)).toBe(true)
+    expect(canNavigateHistoryAtCursor("up", "abc", 0)).toBe(false)
     expect(canNavigateHistoryAtCursor("down", "abc", 3)).toBe(true)
     expect(canNavigateHistoryAtCursor("up", "abc", 1)).toBe(false)
     expect(canNavigateHistoryAtCursor("down", "abc", 1)).toBe(false)
+
+    expect(canNavigateHistoryAtCursor("up", "", 0)).toBe(true)
+    expect(canNavigateHistoryAtCursor("down", "", 0)).toBe(true)
 
     expect(canNavigateHistoryAtCursor("up", "abc", 0, true)).toBe(true)
     expect(canNavigateHistoryAtCursor("up", "abc", 3, true)).toBe(true)

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -27,7 +27,7 @@ export function canNavigateHistoryAtCursor(direction: "up" | "down", text: strin
   const atStart = position === 0
   const atEnd = position === text.length
   if (inHistory) return atStart || atEnd
-  if (direction === "up") return position === 0
+  if (direction === "up") return position === 0 && text.length === 0
   return position === text.length
 }
 


### PR DESCRIPTION
https://github.com/orgs/anomalyco/projects/4/views/3?pane=issue&itemId=167902245

This matches the TUI's behaviour