### PR TITLE
fix(tui): reset leaked mouse tracking on startup

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -119,6 +119,11 @@ export function tui(input: {
   return new Promise<void>(async (resolve) => {
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
+    // If a previous process was killed externally (TerminateProcess on Windows,
+    // SIGKILL on POSIX), mouse tracking can be left enabled. Reset it before
+    // the renderer configures its own mouse state.
+    if (process.stdout.isTTY)
+      process.stdout.write("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
 
     const mode = await getTerminalBackgroundColor()
 


### PR DESCRIPTION
### Issue for this PR

Closes #18901

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the TUI is force-killed externally (`taskkill /F` on Windows, `kill -9` on POSIX), for instance when installing OpenCode Desktop while OpenCode CLI is running, mouse tracking stays enabled in the terminal. The next `opencode` launch inherits this dirty state because the renderer starts from whatever baseline the terminal is already in.

This sends `?1000l ?1002l ?1003l ?1006l` on startup to clear any leaked mouse modes before the renderer sets up its own. Disabling already-disabled modes is a safe no-op.

### How did you verify your code works?

- Launch on Windows Terminal, `taskkill /F /PID`, relaunch — terminal is clean
- Normal exit (`/exit`) — no change in behavior
- Ctrl+C exit — no change in behavior

### Screenshots / recordings

_N/A — not a UI change, terminal state fix._
Screenshot of the issue:
<img width="1207" height="653" alt="SCR-20260324-hxjd" src="https://github.com/user-attachments/assets/9d121a99-ece1-4b71-9389-a1d886cd3b96" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR