### PR TITLE
fix: trigger auto-compaction at the configured threshold

### DIFF
--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -8,6 +8,7 @@ import { SettingsGeneral } from "./settings-general"
 import { SettingsKeybinds } from "./settings-keybinds"
 import { SettingsProviders } from "./settings-providers"
 import { SettingsModels } from "./settings-models"
+import { SettingsSessions } from "./settings-sessions"
 
 export const DialogSettings: Component = () => {
   const language = useLanguage()
@@ -45,6 +46,10 @@ export const DialogSettings: Component = () => {
                       <Icon name="models" />
                       {language.t("settings.models.title")}
                     </Tabs.Trigger>
+                    <Tabs.Trigger value="sessions">
+                      <Icon name="sliders" />
+                      Sessions
+                    </Tabs.Trigger>
                   </div>
                 </div>
               </div>
@@ -66,6 +71,9 @@ export const DialogSettings: Component = () => {
         </Tabs.Content>
         <Tabs.Content value="models" class="no-scrollbar">
           <SettingsModels />
+        </Tabs.Content>
+        <Tabs.Content value="sessions" class="no-scrollbar">
+          <SettingsSessions />
         </Tabs.Content>
       </Tabs>
     </Dialog>

--- a/packages/app/src/components/settings-sessions.tsx
+++ b/packages/app/src/components/settings-sessions.tsx
@@ -1,0 +1,192 @@
+import { Button } from "@opencode-ai/ui/button"
+import { Switch } from "@opencode-ai/ui/switch"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { showToast } from "@opencode-ai/ui/toast"
+import { createEffect, createMemo, type Component, type JSX } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useLanguage } from "@/context/language"
+import { useGlobalSync } from "@/context/global-sync"
+import { SettingsList } from "./settings-list"
+
+const DEFAULT_THRESHOLD = 80
+const MIN_THRESHOLD = 5
+const MAX_THRESHOLD = 95
+
+function clampPercent(value: number) {
+  return Math.min(MAX_THRESHOLD, Math.max(MIN_THRESHOLD, Math.round(value)))
+}
+
+export const SettingsSessions: Component = () => {
+  const language = useLanguage()
+  const globalSync = useGlobalSync()
+
+  const [store, setStore] = createStore({
+    threshold: String(DEFAULT_THRESHOLD),
+    dirty: false,
+    savingThreshold: false,
+    savingAuto: false,
+  })
+
+  const compaction = createMemo(() => globalSync.data.config.compaction)
+  const auto = createMemo(() => compaction()?.auto ?? true)
+  const thresholdPercent = createMemo(() => Math.round((compaction()?.threshold ?? 0.8) * 100))
+
+  createEffect(() => {
+    if (store.dirty) return
+    setStore("threshold", String(thresholdPercent()))
+  })
+
+  const parsedThreshold = createMemo(() => {
+    const value = Number(store.threshold)
+    if (!Number.isFinite(value)) return undefined
+    return clampPercent(value)
+  })
+
+  const thresholdChanged = createMemo(() => parsedThreshold() !== undefined && parsedThreshold() !== thresholdPercent())
+
+  const updateCompaction = async (patch: NonNullable<typeof globalSync.data.config.compaction>) => {
+    const before = globalSync.data.config.compaction
+    const next = { ...before, ...patch }
+    globalSync.set("config", "compaction", next)
+    try {
+      await globalSync.updateConfig({ compaction: next })
+    } catch (err: unknown) {
+      globalSync.set("config", "compaction", before)
+      const message = err instanceof Error ? err.message : String(err)
+      showToast({ title: language.t("common.requestFailed"), description: message })
+      throw err
+    }
+  }
+
+  const saveThreshold = async () => {
+    const value = parsedThreshold()
+    if (value === undefined) return
+    setStore("savingThreshold", true)
+    try {
+      await updateCompaction({ threshold: value / 100 })
+      setStore({ dirty: false, threshold: String(value) })
+    } finally {
+      setStore("savingThreshold", false)
+    }
+  }
+
+  const resetThreshold = async () => {
+    setStore({ threshold: String(DEFAULT_THRESHOLD), dirty: true })
+    await saveThreshold()
+  }
+
+  return (
+    <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
+      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
+        <div class="flex flex-col gap-1 pt-6 pb-8 max-w-[720px]">
+          <h2 class="text-16-medium text-text-strong">Sessions</h2>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8 max-w-[720px]">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-14-medium text-text-strong pb-2">Compaction</h3>
+
+          <SettingsList>
+            <SettingsRow
+              title="Auto-compact"
+              description="Automatically compact sessions before they hit the model context limit."
+            >
+              <div data-action="settings-session-auto-compact">
+                <Switch
+                  checked={auto()}
+                  disabled={store.savingAuto}
+                  onChange={(checked) => {
+                    setStore("savingAuto", true)
+                    void updateCompaction({ auto: checked }).finally(() => setStore("savingAuto", false))
+                  }}
+                />
+              </div>
+            </SettingsRow>
+
+            <SettingsRow
+              title="Auto-compact threshold"
+              description="Choose how full a session context should get before OpenCode compacts it automatically."
+            >
+              <div
+                class="flex w-full flex-col gap-3 sm:w-[340px]"
+                data-action="settings-session-auto-compact-threshold"
+              >
+                <div class="flex items-center gap-3">
+                  <input
+                    type="range"
+                    min={MIN_THRESHOLD}
+                    max={MAX_THRESHOLD}
+                    step="1"
+                    value={parsedThreshold() ?? thresholdPercent()}
+                    disabled={!auto() || store.savingThreshold}
+                    class="h-2 w-full accent-text-interactive-base disabled:opacity-50"
+                    onInput={(event) => {
+                      setStore({ threshold: event.currentTarget.value, dirty: true })
+                    }}
+                  />
+                  <div class="w-20 shrink-0">
+                    <TextField
+                      type="number"
+                      value={store.threshold}
+                      min={MIN_THRESHOLD}
+                      max={MAX_THRESHOLD}
+                      step="1"
+                      inputmode="numeric"
+                      disabled={!auto() || store.savingThreshold}
+                      onInput={(event) => {
+                        setStore({ threshold: event.currentTarget.value.replace(/[^\d]/g, ""), dirty: true })
+                      }}
+                    />
+                  </div>
+                  <span class="w-8 text-right text-12-medium text-text-weak">%</span>
+                </div>
+                <div class="flex items-center justify-between gap-3">
+                  <span class="text-12-regular text-text-weak">Default: {DEFAULT_THRESHOLD}%</span>
+                  <div class="flex items-center gap-2">
+                    <Button
+                      size="small"
+                      variant="ghost"
+                      disabled={!auto() || store.savingThreshold || thresholdPercent() === DEFAULT_THRESHOLD}
+                      onClick={() => void resetThreshold()}
+                    >
+                      Reset
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="secondary"
+                      disabled={
+                        !auto() || store.savingThreshold || parsedThreshold() === undefined || !thresholdChanged()
+                      }
+                      onClick={() => void saveThreshold()}
+                    >
+                      Save
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </SettingsRow>
+          </SettingsList>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface SettingsRowProps {
+  title: string | JSX.Element
+  description: string | JSX.Element
+  children: JSX.Element
+}
+
+const SettingsRow: Component<SettingsRowProps> = (props) => {
+  return (
+    <div class="flex flex-wrap items-center gap-4 py-3 border-b border-border-weak-base last:border-none sm:flex-nowrap">
+      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span class="text-14-medium text-text-strong">{props.title}</span>
+        <span class="text-12-regular text-text-weak">{props.description}</span>
+      </div>
+      <div class="flex w-full justify-end sm:w-auto sm:shrink-0">{props.children}</div>
+    </div>
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1197,6 +1197,14 @@ export namespace Config {
       compaction: z
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),
+          threshold: z
+            .number()
+            .min(0)
+            .max(1)
+            .optional()
+            .describe(
+              "Usage ratio for proactive auto-compaction before overflow (default: 0.8). Example: 0.1 triggers at 10% of context.",
+            ),
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
           reserved: z
             .number()

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -18,6 +18,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
+  const DEFAULT_AUTO_COMPACTION_THRESHOLD = 0.8
 
   export const Event = {
     Compacted: BusEvent.define(
@@ -29,6 +30,36 @@ export namespace SessionCompaction {
   }
 
   const COMPACTION_BUFFER = 20_000
+
+  function tokenTotal(tokens: MessageV2.Assistant["tokens"]) {
+    return tokens.total || tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+  }
+
+  function contextUsage(tokens: MessageV2.Assistant["tokens"], model?: Provider.Model) {
+    const limit = model?.limit.context
+    if (!limit) return
+    return tokenTotal(tokens) / limit
+  }
+
+  export async function shouldAutoCompact(input: {
+    tokens: MessageV2.Assistant["tokens"]
+    model?: Provider.Model
+    previous?: {
+      tokens: MessageV2.Assistant["tokens"]
+      model?: Provider.Model
+    }
+  }) {
+    const config = await Config.get()
+    if (config.compaction?.auto === false) return false
+    const threshold = config.compaction?.threshold ?? DEFAULT_AUTO_COMPACTION_THRESHOLD
+
+    const current = contextUsage(input.tokens, input.model)
+    if (current === undefined) return false
+    if (current < threshold) return false
+
+    const previous = input.previous ? contextUsage(input.previous.tokens, input.previous.model) : undefined
+    return previous === undefined || previous < threshold
+  }
 
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     const config = await Config.get()
@@ -107,71 +138,72 @@ export namespace SessionCompaction {
     auto: boolean
     overflow?: boolean
   }) {
-    const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
+    try {
+      const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
 
-    let messages = input.messages
-    let replay: MessageV2.WithParts | undefined
-    if (input.overflow) {
-      const idx = input.messages.findIndex((m) => m.info.id === input.parentID)
-      for (let i = idx - 1; i >= 0; i--) {
-        const msg = input.messages[i]
-        if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "compaction")) {
-          replay = msg
-          messages = input.messages.slice(0, i)
-          break
+      let messages = input.messages
+      let replay: MessageV2.WithParts | undefined
+      if (input.overflow) {
+        const idx = input.messages.findIndex((m) => m.info.id === input.parentID)
+        for (let i = idx - 1; i >= 0; i--) {
+          const msg = input.messages[i]
+          if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "compaction")) {
+            replay = msg
+            messages = input.messages.slice(0, i)
+            break
+          }
+        }
+        const hasContent =
+          replay && messages.some((m) => m.info.role === "user" && !m.parts.some((p) => p.type === "compaction"))
+        if (!hasContent) {
+          replay = undefined
+          messages = input.messages
         }
       }
-      const hasContent =
-        replay && messages.some((m) => m.info.role === "user" && !m.parts.some((p) => p.type === "compaction"))
-      if (!hasContent) {
-        replay = undefined
-        messages = input.messages
-      }
-    }
 
-    const agent = await Agent.get("compaction")
-    const model = agent.model
-      ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
-      : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
-    const msg = (await Session.updateMessage({
-      id: MessageID.ascending(),
-      role: "assistant",
-      parentID: input.parentID,
-      sessionID: input.sessionID,
-      mode: "compaction",
-      agent: "compaction",
-      variant: userMessage.variant,
-      summary: true,
-      path: {
-        cwd: Instance.directory,
-        root: Instance.worktree,
-      },
-      cost: 0,
-      tokens: {
-        output: 0,
-        input: 0,
-        reasoning: 0,
-        cache: { read: 0, write: 0 },
-      },
-      modelID: model.id,
-      providerID: model.providerID,
-      time: {
-        created: Date.now(),
-      },
-    })) as MessageV2.Assistant
-    const processor = SessionProcessor.create({
-      assistantMessage: msg,
-      sessionID: input.sessionID,
-      model,
-      abort: input.abort,
-    })
-    // Allow plugins to inject context or replace compaction prompt
-    const compacting = await Plugin.trigger(
-      "experimental.session.compacting",
-      { sessionID: input.sessionID },
-      { context: [], prompt: undefined },
-    )
-    const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
+      const agent = await Agent.get("compaction")
+      const model = agent.model
+        ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
+        : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
+      const msg = (await Session.updateMessage({
+        id: MessageID.ascending(),
+        role: "assistant",
+        parentID: input.parentID,
+        sessionID: input.sessionID,
+        mode: "compaction",
+        agent: "compaction",
+        variant: userMessage.variant,
+        summary: true,
+        path: {
+          cwd: Instance.directory,
+          root: Instance.worktree,
+        },
+        cost: 0,
+        tokens: {
+          output: 0,
+          input: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        },
+        modelID: model.id,
+        providerID: model.providerID,
+        time: {
+          created: Date.now(),
+        },
+      })) as MessageV2.Assistant
+      const processor = SessionProcessor.create({
+        assistantMessage: msg,
+        sessionID: input.sessionID,
+        model,
+        abort: input.abort,
+      })
+      // Allow plugins to inject context or replace compaction prompt
+      const compacting = await Plugin.trigger(
+        "experimental.session.compacting",
+        { sessionID: input.sessionID },
+        { context: [], prompt: undefined },
+      )
+      const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
 Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
 The summary that you construct will be used so that another agent can read it and continue the work.
 
@@ -199,101 +231,104 @@ When constructing the summary, try to stick to this template:
 [Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
 ---`
 
-    const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
-    const msgs = structuredClone(messages)
-    await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-    const result = await processor.process({
-      user: userMessage,
-      agent,
-      abort: input.abort,
-      sessionID: input.sessionID,
-      tools: {},
-      system: [],
-      messages: [
-        ...MessageV2.toModelMessages(msgs, model, { stripMedia: true }),
-        {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: promptText,
-            },
-          ],
-        },
-      ],
-      model,
-    })
+      const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
+      const msgs = structuredClone(messages)
+      await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+      const result = await processor.process({
+        user: userMessage,
+        agent,
+        abort: input.abort,
+        sessionID: input.sessionID,
+        tools: {},
+        system: [],
+        messages: [
+          ...MessageV2.toModelMessages(msgs, model, { stripMedia: true }),
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: promptText,
+              },
+            ],
+          },
+        ],
+        model,
+      })
 
-    if (result === "compact") {
-      processor.message.error = new MessageV2.ContextOverflowError({
-        message: replay
-          ? "Conversation history too large to compact - exceeds model context limit"
-          : "Session too large to compact - context exceeds model limit even after stripping media",
-      }).toObject()
-      processor.message.finish = "error"
-      await Session.updateMessage(processor.message)
-      return "stop"
-    }
+      if (result === "compact") {
+        processor.message.error = new MessageV2.ContextOverflowError({
+          message: replay
+            ? "Conversation history too large to compact - exceeds model context limit"
+            : "Session too large to compact - context exceeds model limit even after stripping media",
+        }).toObject()
+        processor.message.finish = "error"
+        await Session.updateMessage(processor.message)
+        return "stop"
+      }
 
-    if (result === "continue" && input.auto) {
-      if (replay) {
-        const original = replay.info as MessageV2.User
-        const replayMsg = await Session.updateMessage({
-          id: MessageID.ascending(),
-          role: "user",
-          sessionID: input.sessionID,
-          time: { created: Date.now() },
-          agent: original.agent,
-          model: original.model,
-          format: original.format,
-          tools: original.tools,
-          system: original.system,
-          variant: original.variant,
-        })
-        for (const part of replay.parts) {
-          if (part.type === "compaction") continue
-          const replayPart =
-            part.type === "file" && MessageV2.isMedia(part.mime)
-              ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
-              : part
-          await Session.updatePart({
-            ...replayPart,
-            id: PartID.ascending(),
-            messageID: replayMsg.id,
+      if (result === "continue" && input.auto) {
+        if (replay) {
+          const original = replay.info as MessageV2.User
+          const replayMsg = await Session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
             sessionID: input.sessionID,
+            time: { created: Date.now() },
+            agent: original.agent,
+            model: original.model,
+            format: original.format,
+            tools: original.tools,
+            system: original.system,
+            variant: original.variant,
+          })
+          for (const part of replay.parts) {
+            if (part.type === "compaction") continue
+            const replayPart =
+              part.type === "file" && MessageV2.isMedia(part.mime)
+                ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
+                : part
+            await Session.updatePart({
+              ...replayPart,
+              id: PartID.ascending(),
+              messageID: replayMsg.id,
+              sessionID: input.sessionID,
+            })
+          }
+        } else {
+          const continueMsg = await Session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user",
+            sessionID: input.sessionID,
+            time: { created: Date.now() },
+            agent: userMessage.agent,
+            model: userMessage.model,
+          })
+          const text =
+            (input.overflow
+              ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
+              : "") +
+            "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: continueMsg.id,
+            sessionID: input.sessionID,
+            type: "text",
+            synthetic: true,
+            text,
+            time: {
+              start: Date.now(),
+              end: Date.now(),
+            },
           })
         }
-      } else {
-        const continueMsg = await Session.updateMessage({
-          id: MessageID.ascending(),
-          role: "user",
-          sessionID: input.sessionID,
-          time: { created: Date.now() },
-          agent: userMessage.agent,
-          model: userMessage.model,
-        })
-        const text =
-          (input.overflow
-            ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
-            : "") +
-          "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
-        await Session.updatePart({
-          id: PartID.ascending(),
-          messageID: continueMsg.id,
-          sessionID: input.sessionID,
-          type: "text",
-          synthetic: true,
-          text,
-          time: {
-            start: Date.now(),
-            end: Date.now(),
-          },
-        })
       }
+      if (processor.message.error) return "stop"
+      Bus.publish(Event.Compacted, { sessionID: input.sessionID })
+      return "continue"
+    } finally {
+      await Session.setCompacting({ sessionID: input.sessionID, time: undefined }).catch(() => {})
     }
-    if (processor.message.error) return "stop"
-    Bus.publish(Event.Compacted, { sessionID: input.sessionID })
-    return "continue"
   }
 
   export const create = fn(
@@ -308,24 +343,35 @@ When constructing the summary, try to stick to this template:
       overflow: z.boolean().optional(),
     }),
     async (input) => {
-      const msg = await Session.updateMessage({
-        id: MessageID.ascending(),
-        role: "user",
-        model: input.model,
-        sessionID: input.sessionID,
-        agent: input.agent,
-        time: {
-          created: Date.now(),
-        },
-      })
-      await Session.updatePart({
-        id: PartID.ascending(),
-        messageID: msg.id,
-        sessionID: msg.sessionID,
-        type: "compaction",
-        auto: input.auto,
-        overflow: input.overflow,
-      })
+      const session = await Session.get(input.sessionID)
+      if (session.time.compacting) return false
+
+      await Session.setCompacting({ sessionID: input.sessionID, time: Date.now() })
+
+      try {
+        const msg = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          model: input.model,
+          sessionID: input.sessionID,
+          agent: input.agent,
+          time: {
+            created: Date.now(),
+          },
+        })
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: msg.id,
+          sessionID: msg.sessionID,
+          type: "compaction",
+          auto: input.auto,
+          overflow: input.overflow,
+        })
+        return true
+      } catch (error) {
+        await Session.setCompacting({ sessionID: input.sessionID, time: undefined }).catch(() => {})
+        throw error
+      }
     },
   )
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -513,6 +513,30 @@ export namespace Session {
     },
   )
 
+  export const setCompacting = fn(
+    z.object({
+      sessionID: SessionID.zod,
+      time: z.number().optional(),
+    }),
+    async (input) => {
+      return Database.use((db) => {
+        const row = db
+          .update(SessionTable)
+          .set({
+            time_compacting: input.time ?? null,
+            time_updated: Date.now(),
+          })
+          .where(eq(SessionTable.id, input.sessionID))
+          .returning()
+          .get()
+        if (!row) throw new NotFoundError({ message: `Session not found: ${input.sessionID}` })
+        const info = fromRow(row)
+        Database.effect(() => Bus.publish(Event.Updated, { info }))
+        return info
+      })
+    },
+  )
+
   export const diff = fn(SessionID.zod, async (sessionID) => {
     try {
       return await Storage.read<Snapshot.FileDiff[]>(["session_diff", sessionID])

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -8,7 +8,7 @@ import { Bus } from "@/bus"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { Plugin } from "@/plugin"
-import type { Provider } from "@/provider/provider"
+import { Provider } from "@/provider/provider"
 import { LLM } from "./llm"
 import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
@@ -280,11 +280,34 @@ export namespace SessionProcessor {
                     sessionID: input.sessionID,
                     messageID: input.assistantMessage.parentID,
                   })
-                  if (
-                    !input.assistantMessage.summary &&
-                    (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model }))
-                  ) {
-                    needsCompaction = true
+                  if (!input.assistantMessage.summary) {
+                    const previousFinished = (await Session.messages({ sessionID: input.sessionID })).findLast(
+                      (msg) =>
+                        msg.info.role === "assistant" &&
+                        msg.info.id !== input.assistantMessage.id &&
+                        msg.info.finish &&
+                        msg.info.summary !== true,
+                    )?.info as MessageV2.Assistant | undefined
+                    const previousModel = previousFinished
+                      ? await Provider.getModel(previousFinished.providerID, previousFinished.modelID).catch(
+                          () => undefined,
+                        )
+                      : undefined
+                    if (
+                      (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model })) ||
+                      (await SessionCompaction.shouldAutoCompact({
+                        tokens: usage.tokens,
+                        model: input.model,
+                        previous: previousFinished
+                          ? {
+                              tokens: previousFinished.tokens,
+                              model: previousModel,
+                            }
+                          : undefined,
+                      }))
+                    ) {
+                      needsCompaction = true
+                    }
                   }
                   break
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -544,18 +544,40 @@ export namespace SessionPrompt {
       }
 
       // context overflow, needs compaction
-      if (
-        lastFinished &&
-        lastFinished.summary !== true &&
-        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
-      ) {
-        await SessionCompaction.create({
-          sessionID,
-          agent: lastUser.agent,
-          model: lastUser.model,
-          auto: true,
-        })
-        continue
+      if (lastFinished && lastFinished.summary !== true) {
+        const previousFinished = msgs.findLast(
+          (msg) =>
+            msg.info.role === "assistant" &&
+            msg.info.id < lastFinished.id &&
+            msg.info.finish &&
+            msg.info.summary !== true,
+        )?.info as MessageV2.Assistant | undefined
+        const previousModel = previousFinished
+          ? await Provider.getModel(previousFinished.providerID, previousFinished.modelID).catch(() => undefined)
+          : undefined
+        const shouldCompact =
+          (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model })) ||
+          (await SessionCompaction.shouldAutoCompact({
+            tokens: lastFinished.tokens,
+            model,
+            previous: previousFinished
+              ? {
+                  tokens: previousFinished.tokens,
+                  model: previousModel,
+                }
+              : undefined,
+          }))
+        if (
+          shouldCompact &&
+          (await SessionCompaction.create({
+            sessionID,
+            agent: lastUser.agent,
+            model: lastUser.model,
+            auto: true,
+          }))
+        ) {
+          continue
+        }
       }
 
       // normal processing

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import path from "path"
 import { SessionCompaction } from "../../src/session/compaction"
 import { Token } from "../../src/util/token"
@@ -6,7 +6,12 @@ import { Instance } from "../../src/project/instance"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 import { Session } from "../../src/session"
-import type { Provider } from "../../src/provider/provider"
+import { Provider } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionSummary } from "../../src/session/summary"
+import { LLM } from "../../src/session/llm"
+import { MessageID } from "../../src/session/schema"
 
 Log.init({ print: false })
 
@@ -38,6 +43,17 @@ function createModel(opts: {
     api: { npm: opts.npm ?? "@ai-sdk/anthropic" },
     options: {},
   } as Provider.Model
+}
+
+function createAgent() {
+  return {
+    name: "build",
+    mode: "primary" as const,
+    description: "test agent",
+    prompt: "",
+    permission: [],
+    options: {},
+  }
 }
 
 describe("session.compaction.isOverflow", () => {
@@ -222,6 +238,317 @@ describe("session.compaction.isOverflow", () => {
         const model = createModel({ context: 100_000, output: 32_000 })
         const tokens = { input: 75_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
         expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
+      },
+    })
+  })
+})
+
+describe("session.compaction.shouldAutoCompact", () => {
+  test("returns true when usage crosses the 80 percent threshold", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 8_000 })
+        expect(
+          await SessionCompaction.shouldAutoCompact({
+            tokens: { input: 70_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } },
+            model,
+            previous: {
+              tokens: { input: 60_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } },
+              model,
+            },
+          }),
+        ).toBe(true)
+      },
+    })
+  })
+
+  test("returns false when usage stays above the threshold", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 8_000 })
+        expect(
+          await SessionCompaction.shouldAutoCompact({
+            tokens: { input: 72_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } },
+            model,
+            previous: {
+              tokens: { input: 71_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } },
+              model,
+            },
+          }),
+        ).toBe(false)
+      },
+    })
+  })
+
+  test("returns false when model context limit is unavailable", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(
+          await SessionCompaction.shouldAutoCompact({
+            tokens: { input: 72_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } },
+          }),
+        ).toBe(false)
+      },
+    })
+  })
+
+  test("respects configured threshold", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            compaction: { threshold: 0.1 },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 8_000 })
+        expect(
+          await SessionCompaction.shouldAutoCompact({
+            tokens: { input: 12_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            model,
+            previous: {
+              tokens: { input: 9_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              model,
+            },
+          }),
+        ).toBe(true)
+      },
+    })
+  })
+})
+
+describe("session.compaction.create", () => {
+  test("does not queue duplicate compactions while one is already active", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const input = {
+          sessionID: session.id,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          auto: true,
+        }
+
+        expect(await SessionCompaction.create(input)).toBe(true)
+        expect(await SessionCompaction.create(input)).toBe(false)
+
+        const updated = await Session.get(session.id)
+        expect(updated.time.compacting).toBeDefined()
+
+        const messages = await Session.messages({ sessionID: session.id })
+        const compactions = messages.flatMap((msg) => msg.parts.filter((part) => part.type === "compaction"))
+        expect(compactions).toHaveLength(1)
+      },
+    })
+  })
+})
+
+describe("session.processor auto-compaction", () => {
+  test("returns compact immediately after a turn crosses the threshold", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        compaction: {
+          threshold: 0.05,
+          auto: true,
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 1_000 })
+        const session = await Session.create({})
+        const user = (await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })) as Extract<Awaited<ReturnType<typeof Session.updateMessage>>, { role: "user" }>
+        const assistant = (await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user.id,
+          agent: "build",
+          mode: "build",
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          sessionID: session.id,
+          time: { created: Date.now() },
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0,
+          path: {
+            cwd: tmp.path,
+            root: tmp.path,
+          },
+        })) as Extract<Awaited<ReturnType<typeof Session.updateMessage>>, { role: "assistant" }>
+
+        const summarySpy = spyOn(SessionSummary, "summarize")
+        summarySpy.mockImplementation((async () => {}) as any)
+        const modelSpy = spyOn(Provider, "getModel")
+        modelSpy.mockResolvedValue(model as any)
+        spyOn(LLM, "stream").mockResolvedValue({
+          fullStream: (async function* () {
+            yield { type: "start" }
+            yield {
+              type: "finish-step",
+              finishReason: "stop",
+              usage: { inputTokens: 4_500, outputTokens: 1_500, totalTokens: 6_000 },
+              providerMetadata: undefined,
+            }
+            yield { type: "finish" }
+          })(),
+        } as unknown as Awaited<ReturnType<typeof LLM.stream>>)
+
+        const processor = SessionProcessor.create({
+          assistantMessage: assistant,
+          sessionID: session.id,
+          model,
+          abort: new AbortController().signal,
+        })
+
+        const result = await processor.process({
+          user: user,
+          sessionID: session.id,
+          agent: createAgent(),
+          model,
+          abort: new AbortController().signal,
+          system: [],
+          messages: [],
+          tools: {},
+        })
+
+        expect(result).toBe("compact")
+        modelSpy.mockRestore()
+        summarySpy.mockRestore()
+      },
+    })
+  })
+
+  test("does not re-trigger when the previous turn was already above threshold", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        compaction: {
+          threshold: 0.05,
+          auto: true,
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 1_000 })
+        const session = await Session.create({})
+        const user1 = (await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() - 10_000 },
+        })) as Extract<Awaited<ReturnType<typeof Session.updateMessage>>, { role: "user" }>
+        await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user1.id,
+          agent: "build",
+          mode: "build",
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          sessionID: session.id,
+          time: { created: Date.now() - 9_000, completed: Date.now() - 9_000 },
+          tokens: { total: 7_000, input: 5_000, output: 2_000, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0,
+          finish: "stop",
+          path: {
+            cwd: tmp.path,
+            root: tmp.path,
+          },
+        })
+
+        const user2 = (await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: session.id,
+          agent: "build",
+          model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") },
+          time: { created: Date.now() },
+        })) as Extract<Awaited<ReturnType<typeof Session.updateMessage>>, { role: "user" }>
+        const assistant = (await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: user2.id,
+          agent: "build",
+          mode: "build",
+          modelID: ModelID.make("test-model"),
+          providerID: ProviderID.make("test"),
+          sessionID: session.id,
+          time: { created: Date.now() },
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0,
+          path: {
+            cwd: tmp.path,
+            root: tmp.path,
+          },
+        })) as Extract<Awaited<ReturnType<typeof Session.updateMessage>>, { role: "assistant" }>
+
+        const summarySpy = spyOn(SessionSummary, "summarize")
+        summarySpy.mockImplementation((async () => {}) as any)
+        const modelSpy = spyOn(Provider, "getModel")
+        modelSpy.mockResolvedValue(model as any)
+        spyOn(LLM, "stream").mockResolvedValue({
+          fullStream: (async function* () {
+            yield { type: "start" }
+            yield {
+              type: "finish-step",
+              finishReason: "stop",
+              usage: { inputTokens: 4_800, outputTokens: 2_200, totalTokens: 7_000 },
+              providerMetadata: undefined,
+            }
+            yield { type: "finish" }
+          })(),
+        } as unknown as Awaited<ReturnType<typeof LLM.stream>>)
+
+        const processor = SessionProcessor.create({
+          assistantMessage: assistant,
+          sessionID: session.id,
+          model,
+          abort: new AbortController().signal,
+        })
+
+        const result = await processor.process({
+          user: user2,
+          sessionID: session.id,
+          agent: createAgent(),
+          model,
+          abort: new AbortController().signal,
+          system: [],
+          messages: [],
+          tools: {},
+        })
+
+        expect(result).toBe("continue")
+        modelSpy.mockRestore()
+        summarySpy.mockRestore()
       },
     })
   })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1473,6 +1473,10 @@ export type Config = {
      */
     auto?: boolean
     /**
+     * Usage ratio for proactive auto-compaction before overflow (default: 0.8). Example: 0.1 triggers at 10% of context.
+     */
+    threshold?: number
+    /**
      * Enable pruning of old tool outputs (default: true)
      */
     prune?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10777,6 +10777,12 @@
                 "description": "Enable automatic compaction when context is full (default: true)",
                 "type": "boolean"
               },
+              "threshold": {
+                "description": "Usage ratio for proactive auto-compaction before overflow (default: 0.8). Example: 0.1 triggers at 10% of context.",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
               "prune": {
                 "description": "Enable pruning of old tool outputs (default: true)",
                 "type": "boolean"


### PR DESCRIPTION
### Issue for this PR

Closes #11314
Refs #15533

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This reuses the existing session compaction flow to compact proactively once a completed assistant turn crosses a configurable context threshold.

It adds `compaction.threshold`, triggers threshold-based auto-compaction in the backend after completed assistant turns, dedupes compaction requests while a session is already compacting, and adds a `Server -> Sessions` settings surface in the app/Desktop UI.

### How did you verify your code works?

- `npm exec -- bun test test/session/compaction.test.ts`
- `npm exec -- tsgo --noEmit` in `packages/opencode`
- `npm exec -- tsgo -b` in `packages/app`
- manually set the threshold to `5%` in the app and verified a fresh session auto-compacted after crossing it

### Screenshots / recordings

![Sessions settings screenshot](https://files.catbox.moe/9qrhvo.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR