### PR TITLE
fix(provider): map model_context_window_exceeded to length finish reason

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/map-openai-compatible-finish-reason.ts
@@ -8,6 +8,8 @@ export function mapOpenAICompatibleFinishReason(finishReason: string | null | un
       return "length"
     case "content_filter":
       return "content-filter"
+    case "model_context_window_exceeded":
+      return "length"
     case "function_call":
     case "tool_calls":
       return "tool-calls"

--- a/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/map-openai-responses-finish-reason.ts
@@ -13,6 +13,7 @@ export function mapOpenAIResponseFinishReason({
     case null:
       return hasFunctionCall ? "tool-calls" : "stop"
     case "max_output_tokens":
+    case "model_context_window_exceeded":
       return "length"
     case "content_filter":
       return "content-filter"


### PR DESCRIPTION
### Issue for this PR

Closes #18813

### Type of change

- [x] Bug fix

### What does this PR do?

Some providers (Anthropic via z.ai, zhipuai) return `finish_reason: "model_context_window_exceeded"` when the prompt exceeds the model's context window. This finish reason was not mapped in the two finish-reason mapping functions, causing it to fall through to `"unknown"`.

When the session loop sees `"unknown"`, it retries indefinitely with exponential backoff instead of triggering compaction — burning tokens and money in an infinite loop.

This PR maps `"model_context_window_exceeded"` to `"length"` in both:

1. `map-openai-compatible-finish-reason.ts` (Chat API path)
2. `map-openai-responses-finish-reason.ts` (Responses API path)

This routes it into the existing context overflow / compaction logic, matching the semantics of `"length"` (prompt too long).

### How did you verify your code works?

- Typecheck passes (all packages)
- The mapping functions are pure switch/case — adding a new case is safe and isolated
- `"length"` already triggers compaction correctly in the session processor (`processor.ts`)
- The previous PR #18814 attempted the same fix but was self-closed by the author; this PR re-implements correctly

### Screenshots / recordings

N/A — finish reason mapping change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR