### PR TITLE
fix: cap active tools for providers with tool count limits

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -54,6 +54,7 @@ export namespace ModelsDev {
       context: z.number(),
       input: z.number().optional(),
       output: z.number(),
+      tools: z.number().optional(),
     }),
     modalities: z
       .object({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -809,6 +809,7 @@ export namespace Provider {
         context: z.number(),
         input: z.number().optional(),
         output: z.number(),
+        tools: z.number().optional(),
       }),
       status: z.enum(["alpha", "beta", "deprecated", "active"]),
       options: z.record(z.string(), z.any()),
@@ -835,6 +836,10 @@ export namespace Provider {
       ref: "Provider",
     })
   export type Info = z.infer<typeof Info>
+
+  const TOOL_LIMITS: Record<string, number> = {
+    xai: 200,
+  }
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     const m: Model = {
@@ -872,6 +877,7 @@ export namespace Provider {
         context: model.limit.context,
         input: model.limit.input,
         output: model.limit.output,
+        tools: model.limit.tools,
       },
       capabilities: {
         temperature: model.temperature,
@@ -896,6 +902,11 @@ export namespace Provider {
       },
       release_date: model.release_date,
       variants: {},
+    }
+
+    if (!m.limit.tools) {
+      const cap = TOOL_LIMITS[provider.id]
+      if (cap) m.limit.tools = cap
     }
 
     m.variants = mapValues(ProviderTransform.variants(m), (v) => v)
@@ -1026,6 +1037,7 @@ export namespace Provider {
           limit: {
             context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
             output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+            tools: model.limit?.tools ?? existingModel?.limit?.tools,
           },
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
           family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -837,6 +837,8 @@ export namespace Provider {
     })
   export type Info = z.infer<typeof Info>
 
+  // Fallback caps for SDKs that reject large tool lists unless the model metadata
+  // overrides them explicitly.
   const TOOL_LIMITS: Record<string, number> = {
     xai: 200,
   }
@@ -904,7 +906,7 @@ export namespace Provider {
       variants: {},
     }
 
-    if (!m.limit.tools) {
+    if (m.limit.tools == null) {
       const cap = TOOL_LIMITS[provider.id]
       if (cap) m.limit.tools = cap
     }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -185,6 +185,18 @@ export namespace LLM {
       })
     }
 
+    const all = Object.keys(tools).filter((x) => x !== "invalid")
+    const cap = input.model.limit.tools
+    let active = all
+    if (cap && all.length > cap) {
+      l.warn("capping tools", {
+        total: all.length,
+        limit: cap,
+        dropped: all.length - cap,
+      })
+      active = all.slice(0, cap)
+    }
+
     // Wire up toolExecutor for DWS workflow models so that tool calls
     // from the workflow service are executed via opencode's tool system
     // and results sent back over the WebSocket.
@@ -244,7 +256,7 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+      activeTools: active,
       tools,
       toolChoice: input.toolChoice,
       maxOutputTokens,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -23,6 +23,8 @@ import { SystemPrompt } from "./system"
 import { Flag } from "@/flag/flag"
 import { Permission } from "@/permission"
 import { Auth } from "@/auth"
+import { Bus } from "@/bus"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -188,12 +190,18 @@ export namespace LLM {
     const all = Object.keys(tools).filter((x) => x !== "invalid")
     const cap = input.model.limit.tools
     let active = all
-    if (cap && all.length > cap) {
+    if (cap != null && all.length > cap) {
       l.warn("capping tools", {
         total: all.length,
         limit: cap,
         dropped: all.length - cap,
       })
+      void Bus.publish(TuiEvent.ToastShow, {
+        title: "Tool limit applied",
+        message: `${input.model.providerID}/${input.model.id} allows ${cap} tools per turn. ${all.length - cap} tool(s) were hidden.`,
+        variant: "warning",
+        duration: 5000,
+      }).catch((err) => l.debug("failed to show tool cap toast", { error: err }))
       active = all.slice(0, cap)
     }
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -982,6 +982,59 @@ test("provider.sort prioritizes preferred models", () => {
   expect(sorted[sorted.length - 1].id).not.toContain("sonnet-4")
 })
 
+test("models.dev fallback sets xai tool cap", () => {
+  const info = Provider.fromModelsDevProvider({
+    id: "xai",
+    name: "xAI",
+    env: [],
+    models: {
+      grok: {
+        id: "grok",
+        name: "Grok",
+        release_date: "2026-01-01",
+        attachment: false,
+        reasoning: false,
+        temperature: true,
+        tool_call: true,
+        limit: {
+          context: 128000,
+          output: 4096,
+        },
+        options: {},
+      },
+    },
+  })
+
+  expect(info.models.grok.limit.tools).toBe(200)
+})
+
+test("models.dev tool cap keeps explicit zero", () => {
+  const info = Provider.fromModelsDevProvider({
+    id: "xai",
+    name: "xAI",
+    env: [],
+    models: {
+      grok: {
+        id: "grok",
+        name: "Grok",
+        release_date: "2026-01-01",
+        attachment: false,
+        reasoning: false,
+        temperature: true,
+        tool_call: true,
+        limit: {
+          context: 128000,
+          output: 4096,
+          tools: 0,
+        },
+        options: {},
+      },
+    },
+  })
+
+  expect(info.models.grok.limit.tools).toBe(0)
+})
+
 test("multiple providers can be configured simultaneously", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1177,6 +1177,7 @@ export type ProviderConfig = {
         context: number
         input?: number
         output: number
+        tools?: number
       }
       modalities?: {
         input: Array<"text" | "audio" | "image" | "video" | "pdf">
@@ -1598,6 +1599,7 @@ export type Model = {
     context: number
     input?: number
     output: number
+    tools?: number
   }
   status: "alpha" | "beta" | "deprecated" | "active"
   options: {
@@ -3985,6 +3987,7 @@ export type ProviderListResponses = {
             context: number
             input?: number
             output: number
+            tools?: number
           }
           modalities?: {
             input: Array<"text" | "audio" | "image" | "video" | "pdf">

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4607,6 +4607,9 @@
                                     },
                                     "output": {
                                       "type": "number"
+                                    },
+                                    "tools": {
+                                      "type": "number"
                                     }
                                   },
                                   "required": ["context", "output"]
@@ -10167,6 +10170,9 @@
                     },
                     "output": {
                       "type": "number"
+                    },
+                    "tools": {
+                      "type": "number"
                     }
                   },
                   "required": ["context", "output"]
@@ -11097,6 +11103,9 @@
                 "type": "number"
               },
               "output": {
+                "type": "number"
+              },
+              "tools": {
                 "type": "number"
               }
             },


### PR DESCRIPTION
### Issue for this PR

Fixes #17405
Split from #18635

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR contains the tool-limit work split out from #18635.

It includes:
- model/provider support for `limit.tools`
- xAI fallback tool caps when model metadata does not provide one
- runtime tool capping in the LLM layer
- a user-facing warning when tools are capped
- a fix to preserve explicit `tools: 0` values instead of treating them as missing

These changes are intended to reduce oversized tool payloads for providers like xAI/Grok that fail when too many tools are exposed in one turn.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/provider/provider.test.ts`

### Screenshots / recordings

_N/A - backend/provider behavior, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR