### PR TITLE
fix(provider): prevent Bedrock from prefixing ARN and deepseek.v3.2 model IDs

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -316,6 +316,11 @@ export namespace Provider {
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           // Skip region prefixing if model already has a cross-region inference profile prefix
           // Models from models.dev may already include prefixes like us., eu., global., etc.
+          // Skip region prefixing for ARN-format model IDs (e.g. arn:aws:bedrock:us-east-1::foundation-model/deepseek.v3.2)
+          if (modelID.startsWith("arn:")) {
+            return sdk.languageModel(modelID)
+          }
+
           const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
           if (crossRegionPrefixes.some((prefix) => modelID.startsWith(prefix))) {
             return sdk.languageModel(modelID)
@@ -338,7 +343,7 @@ export namespace Provider {
                 "nova-premier",
                 "nova-2",
                 "claude",
-                "deepseek",
+                "deepseek-r1",
               ].some((m) => modelID.includes(m))
               const isGovCloud = region.startsWith("us-gov")
               if (modelRequiresPrefix && !isGovCloud) {


### PR DESCRIPTION
### Issue for this PR

Closes #18812

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes two issues in the Amazon Bedrock model ID transformation logic (`provider.ts` `getModel()`):

1. **ARN guard** — Foundation-model ARN IDs (`arn:aws:bedrock:us-east-1::foundation-model/deepseek.v3.2`) were incorrectly prefixed with region codes (e.g. `us.arn:aws:bedrock:...`), making them invalid. Added a guard to pass ARN-format model IDs through unchanged.

2. **DeepSeek prefix narrowing** — The broad `"deepseek"` match in the US cross-region prefix list incorrectly prefixed `deepseek.v3.2` with `us.`, but this model has no cross-region inference profile. Narrowed the match to `"deepseek-r1"` which does support cross-region inference.

Before this fix:
- `deepseek.v3.2` → `us.deepseek.v3.2` → `ValidationException: The provided model identifier is invalid.`
- `arn:aws:bedrock:...` → `us.arn:aws:bedrock:...` → same error

After this fix:
- `deepseek.v3.2` → passed through unchanged → works
- `arn:aws:bedrock:...` → passed through unchanged → works
- `deepseek-r1-v1:0` → `us.deepseek-r1-v1:0` → still gets cross-region prefix correctly

### How did you verify your code works?

- Typecheck passes (all packages)
- Existing Bedrock tests in `packages/opencode/test/provider/amazon-bedrock.test.ts` still pass
- The reporter verified via AWS CLI that `deepseek.v3.2` works without prefix and fails with `us.` prefix
- ARN-format model IDs are a standard AWS pattern that should never be modified

### Screenshots / recordings

N/A — provider model ID transformation change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR