### PR TITLE
docs: add opencode-terminal-bell-notifier to ecosystem plugins documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -36,6 +36,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
+| [opencode-terminal-bell-notifier](https://github.com/amedve/opencode-terminal-bell-notifier)       | Zero-dependency desktop notifications using built-in terminal emulator notifications.             |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |


### PR DESCRIPTION
### Issue for this PR

Closes #18973

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-terminal-bell-notifier](https://www.npmjs.com/package/opencode-terminal-bell-notifier) to the Plugins table on the ecosystem page.

Zero-dependency plugin that sends desktop notifications using [OSC 9](https://ghostty.org/docs/vt/osc/9) terminal escape sequences.

### How did you verify your code works?
- Verified the markdown table row renders correctly.
- Manually tested the plugin with multiple terminals.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR