### PR TITLE
fix(opencode): guard against large files in diffFull

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -261,6 +261,19 @@ export namespace Snapshot {
             const diffFull = Effect.fnUntraced(function* (from: string, to: string) {
               const result: Snapshot.FileDiff[] = []
               const status = new Map<string, "added" | "deleted" | "modified">()
+              const max = 2 * 1024 * 1024
+
+              const load = Effect.fnUntraced(function* (rev: string, file: string) {
+                const probe = yield* git([...args(["cat-file", "-s", `${rev}:${file}`])], {
+                  cwd: state.directory,
+                })
+                const size = parseInt(probe.text.trim(), 10)
+                if (Number.isFinite(size) && size > max) return ""
+                const result = yield* git([...cfg, ...args(["show", `${rev}:${file}`])], {
+                  cwd: state.directory,
+                })
+                return result.text
+              })
 
               const statuses = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--name-status", "--no-renames", from, to, "--", "."])],
@@ -288,13 +301,7 @@ export namespace Snapshot {
                 const binary = adds === "-" && dels === "-"
                 const [before, after] = binary
                   ? ["", ""]
-                  : yield* Effect.all(
-                      [
-                        git([...cfg, ...args(["show", `${from}:${file}`])]).pipe(Effect.map((item) => item.text)),
-                        git([...cfg, ...args(["show", `${to}:${file}`])]).pipe(Effect.map((item) => item.text)),
-                      ],
-                      { concurrency: 2 },
-                    )
+                  : yield* Effect.all([load(from, file), load(to, file)], { concurrency: 2 })
                 const additions = binary ? 0 : parseInt(adds)
                 const deletions = binary ? 0 : parseInt(dels)
                 result.push({

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1159,6 +1159,30 @@ test("diffFull with binary file changes", async () => {
   })
 })
 
+test("diffFull with large file changes", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      await Filesystem.write(`${tmp.path}/too_large_txt.txt`, "x".repeat(1 + 2 * 1024 * 1024))
+
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+
+      const diffs = await Snapshot.diffFull(before!, after!)
+      expect(diffs.length).toBe(1)
+
+      const large = diffs[0]
+      expect(large.file).toBe("too_large_txt.txt")
+      expect(large.after).toBe("")
+      expect(large.before).toBe("")
+    },
+  })
+})
+
 test("diffFull with whitespace changes", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
Prevent large files from being stored in sessions potentially causing oom issues.

This is a small, targeted, non AI slop PR. I have carefully reviewed and understand the changes myself.

### Issue for this PR

Closes #17252 #2585 #17226 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Use `git file-stat -s` to check size of text file before reading it in `Snapshot.diffFull`. If it is larger than 2MB the file is not read.

This simple fix mitigates one avenue that causes OpenCodes memory usage to balloon w/o harming current functionality.

### How did you verify your code works?

1. Have large text file (easy way to generate a large file is by doing `Write heap snapshot` in opencode).
2. Start a session and send a message.
3. Delete large file
4. send another message
5. export session via `opencode export <session id>`

w/ fix the exported session will be small
w/o fix the exported session will be large (at least the size of the heapsnapshot file).

If the heap snapshot is very large then you can just look at memory usage and see it jump. If the jump is temporary grep dev.log for ERROR and you'll see

`ERROR 2026-03-24T17:31:26 +90ms service=default e=Out of memory rejection`

This is from `session/summary.ts:101` 
`    await Storage.write(["session_diff", input.sessionID], diffs)`

Where it tries to write the large file and blows up.

If you want to verify yourself
```diff
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -10,6 +10,7 @@ import { Snapshot } from "@/snapshot"
 import { Storage } from "@/storage/storage"
 import { Bus } from "@/bus"
 import { NotFoundError } from "@/storage/db"
+import { Log } from "@/util/log"

 export namespace SessionSummary {
   function unquoteGitPath(input: string) {
@@ -90,6 +91,7 @@ export namespace SessionSummary {

   async function summarizeSession(input: { sessionID: SessionID; messages: MessageV2.WithParts[] }) {
     const diffs = await computeDiff({ messages: input.messages })
+
     await Session.setSummary({
       sessionID: input.sessionID,
       summary: {
@@ -98,7 +100,17 @@ export namespace SessionSummary {
         files: diffs.length,
       },
     })
-    await Storage.write(["session_diff", input.sessionID], diffs)
+
+    Log.Default.info("session_diff write start", { sessionID: input.sessionID })
+    try {
+      await Storage.write(["session_diff", input.sessionID], diffs)
+      Log.Default.info("session_diff write done", { sessionID: input.sessionID })
+    } catch (err) {
+      Log.Default.error("session_diff write failed", {
+        sessionID: input.sessionID,
+        err: err instanceof Error ? err.message : String(err),
+      })
+    }
     Bus.publish(Session.Event.Diff, {
       sessionID: input.sessionID,
       diff: diffs,
```

This fix applies to many large text files - the heap snapshot is just an easy way to generate a large text file.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
