### PR TITLE
docs(web): clarify GitHub token usage

### DIFF
--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -97,6 +97,15 @@ Or you can set it up manually.
     issues: write
   ```
 
+  :::note
+  `token` and `GITHUB_TOKEN` here only authenticate GitHub operations such as
+  comments, commits, and pull requests. They do not configure a model provider.
+
+  The `opencode github install` flow does not currently offer
+  `github-copilot` in its provider list, so set up the GitHub agent with a
+  provider that has its own API credentials available to the runner.
+  :::
+
   You can also use a [personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT) if preferred.
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #1341

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a short note to the GitHub docs to make the token usage boundary clearer. `token` and `GITHUB_TOKEN` are for GitHub operations, and the current `opencode github install` flow does not offer `github-copilot` in the provider list.

### How did you verify your code works?

- `git diff --check`

### Screenshots / recordings

- N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
