### PR TITLE
feat: configurable history limits (improved)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1204,6 +1204,24 @@ export namespace Config {
             .min(0)
             .optional()
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
+          pruneProtect: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("Keep this many tokens worth of recent tool outputs untouched before pruning anything (default: 40k)."),
+          pruneMinimum: z
+            .number()
+            .int()
+            .min(0)
+            .optional()
+            .describe("Only mark tool outputs as compacted if at least this many tokens would be chopped off (default: 20k)."),
+          contextLimit: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Clamp model context/input limits to this value during compaction checks (useful to simulate smaller contexts)."),
         })
         .optional(),
       experimental: z

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1202,24 +1202,28 @@ export namespace Config {
             .number()
             .int()
             .min(0)
+            .max(1_000_000)
             .optional()
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
           pruneProtect: z
             .number()
             .int()
-            .min(0)
+            .min(1_000)
+            .max(1_000_000)
             .optional()
             .describe("Keep this many tokens worth of recent tool outputs untouched before pruning anything (default: 40k)."),
           pruneMinimum: z
             .number()
             .int()
-            .min(0)
+            .min(1_000)
+            .max(500_000)
             .optional()
             .describe("Only mark tool outputs as compacted if at least this many tokens would be chopped off (default: 20k)."),
           contextLimit: z
             .number()
             .int()
             .positive()
+            .max(10_000_000)
             .optional()
             .describe("Clamp model context/input limits to this value during compaction checks (useful to simulate smaller contexts)."),
         })

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -32,6 +32,8 @@ export namespace SessionCompaction {
 
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     const config = await Config.get()
+    const maxOutput = ProviderTransform.maxOutputTokens(input.model)
+
     if (config.compaction?.auto === false) return false
     const context = input.model.limit.context
     if (context === 0) return false
@@ -40,24 +42,36 @@ export namespace SessionCompaction {
       input.tokens.total ||
       input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
 
-    const reserved =
-      config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))
-    const usable = input.model.limit.input
-      ? input.model.limit.input - reserved
-      : context - ProviderTransform.maxOutputTokens(input.model)
+    const contextLimit = config.compaction?.contextLimit
+    const effectiveContext =
+      typeof contextLimit === "number" && contextLimit > 0 ? Math.min(context, contextLimit) : context
+
+    const inputLimit = input.model.limit.input
+    const hasInputLimit = typeof inputLimit === "number" && inputLimit > 0
+    const effectiveInput = hasInputLimit
+      ? typeof contextLimit === "number" && contextLimit > 0
+        ? Math.min(inputLimit, contextLimit)
+        : inputLimit
+      : undefined
+
+    const reserved = config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, maxOutput)
+    const usable = typeof effectiveInput === "number"
+      ? Math.max(0, effectiveInput - reserved)
+      : Math.max(0, effectiveContext - maxOutput)
     return count >= usable
   }
 
-  export const PRUNE_MINIMUM = 20_000
-  export const PRUNE_PROTECT = 40_000
+  export const DEFAULT_PRUNE_MINIMUM = 20_000
+  export const DEFAULT_PRUNE_PROTECT = 40_000
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 
-  // goes backwards through parts until there are 40_000 tokens worth of tool
-  // calls. then erases output of previous tool calls. idea is to throw away old
-  // tool calls that are no longer relevant.
+  // goes backwards through parts until there are tokens worth of tool calls,
+  // then marks them compacted. idea is to throw away old tool calls that are no longer relevant.
   export async function prune(input: { sessionID: SessionID }) {
     const config = await Config.get()
+    const pruneProtect = config.compaction?.pruneProtect ?? DEFAULT_PRUNE_PROTECT
+    const pruneMinimum = config.compaction?.pruneMinimum ?? DEFAULT_PRUNE_MINIMUM
     if (config.compaction?.prune === false) return
     log.info("pruning")
     const msgs = await Session.messages({ sessionID: input.sessionID })
@@ -80,7 +94,7 @@ export namespace SessionCompaction {
             if (part.state.time.compacted) break loop
             const estimate = Token.estimate(part.state.output)
             total += estimate
-            if (total > PRUNE_PROTECT) {
+            if (total > pruneProtect) {
               pruned += estimate
               toPrune.push(part)
             }
@@ -88,7 +102,7 @@ export namespace SessionCompaction {
       }
     }
     log.info("found", { pruned, total })
-    if (pruned > PRUNE_MINIMUM) {
+    if (pruned > pruneMinimum) {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -30,8 +30,12 @@ export namespace SessionCompaction {
 
   const COMPACTION_BUFFER = 20_000
 
-  export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
-    const config = await Config.get()
+  export async function isOverflow(input: {
+    tokens: MessageV2.Assistant["tokens"]
+    model: Provider.Model
+    config?: Awaited<ReturnType<typeof Config.get>>
+  }) {
+    const config = input.config ?? (await Config.get())
     const maxOutput = ProviderTransform.maxOutputTokens(input.model)
 
     if (config.compaction?.auto === false) return false
@@ -55,9 +59,13 @@ export namespace SessionCompaction {
       : undefined
 
     const reserved = config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, maxOutput)
+    const pruneProtect = config.compaction?.pruneProtect ?? DEFAULT_PRUNE_PROTECT
+    const pruneMinimum = config.compaction?.pruneMinimum ?? DEFAULT_PRUNE_MINIMUM
+
     const usable = typeof effectiveInput === "number"
       ? Math.max(0, effectiveInput - reserved)
       : Math.max(0, effectiveContext - maxOutput)
+
     return count >= usable
   }
 
@@ -68,10 +76,13 @@ export namespace SessionCompaction {
 
   // goes backwards through parts until there are tokens worth of tool calls,
   // then marks them compacted. idea is to throw away old tool calls that are no longer relevant.
-  export async function prune(input: { sessionID: SessionID }) {
-    const config = await Config.get()
-    const pruneProtect = config.compaction?.pruneProtect ?? DEFAULT_PRUNE_PROTECT
-    const pruneMinimum = config.compaction?.pruneMinimum ?? DEFAULT_PRUNE_MINIMUM
+  export async function prune(input: {
+    sessionID: SessionID
+    config?: Awaited<ReturnType<typeof Config.get>>
+  }) {
+    const config = input.config ?? (await Config.get())
+    const protect = config.compaction?.pruneProtect ?? DEFAULT_PRUNE_PROTECT
+    const minimum = config.compaction?.pruneMinimum ?? DEFAULT_PRUNE_MINIMUM
     if (config.compaction?.prune === false) return
     log.info("pruning")
     const msgs = await Session.messages({ sessionID: input.sessionID })
@@ -94,7 +105,7 @@ export namespace SessionCompaction {
             if (part.state.time.compacted) break loop
             const estimate = Token.estimate(part.state.output)
             total += estimate
-            if (total > pruneProtect) {
+            if (total > protect) {
               pruned += estimate
               toPrune.push(part)
             }
@@ -102,7 +113,7 @@ export namespace SessionCompaction {
       }
     }
     log.info("found", { pruned, total })
-    if (pruned > pruneMinimum) {
+    if (pruned > minimum) {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -280,11 +280,11 @@ export namespace SessionProcessor {
                     sessionID: input.sessionID,
                     messageID: input.assistantMessage.parentID,
                   })
-                  if (
-                    !input.assistantMessage.summary &&
-                    (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model }))
-                  ) {
-                    needsCompaction = true
+                  if (!input.assistantMessage.summary) {
+                    const config = await Config.get()
+                    if (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model, config })) {
+                      needsCompaction = true
+                    }
                   }
                   break
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -19,6 +19,7 @@ import { ProviderTransform } from "../provider/transform"
 import { SystemPrompt } from "./system"
 import { InstructionPrompt } from "./instruction"
 import { Plugin } from "../plugin"
+import { Config } from "../config/config"
 import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
@@ -544,18 +545,17 @@ export namespace SessionPrompt {
       }
 
       // context overflow, needs compaction
-      if (
-        lastFinished &&
-        lastFinished.summary !== true &&
-        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
-      ) {
-        await SessionCompaction.create({
-          sessionID,
-          agent: lastUser.agent,
-          model: lastUser.model,
-          auto: true,
-        })
-        continue
+      if (lastFinished && lastFinished.summary !== true) {
+        const config = await Config.get()
+        if (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model, config })) {
+          await SessionCompaction.create({
+            sessionID,
+            agent: lastUser.agent,
+            model: lastUser.model,
+            auto: true,
+          })
+          continue
+        }
       }
 
       // normal processing
@@ -723,7 +723,8 @@ export namespace SessionPrompt {
       }
       continue
     }
-    SessionCompaction.prune({ sessionID })
+    const config = await Config.get()
+    SessionCompaction.prune({ sessionID, config })
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
       const queued = state()[sessionID]?.callbacks ?? []

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1480,6 +1480,18 @@ export type Config = {
      * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
      */
     reserved?: number
+    /**
+     * Keep this many tokens worth of recent tool outputs untouched before pruning anything (default: 40k).
+     */
+    pruneProtect?: number
+    /**
+     * Only mark tool outputs as compacted if at least this many tokens would be chopped off (default: 20k).
+     */
+    pruneMinimum?: number
+    /**
+     * Clamp model context/input limits to this value during compaction checks (useful to simulate smaller contexts).
+     */
+    contextLimit?: number
   }
   experimental?: {
     disable_paste_summary?: boolean

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -523,10 +523,10 @@ You can control context compaction behavior through the `compaction` option.
 
 - `auto` - Automatically compact the session when context is full (default: `true`).
 - `prune` - Remove old tool outputs to save tokens (default: `true`).
-- `reserved` - Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
+- `reserved` - Token buffer for compaction. Leaves enough window to avoid overflow during compaction (default: `min(20 000, maxOutputTokens)` if not specified).
 - `pruneProtect` - Protects this many tokens worth of recent tool output before pruning begins (default: `40 000`).
 - `pruneMinimum` - Minimum token savings required before tool outputs are marked compacted (default: `20 000`).
-- `contextLimit` - Pretend every model has this context/input limit when deciding whether to compact (useful for simulating smaller models).
+- `contextLimit` - Pretend every model has this context/input limit when deciding whether to compact (default: not set; uses the model's real limits).
 
 ---
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -513,14 +513,20 @@ You can control context compaction behavior through the `compaction` option.
   "compaction": {
     "auto": true,
     "prune": true,
-    "reserved": 10000
+    "reserved": 10000,
+    "pruneProtect": 40000,
+    "pruneMinimum": 20000,
+    "contextLimit": 110000
   }
 }
 ```
 
 - `auto` - Automatically compact the session when context is full (default: `true`).
 - `prune` - Remove old tool outputs to save tokens (default: `true`).
-- `reserved` - Token buffer for compaction. Leaves enough window to avoid overflow during compaction
+- `reserved` - Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
+- `pruneProtect` - Protects this many tokens worth of recent tool output before pruning begins (default: `40 000`).
+- `pruneMinimum` - Minimum token savings required before tool outputs are marked compacted (default: `20 000`).
+- `contextLimit` - Pretend every model has this context/input limit when deciding whether to compact (useful for simulating smaller models).
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

This PR provides groundwork for configurable compaction settings (see #11930).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR is a revised version of the history limits feature work. It makes the history/compaction limits configurable at runtime instead of relying only on hardcoded defaults.

Changes included:

- Extend the server config schema with compaction limit settings and validation bounds.
- Apply the configured compaction limits in runtime compaction logic.
- Update the configuration documentation to describe the new fields and defaults.
- Update generated SDK types so clients can use the new config fields.

Why this works:

The new limits are now read from the validated server config and used by compaction at runtime, with safe fallbacks to the existing defaults when the config is not set.

Files touched:

- packages/opencode/src/config/config.ts
- packages/opencode/src/session/compaction.ts
- packages/opencode/src/session/prompt.ts
- packages/opencode/src/session/processor.ts
- packages/web/src/content/docs/config.mdx
- packages/sdk/js/src/v2/gen/types.gen.ts

### How did you verify your code works?

- bun turbo typecheck
- bun test --cwd packages/opencode test/session/compaction.test.ts

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
