### PR TITLE
feat(review): show GitHub PR review comments inline

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -10,6 +10,7 @@ import {
   createMemo,
   createEffect,
   createComputed,
+  createResource,
   on,
   onMount,
   untrack,
@@ -550,6 +551,19 @@ export default function Page() {
 
   const turnDiffs = createMemo(() => lastUserMessage()?.summary?.diffs ?? [])
   const reviewDiffs = createMemo(() => (store.changes === "session" ? diffs() : turnDiffs()))
+  const ghKey = createMemo(() => {
+    if (!params.dir) return
+    if (!sync.data.vcs?.branch) return
+    if (reviewDiffs().length === 0) return
+    return `${params.dir}\n${sync.data.vcs.branch}`
+  })
+  const [ghComments] = createResource(
+    ghKey,
+    async () => sdk.client.vcs.reviewComments().then((x) => x.data ?? []).catch(() => []),
+    {
+      initialValue: [] as NonNullable<SessionReviewTabProps["githubComments"]>,
+    },
+  )
 
   const newSessionWorktree = createMemo(() => {
     if (store.newSessionWorktree === "create") return "create"
@@ -1001,6 +1015,7 @@ export default function Page() {
         onLineCommentDelete={removeCommentFromContext}
         lineCommentActions={reviewCommentActions()}
         comments={comments.all()}
+        githubComments={ghKey() ? ghComments() : []}
         focusedComment={comments.focus()}
         onFocusedCommentChange={comments.setFocus}
         onViewFile={openReviewFile}

--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -4,6 +4,7 @@ import { SessionReview } from "@opencode-ai/ui/session-review"
 import type {
   SessionReviewCommentActions,
   SessionReviewCommentDelete,
+  SessionReviewGitHubComment,
   SessionReviewCommentUpdate,
 } from "@opencode-ai/ui/session-review"
 import type { SelectedLineRange } from "@/context/file"
@@ -26,6 +27,7 @@ export interface SessionReviewTabProps {
   onLineCommentDelete?: (comment: SessionReviewCommentDelete) => void
   lineCommentActions?: SessionReviewCommentActions
   comments?: LineComment[]
+  githubComments?: SessionReviewGitHubComment[]
   focusedComment?: { file: string; id: string } | null
   onFocusedCommentChange?: (focus: { file: string; id: string } | null) => void
   focusedFile?: string
@@ -163,6 +165,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
       onLineCommentDelete={props.onLineCommentDelete}
       lineCommentActions={props.lineCommentActions}
       comments={props.comments}
+      githubComments={props.githubComments}
       focusedComment={props.focusedComment}
       onFocusedCommentChange={props.onFocusedCommentChange}
     />

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,3 +1,4 @@
+import { Octokit } from "@octokit/rest"
 import { Effect, Layer, ServiceMap } from "effect"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
@@ -6,6 +7,7 @@ import { makeRunPromise } from "@/effect/run-service"
 import { FileWatcher } from "@/file/watcher"
 import { Log } from "@/util/log"
 import { git } from "@/util/git"
+import { Process } from "@/util/process"
 import { Instance } from "./instance"
 import z from "zod"
 
@@ -29,6 +31,27 @@ export namespace Vcs {
       ref: "VcsInfo",
     })
   export type Info = z.infer<typeof Info>
+
+  const Side = z.enum(["additions", "deletions"])
+
+  export const ReviewComment = z
+    .object({
+      id: z.string(),
+      file: z.string(),
+      selection: z.object({
+        start: z.number().int().positive(),
+        end: z.number().int().positive(),
+        side: Side.optional(),
+        endSide: Side.optional(),
+      }),
+      comment: z.string(),
+      reviewer: z.string(),
+      time: z.number().int().nonnegative(),
+    })
+    .meta({
+      ref: "VcsReviewComment",
+    })
+  export type ReviewComment = z.infer<typeof ReviewComment>
 
   export interface Interface {
     readonly init: () => Effect.Effect<void>
@@ -107,5 +130,172 @@ export namespace Vcs {
 
   export function branch() {
     return runPromise((svc) => svc.branch())
+  }
+
+  type Repo = {
+    owner: string
+    repo: string
+  }
+
+  type Pull = Repo & {
+    number: number
+  }
+
+  function parse(url: string) {
+    const match = url.match(/^(?:(?:https?|ssh):\/\/)?(?:git@)?github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
+    if (!match) return
+    return {
+      owner: match[1],
+      repo: match[2],
+    }
+  }
+
+  const side = (input: string | null | undefined) => {
+    if (input === "LEFT") return "deletions" as const
+    if (input === "RIGHT") return "additions" as const
+  }
+
+  const read = async (args: string[]) => {
+    const result = await git(args, {
+      cwd: Instance.worktree,
+    })
+    if (result.exitCode !== 0) return
+    const text = result.text().trim()
+    if (!text) return
+    return text
+  }
+
+  const uniq = (list: string[]) => list.filter((item, i) => list.indexOf(item) === i)
+
+  function dedupe(list: Repo[]) {
+    const seen = new Set<string>()
+    return list.filter((item) => {
+      const key = `${item.owner}/${item.repo}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+  }
+
+  async function refs(branch: string) {
+    const [list, track, push] = await Promise.all([
+      read(["remote"]).then((text) => text?.split(/\r?\n/).map((item) => item.trim()).filter(Boolean) ?? []),
+      read(["config", "--get", `branch.${branch}.remote`]),
+      read(["config", "--get", `branch.${branch}.pushRemote`]),
+    ])
+
+    const names = uniq([push, track, "origin", "upstream", ...list].filter((item): item is string => !!item))
+    const repos = await Promise.all(
+      names.map(async (name) => {
+        const url = await read(["remote", "get-url", name])
+        if (!url) return
+        return parse(url)
+      }),
+    ).then((list) => list.filter((item): item is Repo => !!item))
+
+    return {
+      base: dedupe(repos),
+      head: uniq(repos.map((item) => item.owner)),
+    }
+  }
+
+  async function token() {
+    const env = process.env["GITHUB_TOKEN"] || process.env["GH_TOKEN"]
+    if (env) return env
+    const out = await Process.run(["gh", "auth", "token"], {
+      nothrow: true,
+    })
+    if (out.code !== 0) return
+    const text = out.stdout.toString().trim()
+    if (!text) return
+    return text
+  }
+
+  async function pull(octo: Octokit, branch: string) {
+    const repo = await refs(branch)
+    if (repo.base.length === 0 || repo.head.length === 0) return
+
+    const list = repo.base.flatMap((base) => repo.head.map((head) => ({ base, head })))
+    const prs = await Promise.all(
+      list.map((item) =>
+        octo.rest.pulls
+          .list({
+            owner: item.base.owner,
+            repo: item.base.repo,
+            state: "open",
+            head: `${item.head}:${branch}`,
+            per_page: 1,
+          })
+          .then((res) => {
+            const pr = res.data[0]
+            if (!pr) return
+            return {
+              owner: item.base.owner,
+              repo: item.base.repo,
+              number: pr.number,
+            } satisfies Pull
+          })
+          .catch(() => undefined),
+      ),
+    )
+
+    return prs.find((item): item is Pull => !!item)
+  }
+
+  export async function reviewComments() {
+    const branch = await Vcs.branch()
+    if (!branch) return []
+
+    const auth = await token()
+    const octo = auth ? new Octokit({ auth }) : new Octokit()
+    const pr = await pull(octo, branch)
+    if (!pr) return []
+
+    const list = await octo
+      .paginate(octo.rest.pulls.listReviewComments, {
+        owner: pr.owner,
+        repo: pr.repo,
+        pull_number: pr.number,
+        per_page: 100,
+      })
+      .catch(() => [])
+
+    return list
+      .flatMap((item) => {
+        if (!item.path) return []
+        const line = item.line ?? item.original_line
+        if (!line) return []
+        const comment = item.body?.trim()
+        if (!comment) return []
+
+        const start = item.start_line ?? item.original_start_line ?? line
+        const selection = {
+          start: Math.min(start, line),
+          end: Math.max(start, line),
+        } as ReviewComment["selection"]
+
+        const from = side(item.start_side)
+        const to = side(item.side)
+
+        if (from) selection.side = from
+        if (to) {
+          if (!selection.side) selection.side = to
+          else if (to !== selection.side) selection.endSide = to
+        }
+
+        const time = Date.parse(item.updated_at ?? item.created_at ?? "")
+
+        return [
+          {
+            id: String(item.id),
+            file: item.path,
+            selection,
+            comment,
+            reviewer: item.user?.login ?? "GitHub",
+            time: Number.isFinite(time) ? time : 0,
+          } satisfies ReviewComment,
+        ]
+      })
+      .sort((a, b) => a.time - b.time)
   }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -337,6 +337,28 @@ export namespace Server {
         },
       )
       .get(
+        "/vcs/review_comments",
+        describeRoute({
+          summary: "Get GitHub review comments",
+          description: "Retrieve GitHub pull request review comments for the current branch when available.",
+          operationId: "vcs.reviewComments",
+          responses: {
+            200: {
+              description: "GitHub review comments",
+              content: {
+                "application/json": {
+                  schema: resolver(Vcs.ReviewComment.array()),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const comments = await Vcs.reviewComments().catch(() => [])
+          return c.json(comments)
+        },
+      )
+      .get(
         "/command",
         describeRoute({
           summary: "List commands",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -175,6 +175,7 @@ import type {
   TuiShowToastResponses,
   TuiSubmitPromptResponses,
   VcsGetResponses,
+  VcsReviewCommentsResponses,
   WorktreeCreateErrors,
   WorktreeCreateInput,
   WorktreeCreateResponses,
@@ -3715,6 +3716,36 @@ export class Vcs extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<VcsGetResponses, unknown, ThrowOnError>({
       url: "/vcs",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get GitHub review comments
+   *
+   * Retrieve GitHub pull request review comments for the current branch when available.
+   */
+  public reviewComments<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsReviewCommentsResponses, unknown, ThrowOnError>({
+      url: "/vcs/review_comments",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1892,6 +1892,20 @@ export type VcsInfo = {
   branch: string
 }
 
+export type VcsReviewComment = {
+  id: string
+  file: string
+  selection: {
+    start: number
+    end: number
+    side?: "additions" | "deletions"
+    endSide?: "additions" | "deletions"
+  }
+  comment: string
+  reviewer: string
+  time: number
+}
+
 export type Command = {
   name: string
   description?: string
@@ -4886,6 +4900,25 @@ export type VcsGetResponses = {
 }
 
 export type VcsGetResponse = VcsGetResponses[keyof VcsGetResponses]
+
+export type VcsReviewCommentsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/review_comments"
+}
+
+export type VcsReviewCommentsResponses = {
+  /**
+   * GitHub review comments
+   */
+  200: Array<VcsReviewComment>
+}
+
+export type VcsReviewCommentsResponse = VcsReviewCommentsResponses[keyof VcsReviewCommentsResponses]
 
 export type CommandListData = {
   body?: never

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -13,16 +13,21 @@ import { useFileComponent } from "../context/file"
 import { useI18n } from "../context/i18n"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
-import { createEffect, createMemo, For, Match, Show, Switch, untrack, type JSX } from "solid-js"
+import { batch, createEffect, createMemo, For, Match, Show, Switch, untrack, type JSX } from "solid-js"
 import { onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { type FileContent, type FileDiff } from "@opencode-ai/sdk/v2"
 import { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
-import { type SelectedLineRange } from "@pierre/diffs"
+import { type DiffLineAnnotation, type SelectedLineRange } from "@pierre/diffs"
 import { Dynamic } from "solid-js/web"
 import { mediaKindFromPath } from "../pierre/media"
-import { cloneSelectedLineRange, previewSelectedLines } from "../pierre/selection-bridge"
-import { createLineCommentController } from "./line-comment-annotations"
+import { cloneSelectedLineRange, formatSelectedLineLabel, previewSelectedLines } from "../pierre/selection-bridge"
+import {
+  createLineCommentAnnotations,
+  createLineCommentController,
+  createManagedLineCommentAnnotationRenderer,
+  type LineCommentAnnotationMeta,
+} from "./line-comment-annotations"
 
 const MAX_DIFF_CHANGED_LINES = 500
 
@@ -40,6 +45,15 @@ export type SessionReviewLineComment = {
   selection: SelectedLineRange
   comment: string
   preview?: string
+}
+
+export type SessionReviewGitHubComment = {
+  id: string
+  file: string
+  selection: SelectedLineRange
+  comment: string
+  reviewer: string
+  time: number
 }
 
 export type SessionReviewCommentUpdate = SessionReviewLineComment & {
@@ -74,6 +88,7 @@ export interface SessionReviewProps {
   onLineCommentDelete?: (comment: SessionReviewCommentDelete) => void
   lineCommentActions?: SessionReviewCommentActions
   comments?: SessionReviewComment[]
+  githubComments?: SessionReviewGitHubComment[]
   focusedComment?: SessionReviewFocus | null
   onFocusedCommentChange?: (focus: SessionReviewFocus | null) => void
   focusedFile?: string
@@ -154,6 +169,7 @@ export const SessionReview = (props: SessionReviewProps) => {
   const diffs = createMemo(() => new Map(props.diffs.map((diff) => [diff.file, diff] as const)))
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
+  const timefmt = createMemo(() => new Intl.DateTimeFormat(i18n.locale(), { dateStyle: "medium", timeStyle: "short" }))
 
   const handleChange = (open: string[]) => {
     props.onOpenChange?.(open)
@@ -292,7 +308,11 @@ export const SessionReview = (props: SessionReviewProps) => {
                     const force = () => !!store.force[file]
 
                     const comments = createMemo(() => (props.comments ?? []).filter((c) => c.file === file))
-                    const commentedLines = createMemo(() => comments().map((c) => c.selection))
+                    const gh = createMemo(() => (props.githubComments ?? []).filter((c) => c.file === file))
+                    const commentedLines = createMemo(() => [
+                      ...comments().map((c) => c.selection),
+                      ...gh().map((c) => c.selection),
+                    ])
 
                     const beforeText = () => (typeof item().before === "string" ? item().before : "")
                     const afterText = () => (typeof item().after === "string" ? item().after : "")
@@ -389,6 +409,75 @@ export const SessionReview = (props: SessionReviewProps) => {
                       if (!props.onLineComment) return
                       commentsUi.onLineSelectionEnd(range)
                     }
+
+                    const ghKey = (id: string) => `gh:${id}`
+
+                    const openGh = (comment: SessionReviewGitHubComment) => {
+                      const id = ghKey(comment.id)
+                      batch(() => {
+                        setStore("commenting", null)
+                        setStore("selection", { file, range: cloneSelectedLineRange(comment.selection) })
+                        setStore("opened", (current) =>
+                          current?.file === file && current.id === id
+                            ? null
+                            : {
+                                file,
+                                id,
+                              },
+                        )
+                      })
+                    }
+
+                    const hoverGh = (comment: SessionReviewGitHubComment) => {
+                      setStore("selection", { file, range: cloneSelectedLineRange(comment.selection) })
+                    }
+
+                    const ghAnnotations = createLineCommentAnnotations<SessionReviewGitHubComment>({
+                      comments: gh,
+                      draftRange: () => null,
+                      draftKey: () => file,
+                      getCommentId: (comment) => ghKey(comment.id),
+                      getCommentSelection: (comment) => comment.selection,
+                      getSide: selectionSide,
+                    })
+
+                    type LocalAnnotation = DiffLineAnnotation<LineCommentAnnotationMeta<SessionReviewComment>>
+                    type GhAnnotation = DiffLineAnnotation<LineCommentAnnotationMeta<SessionReviewGitHubComment>>
+                    type Annotation = LocalAnnotation | GhAnnotation
+
+                    const ghUi = createManagedLineCommentAnnotationRenderer<SessionReviewGitHubComment>({
+                      annotations: ghAnnotations,
+                      renderComment: (comment) => ({
+                        id: ghKey(comment.id),
+                        open: opened()?.file === file && opened()?.id === ghKey(comment.id),
+                        comment: (
+                          <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-2 text-11-medium text-text-weak">
+                              <span class="text-text-strong">{comment.reviewer}</span>
+                              <span>{timefmt().format(comment.time)}</span>
+                            </div>
+                            <div class="whitespace-pre-wrap break-words">{comment.comment}</div>
+                          </div>
+                        ),
+                        selection: formatSelectedLineLabel(comment.selection, i18n.t),
+                        onMouseEnter: () => hoverGh(comment),
+                        onClick: () => openGh(comment),
+                      }),
+                      renderDraft: (range) => ({
+                        value: "",
+                        selection: formatSelectedLineLabel(range, i18n.t),
+                        onInput: () => undefined,
+                        onCancel: () => undefined,
+                        onSubmit: () => undefined,
+                      }),
+                    })
+
+                    const annotations = createMemo<Annotation[]>(() => [...commentsUi.annotations(), ...ghAnnotations()])
+
+                    const renderAnnotation = (annotation: Annotation) =>
+                      annotation.metadata.key.startsWith("comment:gh:")
+                        ? ghUi.renderAnnotation(annotation as GhAnnotation)
+                        : commentsUi.renderAnnotation(annotation as LocalAnnotation)
 
                     return (
                       <Accordion.Item
@@ -502,8 +591,8 @@ export const SessionReview = (props: SessionReviewProps) => {
                                     onLineSelected={handleLineSelected}
                                     onLineSelectionEnd={handleLineSelectionEnd}
                                     onLineNumberSelectionEnd={commentsUi.onLineNumberSelectionEnd}
-                                    annotations={commentsUi.annotations()}
-                                    renderAnnotation={commentsUi.renderAnnotation}
+                                    annotations={annotations()}
+                                    renderAnnotation={renderAnnotation}
                                     renderHoverUtility={props.onLineComment ? commentsUi.renderHoverUtility : undefined}
                                     selectedLines={selectedLines()}
                                     commentedLines={commentedLines()}


### PR DESCRIPTION
### Issue for this PR

Closes #18964

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds read-only GitHub PR review comments to the Desktop review panel.

Before this change, the review panel could render local inline comments, but it had no way to fetch and show existing GitHub review comments for the current PR. That meant users still had to switch back to GitHub to see reviewer feedback next to the relevant diff.

This change adds a small VCS endpoint to fetch review comments for the PR associated with the current branch, maps GitHub review comment positions into the same file/line selection model already used by the review UI, and then renders those comments inline in the existing review panel.

I kept GitHub comments read-only on purpose. Local editable comments still work the same way as before, and this PR does not try to handle posting/replying/resolving review comments.

Why this works:
- the app already had inline annotation rendering for file + selection based comments
- GitHub review comments can be adapted into that same structure
- by keeping GitHub comments separate from local editable comments, the UI gains reviewer context without changing the existing local comment flow

### How did you verify your code works?

I verified it by:
- regenerating the SDK with `cd packages/sdk/js && bun ./script/build.ts`
- running package typechecks:
  - `cd packages/opencode && bun typecheck`
  - `cd packages/app && bun typecheck`
  - `cd packages/ui && bun typecheck`
  - `cd packages/sdk/js && bun typecheck`
- running repo-wide typecheck with `bun turbo typecheck`

All of those completed successfully locally.

### Screenshots / recordings

I do not have a screenshot/recording attached yet. The UI change is limited to showing GitHub PR review comments inline in the existing review panel.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR