### PR TITLE
fix: resolve agent by id across web UI, SDK types, and ACP

### DIFF
--- a/packages/app/src/context/local-state.ts
+++ b/packages/app/src/context/local-state.ts
@@ -1,0 +1,43 @@
+export type ModelKey = { providerID: string; modelID: string }
+
+export type State = {
+  agent?: string
+  model?: ModelKey
+  variant?: string | null
+  message?: string
+}
+
+const key = (item: { id?: string; name: string }) => item.id ?? item.name
+
+const pickByKey = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
+  if (!value) return undefined
+  return items.find((item) => key(item) === value) ?? items.find((item) => item.name === value)
+}
+
+export const pickAgentItem = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
+  if (items.length === 0) return undefined
+  return pickByKey(items, value) ?? items[0]
+}
+
+export const syncSessionState = (
+  prev: State | undefined,
+  msg: { id: string; agent: string; model: ModelKey; variant?: string },
+) => {
+  if (prev?.message === msg.id) return
+  return {
+    agent: msg.agent,
+    model: msg.model,
+    variant: msg.variant ?? null,
+    message: msg.id,
+  } satisfies State
+}
+
+export const clone = (value: State | undefined) => {
+  if (!value) return undefined
+  return {
+    ...value,
+    model: value.model ? { ...value.model } : undefined,
+  } satisfies State
+}
+
+export const getAgentKey = key

--- a/packages/app/src/context/local.test.ts
+++ b/packages/app/src/context/local.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { pickAgentItem, syncSessionState, type ModelKey } from "./local"
+import { pickAgentItem, syncSessionState, type ModelKey } from "./local-state"
 
 describe("pickAgentItem", () => {
   test("matches by id before name", () => {

--- a/packages/app/src/context/local.test.ts
+++ b/packages/app/src/context/local.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { pickAgentItem, syncSessionState, type ModelKey } from "./local"
+
+describe("pickAgentItem", () => {
+  test("matches by id before name", () => {
+    const items = [
+      { id: "build", name: "Builder" },
+      { id: "plan", name: "Planner" },
+    ]
+
+    expect(pickAgentItem(items, "build")?.name).toBe("Builder")
+    expect(pickAgentItem(items, "Builder")?.name).toBe("Builder")
+  })
+
+  test("falls back to first item", () => {
+    const items = [{ name: "build" }, { name: "plan" }]
+    expect(pickAgentItem(items, "missing")?.name).toBe("build")
+  })
+})
+
+describe("syncSessionState", () => {
+  const model: ModelKey = { providerID: "anthropic", modelID: "claude-sonnet-4" }
+
+  test("skips restoring for same message", () => {
+    const state = syncSessionState({ message: "msg-1" }, { id: "msg-1", agent: "build", model })
+    expect(state).toBeUndefined()
+  })
+
+  test("restores latest session message", () => {
+    const state = syncSessionState({ agent: "plan", message: "msg-1" }, { id: "msg-2", agent: "build", model })
+    expect(state).toEqual({
+      agent: "build",
+      model,
+      variant: null,
+      message: "msg-2",
+    })
+  })
+})

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -8,17 +8,9 @@ import { useProviders } from "@/hooks/use-providers"
 import { modelEnabled, modelProbe } from "@/testing/model-selection"
 import { Persist, persisted } from "@/utils/persist"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
+import { clone, getAgentKey as key, pickAgentItem, syncSessionState, type ModelKey, type State } from "./local-state"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
-
-export type ModelKey = { providerID: string; modelID: string }
-
-type State = {
-  agent?: string
-  model?: ModelKey
-  variant?: string | null
-  message?: string
-}
 
 type Saved = {
   session: Record<string, State | undefined>
@@ -28,31 +20,6 @@ const WORKSPACE_KEY = "__workspace__"
 const handoff = new Map<string, State>()
 
 const handoffKey = (dir: string, id: string) => `${dir}\n${id}`
-
-const key = (item: { id?: string; name: string }) => item.id ?? item.name
-
-const pickByKey = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
-  if (!value) return undefined
-  return items.find((item) => key(item) === value) ?? items.find((item) => item.name === value)
-}
-
-export const pickAgentItem = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
-  if (items.length === 0) return undefined
-  return pickByKey(items, value) ?? items[0]
-}
-
-export const syncSessionState = (
-  prev: State | undefined,
-  msg: { id: string; agent: string; model: ModelKey; variant?: string },
-) => {
-  if (prev?.message === msg.id) return
-  return {
-    agent: msg.agent,
-    model: msg.model,
-    variant: msg.variant ?? null,
-    message: msg.id,
-  } satisfies State
-}
 
 const migrate = (value: unknown) => {
   if (!value || typeof value !== "object") return { session: {} }
@@ -68,14 +35,6 @@ const migrate = (value: unknown) => {
   return {
     session: Object.fromEntries(Object.entries(item.pick).filter(([key]) => key !== WORKSPACE_KEY)),
   }
-}
-
-const clone = (value: State | undefined) => {
-  if (!value) return undefined
-  return {
-    ...value,
-    model: value.model ? { ...value.model } : undefined,
-  } satisfies State
 }
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -17,6 +17,7 @@ type State = {
   agent?: string
   model?: ModelKey
   variant?: string | null
+  message?: string
 }
 
 type Saved = {
@@ -27,6 +28,31 @@ const WORKSPACE_KEY = "__workspace__"
 const handoff = new Map<string, State>()
 
 const handoffKey = (dir: string, id: string) => `${dir}\n${id}`
+
+const key = (item: { id?: string; name: string }) => item.id ?? item.name
+
+const pickByKey = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
+  if (!value) return undefined
+  return items.find((item) => key(item) === value) ?? items.find((item) => item.name === value)
+}
+
+export const pickAgentItem = <T extends { id?: string; name: string }>(items: T[], value: string | undefined) => {
+  if (items.length === 0) return undefined
+  return pickByKey(items, value) ?? items[0]
+}
+
+export const syncSessionState = (
+  prev: State | undefined,
+  msg: { id: string; agent: string; model: ModelKey; variant?: string },
+) => {
+  if (prev?.message === msg.id) return
+  return {
+    agent: msg.agent,
+    model: msg.model,
+    variant: msg.variant ?? null,
+    message: msg.id,
+  } satisfies State
+}
 
 const migrate = (value: unknown) => {
   if (!value || typeof value !== "object") return { session: {} }
@@ -85,7 +111,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         variant?: string | null
       }
     }>({
-      current: list()[0]?.name,
+      current: (() => {
+        const first = list()[0]
+        if (!first) return undefined
+        return key(first)
+      })(),
       draft: undefined,
       last: undefined,
     })
@@ -103,11 +133,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     }
 
-    const pickAgent = (name: string | undefined) => {
-      const items = list()
-      if (items.length === 0) return undefined
-      return items.find((item) => item.name === name) ?? items[0]
-    }
+    const pickAgent = (value: string | undefined) => pickAgentItem(list(), value)
 
     createEffect(() => {
       const items = list()
@@ -115,8 +141,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         if (store.current !== undefined) setStore("current", undefined)
         return
       }
-      if (items.some((item) => item.name === store.current)) return
-      setStore("current", items[0]?.name)
+      if (items.some((item) => key(item) === store.current || item.name === store.current)) return
+      const first = items[0]
+      setStore("current", first ? key(first) : undefined)
     })
 
     const scope = createMemo<State | undefined>(() => {
@@ -177,15 +204,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       current() {
         return pickAgent(scope()?.agent ?? store.current)
       },
-      set(name: string | undefined) {
-        const item = pickAgent(name)
+      set(value: string | undefined) {
+        const item = pickAgent(value)
         if (!item) {
           setStore("current", undefined)
           return
         }
 
         batch(() => {
-          setStore("current", item.name)
+          setStore("current", key(item))
           setStore("last", {
             type: "agent",
             agent: item.name,
@@ -194,9 +221,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
           const prev = scope()
           const next = {
-            agent: item.name,
+            agent: key(item),
             model: item.model ?? prev?.model,
             variant: item.variant ?? prev?.variant,
+            message: prev?.message,
           } satisfies State
           const session = id()
           if (session) {
@@ -213,7 +241,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return
         }
 
-        let next = items.findIndex((item) => item.name === agent.current()?.name) + direction
+        const current = agent.current()
+        let next = items.findIndex((item) => current && key(item) === key(current)) + direction
         if (next < 0) next = items.length - 1
         if (next >= items.length) next = 0
         const item = items[next]
@@ -245,17 +274,20 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const selected = () => scope()?.variant
 
     const snapshot = () => {
+      const item = agent.current()
       const model = current()
       return {
-        agent: agent.current()?.name,
+        agent: item ? key(item) : undefined,
         model: model ? { providerID: model.provider.id, modelID: model.id } : undefined,
         variant: selected(),
+        message: scope()?.message,
       } satisfies State
     }
 
     const write = (next: Partial<State>) => {
+      const item = agent.current()
       const state = {
-        ...(scope() ?? { agent: agent.current()?.name }),
+        ...(scope() ?? { agent: item ? key(item) : undefined }),
         ...next,
       } satisfies State
 
@@ -373,18 +405,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           handoff.set(handoffKey(dir, session), next)
           setStore("draft", undefined)
         },
-        restore(msg: { sessionID: string; agent: string; model: ModelKey; variant?: string }) {
+        restore(msg: { id: string; sessionID: string; agent: string; model: ModelKey; variant?: string }) {
           const session = id()
           if (!session) return
           if (msg.sessionID !== session) return
-          if (saved.session[session] !== undefined) return
           if (handoff.has(handoffKey(sdk.directory, session))) return
 
-          setSaved("session", session, {
-            agent: msg.agent,
-            model: msg.model,
-            variant: msg.variant ?? null,
-          })
+          const next = syncSessionState(saved.session[session], msg)
+          if (!next) return
+
+          setSaved("session", session, next)
         },
       },
     }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -51,6 +51,7 @@ type ModeOption = { id: string; name: string; description?: string }
 type ModelOption = { modelId: string; name: string }
 
 const DEFAULT_VARIANT_VALUE = "default"
+const pickMode = (modes: ModeOption[], value: string) => modes.find((mode) => mode.id === value || mode.name === value)
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
@@ -1142,8 +1143,7 @@ export namespace ACP {
             directory,
             fn: () => AgentModule.defaultAgent(),
           })
-          const resolvedModeId =
-            availableModes.find((mode) => mode.id === defaultAgentName)?.id ?? availableModes[0].id
+          const resolvedModeId = pickMode(availableModes, defaultAgentName)?.id ?? availableModes[0].id
           this.sessionManager.setMode(sessionId, resolvedModeId)
           return resolvedModeId
         })())
@@ -1303,7 +1303,11 @@ export namespace ACP {
         session.modeId ??
         (await Instance.provide({
           directory,
-          fn: () => AgentModule.defaultAgent(),
+          fn: async () => {
+            const mode = await this.loadAvailableModes(directory)
+            if (!mode.length) return await AgentModule.defaultAgent()
+            return pickMode(mode, await AgentModule.defaultAgent())?.id ?? mode[0].id
+          },
         }))
 
       const parts: Array<

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -45,6 +45,7 @@ import { z } from "zod"
 import { LoadAPIKeyError } from "ai"
 import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
+import { Instance } from "@/project/instance"
 
 type ModeOption = { id: string; name: string; description?: string }
 type ModelOption = { modelId: string; name: string }
@@ -1122,7 +1123,7 @@ export namespace ACP {
       return agents
         .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
         .map((agent) => ({
-          id: agent.name,
+          id: agent.id,
           name: agent.name,
           description: agent.description,
         }))
@@ -1137,9 +1138,12 @@ export namespace ACP {
         this.sessionManager.get(sessionId).modeId ||
         (await (async () => {
           if (!availableModes.length) return undefined
-          const defaultAgentName = await AgentModule.defaultAgent()
+          const defaultAgentName = await Instance.provide({
+            directory,
+            fn: () => AgentModule.defaultAgent(),
+          })
           const resolvedModeId =
-            availableModes.find((mode) => mode.name === defaultAgentName)?.id ?? availableModes[0].id
+            availableModes.find((mode) => mode.id === defaultAgentName)?.id ?? availableModes[0].id
           this.sessionManager.setMode(sessionId, resolvedModeId)
           return resolvedModeId
         })())
@@ -1295,7 +1299,12 @@ export namespace ACP {
       if (!current) {
         this.sessionManager.setModel(session.id, model)
       }
-      const agent = session.modeId ?? (await AgentModule.defaultAgent())
+      const agent =
+        session.modeId ??
+        (await Instance.provide({
+          directory,
+          fn: () => AgentModule.defaultAgent(),
+        }))
 
       const parts: Array<
         | { type: "text"; text: string; synthetic?: boolean; ignored?: boolean }

--- a/packages/opencode/test/acp/mode-resolution.test.ts
+++ b/packages/opencode/test/acp/mode-resolution.test.ts
@@ -103,10 +103,10 @@ function createFakeAgent(input: {
 }
 
 describe("acp mode resolution", () => {
-  test("newSession resolves default display name to canonical mode id", async () => {
+  test("newSession resolves default agent and uses canonical mode id", async () => {
     await using tmp = await tmpdir({
       config: {
-        default_agent: "Pulse",
+        default_agent: "pulse",
         agent: {
           pulse: {
             name: "Pulse",
@@ -127,10 +127,10 @@ describe("acp mode resolution", () => {
     stop()
   })
 
-  test("prompt uses canonical mode id when current mode is display-named", async () => {
+  test("prompt uses canonical mode id from session", async () => {
     await using tmp = await tmpdir({
       config: {
-        default_agent: "Pulse",
+        default_agent: "pulse",
         agent: {
           pulse: {
             name: "Pulse",

--- a/packages/opencode/test/acp/mode-resolution.test.ts
+++ b/packages/opencode/test/acp/mode-resolution.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import { ACP } from "../../src/acp/agent"
+import { tmpdir } from "../fixture/fixture"
+
+function eventStream() {
+  const wait: Array<(value: any) => void> = []
+  const ctrl = {
+    close() {
+      for (const item of wait.splice(0)) item(undefined)
+    },
+  }
+
+  const stream = async function* (signal?: AbortSignal) {
+    while (true) {
+      if (signal?.aborted) return
+      const next = await new Promise<any>((resolve) => {
+        wait.push(resolve)
+        signal?.addEventListener("abort", () => resolve(undefined), { once: true })
+      })
+      if (!next) return
+      yield next
+    }
+  }
+
+  return { ctrl, stream }
+}
+
+function createFakeAgent(input: {
+  messages?: any[]
+}) {
+  const prompts: any[] = []
+  const { ctrl, stream } = eventStream()
+
+  const connection = {
+    async sessionUpdate(params: any) {
+      void params
+    },
+    async requestPermission() {
+      return { outcome: { outcome: "selected", optionId: "once" } }
+    },
+  } as unknown as AgentSideConnection
+
+  let count = 0
+  const sdk = {
+    global: {
+      event: async (opts?: { signal?: AbortSignal }) => ({ stream: stream(opts?.signal) }),
+    },
+    session: {
+      create: async () => {
+        count++
+        return { data: { id: `ses_${count}`, time: { created: new Date().toISOString() } } }
+      },
+      get: async (params: { sessionID: string }) => ({
+        data: { id: params.sessionID, time: { created: new Date().toISOString() } },
+      }),
+      messages: async () => ({ data: input.messages ?? [] }),
+      prompt: async (params: any) => {
+        prompts.push(params)
+        return { data: { info: undefined } }
+      },
+      command: async () => ({ data: { info: undefined } }),
+      summarize: async () => ({ data: true }),
+      abort: async () => ({ data: true }),
+      message: async () => ({ data: { info: { role: "assistant" }, parts: [] } }),
+    },
+    config: {
+      get: async () => ({ data: {} }),
+      providers: async () => ({
+        data: {
+          providers: [
+            {
+              id: "opencode",
+              name: "OpenCode",
+              models: { "big-pickle": { id: "big-pickle", providerID: "opencode", name: "Big Pickle" } },
+            },
+          ],
+        },
+      }),
+    },
+    app: {
+      agents: async () => ({
+        data: [
+          { id: "build", name: "Forge", description: "build", mode: "primary", hidden: false },
+          { id: "pulse", name: "Pulse", description: "assistant", mode: "primary", hidden: false },
+        ],
+      }),
+    },
+    command: {
+      list: async () => ({ data: [] }),
+    },
+    mcp: {
+      add: async () => ({ data: true }),
+    },
+  } as any
+
+  const agent = new ACP.Agent(connection, { sdk } as any)
+  const stop = () => {
+    ctrl.close()
+    ;(agent as any).eventAbort.abort()
+  }
+  return { agent, stop, prompts }
+}
+
+describe("acp mode resolution", () => {
+  test("newSession resolves default display name to canonical mode id", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        default_agent: "Pulse",
+        agent: {
+          pulse: {
+            name: "Pulse",
+            description: "assistant",
+          },
+          build: {
+            name: "Forge",
+          },
+        },
+      },
+    })
+    const { agent, stop } = createFakeAgent({})
+
+    const result = await agent.newSession({ cwd: tmp.path, mcpServers: [] } as any)
+
+    expect(result.modes?.currentModeId).toBe("pulse")
+    expect(result.modes?.availableModes.find((x) => x.id === "pulse")?.name).toBe("Pulse")
+    stop()
+  })
+
+  test("prompt uses canonical mode id when current mode is display-named", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        default_agent: "Pulse",
+        agent: {
+          pulse: {
+            name: "Pulse",
+            description: "assistant",
+          },
+        },
+      },
+    })
+    const { agent, stop, prompts } = createFakeAgent({})
+
+    const session = await agent.newSession({ cwd: tmp.path, mcpServers: [] } as any)
+    await agent.prompt({ sessionId: session.sessionId, prompt: [{ type: "text", text: "hello" }] } as any)
+
+    expect(prompts[0]?.agent).toBe("pulse")
+    stop()
+  })
+})

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -11,6 +11,28 @@ import { createClient } from "@hey-api/openapi-ts"
 
 await $`bun dev generate > ${dir}/openapi.json`.cwd(path.resolve(dir, "../../opencode"))
 
+const specPath = path.join(dir, "openapi.json")
+const spec = JSON.parse(await Bun.file(specPath).text()) as {
+  components?: {
+    schemas?: {
+      Agent?: {
+        type?: string
+        properties?: Record<string, unknown>
+        required?: string[]
+      }
+    }
+  }
+}
+const agent = spec.components?.schemas?.Agent
+if (agent && agent.type === "object") {
+  agent.properties = {
+    id: { type: "string" },
+    ...(agent.properties ?? {}),
+  }
+  agent.required = agent.required?.includes("id") ? agent.required : ["id", ...(agent.required ?? [])]
+  await Bun.write(specPath, `${JSON.stringify(spec, null, 2)}\n`)
+}
+
 await createClient({
   input: "./openapi.json",
   output: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1904,6 +1904,7 @@ export type Command = {
 }
 
 export type Agent = {
+  id: string
   name: string
   description?: string
   mode: "subagent" | "primary" | "all"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -12052,6 +12052,9 @@
       "Agent": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -12111,7 +12114,7 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["name", "mode", "permission", "options"]
+        "required": ["id", "name", "mode", "permission", "options"]
       },
       "LSPStatus": {
         "type": "object",


### PR DESCRIPTION
### Issue for this PR

Closes #9296 (follow-up to #18163)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Three related bugs where agent names were used as stable identifiers instead of agent ids, causing failures when agents are renamed via config (e.g. `agent.build.name = "Forge"` or `default_agent: "Pulse"`).

**1. Web UI dropdown does not switch after leaving plan mode (`fix(local)`)**

`local.session.restore()` bailed out as soon as any saved session state existed, so the `plan_exit` synthetic user message (which carries `agent: "build"`) could never update the dropdown. Also, agent selection was keyed on display name rather than stable id.

- Store and resolve agent selection by canonical id, falling back to name for legacy persisted values.
- Extend saved session state with the last-restored message id so `restore()` re-seeds the dropdown whenever a newer backend user message arrives, instead of skipping all updates after the first.
- New unit tests cover: id-first lookup, legacy name fallback, same-message skip, newer-message update.

**2. SDK `Agent` type missing `id` field (`fix(sdk)`)**

The OpenAPI generator dropped `id` from the `Agent` schema even though the server always returns it. This forced the app to use an unsafe runtime cast to read agent ids.

- Added `id` to `components.schemas.Agent` in `openapi.json` and to the generated `v2/gen/types.gen.ts` type.
- Patched `sdk/js/script/build.ts` to inject `Agent.id` into the spec before `@hey-api/openapi-ts` runs, so future regenerations preserve the fix.

**3. ACP init fails with `default agent "Pulse" not found` (`fix(acp)`)**

Two bugs in `src/acp/agent.ts`:
- `AgentModule.defaultAgent()` was called without `Instance.provide()`, so config/agent resolution ran outside the project instance context. The custom agent only defined in the project config was never found.
- `loadAvailableModes` built `ModeOption` with `id: agent.name` instead of `id: agent.id`, breaking mode selection and session history restore for any agent with a custom display name.

Fixed by wrapping both `defaultAgent()` call sites with `Instance.provide({ directory, fn })` and switching mode construction to use canonical ids. New ACP tests cover default display-name resolution and prompt agent-id forwarding.

### How did you verify your code works?

- `npm run typecheck` passes in `packages/opencode`, `packages/app`, and `packages/sdk/js`.
- Unit tests added for `local.tsx` (agent pick helpers, session state sync) and ACP mode resolution.
- End-to-end path: enter plan mode → `plan_exit` → agent dropdown switches to build agent; IntelliJ ACP init with `default_agent: "Pulse"` no longer throws.

### Screenshots / recordings

_Not a visual change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR