### PR TITLE
fix(skill): discover project symlinked skills from repo root in worktrees

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -117,7 +117,7 @@ export namespace Skill {
   }
 
   // TODO: Migrate to Effect
-  const create = (discovery: Discovery.Interface, directory: string, worktree: string): Cache => {
+  const create = (discovery: Discovery.Interface, directory: string, worktree: string, project: string): Cache => {
     const state: State = {
       skills: {},
       dirs: new Set<string>(),
@@ -131,12 +131,26 @@ export namespace Skill {
           await scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
         }
 
-        for await (const root of Filesystem.up({
-          targets: EXTERNAL_DIRS,
-          start: directory,
-          stop: worktree,
-        })) {
-          await scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
+        const seen = new Set<string>()
+        const pull = async (start: string, stop: string, skip = false) => {
+          for await (const root of Filesystem.up({
+            targets: EXTERNAL_DIRS,
+            start,
+            stop,
+          })) {
+            const name = path.basename(root)
+            if (skip && seen.has(name)) continue
+            seen.add(name)
+            await scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
+          }
+        }
+
+        await pull(directory, worktree)
+
+        if (project !== worktree) {
+          const rel = path.relative(worktree, directory)
+          const root = rel.startsWith("..") ? project : path.join(project, rel)
+          await pull(root, project, true)
         }
       }
 
@@ -185,7 +199,9 @@ export namespace Skill {
     Effect.gen(function* () {
       const discovery = yield* Discovery.Service
       const state = yield* InstanceState.make(
-        Effect.fn("Skill.state")((ctx) => Effect.sync(() => create(discovery, ctx.directory, ctx.worktree))),
+        Effect.fn("Skill.state")((ctx) =>
+          Effect.sync(() => create(discovery, ctx.directory, ctx.worktree, ctx.project.worktree)),
+        ),
       )
 
       const ensure = Effect.fn("Skill.ensure")(function* () {

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun"
 import { afterEach, test, expect } from "bun:test"
 import { Skill } from "../../src/skill"
 import { Instance } from "../../src/project/instance"
@@ -187,6 +188,52 @@ description: A skill in the .claude/skills directory.
       expect(claudeSkill!.location).toContain(path.join(".claude", "skills", "claude-skill", "SKILL.md"))
     },
   })
+})
+
+test("discovers project skills from symlinked .claude/skills in worktree sandbox", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  const wt = path.join(tmp.path, "..", `${path.basename(tmp.path)}-skills-wt`)
+  const home = process.env.OPENCODE_TEST_HOME
+  process.env.OPENCODE_TEST_HOME = path.join(tmp.path, ".home")
+
+  try {
+    const real = path.join(tmp.path, "shared-skills", "linked-skill")
+    const link = path.join(tmp.path, ".claude", "skills")
+
+    await fs.mkdir(real, { recursive: true })
+    await fs.mkdir(path.dirname(link), { recursive: true })
+    await Bun.write(
+      path.join(real, "SKILL.md"),
+      `---
+name: linked-skill
+description: A project skill behind a symlink.
+---
+
+# Linked Skill
+`,
+    )
+    await fs.symlink(path.join(tmp.path, "shared-skills"), link, "dir")
+
+    await $`git worktree add ${wt} -b linked-skill-${Date.now()}`.cwd(tmp.path).quiet()
+
+    expect(await fs.lstat(link).then((x) => x.isSymbolicLink())).toBe(true)
+    expect(await fs.access(path.join(wt, ".claude")).then(() => true).catch(() => false)).toBe(false)
+
+    await Instance.provide({
+      directory: wt,
+      fn: async () => {
+        const skills = await Skill.all()
+        const skill = skills.find((item) => item.name === "linked-skill")
+
+        expect(skill).toBeDefined()
+        expect(skill!.location).toContain(path.join(".claude", "skills", "linked-skill", "SKILL.md"))
+      },
+    })
+  } finally {
+    process.env.OPENCODE_TEST_HOME = home
+    await $`git worktree remove --force ${wt}`.cwd(tmp.path).quiet().nothrow()
+  }
 })
 
 test("discovers global skills from ~/.claude/skills/ directory", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #18848

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes project-level skill discovery in git worktree sessions when `.claude/skills` is a symlink.

The bug was not in `Glob.scan`, since that path already uses `symlink: true`. The issue was that project-level external skills were only discovered by walking upward from the current session directory to `ctx.worktree`. In a git worktree session, `ctx.worktree` is the sandbox path rather than the main repo root, so if `.claude/skills` only exists in the main repo root, the scan never reaches that directory and the skill is not discovered.

This change keeps the existing sandbox scan and adds a fallback scan from the corresponding path in the main project worktree back to the repo root when the session is running in a worktree. That allows symlinked project-level skills to be discovered without changing the normal non-worktree path.

I also added a regression test that creates a real git worktree and verifies a skill behind a symlinked `.claude/skills` directory is discovered from the worktree session.

### How did you verify your code works?

I verified it locally with:

- `bun test test/skill/skill.test.ts`
- `bun test test/skill/discovery.test.ts`
- `bun typecheck`

I also confirmed the new regression test fails before the fix and passes after the fix.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR