### PR TITLE
fix: map model_context_window_exceeded to length to prevent unknown loop

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -5,6 +5,7 @@ export function mapOpenAICompatibleFinishReason(finishReason: string | null | un
     case "stop":
       return "stop"
     case "length":
+    case "model_context_window_exceeded":
       return "length"
     case "content_filter":
       return "content-filter"

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -51,6 +51,7 @@ export namespace SessionProcessor {
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
+            let empty = true
             const stream = await LLM.stream(streamInput)
 
             for await (const value of stream.fullStream) {
@@ -61,6 +62,7 @@ export namespace SessionProcessor {
                   break
 
                 case "reasoning-start":
+                  empty = false
                   if (value.id in reasoningMap) {
                     continue
                   }
@@ -80,6 +82,7 @@ export namespace SessionProcessor {
                   break
 
                 case "reasoning-delta":
+                  empty = false
                   if (value.id in reasoningMap) {
                     const part = reasoningMap[value.id]
                     part.text += value.text
@@ -110,6 +113,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-input-start":
+                  empty = false
                   const part = await Session.updatePart({
                     id: toolcalls[value.id]?.id ?? PartID.ascending(),
                     messageID: input.assistantMessage.id,
@@ -133,6 +137,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-call": {
+                  empty = false
                   const match = toolcalls[value.toolCallId]
                   if (match) {
                     const part = await Session.updatePart({
@@ -243,17 +248,23 @@ export namespace SessionProcessor {
                   break
 
                 case "finish-step":
+                  const reason =
+                    value.finishReason === "unknown" &&
+                    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+                    empty
+                      ? "length"
+                      : value.finishReason
                   const usage = Session.getUsage({
                     model: input.model,
                     usage: value.usage,
                     metadata: value.providerMetadata,
                   })
-                  input.assistantMessage.finish = value.finishReason
+                  input.assistantMessage.finish = reason
                   input.assistantMessage.cost += usage.cost
                   input.assistantMessage.tokens = usage.tokens
                   await Session.updatePart({
                     id: PartID.ascending(),
-                    reason: value.finishReason,
+                    reason,
                     snapshot: await Snapshot.track(),
                     messageID: input.assistantMessage.id,
                     sessionID: input.assistantMessage.sessionID,
@@ -289,6 +300,7 @@ export namespace SessionProcessor {
                   break
 
                 case "text-start":
+                  empty = false
                   currentText = {
                     id: PartID.ascending(),
                     messageID: input.assistantMessage.id,
@@ -304,6 +316,7 @@ export namespace SessionProcessor {
                   break
 
                 case "text-delta":
+                  empty = false
                   if (currentText) {
                     currentText.text += value.text
                     if (value.providerMetadata) currentText.metadata = value.providerMetadata


### PR DESCRIPTION
### Issue for this PR

Closes #18813
Related: #15778

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Issue #18813 reports that some providers can return a non-standard finish reason:

- `finish_reason: "model_context_window_exceeded"`

From the report, z.ai returns this when context is too long; Anthropic appears to have introduced the same value (based on internet search, not directly verified via Anthropic API in this PR).

OpenCode session flow treats `finish: "unknown"` as unfinished. That can keep the loop running and repeatedly send requests.

This PR adds a guard in session processing for **all models using `@ai-sdk/openai-compatible`**:

- if a step finishes with `finishReason === "unknown"`
- and the step produced no text/reasoning/tool output

then OpenCode rewrites that finish reason to `length`.

This prevents the unknown-loop behavior described in #18813 and routes the result into normal length/context-limit handling.

(Additionally, the existing Copilot-specific mapper already handles `model_context_window_exceeded` directly.)

Reference implementation:
- https://github.com/openclaw/openclaw/pull/35934

### How did you verify your code works?

- Rechecked the reported behavior and payload shape from #18813.
- Ran local tests:
  - `bun test test/provider/copilot/copilot-chat-model.test.ts`
  - `bun test test/session/llm.test.ts`

### Screenshots / recordings

N/A (non-UI change). See screenshots and payload examples in #18813.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
