### PR TITLE
test(opencode): cover negative read offsets

### DIFF
--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -304,6 +304,23 @@ describe("tool.read truncation", () => {
     })
   })
 
+  test("throws when offset is negative", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "short.txt"), "line1\nline2")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, "short.txt"), offset: -2 }, ctx)).rejects.toThrow(
+          "offset must be greater than or equal to 1",
+        )
+      },
+    })
+  })
+
   test("allows reading empty file at default offset", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #4398

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ReadTool.execute()` already rejects negative offsets, but there was no regression test covering that path. This PR adds the missing test so the behavior reported in #4398 stays locked in.

### How did you verify your code works?

- Added a regression test that calls `read.execute()` with a negative offset and asserts the tool throws the expected error
- Ran `bun test test/tool/read.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR