### PR TITLE
fix(opencode): handle wrapped responses stream errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -100,6 +100,27 @@ export namespace ProviderError {
     return undefined
   }
 
+  function stream(body: object) {
+    const root = body as Record<string, unknown>
+    const raw =
+      typeof root.error === "object" && root.error !== null ? root.error : root.type === "error" ? root : undefined
+    if (!raw || typeof raw !== "object") return
+    const item = raw as Record<string, unknown>
+
+    const code = typeof item.code === "string" ? item.code : undefined
+    const type = typeof item.type === "string" ? item.type : undefined
+    const message = typeof item.message === "string" ? item.message : undefined
+    const param = typeof item.param === "string" || item.param === null ? item.param : undefined
+
+    if (!code && !type && !message && param === undefined) return
+    return {
+      code,
+      type,
+      message,
+      param,
+    }
+  }
+
   export type ParsedStreamError =
     | {
         type: "context_overflow"
@@ -109,7 +130,7 @@ export namespace ProviderError {
     | {
         type: "api_error"
         message: string
-        isRetryable: false
+        isRetryable: boolean
         responseBody: string
       }
 
@@ -118,9 +139,10 @@ export namespace ProviderError {
     if (!body) return
 
     const responseBody = JSON.stringify(body)
-    if (body.type !== "error") return
+    const err = stream(body)
+    if (!err) return
 
-    switch (body?.error?.code) {
+    switch (err.code) {
       case "context_length_exceeded":
         return {
           type: "context_overflow",
@@ -144,10 +166,27 @@ export namespace ProviderError {
       case "invalid_prompt":
         return {
           type: "api_error",
-          message: typeof body?.error?.message === "string" ? body?.error?.message : "Invalid prompt.",
+          message: err.message ?? "Invalid prompt.",
           isRetryable: false,
           responseBody,
         }
+    }
+
+    if (err.type === "too_many_requests" || err.type === "rate_limit_error" || err.code?.includes("rate_limit")) {
+      return {
+        type: "api_error",
+        message: err.message ?? "Rate Limited",
+        isRetryable: true,
+        responseBody,
+      }
+    }
+
+    if (!err.message) return
+    return {
+      type: "api_error",
+      message: err.message,
+      isRetryable: false,
+      responseBody,
     }
   }
 

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -1275,7 +1275,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
                   filename: value.annotation.filename ?? value.annotation.file_id,
                 })
               }
-            } else if (isErrorChunk(value)) {
+            } else if (isErrorChunk(value) || isWrappedErrorChunk(value)) {
               controller.enqueue({ type: "error", error: value })
             }
           },
@@ -1330,12 +1330,31 @@ const textDeltaChunkSchema = z.object({
   logprobs: LOGPROBS_SCHEMA.nullish(),
 })
 
-const errorChunkSchema = z.object({
-  type: z.literal("error"),
-  code: z.string(),
-  message: z.string(),
+const errorDetailSchema = z.object({
+  type: z.string().nullish(),
+  code: z.string().nullish(),
+  message: z.string().nullish(),
   param: z.string().nullish(),
-  sequence_number: z.number(),
+})
+
+const errorChunkSchema = z.union([
+  z.object({
+    type: z.literal("error"),
+    code: z.string().nullish(),
+    message: z.string().nullish(),
+    param: z.string().nullish(),
+    sequence_number: z.number().nullish(),
+  }),
+  z.object({
+    type: z.literal("error"),
+    error: errorDetailSchema,
+    sequence_number: z.number().nullish(),
+  }),
+])
+
+const wrappedErrorChunkSchema = z.object({
+  type: z.undefined().optional(),
+  error: errorDetailSchema,
 })
 
 const responseFinishedChunkSchema = z.object({
@@ -1528,6 +1547,7 @@ const openaiResponsesChunkSchema = z.union([
   responseReasoningSummaryPartAddedSchema,
   responseReasoningSummaryTextDeltaSchema,
   errorChunkSchema,
+  wrappedErrorChunkSchema,
   z.object({ type: z.string() }).loose(), // fallback for unknown chunks
 ])
 
@@ -1622,6 +1642,12 @@ function isResponseReasoningSummaryTextDeltaChunk(
 
 function isErrorChunk(chunk: z.infer<typeof openaiResponsesChunkSchema>): chunk is z.infer<typeof errorChunkSchema> {
   return chunk.type === "error"
+}
+
+function isWrappedErrorChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof wrappedErrorChunkSchema> {
+  return "error" in chunk && typeof chunk.error === "object" && chunk.error !== null && chunk.type === undefined
 }
 
 type ResponsesModelConfig = {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -10,6 +10,7 @@ import {
   type ToolSet,
   tool,
   jsonSchema,
+  TypeValidationError,
 } from "ai"
 import { mergeDeep, pipe } from "remeda"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
@@ -23,6 +24,7 @@ import { SystemPrompt } from "./system"
 import { Flag } from "@/flag/flag"
 import { Permission } from "@/permission"
 import { Auth } from "@/auth"
+import { ProviderError } from "@/provider/error"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -275,6 +277,30 @@ export namespace LLM {
                 args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
               }
               return args.params
+            },
+            async wrapStream(args) {
+              const result = await args.doStream()
+              return {
+                ...result,
+                stream: result.stream.pipeThrough(
+                  new TransformStream({
+                    transform(part, ctl) {
+                      if (
+                        part.type === "error" &&
+                        TypeValidationError.isInstance(part.error) &&
+                        ProviderError.parseStreamError(part.error.value)
+                      ) {
+                        ctl.enqueue({
+                          ...part,
+                          error: part.error.value,
+                        })
+                        return
+                      }
+                      ctl.enqueue(part)
+                    },
+                  }),
+                ),
+              }
             },
           },
         ],

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -535,6 +535,113 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("accepts wrapped responses stream errors without schema validation failure", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("openai", "gpt-5.2")
+    const model = source.model
+    const msg = "Concurrency limit exceeded for user, please retry later"
+    const request = waitRequest(
+      "/responses",
+      createEventResponse(
+        [
+          {
+            error: {
+              type: "rate_limit_error",
+              message: msg,
+            },
+          },
+        ],
+        true,
+      ),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["openai"],
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.openai, ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-2-error")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.2,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-2-error"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("openai"), modelID: resolved.id },
+          variant: "high",
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        let got = false
+        let data: unknown = undefined
+        for await (const part of stream.fullStream) {
+          if (part.type !== "error") continue
+          got = true
+          data = part.error
+        }
+
+        expect(got).toBe(true)
+        expect(data).toStrictEqual({
+          error: {
+            type: "rate_limit_error",
+            message: msg,
+          },
+        })
+      },
+    })
+
+    const capture = await request
+    expect(capture.body.stream).toBe(true)
+  })
+
   test("sends messages API payload for Anthropic models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -846,6 +846,43 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("serializes wrapped rate limit stream errors as retryable APIError", () => {
+    const input = {
+      error: {
+        type: "rate_limit_error",
+        message: "Concurrency limit exceeded for user, please retry later",
+      },
+    }
+    const result = MessageV2.fromError(input, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: "Concurrency limit exceeded for user, please retry later",
+        isRetryable: true,
+        responseBody: JSON.stringify(input),
+      },
+    })
+  })
+
+  test("serializes top-level stream rate limit errors as retryable APIError", () => {
+    const input = {
+      type: "error",
+      code: "rate_limit_exceeded",
+      message: "Too many requests",
+    }
+    const result = MessageV2.fromError(input, { providerID })
+
+    expect(result).toStrictEqual({
+      name: "APIError",
+      data: {
+        message: "Too many requests",
+        isRetryable: true,
+        responseBody: JSON.stringify(input),
+      },
+    })
+  })
+
   test("detects context overflow from APICallError provider messages", () => {
     const cases = [
       "prompt is too long: 213462 tokens > 200000 maximum",

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -125,6 +125,20 @@ describe("session.retry.retryable", () => {
 
     expect(SessionRetry.retryable(error)).toBeUndefined()
   })
+
+  test("retries wrapped rate limit stream errors after normalization", () => {
+    const error = MessageV2.fromError(
+      {
+        error: {
+          type: "rate_limit_error",
+          message: "Concurrency limit exceeded for user, please retry later",
+        },
+      },
+      { providerID },
+    )
+
+    expect(SessionRetry.retryable(error)).toBe("Concurrency limit exceeded for user, please retry later")
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
### Issue for this PR

  Closes #18897

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Fixes a Responses API stream compatibility bug where some providers return rate limit errors as wrapped chunks like:

  ```json
  {"error":{"type":"rate_limit_error","message":"Concurrency limit exceeded for user, please retry later"}}
```

  OpenCode 1.3.0 only handled stream errors with a top-level type: "error" shape, so these chunks failed schema validation and surfaced as Type validation failed.

  This change:

  - accepts wrapped { "error": { ... } } Responses stream chunks in the custom Responses implementation
  - normalizes wrapped rate_limit_error payloads into retryable APIErrors
  - adds a stream-level fallback in LLM.wrapLanguageModel(...) so OpenAI SDK TypeValidationErrors caused by wrapped stream errors are converted back into the original error payload when possible
  - lets existing retry handling run instead of failing during stream validation

  ### How did you verify your code works?

  Ran:

  cd packages/opencode
  bun test test/session/message-v2.test.ts test/session/retry.test.ts test/session/llm.test.ts
  bun typecheck

  Added regression coverage for:

  - wrapped Responses stream errors being converted into APIError
  - wrapped rate_limit_error being marked retryable
  - a Responses SSE stream containing a wrapped error chunk no longer failing schema validation

  ### Screenshots / recordings

  N/A

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR


 