### PR TITLE
docs(opencode): clarify edit tool read requirement

### DIFF
--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -1,7 +1,7 @@
 Performs exact string replacements in files. 
 
 Usage:
-- You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
+- Before editing an existing file, use your `Read` tool on that file first in the current conversation. This lets the edit verify the file has not changed since it was last read. Creating a new file with an empty `oldString` does not require a prior read.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: line number + colon + space (e.g., `1: `). Everything after that space is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.


### PR DESCRIPTION
### Issue for this PR

Closes #4406

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the `edit` tool description so it matches the current behavior. The note now makes it clear that existing files should be read before editing them, and that creating a new file with an empty `oldString` does not need a prior read.

### How did you verify your code works?

- `git diff --check`

### Screenshots / recordings

- N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
