### PR TITLE
fix(session): stop replaying compaction recovery as user prompts

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -276,13 +276,14 @@ When constructing the summary, try to stick to this template:
           (input.overflow
             ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
             : "") +
-          "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+          "Resume the interrupted task from the compaction summary above. Do not generate a recap or summary unless the user explicitly asks for one. Ask for clarification only if you are blocked."
         await Session.updatePart({
           id: PartID.ascending(),
           messageID: continueMsg.id,
           sessionID: input.sessionID,
           type: "text",
           synthetic: true,
+          ignored: true,
           text,
           time: {
             start: Date.now(),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -650,12 +650,6 @@ export namespace MessageV2 {
             }
           }
 
-          if (part.type === "compaction") {
-            userMessage.parts.push({
-              type: "text",
-              text: "What did we do so far?",
-            })
-          }
           if (part.type === "subtask") {
             userMessage.parts.push({
               type: "text",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -654,10 +654,14 @@ export namespace SessionPrompt {
 
       // Build system prompt, adding structured output instruction if needed
       const skills = await SystemPrompt.skills(agent)
+      const notes = (lastUserMsg?.parts ?? []).filter(
+        (part): part is MessageV2.TextPart => part.type === "text" && part.synthetic === true && part.ignored === true,
+      )
       const system = [
         ...(await SystemPrompt.environment(model)),
         ...(skills ? [skills] : []),
         ...(await InstructionPrompt.system()),
+        ...(notes.length > 0 && notes.length === lastUserMsg?.parts.length ? notes.map((part) => part.text) : []),
       ]
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -194,7 +194,7 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
-  test("converts user text/file parts and injects compaction/subtask prompts", () => {
+  test("converts user text/file parts and omits compaction prompts", () => {
     const messageID = "m-user"
 
     const input: MessageV2.WithParts[] = [
@@ -260,7 +260,6 @@ describe("session.message-v2.toModelMessage", () => {
             filename: "img.png",
             data: "https://example.com/img.png",
           },
-          { type: "text", text: "What did we do so far?" },
           { type: "text", text: "The following tool was executed by the user" },
         ],
       },


### PR DESCRIPTION
### Issue for this PR

Closes #13838

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a compaction recovery bug where recovery state could be replayed back to the model as if it were a real user turn.

Before this change, compaction-related replay could introduce fake user-facing prompts such as `What did we do so far?`, and the auto-compaction continue path also created a synthetic user message. That made the next model turn look like the user was asking for a recap / continuation, which could trigger an unwanted summary instead of normal recovery.

This PR makes three small changes:

- stop serializing `compaction` parts into a fake user text prompt
- keep the auto-compaction recovery note, but mark it as ignored synthetic state instead of a visible user request
- lift that recovery note into system recovery context during prompt construction

This works because the model no longer sees compaction recovery as fresh user intent. It still gets the recovery instruction needed to continue after compaction, but that instruction is no longer shaped like a real user message.

### How did you verify your code works?

Tested locally with:

- `bun test test/session/message-v2.test.ts`
- `bun turbo typecheck`

I also checked the diff to make sure the change stayed limited to the compaction/replay path and did not alter unrelated message handling.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR