### PR TITLE
fix(provider): exclude codex-spark from reasoning.summary parameter

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -505,12 +505,13 @@ export namespace ProviderTransform {
           }
           return arr
         })
+        const openaiSupportsReasoningSummary = !id.includes("codex-spark")
         return Object.fromEntries(
           openaiEfforts.map((effort) => [
             effort,
             {
               reasoningEffort: effort,
-              reasoningSummary: "auto",
+              ...(openaiSupportsReasoningSummary ? { reasoningSummary: "auto" } : {}),
               include: ["reasoning.encrypted_content"],
             },
           ]),
@@ -794,7 +795,9 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
+        if (!input.model.api.id.includes("codex-spark")) {
+          result["reasoningSummary"] = "auto"
+        }
       }
 
       // Only set textVerbosity for non-chat gpt-5.x models


### PR DESCRIPTION
### Issue for this PR

Closes #18791

### Type of change

- [x] Bug fix

### What does this PR do?

`gpt-5.3-codex-spark` does not support the `reasoning.summary` parameter, but OpenCode unconditionally sets `reasoningSummary: "auto"` for all GPT-5 models. This causes an immediate API error:

```
Unsupported parameter: 'reasoning.summary' is not supported with the 'gpt-5.3-codex-spark' model.
```

This PR skips `reasoningSummary` for `codex-spark` models in two places:

1. **Variant definitions** (`transform.ts` `variants()`) — conditionally omit `reasoningSummary` from the effort variants
2. **Default provider options** (`transform.ts` `options()`) — skip setting `reasoningSummary` when the model ID contains `codex-spark`

### How did you verify your code works?

- Typecheck passes (all packages)
- The fix mirrors the existing exclusion pattern used for `gpt-5-pro` and `gpt-5-chat` in the same code paths
- Verified that the OpenAI API rejects `reasoning.summary` for codex-spark models (documented in issue and upstream `openai/codex#13009`)

### Screenshots / recordings

N/A — provider option change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR