### PR TITLE
fix: patches gh(e) to accept empty tool similar to the LiteLLM fix

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -171,12 +171,16 @@ export namespace LLM {
     // This is enabled for:
     // 1. Providers with "litellm" in their ID or API ID (auto-detected)
     // 2. Providers with explicit "litellmProxy: true" option (opt-in for custom gateways)
+    // 3. GitHub Copilot / GitHub Copilot Enterprise (copilot-api proxy rejects tool_calls without tools)
     const isLiteLLMProxy =
       provider.options?.["litellmProxy"] === true ||
       input.model.providerID.toLowerCase().includes("litellm") ||
       input.model.api.id.toLowerCase().includes("litellm")
+    const isCopilot =
+      input.model.providerID.toLowerCase().includes("github-copilot") ||
+      input.model.api.id.toLowerCase().includes("github-copilot")
 
-    if (isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
+    if ((isLiteLLMProxy || isCopilot) && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
       tools["_noop"] = tool({
         description:
           "Placeholder for LiteLLM/Anthropic proxy compatibility - required when message history contains tool calls but no active tools are needed",


### PR DESCRIPTION
### Issue for this PR
Closes #11157

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TLDR: #8246 same fix, except the `Bad Request` also happens on Github Copilot Enterprise.

This resolves an issue when the agent uses tools and requests the compaction endpoint without providing a tools list. This error is similar to LiteLLM where it expects an empty/noop tool. This is a workaround just like the LiteLLM fix. Happens with Anthropic models

### How did you verify your code works?

```sh
alias opencode='OPENCODE_DISABLE_CHANNEL_DB=1 bun run --cwd ~/Code/opencode/packages/opencode ~/Code/opencode/packages/opencode/src/index.ts'
```

Opened same session that produced the `Bad Request` error and ran `/compact` again. This time it returned a valid compacted result and didn't loop indefinitely when writing something.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR