### PR TITLE
fix(tui): fit tui to show selected item when click up/down button in small windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -130,7 +130,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
 
   const dimensions = useTerminalDimensions()
-  const height = createMemo(() => Math.min(rows(), Math.floor(dimensions().height / 2) - 6))
+  const height = createMemo(() => Math.max(1, Math.min(rows(), Math.floor(dimensions().height / 2) - 6)))
 
   const selected = createMemo(() => flat()[store.selected])
 
@@ -162,14 +162,20 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     const option = selected()
     if (option) props.onMove?.(option)
     if (!scroll) return
-    const target = scroll.getChildren().find((child) => {
-      return child.id === JSON.stringify(selected()?.value)
-    })
-    if (!target) return
+    const id = JSON.stringify(selected()?.value)
+    const target = scroll.getChildren().find((child) => child.id === id)
+    if (!target) {
+      scroll.scrollChildIntoView(id)
+      return
+    }
     const y = target.y - scroll.y
     if (center) {
-      const centerOffset = Math.floor(scroll.height / 2)
-      scroll.scrollBy(y - centerOffset)
+      if (scroll.height > 0) {
+        const offset = Math.floor(scroll.height / 2)
+        scroll.scrollBy(y - offset)
+      } else {
+        scroll.scrollChildIntoView(id)
+      }
     } else {
       if (y >= scroll.height) {
         scroll.scrollBy(y - scroll.height + 1)

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -41,7 +41,7 @@ export function Dialog(
       alignItems="center"
       position="absolute"
       zIndex={3000}
-      paddingTop={dimensions().height / 4}
+      paddingTop={Math.max(1, Math.min(Math.floor(dimensions().height / 4), dimensions().height - 16))}
       left={0}
       top={0}
       backgroundColor={RGBA.fromInts(0, 0, 0, 150)}


### PR DESCRIPTION
### Issue for this PR
Closes #18876 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. file: `src/cli/cmd/tui/ui/dialog-select.tsx`, two fixes:

- Line 133, Added Math.max(1, ...) guard to the list height calculation. Previously, on a terminal with height ≤ 12, the formula floor(height/2) - 6 could produce 0 or negative values, making the scrollbox invisible. Now it always shows at least 1 row.
- Lines 160-189, Made moveTo more robust:
  - Uses scrollChildIntoView(id) as a fallback when scroll.getChildren() can't find the target element (handles nested/fragment children).
  - Guards against scroll.height <= 0 in the centering path — falls back to scrollChildIntoView instead of computing bad scroll offsets.
2. file: `src/cli/cmd/tui/ui/dialog.tsx`, one fix:
-  Line 38, Changed paddingTop={dimensions().height / 4} to paddingTop={Math.max(1, Math.min(floor(height/4), height - 16))}. On very small terminals (≤16 rows), the top padding shrinks so the dialog gets more vertical space. On normal-sized terminals, behavior is unchanged (height/4 is still used when height >= ~21).

3. Scope

- Since all dialog-based lists (models, commands, sessions, workspaces, themes, agents, providers, skills, MCP servers, stash, tags, timeline, fork) use the shared DialogSelect component, they all benefit from these fixes.

### How did you verify your code works?
I have run the command localy to verify

- bun typecheck
- tsgo --noEmit
- bun dev

### Screenshots / recordings

- normal window size

<img width="1604" height="428" alt="image" src="https://github.com/user-attachments/assets/f0693e8e-d7a8-41a8-a527-e72cb6126537" />

- small window size

<img width="1609" height="200" alt="image" src="https://github.com/user-attachments/assets/edfc46bb-69a5-4828-9897-dfd46a9f5616" />






### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
