### PR TITLE
docs(web): clarify Amazon Bedrock setup

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -158,8 +158,9 @@ Don't see a provider here? Submit a PR.
 
 To use Amazon Bedrock with OpenCode:
 
-1. Head over to the **Model catalog** in the Amazon Bedrock console and request
-   access to the models you want.
+1. Make sure the models you want are available in your AWS account and region.
+   Some AWS accounts still require requesting access from the **Model catalog**
+   before a model can be used.
 
    :::tip
    You need to have access to the model you want in Amazon Bedrock.
@@ -190,6 +191,12 @@ To use Amazon Bedrock with OpenCode:
    export AWS_PROFILE=my-dev-profile
    export AWS_REGION=us-east-1
    ```
+
+   :::tip
+   If your AWS credentials are already available through environment variables,
+   a named profile, SSO, IAM roles, or web identity, you can start OpenCode and
+   go straight to `/models` without running `/connect` first.
+   :::
 
    ***
 
@@ -250,7 +257,7 @@ To use Amazon Bedrock with OpenCode:
    #### Authentication Methods
    - **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`**: Create an IAM user and generate access keys in the AWS Console
    - **`AWS_PROFILE`**: Use named profiles from `~/.aws/credentials`. First configure with `aws configure --profile my-profile` or `aws sso login`
-   - **`AWS_BEARER_TOKEN_BEDROCK`**: Generate long-term API keys from the Amazon Bedrock console
+   - **`AWS_BEARER_TOKEN_BEDROCK`**: Generate long-term API keys from the Amazon Bedrock console. See [Amazon Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html)
    - **`AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN`**: For EKS IRSA (IAM Roles for Service Accounts) or other Kubernetes environments with OIDC federation. These environment variables are automatically injected by Kubernetes when using service account annotations.
 
    ***


### PR DESCRIPTION
### Issue for this PR

Closes #16576

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Clarifies the Amazon Bedrock setup docs in three small places: model availability, the Bedrock API key docs link, and when `/models` can be used directly without `/connect`.

### How did you verify your code works?

- `git diff --check`

### Screenshots / recordings

- N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
