### PR TITLE
fix: prevent subagents from inheriting main-agent instruction files

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -271,6 +271,12 @@ export namespace SessionPrompt {
     return
   }
 
+  function shouldLoadMainInstructions(session: Session.Info, agent: Agent.Info) {
+    if (session.parentID) return false
+    if (agent.mode === "subagent") return false
+    return true
+  }
+
   export const LoopInput = z.object({
     sessionID: SessionID.zod,
     resume_existing: z.boolean().optional(),
@@ -654,10 +660,11 @@ export namespace SessionPrompt {
 
       // Build system prompt, adding structured output instruction if needed
       const skills = await SystemPrompt.skills(agent)
+      const instructions = shouldLoadMainInstructions(session, agent) ? await InstructionPrompt.system() : []
       const system = [
         ...(await SystemPrompt.environment(model)),
         ...(skills ? [skills] : []),
-        ...(await InstructionPrompt.system()),
+        ...instructions,
       ]
       const format = lastUser.format ?? { type: "text" }
       if (format.type === "json_schema") {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,11 +1,13 @@
 import path from "path"
-import { describe, expect, test } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import { fileURLToPath } from "url"
 import { Instance } from "../../src/project/instance"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
+import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { SessionProcessor } from "../../src/session/processor"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -202,6 +204,148 @@ describe("session.prompt agent variant", () => {
           expect(override.info.variant).toBe("high")
 
           await Session.remove(session.id)
+        },
+      })
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_API_KEY
+      else process.env.OPENAI_API_KEY = prev
+    }
+  })
+})
+
+describe("session.prompt main instruction loading", () => {
+  test("loads project and config instructions for a primary root session", async () => {
+    const prev = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = "test-openai-key"
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        config: {
+          instructions: ["primary-instructions.md"],
+          agent: {
+            build: {
+              model: "openai/gpt-5.2",
+            },
+          },
+        },
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "AGENTS.md"), "# Root Instructions")
+          await Bun.write(path.join(dir, "primary-instructions.md"), "# Extra Instructions")
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "primary-session" })
+          let capturedSystem: string[] | undefined
+
+          const createSpy = spyOn(SessionProcessor, "create").mockImplementation((input) => {
+            return {
+              message: input.assistantMessage,
+              partFromToolCall() {
+                return undefined
+              },
+              async process(streamInput: LLM.StreamInput) {
+                capturedSystem = streamInput.system
+                input.assistantMessage.finish = "stop"
+                return "stop"
+              },
+            } as any
+          })
+
+          try {
+            await SessionPrompt.prompt({
+              sessionID: session.id,
+              agent: "build",
+              parts: [{ type: "text", text: "hello" }],
+            })
+          } finally {
+            createSpy.mockRestore()
+          }
+
+          expect(capturedSystem).toBeDefined()
+          const system = capturedSystem!.join("\n")
+          expect(system).toContain(`Instructions from: ${path.join(tmp.path, "AGENTS.md")}`)
+          expect(system).toContain(`Instructions from: ${path.join(tmp.path, "primary-instructions.md")}`)
+
+          await Session.remove(session.id)
+        },
+      })
+    } finally {
+      if (prev === undefined) delete process.env.OPENAI_API_KEY
+      else process.env.OPENAI_API_KEY = prev
+    }
+  })
+
+  test("excludes main-agent instructions for child subagent sessions while preserving agent prompts", async () => {
+    const prev = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = "test-openai-key"
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        config: {
+          instructions: ["primary-instructions.md"],
+          agent: {
+            build: {
+              model: "openai/gpt-5.2",
+            },
+            helper: {
+              mode: "all",
+              model: "openai/gpt-5.2",
+              prompt: "Helper agent prompt",
+            },
+          },
+        },
+        init: async (dir) => {
+          await Bun.write(path.join(dir, "AGENTS.md"), "# Root Instructions")
+          await Bun.write(path.join(dir, "primary-instructions.md"), "# Extra Instructions")
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const parent = await Session.create({ title: "parent-session" })
+          const session = await Session.create({ title: "child-session", parentID: parent.id })
+          let capturedSystem: string[] | undefined
+          let capturedAgentPrompt: string | undefined
+
+          const createSpy = spyOn(SessionProcessor, "create").mockImplementation((input) => {
+            return {
+              message: input.assistantMessage,
+              partFromToolCall() {
+                return undefined
+              },
+              async process(streamInput: LLM.StreamInput) {
+                capturedSystem = streamInput.system
+                capturedAgentPrompt = streamInput.agent.prompt
+                input.assistantMessage.finish = "stop"
+                return "stop"
+              },
+            } as any
+          })
+
+          try {
+            await SessionPrompt.prompt({
+              sessionID: session.id,
+              agent: "helper",
+              parts: [{ type: "text", text: "hello" }],
+            })
+          } finally {
+            createSpy.mockRestore()
+          }
+
+          expect(capturedSystem).toBeDefined()
+          const system = capturedSystem!.join("\n")
+          expect(system).not.toContain(`Instructions from: ${path.join(tmp.path, "AGENTS.md")}`)
+          expect(system).not.toContain(`Instructions from: ${path.join(tmp.path, "primary-instructions.md")}`)
+          expect(capturedAgentPrompt).toBe("Helper agent prompt")
+
+          await Session.remove(session.id)
+          await Session.remove(parent.id)
         },
       })
     } finally {


### PR DESCRIPTION
### Issue for this PR

Closes #4483

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a prompt assembly bug where child/subagent sessions were inheriting main-agent instruction sources like `AGENTS.md` and `config.instructions`.

The root cause was in `SessionPrompt.loop()`, which always appended `InstructionPrompt.system()` to the system prompt regardless of whether the session was a root session or a child/subagent session.

I fixed it by only loading those main instructions for root/primary execution contexts. Child sessions (`session.parentID`) no longer get them, and there is also a fallback to avoid loading them for direct `mode: "subagent"` agents. This keeps the existing behavior for the primary agent, while preventing instruction leakage into subagents. Agent-specific prompts are still preserved.

I also added focused tests to cover:
- root sessions still loading project/config instructions
- child subagent sessions not loading main-agent instructions
- child sessions still preserving the selected agent's own prompt

### How did you verify your code works?

I verified it locally with:

- `cd packages/opencode && bun test test/session/prompt.test.ts`
- `cd packages/opencode && bun test test/session/instruction.test.ts`
- `cd packages/opencode && bun run typecheck`

All passed locally.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR