### PR TITLE
fix(app): avoid false follow-up queue after session becomes idle

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -46,6 +46,7 @@ import {
   createSessionTabs,
   createSizing,
   focusTerminalById,
+  shouldQueueFollowup,
   shouldFocusTerminalOnKeyDown,
 } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
@@ -63,6 +64,7 @@ import { formatServerError } from "@/utils/server-errors"
 
 const emptyUserMessages: UserMessage[] = []
 const emptyFollowups: (FollowupDraft & { id: string })[] = []
+const idle = { type: "idle" as const }
 
 type SessionHistoryWindowInput = {
   sessionID: () => string | undefined
@@ -1362,12 +1364,12 @@ export default function Page() {
       return out
     })
 
-  const busy = (sessionID: string) => {
-    if ((sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle") return true
-    return (sync.data.message[sessionID] ?? []).some(
-      (item) => item.role === "assistant" && typeof item.time.completed !== "number",
-    )
-  }
+  const status = (sessionID: string) => sync.data.session_status[sessionID] ?? idle
+
+  const pending = (sessionID: string) =>
+    (sync.data.message[sessionID] ?? []).some((item) => item.role === "assistant" && typeof item.time.completed !== "number")
+
+  const busy = (sessionID: string) => status(sessionID).type !== "idle" || pending(sessionID)
 
   const queuedFollowups = createMemo(() => {
     const id = params.id
@@ -1420,7 +1422,12 @@ export default function Page() {
   const queueEnabled = createMemo(() => {
     const id = params.id
     if (!id) return false
-    return settings.general.followup() === "queue" && busy(id) && !composer.blocked()
+    return shouldQueueFollowup({
+      followup: settings.general.followup(),
+      blocked: composer.blocked(),
+      pending: pending(id),
+      status: status(id),
+    })
   })
 
   const followupText = (item: FollowupDraft) => {

--- a/packages/app/src/pages/session/helpers.test.ts
+++ b/packages/app/src/pages/session/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   createSessionTabs,
   focusTerminalById,
   getTabReorderIndex,
+  shouldQueueFollowup,
   shouldFocusTerminalOnKeyDown,
 } from "./helpers"
 
@@ -104,6 +105,38 @@ describe("shouldFocusTerminalOnKeyDown", () => {
   test("keeps plain typing focused on terminal", () => {
     expect(shouldFocusTerminalOnKeyDown(new KeyboardEvent("keydown", { key: "a" }))).toBe(true)
     expect(shouldFocusTerminalOnKeyDown(new KeyboardEvent("keydown", { key: "A", shiftKey: true }))).toBe(true)
+  })
+})
+
+describe("shouldQueueFollowup", () => {
+  test("does not queue once the session status is idle, even if assistant completion still looks pending", () => {
+    expect(
+      shouldQueueFollowup({
+        followup: "queue",
+        blocked: false,
+        pending: true,
+        status: { type: "idle" },
+      }),
+    ).toBe(false)
+  })
+
+  test("keeps queue mode active while the session status is still live", () => {
+    expect(
+      shouldQueueFollowup({
+        followup: "queue",
+        blocked: false,
+        pending: false,
+        status: { type: "busy" },
+      }),
+    ).toBe(true)
+    expect(
+      shouldQueueFollowup({
+        followup: "queue",
+        blocked: false,
+        pending: true,
+        status: { type: "retry", attempt: 1, message: "retrying", next: 1 },
+      }),
+    ).toBe(true)
   })
 })
 

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -1,3 +1,4 @@
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
 import { batch, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
 import { createStore } from "solid-js/store"
 import { same } from "@/utils/same"
@@ -98,6 +99,20 @@ const skip = new Set(["Alt", "Control", "Meta", "Shift"])
 export const shouldFocusTerminalOnKeyDown = (event: Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "altKey">) => {
   if (skip.has(event.key)) return false
   return !(event.ctrlKey || event.metaKey || event.altKey)
+}
+
+export const shouldQueueFollowup = (input: {
+  followup: "queue" | "steer"
+  blocked: boolean
+  pending: boolean
+  status: SessionStatus
+}) => {
+  if (input.followup !== "queue") return false
+  if (input.blocked) return false
+  if (input.status.type !== "idle") return true
+  // Message completion can lag briefly after the session already reports idle.
+  if (input.pending) return false
+  return false
 }
 
 export const createOpenReviewFile = (input: {


### PR DESCRIPTION
### Issue for this PR

Closes #18713

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a follow-up queue bug in the app session page.

Before this change, follow-up queueing used a broader `busy()` check that looked at both:

- `session_status`
- whether an assistant message still had no `time.completed`

That created a short mismatch window where the session had already become `idle`, the UI looked finished, but the assistant completion metadata had not synced yet. In that case, a new prompt could be incorrectly queued instead of being sent immediately.

This patch narrows the queue decision to the authoritative `session_status` signal:

- if follow-up mode is not `queue`, do not queue
- if the composer is blocked, do not queue
- if `session_status.type !== "idle"`, keep queue mode active
- if the session is already `idle`, do not queue even if assistant completion metadata is still lagging

The existing `busy()` logic is still kept for the other session flows that already depend on it, so this change only affects the false-positive queue decision.

I also added regression tests for:
- `idle + pending assistant completion` -> should **not** queue
- `busy/retry` -> should still queue

### How did you verify your code works?

Tested locally with:

- `bun test src/pages/session/helpers.test.ts`
- `bun typecheck`
- `bun turbo typecheck`

The new regression tests cover the queue decision directly.

### Screenshots / recordings

N/A — this is a behavior fix for follow-up queueing, not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR