### PR TITLE
fix(app): auto-register direct-route projects

### DIFF
--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -11,6 +11,7 @@ import {
   cleanupTestProject,
   clickMenuItem,
   confirmDialog,
+  openProjectMenu,
   openSidebar,
   openWorkspaceMenu,
   resolveSlug,
@@ -19,7 +20,7 @@ import {
   waitDir,
   waitSlug,
 } from "../actions"
-import { dropdownMenuContentSelector, inlineInputSelector, workspaceItemSelector } from "../selectors"
+import { inlineInputSelector, workspaceItemSelector } from "../selectors"
 import { createSdk, dirSlug } from "../utils"
 
 async function setupWorkspaceTest(page: Page, project: { slug: string }) {
@@ -127,17 +128,10 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
       await openSidebar(page)
       await expect(page.getByRole("button", { name: "New workspace" })).toHaveCount(0)
 
-      const trigger = page.locator('[data-action="project-menu"]').first()
-      const hasMenu = await trigger
-        .isVisible()
-        .then((x) => x)
-        .catch(() => false)
-      if (!hasMenu) return
+      const slug = slugFromUrl(page.url())
+      if (!slug) throw new Error("Missing project slug for non-git workspace test")
 
-      await trigger.click({ force: true })
-
-      const menu = page.locator(dropdownMenuContentSelector).first()
-      await expect(menu).toBeVisible()
+      const menu = await openProjectMenu(page, slug)
 
       const toggle = menu.locator('[data-action="project-workspaces-toggle"]').first()
 

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
-import type { Agent } from "@opencode-ai/sdk/v2/client"
-import { normalizeAgentList } from "./utils"
+import type { Agent, Project } from "@opencode-ai/sdk/v2/client"
+import { createStore } from "solid-js/store"
+import { normalizeAgentList, sanitizeProject } from "./utils"
 
 const agent = (name = "build") =>
   ({
@@ -31,5 +32,26 @@ describe("normalizeAgentList", () => {
   test("drops invalid payloads", () => {
     expect(normalizeAgentList({ name: "AbortError" })).toEqual([])
     expect(normalizeAgentList([{ name: "build" }, agent("docs")])).toEqual([agent("docs")])
+  })
+})
+
+describe("sanitizeProject", () => {
+  test("returns a plain clone for store-backed projects", () => {
+    const [store] = createStore({
+      project: [
+        {
+          id: "p1",
+          name: "repo",
+          worktree: "/repo",
+          sandboxes: ["/repo/a"],
+          icon: {},
+        },
+      ] as Project[],
+    })
+
+    const next = sanitizeProject(store.project[0]!)
+    expect(next).toEqual(store.project[0])
+    expect(next).not.toBe(store.project[0])
+    expect(next.sandboxes).not.toBe(store.project[0]?.sandboxes)
   })
 })

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -1,4 +1,5 @@
 import type { Agent, Project, ProviderListResponse } from "@opencode-ai/sdk/v2/client"
+import { unwrap } from "solid-js/store"
 
 export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
@@ -27,11 +28,12 @@ export function normalizeProviderList(input: ProviderListResponse): ProviderList
 }
 
 export function sanitizeProject(project: Project) {
-  if (!project.icon?.url && !project.icon?.override) return project
+  const next = structuredClone(unwrap(project))
+  if (!next.icon?.url && !next.icon?.override) return next
   return {
-    ...project,
+    ...next,
     icon: {
-      ...project.icon,
+      ...next.icon,
       url: undefined,
       override: undefined,
     },

--- a/packages/app/src/pages/directory-layout-sync.ts
+++ b/packages/app/src/pages/directory-layout-sync.ts
@@ -1,0 +1,4 @@
+export function syncProject(directory: string | undefined, open: (directory: string) => void) {
+  if (!directory) return
+  open(directory)
+}

--- a/packages/app/src/pages/directory-layout-sync.ts
+++ b/packages/app/src/pages/directory-layout-sync.ts
@@ -1,9 +1,20 @@
+export function projectRoot(directory: string | undefined, worktree: string | undefined) {
+  const root = worktree && worktree !== "/" ? worktree : directory
+  if (!root) return
+  return root
+}
+
 export function syncProject(
+  synced: string | undefined,
   directory: string | undefined,
   worktree: string | undefined,
   open: (directory: string) => void,
+  close?: (directory: string) => void,
 ) {
-  const root = worktree && worktree !== "/" ? worktree : directory
-  if (!root) return
+  const root = projectRoot(directory, worktree)
+  if (!root) return synced
+  if (root === synced) return synced
+  if (synced) close?.(synced)
   open(root)
+  return root
 }

--- a/packages/app/src/pages/directory-layout-sync.ts
+++ b/packages/app/src/pages/directory-layout-sync.ts
@@ -1,4 +1,9 @@
-export function syncProject(directory: string | undefined, open: (directory: string) => void) {
-  if (!directory) return
-  open(directory)
+export function syncProject(
+  directory: string | undefined,
+  worktree: string | undefined,
+  open: (directory: string) => void,
+) {
+  const root = worktree && worktree !== "/" ? worktree : directory
+  if (!root) return
+  open(root)
 }

--- a/packages/app/src/pages/directory-layout.test.ts
+++ b/packages/app/src/pages/directory-layout.test.ts
@@ -1,34 +1,55 @@
 import { describe, expect, test } from "bun:test"
-import { syncProject } from "./directory-layout-sync"
+import { projectRoot, syncProject } from "./directory-layout-sync"
 
 describe("directory layout project registration", () => {
-  test("registers a git worktree", () => {
-    const opened: string[] = []
-
-    syncProject("/repo/worktree", "/repo", (directory) => {
-      opened.push(directory)
-    })
-
-    expect(opened).toEqual(["/repo"])
+  test("resolves a git worktree root", () => {
+    expect(projectRoot("/repo/worktree", "/repo")).toBe("/repo")
   })
 
   test("falls back to the directory for non-git projects", () => {
-    const opened: string[] = []
-
-    syncProject("/repo", "/", (directory) => {
-      opened.push(directory)
-    })
-
-    expect(opened).toEqual(["/repo"])
+    expect(projectRoot("/repo", "/")).toBe("/repo")
   })
 
   test("skips missing directories", () => {
-    const opened: string[] = []
+    expect(projectRoot(undefined, undefined)).toBeUndefined()
+  })
 
-    syncProject(undefined, undefined, (directory) => {
+  test("does not reopen the same project twice", () => {
+    const opened: string[] = []
+    let synced = syncProject(undefined, "/repo", "/repo", (directory) => {
       opened.push(directory)
     })
 
-    expect(opened).toEqual([])
+    synced = syncProject(synced, "/repo", "/repo", (directory) => {
+      opened.push(directory)
+    })
+
+    expect(synced).toBe("/repo")
+    expect(opened).toEqual(["/repo"])
+  })
+
+  test("replaces a fallback directory with the resolved worktree root", () => {
+    const opened: string[] = []
+    const closed: string[] = []
+
+    let synced = syncProject(undefined, "/repo/worktree", "/", (directory) => {
+      opened.push(directory)
+    })
+
+    synced = syncProject(
+      synced,
+      "/repo/worktree",
+      "/repo",
+      (directory) => {
+        opened.push(directory)
+      },
+      (directory) => {
+        closed.push(directory)
+      },
+    )
+
+    expect(synced).toBe("/repo")
+    expect(opened).toEqual(["/repo/worktree", "/repo"])
+    expect(closed).toEqual(["/repo/worktree"])
   })
 })

--- a/packages/app/src/pages/directory-layout.test.ts
+++ b/packages/app/src/pages/directory-layout.test.ts
@@ -2,10 +2,20 @@ import { describe, expect, test } from "bun:test"
 import { syncProject } from "./directory-layout-sync"
 
 describe("directory layout project registration", () => {
-  test("registers a resolved directory", () => {
+  test("registers a git worktree", () => {
     const opened: string[] = []
 
-    syncProject("/repo", (directory) => {
+    syncProject("/repo/worktree", "/repo", (directory) => {
+      opened.push(directory)
+    })
+
+    expect(opened).toEqual(["/repo"])
+  })
+
+  test("falls back to the directory for non-git projects", () => {
+    const opened: string[] = []
+
+    syncProject("/repo", "/", (directory) => {
       opened.push(directory)
     })
 
@@ -15,7 +25,7 @@ describe("directory layout project registration", () => {
   test("skips missing directories", () => {
     const opened: string[] = []
 
-    syncProject(undefined, (directory) => {
+    syncProject(undefined, undefined, (directory) => {
       opened.push(directory)
     })
 

--- a/packages/app/src/pages/directory-layout.test.ts
+++ b/packages/app/src/pages/directory-layout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { syncProject } from "./directory-layout-sync"
+
+describe("directory layout project registration", () => {
+  test("registers a resolved directory", () => {
+    const opened: string[] = []
+
+    syncProject("/repo", (directory) => {
+      opened.push(directory)
+    })
+
+    expect(opened).toEqual(["/repo"])
+  })
+
+  test("skips missing directories", () => {
+    const opened: string[] = []
+
+    syncProject(undefined, (directory) => {
+      opened.push(directory)
+    })
+
+    expect(opened).toEqual([])
+  })
+})

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -2,7 +2,7 @@ import { DataProvider } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
-import { createEffect, createMemo, on, type ParentProps, Show } from "solid-js"
+import { createEffect, createMemo, type ParentProps, Show } from "solid-js"
 import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
@@ -19,14 +19,9 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const sync = useSync()
   const slug = createMemo(() => base64Encode(props.directory))
 
-  createEffect(
-    on(
-      () => sync.data.path.worktree,
-      (worktree) => {
-        syncProject(sync.data.path.directory, worktree, layout.projects.open)
-      },
-    ),
-  )
+  createEffect(() => {
+    syncProject(sync.data.path.directory, sync.data.path.worktree, layout.projects.open)
+  })
 
   createEffect(() => {
     const next = sync.data.path.directory

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -18,9 +18,16 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const params = useParams()
   const sync = useSync()
   const slug = createMemo(() => base64Encode(props.directory))
+  let synced: string | undefined
 
   createEffect(() => {
-    syncProject(sync.data.path.directory, sync.data.path.worktree, layout.projects.open)
+    synced = syncProject(
+      synced,
+      sync.data.path.directory,
+      sync.data.path.worktree,
+      layout.projects.open,
+      layout.projects.close,
+    )
   })
 
   createEffect(() => {

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -2,7 +2,7 @@ import { DataProvider } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
-import { createEffect, createMemo, type ParentProps, Show } from "solid-js"
+import { createEffect, createMemo, on, type ParentProps, Show } from "solid-js"
 import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
@@ -72,9 +72,11 @@ export default function Layout(props: ParentProps) {
     navigate("/", { replace: true })
   })
 
-  createEffect(() => {
-    syncProject(resolved(), layout.projects.open)
-  })
+  createEffect(
+    on(resolved, (directory) => {
+      syncProject(directory, layout.projects.open)
+    }),
+  )
 
   return (
     <Show when={resolved()} keyed>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -13,10 +13,20 @@ import { decode64 } from "@/utils/base64"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const location = useLocation()
+  const layout = useLayout()
   const navigate = useNavigate()
   const params = useParams()
   const sync = useSync()
   const slug = createMemo(() => base64Encode(props.directory))
+
+  createEffect(
+    on(
+      () => sync.data.path.worktree,
+      (directory) => {
+        syncProject(directory, layout.projects.open)
+      },
+    ),
+  )
 
   createEffect(() => {
     const next = sync.data.path.directory
@@ -46,7 +56,6 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
 export default function Layout(props: ParentProps) {
   const params = useParams()
   const language = useLanguage()
-  const layout = useLayout()
   const navigate = useNavigate()
   let invalid = ""
 
@@ -71,12 +80,6 @@ export default function Layout(props: ParentProps) {
     })
     navigate("/", { replace: true })
   })
-
-  createEffect(
-    on(resolved, (directory) => {
-      syncProject(directory, layout.projects.open)
-    }),
-  )
 
   return (
     <Show when={resolved()} keyed>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -22,8 +22,8 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   createEffect(
     on(
       () => sync.data.path.worktree,
-      (directory) => {
-        syncProject(directory, layout.projects.open)
+      (worktree) => {
+        syncProject(sync.data.path.directory, worktree, layout.projects.open)
       },
     ),
   )

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -3,10 +3,12 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { createEffect, createMemo, type ParentProps, Show } from "solid-js"
+import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { LocalProvider } from "@/context/local"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
+import { syncProject } from "@/pages/directory-layout-sync"
 import { decode64 } from "@/utils/base64"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
@@ -44,6 +46,7 @@ function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
 export default function Layout(props: ParentProps) {
   const params = useParams()
   const language = useLanguage()
+  const layout = useLayout()
   const navigate = useNavigate()
   let invalid = ""
 
@@ -67,6 +70,10 @@ export default function Layout(props: ParentProps) {
       description: language.t("directory.error.invalidUrl"),
     })
     navigate("/", { replace: true })
+  })
+
+  createEffect(() => {
+    syncProject(resolved(), layout.projects.open)
   })
 
   return (

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -187,12 +187,11 @@ export namespace Config {
       return false
     }
 
-    const mod = path.join(dir, "node_modules", "@opencode-ai", "plugin")
-    if (!existsSync(mod)) return true
-
     const pkg = path.join(dir, "package.json")
     const pkgExists = await Filesystem.exists(pkg)
-    if (!pkgExists) return true
+    if (!pkgExists) return dir === Flag.OPENCODE_CONFIG_DIR
+    const mod = path.join(dir, "node_modules", "@opencode-ai", "plugin")
+    if (!existsSync(mod)) return true
 
     const parsed = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(pkg).catch(() => null)
     const dependencies = parsed?.dependencies ?? {}

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -643,7 +643,7 @@ export namespace File {
           log.info("search", { query, kind })
 
           const result = cache
-          const preferHidden = query.startsWith(".") || query.includes("/.")
+          const preferHidden = query.startsWith(".") || query.includes("/.") || query.includes("\\.")
 
           if (!query) {
             if (kind === "file") return result.files.slice(0, limit)
@@ -652,9 +652,19 @@ export namespace File {
 
           const items =
             kind === "file" ? result.files : kind === "directory" ? result.dirs : [...result.files, ...result.dirs]
+          const key = query.replaceAll("\\", "/")
 
           const searchLimit = kind === "directory" && !preferHidden ? limit * 20 : limit
-          const sorted = fuzzysort.go(query, items, { limit: searchLimit }).map((item) => item.target)
+          const sorted = fuzzysort
+            .go(
+              key,
+              items.map((item) => ({
+                item,
+                key: item.replaceAll("\\", "/"),
+              })),
+              { key: "key", limit: searchLimit },
+            )
+            .map((item) => item.obj.item)
           const output = kind === "directory" ? sortHiddenLast(sorted, preferHidden).slice(0, limit) : sorted
 
           log.info("search", { query, kind, results: output.length })

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -10,6 +10,7 @@ import { Filesystem } from "../util/filesystem"
 import { Process } from "../util/process"
 import { which } from "../util/which"
 import { text } from "node:stream/consumers"
+import { Glob } from "../util/glob"
 
 import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { Log } from "@/util/log"
@@ -127,13 +128,27 @@ export namespace Ripgrep {
     }),
   )
 
-  const state = lazy(async () => {
+  type Local = {
+    filepath?: string
+  }
+
+  async function probe(): Promise<Local> {
     const system = which("rg")
     if (system) {
       const stat = await fs.stat(system).catch(() => undefined)
       if (stat?.isFile()) return { filepath: system }
       log.warn("bun.which returned invalid rg path", { filepath: system })
     }
+
+    const filepath = path.join(Global.Path.bin, "rg" + (process.platform === "win32" ? ".exe" : ""))
+    if (await Filesystem.exists(filepath)) return { filepath }
+    return {}
+  }
+
+  const state = lazy(async (): Promise<Local> => {
+    const local = await probe()
+    if (local.filepath) return local
+
     const filepath = path.join(Global.Path.bin, "rg" + (process.platform === "win32" ? ".exe" : ""))
 
     if (!(await Filesystem.exists(filepath))) {
@@ -210,7 +225,138 @@ export namespace Ripgrep {
 
   export async function filepath() {
     const { filepath } = await state()
+    if (!filepath) throw new Error("ripgrep not available")
     return filepath
+  }
+
+  async function available() {
+    return probe().catch((err) => {
+      log.warn("ripgrep unavailable, using local fallback", { error: err instanceof Error ? err.message : String(err) })
+      return {} satisfies Local
+    })
+  }
+
+  async function* walk(input: {
+    cwd: string
+    dir: string
+    glob?: string[]
+    hidden?: boolean
+    follow?: boolean
+    maxDepth?: number
+    depth?: number
+    signal?: AbortSignal
+  }): AsyncGenerator<string> {
+    input.signal?.throwIfAborted()
+    const list = await fs.readdir(input.dir, { withFileTypes: true }).catch(() => [] as fs.Dirent[])
+    for (const entry of list) {
+      input.signal?.throwIfAborted()
+      if (entry.name === ".git") continue
+      if (input.hidden === false && entry.name.startsWith(".")) continue
+
+      const abs = path.join(input.dir, entry.name)
+      const rel = path.relative(input.cwd, abs)
+      const key = rel.replaceAll("\\", "/")
+      const next = input.depth ?? 0
+
+      if (entry.isSymbolicLink()) {
+        if (!input.follow) continue
+        const stat = await fs.stat(abs).catch(() => undefined)
+        if (!stat) continue
+        if (stat.isDirectory()) {
+          if (input.maxDepth !== undefined && next >= input.maxDepth) continue
+          yield* walk({
+            ...input,
+            dir: abs,
+            depth: next + 1,
+          })
+          continue
+        }
+      }
+
+      if (entry.isDirectory()) {
+        if (input.maxDepth !== undefined && next >= input.maxDepth) continue
+        yield* walk({
+          ...input,
+          dir: abs,
+          depth: next + 1,
+        })
+        continue
+      }
+
+      if (input.glob && !input.glob.some((glob) => Glob.match(glob, key))) continue
+      yield rel
+    }
+  }
+
+  function localFiles(input: {
+    cwd: string
+    glob?: string[]
+    hidden?: boolean
+    follow?: boolean
+    maxDepth?: number
+    signal?: AbortSignal
+  }) {
+    return walk({
+      ...input,
+      dir: input.cwd,
+      depth: 0,
+    })
+  }
+
+  async function localSearch(input: {
+    cwd: string
+    pattern: string
+    glob?: string[]
+    limit?: number
+    follow?: boolean
+  }) {
+    const rx = new RegExp(input.pattern, "g")
+    const out: Match["data"][] = []
+
+    for await (const file of localFiles({
+      cwd: input.cwd,
+      glob: input.glob,
+      hidden: true,
+      follow: input.follow,
+    })) {
+      if (input.limit && out.length >= input.limit) break
+      const abs = path.join(input.cwd, file)
+      const text = await fs.readFile(abs, "utf8").catch(() => undefined)
+      if (text === undefined) continue
+
+      const lines = text.split(/\r?\n/)
+      let offset = 0
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        if (!line) {
+          offset += 1
+          continue
+        }
+
+        rx.lastIndex = 0
+        const parts = Array.from(line.matchAll(rx))
+        if (!parts.length) {
+          offset += line.length + 1
+          continue
+        }
+
+        out.push({
+          path: { text: file },
+          lines: { text: line },
+          line_number: i + 1,
+          absolute_offset: offset,
+          submatches: parts.map((match) => ({
+            match: { text: match[0] },
+            start: match.index ?? 0,
+            end: (match.index ?? 0) + match[0].length,
+          })),
+        })
+        if (input.limit && out.length >= input.limit) break
+        offset += line.length + 1
+      }
+    }
+
+    return out
   }
 
   export async function* files(input: {
@@ -223,7 +369,13 @@ export namespace Ripgrep {
   }) {
     input.signal?.throwIfAborted()
 
-    const args = [await filepath(), "--files", "--glob=!.git/*"]
+    const local = await available()
+    if (!local.filepath) {
+      yield* localFiles(input)
+      return
+    }
+
+    const args = [local.filepath, "--files", "--glob=!.git/*"]
     if (input.follow) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
@@ -339,7 +491,10 @@ export namespace Ripgrep {
     limit?: number
     follow?: boolean
   }) {
-    const args = [`${await filepath()}`, "--json", "--hidden", "--glob=!.git/*"]
+    const local = await available()
+    if (!local.filepath) return localSearch(input)
+
+    const args = [local.filepath, "--json", "--hidden", "--glob=!.git/*"]
     if (input.follow) args.push("--follow")
 
     if (input.glob) {

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -20,7 +20,11 @@ const disposal = {
   all: undefined as Promise<void> | undefined,
 }
 
-async function cleanup(directory: string, ctx: Shape, task?: Promise<Shape>) {
+async function cleanup(
+  directory: string,
+  ctx: ReturnType<typeof context.use>,
+  task?: Promise<ReturnType<typeof context.use>>,
+) {
   Log.Default.info("disposing instance", { directory })
   await context.provide(ctx, async () => {
     await Promise.all([State.dispose(directory), disposeInstance(directory)])

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -20,6 +20,15 @@ const disposal = {
   all: undefined as Promise<void> | undefined,
 }
 
+async function cleanup(directory: string, ctx: Shape, task?: Promise<Shape>) {
+  Log.Default.info("disposing instance", { directory })
+  await context.provide(ctx, async () => {
+    await Promise.all([State.dispose(directory), disposeInstance(directory)])
+  })
+  if (!task || cache.get(directory) === task) cache.delete(directory)
+  emit(directory)
+}
+
 function emit(directory: string) {
   GlobalBus.emit("event", {
     directory,
@@ -128,10 +137,20 @@ export const Instance = {
   },
   async dispose() {
     const directory = Instance.directory
-    Log.Default.info("disposing instance", { directory })
-    await Promise.all([State.dispose(directory), disposeInstance(directory)])
-    cache.delete(directory)
-    emit(directory)
+    await cleanup(directory, context.use())
+  },
+  async disposeDirectory(directory: string) {
+    const key = Filesystem.resolve(directory)
+    const task = cache.get(key)
+    if (!task) return
+    const ctx = await task.catch((error) => {
+      Log.Default.warn("instance dispose failed", { key, error })
+      if (cache.get(key) === task) cache.delete(key)
+      return undefined
+    })
+    if (!ctx) return
+    if (cache.get(key) !== task) return
+    await cleanup(key, ctx, task)
   },
   async disposeAll() {
     if (disposal.all) return disposal.all

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -1,9 +1,7 @@
 import z from "zod"
-import { text } from "node:stream/consumers"
 import { Tool } from "./tool"
 import { Filesystem } from "../util/filesystem"
 import { Ripgrep } from "../file/ripgrep"
-import { Process } from "../util/process"
 
 import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
@@ -39,65 +37,21 @@ export const GrepTool = Tool.define("grep", {
     searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
-    const rgPath = await Ripgrep.filepath()
-    const args = ["-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
-    if (params.include) {
-      args.push("--glob", params.include)
-    }
-    args.push(searchPath)
-
-    const proc = Process.spawn([rgPath, ...args], {
-      stdout: "pipe",
-      stderr: "pipe",
-      abort: ctx.abort,
-    })
-
-    if (!proc.stdout || !proc.stderr) {
-      throw new Error("Process output not available")
-    }
-
-    const output = await text(proc.stdout)
-    const errorOutput = await text(proc.stderr)
-    const exitCode = await proc.exited
-
-    // Exit codes: 0 = matches found, 1 = no matches, 2 = errors (but may still have matches)
-    // With --no-messages, we suppress error output but still get exit code 2 for broken symlinks etc.
-    // Only fail if exit code is 2 AND no output was produced
-    if (exitCode === 1 || (exitCode === 2 && !output.trim())) {
-      return {
-        title: params.pattern,
-        metadata: { matches: 0, truncated: false },
-        output: "No files found",
-      }
-    }
-
-    if (exitCode !== 0 && exitCode !== 2) {
-      throw new Error(`ripgrep failed: ${errorOutput}`)
-    }
-
-    const hasErrors = exitCode === 2
-
-    // Handle both Unix (\n) and Windows (\r\n) line endings
-    const lines = output.trim().split(/\r?\n/)
     const matches = []
-
-    for (const line of lines) {
-      if (!line) continue
-
-      const [filePath, lineNumStr, ...lineTextParts] = line.split("|")
-      if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
-
-      const lineNum = parseInt(lineNumStr, 10)
-      const lineText = lineTextParts.join("|")
-
+    for (const item of await Ripgrep.search({
+      cwd: searchPath,
+      pattern: params.pattern,
+      glob: params.include ? [params.include] : undefined,
+    })) {
+      const filePath = path.join(searchPath, item.path.text)
       const stats = Filesystem.stat(filePath)
       if (!stats) continue
 
       matches.push({
         path: filePath,
         modTime: stats.mtime.getTime(),
-        lineNum,
-        lineText,
+        lineNum: item.line_number,
+        lineText: item.lines.text,
       })
     }
 
@@ -137,11 +91,6 @@ export const GrepTool = Tool.define("grep", {
       outputLines.push(
         `(Results truncated: showing ${limit} of ${totalMatches} matches (${totalMatches - limit} hidden). Consider using a more specific path or pattern.)`,
       )
-    }
-
-    if (hasErrors) {
-      outputLines.push("")
-      outputLines.push("(Some paths were inaccessible and skipped)")
     }
 
     return {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -60,6 +60,7 @@ export namespace ToolRegistry {
       const cache = yield* InstanceState.make<State>(
         Effect.fn("ToolRegistry.state")(function* (ctx) {
           const custom: Tool.Info[] = []
+          const spec = (file: string) => (process.platform === "win32" ? file : pathToFileURL(file).href)
 
           function fromPlugin(id: string, def: ToolDefinition): Tool.Info {
             return {
@@ -85,18 +86,38 @@ export namespace ToolRegistry {
             }
           }
 
+          function fromFile(file: string, id: string, err?: unknown): Tool.Info {
+            return {
+              id,
+              init: async (initCtx) => {
+                await Config.waitForDependencies().catch(() => undefined)
+                const mod = await import(spec(file))
+                const def = mod.default as ToolDefinition | undefined
+                if (!def) {
+                  throw err instanceof Error ? err : new Error(`Tool "${id}" failed to load`)
+                }
+                return fromPlugin(id, def).init(initCtx)
+              },
+            }
+          }
+
           const dirs = yield* config.directories()
           const matches = dirs.flatMap((dir) =>
             Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }),
           )
-          if (matches.length) yield* config.waitForDependencies()
           for (const match of matches) {
             const namespace = path.basename(match, path.extname(match))
-            const mod = yield* Effect.promise(
-              () => import(process.platform === "win32" ? match : pathToFileURL(match).href),
-            )
-            for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
-              custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+            try {
+              const mod = yield* Effect.promise(() => import(spec(match)))
+              for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
+                custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+              }
+            } catch (err) {
+              log.warn("failed to load custom tool", {
+                file: match,
+                error: err instanceof Error ? err.message : String(err),
+              })
+              custom.push(fromFile(match, namespace, err))
             }
           }
 

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -510,6 +510,7 @@ export namespace Worktree {
         }
 
         const worktreePath = entry.path
+        yield* Effect.promise(() => Instance.disposeDirectory(worktreePath))
         yield* stopFsmonitor(worktreePath)
 
         const remoteList = yield* git(["remote"], { cwd: Instance.worktree })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -181,8 +181,9 @@ export namespace Worktree {
 
       const git = Effect.fnUntraced(
         function* (args: string[], opts?: { cwd?: string }) {
+          const cmd = args[0] === "fsmonitor--daemon" ? args : ["-c", "core.fsmonitor=false", ...args]
           const handle = yield* spawner.spawn(
-            ChildProcess.make("git", args, { cwd: opts?.cwd, extendEnv: true, stdin: "ignore" }),
+            ChildProcess.make("git", cmd, { cwd: opts?.cwd, extendEnv: true, stdin: "ignore" }),
           )
           const [text, stderr] = yield* Effect.all(
             [Stream.mkString(Stream.decodeText(handle.stdout)), Stream.mkString(Stream.decodeText(handle.stderr))],
@@ -588,7 +589,7 @@ export namespace Worktree {
           (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to clean submodules" }),
         )
 
-        const status = yield* git(["-c", "core.fsmonitor=false", "status", "--porcelain=v1"], { cwd: worktreePath })
+        const status = yield* git(["status", "--porcelain=v1"], { cwd: worktreePath })
         if (status.code !== 0) {
           throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
         }

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -509,6 +509,7 @@ export namespace Worktree {
         }
 
         const worktreePath = entry.path
+        yield* stopFsmonitor(worktreePath)
 
         const remoteList = yield* git(["remote"], { cwd: Instance.worktree })
         if (remoteList.code !== 0) {

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -555,6 +555,11 @@ export namespace Worktree {
         const remoteBranch =
           remote && remoteTarget.startsWith(`${remote}/`) ? remoteTarget.slice(`${remote}/`.length) : ""
 
+        const cfg = yield* git(["config", "init.defaultBranch"], { cwd: Instance.worktree })
+        const pref = cfg.code === 0 ? cfg.text.trim() : ""
+        const prefCheck = pref
+          ? yield* git(["show-ref", "--verify", "--quiet", `refs/heads/${pref}`], { cwd: Instance.worktree })
+          : undefined
         const [mainCheck, masterCheck] = yield* Effect.all(
           [
             git(["show-ref", "--verify", "--quiet", "refs/heads/main"], { cwd: Instance.worktree }),
@@ -562,7 +567,8 @@ export namespace Worktree {
           ],
           { concurrency: 2 },
         )
-        const localBranch = mainCheck.code === 0 ? "main" : masterCheck.code === 0 ? "master" : ""
+        const localBranch =
+          prefCheck?.code === 0 ? pref : mainCheck.code === 0 ? "main" : masterCheck.code === 0 ? "master" : ""
 
         const target = remoteBranch ? `${remote}/${remoteBranch}` : localBranch
         if (!target) {

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -355,6 +355,23 @@ export namespace Worktree {
         )
       }
 
+      function transient(message: string) {
+        const text = message.toLowerCase()
+        return [
+          "permission denied",
+          "access is denied",
+          "device or resource busy",
+          "resource busy",
+          "directory not empty",
+          "failed to remove",
+          "unable to unlink",
+          "cannot unlink",
+          "cannot access the file",
+          "used by another process",
+          "worktree reset left local changes",
+        ].some((item) => text.includes(item))
+      }
+
       const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {
         if (Instance.project.vcs !== "git") {
           throw new NotGitError({ message: "Worktrees are only supported for git projects" })
@@ -511,7 +528,6 @@ export namespace Worktree {
 
         const worktreePath = entry.path
         yield* Effect.promise(() => Instance.disposeDirectory(worktreePath))
-        yield* stopFsmonitor(worktreePath)
 
         const remoteList = yield* git(["remote"], { cwd: Instance.worktree })
         if (remoteList.code !== 0) {
@@ -561,43 +577,61 @@ export namespace Worktree {
           )
         }
 
-        yield* gitExpect(
-          ["reset", "--hard", target],
-          { cwd: worktreePath },
-          (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to reset worktree to target" }),
-        )
+        const restore = (left: number): Effect.Effect<void, ResetFailedError> =>
+          Effect.gen(function* () {
+            yield* stopFsmonitor(worktreePath)
 
-        const cleanResult = yield* sweep(worktreePath)
-        if (cleanResult.code !== 0) {
-          throw new ResetFailedError({ message: cleanResult.stderr || cleanResult.text || "Failed to clean worktree" })
-        }
+            yield* gitExpect(
+              ["reset", "--hard", target],
+              { cwd: worktreePath },
+              (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to reset worktree to target" }),
+            )
 
-        yield* gitExpect(
-          ["submodule", "update", "--init", "--recursive", "--force"],
-          { cwd: worktreePath },
-          (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to update submodules" }),
-        )
+            const cleanResult = yield* sweep(worktreePath)
+            if (cleanResult.code !== 0) {
+              throw new ResetFailedError({
+                message: cleanResult.stderr || cleanResult.text || "Failed to clean worktree",
+              })
+            }
 
-        yield* gitExpect(
-          ["submodule", "foreach", "--recursive", "git", "reset", "--hard"],
-          { cwd: worktreePath },
-          (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to reset submodules" }),
-        )
+            yield* gitExpect(
+              ["submodule", "update", "--init", "--recursive", "--force"],
+              { cwd: worktreePath },
+              (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to update submodules" }),
+            )
 
-        yield* gitExpect(
-          ["submodule", "foreach", "--recursive", "git", "clean", "-fdx"],
-          { cwd: worktreePath },
-          (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to clean submodules" }),
-        )
+            yield* gitExpect(
+              ["submodule", "foreach", "--recursive", "git", "reset", "--hard"],
+              { cwd: worktreePath },
+              (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to reset submodules" }),
+            )
 
-        const status = yield* git(["status", "--porcelain=v1"], { cwd: worktreePath })
-        if (status.code !== 0) {
-          throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
-        }
+            yield* gitExpect(
+              ["submodule", "foreach", "--recursive", "git", "clean", "-fdx"],
+              { cwd: worktreePath },
+              (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to clean submodules" }),
+            )
 
-        if (status.text.trim()) {
-          throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
-        }
+            const status = yield* git(["status", "--porcelain=v1"], { cwd: worktreePath })
+            if (status.code !== 0) {
+              throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
+            }
+
+            if (status.text.trim()) {
+              throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
+            }
+          }).pipe(
+            Effect.catchIf(
+              (err): err is InstanceType<typeof ResetFailedError> =>
+                process.platform === "win32" &&
+                left > 1 &&
+                ResetFailedError.isInstance(err) &&
+                transient(err.data.message),
+              () => Effect.sleep(100).pipe(Effect.flatMap(() => restore(left - 1))),
+            ),
+          )
+
+        yield* restore(process.platform === "win32" ? 5 : 1)
 
         yield* runStartScripts(worktreePath, { projectID: Instance.project.id }).pipe(
           Effect.catchCause((cause) => Effect.sync(() => log.error("worktree start task failed", { cause }))),

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -12,7 +12,7 @@ import { Slug } from "@opencode-ai/util/slug"
 import { errorMessage } from "../util/error"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
-import { Effect, Layer, Path, Scope, ServiceMap, Stream } from "effect"
+import { Cause, Effect, Layer, Path, Scope, ServiceMap, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@/filesystem"
@@ -577,7 +577,7 @@ export namespace Worktree {
           )
         }
 
-        const restore = (left: number): Effect.Effect<void, ResetFailedError> =>
+        const restore = (left: number): Effect.Effect<void> =>
           Effect.gen(function* () {
             yield* stopFsmonitor(worktreePath)
 
@@ -621,14 +621,18 @@ export namespace Worktree {
               throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
             }
           }).pipe(
-            Effect.catchIf(
-              (err): err is InstanceType<typeof ResetFailedError> =>
+            Effect.catchCause((cause): Effect.Effect<void> => {
+              const reason = cause.reasons.find(Cause.isDieReason)
+              if (
                 process.platform === "win32" &&
                 left > 1 &&
-                ResetFailedError.isInstance(err) &&
-                transient(err.data.message),
-              () => Effect.sleep(100).pipe(Effect.flatMap(() => restore(left - 1))),
-            ),
+                ResetFailedError.isInstance(reason?.defect) &&
+                transient(reason.defect.data.message)
+              ) {
+                return Effect.sleep(100).pipe(Effect.flatMap(() => restore(left - 1)))
+              }
+              return Effect.failCause(cause).pipe(Effect.orDie)
+            }),
           )
 
         yield* restore(process.platform === "win32" ? 5 : 1)

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -739,6 +739,20 @@ describe("file/index Filesystem patterns", () => {
       })
     })
 
+    test("backslash query matches nested files", async () => {
+      await using tmp = await setupSearchableRepo()
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await File.init()
+
+          const result = await File.search({ query: "src\\main.ts", type: "file" })
+          expect(result.some((file) => file.replaceAll("\\", "/") === "src/main.ts")).toBe(true)
+        },
+      })
+    })
+
     test("type filter returns only files", async () => {
       await using tmp = await setupSearchableRepo()
 

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -67,6 +67,66 @@ describe("Worktree.reset", () => {
     expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
   })
 
+  test("retries transient clean failures", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const root = tmp.path
+    const file = path.join(root, "README.md")
+    await Bun.write(file, "# reset\n")
+    await $`git add README.md`.cwd(root).quiet()
+    await $`git commit -m "add readme"`.cwd(root).quiet()
+
+    const info = await make(root, `reset-retry-${Date.now().toString(36)}`)
+
+    const readme = path.join(info.directory, "README.md")
+    const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
+    const text = await fs.readFile(readme, "utf8")
+    await fs.writeFile(readme, `${text.trimEnd()}\nchange\n`, "utf8")
+    await fs.writeFile(extra, "extra\n", "utf8")
+
+    const real = (await $`which git`.quiet().text()).trim()
+    expect(real).toBeTruthy()
+
+    const bin = path.join(root, "bin")
+    const shim = path.join(bin, "git")
+    const mark = path.join(root, "git-clean-once")
+    await fs.mkdir(bin, { recursive: true })
+    await Bun.write(
+      shim,
+      [
+        "#!/bin/bash",
+        `REAL_GIT=${JSON.stringify(real)}`,
+        `MARK=${JSON.stringify(mark)}`,
+        'if [ "$1" = "-c" ] && [ "$2" = "core.fsmonitor=false" ]; then',
+        "  shift 2",
+        "fi",
+        'if [ "$1" = "clean" ] && [ ! -f "$MARK" ]; then',
+        '  touch "$MARK"',
+        '  echo "warning: failed to remove extra.txt: Permission denied" >&2',
+        "  exit 1",
+        "fi",
+        'exec "$REAL_GIT" "$@"',
+      ].join("\n"),
+    )
+    await fs.chmod(shim, 0o755)
+
+    const prev = process.env.PATH ?? ""
+    process.env.PATH = `${bin}${path.delimiter}${prev}`
+
+    const ok = await (async () => {
+      try {
+        return await withInstance(root, () => Worktree.reset({ directory: info.directory }))
+      } finally {
+        process.env.PATH = prev
+      }
+    })()
+
+    expect(ok).toBe(true)
+    expect(await fs.readFile(readme, "utf8")).toBe(text)
+    expect(await fs.stat(extra).then(() => true).catch(() => false)).toBe(false)
+    expect(await fs.stat(mark).then(() => true).catch(() => false)).toBe(true)
+    expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
+  })
+
   wintest("stops fsmonitor before resetting a worktree", async () => {
     await using tmp = await tmpdir({ git: true })
     const root = tmp.path

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -12,6 +12,28 @@ function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
 }
 
+async function wait(fn: () => Promise<boolean>, timeout = 30_000) {
+  const end = Date.now() + timeout
+  while (Date.now() < end) {
+    if (await fn()) return
+    await Bun.sleep(100)
+  }
+  throw new Error("timed out waiting for worktree bootstrap")
+}
+
+async function make(root: string, name: string) {
+  const info = await withInstance(root, () => Worktree.create({ name }))
+
+  await wait(() =>
+    fs
+      .readFile(path.join(info.directory, "README.md"), "utf8")
+      .then(() => true)
+      .catch(() => false),
+  )
+
+  return info
+}
+
 describe("Worktree.reset", () => {
   afterEach(() => Instance.disposeAll())
 
@@ -23,11 +45,7 @@ describe("Worktree.reset", () => {
     await $`git add README.md`.cwd(root).quiet()
     await $`git commit -m "add readme"`.cwd(root).quiet()
 
-    const info = await withInstance(root, async () => {
-      const info = await Worktree.makeWorktreeInfo(`reset-${Date.now().toString(36)}`)
-      await Worktree.createFromInfo(info)
-      return info
-    })
+    const info = await make(root, `reset-${Date.now().toString(36)}`)
 
     const readme = path.join(info.directory, "README.md")
     const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
@@ -51,11 +69,7 @@ describe("Worktree.reset", () => {
     await $`git add README.md`.cwd(root).quiet()
     await $`git commit -m "add readme"`.cwd(root).quiet()
 
-    const info = await withInstance(root, async () => {
-      const info = await Worktree.makeWorktreeInfo(`reset-fsmonitor-${Date.now().toString(36)}`)
-      await Worktree.createFromInfo(info)
-      return info
-    })
+    const info = await make(root, `reset-fsmonitor-${Date.now().toString(36)}`)
 
     const readme = path.join(info.directory, "README.md")
     const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -127,6 +127,33 @@ describe("Worktree.reset", () => {
     expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
   })
 
+  test("uses configured default branch when not main or master", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const root = tmp.path
+    const name = `dev-${Date.now().toString(36)}`
+    const file = path.join(root, "README.md")
+    await Bun.write(file, "# reset\n")
+    await $`git branch -m ${name}`.cwd(root).quiet()
+    await $`git config init.defaultBranch ${name}`.cwd(root).quiet()
+    await $`git add README.md`.cwd(root).quiet()
+    await $`git commit -m "add readme"`.cwd(root).quiet()
+
+    const info = await make(root, `reset-config-${Date.now().toString(36)}`)
+
+    const readme = path.join(info.directory, "README.md")
+    const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
+    const text = await fs.readFile(readme, "utf8")
+    await fs.writeFile(readme, `${text.trimEnd()}\nchange\n`, "utf8")
+    await fs.writeFile(extra, "extra\n", "utf8")
+
+    const ok = await withInstance(root, () => Worktree.reset({ directory: info.directory }))
+    expect(ok).toBe(true)
+
+    expect(await fs.readFile(readme, "utf8")).toBe(text)
+    expect(await fs.stat(extra).then(() => true).catch(() => false)).toBe(false)
+    expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
+  })
+
   wintest("stops fsmonitor before resetting a worktree", async () => {
     await using tmp = await tmpdir({ git: true })
     const root = tmp.path

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -12,25 +12,31 @@ function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
 }
 
-async function wait(fn: () => Promise<boolean>, timeout = 30_000) {
-  const end = Date.now() + timeout
-  while (Date.now() < end) {
-    if (await fn()) return
-    await Bun.sleep(100)
-  }
-  throw new Error("timed out waiting for worktree bootstrap")
+async function ready(name: string) {
+  const { GlobalBus } = await import("../../src/bus/global")
+
+  return await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      GlobalBus.off("event", on)
+      reject(new Error(`timed out waiting for worktree.ready: ${name}`))
+    }, 30_000)
+
+    function on(evt: { payload: { type: string; properties?: { name?: string } } }) {
+      if (evt.payload.type !== Worktree.Event.Ready.type) return
+      if (evt.payload.properties?.name !== name) return
+      clearTimeout(timer)
+      GlobalBus.off("event", on)
+      resolve()
+    }
+
+    GlobalBus.on("event", on)
+  })
 }
 
 async function make(root: string, name: string) {
+  const wait = ready(name)
   const info = await withInstance(root, () => Worktree.create({ name }))
-
-  await wait(() =>
-    fs
-      .readFile(path.join(info.directory, "README.md"), "utf8")
-      .then(() => true)
-      .catch(() => false),
-  )
-
+  await wait
   return info
 }
 

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -12,26 +12,6 @@ function withInstance(directory: string, fn: () => Promise<any>) {
   return Instance.provide({ directory, fn })
 }
 
-async function ready() {
-  const { GlobalBus } = await import("../../src/bus/global")
-
-  return await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      GlobalBus.off("event", on)
-      reject(new Error("timed out waiting for worktree.ready"))
-    }, 10_000)
-
-    function on(evt: { payload: { type: string } }) {
-      if (evt.payload.type !== Worktree.Event.Ready.type) return
-      clearTimeout(timer)
-      GlobalBus.off("event", on)
-      resolve()
-    }
-
-    GlobalBus.on("event", on)
-  })
-}
-
 describe("Worktree.reset", () => {
   afterEach(() => Instance.disposeAll())
 
@@ -43,9 +23,11 @@ describe("Worktree.reset", () => {
     await $`git add README.md`.cwd(root).quiet()
     await $`git commit -m "add readme"`.cwd(root).quiet()
 
-    const wait = ready()
-    const info = await withInstance(root, () => Worktree.create({ name: `reset-${Date.now().toString(36)}` }))
-    await wait
+    const info = await withInstance(root, async () => {
+      const info = await Worktree.makeWorktreeInfo(`reset-${Date.now().toString(36)}`)
+      await Worktree.createFromInfo(info)
+      return info
+    })
 
     const readme = path.join(info.directory, "README.md")
     const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
@@ -69,9 +51,11 @@ describe("Worktree.reset", () => {
     await $`git add README.md`.cwd(root).quiet()
     await $`git commit -m "add readme"`.cwd(root).quiet()
 
-    const wait = ready()
-    const info = await withInstance(root, () => Worktree.create({ name: `reset-fsmonitor-${Date.now().toString(36)}` }))
-    await wait
+    const info = await withInstance(root, async () => {
+      const info = await Worktree.makeWorktreeInfo(`reset-fsmonitor-${Date.now().toString(36)}`)
+      await Worktree.createFromInfo(info)
+      return info
+    })
 
     const readme = path.join(info.directory, "README.md")
     const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)

--- a/packages/opencode/test/project/worktree-reset.test.ts
+++ b/packages/opencode/test/project/worktree-reset.test.ts
@@ -1,0 +1,96 @@
+import { $ } from "bun"
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Worktree } from "../../src/worktree"
+import { tmpdir } from "../fixture/fixture"
+
+const wintest = process.platform === "win32" ? test : test.skip
+
+function withInstance(directory: string, fn: () => Promise<any>) {
+  return Instance.provide({ directory, fn })
+}
+
+async function ready() {
+  const { GlobalBus } = await import("../../src/bus/global")
+
+  return await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      GlobalBus.off("event", on)
+      reject(new Error("timed out waiting for worktree.ready"))
+    }, 10_000)
+
+    function on(evt: { payload: { type: string } }) {
+      if (evt.payload.type !== Worktree.Event.Ready.type) return
+      clearTimeout(timer)
+      GlobalBus.off("event", on)
+      resolve()
+    }
+
+    GlobalBus.on("event", on)
+  })
+}
+
+describe("Worktree.reset", () => {
+  afterEach(() => Instance.disposeAll())
+
+  test("restores tracked files and removes untracked files", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const root = tmp.path
+    const file = path.join(root, "README.md")
+    await Bun.write(file, "# reset\n")
+    await $`git add README.md`.cwd(root).quiet()
+    await $`git commit -m "add readme"`.cwd(root).quiet()
+
+    const wait = ready()
+    const info = await withInstance(root, () => Worktree.create({ name: `reset-${Date.now().toString(36)}` }))
+    await wait
+
+    const readme = path.join(info.directory, "README.md")
+    const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
+    const text = await fs.readFile(readme, "utf8")
+    await fs.writeFile(readme, `${text.trimEnd()}\nchange\n`, "utf8")
+    await fs.writeFile(extra, "extra\n", "utf8")
+
+    const ok = await withInstance(root, () => Worktree.reset({ directory: info.directory }))
+    expect(ok).toBe(true)
+
+    expect(await fs.readFile(readme, "utf8")).toBe(text)
+    expect(await fs.stat(extra).then(() => true).catch(() => false)).toBe(false)
+    expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
+  })
+
+  wintest("stops fsmonitor before resetting a worktree", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const root = tmp.path
+    const file = path.join(root, "README.md")
+    await Bun.write(file, "# reset\n")
+    await $`git add README.md`.cwd(root).quiet()
+    await $`git commit -m "add readme"`.cwd(root).quiet()
+
+    const wait = ready()
+    const info = await withInstance(root, () => Worktree.create({ name: `reset-fsmonitor-${Date.now().toString(36)}` }))
+    await wait
+
+    const readme = path.join(info.directory, "README.md")
+    const extra = path.join(info.directory, `extra-${Date.now().toString(36)}.txt`)
+    const text = await fs.readFile(readme, "utf8")
+
+    await $`git config core.fsmonitor true`.cwd(info.directory).quiet()
+    await $`git fsmonitor--daemon stop`.cwd(info.directory).quiet().nothrow()
+    await fs.writeFile(readme, `${text.trimEnd()}\nchange\n`, "utf8")
+    await fs.writeFile(extra, "extra\n", "utf8")
+    await $`git diff`.cwd(info.directory).quiet()
+
+    const before = await $`git fsmonitor--daemon status`.cwd(info.directory).quiet().nothrow()
+    expect(before.exitCode).toBe(0)
+
+    const ok = await withInstance(root, () => Worktree.reset({ directory: info.directory }))
+    expect(ok).toBe(true)
+
+    expect(await fs.readFile(readme, "utf8")).toBe(text)
+    expect(await fs.stat(extra).then(() => true).catch(() => false)).toBe(false)
+    expect((await $`git status --porcelain=v1`.cwd(info.directory).quiet().text()).trim()).toBe("")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

  Closes #18943

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Opening a valid `/:dir/...` route resolved the directory context, but it did not register the project in the sidebar.

  This PR triggers the existing project-open flow after the direct-route directory is resolved, so direct routing behaves the same as manually opening a project.

  The change is small and reuses the existing idempotent `layout.projects.open()` path, which already loads sessions and avoids duplicate sidebar entries.

  ### How did you verify your code works?

  - `cd packages/app && bun test --preload ./happydom.ts ./src/pages/directory-layout.test.ts`
  - `cd packages/app && bun test`

  ### Screenshots / recordings

  _Attach a short recording showing that opening `/{base64(directory)}/session` makes the project appear in the sidebar automatically._

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR