### PR TITLE
fix(provider): avoid incompatible GPT-5 defaults and sanitize Gemini tool schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -328,6 +328,21 @@ export namespace ProviderTransform {
 
   const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
   const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+  const GPT5_DEFAULT_OPTION_NPMS = new Set(["@ai-sdk/openai", "@ai-sdk/azure", "@ai-sdk/github-copilot"])
+  const GEMINI_SCHEMA_NPMS = new Set(["@ai-sdk/google", "@ai-sdk/google-vertex"])
+
+  function supportsGpt5DefaultOptions(model: Provider.Model) {
+    return GPT5_DEFAULT_OPTION_NPMS.has(model.api.npm) || model.providerID.startsWith("opencode")
+  }
+
+  function usesGeminiSchemaTransport(model: Provider.Model) {
+    if (GEMINI_SCHEMA_NPMS.has(model.api.npm)) return true
+    if (model.providerID === "google" || model.providerID === "google-vertex") return true
+    if (model.api.npm === "@ai-sdk/gateway") {
+      return model.api.id.startsWith("google/") || model.api.id.startsWith("google-vertex/")
+    }
+    return false
+  }
 
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities.reasoning) return {}
@@ -791,7 +806,11 @@ export namespace ProviderTransform {
       result["enable_thinking"] = true
     }
 
-    if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
+    if (
+      supportsGpt5DefaultOptions(input.model) &&
+      input.model.api.id.includes("gpt-5") &&
+      !input.model.api.id.includes("gpt-5-chat")
+    ) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
         result["reasoningSummary"] = "auto"
@@ -931,7 +950,7 @@ export namespace ProviderTransform {
     */
 
     // Convert integer enums to string enums for Google/Gemini
-    if (model.providerID === "google" || model.api.id.includes("gemini")) {
+    if (usesGeminiSchemaTransport(model)) {
       const isPlainObject = (node: unknown): node is Record<string, any> =>
         typeof node === "object" && node !== null && !Array.isArray(node)
       const hasCombiner = (node: unknown) =>
@@ -947,6 +966,9 @@ export namespace ProviderTransform {
           "enum",
           "const",
           "$ref",
+          "ref",
+          "$defs",
+          "definitions",
           "additionalProperties",
           "patternProperties",
           "required",
@@ -955,6 +977,61 @@ export namespace ProviderTransform {
           "then",
           "else",
         ].some((key) => key in node)
+      }
+
+      const resolvePointer = (root: unknown, pointer: string) => {
+        if (!pointer.startsWith("#/")) return undefined
+        let current: unknown = root
+        for (const segment of pointer
+          .slice(2)
+          .split("/")
+          .map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"))) {
+          if (Array.isArray(current)) {
+            const index = Number(segment)
+            if (!Number.isInteger(index)) return undefined
+            current = current[index]
+          } else if (isPlainObject(current)) {
+            current = current[segment]
+          } else {
+            return undefined
+          }
+          if (current === undefined) return undefined
+        }
+        return current
+      }
+
+      const inlineRefs = (node: any, root: any, seen = new Set<string>()): any => {
+        if (node === null || typeof node !== "object") {
+          return node
+        }
+
+        if (Array.isArray(node)) {
+          return node.map((item) => inlineRefs(item, root, seen))
+        }
+
+        const refKey =
+          typeof node.$ref === "string" ? "$ref" : typeof node.ref === "string" ? "ref" : undefined
+        if (refKey) {
+          const ref = node[refKey]
+          const siblings = Object.fromEntries(Object.entries(node).filter(([key]) => key !== "$ref" && key !== "ref"))
+          const target = typeof ref === "string" ? resolvePointer(root, ref) : undefined
+          if (target && !seen.has(ref)) {
+            const nextSeen = new Set(seen)
+            nextSeen.add(ref)
+            const resolvedTarget = inlineRefs(target, root, nextSeen)
+            const resolvedSiblings = inlineRefs(siblings, root, seen)
+            if (isPlainObject(resolvedTarget) && isPlainObject(resolvedSiblings)) {
+              return {
+                ...resolvedTarget,
+                ...resolvedSiblings,
+              }
+            }
+            return resolvedTarget
+          }
+          return inlineRefs(siblings, root, seen)
+        }
+
+        return Object.fromEntries(Object.entries(node).map(([key, value]) => [key, inlineRefs(value, root, seen)]))
       }
 
       const sanitizeGemini = (obj: any): any => {
@@ -968,18 +1045,21 @@ export namespace ProviderTransform {
 
         const result: any = {}
         for (const [key, value] of Object.entries(obj)) {
+          if (["$schema", "$ref", "ref", "$defs", "definitions", "additionalProperties"].includes(key)) {
+            continue
+          }
           if (key === "enum" && Array.isArray(value)) {
             // Convert all enum values to strings
             result[key] = value.map((v) => String(v))
-            // If we have integer type with enum, change type to string
-            if (result.type === "integer" || result.type === "number") {
-              result.type = "string"
-            }
           } else if (typeof value === "object" && value !== null) {
             result[key] = sanitizeGemini(value)
           } else {
             result[key] = value
           }
+        }
+
+        if (Array.isArray(result.enum) && (result.type === "integer" || result.type === "number")) {
+          result.type = "string"
         }
 
         // Filter required array to only include fields that exist in properties
@@ -1006,7 +1086,7 @@ export namespace ProviderTransform {
         return result
       }
 
-      schema = sanitizeGemini(schema)
+      schema = sanitizeGemini(inlineRefs(schema, schema))
     }
 
     return schema as JSONSchema7

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -617,6 +617,7 @@ export namespace SessionPrompt {
       // Inject StructuredOutput tool if JSON schema mode enabled
       if (lastUser.format?.type === "json_schema") {
         tools["StructuredOutput"] = createStructuredOutputTool({
+          model,
           schema: lastUser.format.schema,
           onSuccess(output) {
             structuredOutput = output
@@ -935,16 +936,18 @@ export namespace SessionPrompt {
 
   /** @internal Exported for testing */
   export function createStructuredOutputTool(input: {
+    model?: Provider.Model
     schema: Record<string, any>
     onSuccess: (output: unknown) => void
   }): AITool {
     // Remove $schema property if present (not needed for tool input)
     const { $schema, ...toolSchema } = input.schema
+    const inputSchema = input.model ? ProviderTransform.schema(input.model, toolSchema as any) : toolSchema
 
     return tool({
       id: "StructuredOutput" as any,
       description: STRUCTURED_OUTPUT_DESCRIPTION,
-      inputSchema: jsonSchema(toolSchema as any),
+      inputSchema: jsonSchema(inputSchema as any),
       async execute(args) {
         // AI SDK validates args against inputSchema before calling execute()
         input.onSuccess(args)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -173,14 +173,23 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 
-  const createGpt5Model = (apiId: string) =>
+  const createGpt5Model = (
+    apiId: string,
+    overrides?: {
+      providerID?: string
+      api?: {
+        url?: string
+        npm?: string
+      }
+    },
+  ) =>
     ({
-      id: `openai/${apiId}`,
-      providerID: "openai",
+      id: `${overrides?.providerID ?? "openai"}/${apiId}`,
+      providerID: overrides?.providerID ?? "openai",
       api: {
         id: apiId,
-        url: "https://api.openai.com",
-        npm: "@ai-sdk/openai",
+        url: overrides?.api?.url ?? "https://api.openai.com",
+        npm: overrides?.api?.npm ?? "@ai-sdk/openai",
       },
       name: apiId,
       capabilities: {
@@ -239,6 +248,40 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     const model = createGpt5Model("gpt-5.2-codex")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
     expect(result.textVerbosity).toBeUndefined()
+  })
+
+  test("generic openai-compatible gpt-5.4 should not inject openai-only defaults", () => {
+    const model = createGpt5Model("gpt-5.4", {
+      providerID: "custom-provider",
+      api: {
+        url: "https://proxy.example.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
+    expect(result.include).toBeUndefined()
+  })
+
+  test("opencode gpt-5.4 should keep supported reasoning defaults", () => {
+    const model = createGpt5Model("gpt-5.4", {
+      providerID: "opencode-proxy",
+      api: {
+        url: "https://api.opencode.ai/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+
+    expect(result.reasoningEffort).toBe("medium")
+    expect(result.reasoningSummary).toBe("auto")
+    expect(result.textVerbosity).toBe("low")
+    expect(result.include).toEqual(["reasoning.encrypted_content"])
   })
 })
 
@@ -761,6 +804,77 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
     expect(result.properties.data.type).toBe("object")
     expect(result.properties.data.properties).toBeDefined()
     expect(result.properties.data.required).toEqual(["name"])
+  })
+
+  test("recursively strips unsupported gemini schema keywords and inlines local refs", () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      additionalProperties: false,
+      $defs: {
+        Shared: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            label: { type: "string" },
+          },
+          required: ["label"],
+        },
+      },
+      definitions: {
+        Legacy: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            count: {
+              type: "integer",
+              enum: [1, 2],
+            },
+          },
+          required: ["count"],
+        },
+      },
+      properties: {
+        shared: {
+          $ref: "#/$defs/Shared",
+        },
+        legacy: {
+          ref: "#/definitions/Legacy",
+        },
+        nested: {
+          type: "object",
+          $schema: "http://json-schema.org/draft-07/schema#",
+          additionalProperties: false,
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name"],
+        },
+      },
+      required: ["shared", "legacy", "nested"],
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.$schema).toBeUndefined()
+    expect(result.additionalProperties).toBeUndefined()
+    expect(result.$defs).toBeUndefined()
+    expect(result.definitions).toBeUndefined()
+
+    expect(result.properties.shared.$ref).toBeUndefined()
+    expect(result.properties.shared.type).toBe("object")
+    expect(result.properties.shared.additionalProperties).toBeUndefined()
+    expect(result.properties.shared.properties.label.type).toBe("string")
+
+    expect(result.properties.legacy.ref).toBeUndefined()
+    expect(result.properties.legacy.type).toBe("object")
+    expect(result.properties.legacy.additionalProperties).toBeUndefined()
+    expect(result.properties.legacy.properties.count.type).toBe("string")
+    expect(result.properties.legacy.properties.count.enum).toEqual(["1", "2"])
+
+    expect(result.properties.nested.$schema).toBeUndefined()
+    expect(result.properties.nested.additionalProperties).toBeUndefined()
+    expect(result.properties.nested.properties.name.type).toBe("string")
   })
 
   test("does not affect non-gemini providers", () => {

--- a/packages/opencode/test/session/structured-output.test.ts
+++ b/packages/opencode/test/session/structured-output.test.ts
@@ -157,6 +157,14 @@ describe("structured-output.AssistantMessage", () => {
 })
 
 describe("structured-output.createStructuredOutputTool", () => {
+  const geminiModel = {
+    providerID: "google",
+    api: {
+      id: "gemini-3.1-pro",
+      npm: "@ai-sdk/google",
+    },
+  } as any
+
   test("creates tool with correct id", () => {
     const tool = SessionPrompt.createStructuredOutputTool({
       schema: { type: "object", properties: { name: { type: "string" } } },
@@ -213,6 +221,45 @@ describe("structured-output.createStructuredOutputTool", () => {
     // AI SDK wraps schema in { jsonSchema: {...} }
     const inputSchema = tool.inputSchema as any
     expect(inputSchema.jsonSchema?.$schema).toBeUndefined()
+  })
+
+  test("sanitizes gemini structured-output schemas recursively", () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      additionalProperties: false,
+      $defs: {
+        Result: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            status: { type: "string" },
+          },
+          required: ["status"],
+        },
+      },
+      properties: {
+        result: {
+          $ref: "#/$defs/Result",
+        },
+      },
+      required: ["result"],
+    }
+
+    const tool = SessionPrompt.createStructuredOutputTool({
+      model: geminiModel,
+      schema,
+      onSuccess: () => {},
+    })
+
+    const inputSchema = tool.inputSchema as any
+    expect(inputSchema.jsonSchema?.$schema).toBeUndefined()
+    expect(inputSchema.jsonSchema?.additionalProperties).toBeUndefined()
+    expect(inputSchema.jsonSchema?.$defs).toBeUndefined()
+    expect(inputSchema.jsonSchema?.properties?.result?.$ref).toBeUndefined()
+    expect(inputSchema.jsonSchema?.properties?.result?.type).toBe("object")
+    expect(inputSchema.jsonSchema?.properties?.result?.additionalProperties).toBeUndefined()
+    expect(inputSchema.jsonSchema?.properties?.result?.properties?.status?.type).toBe("string")
   })
 
   test("execute calls onSuccess with valid args", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #18882

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two compatibility problems from #18882.

`ProviderTransform.options()` was applying GPT-5 default request fields too broadly based on the model ID. That caused generic `@ai-sdk/openai-compatible` providers or proxies using models like `gpt-5.4` to receive fields such as `reasoningSummary`, `reasoningEffort`, `textVerbosity`, and `include`, even when the backend did not support them. This change limits those defaults to transports/providers that explicitly support them.

This PR also tightens Gemini tool schema sanitization. The Gemini schema path now inlines local refs and recursively removes unsupported keys such as `$schema`, `additionalProperties`, `$ref`, `ref`, `$defs`, and `definitions`. Structured output now reuses the same sanitization path so it does not bypass the Gemini-specific cleanup.

### How did you verify your code works?

I added regression tests covering:
- generic `@ai-sdk/openai-compatible` `gpt-5.4` models no longer receiving OpenAI-only defaults
- `opencode*` GPT-5 providers still keeping supported defaults
- recursive Gemini schema sanitization, including local ref inlining
- structured output using the same Gemini schema sanitization path

I also ran:

- `git diff --check`
- `cd packages/opencode && bun run typecheck`
- `bunx turbo typecheck`

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._