### PR TITLE
feat(app): sync web project sidebar across devices

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -39,6 +39,12 @@ export async function enableE2E(page: Page) {
     const win = window as E2EWindow
     win.__opencode_e2e = {
       ...win.__opencode_e2e,
+      sidebar: {
+        enabled: true,
+      },
+      session: {
+        enabled: true,
+      },
       model: {
         enabled: true,
       },
@@ -390,6 +396,27 @@ export async function seedProjects(page: Page, input: { directory: string; extra
       )
     },
     { directory: input.directory, serverUrl, extra: input.extra ?? [] },
+  )
+}
+
+export async function seedSidebar(page: Page, input: { directory: string; extra?: string[] }) {
+  await page.addInitScript(
+    (args: { directory: string; extra: string[] }) => {
+      const key = "opencode.e2e.dat:sidebar"
+      const raw = localStorage.getItem(key)
+      const list = (() => {
+        if (!raw) return []
+        try {
+          const value = JSON.parse(raw) as unknown
+          return Array.isArray(value) ? value.filter((x): x is string => typeof x === "string") : []
+        } catch {
+          return []
+        }
+      })()
+
+      localStorage.setItem(key, JSON.stringify([...new Set([...list, args.directory, ...args.extra])]))
+    },
+    { directory: input.directory, extra: input.extra ?? [] },
   )
 }
 
@@ -958,7 +985,7 @@ export async function openStatusPopover(page: Page) {
 export async function openProjectMenu(page: Page, projectSlug: string) {
   await openSidebar(page)
   const item = page.locator(projectSwitchSelector(projectSlug)).first()
-  await expect(item).toBeVisible()
+  await expect(item).toBeVisible({ timeout: 30_000 })
   await item.hover()
 
   const trigger = page.locator(projectMenuTriggerSelector(projectSlug)).first()

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -34,6 +34,33 @@ export function healthPhase(page: Page) {
   return phase.get(page) ?? "test"
 }
 
+export async function enableE2E(page: Page) {
+  await page.addInitScript(() => {
+    const win = window as E2EWindow
+    win.__opencode_e2e = {
+      ...win.__opencode_e2e,
+      model: {
+        enabled: true,
+      },
+      prompt: {
+        enabled: true,
+      },
+      terminal: {
+        enabled: true,
+        terminals: {},
+      },
+    }
+    localStorage.setItem(
+      "opencode.global.dat:model",
+      JSON.stringify({
+        recent: [{ providerID: "opencode", modelID: "big-pickle" }],
+        user: [],
+        variant: {},
+      }),
+    )
+  })
+}
+
 export async function defocus(page: Page) {
   await page
     .evaluate(() => {

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -1,10 +1,10 @@
 import { test as base, expect, type Page } from "@playwright/test"
-import type { E2EWindow } from "../src/testing/terminal"
 import {
   healthPhase,
   cleanupSession,
   cleanupTestProject,
   createTestProject,
+  enableE2E,
   setHealthPhase,
   seedProjects,
   sessionIDFromUrl,
@@ -125,30 +125,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 async function seedStorage(page: Page, input: { directory: string; extra?: string[] }) {
   await seedProjects(page, input)
-  await page.addInitScript(() => {
-    const win = window as E2EWindow
-    win.__opencode_e2e = {
-      ...win.__opencode_e2e,
-      model: {
-        enabled: true,
-      },
-      prompt: {
-        enabled: true,
-      },
-      terminal: {
-        enabled: true,
-        terminals: {},
-      },
-    }
-    localStorage.setItem(
-      "opencode.global.dat:model",
-      JSON.stringify({
-        recent: [{ providerID: "opencode", modelID: "big-pickle" }],
-        user: [],
-        variant: {},
-      }),
-    )
-  })
+  await enableE2E(page)
 }
 
 export { expect }

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -6,6 +6,7 @@ import {
   createTestProject,
   enableE2E,
   setHealthPhase,
+  seedSidebar,
   seedProjects,
   sessionIDFromUrl,
   waitSlug,
@@ -125,6 +126,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 async function seedStorage(page: Page, input: { directory: string; extra?: string[] }) {
   await seedProjects(page, input)
+  await seedSidebar(page, input)
   await enableE2E(page)
 }
 

--- a/packages/app/e2e/session/session-model-persistence.spec.ts
+++ b/packages/app/e2e/session/session-model-persistence.spec.ts
@@ -1,14 +1,6 @@
 import type { Locator, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import {
-  openSidebar,
-  resolveSlug,
-  sessionIDFromUrl,
-  setWorkspacesEnabled,
-  waitSession,
-  waitSessionIdle,
-  waitSlug,
-} from "../actions"
+import { openSidebar, resolveSlug, sessionIDFromUrl, setWorkspacesEnabled, waitSession, waitSlug } from "../actions"
 import {
   promptAgentSelector,
   promptModelSelector,
@@ -29,6 +21,17 @@ type Probe = {
   dir?: string
   sessionID?: string
   model?: { providerID: string; modelID: string }
+  variants?: string[]
+}
+
+type SessionWindow = Window & {
+  __opencode_e2e?: {
+    session?: {
+      controls?: {
+        promote?: (dir: string, session: string) => void
+      }
+    }
+  }
 }
 
 const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
@@ -95,9 +98,23 @@ async function variantCount(page: Page) {
   const select = page.locator(promptVariantSelector)
   await expect(select).toBeVisible()
   await select.locator('[data-slot="select-select-trigger"]').click()
-  const count = await page.locator('[data-slot="select-select-item"]').count()
+  const list = page.locator('[data-slot="select-select-content-list"]').last()
+  await expect(list).toBeVisible()
+  const count = await list.locator('[data-slot="select-select-item"]').count()
   await page.keyboard.press("Escape")
   return count
+}
+
+async function waitVariants(page: Page, count: number) {
+  await expect
+    .poll(
+      () =>
+        probe(page).then((state) => {
+          return (state?.variants?.length ?? 0) + 1
+        }),
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThanOrEqual(count)
 }
 
 async function agents(page: Page) {
@@ -111,6 +128,7 @@ async function agents(page: Page) {
 
 async function ensureVariant(page: Page, directory: string): Promise<Footer> {
   const current = await read(page)
+  await waitVariants(page, 2)
   if ((await variantCount(page)) >= 2) return current
 
   const cfg = await createSdk(directory)
@@ -132,11 +150,14 @@ async function ensureVariant(page: Page, directory: string): Promise<Footer> {
 
 async function chooseDifferentVariant(page: Page): Promise<Footer> {
   const current = await read(page)
+  await waitVariants(page, 2)
   const select = page.locator(promptVariantSelector)
   await expect(select).toBeVisible()
   await select.locator('[data-slot="select-select-trigger"]').click()
 
-  const items = page.locator('[data-slot="select-select-item"]')
+  const list = page.locator('[data-slot="select-select-content-list"]').last()
+  await expect(list).toBeVisible()
+  const items = list.locator('[data-slot="select-select-item"]')
   const count = await items.count()
   if (count < 2) throw new Error("Current model has no alternate variant to select")
 
@@ -194,19 +215,21 @@ async function submit(page: Page, value: string) {
   return id
 }
 
-async function waitUser(directory: string, sessionID: string) {
+async function createSession(page: Page, directory: string, title: string) {
   const sdk = createSdk(directory)
-  await expect
-    .poll(
-      async () => {
-        const items = await sdk.session.messages({ sessionID, limit: 20 }).then((x) => x.data ?? [])
-        return items.some((item) => item.info.role === "user")
-      },
-      { timeout: 30_000 },
-    )
-    .toBe(true)
-  await sdk.session.abort({ sessionID }).catch(() => undefined)
-  await waitSessionIdle(sdk, sessionID, 30_000).catch(() => undefined)
+  const data = await sdk.session.create({ title }).then((x) => x.data)
+  if (!data?.id) throw new Error("Session create did not return an id")
+
+  await page.evaluate(
+    (input) => {
+      const fn = (window as SessionWindow).__opencode_e2e?.session?.controls?.promote
+      if (!fn) throw new Error("Session promote control is unavailable")
+      fn(input.directory, input.id)
+    },
+    { directory, id: data.id },
+  )
+
+  return data.id
 }
 
 async function createWorkspace(page: Page, root: string, seen: string[]) {
@@ -260,9 +283,9 @@ test("session model and variant restore per session without leaking into new ses
 
     await ensureVariant(page, directory)
     const firstState = await chooseDifferentVariant(page)
-    const first = await submit(page, `session variant ${Date.now()}`)
+    const first = await createSession(page, directory, `session variant ${Date.now()}`)
     trackSession(first)
-    await waitUser(directory, first)
+    await goto(page, directory, first)
 
     await page.reload()
     await waitSession(page, { directory, sessionID: first })
@@ -273,9 +296,9 @@ test("session model and variant restore per session without leaking into new ses
     expect(fresh.variant).not.toBe(firstState.variant)
 
     const secondState = await chooseOtherModel(page)
-    const second = await submit(page, `session model ${Date.now()}`)
+    const second = await createSession(page, directory, `session model ${Date.now()}`)
     trackSession(second)
-    await waitUser(directory, second)
+    await goto(page, directory, second)
 
     await goto(page, directory, first)
     await waitFooter(page, firstState)
@@ -296,9 +319,9 @@ test("session model restore across workspaces", async ({ page, withProject }) =>
 
     await ensureVariant(page, root)
     const firstState = await chooseDifferentVariant(page)
-    const first = await submit(page, `root session ${Date.now()}`)
+    const first = await createSession(page, root, `root session ${Date.now()}`)
     trackSession(first, root)
-    await waitUser(root, first)
+    await goto(page, root, first)
 
     await openSidebar(page)
     await setWorkspacesEnabled(page, slug, true)
@@ -308,9 +331,9 @@ test("session model restore across workspaces", async ({ page, withProject }) =>
     trackDirectory(oneDir)
 
     const secondState = await chooseOtherModel(page)
-    const second = await submit(page, `workspace one ${Date.now()}`)
+    const second = await createSession(page, oneDir, `workspace one ${Date.now()}`)
     trackSession(second, oneDir)
-    await waitUser(oneDir, second)
+    await goto(page, oneDir, second)
 
     const two = await createWorkspace(page, slug, [one.slug])
     const twoDir = await newWorkspaceSession(page, two.slug)
@@ -318,9 +341,9 @@ test("session model restore across workspaces", async ({ page, withProject }) =>
 
     await ensureVariant(page, twoDir)
     const thirdState = await chooseDifferentVariant(page)
-    const third = await submit(page, `workspace two ${Date.now()}`)
+    const third = await createSession(page, twoDir, `workspace two ${Date.now()}`)
     trackSession(third, twoDir)
-    await waitUser(twoDir, third)
+    await goto(page, twoDir, third)
 
     await goto(page, root, first)
     await waitFooter(page, firstState)

--- a/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts
@@ -66,9 +66,7 @@ test("open sidebar project popover stays closed after clicking avatar", async ({
         await project.hover()
         await expect(card.getByText(/recent sessions/i)).toBeVisible()
 
-        await page.mouse.down()
-        await expect(card).toHaveCount(0)
-        await page.mouse.up()
+        await project.click()
 
         await waitSession(page, { directory: other })
         await expect(card).toHaveCount(0)

--- a/packages/app/e2e/sidebar/sidebar-sync.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-sync.spec.ts
@@ -1,95 +1,198 @@
+import type { Browser, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import { createTestProject, cleanupTestProject } from "../actions"
-import { createSdk, dirSlug } from "../utils"
+import { cleanupTestProject, clickMenuItem, createTestProject, enableE2E, openProjectMenu, openSidebar, seedProjects, waitSession } from "../actions"
+import { projectSwitchSelector, sidebarNavSelector } from "../selectors"
+import { createSdk, dirSlug, sessionPath } from "../utils"
+
+async function openFresh(browser: Browser, directory: string) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await enableE2E(page)
+  await page.setViewportSize({ width: 1400, height: 800 })
+  await page.goto(sessionPath(directory))
+  await waitSession(page, { directory })
+  await openSidebar(page)
+  return { context, page }
+}
+
+async function listProjects(page: Page) {
+  return page.locator(`${sidebarNavSelector} [data-action="project-switch"]`).evaluateAll((els) => {
+    return els.map((el) => el.getAttribute("data-project") ?? "").filter((x) => x.length > 0)
+  })
+}
+
+async function clearRail(sdk: ReturnType<typeof createSdk>) {
+  const items = await sdk.project.sidebar.list().then((x) => x.data ?? [])
+  if (items.length === 0) return
+  await sdk.project.sidebar.reorder({ worktrees: [] })
+}
 
 test.describe("sidebar sync", () => {
-  test("project opened via API is visible from a fresh page load", async ({ page, withProject }) => {
-    await withProject(async ({ directory }) => {
+  test("project opened syncs to a fresh client UI", async ({ browser }) => {
+    let directory = ""
+    try {
+      directory = await createTestProject()
       const sdk = createSdk(directory)
+      const slug = dirSlug(directory)
+      await clearRail(sdk)
+
       await sdk.project.sidebar.open({ worktree: directory })
 
-      // Fresh navigation triggers bootstrap which fetches sidebar
-      await page.goto(`/${dirSlug(directory)}/session`)
-
-      // Verify the server-side state is correct
-      const res = await sdk.project.sidebar.list()
-      expect(res.data!).toHaveLength(1)
-      expect(res.data![0].worktree).toBe(directory)
-    })
+      const fresh = await openFresh(browser, directory)
+      try {
+        await expect(fresh.page.locator(projectSwitchSelector(slug)).first()).toBeVisible()
+      } finally {
+        await fresh.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+    }
   })
 
-  test("project closed via API is absent from server sidebar", async ({ withProject }) => {
-    await withProject(async ({ directory }) => {
+  test("project closed syncs to a fresh client UI", async ({ browser }) => {
+    let directory = ""
+    let other = ""
+    try {
+      directory = await createTestProject()
+      other = await createTestProject()
       const sdk = createSdk(directory)
-      await sdk.project.sidebar.open({ worktree: directory })
-      await sdk.project.sidebar.close({ worktree: directory })
+      const slug = dirSlug(directory)
+      const otherSlug = dirSlug(other)
+      await clearRail(sdk)
+      await sdk.project.sidebar.reorder({ worktrees: [directory, other] })
 
-      const res = await sdk.project.sidebar.list()
-      expect(res.data!.every((item: { worktree: string }) => item.worktree !== directory)).toBe(true)
-    })
+      const pageA = await openFresh(browser, directory)
+      try {
+        const menu = await openProjectMenu(pageA.page, slug)
+        await clickMenuItem(menu, /^Close$/i, { force: true })
+
+        const pageB = await openFresh(browser, other)
+        try {
+          await expect(pageB.page.locator(projectSwitchSelector(otherSlug)).first()).toBeVisible()
+          await expect.poll(() => pageB.page.locator(projectSwitchSelector(slug)).count()).toBe(0)
+        } finally {
+          await pageB.context.close()
+        }
+      } finally {
+        await pageA.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+      if (other) await cleanupTestProject(other)
+    }
   })
 
-  test("reorder via API persists order for fresh clients", async ({ withProject }) => {
+  test("reorder syncs to a fresh client UI", async ({ browser }) => {
+    let directory = ""
     let dir2 = ""
-    await withProject(async ({ directory }) => {
+    let dir3 = ""
+    try {
+      directory = await createTestProject()
       dir2 = await createTestProject()
+      dir3 = await createTestProject()
       const sdk = createSdk(directory)
-      await sdk.project.sidebar.reorder({ worktrees: [dir2, directory] })
+      const worktrees = [dir3, directory, dir2]
+      await clearRail(sdk)
 
-      const res = await sdk.project.sidebar.list()
-      const worktrees = res.data!.map((x: { worktree: string }) => x.worktree)
-      expect(worktrees).toEqual([dir2, directory])
-    })
-    if (dir2) await cleanupTestProject(dir2)
+      await sdk.project.sidebar.reorder({ worktrees })
+
+      const fresh = await openFresh(browser, directory)
+      try {
+        await expect.poll(() => listProjects(fresh.page)).toEqual(worktrees.map(dirSlug))
+      } finally {
+        await fresh.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+      if (dir2) await cleanupTestProject(dir2)
+      if (dir3) await cleanupTestProject(dir3)
+    }
   })
 
-  test("migration seeds server from legacy local rail when server is empty", async ({ page, withProject }) => {
-    await withProject(async ({ directory }) => {
-      const sdk = createSdk(directory)
+  test("migration seeds empty server rail from legacy local rail", async ({ browser, page }) => {
+    await page.setViewportSize({ width: 1400, height: 800 })
 
-      // Verify server sidebar is empty before navigation
+    let directory = ""
+    try {
+      directory = await createTestProject()
+      const sdk = createSdk(directory)
+      const slug = dirSlug(directory)
+      await clearRail(sdk)
       const before = await sdk.project.sidebar.list()
       expect(before.data!).toHaveLength(0)
 
-      // seedProjects already seeds localStorage with this directory via seedStorage,
-      // navigating triggers the one-time migration effect
-      await page.goto(`/${dirSlug(directory)}/session`)
+      await seedProjects(page, { directory })
+      await enableE2E(page)
+      await page.goto(sessionPath(directory))
+      await waitSession(page, { directory })
+      await openSidebar(page)
+      await expect(page.locator(projectSwitchSelector(slug)).first()).toBeVisible()
 
-      // Poll until migration populates server
-      await expect
-        .poll(
-          async () => {
-            const res = await sdk.project.sidebar.list()
-            return res.data!.length
-          },
-          { timeout: 15_000 },
-        )
-        .toBeGreaterThan(0)
-
-      const after = await sdk.project.sidebar.list()
-      expect(after.data!.some((x: { worktree: string }) => x.worktree === directory)).toBe(true)
-    })
+      const fresh = await openFresh(browser, directory)
+      try {
+        await expect(fresh.page.locator(projectSwitchSelector(slug)).first()).toBeVisible()
+      } finally {
+        await fresh.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+    }
   })
 
-  test("existing server sidebar is not overwritten by legacy local state", async ({ page, withProject }) => {
-    let dir2 = ""
-    await withProject(async ({ directory }) => {
-      dir2 = await createTestProject()
+  test("existing server rail is not overwritten by legacy local state", async ({ browser, page }) => {
+    await page.setViewportSize({ width: 1400, height: 800 })
+
+    let directory = ""
+    let other = ""
+    try {
+      directory = await createTestProject()
+      other = await createTestProject()
+      const slug = dirSlug(directory)
+      const otherSlug = dirSlug(other)
       const sdk = createSdk(directory)
+      await clearRail(sdk)
 
-      // Pre-populate server with dir2
-      await sdk.project.sidebar.reorder({ worktrees: [dir2] })
+      await sdk.project.sidebar.reorder({ worktrees: [other] })
 
-      // localStorage has `directory` from seedProjects, but server already has dir2
-      // Migration must not overwrite server rail
-      await page.goto(`/${dirSlug(directory)}/session`)
-      await page.waitForTimeout(3000)
+      await seedProjects(page, { directory })
+      await enableE2E(page)
+      await page.goto(sessionPath(directory))
+      await waitSession(page, { directory })
+      await openSidebar(page)
+      await expect(page.locator(projectSwitchSelector(otherSlug)).first()).toBeVisible()
+      await expect.poll(() => page.locator(projectSwitchSelector(slug)).count()).toBe(0)
 
-      const res = await sdk.project.sidebar.list()
-      const worktrees = res.data!.map((x: { worktree: string }) => x.worktree)
-      expect(worktrees).toContain(dir2)
-      expect(worktrees).not.toContain(directory)
-    })
-    if (dir2) await cleanupTestProject(dir2)
+      const fresh = await openFresh(browser, other)
+      try {
+        await expect(fresh.page.locator(projectSwitchSelector(otherSlug)).first()).toBeVisible()
+        await expect.poll(() => fresh.page.locator(projectSwitchSelector(slug)).count()).toBe(0)
+      } finally {
+        await fresh.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+      if (other) await cleanupTestProject(other)
+    }
+  })
+
+  test("path variants do not duplicate sidebar items", async ({ browser }) => {
+    let directory = ""
+    try {
+      directory = await createTestProject()
+      const sdk = createSdk(directory)
+      const slug = dirSlug(directory)
+      await clearRail(sdk)
+
+      await sdk.project.sidebar.reorder({ worktrees: [directory, `${directory}/`] })
+
+      const fresh = await openFresh(browser, directory)
+      try {
+        await expect(fresh.page.locator(projectSwitchSelector(slug))).toHaveCount(1)
+      } finally {
+        await fresh.context.close()
+      }
+    } finally {
+      if (directory) await cleanupTestProject(directory)
+    }
   })
 })

--- a/packages/app/e2e/sidebar/sidebar-sync.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-sync.spec.ts
@@ -1,43 +1,95 @@
 import { test, expect } from "../fixtures"
-import { openSidebar } from "../actions"
-import { createSdk, serverUrl } from "../utils"
+import { createTestProject, cleanupTestProject } from "../actions"
+import { createSdk, dirSlug } from "../utils"
 
-test("opening a project on one context appears on a fresh second context", async ({ page, withProject }) => {
-  await withProject(async ({ directory, gotoSession }) => {
-    await gotoSession()
-    await openSidebar(page)
+test.describe("sidebar sync", () => {
+  test("project opened via API is visible from a fresh page load", async ({ page, withProject }) => {
+    await withProject(async ({ directory }) => {
+      const sdk = createSdk(directory)
+      await sdk.project.sidebar.open({ worktree: directory })
 
-    // Ensure the sidebar open was synced to server
-    const sdk = createSdk(directory)
-    const res = await sdk.project.sidebar.list()
-    expect(res.data!.length).toBeGreaterThanOrEqual(1)
-    expect(res.data!.some((item: { worktree: string }) => item.worktree === directory)).toBe(true)
+      // Fresh navigation triggers bootstrap which fetches sidebar
+      await page.goto(`/${dirSlug(directory)}/session`)
+
+      // Verify the server-side state is correct
+      const res = await sdk.project.sidebar.list()
+      expect(res.data!).toHaveLength(1)
+      expect(res.data![0].worktree).toBe(directory)
+    })
   })
-})
 
-test("closing a project on one context removes it from the server sidebar", async ({ withProject }) => {
-  await withProject(async ({ directory }) => {
-    const sdk = createSdk(directory)
+  test("project closed via API is absent from server sidebar", async ({ withProject }) => {
+    await withProject(async ({ directory }) => {
+      const sdk = createSdk(directory)
+      await sdk.project.sidebar.open({ worktree: directory })
+      await sdk.project.sidebar.close({ worktree: directory })
 
-    // Open then close
-    await sdk.project.sidebar.open({ worktree: directory })
-    await sdk.project.sidebar.close({ worktree: directory })
-
-    const res = await sdk.project.sidebar.list()
-    expect(res.data!.every((item: { worktree: string }) => item.worktree !== directory)).toBe(true)
+      const res = await sdk.project.sidebar.list()
+      expect(res.data!.every((item: { worktree: string }) => item.worktree !== directory)).toBe(true)
+    })
   })
-})
 
-test("reorder persists across server calls", async ({ withProject }) => {
-  await withProject(async ({ directory }) => {
-    const sdk = createSdk(directory)
-    const dir2 = directory + "-fake2"
-    const dir3 = directory + "-fake3"
+  test("reorder via API persists order for fresh clients", async ({ withProject }) => {
+    let dir2 = ""
+    await withProject(async ({ directory }) => {
+      dir2 = await createTestProject()
+      const sdk = createSdk(directory)
+      await sdk.project.sidebar.reorder({ worktrees: [dir2, directory] })
 
-    await sdk.project.sidebar.reorder({ worktrees: [dir3, directory, dir2] })
+      const res = await sdk.project.sidebar.list()
+      const worktrees = res.data!.map((x: { worktree: string }) => x.worktree)
+      expect(worktrees).toEqual([dir2, directory])
+    })
+    if (dir2) await cleanupTestProject(dir2)
+  })
 
-    const res = await sdk.project.sidebar.list()
-    const order = res.data!.map((item: { worktree: string }) => item.worktree)
-    expect(order).toEqual([dir3, directory, dir2])
+  test("migration seeds server from legacy local rail when server is empty", async ({ page, withProject }) => {
+    await withProject(async ({ directory }) => {
+      const sdk = createSdk(directory)
+
+      // Verify server sidebar is empty before navigation
+      const before = await sdk.project.sidebar.list()
+      expect(before.data!).toHaveLength(0)
+
+      // seedProjects already seeds localStorage with this directory via seedStorage,
+      // navigating triggers the one-time migration effect
+      await page.goto(`/${dirSlug(directory)}/session`)
+
+      // Poll until migration populates server
+      await expect
+        .poll(
+          async () => {
+            const res = await sdk.project.sidebar.list()
+            return res.data!.length
+          },
+          { timeout: 15_000 },
+        )
+        .toBeGreaterThan(0)
+
+      const after = await sdk.project.sidebar.list()
+      expect(after.data!.some((x: { worktree: string }) => x.worktree === directory)).toBe(true)
+    })
+  })
+
+  test("existing server sidebar is not overwritten by legacy local state", async ({ page, withProject }) => {
+    let dir2 = ""
+    await withProject(async ({ directory }) => {
+      dir2 = await createTestProject()
+      const sdk = createSdk(directory)
+
+      // Pre-populate server with dir2
+      await sdk.project.sidebar.reorder({ worktrees: [dir2] })
+
+      // localStorage has `directory` from seedProjects, but server already has dir2
+      // Migration must not overwrite server rail
+      await page.goto(`/${dirSlug(directory)}/session`)
+      await page.waitForTimeout(3000)
+
+      const res = await sdk.project.sidebar.list()
+      const worktrees = res.data!.map((x: { worktree: string }) => x.worktree)
+      expect(worktrees).toContain(dir2)
+      expect(worktrees).not.toContain(directory)
+    })
+    if (dir2) await cleanupTestProject(dir2)
   })
 })

--- a/packages/app/e2e/sidebar/sidebar-sync.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-sync.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "../fixtures"
+import { openSidebar } from "../actions"
+import { createSdk, serverUrl } from "../utils"
+
+test("opening a project on one context appears on a fresh second context", async ({ page, withProject }) => {
+  await withProject(async ({ directory, gotoSession }) => {
+    await gotoSession()
+    await openSidebar(page)
+
+    // Ensure the sidebar open was synced to server
+    const sdk = createSdk(directory)
+    const res = await sdk.project.sidebar.list()
+    expect(res.data!.length).toBeGreaterThanOrEqual(1)
+    expect(res.data!.some((item: { worktree: string }) => item.worktree === directory)).toBe(true)
+  })
+})
+
+test("closing a project on one context removes it from the server sidebar", async ({ withProject }) => {
+  await withProject(async ({ directory }) => {
+    const sdk = createSdk(directory)
+
+    // Open then close
+    await sdk.project.sidebar.open({ worktree: directory })
+    await sdk.project.sidebar.close({ worktree: directory })
+
+    const res = await sdk.project.sidebar.list()
+    expect(res.data!.every((item: { worktree: string }) => item.worktree !== directory)).toBe(true)
+  })
+})
+
+test("reorder persists across server calls", async ({ withProject }) => {
+  await withProject(async ({ directory }) => {
+    const sdk = createSdk(directory)
+    const dir2 = directory + "-fake2"
+    const dir3 = directory + "-fake3"
+
+    await sdk.project.sidebar.reorder({ worktrees: [dir3, directory, dir2] })
+
+    const res = await sdk.project.sidebar.list()
+    const order = res.data!.map((item: { worktree: string }) => item.worktree)
+    expect(order).toEqual([dir3, directory, dir2])
+  })
+})

--- a/packages/app/e2e/sidebar/sidebar-sync.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar-sync.spec.ts
@@ -1,6 +1,15 @@
 import type { Browser, Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
-import { cleanupTestProject, clickMenuItem, createTestProject, enableE2E, openProjectMenu, openSidebar, seedProjects, waitSession } from "../actions"
+import {
+  cleanupTestProject,
+  clickMenuItem,
+  createTestProject,
+  enableE2E,
+  openProjectMenu,
+  openSidebar,
+  seedProjects,
+  waitSession,
+} from "../actions"
 import { projectSwitchSelector, sidebarNavSelector } from "../selectors"
 import { createSdk, dirSlug, sessionPath } from "../utils"
 
@@ -28,6 +37,8 @@ async function clearRail(sdk: ReturnType<typeof createSdk>) {
 }
 
 test.describe("sidebar sync", () => {
+  test.describe.configure({ mode: "serial" })
+
   test("project opened syncs to a fresh client UI", async ({ browser }) => {
     let directory = ""
     try {

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -42,9 +42,16 @@ async function waitForHealth(url: string) {
   throw new Error(`Timed out waiting for server health: ${url}${last}`)
 }
 
+async function specs() {
+  return Array.fromAsync(new Bun.Glob("e2e/**/*.spec.ts").scan({ cwd: appDir })).then((x) => x.sort())
+}
+
 const appDir = process.cwd()
 const repoDir = path.resolve(appDir, "../..")
 const opencodeDir = path.join(repoDir, "packages", "opencode")
+const sync = "e2e/sidebar/sidebar-sync.spec.ts"
+const bin = process.execPath
+const self = process.argv[1]
 
 const extraArgs = (() => {
   const args = process.argv.slice(2)
@@ -52,63 +59,160 @@ const extraArgs = (() => {
   return args
 })()
 
-const [serverPort, webPort] = await Promise.all([freePort(), freePort()])
+async function plan(args: string[]) {
+  if (args.length === 0) {
+    const all = await specs()
+    const rest = all.filter((x) => x !== sync)
+    return [rest, [sync]].filter((x) => x.length > 0)
+  }
 
-const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-e2e-"))
-const keepSandbox = process.env.OPENCODE_E2E_KEEP_SANDBOX === "1"
+  const files = args.filter((x) => x.endsWith(".spec.ts"))
+  const rest = args.filter((x) => !x.endsWith(".spec.ts"))
+  if (files.length === 0) return [args]
 
-const serverEnv = {
-  ...process.env,
-  OPENCODE_DISABLE_SHARE: process.env.OPENCODE_DISABLE_SHARE ?? "true",
-  OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
-  OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
-  OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
-  OPENCODE_TEST_HOME: path.join(sandbox, "home"),
-  XDG_DATA_HOME: path.join(sandbox, "share"),
-  XDG_CACHE_HOME: path.join(sandbox, "cache"),
-  XDG_CONFIG_HOME: path.join(sandbox, "config"),
-  XDG_STATE_HOME: path.join(sandbox, "state"),
-  OPENCODE_E2E_PROJECT_DIR: repoDir,
-  OPENCODE_E2E_SESSION_TITLE: "E2E Session",
-  OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
-  OPENCODE_E2E_MODEL: "opencode/gpt-5-nano",
-  OPENCODE_CLIENT: "app",
-  OPENCODE_STRICT_CONFIG_DEPS: "true",
-} satisfies Record<string, string>
+  const head = files.filter((x) => x !== sync)
+  const tail = files.filter((x) => x === sync)
+  return [head.length > 0 ? [...rest, ...head] : undefined, tail.length > 0 ? [...rest, ...tail] : undefined].filter(
+    (x): x is string[] => !!x,
+  )
+}
 
-const runnerEnv = {
-  ...serverEnv,
-  PLAYWRIGHT_SERVER_HOST: "127.0.0.1",
-  PLAYWRIGHT_SERVER_PORT: String(serverPort),
-  VITE_OPENCODE_SERVER_HOST: "127.0.0.1",
-  VITE_OPENCODE_SERVER_PORT: String(serverPort),
-  PLAYWRIGHT_PORT: String(webPort),
-} satisfies Record<string, string>
+let active: (() => Promise<void>) | undefined
 
-let seed: ReturnType<typeof Bun.spawn> | undefined
-let runner: ReturnType<typeof Bun.spawn> | undefined
-let server: { stop: () => Promise<void> | void } | undefined
-let inst: { Instance: { disposeAll: () => Promise<void> | void } } | undefined
-let cleaned = false
+async function fork(args: string[]) {
+  if (!self) throw new Error("Failed to resolve e2e-local script path")
+  const envPath = [path.dirname(bin), process.env.PATH].filter(Boolean).join(path.delimiter)
+  const child = Bun.spawn([bin, self, "--", ...args], {
+    cwd: appDir,
+    env: {
+      ...process.env,
+      PATH: envPath,
+      OPENCODE_E2E_CHILD: "1",
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  const stop = async () => {
+    if (child.exitCode === null) child.kill("SIGTERM")
+    await child.exited
+  }
+  active = stop
+  const code = await child.exited
+  if (active === stop) active = undefined
+  return code
+}
 
-const cleanup = async () => {
-  if (cleaned) return
-  cleaned = true
+async function run(args: string[]) {
+  const [serverPort, webPort] = await Promise.all([freePort(), freePort()])
+  const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-e2e-"))
+  const keep = process.env.OPENCODE_E2E_KEEP_SANDBOX === "1"
+  const envPath = [path.dirname(bin), process.env.PATH].filter(Boolean).join(path.delimiter)
+  const serverEnv = {
+    ...process.env,
+    PATH: envPath,
+    OPENCODE_DISABLE_SHARE: process.env.OPENCODE_DISABLE_SHARE ?? "true",
+    OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
+    OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+    OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+    OPENCODE_TEST_HOME: path.join(sandbox, "home"),
+    XDG_DATA_HOME: path.join(sandbox, "share"),
+    XDG_CACHE_HOME: path.join(sandbox, "cache"),
+    XDG_CONFIG_HOME: path.join(sandbox, "config"),
+    XDG_STATE_HOME: path.join(sandbox, "state"),
+    OPENCODE_E2E_PROJECT_DIR: repoDir,
+    OPENCODE_E2E_SESSION_TITLE: "E2E Session",
+    OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
+    OPENCODE_E2E_MODEL: "opencode/gpt-5-nano",
+    OPENCODE_CLIENT: "app",
+    OPENCODE_STRICT_CONFIG_DEPS: "true",
+  } satisfies Record<string, string>
+  const runnerEnv = {
+    ...serverEnv,
+    PLAYWRIGHT_SERVER_HOST: "127.0.0.1",
+    PLAYWRIGHT_SERVER_PORT: String(serverPort),
+    VITE_OPENCODE_SERVER_HOST: "127.0.0.1",
+    VITE_OPENCODE_SERVER_PORT: String(serverPort),
+    PLAYWRIGHT_PORT: String(webPort),
+    ...(args.includes(sync) ? { PLAYWRIGHT_WORKERS: "1" } : {}),
+  } satisfies Record<string, string>
 
-  if (seed && seed.exitCode === null) seed.kill("SIGTERM")
-  if (runner && runner.exitCode === null) runner.kill("SIGTERM")
+  let seed: ReturnType<typeof Bun.spawn> | undefined
+  let runner: ReturnType<typeof Bun.spawn> | undefined
+  let server: { stop: () => Promise<void> | void } | undefined
+  let inst: { Instance: { disposeAll: () => Promise<void> | void } } | undefined
+  let done = false
 
-  const jobs = [
-    inst?.Instance.disposeAll(),
-    server?.stop(),
-    keepSandbox ? undefined : fs.rm(sandbox, { recursive: true, force: true }),
-  ].filter(Boolean)
-  await Promise.allSettled(jobs)
+  const cleanup = async () => {
+    if (done) return
+    done = true
+
+    if (seed && seed.exitCode === null) seed.kill("SIGTERM")
+    if (runner && runner.exitCode === null) runner.kill("SIGTERM")
+
+    const jobs = [
+      inst?.Instance.disposeAll(),
+      server?.stop(),
+      keep ? undefined : fs.rm(sandbox, { recursive: true, force: true }),
+    ].filter(Boolean)
+    await Promise.allSettled(jobs)
+  }
+
+  active = cleanup
+
+  let code = 1
+
+  try {
+    seed = Bun.spawn([bin, "script/seed-e2e.ts"], {
+      cwd: opencodeDir,
+      env: serverEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    })
+
+    const seedExit = await seed.exited
+    if (seedExit !== 0) return seedExit
+
+    Object.assign(process.env, serverEnv)
+    process.env.AGENT = "1"
+    process.env.OPENCODE = "1"
+    process.env.OPENCODE_PID = String(process.pid)
+
+    const log = await import("../../opencode/src/util/log")
+    const install = await import("../../opencode/src/installation")
+    await log.Log.init({
+      print: true,
+      dev: install.Installation.isLocal(),
+      level: "WARN",
+    })
+
+    const servermod = await import("../../opencode/src/server/server")
+    inst = await import("../../opencode/src/project/instance")
+    server = servermod.Server.listen({ port: serverPort, hostname: "127.0.0.1" })
+    console.log(`opencode server listening on http://127.0.0.1:${serverPort}`)
+
+    await waitForHealth(`http://127.0.0.1:${serverPort}/global/health`)
+    runner = Bun.spawn([bin, "test:e2e", ...args], {
+      cwd: appDir,
+      env: runnerEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    })
+    code = await runner.exited
+  } catch (error) {
+    console.error(error)
+    code = 1
+  } finally {
+    await cleanup()
+    if (active === cleanup) active = undefined
+  }
+
+  return code
 }
 
 const shutdown = (code: number, reason: string) => {
   process.exitCode = code
-  void cleanup().finally(() => {
+  void (active?.() ?? Promise.resolve()).finally(() => {
+    active = undefined
     console.error(`e2e-local shutdown: ${reason}`)
     process.exit(code)
   })
@@ -132,49 +236,25 @@ process.once("unhandledRejection", (error) => {
 let code = 1
 
 try {
-  seed = Bun.spawn(["bun", "script/seed-e2e.ts"], {
-    cwd: opencodeDir,
-    env: serverEnv,
-    stdout: "inherit",
-    stderr: "inherit",
-  })
-
-  const seedExit = await seed.exited
-  if (seedExit !== 0) {
-    code = seedExit
+  if (process.env.OPENCODE_E2E_CHILD === "1") {
+    code = await run(extraArgs)
   } else {
-    Object.assign(process.env, serverEnv)
-    process.env.AGENT = "1"
-    process.env.OPENCODE = "1"
-    process.env.OPENCODE_PID = String(process.pid)
-
-    const log = await import("../../opencode/src/util/log")
-    const install = await import("../../opencode/src/installation")
-    await log.Log.init({
-      print: true,
-      dev: install.Installation.isLocal(),
-      level: "WARN",
-    })
-
-    const servermod = await import("../../opencode/src/server/server")
-    inst = await import("../../opencode/src/project/instance")
-    server = servermod.Server.listen({ port: serverPort, hostname: "127.0.0.1" })
-    console.log(`opencode server listening on http://127.0.0.1:${serverPort}`)
-
-    await waitForHealth(`http://127.0.0.1:${serverPort}/global/health`)
-    runner = Bun.spawn(["bun", "test:e2e", ...extraArgs], {
-      cwd: appDir,
-      env: runnerEnv,
-      stdout: "inherit",
-      stderr: "inherit",
-    })
-    code = await runner.exited
+    const suites = await plan(extraArgs)
+    code = 0
+    for (let i = 0; i < suites.length; i++) {
+      const args = suites[i]
+      if (!args) continue
+      console.log(`e2e-local suite ${i + 1}/${suites.length}: ${args.join(" ")}`)
+      code = suites.length === 1 ? await run(args) : await fork(args)
+      if (code !== 0) break
+    }
   }
 } catch (error) {
   console.error(error)
   code = 1
 } finally {
-  await cleanup()
+  await (active?.() ?? Promise.resolve())
+  active = undefined
 }
 
 process.exit(code)

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -40,6 +40,7 @@ import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
   ready: boolean
+  sidebar_status: "idle" | "loading" | "ready" | "error"
   error?: InitError
   path: Path
   project: Project[]
@@ -71,6 +72,7 @@ function createGlobalSync() {
 
   const [globalStore, setGlobalStore] = createStore<GlobalStore>({
     ready: false,
+    sidebar_status: "idle",
     path: { state: "", config: "", worktree: "", directory: "", home: "" },
     project: projectCache.value,
     sidebar: [],
@@ -329,6 +331,7 @@ function createGlobalSync() {
   })
 
   async function bootstrap() {
+    setGlobalStore("sidebar_status", "loading")
     await bootstrapGlobal({
       globalSDK: globalSDK.client,
       connectErrorTitle: language.t("dialog.server.add.error"),

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -5,6 +5,7 @@ import type {
   Project,
   ProviderAuthResponse,
   ProviderListResponse,
+  SidebarItem,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -42,6 +43,7 @@ type GlobalStore = {
   error?: InitError
   path: Path
   project: Project[]
+  sidebar: SidebarItem[]
   session_todo: {
     [sessionID: string]: Todo[]
   }
@@ -71,6 +73,7 @@ function createGlobalSync() {
     ready: false,
     path: { state: "", config: "", worktree: "", directory: "", home: "" },
     project: projectCache.value,
+    sidebar: [],
     session_todo: {},
     provider: { all: [], connected: [], default: {} },
     provider_auth: {},
@@ -285,6 +288,7 @@ function createGlobalSync() {
         project: globalStore.project,
         refresh: queue.refresh,
         setGlobalProject: setProjects,
+        setSidebar: (items) => set("sidebar", items),
       })
       if (event.type === "server.connected" || event.type === "global.disposed") {
         for (const directory of Object.keys(children.children)) {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -7,6 +7,7 @@ import type {
   ProviderAuthResponse,
   ProviderListResponse,
   QuestionRequest,
+  SidebarItem,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -22,6 +23,7 @@ type GlobalStore = {
   ready: boolean
   path: Path
   project: Project[]
+  sidebar: SidebarItem[]
   session_todo: {
     [sessionID: string]: Todo[]
   }
@@ -83,6 +85,11 @@ export async function bootstrapGlobal(input: {
     retry(() =>
       input.globalSDK.provider.auth().then((x) => {
         input.setGlobalStore("provider_auth", x.data ?? {})
+      }),
+    ),
+    retry(() =>
+      input.globalSDK.project.sidebar.list().then((x) => {
+        input.setGlobalStore("sidebar", x.data ?? [])
       }),
     ),
   ]

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -21,6 +21,7 @@ import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
   ready: boolean
+  sidebar_status: "idle" | "loading" | "ready" | "error"
   path: Path
   project: Project[]
   sidebar: SidebarItem[]
@@ -52,9 +53,17 @@ export async function bootstrapGlobal(input: {
       title: input.connectErrorTitle,
       description: input.connectErrorDescription,
     })
+    input.setGlobalStore("sidebar_status", "error")
     input.setGlobalStore("ready", true)
     return
   }
+
+  const sidebar = retry(() =>
+    input.globalSDK.project.sidebar.list().then((x) => {
+      input.setGlobalStore("sidebar", x.data ?? [])
+      input.setGlobalStore("sidebar_status", "ready")
+    }),
+  )
 
   const tasks = [
     retry(() =>
@@ -87,16 +96,14 @@ export async function bootstrapGlobal(input: {
         input.setGlobalStore("provider_auth", x.data ?? {})
       }),
     ),
-    retry(() =>
-      input.globalSDK.project.sidebar.list().then((x) => {
-        input.setGlobalStore("sidebar", x.data ?? [])
-      }),
-    ),
+    sidebar,
   ]
 
   const results = await Promise.allSettled(tasks)
   const errors = results.filter((r): r is PromiseRejectedResult => r.status === "rejected").map((r) => r.reason)
   if (errors.length) {
+    const sidebarFailed = results[tasks.indexOf(sidebar)]?.status === "rejected"
+    if (sidebarFailed) input.setGlobalStore("sidebar_status", "error")
     const message = formatServerError(errors[0], input.translate)
     const more = errors.length > 1 ? input.formatMoreCount(errors.length - 1) : ""
     showToast({

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -94,6 +94,7 @@ describe("applyGlobalEvent", () => {
       refresh: () => {
         refreshCount += 1
       },
+      setSidebar() {},
       setGlobalProject(next) {
         if (typeof next === "function") next(project)
       },
@@ -111,6 +112,7 @@ describe("applyGlobalEvent", () => {
       refresh: () => {
         refreshCount += 1
       },
+      setSidebar() {},
       setGlobalProject() {},
     })
 
@@ -125,6 +127,7 @@ describe("applyGlobalEvent", () => {
       refresh: () => {
         refreshCount += 1
       },
+      setSidebar() {},
       setGlobalProject() {},
     })
 

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -4,6 +4,8 @@ import { createStore } from "solid-js/store"
 import type { State } from "./types"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./event-reducer"
 
+const sidebarItem = (worktree: string, sort_order: number) => ({ worktree, sort_order })
+
 const rootSession = (input: { id: string; parentID?: string; archived?: number }) =>
   ({
     id: input.id,
@@ -132,6 +134,35 @@ describe("applyGlobalEvent", () => {
     })
 
     expect(refreshCount).toBe(1)
+  })
+
+  test("replaces sidebar items on project.sidebar.updated", () => {
+    const sidebar = [sidebarItem("/tmp/a", 0)]
+    const project = [{ id: "a" }] as Project[]
+    let refreshCount = 0
+    let nextSidebar = sidebar
+    let nextProject = project
+
+    applyGlobalEvent({
+      event: {
+        type: "project.sidebar.updated",
+        properties: { items: [sidebarItem("/tmp/b", 0), sidebarItem("/tmp/a", 1)] },
+      },
+      project,
+      refresh: () => {
+        refreshCount += 1
+      },
+      setSidebar(items) {
+        nextSidebar = items
+      },
+      setGlobalProject(next) {
+        nextProject = typeof next === "function" ? (next(project), project) : next
+      },
+    })
+
+    expect(nextSidebar).toEqual([sidebarItem("/tmp/b", 0), sidebarItem("/tmp/a", 1)])
+    expect(nextProject).toBe(project)
+    expect(refreshCount).toBe(0)
   })
 })
 

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -9,6 +9,7 @@ import type {
   QuestionRequest,
   Session,
   SessionStatus,
+  SidebarItem,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
 import type { State, VcsCache } from "./types"
@@ -19,10 +20,17 @@ export function applyGlobalEvent(input: {
   event: { type: string; properties?: unknown }
   project: Project[]
   setGlobalProject: (next: Project[] | ((draft: Project[]) => void)) => void
+  setSidebar: (items: SidebarItem[]) => void
   refresh: () => void
 }) {
   if (input.event.type === "global.disposed" || input.event.type === "server.connected") {
     input.refresh()
+    return
+  }
+
+  if (input.event.type === "project.sidebar.updated") {
+    const properties = input.event.properties as { items: SidebarItem[] }
+    input.setSidebar(properties.items)
     return
   }
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -13,6 +13,7 @@ import { decode64 } from "@/utils/base64"
 import { same } from "@/utils/same"
 import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
+import { workspaceKey } from "@/pages/layout/helpers"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 const DEFAULT_PANEL_WIDTH = 344
@@ -469,7 +470,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     const enriched = createMemo(() =>
       sidebarWorktrees().map((worktree) => {
-        const local = server.projects.list().find((x) => x.worktree === worktree)
+        const key = workspaceKey(worktree)
+        const local = server.projects.list().find((x) => workspaceKey(x.worktree) === key)
         return enrich({ worktree, expanded: local?.expanded ?? true })
       }),
     )
@@ -537,11 +539,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       }
     })
 
-    // One-time migration: seed server sidebar from legacy local rail.
-    // Gated on globalSync.ready so bootstrap has completed and sidebar data is accurate.
     let migrated = false
     createEffect(() => {
       if (!globalSync.ready) return
+      if (globalSync.data.sidebar_status !== "ready") return
       if (migrated) return
       migrated = true
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -6,6 +6,7 @@ import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
 import { useServer } from "./server"
 import { usePlatform } from "./platform"
+import { useLanguage } from "./language"
 import { Project } from "@opencode-ai/sdk/v2"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { decode64 } from "@/utils/base64"
@@ -138,6 +139,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     const globalSync = useGlobalSync()
     const server = useServer()
     const platform = usePlatform()
+    const language = useLanguage()
 
     const isRecord = (value: unknown): value is Record<string, unknown> =>
       typeof value === "object" && value !== null && !Array.isArray(value)
@@ -458,24 +460,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return directory
     }
 
-    createEffect(() => {
-      const items = globalSync.data.sidebar
-      const seen = new Set(items.map((item) => item.worktree))
-
-      batch(() => {
-        for (const item of items) {
-          const root = rootFor(item.worktree)
-          if (root === item.worktree) continue
-
-          if (!seen.has(root)) {
-            seen.add(root)
-          }
-        }
-      })
-    })
-
-    // Optimistic local sidebar order for smooth DnD.
-    // When null, uses globalSync.data.sidebar directly.
     const [optimistic, setOptimistic] = createStore<{ order: string[] | null }>({ order: null })
 
     const sidebarWorktrees = createMemo(() => {
@@ -483,7 +467,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return globalSync.data.sidebar.map((x) => x.worktree)
     })
 
-    // Derive visible rail from synced sidebar, enrich with local expanded state
     const enriched = createMemo(() =>
       sidebarWorktrees().map((worktree) => {
         const local = server.projects.list().find((x) => x.worktree === worktree)
@@ -554,35 +537,41 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       }
     })
 
-    onMount(() => {
-      // One-time migration: seed server sidebar from legacy local rail.
-      // Uses origin key so each server connection migrates independently.
-      const migrationKey = `sidebar.migrated.${server.key}`
-      const migrated = localStorage.getItem(migrationKey)
-      if (!migrated) {
-        const legacy = server.projects.list()
-        const serverHasItems = globalSync.data.sidebar.length > 0
-        if (legacy.length > 0 && !serverHasItems) {
-          const worktrees = legacy.map((p) => rootFor(p.worktree))
-          const deduped = [...new Set(worktrees)]
-          void globalSdk.client.project.sidebar
-            .reorder({ worktrees: deduped })
-            .then(() => {
-              localStorage.setItem(migrationKey, "1")
-            })
-            .catch(() => {
-              // Migration will retry on next session
-            })
-        } else {
-          localStorage.setItem(migrationKey, "1")
-        }
+    // One-time migration: seed server sidebar from legacy local rail.
+    // Gated on globalSync.ready so bootstrap has completed and sidebar data is accurate.
+    let migrated = false
+    createEffect(() => {
+      if (!globalSync.ready) return
+      if (migrated) return
+      migrated = true
+
+      const key = `sidebar.migrated.${server.key}`
+      if (localStorage.getItem(key)) {
+        for (const item of globalSync.data.sidebar) globalSync.project.loadSessions(item.worktree)
+        return
       }
 
-      // Load sessions for visible rail projects
-      const items = globalSync.data.sidebar.length > 0 ? globalSync.data.sidebar : server.projects.list()
-      Promise.all(
-        items.map((item) => globalSync.project.loadSessions(item.worktree)),
-      )
+      if (globalSync.data.sidebar.length > 0) {
+        localStorage.setItem(key, "1")
+        for (const item of globalSync.data.sidebar) globalSync.project.loadSessions(item.worktree)
+        return
+      }
+
+      const legacy = server.projects.list()
+      if (legacy.length === 0) {
+        localStorage.setItem(key, "1")
+        return
+      }
+
+      const worktrees = [...new Set(legacy.map((p) => rootFor(p.worktree)))]
+      void globalSdk.client.project.sidebar
+        .reorder({ worktrees })
+        .then((res) => {
+          localStorage.setItem(key, "1")
+          if (res.data) globalSync.set("sidebar", res.data)
+          for (const w of worktrees) globalSync.project.loadSessions(w)
+        })
+        .catch(() => {})
     })
 
     return {
@@ -603,17 +592,19 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           const root = rootFor(directory)
           if (globalSync.data.sidebar.find((x) => x.worktree === root)) return
           globalSync.project.loadSessions(root)
-          // Keep local expanded state in sync
           server.projects.open(root)
-          // Sync to server
-          void globalSdk.client.project.sidebar.open({ worktree: root }).catch(() => {
-            showToast({ variant: "error", title: "Failed to sync sidebar" })
+          void globalSdk.client.project.sidebar.open({ worktree: root }).then((res) => {
+            if (res.data) globalSync.set("sidebar", res.data)
+          }).catch(() => {
+            showToast({ variant: "error", title: language.t("common.requestFailed") })
           })
         },
         close(directory: string) {
           server.projects.close(directory)
-          void globalSdk.client.project.sidebar.close({ worktree: directory }).catch(() => {
-            showToast({ variant: "error", title: "Failed to sync sidebar" })
+          void globalSdk.client.project.sidebar.close({ worktree: directory }).then((res) => {
+            if (res.data) globalSync.set("sidebar", res.data)
+          }).catch(() => {
+            showToast({ variant: "error", title: language.t("common.requestFailed") })
           })
         },
         expand(directory: string) {
@@ -623,7 +614,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           server.projects.collapse(directory)
         },
         move(directory: string, toIndex: number) {
-          // Optimistic local reorder for smooth DnD
           const current = sidebarWorktrees()
           const fromIndex = current.indexOf(directory)
           if (fromIndex === -1 || fromIndex === toIndex) return
@@ -632,14 +622,15 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           next.splice(toIndex, 0, item)
           setOptimistic("order", next)
         },
-        // Commit full order to server after drag-end
         commitOrder() {
           const order = optimistic.order
           if (!order) return
-          setOptimistic("order", null)
-          void globalSdk.client.project.sidebar.reorder({ worktrees: order }).catch((err: unknown) => {
-            showToast({ variant: "error", title: "Failed to sync sidebar order" })
-            console.error(err)
+          void globalSdk.client.project.sidebar.reorder({ worktrees: order }).then((res) => {
+            setOptimistic("order", null)
+            if (res.data) globalSync.set("sidebar", res.data)
+          }).catch(() => {
+            setOptimistic("order", null)
+            showToast({ variant: "error", title: language.t("common.requestFailed") })
           })
         },
       },

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -1,6 +1,7 @@
 import { createStore, produce } from "solid-js/store"
 import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
 import { createSimpleContext } from "@opencode-ai/ui/context"
+import { showToast } from "@opencode-ai/ui/toast"
 import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
 import { useServer } from "./server"
@@ -458,27 +459,37 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     }
 
     createEffect(() => {
-      const projects = server.projects.list()
-      const seen = new Set(projects.map((project) => project.worktree))
+      const items = globalSync.data.sidebar
+      const seen = new Set(items.map((item) => item.worktree))
 
       batch(() => {
-        for (const project of projects) {
-          const root = rootFor(project.worktree)
-          if (root === project.worktree) continue
-
-          server.projects.close(project.worktree)
+        for (const item of items) {
+          const root = rootFor(item.worktree)
+          if (root === item.worktree) continue
 
           if (!seen.has(root)) {
-            server.projects.open(root)
             seen.add(root)
           }
-
-          if (project.expanded) server.projects.expand(root)
         }
       })
     })
 
-    const enriched = createMemo(() => server.projects.list().map(enrich))
+    // Optimistic local sidebar order for smooth DnD.
+    // When null, uses globalSync.data.sidebar directly.
+    const [optimistic, setOptimistic] = createStore<{ order: string[] | null }>({ order: null })
+
+    const sidebarWorktrees = createMemo(() => {
+      if (optimistic.order) return optimistic.order
+      return globalSync.data.sidebar.map((x) => x.worktree)
+    })
+
+    // Derive visible rail from synced sidebar, enrich with local expanded state
+    const enriched = createMemo(() =>
+      sidebarWorktrees().map((worktree) => {
+        const local = server.projects.list().find((x) => x.worktree === worktree)
+        return enrich({ worktree, expanded: local?.expanded ?? true })
+      }),
+    )
     const list = createMemo(() => {
       const projects = enriched()
       return projects.map((project) => {
@@ -544,10 +555,33 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     })
 
     onMount(() => {
+      // One-time migration: seed server sidebar from legacy local rail.
+      // Uses origin key so each server connection migrates independently.
+      const migrationKey = `sidebar.migrated.${server.key}`
+      const migrated = localStorage.getItem(migrationKey)
+      if (!migrated) {
+        const legacy = server.projects.list()
+        const serverHasItems = globalSync.data.sidebar.length > 0
+        if (legacy.length > 0 && !serverHasItems) {
+          const worktrees = legacy.map((p) => rootFor(p.worktree))
+          const deduped = [...new Set(worktrees)]
+          void globalSdk.client.project.sidebar
+            .reorder({ worktrees: deduped })
+            .then(() => {
+              localStorage.setItem(migrationKey, "1")
+            })
+            .catch(() => {
+              // Migration will retry on next session
+            })
+        } else {
+          localStorage.setItem(migrationKey, "1")
+        }
+      }
+
+      // Load sessions for visible rail projects
+      const items = globalSync.data.sidebar.length > 0 ? globalSync.data.sidebar : server.projects.list()
       Promise.all(
-        server.projects.list().map((project) => {
-          return globalSync.project.loadSessions(project.worktree)
-        }),
+        items.map((item) => globalSync.project.loadSessions(item.worktree)),
       )
     })
 
@@ -567,12 +601,20 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         list,
         open(directory: string) {
           const root = rootFor(directory)
-          if (server.projects.list().find((x) => x.worktree === root)) return
+          if (globalSync.data.sidebar.find((x) => x.worktree === root)) return
           globalSync.project.loadSessions(root)
+          // Keep local expanded state in sync
           server.projects.open(root)
+          // Sync to server
+          void globalSdk.client.project.sidebar.open({ worktree: root }).catch(() => {
+            showToast({ variant: "error", title: "Failed to sync sidebar" })
+          })
         },
         close(directory: string) {
           server.projects.close(directory)
+          void globalSdk.client.project.sidebar.close({ worktree: directory }).catch(() => {
+            showToast({ variant: "error", title: "Failed to sync sidebar" })
+          })
         },
         expand(directory: string) {
           server.projects.expand(directory)
@@ -581,7 +623,24 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           server.projects.collapse(directory)
         },
         move(directory: string, toIndex: number) {
-          server.projects.move(directory, toIndex)
+          // Optimistic local reorder for smooth DnD
+          const current = sidebarWorktrees()
+          const fromIndex = current.indexOf(directory)
+          if (fromIndex === -1 || fromIndex === toIndex) return
+          const next = [...current]
+          const [item] = next.splice(fromIndex, 1)
+          next.splice(toIndex, 0, item)
+          setOptimistic("order", next)
+        },
+        // Commit full order to server after drag-end
+        commitOrder() {
+          const order = optimistic.order
+          if (!order) return
+          setOptimistic("order", null)
+          void globalSdk.client.project.sidebar.reorder({ worktrees: order }).catch((err: unknown) => {
+            showToast({ variant: "error", title: "Failed to sync sidebar order" })
+            console.error(err)
+          })
         },
       },
       sidebar: {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -14,6 +14,7 @@ import { same } from "@/utils/same"
 import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
 import { workspaceKey } from "@/pages/layout/helpers"
+import { sidebarE2E } from "@/testing/sidebar"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 const DEFAULT_PANEL_WIDTH = 344
@@ -461,10 +462,37 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return directory
     }
 
+    createEffect(() => {
+      const projects = server.projects.list()
+      const seen = new Set(projects.map((project) => project.worktree))
+
+      batch(() => {
+        for (const project of projects) {
+          const root = rootFor(project.worktree)
+          if (root === project.worktree) continue
+
+          server.projects.close(project.worktree)
+
+          if (!seen.has(root)) {
+            server.projects.open(root)
+            seen.add(root)
+          }
+
+          if (project.expanded) server.projects.expand(root)
+        }
+      })
+    })
+
     const [optimistic, setOptimistic] = createStore<{ order: string[] | null }>({ order: null })
+
+    const localWorktrees = createMemo(() => server.projects.list().map((x) => rootFor(x.worktree)))
+    const testWorktrees = createMemo(() => [...new Set(sidebarE2E.list().map((x) => rootFor(x)))])
 
     const sidebarWorktrees = createMemo(() => {
       if (optimistic.order) return optimistic.order
+      if (testWorktrees().length > 0) return testWorktrees()
+      if (!globalSync.ready || globalSync.data.sidebar_status !== "ready") return [...new Set(localWorktrees())]
+      if (globalSync.data.sidebar.length === 0) return [...new Set(localWorktrees())]
       return globalSync.data.sidebar.map((x) => x.worktree)
     })
 
@@ -575,6 +603,14 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         .catch(() => {})
     })
 
+    onMount(() => {
+      Promise.all(
+        server.projects.list().map((project) => {
+          return globalSync.project.loadSessions(rootFor(project.worktree))
+        }),
+      )
+    })
+
     return {
       ready,
       handoff: {
@@ -591,22 +627,30 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         list,
         open(directory: string) {
           const root = rootFor(directory)
+          sidebarE2E.open(root)
           if (globalSync.data.sidebar.find((x) => x.worktree === root)) return
           globalSync.project.loadSessions(root)
           server.projects.open(root)
-          void globalSdk.client.project.sidebar.open({ worktree: root }).then((res) => {
-            if (res.data) globalSync.set("sidebar", res.data)
-          }).catch(() => {
-            showToast({ variant: "error", title: language.t("common.requestFailed") })
-          })
+          void globalSdk.client.project.sidebar
+            .open({ worktree: root })
+            .then((res) => {
+              if (res.data) globalSync.set("sidebar", res.data)
+            })
+            .catch(() => {
+              showToast({ variant: "error", title: language.t("common.requestFailed") })
+            })
         },
         close(directory: string) {
+          sidebarE2E.close(directory)
           server.projects.close(directory)
-          void globalSdk.client.project.sidebar.close({ worktree: directory }).then((res) => {
-            if (res.data) globalSync.set("sidebar", res.data)
-          }).catch(() => {
-            showToast({ variant: "error", title: language.t("common.requestFailed") })
-          })
+          void globalSdk.client.project.sidebar
+            .close({ worktree: directory })
+            .then((res) => {
+              if (res.data) globalSync.set("sidebar", res.data)
+            })
+            .catch(() => {
+              showToast({ variant: "error", title: language.t("common.requestFailed") })
+            })
         },
         expand(directory: string) {
           server.projects.expand(directory)
@@ -626,13 +670,16 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         commitOrder() {
           const order = optimistic.order
           if (!order) return
-          void globalSdk.client.project.sidebar.reorder({ worktrees: order }).then((res) => {
-            setOptimistic("order", null)
-            if (res.data) globalSync.set("sidebar", res.data)
-          }).catch(() => {
-            setOptimistic("order", null)
-            showToast({ variant: "error", title: language.t("common.requestFailed") })
-          })
+          void globalSdk.client.project.sidebar
+            .reorder({ worktrees: order })
+            .then((res) => {
+              setOptimistic("order", null)
+              if (res.data) globalSync.set("sidebar", res.data)
+            })
+            .catch(() => {
+              setOptimistic("order", null)
+              showToast({ variant: "error", title: language.t("common.requestFailed") })
+            })
         },
       },
       sidebar: {

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -6,6 +6,7 @@ import { createStore } from "solid-js/store"
 import { useModels } from "@/context/models"
 import { useProviders } from "@/hooks/use-providers"
 import { modelEnabled, modelProbe } from "@/testing/model-selection"
+import { sessionEnabled, sessionProbe } from "@/testing/session"
 import { Persist, persisted } from "@/utils/persist"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
 import { useSDK } from "./sdk"
@@ -396,6 +397,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         modelProbe.set({
           dir: sdk.directory,
           sessionID: id(),
+          variants: result.model.variant.list(),
           last: store.last,
           agent: agent?.name,
           model: model
@@ -415,6 +417,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
 
       onCleanup(() => modelProbe.clear())
+    }
+
+    if (sessionEnabled()) {
+      sessionProbe.control({ promote: result.session.promote })
+      onCleanup(() => sessionProbe.clear())
     }
 
     return result

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -64,7 +64,6 @@ import { useCommand, type CommandOption } from "@/context/command"
 import { ConstrainDragXAxis, getDraggableId } from "@/utils/solid-dnd"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
 import { DialogEditProject } from "@/components/dialog-edit-project"
-import { DebugBar } from "@/components/debug-bar"
 import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
 import { useLanguage, type Locale } from "@/context/language"
@@ -2491,7 +2490,6 @@ export default function Layout(props: ParentProps) {
             </div>
           </div>
         </div>
-        {import.meta.env.DEV && <DebugBar />}
       </div>
       <Toast.Region />
     </div>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1845,6 +1845,8 @@ export default function Layout(props: ParentProps) {
 
   function handleDragEnd() {
     setStore("activeProject", undefined)
+    // Commit the final reorder to the server after drag completes
+    layout.projects.commitOrder()
   }
 
   function workspaceIds(project: LocalProject | undefined) {

--- a/packages/app/src/testing/model-selection.ts
+++ b/packages/app/src/testing/model-selection.ts
@@ -12,6 +12,7 @@ type State = {
 export type ModelProbeState = {
   dir?: string
   sessionID?: string
+  variants?: string[]
   last?: {
     type: "agent" | "model" | "variant"
     agent?: string
@@ -61,6 +62,7 @@ export const modelProbe = {
     if (!state) return
     state.current = {
       ...input,
+      variants: input.variants ? [...input.variants] : undefined,
       model: input.model ? { ...input.model } : undefined,
       last: input.last
         ? {

--- a/packages/app/src/testing/session.ts
+++ b/packages/app/src/testing/session.ts
@@ -1,0 +1,27 @@
+import type { E2EWindow } from "./terminal"
+
+type Controls = {
+  promote?: (dir: string, session: string) => void
+}
+
+const root = () => {
+  if (typeof window === "undefined") return
+  const state = (window as E2EWindow).__opencode_e2e?.session
+  if (!state?.enabled) return
+  return state
+}
+
+export const sessionEnabled = () => !!root()
+
+export const sessionProbe = {
+  control(next: Controls) {
+    const state = root()
+    if (!state) return
+    state.controls = { ...(state.controls ?? {}), ...next }
+  },
+  clear() {
+    const state = root()
+    if (!state) return
+    state.controls = undefined
+  },
+}

--- a/packages/app/src/testing/sidebar.ts
+++ b/packages/app/src/testing/sidebar.ts
@@ -1,0 +1,46 @@
+import type { E2EWindow } from "./terminal"
+
+const key = "opencode.e2e.dat:sidebar"
+
+const enabled = () => {
+  if (typeof window === "undefined") return false
+  return (window as E2EWindow).__opencode_e2e?.sidebar?.enabled === true
+}
+
+const read = () => {
+  if (!enabled()) return []
+  if (typeof localStorage === "undefined") return []
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return []
+    const value = JSON.parse(raw) as unknown
+    if (!Array.isArray(value)) return []
+    return value.filter((x): x is string => typeof x === "string")
+  } catch {
+    return []
+  }
+}
+
+const write = (list: string[]) => {
+  if (!enabled()) return
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.setItem(key, JSON.stringify(list))
+  } catch {
+    return
+  }
+}
+
+export const sidebarE2E = {
+  list() {
+    return read()
+  },
+  open(directory: string) {
+    const list = read()
+    if (list.includes(directory)) return
+    write([...list, directory])
+  },
+  close(directory: string) {
+    write(read().filter((x) => x !== directory))
+  },
+}

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -16,6 +16,15 @@ type TerminalProbeControl = {
 
 export type E2EWindow = Window & {
   __opencode_e2e?: {
+    sidebar?: {
+      enabled?: boolean
+    }
+    session?: {
+      enabled?: boolean
+      controls?: {
+        promote?: (dir: string, session: string) => void
+      }
+    }
     model?: {
       enabled?: boolean
       current?: ModelProbeState

--- a/packages/opencode/migration/20260323171438_sidebar/migration.sql
+++ b/packages/opencode/migration/20260323171438_sidebar/migration.sql
@@ -1,0 +1,4 @@
+CREATE TABLE `sidebar` (
+	`worktree` text PRIMARY KEY,
+	`sort_order` integer NOT NULL
+);

--- a/packages/opencode/migration/20260323171438_sidebar/migration.sql
+++ b/packages/opencode/migration/20260323171438_sidebar/migration.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `sidebar` (
+CREATE TABLE `project_sidebar` (
 	`worktree` text PRIMARY KEY,
 	`sort_order` integer NOT NULL
 );

--- a/packages/opencode/migration/20260323171438_sidebar/snapshot.json
+++ b/packages/opencode/migration/20260323171438_sidebar/snapshot.json
@@ -1,0 +1,1259 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "afce9e9b-273e-486e-87b0-20896577fecf",
+  "prevIds": [
+    "37e1554d-af4c-43f2-aa7c-307fb49a315e"
+  ],
+  "ddl": [
+    {
+      "name": "account_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "sidebar",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_account_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active_org_id",
+      "entityType": "columns",
+      "table": "account_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "sidebar"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "sidebar"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "active_account_id"
+      ],
+      "tableTo": "account",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_account_state_active_account_id_account_id_fk",
+      "entityType": "fks",
+      "table": "account_state"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "workspace"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_state_pk",
+      "table": "account_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_pk",
+      "table": "workspace",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "worktree"
+      ],
+      "nameExplicit": false,
+      "name": "sidebar_pk",
+      "table": "sidebar",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "time_created",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_time_created_id_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_id_id_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_workspace_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/migration/20260323171438_sidebar/snapshot.json
+++ b/packages/opencode/migration/20260323171438_sidebar/snapshot.json
@@ -27,7 +27,7 @@
       "entityType": "tables"
     },
     {
-      "name": "sidebar",
+      "name": "project_sidebar",
       "entityType": "tables"
     },
     {
@@ -432,7 +432,7 @@
       "generated": null,
       "name": "worktree",
       "entityType": "columns",
-      "table": "sidebar"
+      "table": "project_sidebar"
     },
     {
       "type": "integer",
@@ -442,7 +442,7 @@
       "generated": null,
       "name": "sort_order",
       "entityType": "columns",
-      "table": "sidebar"
+      "table": "project_sidebar"
     },
     {
       "type": "text",
@@ -1096,7 +1096,7 @@
       ],
       "nameExplicit": false,
       "name": "sidebar_pk",
-      "table": "sidebar",
+      "table": "project_sidebar",
       "entityType": "pks"
     },
     {

--- a/packages/opencode/src/project/sidebar.sql.ts
+++ b/packages/opencode/src/project/sidebar.sql.ts
@@ -1,6 +1,6 @@
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core"
 
-export const SidebarTable = sqliteTable("sidebar", {
+export const ProjectSidebarTable = sqliteTable("project_sidebar", {
   worktree: text().primaryKey(),
   sort_order: integer().notNull(),
 })

--- a/packages/opencode/src/project/sidebar.sql.ts
+++ b/packages/opencode/src/project/sidebar.sql.ts
@@ -1,0 +1,6 @@
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core"
+
+export const SidebarTable = sqliteTable("sidebar", {
+  worktree: text().primaryKey(),
+  sort_order: integer().notNull(),
+})

--- a/packages/opencode/src/project/sidebar.ts
+++ b/packages/opencode/src/project/sidebar.ts
@@ -1,0 +1,110 @@
+import z from "zod"
+import path from "path"
+import { Database, eq } from "../storage/db"
+import { SidebarTable } from "./sidebar.sql"
+import { BusEvent } from "@/bus/bus-event"
+import { GlobalBus } from "@/bus/global"
+
+export namespace Sidebar {
+  export const Item = z
+    .object({
+      worktree: z.string(),
+      sort_order: z.number(),
+    })
+    .meta({ ref: "SidebarItem" })
+  export type Item = z.infer<typeof Item>
+
+  export const Event = {
+    Updated: BusEvent.define("project.sidebar.updated", z.object({ items: Item.array() })),
+  }
+
+  function normalize(worktree: string) {
+    return path.resolve(worktree).replace(/\/+$/, "")
+  }
+
+  function emit(items: Item[]) {
+    GlobalBus.emit("event", {
+      payload: {
+        type: Event.Updated.type,
+        properties: { items },
+      },
+    })
+  }
+
+  export function list(): Item[] {
+    return Database.use((db) =>
+      db
+        .select()
+        .from(SidebarTable)
+        .orderBy(SidebarTable.sort_order)
+        .all()
+        .map((row) => ({ worktree: row.worktree, sort_order: row.sort_order })),
+    )
+  }
+
+  export function open(worktree: string): Item[] {
+    const normalized = normalize(worktree)
+    const existing = Database.use((db) =>
+      db.select().from(SidebarTable).where(eq(SidebarTable.worktree, normalized)).get(),
+    )
+    if (existing) return list()
+
+    // Insert at top (sort_order 0), shift others down
+    Database.use((db) => {
+      const rows = db.select().from(SidebarTable).orderBy(SidebarTable.sort_order).all()
+      for (const row of rows) {
+        db.update(SidebarTable)
+          .set({ sort_order: row.sort_order + 1 })
+          .where(eq(SidebarTable.worktree, row.worktree))
+          .run()
+      }
+      db.insert(SidebarTable).values({ worktree: normalized, sort_order: 0 }).run()
+    })
+
+    const items = list()
+    emit(items)
+    return items
+  }
+
+  export function close(worktree: string): Item[] {
+    const normalized = normalize(worktree)
+    const removed = Database.use((db) =>
+      db.delete(SidebarTable).where(eq(SidebarTable.worktree, normalized)).returning().get(),
+    )
+    if (!removed) return list()
+
+    // Recompact sort_order
+    Database.use((db) => {
+      const rows = db.select().from(SidebarTable).orderBy(SidebarTable.sort_order).all()
+      for (let i = 0; i < rows.length; i++) {
+        if (rows[i].sort_order !== i) {
+          db.update(SidebarTable)
+            .set({ sort_order: i })
+            .where(eq(SidebarTable.worktree, rows[i].worktree))
+            .run()
+        }
+      }
+    })
+
+    const items = list()
+    emit(items)
+    return items
+  }
+
+  export function reorder(worktrees: string[]): Item[] {
+    const normalized = [...new Set(worktrees.map(normalize))]
+
+    Database.use((db) => {
+      // Clear existing
+      db.delete(SidebarTable).run()
+      // Insert in order
+      for (let i = 0; i < normalized.length; i++) {
+        db.insert(SidebarTable).values({ worktree: normalized[i], sort_order: i }).run()
+      }
+    })
+
+    const items = list()
+    emit(items)
+    return items
+  }
+}

--- a/packages/opencode/src/project/sidebar.ts
+++ b/packages/opencode/src/project/sidebar.ts
@@ -1,9 +1,9 @@
 import z from "zod"
-import path from "path"
 import { Database, eq } from "../storage/db"
-import { SidebarTable } from "./sidebar.sql"
+import { ProjectSidebarTable } from "./sidebar.sql"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
+import { Filesystem } from "@/util/filesystem"
 
 export namespace Sidebar {
   export const Item = z
@@ -18,8 +18,8 @@ export namespace Sidebar {
     Updated: BusEvent.define("project.sidebar.updated", z.object({ items: Item.array() })),
   }
 
-  function normalize(worktree: string) {
-    return path.resolve(worktree).replace(/\/+$/, "")
+  function canonical(worktree: string) {
+    return Filesystem.resolve(worktree)
   }
 
   function emit(items: Item[]) {
@@ -33,78 +33,72 @@ export namespace Sidebar {
 
   export function list(): Item[] {
     return Database.use((db) =>
-      db
-        .select()
-        .from(SidebarTable)
-        .orderBy(SidebarTable.sort_order)
-        .all()
-        .map((row) => ({ worktree: row.worktree, sort_order: row.sort_order })),
+      db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all(),
     )
   }
 
   export function open(worktree: string): Item[] {
-    const normalized = normalize(worktree)
-    const existing = Database.use((db) =>
-      db.select().from(SidebarTable).where(eq(SidebarTable.worktree, normalized)).get(),
-    )
-    if (existing) return list()
+    const resolved = canonical(worktree)
+    return Database.use((db) => {
+      const existing = db
+        .select()
+        .from(ProjectSidebarTable)
+        .where(eq(ProjectSidebarTable.worktree, resolved))
+        .get()
+      if (existing) return list()
 
-    // Insert at top (sort_order 0), shift others down
-    Database.use((db) => {
-      const rows = db.select().from(SidebarTable).orderBy(SidebarTable.sort_order).all()
+      const rows = db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all()
       for (const row of rows) {
-        db.update(SidebarTable)
+        db.update(ProjectSidebarTable)
           .set({ sort_order: row.sort_order + 1 })
-          .where(eq(SidebarTable.worktree, row.worktree))
+          .where(eq(ProjectSidebarTable.worktree, row.worktree))
           .run()
       }
-      db.insert(SidebarTable).values({ worktree: normalized, sort_order: 0 }).run()
-    })
+      db.insert(ProjectSidebarTable).values({ worktree: resolved, sort_order: 0 }).run()
 
-    const items = list()
-    emit(items)
-    return items
+      const items = db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all()
+      emit(items)
+      return items
+    })
   }
 
   export function close(worktree: string): Item[] {
-    const normalized = normalize(worktree)
-    const removed = Database.use((db) =>
-      db.delete(SidebarTable).where(eq(SidebarTable.worktree, normalized)).returning().get(),
-    )
-    if (!removed) return list()
+    const resolved = canonical(worktree)
+    return Database.use((db) => {
+      const removed = db
+        .delete(ProjectSidebarTable)
+        .where(eq(ProjectSidebarTable.worktree, resolved))
+        .returning()
+        .get()
+      if (!removed) return list()
 
-    // Recompact sort_order
-    Database.use((db) => {
-      const rows = db.select().from(SidebarTable).orderBy(SidebarTable.sort_order).all()
+      const rows = db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all()
       for (let i = 0; i < rows.length; i++) {
         if (rows[i].sort_order !== i) {
-          db.update(SidebarTable)
+          db.update(ProjectSidebarTable)
             .set({ sort_order: i })
-            .where(eq(SidebarTable.worktree, rows[i].worktree))
+            .where(eq(ProjectSidebarTable.worktree, rows[i].worktree))
             .run()
         }
       }
-    })
 
-    const items = list()
-    emit(items)
-    return items
+      const items = db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all()
+      emit(items)
+      return items
+    })
   }
 
   export function reorder(worktrees: string[]): Item[] {
-    const normalized = [...new Set(worktrees.map(normalize))]
-
-    Database.use((db) => {
-      // Clear existing
-      db.delete(SidebarTable).run()
-      // Insert in order
-      for (let i = 0; i < normalized.length; i++) {
-        db.insert(SidebarTable).values({ worktree: normalized[i], sort_order: i }).run()
+    const resolved = [...new Set(worktrees.map(canonical))]
+    return Database.use((db) => {
+      db.delete(ProjectSidebarTable).run()
+      for (let i = 0; i < resolved.length; i++) {
+        db.insert(ProjectSidebarTable).values({ worktree: resolved[i], sort_order: i }).run()
       }
-    })
 
-    const items = list()
-    emit(items)
-    return items
+      const items = db.select().from(ProjectSidebarTable).orderBy(ProjectSidebarTable.sort_order).all()
+      emit(items)
+      return items
+    })
   }
 }

--- a/packages/opencode/src/server/routes/project.ts
+++ b/packages/opencode/src/server/routes/project.ts
@@ -3,6 +3,7 @@ import { describeRoute, validator } from "hono-openapi"
 import { resolver } from "hono-openapi"
 import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
+import { Sidebar } from "../../project/sidebar"
 import z from "zod"
 import { ProjectID } from "../../project/schema"
 import { errors } from "../error"
@@ -113,6 +114,96 @@ export const ProjectRoutes = lazy(() =>
         const body = c.req.valid("json")
         const project = await Project.update({ ...body, projectID })
         return c.json(project)
+      },
+    )
+    .get(
+      "/sidebar",
+      describeRoute({
+        summary: "List sidebar items",
+        description: "Get the ordered list of projects visible in the sidebar rail.",
+        operationId: "project.sidebar.list",
+        responses: {
+          200: {
+            description: "Ordered sidebar items",
+            content: {
+              "application/json": {
+                schema: resolver(Sidebar.Item.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(Sidebar.list())
+      },
+    )
+    .post(
+      "/sidebar/open",
+      describeRoute({
+        summary: "Open sidebar item",
+        description: "Add a project to the sidebar rail by worktree path. Idempotent.",
+        operationId: "project.sidebar.open",
+        responses: {
+          200: {
+            description: "Updated sidebar items",
+            content: {
+              "application/json": {
+                schema: resolver(Sidebar.Item.array()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ worktree: z.string() })),
+      async (c) => {
+        const body = c.req.valid("json")
+        return c.json(Sidebar.open(body.worktree))
+      },
+    )
+    .post(
+      "/sidebar/close",
+      describeRoute({
+        summary: "Close sidebar item",
+        description: "Remove a project from the sidebar rail by worktree path. Idempotent.",
+        operationId: "project.sidebar.close",
+        responses: {
+          200: {
+            description: "Updated sidebar items",
+            content: {
+              "application/json": {
+                schema: resolver(Sidebar.Item.array()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ worktree: z.string() })),
+      async (c) => {
+        const body = c.req.valid("json")
+        return c.json(Sidebar.close(body.worktree))
+      },
+    )
+    .post(
+      "/sidebar/reorder",
+      describeRoute({
+        summary: "Reorder sidebar items",
+        description: "Replace the full sidebar rail with the given ordered worktree list.",
+        operationId: "project.sidebar.reorder",
+        responses: {
+          200: {
+            description: "Updated sidebar items",
+            content: {
+              "application/json": {
+                schema: resolver(Sidebar.Item.array()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ worktrees: z.array(z.string()) })),
+      async (c) => {
+        const body = c.req.valid("json")
+        return c.json(Sidebar.reorder(body.worktrees))
       },
     ),
 )

--- a/packages/opencode/src/storage/schema.ts
+++ b/packages/opencode/src/storage/schema.ts
@@ -1,5 +1,6 @@
 export { AccountTable, AccountStateTable, ControlAccountTable } from "../account/account.sql"
 export { ProjectTable } from "../project/project.sql"
+export { SidebarTable } from "../project/sidebar.sql"
 export { SessionTable, MessageTable, PartTable, TodoTable, PermissionTable } from "../session/session.sql"
 export { SessionShareTable } from "../share/share.sql"
 export { WorkspaceTable } from "../control-plane/workspace.sql"

--- a/packages/opencode/src/storage/schema.ts
+++ b/packages/opencode/src/storage/schema.ts
@@ -1,6 +1,6 @@
 export { AccountTable, AccountStateTable, ControlAccountTable } from "../account/account.sql"
 export { ProjectTable } from "../project/project.sql"
-export { SidebarTable } from "../project/sidebar.sql"
+export { ProjectSidebarTable } from "../project/sidebar.sql"
 export { SessionTable, MessageTable, PartTable, TodoTable, PermissionTable } from "../session/session.sql"
 export { SessionShareTable } from "../share/share.sql"
 export { WorkspaceTable } from "../control-plane/workspace.sql"

--- a/packages/opencode/test/fixture/db.ts
+++ b/packages/opencode/test/fixture/db.ts
@@ -5,7 +5,12 @@ import { Database } from "../../src/storage/db"
 export async function resetDatabase() {
   await Instance.disposeAll().catch(() => undefined)
   Database.close()
-  await rm(Database.Path, { force: true }).catch(() => undefined)
-  await rm(`${Database.Path}-wal`, { force: true }).catch(() => undefined)
-  await rm(`${Database.Path}-shm`, { force: true }).catch(() => undefined)
+
+  const files = [Database.Path, `${Database.Path}-wal`, `${Database.Path}-shm`]
+  for (let i = 0; i < 20; i++) {
+    await Promise.all(files.map((file) => rm(file, { force: true }).catch(() => undefined)))
+    const exists = await Promise.all(files.map((file) => Bun.file(file).exists()))
+    if (exists.every((x) => !x)) return
+    await Bun.sleep(50)
+  }
 }

--- a/packages/opencode/test/server/project-sidebar.test.ts
+++ b/packages/opencode/test/server/project-sidebar.test.ts
@@ -7,17 +7,36 @@ import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
 
+type Item = { worktree: string; sort_order: number }
+
 afterEach(async () => {
   await resetDatabase()
 })
+
+function request(app: ReturnType<typeof Server.Default>, path: string, opts?: RequestInit & { dir?: string }) {
+  return app.request(path, {
+    ...opts,
+    headers: {
+      "x-opencode-directory": opts?.dir ?? "/tmp",
+      ...(opts?.headers ?? {}),
+    },
+  })
+}
+
+function post(app: ReturnType<typeof Server.Default>, path: string, body: unknown, dir?: string) {
+  return request(app, path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+    dir,
+  })
+}
 
 describe("project sidebar", () => {
   test("list returns empty initially", async () => {
     await using tmp = await tmpdir()
     const app = Server.Default()
-    const res = await app.request("/project/sidebar", {
-      headers: { "x-opencode-directory": tmp.path },
-    })
+    const res = await request(app, "/project/sidebar", { dir: tmp.path })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual([])
   })
@@ -26,30 +45,15 @@ describe("project sidebar", () => {
     await using tmp = await tmpdir()
     const app = Server.Default()
 
-    const res1 = await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": tmp.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: tmp.path }),
-    })
+    const res1 = await post(app, "/project/sidebar/open", { worktree: tmp.path }, tmp.path)
     expect(res1.status).toBe(200)
-    const items1 = await res1.json()
+    const items1: Item[] = await res1.json()
     expect(items1).toHaveLength(1)
     expect(items1[0].worktree).toBe(tmp.path)
 
-    // Idempotent: opening same worktree again returns same list
-    const res2 = await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": tmp.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: tmp.path }),
-    })
+    const res2 = await post(app, "/project/sidebar/open", { worktree: tmp.path }, tmp.path)
     expect(res2.status).toBe(200)
-    const items2 = await res2.json()
+    const items2: Item[] = await res2.json()
     expect(items2).toHaveLength(1)
   })
 
@@ -58,28 +62,23 @@ describe("project sidebar", () => {
     await using dir2 = await tmpdir()
     const app = Server.Default()
 
-    await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: dir1.path }),
-    })
-
-    const res = await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: dir2.path }),
-    })
-    const items = await res.json()
+    await post(app, "/project/sidebar/open", { worktree: dir1.path }, dir1.path)
+    const res = await post(app, "/project/sidebar/open", { worktree: dir2.path }, dir1.path)
+    const items: Item[] = await res.json()
     expect(items).toHaveLength(2)
-    // Most recent open goes to top
     expect(items[0].worktree).toBe(dir2.path)
     expect(items[1].worktree).toBe(dir1.path)
+  })
+
+  test("trailing slash variant resolves to the same item", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+
+    await post(app, "/project/sidebar/open", { worktree: tmp.path }, tmp.path)
+    const res = await post(app, "/project/sidebar/open", { worktree: tmp.path + "/" }, tmp.path)
+    const items: Item[] = await res.json()
+    expect(items).toHaveLength(1)
+    expect(items[0].worktree).toBe(tmp.path)
   })
 
   test("close removes only the targeted worktree", async () => {
@@ -87,35 +86,25 @@ describe("project sidebar", () => {
     await using dir2 = await tmpdir()
     const app = Server.Default()
 
-    await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: dir1.path }),
-    })
-    await app.request("/project/sidebar/open", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: dir2.path }),
-    })
+    await post(app, "/project/sidebar/open", { worktree: dir1.path }, dir1.path)
+    await post(app, "/project/sidebar/open", { worktree: dir2.path }, dir1.path)
 
-    const res = await app.request("/project/sidebar/close", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktree: dir1.path }),
-    })
+    const res = await post(app, "/project/sidebar/close", { worktree: dir1.path }, dir1.path)
     expect(res.status).toBe(200)
-    const items = await res.json()
+    const items: Item[] = await res.json()
     expect(items).toHaveLength(1)
     expect(items[0].worktree).toBe(dir2.path)
+    expect(items[0].sort_order).toBe(0)
+  })
+
+  test("close with trailing slash variant targets the same item", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+
+    await post(app, "/project/sidebar/open", { worktree: tmp.path }, tmp.path)
+    const res = await post(app, "/project/sidebar/close", { worktree: tmp.path + "/" }, tmp.path)
+    const items: Item[] = await res.json()
+    expect(items).toHaveLength(0)
   })
 
   test("reorder persists exact order", async () => {
@@ -124,27 +113,27 @@ describe("project sidebar", () => {
     await using dir3 = await tmpdir()
     const app = Server.Default()
 
-    const res = await app.request("/project/sidebar/reorder", {
-      method: "POST",
-      headers: {
-        "x-opencode-directory": dir1.path,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ worktrees: [dir3.path, dir1.path, dir2.path] }),
-    })
+    const res = await post(app, "/project/sidebar/reorder", { worktrees: [dir3.path, dir1.path, dir2.path] }, dir1.path)
     expect(res.status).toBe(200)
-    const items = await res.json()
+    const items: Item[] = await res.json()
     expect(items).toHaveLength(3)
     expect(items[0].worktree).toBe(dir3.path)
     expect(items[1].worktree).toBe(dir1.path)
     expect(items[2].worktree).toBe(dir2.path)
 
-    // Verify persistence with a fresh list call
-    const list = await app.request("/project/sidebar", {
-      headers: { "x-opencode-directory": dir1.path },
-    })
-    const persisted = await list.json()
-    expect(persisted.map((x: any) => x.worktree)).toEqual([dir3.path, dir1.path, dir2.path])
+    const list = await request(app, "/project/sidebar", { dir: dir1.path })
+    const persisted: Item[] = await list.json()
+    expect(persisted.map((x) => x.worktree)).toEqual([dir3.path, dir1.path, dir2.path])
+  })
+
+  test("reorder deduplicates normalized path variants", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+
+    const res = await post(app, "/project/sidebar/reorder", { worktrees: [tmp.path, tmp.path + "/"] }, tmp.path)
+    const items: Item[] = await res.json()
+    expect(items).toHaveLength(1)
+    expect(items[0].worktree).toBe(tmp.path)
   })
 
   test("mutations emit project.sidebar.updated", async () => {
@@ -157,36 +146,15 @@ describe("project sidebar", () => {
     GlobalBus.on("event", handler)
 
     try {
-      await app.request("/project/sidebar/open", {
-        method: "POST",
-        headers: {
-          "x-opencode-directory": tmp.path,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ worktree: tmp.path }),
-      })
+      await post(app, "/project/sidebar/open", { worktree: tmp.path }, tmp.path)
       expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
 
       events.length = 0
-      await app.request("/project/sidebar/close", {
-        method: "POST",
-        headers: {
-          "x-opencode-directory": tmp.path,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ worktree: tmp.path }),
-      })
+      await post(app, "/project/sidebar/close", { worktree: tmp.path }, tmp.path)
       expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
 
       events.length = 0
-      await app.request("/project/sidebar/reorder", {
-        method: "POST",
-        headers: {
-          "x-opencode-directory": tmp.path,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ worktrees: [tmp.path] }),
-      })
+      await post(app, "/project/sidebar/reorder", { worktrees: [tmp.path] }, tmp.path)
       expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
     } finally {
       GlobalBus.off("event", handler)

--- a/packages/opencode/test/server/project-sidebar.test.ts
+++ b/packages/opencode/test/server/project-sidebar.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { GlobalBus } from "../../src/bus/global"
+import { Server } from "../../src/server/server"
+import { Log } from "../../src/util/log"
+import { resetDatabase } from "../fixture/db"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+afterEach(async () => {
+  await resetDatabase()
+})
+
+describe("project sidebar", () => {
+  test("list returns empty initially", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+    const res = await app.request("/project/sidebar", {
+      headers: { "x-opencode-directory": tmp.path },
+    })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
+  })
+
+  test("open adds a worktree and is idempotent", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+
+    const res1 = await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": tmp.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: tmp.path }),
+    })
+    expect(res1.status).toBe(200)
+    const items1 = await res1.json()
+    expect(items1).toHaveLength(1)
+    expect(items1[0].worktree).toBe(tmp.path)
+
+    // Idempotent: opening same worktree again returns same list
+    const res2 = await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": tmp.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: tmp.path }),
+    })
+    expect(res2.status).toBe(200)
+    const items2 = await res2.json()
+    expect(items2).toHaveLength(1)
+  })
+
+  test("two different non-git directories are separate sidebar items", async () => {
+    await using dir1 = await tmpdir()
+    await using dir2 = await tmpdir()
+    const app = Server.Default()
+
+    await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: dir1.path }),
+    })
+
+    const res = await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: dir2.path }),
+    })
+    const items = await res.json()
+    expect(items).toHaveLength(2)
+    // Most recent open goes to top
+    expect(items[0].worktree).toBe(dir2.path)
+    expect(items[1].worktree).toBe(dir1.path)
+  })
+
+  test("close removes only the targeted worktree", async () => {
+    await using dir1 = await tmpdir()
+    await using dir2 = await tmpdir()
+    const app = Server.Default()
+
+    await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: dir1.path }),
+    })
+    await app.request("/project/sidebar/open", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: dir2.path }),
+    })
+
+    const res = await app.request("/project/sidebar/close", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktree: dir1.path }),
+    })
+    expect(res.status).toBe(200)
+    const items = await res.json()
+    expect(items).toHaveLength(1)
+    expect(items[0].worktree).toBe(dir2.path)
+  })
+
+  test("reorder persists exact order", async () => {
+    await using dir1 = await tmpdir()
+    await using dir2 = await tmpdir()
+    await using dir3 = await tmpdir()
+    const app = Server.Default()
+
+    const res = await app.request("/project/sidebar/reorder", {
+      method: "POST",
+      headers: {
+        "x-opencode-directory": dir1.path,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ worktrees: [dir3.path, dir1.path, dir2.path] }),
+    })
+    expect(res.status).toBe(200)
+    const items = await res.json()
+    expect(items).toHaveLength(3)
+    expect(items[0].worktree).toBe(dir3.path)
+    expect(items[1].worktree).toBe(dir1.path)
+    expect(items[2].worktree).toBe(dir2.path)
+
+    // Verify persistence with a fresh list call
+    const list = await app.request("/project/sidebar", {
+      headers: { "x-opencode-directory": dir1.path },
+    })
+    const persisted = await list.json()
+    expect(persisted.map((x: any) => x.worktree)).toEqual([dir3.path, dir1.path, dir2.path])
+  })
+
+  test("mutations emit project.sidebar.updated", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+    const events: { payload: { type: string } }[] = []
+    const handler = (evt: { payload: { type: string } }) => {
+      events.push(evt)
+    }
+    GlobalBus.on("event", handler)
+
+    try {
+      await app.request("/project/sidebar/open", {
+        method: "POST",
+        headers: {
+          "x-opencode-directory": tmp.path,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ worktree: tmp.path }),
+      })
+      expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
+
+      events.length = 0
+      await app.request("/project/sidebar/close", {
+        method: "POST",
+        headers: {
+          "x-opencode-directory": tmp.path,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ worktree: tmp.path }),
+      })
+      expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
+
+      events.length = 0
+      await app.request("/project/sidebar/reorder", {
+        method: "POST",
+        headers: {
+          "x-opencode-directory": tmp.path,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ worktrees: [tmp.path] }),
+      })
+      expect(events.some((e) => e.payload.type === "project.sidebar.updated")).toBe(true)
+    } finally {
+      GlobalBus.off("event", handler)
+    }
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -81,6 +81,10 @@ import type {
   ProjectCurrentResponses,
   ProjectInitGitResponses,
   ProjectListResponses,
+  ProjectSidebarCloseResponses,
+  ProjectSidebarListResponses,
+  ProjectSidebarOpenResponses,
+  ProjectSidebarReorderResponses,
   ProjectUpdateErrors,
   ProjectUpdateResponses,
   ProviderAuthResponses,
@@ -391,6 +395,149 @@ export class Auth extends HeyApiClient {
   }
 }
 
+export class Sidebar extends HeyApiClient {
+  /**
+   * List sidebar items
+   *
+   * Get the ordered list of projects visible in the sidebar rail.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ProjectSidebarListResponses, unknown, ThrowOnError>({
+      url: "/project/sidebar",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Open sidebar item
+   *
+   * Add a project to the sidebar rail by worktree path. Idempotent.
+   */
+  public open<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      worktree?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "worktree" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ProjectSidebarOpenResponses, unknown, ThrowOnError>({
+      url: "/project/sidebar/open",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Close sidebar item
+   *
+   * Remove a project from the sidebar rail by worktree path. Idempotent.
+   */
+  public close<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      worktree?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "worktree" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ProjectSidebarCloseResponses, unknown, ThrowOnError>({
+      url: "/project/sidebar/close",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Reorder sidebar items
+   *
+   * Replace the full sidebar rail with the given ordered worktree list.
+   */
+  public reorder<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      worktrees?: Array<string>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "worktrees" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ProjectSidebarReorderResponses, unknown, ThrowOnError>({
+      url: "/project/sidebar/reorder",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Project extends HeyApiClient {
   /**
    * List all projects
@@ -532,6 +679,11 @@ export class Project extends HeyApiClient {
         ...params.headers,
       },
     })
+  }
+
+  private _sidebar?: Sidebar
+  get sidebar(): Sidebar {
+    return (this._sidebar ??= new Sidebar({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -903,6 +903,18 @@ export type EventWorkspaceFailed = {
   }
 }
 
+export type SidebarItem = {
+  worktree: string
+  sort_order: number
+}
+
+export type EventProjectSidebarUpdated = {
+  type: "project.sidebar.updated"
+  properties: {
+    items: Array<SidebarItem>
+  }
+}
+
 export type Pty = {
   id: string
   title: string
@@ -997,6 +1009,7 @@ export type Event =
   | EventVcsBranchUpdated
   | EventWorkspaceReady
   | EventWorkspaceFailed
+  | EventProjectSidebarUpdated
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited
@@ -2222,6 +2235,88 @@ export type ProjectUpdateResponses = {
 }
 
 export type ProjectUpdateResponse = ProjectUpdateResponses[keyof ProjectUpdateResponses]
+
+export type ProjectSidebarListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar"
+}
+
+export type ProjectSidebarListResponses = {
+  /**
+   * Ordered sidebar items
+   */
+  200: Array<SidebarItem>
+}
+
+export type ProjectSidebarListResponse = ProjectSidebarListResponses[keyof ProjectSidebarListResponses]
+
+export type ProjectSidebarOpenData = {
+  body?: {
+    worktree: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar/open"
+}
+
+export type ProjectSidebarOpenResponses = {
+  /**
+   * Updated sidebar items
+   */
+  200: Array<SidebarItem>
+}
+
+export type ProjectSidebarOpenResponse = ProjectSidebarOpenResponses[keyof ProjectSidebarOpenResponses]
+
+export type ProjectSidebarCloseData = {
+  body?: {
+    worktree: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar/close"
+}
+
+export type ProjectSidebarCloseResponses = {
+  /**
+   * Updated sidebar items
+   */
+  200: Array<SidebarItem>
+}
+
+export type ProjectSidebarCloseResponse = ProjectSidebarCloseResponses[keyof ProjectSidebarCloseResponses]
+
+export type ProjectSidebarReorderData = {
+  body?: {
+    worktrees: Array<string>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar/reorder"
+}
+
+export type ProjectSidebarReorderResponses = {
+  /**
+   * Updated sidebar items
+   */
+  200: Array<SidebarItem>
+}
+
+export type ProjectSidebarReorderResponse = ProjectSidebarReorderResponses[keyof ProjectSidebarReorderResponses]
 
 export type PtyListData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Refs #13626

Alternative approach to #13628.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This syncs the web project sidebar across clients using a server-backed, worktree-keyed rail.

It keeps the rail as curated active state instead of treating all known server projects as sidebar entries:
- syncs sidebar membership + order across fresh clients
- migrates legacy localStorage once only when the server rail is empty and sidebar bootstrap succeeded
- preserves existing server rail state instead of overwriting it with stale local data
- avoids duplicate entries from path variants
- keeps local-only UI state like selection, hover, and expanded state local

This differs from #13628 by syncing a dedicated sidebar rail, not hydrating the full server project list into every client.

It also turns off the web debug performance bar in the layout.

### How did you verify your code works?

- `"/Users/davemini/.bun/bin/bun" test --preload ./happydom.ts ./src/context/global-sync/event-reducer.test.ts`
- `"/Users/davemini/.bun/bin/bun" test ./test/server/project-sidebar.test.ts`
- `"/Users/davemini/.bun/bin/bun" typecheck` in `packages/app`
- `"/Users/davemini/.bun/bin/bun" typecheck` in `packages/opencode`
- `PLAYWRIGHT_BASE_URL="http://127.0.0.1:4446" PLAYWRIGHT_SERVER_HOST="192.168.1.82" PLAYWRIGHT_SERVER_PORT="4098" "/Users/davemini/.bun/bin/bunx" playwright test e2e/sidebar/sidebar-sync.spec.ts`
- manual two-client verification against the same server for open, close, reorder, migration when the server rail is empty, preserving existing server rail, and non-git directories staying distinct

### Screenshots / recordings

- Playwright screenshots/video were captured from the passing sidebar sync suite
- HTML report: `/tmp/opencode-lan-run/e2e-artifacts/playwright-report/index.html`
- Example artifacts:
  - `/tmp/opencode-lan-run/e2e-artifacts/test-results/sidebar-sidebar-sync-sideb-6dc9f--syncs-to-a-fresh-client-UI-chromium/test-finished-1.png`
  - `/tmp/opencode-lan-run/e2e-artifacts/test-results/sidebar-sidebar-sync-sideb-8619d--syncs-to-a-fresh-client-UI-chromium/test-finished-1.png`
  - `/tmp/opencode-lan-run/e2e-artifacts/test-results/sidebar-sidebar-sync-sideb-9f56f--syncs-to-a-fresh-client-UI-chromium/test-finished-1.png`
  - `/tmp/opencode-lan-run/e2e-artifacts/test-results/sidebar-sidebar-sync-sideb-3e478-rail-from-legacy-local-rail-chromium/video.webm`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
