### PR TITLE
feat(opencode): add ast_grep and ast_edit tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -324,6 +324,7 @@
         "@ai-sdk/togetherai": "1.0.34",
         "@ai-sdk/vercel": "1.0.33",
         "@ai-sdk/xai": "2.0.51",
+        "@ast-grep/napi": "0.42.0",
         "@aws-sdk/credential-providers": "3.993.0",
         "@clack/prompts": "1.0.0-alpha.1",
         "@effect/platform-node": "catalog:",
@@ -713,6 +714,26 @@
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 
     "@anycable/core": ["@anycable/core@0.9.2", "", { "dependencies": { "nanoevents": "^7.0.1" } }, "sha512-x5ZXDcW/N4cxWl93CnbHs/u7qq4793jS2kNPWm+duPrXlrva+ml2ZGT7X9tuOBKzyIHf60zWCdIK7TUgMPAwXA=="],
+
+    "@ast-grep/napi": ["@ast-grep/napi@0.42.0", "", { "optionalDependencies": { "@ast-grep/napi-darwin-arm64": "0.42.0", "@ast-grep/napi-darwin-x64": "0.42.0", "@ast-grep/napi-linux-arm64-gnu": "0.42.0", "@ast-grep/napi-linux-arm64-musl": "0.42.0", "@ast-grep/napi-linux-x64-gnu": "0.42.0", "@ast-grep/napi-linux-x64-musl": "0.42.0", "@ast-grep/napi-win32-arm64-msvc": "0.42.0", "@ast-grep/napi-win32-ia32-msvc": "0.42.0", "@ast-grep/napi-win32-x64-msvc": "0.42.0" } }, "sha512-f3DAjeC657EqbWN2In+girgbpvnKMV77bONyhuezXK4XQtvbGCB55u3CnNvQv6EP0caIBTtDHqO5CVyO6qY4LQ=="],
+
+    "@ast-grep/napi-darwin-arm64": ["@ast-grep/napi-darwin-arm64@0.42.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HOPvjsrsASvfkRJGCd/++KZvfDCtBx6v8DKTEzzlc6fQJlhiRMPKe8T4d5I2T2rgV5pHsyJLSBLqEK7m346NTw=="],
+
+    "@ast-grep/napi-darwin-x64": ["@ast-grep/napi-darwin-x64@0.42.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-q3jt+a6kDbXgbCSuIqaxjgLbTCDYGE2yb1o6metpsGbW+xVZR4ATYMJ8izyYhn2sQungTfUNn2/vo/2Bhbvpxg=="],
+
+    "@ast-grep/napi-linux-arm64-gnu": ["@ast-grep/napi-linux-arm64-gnu@0.42.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+e2ThyRiBZATlcdgfrD7uYy9oWVS6/AdUTnC3xOwR+lCz80lr87kmcmeK6XN6hBwaqncBBkKV3ECMA8ibZPUZA=="],
+
+    "@ast-grep/napi-linux-arm64-musl": ["@ast-grep/napi-linux-arm64-musl@0.42.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-f/oW3KaHuOMuBkCcvI6R71xM9SvkdUVKHhbJEtBFo5D1j6CjY9ipWdjlk9mOJ2KLLM6uYdjjvkJkBPlPuFTukg=="],
+
+    "@ast-grep/napi-linux-x64-gnu": ["@ast-grep/napi-linux-x64-gnu@0.42.0", "", { "os": "linux", "cpu": "x64" }, "sha512-y9T/Tm6V6zkmcAJlWXUO0ACYLSlk5o5NVU+AYun7NzDWIM86Y3lnoDF5WxeZKonVoaGAnkCXVlNH8Tsr/NTQWw=="],
+
+    "@ast-grep/napi-linux-x64-musl": ["@ast-grep/napi-linux-x64-musl@0.42.0", "", { "os": "linux", "cpu": "x64" }, "sha512-t1PwL6YweDL63QDK3TC9QTKROcVgN4XoMxlp/zN2NYvCUM90mSvqh/Py/ouchzluHaqCzEeEp9089WFEDWwQOA=="],
+
+    "@ast-grep/napi-win32-arm64-msvc": ["@ast-grep/napi-win32-arm64-msvc@0.42.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-bxKLXF1JmU33BoJKrbWcGsG7Xmk2zCQaUjmeHrxhgBhg2w2zo3CSf5S6DOyOp13hefgLXBLn6oXNzXgqpX/+lA=="],
+
+    "@ast-grep/napi-win32-ia32-msvc": ["@ast-grep/napi-win32-ia32-msvc@0.42.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-+/XbHDN+558rXwB2BylWPHj/cczRGDKivToHS2120TGQePmUetspu93wltqzAD7SVJnBILc2sEK1T1/jutZEvw=="],
+
+    "@ast-grep/napi-win32-x64-msvc": ["@ast-grep/napi-win32-x64-msvc@0.42.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/5PTpk7EFuqwdJyKleX2gPztL5j73Nq/cdkEJQq1Fbx+ze+UM75JniW3D7J7WZygN58+EN9DAxpc2QOlK32urQ=="],
 
     "@astrojs/check": ["@astrojs/check@0.9.6", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.1", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -87,6 +87,7 @@
     "@ai-sdk/togetherai": "1.0.34",
     "@ai-sdk/vercel": "1.0.33",
     "@ai-sdk/xai": "2.0.51",
+    "@ast-grep/napi": "0.42.0",
     "@aws-sdk/credential-providers": "3.993.0",
     "@clack/prompts": "1.0.0-alpha.1",
     "@effect/platform-node": "catalog:",

--- a/packages/opencode/src/tool/ast.ts
+++ b/packages/opencode/src/tool/ast.ts
@@ -1,0 +1,93 @@
+import { Lang, parse, pattern, type NapiConfig, type SgNode } from "@ast-grep/napi"
+import path from "path"
+import z from "zod"
+import { Ripgrep } from "../file/ripgrep"
+import { Instance } from "../project/instance"
+import { Filesystem } from "../util/filesystem"
+
+export const AstLang = z.enum(["typescript", "tsx", "javascript", "jsx"])
+export type AstLang = z.infer<typeof AstLang>
+
+export type AstHit = {
+  path: string
+  line: number
+  text: string
+  mtime: number
+}
+
+const MAX_TEXT = 2000
+
+const langs = {
+  typescript: { lang: Lang.TypeScript, globs: ["*.ts"] },
+  tsx: { lang: Lang.Tsx, globs: ["*.tsx"] },
+  javascript: { lang: Lang.JavaScript, globs: ["*.js"] },
+  jsx: { lang: Lang.Tsx, globs: ["*.jsx"] },
+} as const satisfies Record<AstLang, { lang: Lang; globs: string[] }>
+
+export function langInfo(lang: AstLang) {
+  return langs[lang]
+}
+
+export function resolveTarget(input?: string) {
+  const next = input ?? Instance.directory
+  return path.isAbsolute(next) ? next : path.resolve(Instance.directory, next)
+}
+
+export function buildMatcher(lang: AstLang, input: string) {
+  try {
+    return pattern(langInfo(lang).lang, input.replaceAll("\r\n", "\n"))
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Invalid AST pattern: ${msg}`)
+  }
+}
+
+function snippet(input: string) {
+  const next = input.replace(/\r?\n/g, "\\n")
+  return next.length > MAX_TEXT ? next.slice(0, MAX_TEXT) + "..." : next
+}
+
+function nodeHit(file: string, mtime: number, node: SgNode) {
+  return {
+    path: file,
+    line: node.range().start.line + 1,
+    text: snippet(node.text()),
+    mtime,
+  }
+}
+
+async function scanFile(input: { file: string; lang: AstLang; matcher: NapiConfig; abort?: AbortSignal; mtime?: number }) {
+  input.abort?.throwIfAborted()
+  try {
+    const root = parse(langInfo(input.lang).lang, await Filesystem.readText(input.file))
+    const mtime = input.mtime ?? Filesystem.stat(input.file)?.mtime.getTime() ?? 0
+    return root.root().findAll(input.matcher).map((node) => nodeHit(input.file, mtime, node))
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to parse ${input.file}: ${msg}`)
+  }
+}
+
+async function scanDir(input: { path: string; lang: AstLang; matcher: NapiConfig; abort?: AbortSignal }) {
+  const out: AstHit[] = []
+  for await (const rel of Ripgrep.files({
+    cwd: input.path,
+    glob: langInfo(input.lang).globs,
+    signal: input.abort,
+  })) {
+    input.abort?.throwIfAborted()
+    const file = path.join(input.path, rel)
+    const stat = Filesystem.stat(file)
+    if (!stat?.isFile()) continue
+    out.push(...(await scanFile({ file, lang: input.lang, matcher: input.matcher, abort: input.abort, mtime: stat.mtime.getTime() })))
+  }
+  return out
+}
+
+export async function searchAst(input: { path: string; lang: AstLang; matcher: NapiConfig; abort?: AbortSignal }) {
+  const stat = Filesystem.stat(input.path)
+  if (!stat) throw new Error(`Path not found: ${input.path}`)
+  if (stat.isDirectory()) return scanDir(input)
+  if (!stat.isFile()) return []
+  return scanFile({ file: input.path, lang: input.lang, matcher: input.matcher, abort: input.abort, mtime: stat.mtime.getTime() })
+}

--- a/packages/opencode/src/tool/ast_edit.ts
+++ b/packages/opencode/src/tool/ast_edit.ts
@@ -1,0 +1,318 @@
+import { parse, type NapiConfig, type SgNode } from "@ast-grep/napi"
+import { diffLines, createTwoFilesPatch } from "diff"
+import path from "path"
+import z from "zod"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileTime } from "../file/time"
+import { FileWatcher } from "../file/watcher"
+import { LSP } from "../lsp"
+import { Instance } from "../project/instance"
+import { Filesystem } from "../util/filesystem"
+import { AstLang, buildMatcher, langInfo, resolveTarget, searchAst } from "./ast"
+import { trimDiff } from "./edit"
+import { assertExternalDirectory } from "./external-directory"
+import { Tool } from "./tool"
+
+import DESCRIPTION from "./ast_edit.txt"
+
+const MAX_DIAGNOSTICS_PER_FILE = 20
+const MAX_DIAGNOSTICS_FILES = 5
+const META = /\$\$\$[A-Z_][A-Z0-9_]*|\$[A-Z_][A-Z0-9_]*/g
+
+type Filediff = ReturnType<typeof filediff>
+type Diagnostics = Awaited<ReturnType<typeof LSP.diagnostics>>
+
+function normalizeLineEndings(text: string) {
+  return text.replaceAll("\r\n", "\n")
+}
+
+function detectLineEnding(text: string): "\n" | "\r\n" {
+  return text.includes("\r\n") ? "\r\n" : "\n"
+}
+
+function convertToLineEnding(text: string, ending: "\n" | "\r\n") {
+  if (ending === "\n") return text
+  return text.replaceAll("\n", "\r\n")
+}
+
+function rel(file: string) {
+  const next = path.relative(Instance.worktree, file).replaceAll("\\", "/")
+  return next || "."
+}
+
+function filediff(file: string, before: string, after: string) {
+  const out = {
+    file,
+    before,
+    after,
+    additions: 0,
+    deletions: 0,
+  }
+  for (const item of diffLines(before, after)) {
+    if (item.added) out.additions += item.count || 0
+    if (item.removed) out.deletions += item.count || 0
+  }
+  return out
+}
+
+function template(node: SgNode, input: string, src: string) {
+  return input.replace(META, (token) => {
+    if (token.startsWith("$$$")) {
+      const list = node.getMultipleMatches(token.slice(3))
+      if (list.length === 0) return token
+      const first = list[0].range()
+      const last = list[list.length - 1].range()
+      return src.slice(first.start.index, last.end.index)
+    }
+
+    return node.getMatch(token.slice(1))?.text() ?? token
+  })
+}
+
+function empty() {
+  return {
+    matches: 0,
+    files: 0,
+    diff: "",
+    filediff: undefined as Filediff | undefined,
+    filediffs: [] as Filediff[],
+    diagnostics: {} as Diagnostics,
+  }
+}
+
+async function rewrite(input: {
+  file: string
+  lang: AstLang
+  matcher: NapiConfig
+  rewrite: string
+  abort: AbortSignal
+}) {
+  input.abort.throwIfAborted()
+  const before = await Filesystem.readText(input.file)
+  const next = convertToLineEnding(normalizeLineEndings(input.rewrite), detectLineEnding(before))
+
+  try {
+    const root = parse(langInfo(input.lang).lang, before)
+    const nodes = root.root().findAll(input.matcher)
+    if (nodes.length === 0) {
+      return {
+        before,
+        after: before,
+        matches: 0,
+      }
+    }
+    const after = nodes[0].commitEdits(nodes.map((node) => node.replace(template(node, next, before))))
+    return {
+      before,
+      after: before.endsWith("\r\n") && !after.endsWith("\r\n") ? after + "\r\n" : before.endsWith("\n") && !after.endsWith("\n") ? after + "\n" : after,
+      matches: nodes.length,
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to rewrite ${input.file}: ${msg}`)
+  }
+}
+
+export const AstEditTool = Tool.define("ast_edit", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    pattern: z.string().describe("AST pattern to rewrite"),
+    rewrite: z.string().describe("Replacement template for the matched AST nodes"),
+    lang: AstLang.describe("Language to parse: typescript, tsx, javascript, or jsx"),
+    path: z.string().optional().describe("The file or directory to rewrite. Defaults to the current working directory."),
+  }),
+  async execute(params, ctx) {
+    if (!params.pattern) {
+      throw new Error("pattern is required")
+    }
+
+    const target = resolveTarget(params.path)
+    const stat = Filesystem.stat(target)
+    await assertExternalDirectory(ctx, target, { kind: stat?.isDirectory() ? "directory" : "file" })
+
+    const matcher = buildMatcher(params.lang, params.pattern)
+    const hits = await searchAst({
+      path: target,
+      lang: params.lang,
+      matcher,
+      abort: ctx.abort,
+    })
+
+    if (hits.length === 0) {
+      return {
+        title: rel(target),
+        metadata: empty(),
+        output: "No matches found",
+      }
+    }
+
+    const files = [...new Set(hits.map((item) => item.path))]
+    const plan: Array<{
+      file: string
+      relative: string
+      diff: string
+      filediff: ReturnType<typeof filediff>
+      before: string
+      after: string
+      matches: number
+    }> = []
+
+    for (const file of files) {
+      const item = await rewrite({
+        file,
+        lang: params.lang,
+        matcher,
+        rewrite: params.rewrite,
+        abort: ctx.abort,
+      })
+      if (item.before === item.after) continue
+
+      const diff = trimDiff(createTwoFilesPatch(file, file, normalizeLineEndings(item.before), normalizeLineEndings(item.after)))
+      await FileTime.read(ctx.sessionID, file)
+      plan.push({
+        file,
+        relative: rel(file),
+        diff,
+        filediff: filediff(file, item.before, item.after),
+        before: item.before,
+        after: item.after,
+        matches: item.matches,
+      })
+    }
+
+    if (plan.length === 0) {
+      return {
+        title: rel(target),
+        metadata: empty(),
+        output: "No changes applied",
+      }
+    }
+
+    const diff = plan.map((item) => item.diff).join("\n")
+
+    await ctx.ask({
+      permission: "edit",
+      patterns: plan.map((item) => item.relative),
+      always: ["*"],
+      metadata: {
+        filepath: plan.map((item) => item.relative).join(", "),
+        diff,
+        files: plan.map((item) => ({
+          filePath: item.file,
+          relativePath: item.relative,
+          diff: item.diff,
+          before: item.before,
+          after: item.after,
+          additions: item.filediff.additions,
+          deletions: item.filediff.deletions,
+        })),
+      },
+    })
+
+    const out: Array<{
+      file: string
+      relative: string
+      diff: string
+      filediff: ReturnType<typeof filediff>
+      matches: number
+    }> = []
+    for (const item of plan) {
+      await FileTime.withLock(item.file, async () => {
+        await FileTime.assert(ctx.sessionID, item.file)
+        const next = await rewrite({
+          file: item.file,
+          lang: params.lang,
+          matcher,
+          rewrite: params.rewrite,
+          abort: ctx.abort,
+        })
+        if (next.before === next.after) return
+
+        const diff = trimDiff(
+          createTwoFilesPatch(item.file, item.file, normalizeLineEndings(next.before), normalizeLineEndings(next.after)),
+        )
+        const filediffs = filediff(item.file, next.before, next.after)
+
+        await Filesystem.write(item.file, next.after)
+        await Bus.publish(File.Event.Edited, {
+          file: item.file,
+        })
+        await Bus.publish(FileWatcher.Event.Updated, {
+          file: item.file,
+          event: "change",
+        })
+        await FileTime.read(ctx.sessionID, item.file)
+
+        out.push({
+          file: item.file,
+          relative: item.relative,
+          diff,
+          filediff: filediffs,
+          matches: next.matches,
+        })
+      })
+    }
+
+    if (out.length === 0) {
+      return {
+        title: rel(target),
+        metadata: empty(),
+        output: "No changes applied",
+      }
+    }
+
+    await Promise.all(out.map((item) => LSP.touchFile(item.file, true)))
+    const diagnostics = await LSP.diagnostics()
+    const finalDiff = out.map((item) => item.diff).join("\n")
+    const filediffs = out.map((item) => item.filediff)
+    const matches = out.reduce((sum, item) => sum + item.matches, 0)
+
+    ctx.metadata({
+      metadata: {
+        matches,
+        files: out.length,
+        diff: finalDiff,
+        filediff: filediffs[0],
+        filediffs,
+        diagnostics,
+      },
+    })
+
+    const output = [`Applied AST rewrite to ${out.length} file${out.length === 1 ? "" : "s"} (${matches} matches).`, "", "Updated files:"]
+    for (const item of out) {
+      output.push(
+        `- ${item.relative} (${item.matches} matches, +${item.filediff.additions}/-${item.filediff.deletions})`,
+      )
+    }
+
+    let shown = 0
+    for (const item of out) {
+      if (shown >= MAX_DIAGNOSTICS_FILES) break
+      const file = Filesystem.normalizePath(item.file)
+      const errs = (diagnostics[file] ?? []).filter((entry) => entry.severity === 1)
+      if (errs.length === 0) continue
+      shown += 1
+      const list = errs.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+      const suffix = errs.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errs.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+      output.push("")
+      output.push(`LSP errors detected in ${item.relative}, please fix:`)
+      output.push(`<diagnostics file="${item.file}">`)
+      output.push(list.map(LSP.Diagnostic.pretty).join("\n") + suffix)
+      output.push(`</diagnostics>`)
+    }
+
+    return {
+      title: out.length === 1 ? out[0].relative : rel(target),
+      metadata: {
+        matches,
+        files: out.length,
+        diff: finalDiff,
+        filediff: filediffs[0],
+        filediffs,
+        diagnostics,
+      },
+      output: output.join("\n"),
+    }
+  },
+})

--- a/packages/opencode/src/tool/ast_edit.txt
+++ b/packages/opencode/src/tool/ast_edit.txt
@@ -1,0 +1,8 @@
+Structural code rewrite tool powered by AST matching.
+
+Usage:
+- Rewrite code using ast-grep patterns and rewrite templates instead of exact string matching.
+- Supports `typescript`, `tsx`, `javascript`, and `jsx`.
+- `pattern` finds the AST nodes to rewrite. `rewrite` is the replacement template and can reference metavariables from the pattern.
+- `path` can point to a file or directory. It defaults to the current working directory.
+- Use this tool for safe codemod-style edits where plain text replacement is too brittle.

--- a/packages/opencode/src/tool/ast_grep.ts
+++ b/packages/opencode/src/tool/ast_grep.ts
@@ -1,0 +1,86 @@
+import z from "zod"
+import { Tool } from "./tool"
+import DESCRIPTION from "./ast_grep.txt"
+import { assertExternalDirectory } from "./external-directory"
+import { AstLang, buildMatcher, resolveTarget, searchAst } from "./ast"
+import { Filesystem } from "../util/filesystem"
+
+const LIMIT = 100
+
+export const AstGrepTool = Tool.define("ast_grep", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    pattern: z.string().describe("AST pattern to search for"),
+    lang: AstLang.describe("Language to parse: typescript, tsx, javascript, or jsx"),
+    path: z.string().optional().describe("The file or directory to search in. Defaults to the current working directory."),
+  }),
+  async execute(params, ctx) {
+    if (!params.pattern) {
+      throw new Error("pattern is required")
+    }
+
+    await ctx.ask({
+      permission: "grep",
+      patterns: [params.pattern],
+      always: ["*"],
+      metadata: {
+        pattern: params.pattern,
+        lang: params.lang,
+        path: params.path,
+      },
+    })
+
+    const target = resolveTarget(params.path)
+    const stat = Filesystem.stat(target)
+    await assertExternalDirectory(ctx, target, { kind: stat?.isDirectory() ? "directory" : "file" })
+
+    const hits = await searchAst({
+      path: target,
+      lang: params.lang,
+      matcher: buildMatcher(params.lang, params.pattern),
+      abort: ctx.abort,
+    })
+
+    if (hits.length === 0) {
+      return {
+        title: params.pattern,
+        metadata: { matches: 0, files: 0, truncated: false },
+        output: "No files found",
+      }
+    }
+
+    hits.sort((a, b) => b.mtime - a.mtime || a.path.localeCompare(b.path) || a.line - b.line)
+
+    const truncated = hits.length > LIMIT
+    const list = truncated ? hits.slice(0, LIMIT) : hits
+    const files = new Set(hits.map((item) => item.path)).size
+    const out = [`Found ${hits.length} matches${truncated ? ` (showing first ${LIMIT})` : ""}`]
+
+    let file = ""
+    for (const item of list) {
+      if (file !== item.path) {
+        if (file !== "") out.push("")
+        file = item.path
+        out.push(`${item.path}:`)
+      }
+      out.push(`  Line ${item.line}: ${item.text}`)
+    }
+
+    if (truncated) {
+      out.push("")
+      out.push(
+        `(Results truncated: showing ${LIMIT} of ${hits.length} matches (${hits.length - LIMIT} hidden). Consider using a more specific path or pattern.)`,
+      )
+    }
+
+    return {
+      title: params.pattern,
+      metadata: {
+        matches: hits.length,
+        files,
+        truncated,
+      },
+      output: out.join("\n"),
+    }
+  },
+})

--- a/packages/opencode/src/tool/ast_grep.txt
+++ b/packages/opencode/src/tool/ast_grep.txt
@@ -1,0 +1,8 @@
+Structural code search tool powered by AST matching.
+
+Usage:
+- Search code structure using ast-grep patterns instead of regular expressions.
+- Supports `typescript`, `tsx`, `javascript`, and `jsx`.
+- Use metavariables like `$A` or `$$$ARGS` when you need wildcard structural matches.
+- `path` can point to a file or directory. It defaults to the current working directory.
+- Results include file paths, line numbers, and the matched code snippet.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -4,6 +4,8 @@ import { BashTool } from "./bash"
 import { EditTool } from "./edit"
 import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
+import { AstGrepTool } from "./ast_grep"
+import { AstEditTool } from "./ast_edit"
 import { BatchTool } from "./batch"
 import { ReadTool } from "./read"
 import { TaskTool } from "./task"
@@ -120,7 +122,9 @@ export namespace ToolRegistry {
           ReadTool,
           GlobTool,
           GrepTool,
+          AstGrepTool,
           EditTool,
+          AstEditTool,
           WriteTool,
           TaskTool,
           WebFetchTool,

--- a/packages/opencode/test/tool/ast_edit.test.ts
+++ b/packages/opencode/test/tool/ast_edit.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { AstEditTool } from "../../src/tool/ast_edit"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-ast-edit"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("tool.ast_edit", () => {
+  test("rewrites structural matches in a single file", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        const result = await tool.execute(
+          {
+            pattern: "console.log($A)",
+            rewrite: "logger.info($A)",
+            lang: "typescript",
+            path: path.join(tmp.path, "a.ts"),
+          },
+          ctx,
+        )
+
+        expect(result.metadata.matches).toBe(1)
+        expect(result.metadata.files).toBe(1)
+        expect(result.metadata.diff).toContain("logger.info(foo)")
+        expect(await Bun.file(path.join(tmp.path, "a.ts")).text()).toBe("logger.info(foo)\n")
+      },
+    })
+  })
+
+  test("rewrites matches across a directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\n`)
+        await Bun.write(path.join(dir, "b.ts"), `console.log(bar)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        const result = await tool.execute(
+          {
+            pattern: "console.log($A)",
+            rewrite: "logger.info($A)",
+            lang: "typescript",
+            path: tmp.path,
+          },
+          ctx,
+        )
+
+        expect(result.metadata.matches).toBe(2)
+        expect(result.metadata.files).toBe(2)
+        expect(result.output).toContain("Updated files:")
+        expect(await Bun.file(path.join(tmp.path, "a.ts")).text()).toBe("logger.info(foo)\n")
+        expect(await Bun.file(path.join(tmp.path, "b.ts")).text()).toBe("logger.info(bar)\n")
+      },
+    })
+  })
+
+  test("preserves original spacing for $$$NAME rewrites", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `foo(a, b)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        await tool.execute(
+          {
+            pattern: "foo($$$ARGS)",
+            rewrite: "bar($$$ARGS)",
+            lang: "typescript",
+            path: path.join(tmp.path, "a.ts"),
+          },
+          ctx,
+        )
+
+        expect(await Bun.file(path.join(tmp.path, "a.ts")).text()).toBe("bar(a, b)\n")
+      },
+    })
+  })
+
+  test("asks for edit and external_directory permissions outside the project", async () => {
+    await using outer = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\n`)
+      },
+    })
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+
+        await tool.execute(
+          {
+            pattern: "console.log($A)",
+            rewrite: "logger.info($A)",
+            lang: "typescript",
+            path: outer.path,
+          },
+          testCtx,
+        )
+
+        expect(requests.find((item) => item.permission === "edit")).toBeDefined()
+        const ext = requests.find((item) => item.permission === "external_directory")
+        expect(ext).toBeDefined()
+        expect(ext!.patterns).toContain(path.join(outer.path, "*").replaceAll("\\", "/"))
+      },
+    })
+  })
+
+  test("fails if the file changes after planning", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        const file = path.join(tmp.path, "a.ts")
+        const testCtx = {
+          ...ctx,
+          ask: async () => {
+            await Bun.write(file, `console.log(bar)\n`)
+          },
+        }
+
+        await expect(
+          tool.execute(
+            {
+              pattern: "console.log($A)",
+              rewrite: "logger.info($A)",
+              lang: "typescript",
+              path: file,
+            },
+            testCtx,
+          ),
+        ).rejects.toThrow("has been modified since it was last read")
+      },
+    })
+  })
+
+  test("returns no matches found when nothing changes", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `logger.info(foo)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstEditTool.init()
+        const result = await tool.execute(
+          {
+            pattern: "console.log($A)",
+            rewrite: "logger.info($A)",
+            lang: "typescript",
+            path: tmp.path,
+          },
+          ctx,
+        )
+
+        expect(result.metadata.matches).toBe(0)
+        expect(result.output).toBe("No matches found")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/ast_edit.test.ts
+++ b/packages/opencode/test/tool/ast_edit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { Permission } from "../../src/permission"
 import { Instance } from "../../src/project/instance"
 import { MessageID, SessionID } from "../../src/session/schema"
@@ -161,7 +162,11 @@ describe("tool.ast_edit", () => {
         const testCtx = {
           ...ctx,
           ask: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 20))
             await Bun.write(file, `console.log(bar)\n`)
+            const time = new Date(Date.now() + 2_000)
+            await fs.utimes(file, time, time)
+            await new Promise((resolve) => setTimeout(resolve, 20))
           },
         }
 

--- a/packages/opencode/test/tool/ast_grep.test.ts
+++ b/packages/opencode/test/tool/ast_grep.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { AstGrepTool } from "../../src/tool/ast_grep"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-ast-grep"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("tool.ast_grep", () => {
+  test("finds structural matches in a directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\nlogger.info(foo)\n`)
+        await Bun.write(path.join(dir, "b.ts"), `if (ok) console.log(bar)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstGrepTool.init()
+        const result = await tool.execute(
+          {
+            pattern: "console.log($A)",
+            lang: "typescript",
+            path: tmp.path,
+          },
+          ctx,
+        )
+
+        expect(result.metadata.matches).toBe(2)
+        expect(result.metadata.files).toBe(2)
+        expect(result.output).toContain("Line 1: console.log(foo)")
+        expect(result.output).toContain("Line 1: console.log(bar)")
+      },
+    })
+  })
+
+  test("returns no files found when there are no matches", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `logger.info(foo)\n`)
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstGrepTool.init()
+        const result = await tool.execute(
+          {
+            pattern: "console.log($A)",
+            lang: "typescript",
+            path: tmp.path,
+          },
+          ctx,
+        )
+
+        expect(result.metadata.matches).toBe(0)
+        expect(result.output).toBe("No files found")
+      },
+    })
+  })
+
+  test("asks for external_directory permission outside the project", async () => {
+    await using outer = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "a.ts"), `console.log(foo)\n`)
+      },
+    })
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const tool = await AstGrepTool.init()
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+
+        await tool.execute(
+          {
+            pattern: "console.log($A)",
+            lang: "typescript",
+            path: outer.path,
+          },
+          testCtx,
+        )
+
+        expect(requests.find((item) => item.permission === "grep")).toBeDefined()
+        const ext = requests.find((item) => item.permission === "external_directory")
+        expect(ext).toBeDefined()
+        expect(ext!.patterns).toContain(path.join(outer.path, "*").replaceAll("\\", "/"))
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -10,6 +10,19 @@ afterEach(async () => {
 })
 
 describe("tool.registry", () => {
+  test("includes builtin ast tools", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).toContain("ast_grep")
+        expect(ids).toContain("ast_edit")
+      },
+    })
+  })
+
   test("loads tools from .opencode/tool (singular)", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #18822

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds two new built-in tools for structural code operations:

- `ast_grep` for AST-based code search
- `ast_edit` for AST-based rewrites

Both tools support `typescript`, `tsx`, `javascript`, and `jsx`.

Implementation summary:
- added a shared AST helper layer for language mapping, pattern compilation, path resolution, and file scanning
- implemented `ast_grep` with grep-style output grouped by file, including line numbers and matched snippets
- implemented `ast_edit` with file and directory support, edit permissions, aggregated diff metadata, and LSP diagnostics reporting
- registered both tools in the built-in tool registry
- added tests for search, rewrite, permissions, and registry presence

Why this works:
- matching is done through `@ast-grep/napi`, so search and rewrite are structural rather than plain text
- directory scanning reuses the existing file discovery flow, which keeps behavior closer to current tool boundaries
- rewrites apply through AST node replacement instead of exact string replacement, which makes codemod-style edits more reliable
- `ast_edit` keeps the existing permission and external-directory validation model used by current tools

I also followed up with a small test-only fix to make the file-change planning test stable in CI by forcing a detectable timestamp change. This does not change the feature implementation.

### How did you verify your code works?

Tested locally with:

- `bun test test/tool/ast_grep.test.ts test/tool/ast_edit.test.ts`
- `bun typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR