### PR TITLE
feat(opencode): support wildcard matching in agent config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -20,6 +20,7 @@ import { Global } from "@/global"
 import path from "path"
 import { Plugin } from "@/plugin"
 import { Skill } from "../skill"
+import { Wildcard } from "@/util/wildcard"
 
 export namespace Agent {
   export const Info = z
@@ -203,20 +204,22 @@ export namespace Agent {
       },
     }
 
-    for (const [key, value] of Object.entries(cfg.agent ?? {})) {
+    const entries = Object.entries(cfg.agent ?? {})
+    const wild = (key: string) => key.includes("*") || key.includes("?")
+    const make = (key: string) => ({
+      name: key,
+      mode: "all" as const,
+      permission: Permission.merge(defaults, user),
+      options: {},
+      native: false,
+    })
+    const apply = (key: string, value: (typeof entries)[number][1], base?: Record<string, Info>) => {
       if (value.disable) {
         delete result[key]
-        continue
+        return
       }
       let item = result[key]
-      if (!item)
-        item = result[key] = {
-          name: key,
-          mode: "all",
-          permission: Permission.merge(defaults, user),
-          options: {},
-          native: false,
-        }
+      if (!item) item = result[key] = base?.[key] ? structuredClone(base[key]) : make(key)
       if (value.model) item.model = Provider.parseModel(value.model)
       item.variant = value.variant ?? item.variant
       item.prompt = value.prompt ?? item.prompt
@@ -230,6 +233,22 @@ export namespace Agent {
       item.steps = value.steps ?? item.steps
       item.options = mergeDeep(item.options, value.options ?? {})
       item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
+    }
+    const exact = entries.filter(([key]) => !wild(key))
+    const glob = entries.filter(([key]) => wild(key))
+
+    for (const [key, value] of exact) apply(key, value)
+
+    if (glob.length) {
+      const base = Object.fromEntries(Object.entries(result).map(([key, value]) => [key, structuredClone(value)]))
+      const names = Object.keys(base)
+      for (const [key, value] of glob) {
+        for (const name of names) {
+          if (!Wildcard.match(name, key)) continue
+          apply(name, value, base)
+        }
+      }
+      for (const [key, value] of exact) apply(key, value, base)
     }
 
     // Ensure Truncate.GLOB is allowed unless explicitly configured

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, test, expect } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
@@ -9,6 +10,18 @@ import { Permission } from "../../src/permission"
 function evalPerm(agent: Agent.Info | undefined, permission: string): Permission.Action | undefined {
   if (!agent) return undefined
   return Permission.evaluate(permission, "*", agent.permission).action
+}
+
+async function seed(dir: string, name: string) {
+  const file = path.join(dir, ".opencode", "agents", `${name}.md`)
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  await Bun.write(
+    file,
+    `---
+mode: subagent
+---
+${name} prompt`,
+  )
 }
 
 afterEach(async () => {
@@ -176,6 +189,210 @@ test("custom agent config overrides native agent properties", async () => {
       expect(build?.temperature).toBe(0.7)
       expect(build?.color).toBe("#FF0000")
       expect(build?.native).toBe(true)
+    },
+  })
+})
+
+test("wildcard agent config matches nested agents without creating literal wildcard agents", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        "researcher/*": {
+          model: "anthropic/claude-opus-4.6",
+          description: "Wildcard researcher",
+          options: {
+            scope: {
+              remote: true,
+            },
+          },
+          permission: {
+            bash: "deny",
+          },
+        },
+      },
+    },
+    init: async (dir) => {
+      await seed(dir, "researcher/agent-a")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const item = await Agent.get("researcher/agent-a")
+      expect(item).toBeDefined()
+      expect(String(item?.model?.providerID)).toBe("anthropic")
+      expect(String(item?.model?.modelID)).toBe("claude-opus-4.6")
+      expect(item?.description).toBe("Wildcard researcher")
+      expect(item?.options.scope).toEqual({ remote: true })
+      expect(evalPerm(item, "bash")).toBe("deny")
+      expect(await Agent.get("researcher/*")).toBeUndefined()
+      expect((await Agent.list()).map((item) => item.name)).not.toContain("researcher/*")
+    },
+  })
+})
+
+test("exact agent config overrides wildcard fields for nested agents", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        "researcher/agent-a": {
+          model: "openai/gpt-4",
+          options: {
+            scope: {
+              local: true,
+            },
+          },
+        },
+        "researcher/*": {
+          model: "anthropic/claude-opus-4.6",
+          description: "Wildcard researcher",
+          options: {
+            scope: {
+              remote: true,
+            },
+          },
+          permission: {
+            bash: "deny",
+          },
+        },
+      },
+    },
+    init: async (dir) => {
+      await seed(dir, "researcher/agent-a")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const item = await Agent.get("researcher/agent-a")
+      expect(item).toBeDefined()
+      expect(String(item?.model?.providerID)).toBe("openai")
+      expect(String(item?.model?.modelID)).toBe("gpt-4")
+      expect(item?.description).toBe("Wildcard researcher")
+      expect(item?.options.scope).toEqual({
+        local: true,
+        remote: true,
+      })
+      expect(evalPerm(item, "bash")).toBe("deny")
+    },
+  })
+})
+
+test("later wildcard agent config overrides earlier wildcard matches", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        "*": {
+          description: "All agents",
+          color: "#111111",
+          options: {
+            rank: 1,
+          },
+        },
+        "researcher/*": {
+          description: "Research agents",
+          color: "#222222",
+          options: {
+            rank: 2,
+          },
+        },
+      },
+    },
+    init: async (dir) => {
+      await seed(dir, "researcher/agent-a")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const item = await Agent.get("researcher/agent-a")
+      expect(item?.description).toBe("Research agents")
+      expect(item?.color).toBe("#222222")
+      expect(item?.options.rank).toBe(2)
+    },
+  })
+})
+
+test("later wildcard agent config can override earlier wildcard disable", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        "*": {
+          disable: true,
+        },
+        "researcher/*": {
+          description: "Research agents",
+        },
+      },
+    },
+    init: async (dir) => {
+      await seed(dir, "researcher/agent-a")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const item = await Agent.get("researcher/agent-a")
+      expect(item).toBeDefined()
+      expect(item?.description).toBe("Research agents")
+      expect(item?.mode).toBe("subagent")
+      expect(item?.prompt).toBe("researcher/agent-a prompt")
+    },
+  })
+})
+
+test("exact agent config overrides wildcard disable without losing native properties", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        build: {
+          description: "Custom build agent",
+        },
+        "*": {
+          disable: true,
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await Agent.get("build")
+      expect(build).toBeDefined()
+      expect(build?.description).toBe("Custom build agent")
+      expect(build?.native).toBe(true)
+      expect(build?.mode).toBe("primary")
+      expect(evalPerm(build, "edit")).toBe("allow")
+    },
+  })
+})
+
+test("nested exact agent config behaves unchanged without wildcards", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        "researcher/agent-a": {
+          model: "openai/gpt-4",
+          description: "Exact researcher",
+          permission: {
+            bash: "deny",
+          },
+        },
+      },
+    },
+    init: async (dir) => {
+      await seed(dir, "researcher/agent-a")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const item = await Agent.get("researcher/agent-a")
+      expect(item).toBeDefined()
+      expect(String(item?.model?.providerID)).toBe("openai")
+      expect(String(item?.model?.modelID)).toBe("gpt-4")
+      expect(item?.description).toBe("Exact researcher")
+      expect(evalPerm(item, "bash")).toBe("deny")
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #18898

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds wildcard matching for `agent` config keys.

For example, a config like `researcher/*` now applies to existing agents such as `researcher/agent-a` instead of being treated as a literal agent name.

I kept exact agent config higher priority than wildcard matches, and added handling for wildcard disable/override order so later, more specific config can still restore the original agent correctly.

### How did you verify your code works?

I tested locally with:

- `cd packages/opencode && bun test --timeout 30000 test/agent/agent.test.ts`
- `cd packages/opencode && bun run typecheck`
- `bun turbo typecheck`

I also added tests for:

- nested agent matching
- exact config overriding wildcard config
- later wildcard entries overriding earlier ones
- wildcard disable followed by a later override

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR