### PR TITLE
fix(tui): handle null agent gracefully in TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -20,7 +20,7 @@ export function DialogAgent() {
   return (
     <DialogSelect
       title="Select agent"
-      current={local.agent.current().name}
+      current={local.agent.current()?.name ?? ""}
       options={options()}
       onSelect={(option) => {
         local.agent.set(option.value)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -541,6 +541,15 @@ export function Prompt(props: PromptProps) {
       promptModelWarning()
       return
     }
+    const currentAgent = local.agent.current()
+    if (!currentAgent) {
+      toast.show({
+        message: "No agent available. Check your agent configuration.",
+        variant: "warning",
+        duration: 3000,
+      })
+      return
+    }
 
     let sessionID = props.sessionID
     if (sessionID == null) {
@@ -591,7 +600,7 @@ export function Prompt(props: PromptProps) {
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
-        agent: local.agent.current().name,
+        agent: currentAgent.name,
         model: {
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
@@ -618,7 +627,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         command: command.slice(1),
         arguments: args,
-        agent: local.agent.current().name,
+        agent: currentAgent.name,
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,
         variant,
@@ -635,7 +644,7 @@ export function Prompt(props: PromptProps) {
           sessionID,
           ...selectedModel,
           messageID,
-          agent: local.agent.current().name,
+          agent: currentAgent.name,
           model: selectedModel,
           variant,
           parts: [
@@ -753,7 +762,7 @@ export function Prompt(props: PromptProps) {
   const highlight = createMemo(() => {
     if (keybind.leader) return theme.border
     if (store.mode === "shell") return theme.primary
-    return local.agent.color(local.agent.current().name)
+    return local.agent.color(local.agent.current()?.name ?? "")
   })
 
   const showVariant = createMemo(() => {
@@ -773,7 +782,7 @@ export function Prompt(props: PromptProps) {
   })
 
   const spinnerDef = createMemo(() => {
-    const color = local.agent.color(local.agent.current().name)
+    const color = local.agent.color(local.agent.current()?.name ?? "")
     return {
       frames: createFrames({
         color,
@@ -1012,7 +1021,11 @@ export function Prompt(props: PromptProps) {
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
               <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
+                {store.mode === "shell"
+                  ? "Shell"
+                  : local.agent.current()?.name
+                    ? Locale.titlecase(local.agent.current()!.name)
+                    : "No agent"}{" "}
               </text>
               <Show when={store.mode === "normal"}>
                 <box flexDirection="row" gap={1}>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -38,10 +38,22 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const agents = createMemo(() => sync.data.agent.filter((x) => x.mode !== "subagent" && !x.hidden))
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore<{
-        current: string
+        current: string | undefined
       }>({
-        current: agents()[0].name,
+        current: agents()[0]?.name,
       })
+
+      // Keep agentStore.current in sync with available agents
+      createEffect(() => {
+        const list = agents()
+        if (list.length === 0) {
+          if (agentStore.current !== undefined) setAgentStore("current", undefined)
+          return
+        }
+        if (list.some((x) => x.name === agentStore.current)) return
+        setAgentStore("current", list[0]?.name)
+      })
+
       const { theme } = useTheme()
       const colors = createMemo(() => [
         theme.secondary,
@@ -57,7 +69,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current)!
+          const list = agents()
+          if (list.length === 0) return undefined
+          return list.find((x) => x.name === agentStore.current) ?? list[0]
         },
         set(name: string) {
           if (!agents().some((x) => x.name === name))
@@ -70,10 +84,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         move(direction: 1 | -1) {
           batch(() => {
-            let next = agents().findIndex((x) => x.name === agentStore.current) + direction
-            if (next < 0) next = agents().length - 1
-            if (next >= agents().length) next = 0
-            const value = agents()[next]
+            const list = agents()
+            if (list.length === 0) return
+            let next = list.findIndex((x) => x.name === agentStore.current) + direction
+            if (next < 0) next = list.length - 1
+            if (next >= list.length) next = 0
+            const value = list[next]
             setAgentStore("current", value.name)
           })
         },
@@ -194,8 +210,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         const a = agent.current()
         return (
           getFirstValidModel(
-            () => modelStore.model[a.name],
-            () => a.model,
+            () => a && modelStore.model[a.name],
+            () => a?.model,
             fallbackModel,
           ) ?? undefined
         )
@@ -232,6 +248,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         cycle(direction: 1 | -1) {
           const current = currentModel()
           if (!current) return
+          const a = agent.current()
+          if (!a) return
           const recent = modelStore.recent
           const index = recent.findIndex((x) => x.providerID === current.providerID && x.modelID === current.modelID)
           if (index === -1) return
@@ -240,7 +258,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (next >= recent.length) next = 0
           const val = recent[next]
           if (!val) return
-          setModelStore("model", agent.current().name, { ...val })
+          setModelStore("model", a.name, { ...val })
         },
         cycleFavorite(direction: 1 | -1) {
           const favorites = modelStore.favorite.filter((item) => isModelValid(item))
@@ -253,6 +271,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             return
           }
           const current = currentModel()
+          const a = agent.current()
+          if (!a) return
           let index = -1
           if (current) {
             index = favorites.findIndex((x) => x.providerID === current.providerID && x.modelID === current.modelID)
@@ -266,7 +286,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           const next = favorites[index]
           if (!next) return
-          setModelStore("model", agent.current().name, { ...next })
+          setModelStore("model", a.name, { ...next })
           const uniq = uniqueBy([next, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
           if (uniq.length > 10) uniq.pop()
           setModelStore(
@@ -277,6 +297,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         set(model: { providerID: string; modelID: string }, options?: { recent?: boolean }) {
           batch(() => {
+            const a = agent.current()
+            if (!a) return
             if (!isModelValid(model)) {
               toast.show({
                 message: `Model ${model.providerID}/${model.modelID} is not valid`,
@@ -285,7 +307,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               })
               return
             }
-            setModelStore("model", agent.current().name, model)
+            setModelStore("model", a.name, model)
             if (options?.recent) {
               const uniq = uniqueBy([model, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
               if (uniq.length > 10) uniq.pop()
@@ -381,6 +403,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     // Automatically update model when agent changes
     createEffect(() => {
       const value = agent.current()
+      if (!value) return
       if (value.model) {
         if (isModelValid(value.model))
           model.set({


### PR DESCRIPTION
### Issue for this PR

Closes #16982

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the TUI crash when `local.agent.current()` is read while the visible agent list is empty or when the stored current agent is no longer valid.

Compared with #17015, this version also fixes the state management side of the bug:

- `agentStore.current` is now `string | undefined`
- initialization uses `agents()[0]?.name` instead of assuming an agent always exists
- `agent.current()` returns `undefined` only when the visible agent list is empty
- if the list is non-empty but the stored current agent is stale, it falls back to the first visible agent
- a sync `createEffect` keeps `agentStore.current` valid when the available agent list changes
- `move()` now handles an empty agent list safely

It also updates the TUI call sites to handle the missing-agent case gracefully:

- submit now exits early with a warning toast when no agent is available
- dialog and prompt UI use optional chaining / fallback values instead of assuming `.name` always exists
- fallback label is now `No agent`

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Verified the modified files compile cleanly after changing `agent.current()` to nullable behavior
- Reviewed all touched `agent.current()` call sites to ensure they now handle the missing-agent case safely

### Screenshots / recordings

Not included. This is a null-safety fix for a crash path rather than a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR