### PR TITLE
fix: keep external edit permission prompts absolute

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -7,7 +7,7 @@ import { FileWatcher } from "../file/watcher"
 import { Instance } from "../project/instance"
 import { Patch } from "../patch"
 import { createTwoFilesPatch, diffLines } from "diff"
-import { assertExternalDirectory } from "./external-directory"
+import { assertExternalDirectory, editPermissionPattern } from "./external-directory"
 import { trimDiff } from "./edit"
 import { LSP } from "../lsp"
 import { Filesystem } from "../util/filesystem"
@@ -172,13 +172,13 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
     }))
 
     // Check permissions if needed
-    const relativePaths = fileChanges.map((c) => path.relative(Instance.worktree, c.filePath).replaceAll("\\", "/"))
+    const editPatterns = fileChanges.map((change) => editPermissionPattern(change.filePath))
     await ctx.ask({
       permission: "edit",
-      patterns: relativePaths,
+      patterns: editPatterns,
       always: ["*"],
       metadata: {
-        filepath: relativePaths.join(", "),
+        filepath: editPatterns.join(", "),
         diff: totalDiff,
         files,
       },

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -16,7 +16,7 @@ import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot/service"
-import { assertExternalDirectory } from "./external-directory"
+import { assertExternalDirectory, editPermissionPattern } from "./external-directory"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 
@@ -63,7 +63,7 @@ export const EditTool = Tool.define("edit", {
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
         await ctx.ask({
           permission: "edit",
-          patterns: [path.relative(Instance.worktree, filePath)],
+          patterns: [editPermissionPattern(filePath)],
           always: ["*"],
           metadata: {
             filepath: filePath,
@@ -99,7 +99,7 @@ export const EditTool = Tool.define("edit", {
       )
       await ctx.ask({
         permission: "edit",
-        patterns: [path.relative(Instance.worktree, filePath)],
+        patterns: [editPermissionPattern(filePath)],
         always: ["*"],
         metadata: {
           filepath: filePath,

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -30,3 +30,10 @@ export async function assertExternalDirectory(ctx: Tool.Context, target?: string
     },
   })
 }
+
+export function editPermissionPattern(target: string) {
+  if (Instance.containsPath(target)) {
+    return path.relative(Instance.worktree, target).replaceAll("\\", "/")
+  }
+  return path.resolve(target).replaceAll("\\", "/")
+}

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,7 +11,7 @@ import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
-import { assertExternalDirectory } from "./external-directory"
+import { assertExternalDirectory, editPermissionPattern } from "./external-directory"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
@@ -33,7 +33,7 @@ export const WriteTool = Tool.define("write", {
     const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
     await ctx.ask({
       permission: "edit",
-      patterns: [path.relative(Instance.worktree, filepath)],
+      patterns: [editPermissionPattern(filepath)],
       always: ["*"],
       metadata: {
         filepath,

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -325,6 +325,40 @@ describe("tool.edit", () => {
         },
       })
     })
+
+    test("uses absolute edit permission pattern for external files", async () => {
+      await using tmp = await tmpdir()
+      const outsideFile = path.resolve(tmp.path, "..", "opencode-edit-permission-test.txt")
+      await fs.writeFile(outsideFile, "old", "utf-8")
+      const requests: any[] = []
+      const askCtx = {
+        ...ctx,
+        ask: async (req: any) => {
+          requests.push(req)
+        },
+      }
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await FileTime.read(ctx.sessionID, outsideFile)
+
+          const edit = await EditTool.init()
+          await edit.execute(
+            {
+              filePath: outsideFile,
+              oldString: "old",
+              newString: "new",
+            },
+            askCtx,
+          )
+        },
+      })
+
+      const editRequest = requests.find((req) => req.permission === "edit")
+      expect(editRequest).toBeDefined()
+      expect(editRequest.patterns).toEqual([outsideFile.replaceAll("\\", "/")])
+    })
   })
 
   describe("edge cases", () => {

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -148,6 +148,36 @@ describe("tool.write", () => {
   })
 
   describe("file permissions", () => {
+    test("uses absolute edit permission pattern for external files", async () => {
+      await using tmp = await tmpdir()
+      const outsideFile = path.resolve(tmp.path, "..", `opencode-write-permission-test-${Date.now()}.txt`)
+      const requests: any[] = []
+      const askCtx = {
+        ...ctx,
+        ask: async (req: any) => {
+          requests.push(req)
+        },
+      }
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const write = await WriteTool.init()
+          await write.execute(
+            {
+              filePath: outsideFile,
+              content: "outside content",
+            },
+            askCtx,
+          )
+        },
+      })
+
+      const editRequest = requests.find((req) => req.permission === "edit")
+      expect(editRequest).toBeDefined()
+      expect(editRequest.patterns).toEqual([outsideFile.replaceAll("\\", "/")])
+    })
+
     test("sets file permissions when writing sensitive data", async () => {
       await using tmp = await tmpdir()
       const filepath = path.join(tmp.path, "sensitive.json")


### PR DESCRIPTION
## Summary
- normalize edit permission patterns so files inside the worktree stay relative while files outside remain absolute paths
- apply the same permission pattern strategy to `edit`, `write`, and `apply_patch` tool flows so permission prompts match the real target location
- add regression tests for external-file edit/write permission requests

## Validation
- bun test test/tool/edit.test.ts test/tool/write.test.ts
- bun typecheck