### PR TITLE
tui: tighten prompt and message attachment presentation

### DIFF
--- a/packages/app/src/components/comment-chip.tsx
+++ b/packages/app/src/components/comment-chip.tsx
@@ -38,9 +38,9 @@ export const CommentChip: Component<CommentChipProps> = (props) => {
 
   return (
     <div
-      class={`group relative flex flex-col rounded-[6px] cursor-default bg-background-stronger ${
-        variant() === "full" ? "border border-border-weak-base" : "shadow-xs-border"
-      } ${variant() === "full" ? `pl-2 py-1 ${pad()}` : `pl-2 py-1 h-12 ${pad()}`} ${props.class ?? ""}`}
+      class={`group relative flex flex-col rounded-[6px] cursor-default bg-background-stronger border border-border-weak-base ${
+        variant() === "full" ? `pl-2 py-1 ${pad()}` : `pl-2 py-1 h-12 ${pad()}`
+      } ${props.class ?? ""}`}
       onClick={() => props.onOpen?.()}
     >
       <div class="flex items-center gap-1.5 min-w-0">

--- a/packages/app/src/components/comment-chip.tsx
+++ b/packages/app/src/components/comment-chip.tsx
@@ -1,0 +1,85 @@
+import { Show, type Component } from "solid-js"
+import { FileIcon } from "@opencode-ai/ui/file-icon"
+import { Icon } from "@opencode-ai/ui/icon"
+
+type Range = {
+  start: number
+  end: number
+}
+
+type CommentChipProps = {
+  variant?: "preview" | "full"
+  path: string
+  label: string
+  selection?: Range
+  comment?: string
+  class?: string
+  onOpen?: () => void
+  onRemove?: () => void
+  removeLabel?: string
+}
+
+const removeClass =
+  "absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+const removeIconClass =
+  "absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active"
+
+export const CommentChip: Component<CommentChipProps> = (props) => {
+  const variant = () => props.variant ?? "preview"
+  const range = () => {
+    const sel = props.selection
+    if (!sel) return
+    const start = Math.min(sel.start, sel.end)
+    const end = Math.max(sel.start, sel.end)
+    return { start, end }
+  }
+
+  const pad = () => (props.onRemove ? "pr-7" : "pr-2")
+
+  return (
+    <div
+      class={`group relative flex flex-col rounded-[6px] cursor-default bg-background-stronger ${
+        variant() === "full" ? "border border-border-weak-base" : "shadow-xs-border"
+      } ${variant() === "full" ? `pl-2 py-1 ${pad()}` : `pl-2 py-1 h-12 ${pad()}`} ${props.class ?? ""}`}
+      onClick={() => props.onOpen?.()}
+    >
+      <div class="flex items-center gap-1.5 min-w-0">
+        <FileIcon node={{ path: props.path, type: "file" }} class="shrink-0 size-3.5" />
+        <div class="flex items-center text-11-regular min-w-0 font-medium">
+          <span class="text-text-strong whitespace-nowrap">{props.label}</span>
+          <Show when={range()}>
+            {(sel) => (
+              <span class="text-text-weak whitespace-nowrap shrink-0">
+                {sel().start === sel().end ? `:${sel().start}` : `:${sel().start}-${sel().end}`}
+              </span>
+            )}
+          </Show>
+        </div>
+      </div>
+      <Show when={(props.comment ?? "").trim().length > 0}>
+        <div
+          class={`text-base text-text-strong ml-5 ${
+            variant() === "full" ? "whitespace-pre-wrap break-words" : "truncate"
+          }`}
+        >
+          {props.comment}
+        </div>
+      </Show>
+      <Show when={props.onRemove}>
+        <button
+          type="button"
+          class={`${removeClass} group/remove`}
+          onClick={(e) => {
+            e.stopPropagation()
+            props.onRemove?.()
+          }}
+          aria-label={props.removeLabel}
+        >
+          <span class={removeIconClass}>
+            <Icon name="close-small" size="small" class="text-text-weak group-hover/remove:text-text-strong" />
+          </span>
+        </button>
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/components/comment-chip.tsx
+++ b/packages/app/src/components/comment-chip.tsx
@@ -22,7 +22,7 @@ type CommentChipProps = {
 const removeClass =
   "absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
 const removeIconClass =
-  "absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active"
+  "absolute top-1 right-1 size-4 rounded-[var(--radius-sm)] border border-border-weak-base flex items-center justify-center bg-[var(--surface-raised-stronger-non-alpha)] group-active/remove:bg-surface-base-active"
 
 export const CommentChip: Component<CommentChipProps> = (props) => {
   const variant = () => props.variant ?? "preview"

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -52,7 +52,6 @@ import {
 import { createPromptSubmit, type FollowupDraft } from "./prompt-input/submit"
 import { PromptPopover, type AtOption, type SlashCommand } from "./prompt-input/slash-popover"
 import { PromptContextItems } from "./prompt-input/context-items"
-import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
@@ -1291,6 +1290,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         />
         <PromptContextItems
           items={contextItems()}
+          images={imageAttachments()}
           active={(item) => {
             const active = comments.active()
             return !!item.commentID && item.commentID === active?.id && item.path === active?.file
@@ -1300,15 +1300,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             if (item.commentID) comments.remove(item.path, item.commentID)
             prompt.context.remove(item.key)
           }}
-          t={(key) => language.t(key as Parameters<typeof language.t>[0])}
-        />
-        <PromptImageAttachments
-          attachments={imageAttachments()}
-          onOpen={(attachment) =>
+          openImage={(attachment) =>
             dialog.show(() => <ImagePreview src={attachment.dataUrl} alt={attachment.filename} />)
           }
-          onRemove={removeAttachment}
-          removeLabel={language.t("prompt.attachment.remove")}
+          removeImage={removeAttachment}
+          imageRemoveLabel={language.t("prompt.attachment.remove")}
+          t={(key) => language.t(key as Parameters<typeof language.t>[0])}
         />
         <div
           class="relative"

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -58,7 +58,6 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
             const directory = getDirectory(row.item.path)
             const filename = getFilename(row.item.path)
             const label = getFilenameTruncated(row.item.path, 14)
-            const selected = props.active(row.item)
 
             return (
               <Tooltip
@@ -75,12 +74,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 class="shrink-0"
               >
                 <div
-                  classList={{
-                    "group relative flex flex-col rounded-[6px] pl-2 pr-7 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
-                    "hover:bg-surface-interactive-weak": !!row.item.commentID && !selected,
-                    "bg-surface-interactive-hover hover:bg-surface-interactive-hover shadow-xs-border-hover": selected,
-                    "bg-background-stronger": !selected,
-                  }}
+                  class="group relative flex flex-col rounded-[6px] pl-2 pr-7 py-1 max-w-[200px] h-12 cursor-default shadow-xs-border bg-background-stronger"
                   onClick={() => props.openComment(row.item)}
                 >
                   <div class="flex items-center gap-1.5">

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -101,7 +101,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                       type="button"
                       icon="close-small"
                       variant="ghost"
-                      class="ml-auto size-3.5 text-text-weak hover:text-text-strong transition-all"
+                      class="ml-auto size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
                       onClick={(e) => {
                         e.stopPropagation()
                         props.remove(row.item)

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -93,7 +93,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                     </div>
                   </div>
                   <Show when={row.item.comment}>
-                    {(comment) => <div class="text-12-regular text-text-strong ml-5 truncate">{comment()}</div>}
+                    {(comment) => <div class="text-base text-text-strong ml-5 truncate">{comment()}</div>}
                   </Show>
                   <button
                     type="button"

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -76,7 +76,7 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
               >
                 <div
                   classList={{
-                    "group flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
+                    "group relative flex flex-col rounded-[6px] pl-2 pr-7 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
                     "hover:bg-surface-interactive-weak": !!row.item.commentID && !selected,
                     "bg-surface-interactive-hover hover:bg-surface-interactive-hover shadow-xs-border-hover": selected,
                     "bg-background-stronger": !selected,
@@ -97,21 +97,21 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                         )}
                       </Show>
                     </div>
-                    <IconButton
-                      type="button"
-                      icon="close-small"
-                      variant="ghost"
-                      class="ml-auto size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        props.remove(row.item)
-                      }}
-                      aria-label={props.t("prompt.context.removeFile")}
-                    />
                   </div>
                   <Show when={row.item.comment}>
-                    {(comment) => <div class="text-12-regular text-text-strong ml-5 pr-1 truncate">{comment()}</div>}
+                    {(comment) => <div class="text-12-regular text-text-strong ml-5 truncate">{comment()}</div>}
                   </Show>
+                  <IconButton
+                    type="button"
+                    icon="close-small"
+                    variant="ghost"
+                    class="absolute top-1 right-1 size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      props.remove(row.item)
+                    }}
+                    aria-label={props.t("prompt.context.removeFile")}
+                  />
                 </div>
               </Tooltip>
             )

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -1,6 +1,6 @@
 import { Component, For, Show, createMemo } from "solid-js"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
-import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getDirectory, getFilename, getFilenameTruncated } from "@opencode-ai/util/path"
 import type { ContextItem, ImageAttachmentPart } from "@/context/prompt"
@@ -95,17 +95,23 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                   <Show when={row.item.comment}>
                     {(comment) => <div class="text-12-regular text-text-strong ml-5 truncate">{comment()}</div>}
                   </Show>
-                  <IconButton
+                  <button
                     type="button"
-                    icon="close-small"
-                    variant="ghost"
-                    class="absolute top-1 right-1 size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+                    class="absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group/remove group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
                     onClick={(e) => {
                       e.stopPropagation()
                       props.remove(row.item)
                     }}
                     aria-label={props.t("prompt.context.removeFile")}
-                  />
+                  >
+                    <span class="absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active">
+                      <Icon
+                        name="close-small"
+                        size="small"
+                        class="text-text-weak group-hover/remove:text-text-strong"
+                      />
+                    </span>
+                  </button>
                 </div>
               </Tooltip>
             )

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -1,10 +1,9 @@
 import { Component, For, Show, createMemo } from "solid-js"
-import { FileIcon } from "@opencode-ai/ui/file-icon"
-import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getDirectory, getFilename, getFilenameTruncated } from "@opencode-ai/util/path"
 import type { ContextItem, ImageAttachmentPart } from "@/context/prompt"
 import { PromptImageAttachment } from "./image-attachments"
+import { CommentChip } from "@/components/comment-chip"
 
 type PromptContextItem = ContextItem & { key: string }
 
@@ -73,46 +72,24 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 openDelay={2000}
                 class="shrink-0"
               >
-                <div
-                  class="group relative flex flex-col rounded-[6px] pl-2 pr-7 py-1 max-w-[200px] h-12 cursor-default shadow-xs-border bg-background-stronger"
-                  onClick={() => props.openComment(row.item)}
-                >
-                  <div class="flex items-center gap-1.5">
-                    <FileIcon node={{ path: row.item.path, type: "file" }} class="shrink-0 size-3.5" />
-                    <div class="flex items-center text-11-regular min-w-0 font-medium">
-                      <span class="text-text-strong whitespace-nowrap">{label}</span>
-                      <Show when={row.item.selection}>
-                        {(sel) => (
-                          <span class="text-text-weak whitespace-nowrap shrink-0">
-                            {sel().startLine === sel().endLine
-                              ? `:${sel().startLine}`
-                              : `:${sel().startLine}-${sel().endLine}`}
-                          </span>
-                        )}
-                      </Show>
-                    </div>
-                  </div>
-                  <Show when={row.item.comment}>
-                    {(comment) => <div class="text-base text-text-strong ml-5 truncate">{comment()}</div>}
-                  </Show>
-                  <button
-                    type="button"
-                    class="absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group/remove group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      props.remove(row.item)
-                    }}
-                    aria-label={props.t("prompt.context.removeFile")}
-                  >
-                    <span class="absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active">
-                      <Icon
-                        name="close-small"
-                        size="small"
-                        class="text-text-weak group-hover/remove:text-text-strong"
-                      />
-                    </span>
-                  </button>
-                </div>
+                <CommentChip
+                  variant="preview"
+                  path={row.item.path}
+                  label={label}
+                  selection={
+                    row.item.selection
+                      ? {
+                          start: row.item.selection.startLine,
+                          end: row.item.selection.endLine,
+                        }
+                      : undefined
+                  }
+                  comment={row.item.comment}
+                  class="max-w-[200px]"
+                  onOpen={() => props.openComment(row.item)}
+                  onRemove={() => props.remove(row.item)}
+                  removeLabel={props.t("prompt.context.removeFile")}
+                />
               </Tooltip>
             )
           }}

--- a/packages/app/src/components/prompt-input/context-items.tsx
+++ b/packages/app/src/components/prompt-input/context-items.tsx
@@ -1,30 +1,64 @@
-import { Component, For, Show } from "solid-js"
+import { Component, For, Show, createMemo } from "solid-js"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getDirectory, getFilename, getFilenameTruncated } from "@opencode-ai/util/path"
-import type { ContextItem } from "@/context/prompt"
+import type { ContextItem, ImageAttachmentPart } from "@/context/prompt"
+import { PromptImageAttachment } from "./image-attachments"
 
 type PromptContextItem = ContextItem & { key: string }
 
 type ContextItemsProps = {
   items: PromptContextItem[]
+  images: ImageAttachmentPart[]
   active: (item: PromptContextItem) => boolean
   openComment: (item: PromptContextItem) => void
   remove: (item: PromptContextItem) => void
+  openImage: (attachment: ImageAttachmentPart) => void
+  removeImage: (id: string) => void
+  imageRemoveLabel: string
   t: (key: string) => string
 }
 
 export const PromptContextItems: Component<ContextItemsProps> = (props) => {
+  const seen = new Map<string, number>()
+  let seq = 0
+
+  const rows = createMemo(() => {
+    const all = [
+      ...props.items.map((item) => ({ type: "ctx" as const, key: `ctx:${item.key}`, item })),
+      ...props.images.map((attachment) => ({ type: "img" as const, key: `img:${attachment.id}`, attachment })),
+    ]
+
+    for (const row of all) {
+      if (seen.has(row.key)) continue
+      seen.set(row.key, seq)
+      seq += 1
+    }
+
+    return all.slice().sort((a, b) => (seen.get(a.key) ?? 0) - (seen.get(b.key) ?? 0))
+  })
+
   return (
-    <Show when={props.items.length > 0}>
+    <Show when={rows().length > 0}>
       <div class="flex flex-nowrap items-start gap-2 p-2 overflow-x-auto no-scrollbar">
-        <For each={props.items}>
-          {(item) => {
-            const directory = getDirectory(item.path)
-            const filename = getFilename(item.path)
-            const label = getFilenameTruncated(item.path, 14)
-            const selected = props.active(item)
+        <For each={rows()}>
+          {(row) => {
+            if (row.type === "img") {
+              return (
+                <PromptImageAttachment
+                  attachment={row.attachment}
+                  onOpen={props.openImage}
+                  onRemove={props.removeImage}
+                  removeLabel={props.imageRemoveLabel}
+                />
+              )
+            }
+
+            const directory = getDirectory(row.item.path)
+            const filename = getFilename(row.item.path)
+            const label = getFilenameTruncated(row.item.path, 14)
+            const selected = props.active(row.item)
 
             return (
               <Tooltip
@@ -38,21 +72,22 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                 }
                 placement="top"
                 openDelay={2000}
+                class="shrink-0"
               >
                 <div
                   classList={{
-                    "group shrink-0 flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
-                    "hover:bg-surface-interactive-weak": !!item.commentID && !selected,
+                    "group flex flex-col rounded-[6px] pl-2 pr-1 py-1 max-w-[200px] h-12 cursor-default transition-all transition-transform shadow-xs-border hover:shadow-xs-border-hover": true,
+                    "hover:bg-surface-interactive-weak": !!row.item.commentID && !selected,
                     "bg-surface-interactive-hover hover:bg-surface-interactive-hover shadow-xs-border-hover": selected,
                     "bg-background-stronger": !selected,
                   }}
-                  onClick={() => props.openComment(item)}
+                  onClick={() => props.openComment(row.item)}
                 >
                   <div class="flex items-center gap-1.5">
-                    <FileIcon node={{ path: item.path, type: "file" }} class="shrink-0 size-3.5" />
+                    <FileIcon node={{ path: row.item.path, type: "file" }} class="shrink-0 size-3.5" />
                     <div class="flex items-center text-11-regular min-w-0 font-medium">
                       <span class="text-text-strong whitespace-nowrap">{label}</span>
-                      <Show when={item.selection}>
+                      <Show when={row.item.selection}>
                         {(sel) => (
                           <span class="text-text-weak whitespace-nowrap shrink-0">
                             {sel().startLine === sel().endLine
@@ -69,12 +104,12 @@ export const PromptContextItems: Component<ContextItemsProps> = (props) => {
                       class="ml-auto size-3.5 text-text-weak hover:text-text-strong transition-all"
                       onClick={(e) => {
                         e.stopPropagation()
-                        props.remove(item)
+                        props.remove(row.item)
                       }}
                       aria-label={props.t("prompt.context.removeFile")}
                     />
                   </div>
-                  <Show when={item.comment}>
+                  <Show when={row.item.comment}>
                     {(comment) => <div class="text-12-regular text-text-strong ml-5 pr-1 truncate">{comment()}</div>}
                   </Show>
                 </div>

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -1,5 +1,6 @@
 import { Component, Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import type { ImageAttachmentPart } from "@/context/prompt"
 
@@ -21,7 +22,7 @@ const fallbackClass =
   "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border cursor-default"
 const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border"
 const removeClass =
-  "absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
+  "absolute top-1 right-1 size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (
@@ -59,14 +60,14 @@ export const PromptImageAttachment: Component<PromptImageAttachmentProps> = (pro
             onClick={() => props.onOpen(props.attachment)}
           />
         </Show>
-        <button
+        <IconButton
           type="button"
-          onClick={() => props.onRemove(props.attachment.id)}
+          icon="close-small"
+          variant="ghost"
           class={removeClass}
+          onClick={() => props.onRemove(props.attachment.id)}
           aria-label={props.removeLabel}
-        >
-          <Icon name="close" class="size-3 text-text-weak" />
-        </button>
+        />
       </div>
     </Tooltip>
   )

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -19,8 +19,8 @@ type PromptImageAttachmentProps = {
 }
 
 const fallbackClass =
-  "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border cursor-default"
-const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border"
+  "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center border border-border-weak-base cursor-default"
+const imageClass = "size-12 rounded-[6px] object-cover border border-border-weak-base"
 const removeClass =
   "absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
 const removeIconClass =

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -1,6 +1,5 @@
 import { Component, Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
-import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import type { ImageAttachmentPart } from "@/context/prompt"
 
@@ -22,7 +21,9 @@ const fallbackClass =
   "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border cursor-default"
 const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border"
 const removeClass =
-  "absolute top-1 right-1 size-3.5 text-text-weak hover:text-text-strong opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+  "absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+const removeIconClass =
+  "absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (
@@ -60,14 +61,16 @@ export const PromptImageAttachment: Component<PromptImageAttachmentProps> = (pro
             onClick={() => props.onOpen(props.attachment)}
           />
         </Show>
-        <IconButton
+        <button
           type="button"
-          icon="close-small"
-          variant="ghost"
-          class={removeClass}
+          class={`${removeClass} group/remove`}
           onClick={() => props.onRemove(props.attachment.id)}
           aria-label={props.removeLabel}
-        />
+        >
+          <span class={removeIconClass}>
+            <Icon name="close-small" size="small" class="text-text-weak group-hover/remove:text-text-strong" />
+          </span>
+        </button>
       </div>
     </Tooltip>
   )

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -11,8 +11,8 @@ type PromptImageAttachmentsProps = {
 }
 
 const fallbackClass =
-  "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border hover:shadow-xs-border-hover transition-all"
-const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border hover:shadow-xs-border-hover transition-all"
+  "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border cursor-default"
+const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border"
 const removeClass =
   "absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
 

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -1,5 +1,6 @@
 import { Component, For, Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 import type { ImageAttachmentPart } from "@/context/prompt"
 
 type PromptImageAttachmentsProps = {
@@ -14,7 +15,6 @@ const fallbackClass =
 const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border hover:shadow-xs-border-hover transition-all"
 const removeClass =
   "absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
-const nameClass = "absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-[6px]"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (
@@ -22,34 +22,33 @@ export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (p
       <div class="flex flex-wrap gap-2 px-3 pt-3">
         <For each={props.attachments}>
           {(attachment) => (
-            <div class="relative group">
-              <Show
-                when={attachment.mime.startsWith("image/")}
-                fallback={
-                  <div class={fallbackClass}>
-                    <Icon name="folder" class="size-6 text-text-weak" />
-                  </div>
-                }
-              >
-                <img
-                  src={attachment.dataUrl}
-                  alt={attachment.filename}
-                  class={imageClass}
-                  onClick={() => props.onOpen(attachment)}
-                />
-              </Show>
-              <button
-                type="button"
-                onClick={() => props.onRemove(attachment.id)}
-                class={removeClass}
-                aria-label={props.removeLabel}
-              >
-                <Icon name="close" class="size-3 text-text-weak" />
-              </button>
-              <div class={nameClass}>
-                <span class="text-10-regular text-white truncate block">{attachment.filename}</span>
+            <Tooltip value={attachment.filename} placement="top" gutter={6}>
+              <div class="relative group">
+                <Show
+                  when={attachment.mime.startsWith("image/")}
+                  fallback={
+                    <div class={fallbackClass}>
+                      <Icon name="folder" class="size-6 text-text-weak" />
+                    </div>
+                  }
+                >
+                  <img
+                    src={attachment.dataUrl}
+                    alt={attachment.filename}
+                    class={imageClass}
+                    onClick={() => props.onOpen(attachment)}
+                  />
+                </Show>
+                <button
+                  type="button"
+                  onClick={() => props.onRemove(attachment.id)}
+                  class={removeClass}
+                  aria-label={props.removeLabel}
+                >
+                  <Icon name="close" class="size-3 text-text-weak" />
+                </button>
               </div>
-            </div>
+            </Tooltip>
           )}
         </For>
       </div>

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -1,5 +1,6 @@
 import { Component, Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
+import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import type { ImageAttachmentPart } from "@/context/prompt"
 
@@ -50,7 +51,7 @@ export const PromptImageAttachment: Component<PromptImageAttachmentProps> = (pro
           when={props.attachment.mime.startsWith("image/")}
           fallback={
             <div class={fallbackClass}>
-              <Icon name="folder" class="size-6 text-text-weak" />
+              <FileIcon node={{ path: props.attachment.filename, type: "file" }} class="size-5" />
             </div>
           }
         >

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -24,7 +24,7 @@ const imageClass = "size-12 rounded-[6px] object-cover border border-border-weak
 const removeClass =
   "absolute top-0 right-0 size-6 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
 const removeIconClass =
-  "absolute top-1 right-1 size-3.5 rounded-[var(--radius-sm)] flex items-center justify-center bg-transparent group-hover/remove:bg-surface-base-hover group-active/remove:bg-surface-base-active"
+  "absolute top-1 right-1 size-4 rounded-[var(--radius-sm)] border border-border-weak-base flex items-center justify-center bg-[var(--surface-raised-stronger-non-alpha)] group-active/remove:bg-surface-base-active"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -1,10 +1,17 @@
-import { Component, For, Show } from "solid-js"
+import { Component, Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import type { ImageAttachmentPart } from "@/context/prompt"
 
 type PromptImageAttachmentsProps = {
   attachments: ImageAttachmentPart[]
+  onOpen: (attachment: ImageAttachmentPart) => void
+  onRemove: (id: string) => void
+  removeLabel: string
+}
+
+type PromptImageAttachmentProps = {
+  attachment: ImageAttachmentPart
   onOpen: (attachment: ImageAttachmentPart) => void
   onRemove: (id: string) => void
   removeLabel: string
@@ -19,39 +26,48 @@ const removeClass =
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (
     <Show when={props.attachments.length > 0}>
-      <div class="flex flex-wrap gap-2 px-3 pt-3">
-        <For each={props.attachments}>
-          {(attachment) => (
-            <Tooltip value={attachment.filename} placement="top" gutter={6}>
-              <div class="relative group">
-                <Show
-                  when={attachment.mime.startsWith("image/")}
-                  fallback={
-                    <div class={fallbackClass}>
-                      <Icon name="folder" class="size-6 text-text-weak" />
-                    </div>
-                  }
-                >
-                  <img
-                    src={attachment.dataUrl}
-                    alt={attachment.filename}
-                    class={imageClass}
-                    onClick={() => props.onOpen(attachment)}
-                  />
-                </Show>
-                <button
-                  type="button"
-                  onClick={() => props.onRemove(attachment.id)}
-                  class={removeClass}
-                  aria-label={props.removeLabel}
-                >
-                  <Icon name="close" class="size-3 text-text-weak" />
-                </button>
-              </div>
-            </Tooltip>
-          )}
-        </For>
-      </div>
+      <>
+        {props.attachments.map((attachment) => (
+          <PromptImageAttachment
+            attachment={attachment}
+            onOpen={props.onOpen}
+            onRemove={props.onRemove}
+            removeLabel={props.removeLabel}
+          />
+        ))}
+      </>
     </Show>
+  )
+}
+
+export const PromptImageAttachment: Component<PromptImageAttachmentProps> = (props) => {
+  return (
+    <Tooltip value={props.attachment.filename} placement="top" gutter={6} class="shrink-0">
+      <div class="relative group">
+        <Show
+          when={props.attachment.mime.startsWith("image/")}
+          fallback={
+            <div class={fallbackClass}>
+              <Icon name="folder" class="size-6 text-text-weak" />
+            </div>
+          }
+        >
+          <img
+            src={props.attachment.dataUrl}
+            alt={props.attachment.filename}
+            class={imageClass}
+            onClick={() => props.onOpen(props.attachment)}
+          />
+        </Show>
+        <button
+          type="button"
+          onClick={() => props.onRemove(props.attachment.id)}
+          class={removeClass}
+          aria-label={props.removeLabel}
+        >
+          <Icon name="close" class="size-3 text-text-weak" />
+        </button>
+      </div>
+    </Tooltip>
   )
 }

--- a/packages/app/src/components/prompt-input/image-attachments.tsx
+++ b/packages/app/src/components/prompt-input/image-attachments.tsx
@@ -9,12 +9,12 @@ type PromptImageAttachmentsProps = {
   removeLabel: string
 }
 
-const fallbackClass = "size-16 rounded-md bg-surface-base flex items-center justify-center border border-border-base"
-const imageClass =
-  "size-16 rounded-md object-cover border border-border-base hover:border-border-strong-base transition-colors"
+const fallbackClass =
+  "size-12 rounded-[6px] bg-background-stronger flex items-center justify-center shadow-xs-border hover:shadow-xs-border-hover transition-all"
+const imageClass = "size-12 rounded-[6px] object-cover shadow-xs-border hover:shadow-xs-border-hover transition-all"
 const removeClass =
   "absolute -top-1.5 -right-1.5 size-5 rounded-full bg-surface-raised-stronger-non-alpha border border-border-base flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-surface-raised-base-hover"
-const nameClass = "absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-md"
+const nameClass = "absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 rounded-b-[6px]"
 
 export const PromptImageAttachments: Component<PromptImageAttachmentsProps> = (props) => {
   return (

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -477,7 +477,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} رسائل تم التراجع عنها",
   "session.revertDock.collapse": "طي الرسائل التي تم التراجع عنها",
   "session.revertDock.expand": "توسيع الرسائل التي تم التراجع عنها",
-  "session.revertDock.restore": "استعادة الرسالة",
+  "session.revertDock.restore": "استعادة",
   "session.new.title": "ابنِ أي شيء",
   "session.new.worktree.main": "الفرع الرئيسي",
   "session.new.worktree.mainWithBranch": "الفرع الرئيسي ({{branch}})",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -481,7 +481,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} mensagens revertidas",
   "session.revertDock.collapse": "Recolher mensagens revertidas",
   "session.revertDock.expand": "Expandir mensagens revertidas",
-  "session.revertDock.restore": "Restaurar mensagem",
+  "session.revertDock.restore": "Restaurar",
   "session.new.title": "Crie qualquer coisa",
   "session.new.worktree.main": "Branch principal",
   "session.new.worktree.mainWithBranch": "Branch principal ({{branch}})",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -536,7 +536,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} vraćenih poruka",
   "session.revertDock.collapse": "Sažmi vraćene poruke",
   "session.revertDock.expand": "Proširi vraćene poruke",
-  "session.revertDock.restore": "Vrati poruku",
+  "session.revertDock.restore": "Vrati",
 
   "session.new.title": "Napravi bilo šta",
   "session.new.worktree.main": "Glavna grana",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -531,7 +531,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} tilbagerullede beskeder",
   "session.revertDock.collapse": "Skjul tilbagerullede beskeder",
   "session.revertDock.expand": "Udvid tilbagerullede beskeder",
-  "session.revertDock.restore": "Gendan besked",
+  "session.revertDock.restore": "Gendan",
 
   "session.new.title": "Byg hvad som helst",
   "session.new.worktree.main": "Hovedgren",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -489,7 +489,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} zurückgesetzte Nachrichten",
   "session.revertDock.collapse": "Zurückgesetzte Nachrichten einklappen",
   "session.revertDock.expand": "Zurückgesetzte Nachrichten ausklappen",
-  "session.revertDock.restore": "Nachricht wiederherstellen",
+  "session.revertDock.restore": "Wiederherstellen",
   "session.new.title": "Baue, was du willst",
   "session.new.worktree.main": "Haupt-Branch",
   "session.new.worktree.mainWithBranch": "Haupt-Branch ({{branch}})",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -561,7 +561,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} rolled back messages",
   "session.revertDock.collapse": "Collapse rolled back messages",
   "session.revertDock.expand": "Expand rolled back messages",
-  "session.revertDock.restore": "Restore message",
+  "session.revertDock.restore": "Restore",
 
   "session.new.title": "Build anything",
   "session.new.worktree.main": "Main branch",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -537,7 +537,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} mensajes revertidos",
   "session.revertDock.collapse": "Contraer mensajes revertidos",
   "session.revertDock.expand": "Expandir mensajes revertidos",
-  "session.revertDock.restore": "Restaurar mensaje",
+  "session.revertDock.restore": "Restaurar",
 
   "session.new.title": "Construye lo que quieras",
   "session.new.worktree.main": "Rama principal",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -486,7 +486,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} messages annulés",
   "session.revertDock.collapse": "Réduire les messages annulés",
   "session.revertDock.expand": "Développer les messages annulés",
-  "session.revertDock.restore": "Restaurer le message",
+  "session.revertDock.restore": "Restaurer",
   "session.new.title": "Créez ce que vous voulez",
   "session.new.worktree.main": "Branche principale",
   "session.new.worktree.mainWithBranch": "Branche principale ({{branch}})",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -478,7 +478,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} 件のロールバックされたメッセージ",
   "session.revertDock.collapse": "ロールバックされたメッセージを折りたたむ",
   "session.revertDock.expand": "ロールバックされたメッセージを展開",
-  "session.revertDock.restore": "メッセージを復元",
+  "session.revertDock.restore": "復元",
   "session.new.title": "何でも作る",
   "session.new.worktree.main": "メインブランチ",
   "session.new.worktree.mainWithBranch": "メインブランチ ({{branch}})",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -480,7 +480,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}}개의 롤백된 메시지",
   "session.revertDock.collapse": "롤백된 메시지 접기",
   "session.revertDock.expand": "롤백된 메시지 펼치기",
-  "session.revertDock.restore": "메시지 복원",
+  "session.revertDock.restore": "복원",
   "session.new.title": "무엇이든 만들기",
   "session.new.worktree.main": "메인 브랜치",
   "session.new.worktree.mainWithBranch": "메인 브랜치 ({{branch}})",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -537,7 +537,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} tilbakestilte meldinger",
   "session.revertDock.collapse": "Skjul tilbakestilte meldinger",
   "session.revertDock.expand": "Utvid tilbakestilte meldinger",
-  "session.revertDock.restore": "Gjenopprett melding",
+  "session.revertDock.restore": "Gjenopprett",
 
   "session.new.title": "Bygg hva som helst",
   "session.new.worktree.main": "Hovedgren",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -479,7 +479,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} cofnięte wiadomości",
   "session.revertDock.collapse": "Zwiń cofnięte wiadomości",
   "session.revertDock.expand": "Rozwiń cofnięte wiadomości",
-  "session.revertDock.restore": "Przywróć wiadomość",
+  "session.revertDock.restore": "Przywróć",
   "session.new.title": "Zbuduj cokolwiek",
   "session.new.worktree.main": "Główna gałąź",
   "session.new.worktree.mainWithBranch": "Główna gałąź ({{branch}})",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -534,7 +534,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} сообщений возвращено",
   "session.revertDock.collapse": "Свернуть возвращённые сообщения",
   "session.revertDock.expand": "Развернуть возвращённые сообщения",
-  "session.revertDock.restore": "Восстановить сообщение",
+  "session.revertDock.restore": "Восстановить",
 
   "session.new.title": "Создавайте что угодно",
   "session.new.worktree.main": "Основная ветка",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -531,7 +531,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} ข้อความที่ถูกย้อนกลับ",
   "session.revertDock.collapse": "ย่อข้อความที่ถูกย้อนกลับ",
   "session.revertDock.expand": "ขยายข้อความที่ถูกย้อนกลับ",
-  "session.revertDock.restore": "กู้คืนข้อความ",
+  "session.revertDock.restore": "กู้คืน",
 
   "session.new.title": "สร้างอะไรก็ได้",
   "session.new.worktree.main": "สาขาหลัก",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -541,7 +541,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} geri alınan mesaj",
   "session.revertDock.collapse": "Geri alınan mesajları daralt",
   "session.revertDock.expand": "Geri alınan mesajları genişlet",
-  "session.revertDock.restore": "Mesajı geri yükle",
+  "session.revertDock.restore": "Geri yükle",
 
   "session.new.title": "İstediğini yap",
   "session.new.worktree.main": "Ana dal",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -531,7 +531,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} 条已回滚消息",
   "session.revertDock.collapse": "折叠已回滚消息",
   "session.revertDock.expand": "展开已回滚消息",
-  "session.revertDock.restore": "恢复消息",
+  "session.revertDock.restore": "恢复",
   "session.new.title": "构建任何东西",
   "session.new.worktree.main": "主分支",
   "session.new.worktree.mainWithBranch": "主分支（{{branch}}）",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -527,7 +527,7 @@ export const dict = {
   "session.revertDock.summary.other": "{{count}} 則已回復訊息",
   "session.revertDock.collapse": "收合已回復訊息",
   "session.revertDock.expand": "展開已回復訊息",
-  "session.revertDock.restore": "還原訊息",
+  "session.revertDock.restore": "還原",
 
   "session.new.title": "建構任何東西",
   "session.new.worktree.main": "主分支",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1324,9 +1324,22 @@ export default function Page() {
       attachmentName: language.t("common.attachment"),
     })
 
+  const tag = (mime: string | undefined) => {
+    if (mime === "application/pdf") return "pdf"
+    if (mime?.startsWith("image/")) return "image"
+    return "file"
+  }
+
+  const chip = (part: { filename: string; mime: string }) => `[${tag(part.mime)}:${part.filename}]`
+
   const line = (id: string) => {
     const text = draft(id)
-      .map((part) => (part.type === "image" ? `[image:${part.filename}]` : part.content))
+      .map((part) => {
+        if (part.type === "image") return chip(part)
+        if (part.type === "file") return `[file:${part.path}]`
+        if (part.type === "agent") return `@${part.name}`
+        return part.content
+      })
       .join("")
       .replace(/\s+/g, " ")
       .trim()
@@ -1394,7 +1407,7 @@ export default function Page() {
   const followupText = (item: FollowupDraft) => {
     const text = item.prompt
       .map((part) => {
-        if (part.type === "image") return `[image:${part.filename}]`
+        if (part.type === "image") return chip(part)
         if (part.type === "file") return `[file:${part.path}]`
         if (part.type === "agent") return `@${part.name}`
         return part.content

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -46,6 +46,14 @@ export function SessionComposerRegion(props: {
   const language = useLanguage()
   const route = useSessionKey()
 
+  const tag = (mime: string) => {
+    if (mime === "application/pdf") return "pdf"
+    if (mime.startsWith("image/")) return "image"
+    return "file"
+  }
+
+  const chip = (part: { filename: string; mime: string }) => `[${tag(part.mime)}:${part.filename}]`
+
   const handoffPrompt = createMemo(() => getSessionHandoff(route.sessionKey())?.prompt)
 
   const previewPrompt = () =>
@@ -54,7 +62,7 @@ export function SessionComposerRegion(props: {
       .map((part) => {
         if (part.type === "file") return `[file:${part.path}]`
         if (part.type === "agent") return `@${part.name}`
-        if (part.type === "image") return `[image:${part.filename}]`
+        if (part.type === "image") return chip(part)
         return part.content
       })
       .join("")

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -259,24 +259,26 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
       header={
         <>
           <div data-slot="question-header-title">{summary()}</div>
-          <div data-slot="question-progress">
-            <For each={questions()}>
-              {(_, i) => (
-                <button
-                  type="button"
-                  data-slot="question-progress-segment"
-                  data-active={i() === store.tab}
-                  data-answered={
-                    (store.answers[i()]?.length ?? 0) > 0 ||
-                    (store.customOn[i()] === true && (store.custom[i()] ?? "").trim().length > 0)
-                  }
-                  disabled={store.sending}
-                  onClick={() => jump(i())}
-                  aria-label={`${language.t("ui.tool.questions")} ${i() + 1}`}
-                />
-              )}
-            </For>
-          </div>
+          <Show when={total() > 1}>
+            <div data-slot="question-progress">
+              <For each={questions()}>
+                {(_, i) => (
+                  <button
+                    type="button"
+                    data-slot="question-progress-segment"
+                    data-active={i() === store.tab}
+                    data-answered={
+                      (store.answers[i()]?.length ?? 0) > 0 ||
+                      (store.customOn[i()] === true && (store.custom[i()] ?? "").trim().length > 0)
+                    }
+                    disabled={store.sending}
+                    onClick={() => jump(i())}
+                    aria-label={`${language.t("ui.tool.questions")} ${i() + 1}`}
+                  />
+                )}
+              </For>
+            </div>
+          </Show>
         </>
       }
       footer={

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -2,7 +2,6 @@ import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX } f
 import { createStore, produce } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { Button } from "@opencode-ai/ui/button"
-import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
@@ -15,7 +14,7 @@ import { TextField } from "@opencode-ai/ui/text-field"
 import type { AssistantMessage, Message as MessageType, Part, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { showToast } from "@opencode-ai/ui/toast"
 import { Binary } from "@opencode-ai/util/binary"
-import { getFilename } from "@opencode-ai/util/path"
+import { getFilenameTruncated } from "@opencode-ai/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
@@ -29,6 +28,7 @@ import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { messageAgentColor } from "@/utils/agent"
 import { parseCommentNote, readCommentMetadata } from "@/utils/comment-note"
+import { CommentChip } from "@/components/comment-chip"
 
 type MessageComment = {
   path: string
@@ -960,40 +960,36 @@ export function MessageTimeline(props: {
                     >
                       <Show when={commentCount() > 0}>
                         <div class="w-full px-4 md:px-5 pb-2">
-                          <div class="ml-auto max-w-[82%] overflow-x-auto no-scrollbar">
-                            <div class="flex w-max min-w-full justify-end gap-2">
-                              <Index each={comments()}>
-                                {(commentAccessor: () => MessageComment) => {
-                                  const comment = createMemo(() => commentAccessor())
-                                  return (
-                                    <Show when={comment()}>
-                                      {(c) => (
-                                        <div class="shrink-0 max-w-[260px] rounded-[6px] border border-border-weak-base bg-background-stronger px-2.5 py-2">
-                                          <div class="flex items-center gap-1.5 min-w-0 text-11-medium text-text-strong">
-                                            <FileIcon
-                                              node={{ path: c().path, type: "file" }}
-                                              class="size-3.5 shrink-0"
-                                            />
-                                            <span class="truncate">{getFilename(c().path)}</span>
-                                            <Show when={c().selection}>
-                                              {(selection) => (
-                                                <span class="shrink-0 text-text-weak">
-                                                  {selection().startLine === selection().endLine
-                                                    ? `:${selection().startLine}`
-                                                    : `:${selection().startLine}-${selection().endLine}`}
-                                                </span>
-                                              )}
-                                            </Show>
-                                          </div>
-                                          <div class="pt-1 text-12-regular text-text-strong whitespace-pre-wrap break-words">
-                                            {c().comment}
-                                          </div>
-                                        </div>
-                                      )}
-                                    </Show>
-                                  )
-                                }}
-                              </Index>
+                          <div class="w-full overflow-visible">
+                            <div class="overflow-x-auto no-scrollbar">
+                              <div class="flex w-max min-w-full justify-end gap-2">
+                                <Index each={comments()}>
+                                  {(commentAccessor: () => MessageComment) => {
+                                    const comment = createMemo(() => commentAccessor())
+                                    return (
+                                      <Show when={comment()}>
+                                        {(c) => (
+                                          <CommentChip
+                                            variant="full"
+                                            path={c().path}
+                                            label={getFilenameTruncated(c().path, 14)}
+                                            selection={
+                                              c().selection
+                                                ? {
+                                                    start: c().selection!.startLine,
+                                                    end: c().selection!.endLine,
+                                                  }
+                                                : undefined
+                                            }
+                                            comment={c().comment}
+                                            class="max-w-[260px]"
+                                          />
+                                        )}
+                                      </Show>
+                                    )
+                                  }}
+                                </Index>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -62,9 +62,10 @@
     }
 
     &[data-type="file"] {
-      width: min(220px, 100%);
+      width: fit-content;
+      max-width: min(260px, 100%);
       height: 48px;
-      padding: 0 10px;
+      padding: 0 18px 0 10px;
       background: var(--background-stronger);
     }
   }
@@ -90,7 +91,8 @@
   }
 
   [data-slot="user-message-attachment-file"] {
-    width: 100%;
+    width: fit-content;
+    max-width: 100%;
     min-width: 0;
     display: flex;
     align-items: center;
@@ -105,6 +107,7 @@
 
   [data-slot="user-message-attachment-name"] {
     min-width: 0;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -49,7 +49,7 @@
       opacity 0.3s ease;
 
     &:hover {
-      border-color: var(--border-strong-base);
+      border-color: var(--border-weak-base);
     }
 
     &[data-clickable] {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -65,6 +65,7 @@
       width: min(220px, 100%);
       height: 48px;
       padding: 0 10px;
+      background: var(--background-stronger);
     }
   }
 
@@ -107,7 +108,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: var(--text-base);
+    color: var(--text-strong);
+    font-weight: var(--font-weight-medium);
     font-size: var(--font-size-small);
     line-height: var(--line-height-large);
   }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -900,6 +900,12 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
 
   const text = createMemo(() => textPart()?.text || "")
 
+  const shown = createMemo(() => {
+    const value = text()
+    if (!value.trim()) return ""
+    return value
+  })
+
   const files = createMemo(() => (props.parts?.filter((p) => p.type === "file") as FilePart[]) ?? [])
 
   const attachments = createMemo(() => files().filter(attached))
@@ -995,11 +1001,11 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
           </For>
         </div>
       </Show>
-      <Show when={text()}>
+      <Show when={shown()}>
         <>
           <div data-slot="user-message-body">
             <div data-slot="user-message-text">
-              <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
+              <HighlightedText text={shown()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>
           <div data-slot="user-message-copy-wrapper">


### PR DESCRIPTION
### Issue for this PR

<img width="553" height="236" alt="CleanShot 2026-03-24 at 12 18 02@2x" src="https://github.com/user-attachments/assets/43548234-2c9a-4960-b379-6c9ff65c2f0e" />


### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This branch cleans up a set of small but visible rough edges in the session composer and message timeline.

In the prompt, file comment chips and attachment previews now share the same compact presentation and remove affordance, so mixed context reads as one row instead of two mismatched UI treatments. In sent messages, attachment cards size to their content more naturally, empty whitespace-only bubbles are hidden, and rolled back attachments are labeled by type (`image`, `pdf`, or `file`) so people can tell what was reverted before reopening it. The single-question dock also drops the progress indicator when there is nothing to progress through, which removes visual noise.

These changes work because they reuse the same chip treatment in the places where users see the same kind of context, and they stop rendering UI that does not communicate anything useful.

### How did you verify your code works?

The branch passed the repo pre-push hook, which ran `bun turbo typecheck` successfully.

### Screenshots / recordings

Not included. These are small UI polish changes across the prompt and message chips.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR