### PR TITLE
feat(plugin): add chat.model hook for dynamic model routing for token savings

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -67,7 +67,7 @@ export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
   // Tracks plugin-routed models per session for subagent inheritance
-  const routedModels: Record<string, { providerID: string; modelID: string }> = {}
+  const routedModels: Record<string, { providerID: ProviderID; modelID: ModelID }> = {}
 
   export function getRoutedModel(sessionID: string) {
     return routedModels[sessionID]
@@ -977,23 +977,28 @@ export namespace SessionPrompt {
     const proposedModel = input.model ?? agent.model ?? (await lastModel(input.sessionID))
 
     // Fire chat.model hook to allow plugins to dynamically route to different models
+    // Plugin types use plain strings; cast branded types for the hook interface
     const modelOverride = await Plugin.trigger(
       "chat.model",
       {
         sessionID: input.sessionID,
         agent: agent.name,
-        proposedModel,
+        proposedModel: { providerID: proposedModel.providerID as string, modelID: proposedModel.modelID as string },
       },
       { model: undefined as { providerID: string; modelID: string } | undefined },
     )
 
-    // If plugin set a model, persist it for subagent inheritance
-    const model = modelOverride.model ?? proposedModel
+    // If plugin set a model, convert plain strings back to branded types and persist
+    let model = proposedModel as { providerID: ProviderID; modelID: ModelID }
     if (modelOverride.model) {
-      routedModels[input.sessionID] = modelOverride.model
+      model = {
+        providerID: ProviderID.make(modelOverride.model.providerID),
+        modelID: ModelID.make(modelOverride.model.modelID),
+      }
+      routedModels[input.sessionID] = model
       log.info("plugin routed model", {
         sessionID: input.sessionID,
-        model: modelOverride.model,
+        model,
       })
     }
     const full =

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -66,6 +66,13 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  // Tracks plugin-routed models per session for subagent inheritance
+  const routedModels: Record<string, { providerID: string; modelID: string }> = {}
+
+  export function getRoutedModel(sessionID: string) {
+    return routedModels[sessionID]
+  }
+
   const state = Instance.state(
     () => {
       const data: Record<
@@ -966,7 +973,29 @@ export namespace SessionPrompt {
   async function createUserMessage(input: PromptInput) {
     const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
 
-    const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
+    // Resolve the proposed model before plugin can override
+    const proposedModel = input.model ?? agent.model ?? (await lastModel(input.sessionID))
+
+    // Fire chat.model hook to allow plugins to dynamically route to different models
+    const modelOverride = await Plugin.trigger(
+      "chat.model",
+      {
+        sessionID: input.sessionID,
+        agent: agent.name,
+        proposedModel,
+      },
+      { model: undefined as { providerID: string; modelID: string } | undefined },
+    )
+
+    // If plugin set a model, persist it for subagent inheritance
+    const model = modelOverride.model ?? proposedModel
+    if (modelOverride.model) {
+      routedModels[input.sessionID] = modelOverride.model
+      log.info("plugin routed model", {
+        sessionID: input.sessionID,
+        model: modelOverride.model,
+      })
+    }
     const full =
       !input.variant && agent.variant
         ? await Provider.getModel(model.providerID, model.modelID).catch(() => undefined)

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -105,7 +105,8 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 
-      const model = agent.model ?? {
+      const routedModel = SessionPrompt.getRoutedModel(ctx.sessionID)
+      const model = agent.model ?? routedModel ?? {
         modelID: msg.info.modelID,
         providerID: msg.info.providerID,
       }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -180,6 +180,21 @@ export interface Hooks {
     output: { message: UserMessage; parts: Part[] },
   ) => Promise<void>
   /**
+   * Called to dynamically route messages to different models.
+   * When a plugin sets output.model, OpenCode updates the session's
+   * active model so future turns and subagents inherit the routed model.
+   */
+  "chat.model"?: (
+    input: {
+      sessionID: string
+      agent: string
+      proposedModel: { providerID: string; modelID: string }
+    },
+    output: {
+      model?: { providerID: string; modelID: string }
+    },
+  ) => Promise<void>
+  /**
    * Modify parameters sent to LLM
    */
   "chat.params"?: (


### PR DESCRIPTION
Adds a new 'chat.model' plugin hook that allows plugins to dynamically route messages to different models based on content/complexity. When a plugin sets output.model, the routed model is persisted in session state so future turns and subagents (via Task tool) inherit it.

Changes:
- packages/plugin/src/index.ts: Add chat.model hook type definition
- packages/opencode/src/session/prompt.ts: Fire chat.model hook before model resolution, persist routed model for subagent inheritance
- packages/opencode/src/tool/task.ts: Check for routed model when resolving subagent model (fixes subagent model inheritance)

Related: #18644, #17870, #6928

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works? 
I used my fork to conduct testing locally

### Screenshots / recordings
<img width="1670" height="635" alt="image" src="https://github.com/user-attachments/assets/24a05d9d-81e1-4e88-afcc-1736b2e27647" />

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
