### PR TITLE
chore: bump gitlab-ai-provider to 5.3.1 for GPT-5.4 model support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -358,7 +358,7 @@
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
-        "gitlab-ai-provider": "5.2.2",
+        "gitlab-ai-provider": "5.3.1",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -3036,7 +3036,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "gitlab-ai-provider": ["gitlab-ai-provider@5.2.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-ejwnie62rimfVHbjYZ2tsnqwLjF9YLgXD3OQA458gHz8hUvw7vEnhuyuMv5PmWQtyS3ISAghiX7r5SBhUWeCTA=="],
+    "gitlab-ai-provider": ["gitlab-ai-provider@5.3.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-QeNP2af/5wyOHYaLvDxn72n4xbMbJNqRiKExZJM8MnynebnqnoaJoojbtue7roCl/XcnjX6Of2+oc7hS44S45Q=="],
 
     "glob": ["glob@13.0.5", "", { "dependencies": { "minimatch": "^10.2.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -121,7 +121,7 @@
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "3.1.0",
-    "gitlab-ai-provider": "5.2.2",
+    "gitlab-ai-provider": "5.3.1",
     "glob": "13.0.5",
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",


### PR DESCRIPTION
### Issue for this PR

Closes #18850

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bumps `gitlab-ai-provider` from 5.2.2 to 5.3.1. Version 5.3.1 adds three new OpenAI GPT-5.4 proxy models to `MODEL_MAPPINGS`:

| Model ID | Underlying Model |
|---|---|
| `duo-chat-gpt-5-4` | `gpt-5.4-2026-03-05` |
| `duo-chat-gpt-5-4-mini` | `gpt-5.4-mini` |
| `duo-chat-gpt-5-4-nano` | `gpt-5.4-nano` |

These models are defined in the ai-gateway [models.yml](https://gitlab.com/gitlab-org/modelops/applied-ml/code-suggestions/ai-assist/-/blob/main/ai_gateway/model_selection/models.yml) with `proxy_provider: openai` and were missing from the provider SDK.

This also requires the companion [models.dev PR](https://github.com/anomalyco/models.dev/pull/1258) which adds the model definitions to the gitlab provider and fixes the `npm` field from the stale scoped `@gitlab/gitlab-ai-provider` (v4.1.0) to the current `gitlab-ai-provider` — without that fix, opencode's `getSDK` falls through the bundled provider check and dynamically installs the old package.

### How did you verify your code works?

- Ran `bun typecheck` — passes
- Ran opencode with `OPENCODE_MODELS_PATH` pointing to a regenerated models.json containing the new gitlab models and confirmed the GPT-5.4 models load and work without the `Unknown model ID` error

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR