### PR TITLE
fix(opencode): ignore invalid custom tui themes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme-parse.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/theme-parse.ts
@@ -1,0 +1,19 @@
+export type ParsedTheme = {
+  $schema?: string
+  defs?: Record<string, string | number>
+  theme: Record<string, unknown>
+}
+
+const required = ["primary", "secondary", "accent", "text", "textMuted", "background"] as const
+
+export function parseTheme(input: unknown): ParsedTheme | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return
+
+  const json = input as Record<string, unknown>
+  if (!json.theme || typeof json.theme !== "object" || Array.isArray(json.theme)) return
+
+  const theme = json.theme as Record<string, unknown>
+  if (required.some((key) => theme[key] === undefined)) return
+
+  return input as ParsedTheme
+}

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -42,6 +42,7 @@ import { createStore, produce } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { useTuiConfig } from "./tui-config"
+import { parseTheme } from "./theme-parse"
 
 type ThemeColors = {
   primary: RGBA
@@ -127,10 +128,10 @@ type Variant = {
   dark: HexColor | RefName
   light: HexColor | RefName
 }
-type ColorValue = HexColor | RefName | Variant | RGBA
+type ColorValue = HexColor | RefName | Variant | RGBA | number
 type ThemeJson = {
   $schema?: string
-  defs?: Record<string, HexColor | RefName>
+  defs?: Record<string, HexColor | RefName | number>
   theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
     selectedListItemText?: ColorValue
     backgroundMenu?: ColorValue
@@ -424,7 +425,9 @@ async function getCustomThemes() {
       symlink: true,
     })) {
       const name = path.basename(item, ".json")
-      result[name] = await Filesystem.readJson(item)
+      const theme = parseTheme(await Filesystem.readJson(item).catch(() => undefined))
+      if (!theme) continue
+      result[name] = theme as ThemeJson
     }
   }
   return result

--- a/packages/opencode/test/cli/tui/theme.test.ts
+++ b/packages/opencode/test/cli/tui/theme.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { parseTheme } from "../../../src/cli/cmd/tui/context/theme-parse"
+
+describe("theme parser", () => {
+  test("accepts schema-compliant theme files", () => {
+    expect(
+      parseTheme({
+        theme: {
+          primary: "#0A84FF",
+          secondary: "#BF5AF2",
+          accent: "#409CFF",
+          text: "#F5F5F7",
+          textMuted: "#98989E",
+          background: "none",
+        },
+      }),
+    ).toBeDefined()
+  })
+
+  test("ignores legacy flat theme files", () => {
+    expect(
+      parseTheme({
+        accent: "#409CFF",
+        background: "none",
+        border: "#3D3D41",
+        diff_added: "#30D158",
+        diff_modified: "#0A84FF",
+        diff_removed: "#FF453A",
+        foreground: "#F5F5F7",
+        muted: "#98989E",
+        name: "liquid-glass",
+        primary: "#0A84FF",
+        secondary: "#BF5AF2",
+        success: "#30D158",
+        warning: "#FFD60A",
+      }),
+    ).toBeUndefined()
+  })
+
+  test("ignores wrapped theme files missing required colors", () => {
+    expect(
+      parseTheme({
+        theme: {
+          primary: "#0A84FF",
+          secondary: "#BF5AF2",
+        },
+      }),
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #5151

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom theme files loaded from `themes/*.json` are currently trusted as if they already match the current theme schema. If an older flat theme file is present, TUI theme resolution crashes while trying to read `theme.theme`.

This change adds a small parser for custom theme files and only loads themes that include the required nested `theme` object and core color keys. Invalid theme files are skipped, so theme loading falls back to the built-in defaults instead of crashing the TUI.

### How did you verify your code works?

- Added a regression test covering valid theme files, legacy flat theme files, and wrapped theme files missing required keys
- Ran `bun test test/cli/tui/theme.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`

### Screenshots / recordings

_Not a UI layout change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR