### PR TITLE
fix(session): preserve wait-for-user state after compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -18,6 +18,11 @@ import { ModelID, ProviderID } from "@/provider/schema"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
+  const RESUME_FINISH = ["tool-calls", "unknown"]
+  const PAUSE_ERROR = [
+    "The user rejected permission to use this specific tool call",
+    "The user dismissed this question",
+  ]
 
   export const Event = {
     Compacted: BusEvent.define(
@@ -108,6 +113,18 @@ export namespace SessionCompaction {
     overflow?: boolean
   }) {
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
+    const resume = (() => {
+      const match = input.messages.findLast((msg) => msg.info.role === "assistant" && msg.info.id < input.parentID)
+      if (!match || match.info.role !== "assistant") return false
+      if (match.info.error) return false
+      if (match.info.finish && !RESUME_FINISH.includes(match.info.finish)) return false
+      return !match.parts.some((part) => {
+        if (part.type !== "tool") return false
+        const state = part.state
+        if (state.status !== "error") return false
+        return PAUSE_ERROR.some((text) => state.error.startsWith(text))
+      })
+    })()
 
     let messages = input.messages
     let replay: MessageV2.WithParts | undefined
@@ -235,7 +252,7 @@ When constructing the summary, try to stick to this template:
       return "stop"
     }
 
-    if (result === "continue" && input.auto) {
+    if (result === "continue" && input.auto && (replay || resume)) {
       if (replay) {
         const original = replay.info as MessageV2.User
         const replayMsg = await Session.updateMessage({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import path from "path"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Token } from "../../src/util/token"
@@ -6,9 +6,29 @@ import { Instance } from "../../src/project/instance"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
-import type { Provider } from "../../src/provider/provider"
+import { Provider } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { SessionProcessor } from "../../src/session/processor"
 
 Log.init({ print: false })
+
+afterEach(() => {
+  mock.restore()
+})
+
+const ref = {
+  providerID: ProviderID.make("openai"),
+  modelID: ModelID.make("gpt-5.2"),
+}
+
+const zero = {
+  output: 0,
+  input: 0,
+  reasoning: 0,
+  cache: { read: 0, write: 0 },
+}
 
 function createModel(opts: {
   context: number
@@ -38,6 +58,119 @@ function createModel(opts: {
     api: { npm: opts.npm ?? "@ai-sdk/anthropic" },
     options: {},
   } as Provider.Model
+}
+
+async function user(input: {
+  sessionID: SessionID
+  text?: string
+  file?: {
+    mime: string
+    url: string
+    filename?: string
+  }
+}) {
+  const msg = await Session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: input.sessionID,
+    agent: "build",
+    model: ref,
+    time: {
+      created: Date.now(),
+    },
+  })
+  if (input.text) {
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      type: "text",
+      text: input.text,
+    })
+  }
+  if (input.file) {
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      type: "file",
+      mime: input.file.mime,
+      url: input.file.url,
+      filename: input.file.filename,
+    })
+  }
+  return msg
+}
+
+async function assistant(input: {
+  sessionID: SessionID
+  parentID: MessageID
+  dir: string
+  finish?: string
+}) {
+  const msg: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    sessionID: input.sessionID,
+    mode: "build",
+    agent: "build",
+    path: {
+      cwd: input.dir,
+      root: input.dir,
+    },
+    cost: 0,
+    tokens: zero,
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    parentID: input.parentID,
+    time: {
+      created: Date.now(),
+      ...(input.finish ? { completed: Date.now() } : {}),
+    },
+    ...(input.finish ? { finish: input.finish } : {}),
+  }
+  await Session.updateMessage(msg)
+  return msg
+}
+
+async function compact(input: { sessionID: SessionID; overflow?: boolean }) {
+  await SessionCompaction.create({
+    sessionID: input.sessionID,
+    agent: "build",
+    model: ref,
+    auto: true,
+    overflow: input.overflow,
+  })
+  return (await Session.messages({ sessionID: input.sessionID })).at(-1)!
+}
+
+function stub(model: Provider.Model) {
+  spyOn(Provider, "getModel").mockResolvedValue(model)
+  spyOn(SessionProcessor, "create").mockImplementation(
+    (input) =>
+      ({
+        message: input.assistantMessage,
+        partFromToolCall() {
+          throw new Error("not used")
+        },
+        async process() {
+          input.assistantMessage.finish = "stop"
+          input.assistantMessage.time.completed = Date.now()
+          await Session.updateMessage(input.assistantMessage)
+          return "continue"
+        },
+      }) satisfies SessionProcessor.Info,
+  )
+}
+
+function texts(msg: MessageV2.WithParts) {
+  return msg.parts.filter((part) => part.type === "text").map((part) => part.text)
+}
+
+function synthetic(msgs: MessageV2.WithParts[]) {
+  return msgs.findLast((msg) =>
+    msg.parts.some((part) => part.type === "text" && part.synthetic && part.text.includes("Continue if you have next steps")),
+  )
 }
 
 describe("session.compaction.isOverflow", () => {
@@ -420,4 +553,137 @@ describe("session.getUsage", () => {
       expect(result.tokens.total).toBe(2000)
     },
   )
+})
+
+describe("session.compaction.process", () => {
+  test("does not inject a synthetic continue message after a natural stop", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 32_000 })
+        stub(model)
+
+        const session = await Session.create({})
+        const first = await user({ sessionID: session.id, text: "hello" })
+        await assistant({
+          sessionID: session.id,
+          parentID: first.id,
+          dir: tmp.path,
+          finish: "stop",
+        })
+        const task = await compact({ sessionID: session.id })
+
+        if (task.info.role !== "user") throw new Error("expected compaction user message")
+
+        await SessionCompaction.process({
+          parentID: task.info.id,
+          messages: await Session.messages({ sessionID: session.id }),
+          sessionID: session.id,
+          abort: new AbortController().signal,
+          auto: true,
+        })
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        expect(synthetic(msgs)).toBeUndefined()
+        expect(msgs.at(-1)?.info.role).toBe("assistant")
+      },
+    })
+  })
+
+  test("replays the interrupted user message when overflow compaction has replay context", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 32_000 })
+        stub(model)
+
+        const session = await Session.create({})
+        const first = await user({ sessionID: session.id, text: "keep this context" })
+        await assistant({
+          sessionID: session.id,
+          parentID: first.id,
+          dir: tmp.path,
+          finish: "stop",
+        })
+        const replay = await user({
+          sessionID: session.id,
+          text: "please continue",
+          file: {
+            mime: "image/png",
+            url: "data:image/png;base64,AA==",
+            filename: "shot.png",
+          },
+        })
+        await assistant({
+          sessionID: session.id,
+          parentID: replay.id,
+          dir: tmp.path,
+        })
+        const task = await compact({ sessionID: session.id, overflow: true })
+
+        if (task.info.role !== "user") throw new Error("expected compaction user message")
+
+        await SessionCompaction.process({
+          parentID: task.info.id,
+          messages: await Session.messages({ sessionID: session.id }),
+          sessionID: session.id,
+          abort: new AbortController().signal,
+          auto: true,
+          overflow: true,
+        })
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        const last = msgs.at(-1)
+        if (!last || last.info.role !== "user") throw new Error("expected replay user message")
+        expect(texts(last)).toEqual(["please continue", "[Attached image/png: shot.png]"])
+        expect(synthetic(msgs)).toBeUndefined()
+      },
+    })
+  })
+
+  test("keeps the overflow synthetic continue when replay is unavailable", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 32_000 })
+        stub(model)
+
+        const session = await Session.create({})
+        const first = await user({
+          sessionID: session.id,
+          text: "look at this image",
+          file: {
+            mime: "image/png",
+            url: "data:image/png;base64,AA==",
+            filename: "big.png",
+          },
+        })
+        await assistant({
+          sessionID: session.id,
+          parentID: first.id,
+          dir: tmp.path,
+        })
+        const task = await compact({ sessionID: session.id, overflow: true })
+
+        if (task.info.role !== "user") throw new Error("expected compaction user message")
+
+        await SessionCompaction.process({
+          parentID: task.info.id,
+          messages: await Session.messages({ sessionID: session.id }),
+          sessionID: session.id,
+          abort: new AbortController().signal,
+          auto: true,
+          overflow: true,
+        })
+
+        const msgs = await Session.messages({ sessionID: session.id })
+        const last = synthetic(msgs)
+        if (!last || last.info.role !== "user") throw new Error("expected synthetic continue user message")
+        expect(texts(last)[0]).toContain("The previous request exceeded the provider's size limit")
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #18794

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes an unwanted continuation after `/compact`.

Before this change, `SessionCompaction.process()` would inject a synthetic "continue" user message whenever compaction returned `continue` and auto-compaction was enabled. That also happened when the previous assistant message had already naturally finished and should have been waiting for user input.

I changed that logic so the synthetic continuation is only injected when compaction is actually resuming work:

- keep the existing replay path for interrupted overflow cases
- keep continuation for assistant states that still need to resume
- do not inject a synthetic continue message when the previous assistant had already naturally stopped or was effectively waiting for the user

This works because the decision is now based on the assistant state before compaction, instead of only looking at the compaction result itself.

### How did you verify your code works?

I tested locally with:

- `cd packages/opencode && bun test test/session/compaction.test.ts --timeout 30000`
- `bun turbo typecheck`

I also added regression tests for these cases:

- no replay + assistant already stopped naturally -> no synthetic continue is injected
- overflow + replay available -> the interrupted user message is replayed
- overflow + replay unavailable -> the existing synthetic continue behavior is preserved

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR