### PR TITLE
fix: createOpencode function failure on Windows due to spawn usage

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -33,6 +33,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
 
   const proc = spawn(`opencode`, args, {
     signal: options.signal,
+    shell: process.platform === 'win32',
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
@@ -108,6 +109,7 @@ export function createOpencodeTui(options?: TuiOptions) {
 
   const proc = spawn(`opencode`, args, {
     signal: options?.signal,
+    shell: process.platform === 'win32',
     stdio: "inherit",
     env: {
       ...process.env,


### PR DESCRIPTION
Adds { shell: process.platform === 'win32' } when spawning child processes on Windows, allowing the system to resolve opencode.cmd from the PATH.

### Issue for this PR

Closes #18792

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When I use opencode sdk on windows. I called `createOpencode` function, then got a fail

```
node:internal/child_process:286
      const err = new ErrnoException(exitCode, syscall);
                  ^

Error: spawn opencode ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn opencode',
  path: 'opencode',
  spawnargs: [ 'serve', '--hostname=127.0.0.1', '--port=0' ]
}
```

So I changed `server.ts`,  I added a `shell` flag to the spawn function arguments, setting it to true for Windows and false otherwise.

### How did you verify your code works?

Verified the fix on Windows 11 and Ubuntu.

### Screenshots / recordings

No ui changed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
