### PR TITLE
fix(app): use optional chaining for model.current() in ProviderIcon

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1497,7 +1497,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                         >
                           <Show when={local.model.current()?.provider?.id}>
                             <ProviderIcon
-                              id={local.model.current()!.provider.id}
+                              id={local.model.current()?.provider?.id ?? ""}
                               class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
                               style={{ "will-change": "opacity", transform: "translateZ(0)" }}
                             />
@@ -1529,7 +1529,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       >
                         <Show when={local.model.current()?.provider?.id}>
                           <ProviderIcon
-                            id={local.model.current()!.provider.id}
+                            id={local.model.current()?.provider?.id ?? ""}
                             class="size-4 shrink-0 opacity-40 group-hover:opacity-100 transition-opacity duration-150"
                             style={{ "will-change": "opacity", transform: "translateZ(0)" }}
                           />


### PR DESCRIPTION
### Issue for this PR

Closes #18923

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prompt-input.tsx` uses `local.model.current()!.provider.id` with a non-null assertion inside a `<Show>` guard. SolidJS compiles `id={expr}` into a `get id()` getter. During a reactive batch, the getter can fire before `<Show>` disposes its children, causing a TypeError when `model.current()` becomes undefined (e.g. provider refresh, model not found).

Replaces the `!` assertion with optional chaining (`?.`) and an empty string fallback at both occurrences (lines 1500 and 1532). The `<Show>` guard still prevents rendering when the model is undefined; the fallback only fires during the reactive race window.

### How did you verify your code works?

- `bun test` passes for `packages/app` (291/291)
- The TypeError `can't access property 'provider', r.model.current() is undefined` no longer occurs

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR