### PR TITLE
feat: add terminal-native TUI notifications

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -42,69 +42,9 @@ import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { TuiConfigProvider } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
-
-async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
-  // can't set raw mode if not a TTY
-  if (!process.stdin.isTTY) return "dark"
-
-  return new Promise((resolve) => {
-    let timeout: NodeJS.Timeout
-
-    const cleanup = () => {
-      process.stdin.setRawMode(false)
-      process.stdin.removeListener("data", handler)
-      clearTimeout(timeout)
-    }
-
-    const handler = (data: Buffer) => {
-      const str = data.toString()
-      const match = str.match(/\x1b]11;([^\x07\x1b]+)/)
-      if (match) {
-        cleanup()
-        const color = match[1]
-        // Parse RGB values from color string
-        // Formats: rgb:RR/GG/BB or #RRGGBB or rgb(R,G,B)
-        let r = 0,
-          g = 0,
-          b = 0
-
-        if (color.startsWith("rgb:")) {
-          const parts = color.substring(4).split("/")
-          r = parseInt(parts[0], 16) >> 8 // Convert 16-bit to 8-bit
-          g = parseInt(parts[1], 16) >> 8 // Convert 16-bit to 8-bit
-          b = parseInt(parts[2], 16) >> 8 // Convert 16-bit to 8-bit
-        } else if (color.startsWith("#")) {
-          r = parseInt(color.substring(1, 3), 16)
-          g = parseInt(color.substring(3, 5), 16)
-          b = parseInt(color.substring(5, 7), 16)
-        } else if (color.startsWith("rgb(")) {
-          const parts = color.substring(4, color.length - 1).split(",")
-          r = parseInt(parts[0])
-          g = parseInt(parts[1])
-          b = parseInt(parts[2])
-        }
-
-        // Calculate luminance using relative luminance formula
-        const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-
-        // Determine if dark or light based on luminance threshold
-        resolve(luminance > 0.5 ? "light" : "dark")
-      }
-    }
-
-    process.stdin.setRawMode(true)
-    process.stdin.on("data", handler)
-    process.stdout.write("\x1b]11;?\x07")
-
-    timeout = setTimeout(() => {
-      cleanup()
-      resolve("dark")
-    }, 1000)
-  })
-}
-
 import type { EventSource } from "./context/sdk"
 import { Installation } from "@/installation"
+import { Terminal } from "./util/terminal"
 
 export function tui(input: {
   url: string
@@ -120,7 +60,7 @@ export function tui(input: {
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
 
-    const mode = await getTerminalBackgroundColor()
+    const mode = await Terminal.getTerminalBackgroundColor()
 
     // Re-clear after getTerminalBackgroundColor() — setRawMode(false) restores
     // the original console mode which re-enables ENABLE_PROCESSED_INPUT.
@@ -257,6 +197,22 @@ function App() {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
+
+  const label = (sessionID: string) => {
+    const session = sync.session.get(sessionID)
+    if (!session || SessionApi.isDefaultTitle(session.title)) return sessionID
+    return session.title
+  }
+
+  const root = (sessionID: string) => {
+    const session = sync.session.get(sessionID)
+    if (!session) return true
+    return !session.parentID
+  }
+
+  const ping = (title: string, body: string) => {
+    Terminal.notify(title, body)
+  }
 
   createEffect(() => {
     console.log(JSON.stringify(route.data))
@@ -729,6 +685,36 @@ function App() {
       message,
       duration: 5000,
     })
+  })
+
+  sdk.event.on("session.status", (evt) => {
+    if (evt.properties.status.type !== "idle") return
+    if (!root(evt.properties.sessionID)) return
+    ping("OpenCode", label(evt.properties.sessionID))
+  })
+
+  sdk.event.on("session.error", (evt) => {
+    const id = evt.properties.sessionID
+    if (!id) return
+    if (!root(id)) return
+    const body = (() => {
+      if (!evt.properties.error) return label(id)
+      if (typeof evt.properties.error === "string") return evt.properties.error
+      if ("data" in evt.properties.error && evt.properties.error.data && "message" in evt.properties.error.data) {
+        return String(evt.properties.error.data.message)
+      }
+      return label(id)
+    })()
+    ping("OpenCode error", body)
+  })
+
+  sdk.event.on("permission.asked", (evt) => {
+    ping("OpenCode permission", `${label(evt.properties.sessionID)} needs approval`)
+  })
+
+  sdk.event.on("question.asked", (evt) => {
+    const body = evt.properties.questions[0]?.question ?? `${label(evt.properties.sessionID)} needs input`
+    ping("OpenCode question", body)
   })
 
   sdk.event.on("installation.update-available", async (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -1,7 +1,42 @@
 import { RGBA } from "@opentui/core"
 
 export namespace Terminal {
+  const ESC = "\u001b"
+  const BEL = "\u0007"
+
   export type Colors = Awaited<ReturnType<typeof colors>>
+
+  function wrap(sequence: string) {
+    if (!process.env["TMUX"] && !process.env["STY"]) return sequence
+    return `${ESC}Ptmux;${sequence.replaceAll(ESC, `${ESC}${ESC}`)}${ESC}\\`
+  }
+
+  function clean(value: string) {
+    return value.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim()
+  }
+
+  export function notify(title: string, body = "") {
+    if (!process.stdout.isTTY) return false
+
+    const kind = (() => {
+      if (process.env["TERM_PROGRAM"] === "ghostty" || process.env["GHOSTTY_RESOURCES_DIR"]) return "ghostty"
+      if (process.env["TERM_PROGRAM"] === "iTerm.app") return "osc9"
+      if (process.env["KITTY_PID"] || process.env["TERM"]?.includes("kitty")) return "osc9"
+      return
+    })()
+
+    if (!kind) return false
+
+    const x = clean(title)
+    const y = clean(body)
+    const seq = kind === "ghostty"
+      ? wrap(`${ESC}]777;notify;${x};${y}${BEL}`)
+      : wrap(`${ESC}]9;${clean([x, y].filter(Boolean).join(": "))}${BEL}`)
+
+    process.stdout.write(seq)
+    return true
+  }
+
   /**
    * Query terminal colors including background, foreground, and palette (0-15).
    * Uses OSC escape sequences to retrieve actual terminal color values.


### PR DESCRIPTION
## Issue for this PR

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

This adds terminal-native notifications to the OpenCode TUI for terminals that support them, mainly Ghostty, plus iTerm2 and Kitty-compatible OSC 9 notifications.

Before this change, OpenCode's web/desktop app could show notifications, but the TUI did not emit terminal-native notification escape sequences. That meant Ghostty could not attach the notification to the live terminal surface the way Claude Code does.

The change adds a shared `Terminal.notify()` helper and uses it from the TUI event stream for:
- session idle
- session errors
- permission prompts
- question prompts

For Ghostty it emits `OSC 777;notify;title;body`, and for iTerm2/Kitty it emits `OSC 9`. When running under tmux it wraps the sequence with tmux passthrough so the outer terminal can still receive it.

This should work because these terminals already support these escape sequences natively, and Ghostty ties its native notifications back to the terminal surface that emitted them.

## How did you verify your code works?

- ran `npm exec --yes bun@1.3.11 -- run typecheck` in `packages/opencode`
- push hook also ran the repo typecheck successfully before the branch was pushed
- verified the implementation against Ghostty and iTerm2 notification escape sequence docs/code paths during development

## Screenshots / recordings

Not included. This is a terminal notification change and I did not capture a recording.

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR