### PR TITLE
fix(opencode): prefer direct OpenAI API keys over OAuth auth

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1074,9 +1074,12 @@ export namespace Provider {
 
       const auth = await Auth.get(providerID)
       if (!auth) continue
+      const cfgKey = config.provider?.[providerID]?.options?.apiKey
+      const hasKey = Boolean(providers[providerID]?.key || cfgKey)
       if (!plugin.auth.loader) continue
 
       if (auth) {
+        if (auth.type === "oauth" && hasKey) continue
         const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
         const opts = options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test"
 import path from "path"
 
 import { tmpdir } from "../fixture/fixture"
+import { Auth } from "../../src/auth"
 import { Instance } from "../../src/project/instance"
 import { Provider } from "../../src/provider/provider"
 import { ProviderID, ModelID } from "../../src/provider/schema"
@@ -1015,6 +1016,89 @@ test("multiple providers can be configured simultaneously", async () => {
       expect(providers[ProviderID.openai].options.timeout).toBe(60000)
     },
   })
+})
+
+test("openai env key takes precedence over oauth auth", async () => {
+  await Auth.remove("openai")
+  await Auth.set("openai", {
+    type: "oauth",
+    access: "test-access",
+    refresh: "test-refresh",
+    expires: Date.now() + 60_000,
+  })
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("OPENAI_API_KEY", "test-openai-key")
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const openai = providers[ProviderID.openai]
+        expect(openai).toBeDefined()
+        expect(openai.key).toBe("test-openai-key")
+        expect(openai.options.apiKey).toBeUndefined()
+        expect(openai.options.fetch).toBeUndefined()
+      },
+    })
+  } finally {
+    await Auth.remove("openai")
+  }
+})
+
+test("openai config apiKey takes precedence over oauth auth", async () => {
+  await Auth.remove("openai")
+  await Auth.set("openai", {
+    type: "oauth",
+    access: "test-access",
+    refresh: "test-refresh",
+    expires: Date.now() + 60_000,
+  })
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              openai: {
+                options: {
+                  apiKey: "config-openai-key",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const openai = providers[ProviderID.openai]
+        expect(openai).toBeDefined()
+        expect(openai.options.apiKey).toBe("config-openai-key")
+        expect(openai.options.fetch).toBeUndefined()
+      },
+    })
+  } finally {
+    await Auth.remove("openai")
+  }
 })
 
 test("provider with custom npm package", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #18862

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `openai` has stale OAuth auth stored, opencode still applies the Codex OAuth plugin loader even if the user is explicitly using a direct OpenAI API key via `OPENAI_API_KEY` or `provider.openai.options.apiKey`. This hijacks the normal OpenAI provider path by injecting the OAuth dummy API key and OAuth fetch override into `provider.options`, making the OpenAI provider unusable for direct API-key users.

The fix checks whether the provider already has an explicit direct API key source (`provider.key` from env, or `config.provider[providerID].options.apiKey`) before running the OAuth plugin loader. If a direct key exists, the OAuth loader is skipped.

Changes:
- `packages/opencode/src/provider/provider.ts`: Add `hasKey` check in the plugin auth loop; skip OAuth loader when direct key is present
- `packages/opencode/test/provider/provider.test.ts`: Add two regression tests for env key and config apiKey precedence over OAuth auth

### How did you verify your code works?

- `bun test test/provider/provider.test.ts` — 72 pass, 0 fail
- `bun test test/provider/provider.test.ts -t "openai env key takes precedence over oauth auth"` — pass
- `bun test test/provider/provider.test.ts -t "openai config apiKey takes precedence over oauth auth"` — pass
- `bun test test/session/llm.test.ts -t "sends responses API payload for OpenAI models"` — pass
- `bun typecheck` — clean

### Screenshots / recordings

N/A (backend fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR