### PR TITLE
fix(app): filter non-renderable part types from browser store

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -15,6 +15,8 @@ import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
 
+const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+
 export function applyGlobalEvent(input: {
   event: { type: string; properties?: unknown }
   project: Project[]
@@ -211,6 +213,7 @@ export function applyDirectoryEvent(input: {
     }
     case "message.part.updated": {
       const part = (event.properties as { part: Part }).part
+      if (SKIP_PARTS.has(part.type)) break
       const parts = input.store.part[part.messageID]
       if (!parts) {
         input.setStore("part", part.messageID, [part])

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -14,6 +14,8 @@ import { useSDK } from "./sdk"
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
 
+const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
+
 function sortParts(parts: Part[]) {
   return parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
 }
@@ -336,7 +338,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           batch(() => {
             input.setStore("message", input.sessionID, reconcile(message, { key: "id" }))
             for (const p of next.part) {
-              input.setStore("part", p.id, p.part)
+              const filtered = p.part.filter((x) => !SKIP_PARTS.has(x.type))
+              if (filtered.length) input.setStore("part", p.id, filtered)
             }
             setMeta("limit", key, message.length)
             setMeta("cursor", key, next.cursor)


### PR DESCRIPTION
### Issue for this PR

Closes #18922

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Part types `patch`, `step-start`, and `step-finish` have no `PART_MAPPING` entry and are never rendered by `SessionTurn` (`partState()` returns `undefined` for them). However, they are loaded into the SolidJS reactive store via both SSE events and the initial page load. For sessions with large snapshot diffs (e.g. 17 MB patch with 99K file entries), SolidJS creates deep reactive proxies over massive arrays, freezing the browser.

Adds a `SKIP_PARTS` set and filters these types at both store entry points:
- `event-reducer.ts`: early break in `message.part.updated` handler
- `sync.tsx`: filter parts during page load before store insertion

For the problematic session this reduces data in the browser store from 24 MB to ~7 MB.

### How did you verify your code works?

- `bun test` passes for `packages/app` (291/291)
- Verified the problematic session has 50 patch parts (17 MB), 238 step-finish parts, 239 step-start parts — all now filtered

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR