### PR TITLE
fix: route GitLab Duo Workflow prompts via flowConfig

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -45,6 +45,8 @@ import {
   VERSION as GITLAB_PROVIDER_VERSION,
   isWorkflowModel,
   discoverWorkflowModels,
+  GitLabWorkflowLanguageModel,
+  type AdditionalContext,
 } from "gitlab-ai-provider"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { GoogleAuth } from "google-auth-library"
@@ -54,6 +56,22 @@ import { ModelID, ProviderID } from "./schema"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
+  type WorkflowInput = {
+    additionalContext?: AdditionalContext[]
+    flowConfig?: unknown
+    flowConfigSchemaVersion?: string
+  }
+
+  function isWorkflow(model: Model) {
+    return model.providerID === "gitlab" && model.api.id.startsWith("duo-workflow-")
+  }
+
+  function applyWorkflow(model: GitLabWorkflowLanguageModel, input?: WorkflowInput) {
+    const opts = (model as unknown as { workflowOptions: WorkflowInput }).workflowOptions
+    opts.additionalContext = input?.additionalContext
+    opts.flowConfig = input?.flowConfig
+    opts.flowConfigSchemaVersion = input?.flowConfigSchemaVersion
+  }
 
   function shouldUseCopilotResponsesApi(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
@@ -557,10 +575,19 @@ export namespace Provider {
         async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string, options?: Record<string, any>) {
           if (modelID.startsWith("duo-workflow-")) {
             const workflowRef = options?.workflowRef as string | undefined
+            const additionalContext = Array.isArray(options?.additionalContext)
+              ? (options.additionalContext as AdditionalContext[])
+              : undefined
+            const flowConfig = options?.flowConfig
+            const flowConfigSchemaVersion =
+              typeof options?.flowConfigSchemaVersion === "string" ? options.flowConfigSchemaVersion : undefined
             // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
             const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
             const model = sdk.workflowChat(sdkModelID, {
               featureFlags,
+              ...(additionalContext ? { additionalContext } : {}),
+              ...(flowConfig ? { flowConfig } : {}),
+              ...(flowConfigSchemaVersion ? { flowConfigSchemaVersion } : {}),
             })
             if (workflowRef) {
               model.selectedModelRef = workflowRef
@@ -1340,17 +1367,35 @@ export namespace Provider {
     return info
   }
 
-  export async function getLanguage(model: Model): Promise<LanguageModelV2> {
+  export async function getLanguage(
+    model: Model,
+    input?: {
+      sessionID?: string
+      workflow?: WorkflowInput
+    },
+  ): Promise<LanguageModelV2> {
     const s = await state()
-    const key = `${model.providerID}/${model.id}`
-    if (s.models.has(key)) return s.models.get(key)!
+    const workflow = isWorkflow(model)
+    const key =
+      workflow && input?.sessionID ? `${model.providerID}/${model.id}/${input.sessionID}` : `${model.providerID}/${model.id}`
+    if (s.models.has(key)) {
+      const language = s.models.get(key)!
+      if (workflow && input?.workflow && language instanceof GitLabWorkflowLanguageModel) {
+        applyWorkflow(language, input.workflow)
+      }
+      return language
+    }
 
     const provider = s.providers[model.providerID]
     const sdk = await getSDK(model)
 
     try {
       const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, { ...provider.options, ...model.options })
+        ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
+            ...provider.options,
+            ...model.options,
+            ...(workflow && input?.workflow ? input.workflow : {}),
+          })
         : sdk.languageModel(model.api.id)
       s.models.set(key, language)
       return language

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -12,7 +12,7 @@ import {
   jsonSchema,
 } from "ai"
 import { mergeDeep, pipe } from "remeda"
-import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
+import { GitLabWorkflowLanguageModel, type AdditionalContext } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider/transform"
 import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
@@ -28,6 +28,36 @@ export namespace LLM {
   const log = Log.create({ service: "llm" })
   export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 
+  function isWorkflow(model: Provider.Model) {
+    return model.providerID === "gitlab" && model.api.id.startsWith("duo-workflow-")
+  }
+
+  function workflowOptions(input: StreamInput, system: string[]) {
+    const prompt = system.join("\n").trim()
+    return {
+      additionalContext: (input.context ?? [])
+        .filter((item) => item.content?.trim())
+        .map((item, i) => ({
+          ...item,
+          id: item.id ?? `${input.user.id}:${item.category}:${i}`,
+        })),
+      ...(prompt
+        ? {
+            flowConfig: {
+              prompts: [
+                {
+                  prompt_template: {
+                    system: prompt,
+                  },
+                },
+              ],
+            },
+            flowConfigSchemaVersion: "v1",
+          }
+        : {}),
+    }
+  }
+
   export type StreamInput = {
     user: MessageV2.User
     sessionID: string
@@ -35,6 +65,7 @@ export namespace LLM {
     agent: Agent.Info
     permission?: Permission.Ruleset
     system: string[]
+    context?: AdditionalContext[]
     abort: AbortSignal
     messages: ModelMessage[]
     small?: boolean
@@ -58,8 +89,7 @@ export namespace LLM {
       modelID: input.model.id,
       providerID: input.model.providerID,
     })
-    const [language, cfg, provider, auth] = await Promise.all([
-      Provider.getLanguage(input.model),
+    const [cfg, provider, auth] = await Promise.all([
       Config.get(),
       Provider.getProvider(input.model.providerID),
       Auth.get(input.model.providerID),
@@ -94,6 +124,17 @@ export namespace LLM {
       system.push(header, rest.join("\n"))
     }
 
+    const workflow = isWorkflow(input.model)
+    const language = await Provider.getLanguage(
+      input.model,
+      workflow
+        ? {
+            sessionID: input.sessionID,
+            workflow: workflowOptions(input, system),
+          }
+        : undefined,
+    )
+
     const variant =
       !input.small && input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
     const base = input.small
@@ -115,15 +156,17 @@ export namespace LLM {
 
     const messages = isOpenaiOauth
       ? input.messages
-      : [
-          ...system.map(
-            (x): ModelMessage => ({
-              role: "system",
-              content: x,
-            }),
-          ),
-          ...input.messages,
-        ]
+      : workflow
+        ? input.messages
+        : [
+            ...system.map(
+              (x): ModelMessage => ({
+                role: "system",
+                content: x,
+              }),
+            ),
+            ...input.messages,
+          ]
 
     const params = await Plugin.trigger(
       "chat.params",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -49,6 +49,7 @@ import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import type { AdditionalContext } from "gitlab-ai-provider"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -562,11 +563,14 @@ export namespace SessionPrompt {
       const agent = await Agent.get(lastUser.agent)
       const maxSteps = agent.steps ?? Infinity
       const isLastStep = step >= maxSteps
-      msgs = await insertReminders({
+      const workflow = isWorkflow(model)
+      const reminder = await insertReminders({
         messages: msgs,
         agent,
         session,
+        workflow,
       })
+      msgs = reminder.messages
 
       const processor = SessionProcessor.create({
         assistantMessage: (await Session.updateMessage({
@@ -632,13 +636,14 @@ export namespace SessionPrompt {
       }
 
       // Ephemerally wrap queued user messages with a reminder to stay on track
+      const extra: string[] = []
       if (step > 1 && lastFinished) {
         for (const msg of msgs) {
           if (msg.info.role !== "user" || msg.info.id <= lastFinished.id) continue
           for (const part of msg.parts) {
             if (part.type !== "text" || part.ignored || part.synthetic) continue
             if (!part.text.trim()) continue
-            part.text = [
+            const text = [
               "<system-reminder>",
               "The user sent the following message:",
               part.text,
@@ -646,6 +651,11 @@ export namespace SessionPrompt {
               "Please address this message and continue with your tasks.",
               "</system-reminder>",
             ].join("\n")
+            if (workflow) {
+              extra.push(text)
+              continue
+            }
+            part.text = text
           }
         }
       }
@@ -653,12 +663,19 @@ export namespace SessionPrompt {
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
       // Build system prompt, adding structured output instruction if needed
+      const env = await SystemPrompt.environment(model)
       const skills = await SystemPrompt.skills(agent)
-      const system = [
-        ...(await SystemPrompt.environment(model)),
-        ...(skills ? [skills] : []),
-        ...(await InstructionPrompt.system()),
-      ]
+      const rules = await InstructionPrompt.system()
+      const system = workflow ? [] : [...env, ...(skills ? [skills] : []), ...rules, ...reminder.system, ...extra]
+      const context: AdditionalContext[] = workflow
+        ? [
+            ...env.map((content) => ({ category: "os_information", content })),
+            ...(skills ? [{ category: "agent_context", content: skills }] : []),
+            ...rules.map((content) => ({ category: "user_rule", content })),
+            ...reminder.system.map((content) => ({ category: "agent_context", content })),
+            ...extra.map((content) => ({ category: "agent_context", content })),
+          ]
+        : []
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
@@ -671,6 +688,7 @@ export namespace SessionPrompt {
         abort,
         sessionID,
         system,
+        context,
         messages: [
           ...MessageV2.toModelMessages(msgs, model),
           ...(isLastStep
@@ -1355,34 +1373,52 @@ export namespace SessionPrompt {
     }
   }
 
-  async function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info; session: Session.Info }) {
+  function isWorkflow(model: Provider.Model) {
+    return model.providerID === "gitlab" && model.api.id.startsWith("duo-workflow-")
+  }
+
+  async function insertReminders(input: {
+    messages: MessageV2.WithParts[]
+    agent: Agent.Info
+    session: Session.Info
+    workflow: boolean
+  }) {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
-    if (!userMessage) return input.messages
+    const system: string[] = []
+    if (!userMessage) return { messages: input.messages, system }
 
     // Original logic when experimental plan mode is disabled
     if (!Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE) {
       if (input.agent.name === "plan") {
-        userMessage.parts.push({
-          id: PartID.ascending(),
-          messageID: userMessage.info.id,
-          sessionID: userMessage.info.sessionID,
-          type: "text",
-          text: PROMPT_PLAN,
-          synthetic: true,
-        })
+        if (input.workflow) {
+          system.push(PROMPT_PLAN)
+        } else {
+          userMessage.parts.push({
+            id: PartID.ascending(),
+            messageID: userMessage.info.id,
+            sessionID: userMessage.info.sessionID,
+            type: "text",
+            text: PROMPT_PLAN,
+            synthetic: true,
+          })
+        }
       }
       const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
       if (wasPlan && input.agent.name === "build") {
-        userMessage.parts.push({
-          id: PartID.ascending(),
-          messageID: userMessage.info.id,
-          sessionID: userMessage.info.sessionID,
-          type: "text",
-          text: BUILD_SWITCH,
-          synthetic: true,
-        })
+        if (input.workflow) {
+          system.push(BUILD_SWITCH)
+        } else {
+          userMessage.parts.push({
+            id: PartID.ascending(),
+            messageID: userMessage.info.id,
+            sessionID: userMessage.info.sessionID,
+            type: "text",
+            text: BUILD_SWITCH,
+            synthetic: true,
+          })
+        }
       }
-      return input.messages
+      return { messages: input.messages, system }
     }
 
     // New plan mode logic when flag is enabled
@@ -1393,18 +1429,22 @@ export namespace SessionPrompt {
       const plan = Session.plan(input.session)
       const exists = await Filesystem.exists(plan)
       if (exists) {
-        const part = await Session.updatePart({
-          id: PartID.ascending(),
-          messageID: userMessage.info.id,
-          sessionID: userMessage.info.sessionID,
-          type: "text",
-          text:
-            BUILD_SWITCH + "\n\n" + `A plan file exists at ${plan}. You should execute on the plan defined within it`,
-          synthetic: true,
-        })
-        userMessage.parts.push(part)
+        const text = BUILD_SWITCH + "\n\n" + `A plan file exists at ${plan}. You should execute on the plan defined within it`
+        if (input.workflow) {
+          system.push(text)
+        } else {
+          const part = await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: userMessage.info.id,
+            sessionID: userMessage.info.sessionID,
+            type: "text",
+            text,
+            synthetic: true,
+          })
+          userMessage.parts.push(part)
+        }
       }
-      return input.messages
+      return { messages: input.messages, system }
     }
 
     // Entering plan mode
@@ -1412,12 +1452,7 @@ export namespace SessionPrompt {
       const plan = Session.plan(input.session)
       const exists = await Filesystem.exists(plan)
       if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })
-      const part = await Session.updatePart({
-        id: PartID.ascending(),
-        messageID: userMessage.info.id,
-        sessionID: userMessage.info.sessionID,
-        type: "text",
-        text: `<system-reminder>
+      const text = `<system-reminder>
 Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
 
 ## Plan File Info:
@@ -1486,13 +1521,23 @@ This is critical - your turn should only end with either asking the user a quest
 **Important:** Use question tool to clarify requirements/approach, use plan_exit to request plan approval. Do NOT use question tool to ask "Is this plan okay?" - that's what plan_exit does.
 
 NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.
-</system-reminder>`,
-        synthetic: true,
-      })
-      userMessage.parts.push(part)
-      return input.messages
+</system-reminder>`
+      if (input.workflow) {
+        system.push(text)
+      } else {
+        const part = await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: userMessage.info.id,
+          sessionID: userMessage.info.sessionID,
+          type: "text",
+          text,
+          synthetic: true,
+        })
+        userMessage.parts.push(part)
+      }
+      return { messages: input.messages, system }
     }
-    return input.messages
+    return { messages: input.messages, system }
   }
 
   export const ShellInput = z.object({

--- a/packages/opencode/test/session/llm-gitlab-workflow.test.ts
+++ b/packages/opencode/test/session/llm-gitlab-workflow.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import path from "path"
+import type { ModelMessage } from "ai"
+import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
+import type { Agent } from "../../src/agent/agent"
+import { Env } from "../../src/env"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import type { MessageV2 } from "../../src/session/message-v2"
+import { LLM } from "../../src/session/llm"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(() => {
+  mock.restore()
+})
+
+function stream() {
+  return new ReadableStream({
+    start(ctrl) {
+      ctrl.enqueue({ type: "stream-start", warnings: [] })
+      ctrl.enqueue({
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+      })
+      ctrl.close()
+    },
+  })
+}
+
+function text(msg: ModelMessage) {
+  if (typeof msg.content === "string") return msg.content
+  if (!Array.isArray(msg.content)) return ""
+  return msg.content.filter((part) => part.type === "text").map((part) => part.text).join("\n")
+}
+
+function options(model: unknown) {
+  return (model as unknown as {
+    workflowOptions: {
+      additionalContext?: Array<{ category: string; id?: string; content?: string }>
+      flowConfig?: {
+        prompts?: Array<{
+          prompt_template?: {
+            system?: string
+          }
+        }>
+      }
+      flowConfigSchemaVersion?: string
+    }
+  }).workflowOptions
+}
+
+type WorkflowOptions = ReturnType<typeof options>
+
+describe("session.llm gitlab workflow", () => {
+  test("routes opencode system text through workflow context", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["gitlab"],
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("GITLAB_TOKEN", "test-token")
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const gitlab = providers[ProviderID.make("gitlab")]
+        gitlab.models["duo-workflow-sonnet-4-6"] = {
+          id: ModelID.make("duo-workflow-sonnet-4-6"),
+          providerID: ProviderID.make("gitlab"),
+          name: "Agent Platform (Claude Sonnet 4.6)",
+          family: "",
+          api: { id: "duo-workflow-sonnet-4-6", url: "https://gitlab.com", npm: "gitlab-ai-provider" },
+          status: "active",
+          headers: {},
+          options: { workflowRef: "claude_sonnet_4_6" },
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 200000, output: 64000 },
+          capabilities: {
+            temperature: false,
+            reasoning: true,
+            attachment: true,
+            toolcall: true,
+            input: { text: true, audio: false, image: true, video: false, pdf: true },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "",
+          variants: {},
+        }
+
+        const model = await Provider.getModel(ProviderID.make("gitlab"), ModelID.make("duo-workflow-sonnet-4-6"))
+        const sessionID = SessionID.make("session-test-workflow")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-workflow"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("gitlab"), modelID: model.id },
+        } satisfies MessageV2.User
+
+        let prompt: ModelMessage[] = []
+        let cfg: WorkflowOptions | undefined
+        spyOn(GitLabWorkflowLanguageModel.prototype, "doStream").mockImplementation(async function (
+          this: GitLabWorkflowLanguageModel,
+          opts,
+        ) {
+          prompt = opts.prompt
+          cfg = options(this)
+          return {
+            stream: stream(),
+          }
+        })
+
+        const result = await LLM.stream({
+          user,
+          sessionID,
+          model,
+          agent,
+          system: ["workflow note"],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of result.fullStream) {
+        }
+
+        expect(prompt.some((msg) => msg.role === "system")).toBe(false)
+        expect(prompt.some((msg) => msg.role === "assistant" && text(msg).includes("workflow note"))).toBe(false)
+        expect(prompt.some((msg) => msg.role === "user" && text(msg) === "Hello")).toBe(true)
+        expect(cfg?.flowConfig?.prompts?.[0]?.prompt_template?.system).toContain("workflow note")
+        expect(cfg?.flowConfigSchemaVersion).toBe("v1")
+      },
+    })
+  })
+
+  test("keeps plan reminders out of workflow user messages", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["gitlab"],
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("GITLAB_TOKEN", "test-token")
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const gitlab = providers[ProviderID.make("gitlab")]
+        gitlab.models["duo-workflow-sonnet-4-6"] = {
+          id: ModelID.make("duo-workflow-sonnet-4-6"),
+          providerID: ProviderID.make("gitlab"),
+          name: "Agent Platform (Claude Sonnet 4.6)",
+          family: "",
+          api: { id: "duo-workflow-sonnet-4-6", url: "https://gitlab.com", npm: "gitlab-ai-provider" },
+          status: "active",
+          headers: {},
+          options: { workflowRef: "claude_sonnet_4_6" },
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 200000, output: 64000 },
+          capabilities: {
+            temperature: false,
+            reasoning: true,
+            attachment: true,
+            toolcall: true,
+            input: { text: true, audio: false, image: true, video: false, pdf: true },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          release_date: "",
+          variants: {},
+        }
+
+        let prompt: ModelMessage[] = []
+        let cfg: WorkflowOptions | undefined
+        spyOn(GitLabWorkflowLanguageModel.prototype, "doStream").mockImplementation(async function (
+          this: GitLabWorkflowLanguageModel,
+          opts,
+        ) {
+          prompt = opts.prompt
+          cfg = options(this)
+          return {
+            stream: stream(),
+          }
+        })
+
+        const session = await Session.create({})
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "plan",
+          model: {
+            providerID: ProviderID.make("gitlab"),
+            modelID: ModelID.make("duo-workflow-sonnet-4-6"),
+          },
+          parts: [{ type: "text", text: "Draft a plan" }],
+        })
+
+        const user = prompt.filter((msg) => msg.role === "user").map(text).join("\n")
+        const note = "The user indicated that they do not want you to execute yet"
+
+        expect(user.includes(note)).toBe(false)
+        expect(cfg?.additionalContext?.some((item) => item.content?.includes(note))).toBe(true)
+        expect(cfg?.additionalContext?.every((item) => item.id)).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #18841

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes how OpenCode sends prompt/context to GitLab Duo Workflow models.

Before this change, workflow-specific reminder text could get mixed into the real user message, and OpenCode system prompt text was being treated like normal chat history instead of workflow configuration. That is the wrong shape for GitLab Duo Workflow / DWS and can lead to prompt conflicts or polluted user input.

This PR changes that flow in three places:

- In `session/prompt.ts`, workflow-only reminder/context is separated from normal user message assembly.
- In `session/llm.ts`, workflow requests now build `flowConfig.prompts[].prompt_template.system` and `additional_context` instead of injecting that content into chat messages.
- In `provider/provider.ts`, those workflow options are passed through to `sdk.workflowChat(...)`, and workflow model instances are scoped by session so workflow state does not leak across sessions.

Why this works:
- real user messages stay clean
- workflow system prompt is sent through the DWS workflow config path
- plan/build/reminder context is sent as `additional_context`
- non-workflow GitLab models keep the existing message flow

### How did you verify your code works?

I verified this locally with:

- `cd packages/opencode && bun test test/session/llm-gitlab-workflow.test.ts`
- `cd packages/opencode && bun test test/provider/gitlab-duo.test.ts`
- `bun typecheck`

The workflow-specific tests confirm:
- system text is routed through `flowConfig`
- plan reminders are not included in real user messages
- reminder/context content is sent through `additional_context`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR