### PR TITLE
tui: keep file tree open at its minimum resized width

### DIFF
--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -438,12 +438,10 @@ export function SessionSidePanel(props: {
                   size={layout.fileTree.width()}
                   min={200}
                   max={480}
-                  collapseThreshold={160}
                   onResize={(width) => {
                     props.size.touch()
                     layout.fileTree.resize(width)
                   }}
-                  onCollapse={layout.fileTree.close}
                 />
               </div>
             </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The file tree in the session side panel was closing itself when a user dragged it down to its minimum width. That made resizing feel broken because hitting the minimum size behaved like a close action instead of keeping the panel visible.

This removes the resize handle's collapse threshold and collapse callback for the file tree panel, so the panel now stays open at whatever width the user resizes it to, including the minimum width. This works because the close behavior was only being triggered by those resize handle props.

### How did you verify your code works?

The branch passed the repository pre-push typecheck hook when pushed with `bun` on `PATH`.

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._