### PR TITLE
fix(opencode): scope root session lists to the active workspace

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -553,6 +553,9 @@ export namespace Session {
     }
     if (input?.directory) {
       conditions.push(eq(SessionTable.directory, input.directory))
+      if (!WorkspaceContext.workspaceID) {
+        conditions.push(isNull(SessionTable.workspace_id))
+      }
     }
     if (input?.roots) {
       conditions.push(isNull(SessionTable.parent_id))


### PR DESCRIPTION
### Issue for this PR

Closes #18833

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops plain workspace session queries from counting sibling logical-workspace chats that share the same physical directory.

That keeps the sidebar from showing `Load more` on refresh when there are no additional visible chats for the active workspace.

### How did you verify your code works?

- Refreshed a workspace locally and confirmed the false `Load more` button no longer appears
- Ran `bun turbo typecheck` during push
- Rebuilt the local app/server and verified the sidebar behavior manually

### Screenshots / recordings

**@Rohansguliani please attach a screenshot or short recording if maintainers want UI proof for the sidebar behavior change.**

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
