### PR TITLE
fix(provider): add Anthropic 200K+ overflow pattern

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -23,6 +23,7 @@ export namespace ProviderError {
     /request entity too large/i, // HTTP 413
     /context length is only \d+ tokens/i, // vLLM
     /input length.*exceeds.*context length/i, // vLLM
+    /extra usage is required for long context/i, // Anthropic billing_error for 200K+ overflow
   ]
 
   function isOpenAiErrorRetryable(e: APICallError) {


### PR DESCRIPTION
## Problem

When Anthropic context exceeds 200K tokens, the API returns:
- HTTP 403 `billing_error`
- Message: "Extra usage is required for long context requests"

Currently, `provider/error.ts` `OVERFLOW_PATTERNS` doesn't match this message, so it's classified as retryable `api_error` instead of `context_overflow`. This causes infinite retry loops instead of triggering compaction.

## Solution

Add pattern to `OVERFLOW_PATTERNS`:
```typescript
/extra usage is required for long context/i, // Anthropic billing_error for 200K+ overflow
```

## Testing

- ✅ Pattern matches actual error message
- ✅ Built and verified locally (92MB binary)
- ✅ Deployed on macOS (opencode 1.3.0)
- ✅ Services restarted successfully

## Related

- Previous attempt: PR #17766 (closed, not merged)
- Issue: ISS-0583 (local tracking)