### PR TITLE
fix: skip invalid agent markdown configs

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -453,7 +453,8 @@ export namespace Config {
         result[config.name] = parsed.data
         continue
       }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      log.warn("skipping agent with invalid config", { path: item, issues: parsed.error.issues })
+      continue
     }
     return result
   }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -587,6 +587,60 @@ Nested agent prompt`,
   })
 })
 
+test("skips invalid agent markdown configs instead of throwing", async () => {
+  await using globalTmp = await tmpdir()
+  await using projectTmp = await tmpdir()
+
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = globalTmp.path
+  Config.global.reset()
+
+  try {
+    const agentsDir = path.join(globalTmp.path, "agents")
+    await fs.mkdir(agentsDir, { recursive: true })
+
+    await Filesystem.write(
+      path.join(agentsDir, "good.md"),
+      `---
+mode: subagent
+tools:
+  bash: true
+color: "#123456"
+---
+Good agent prompt`,
+    )
+
+    await Filesystem.write(
+      path.join(agentsDir, "bad.md"),
+      `---
+tools:
+  - Bash
+color: purple
+---
+Bad agent prompt`,
+    )
+
+    await Instance.provide({
+      directory: projectTmp.path,
+      fn: async () => {
+        const config = await Config.get()
+
+        expect(config.agent?.["good"]).toMatchObject({
+          name: "good",
+          mode: "subagent",
+          color: "#123456",
+          prompt: "Good agent prompt",
+        })
+        expect(config.agent?.["bad"]).toBeUndefined()
+      },
+    })
+  } finally {
+    await Instance.disposeAll()
+    ;(Global.Path as { config: string }).config = prev
+    Config.global.reset()
+  }
+})
+
 test("loads commands from .opencode/command (singular)", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
## Summary
- skip invalid agent markdown configs during config loading instead of throwing `ConfigInvalidError`
- add a regression test covering a managed/global config directory that contains one valid and one invalid agent

## Why
AgentLoop vendors OpenCode under the `agentloop` app name, so OpenCode scans `~/.config/agentloop`. That directory can contain AgentLoop-specific agent markdown files whose frontmatter does not match OpenCode's agent schema (`tools` arrays, non-hex colors, etc.).

Before this change, a single invalid agent file caused provider bootstrap to fail with `ConfigInvalidError`, which then surfaced downstream as model/API startup failures.

## Testing
- `bun test test/config/config.test.ts -t "skips invalid agent markdown configs instead of throwing"`