### PR TITLE
fix: align subagent TodoWrite instructions with actual tool availability

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -66,12 +66,13 @@ export namespace LLM {
     ])
     // TODO: move this to a proper hook
     const isOpenaiOauth = provider.id === "openai" && auth?.type === "oauth"
+    const tools = await resolveTools(input)
 
     const system: string[] = []
     system.push(
       [
         // use agent prompt otherwise provider prompt
-        ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
+        ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model, { tools: Object.keys(tools) })),
         // any custom prompt passed into this call
         ...input.system,
         // any custom prompt from last user message
@@ -165,8 +166,6 @@ export namespace LLM {
       isOpenaiOauth || provider.id.includes("github-copilot")
         ? undefined
         : ProviderTransform.maxOutputTokens(input.model)
-
-    const tools = await resolveTools(input)
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.

--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -20,57 +20,12 @@ When the user directly asks about OpenCode (eg. "can OpenCode do...", "does Open
 # Professional objectivity
 Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if OpenCode honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
 
-# Task Management
-You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
-These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
-
-It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
-
-Examples:
-
-<example>
-user: Run the build and fix any type errors
-assistant: I'm going to use the TodoWrite tool to write the following items to the todo list:
-- Run the build
-- Fix any type errors
-
-I'm now going to run the build using Bash.
-
-Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
-
-marking the first todo as in_progress
-
-Let me start working on the first item...
-
-The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
-..
-..
-</example>
-In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
-
-<example>
-user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
-assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
-Adding the following todos to the todo list:
-1. Research existing metrics tracking in the codebase
-2. Design the metrics collection system
-3. Implement core metrics tracking functionality
-4. Create export functionality for different formats
-
-Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
-
-I'm going to search for any existing metrics or telemetry code in the project.
-
-I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
-
-[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
-</example>
+{{TODO_TASK_MANAGEMENT}}
 
 
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
-- 
-- Use the TodoWrite tool to plan the task if required
+{{TODO_TASK_PLANNING}}
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.
 
@@ -93,7 +48,7 @@ user: What is the codebase structure?
 assistant: [Uses the Task tool]
 </example>
 
-IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
+{{TODO_ALWAYS_USE}}
 
 # Code References
 

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -15,14 +15,74 @@ import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 
 export namespace SystemPrompt {
-  export function provider(model: Provider.Model) {
+  const TODO_TASK_MANAGEMENT = `# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+
+Examples:
+
+<example>
+user: Run the build and fix any type errors
+assistant: I'm going to use the TodoWrite tool to write the following items to the todo list:
+- Run the build
+- Fix any type errors
+
+I'm now going to run the build using Bash.
+
+Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
+
+marking the first todo as in_progress
+
+Let me start working on the first item...
+
+The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
+..
+..
+</example>
+In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
+
+<example>
+user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
+assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
+Adding the following todos to the todo list:
+1. Research existing metrics tracking in the codebase
+2. Design the metrics collection system
+3. Implement core metrics tracking functionality
+4. Create export functionality for different formats
+
+Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
+
+I'm going to search for any existing metrics or telemetry code in the project.
+
+I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
+
+[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
+</example>`
+
+  const TODO_TASK_PLANNING = "- Use the TodoWrite tool to plan the task if required"
+  const TODO_ALWAYS_USE = "IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation."
+
+  function applyToolAvailability(prompt: string, tools: string[] = []) {
+    if (!prompt.includes("{{TODO_")) return prompt
+    const hasTodoWrite = tools.includes("todowrite")
+    return prompt
+      .replace("{{TODO_TASK_MANAGEMENT}}", hasTodoWrite ? TODO_TASK_MANAGEMENT : "")
+      .replace("{{TODO_TASK_PLANNING}}", hasTodoWrite ? TODO_TASK_PLANNING : "")
+      .replace("{{TODO_ALWAYS_USE}}", hasTodoWrite ? TODO_ALWAYS_USE : "")
+      .replace(/\n{3,}/g, "\n\n")
+  }
+
+  export function provider(model: Provider.Model, input?: { tools?: string[] }) {
+    const tools = input?.tools ?? []
     if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
-      return [PROMPT_BEAST]
-    if (model.api.id.includes("gpt")) return [PROMPT_CODEX]
-    if (model.api.id.includes("gemini-")) return [PROMPT_GEMINI]
-    if (model.api.id.includes("claude")) return [PROMPT_ANTHROPIC]
-    if (model.api.id.toLowerCase().includes("trinity")) return [PROMPT_TRINITY]
-    return [PROMPT_DEFAULT]
+      return [applyToolAvailability(PROMPT_BEAST, tools)]
+    if (model.api.id.includes("gpt")) return [applyToolAvailability(PROMPT_CODEX, tools)]
+    if (model.api.id.includes("gemini-")) return [applyToolAvailability(PROMPT_GEMINI, tools)]
+    if (model.api.id.includes("claude")) return [applyToolAvailability(PROMPT_ANTHROPIC, tools)]
+    if (model.api.id.toLowerCase().includes("trinity")) return [applyToolAvailability(PROMPT_TRINITY, tools)]
+    return [applyToolAvailability(PROMPT_DEFAULT, tools)]
   }
 
   export async function environment(model: Provider.Model) {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { Permission } from "@/permission"
+import { Wildcard } from "@/util/wildcard"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -63,7 +64,10 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const agent = await Agent.get(params.subagent_type)
       if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
 
-      const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
+      const subagentAccess = resolveSubagentToolAccess({
+        agent,
+        config,
+      })
 
       const session = await iife(async () => {
         if (params.task_id) {
@@ -74,32 +78,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         return await Session.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
-          permission: [
-            {
-              permission: "todowrite",
-              pattern: "*",
-              action: "deny",
-            },
-            {
-              permission: "todoread",
-              pattern: "*",
-              action: "deny",
-            },
-            ...(hasTaskPermission
-              ? []
-              : [
-                  {
-                    permission: "task" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(config.experimental?.primary_tools?.map((t) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: t,
-            })) ?? []),
-          ],
+          permission: subagentAccess.permission,
         })
       })
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
@@ -135,12 +114,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
-        tools: {
-          todowrite: false,
-          todoread: false,
-          ...(hasTaskPermission ? {} : { task: false }),
-          ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
-        },
+        tools: subagentAccess.tools,
         parts: promptParts,
       })
 
@@ -165,3 +139,53 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     },
   }
 })
+
+type SubagentToolAccessInput = {
+  agent: Agent.Info
+  config: Awaited<ReturnType<typeof Config.get>>
+}
+
+function hasExplicitSubagentToolAccess(permission: string, ruleset: Permission.Ruleset) {
+  const explicit = ruleset.findLast((rule) => rule.permission !== "*" && Wildcard.match(permission, rule.permission))
+  return explicit ? explicit.action !== "deny" : false
+}
+
+/** @internal Exported for testing */
+export function resolveSubagentToolAccess(input: SubagentToolAccessInput) {
+  const permission: Permission.Ruleset = []
+  const tools: Record<string, boolean> = {}
+  const hasTaskPermission = input.agent.permission.some((rule) => rule.permission === "task")
+
+  for (const tool of ["todowrite", "todoread"] as const) {
+    if (hasExplicitSubagentToolAccess(tool, input.agent.permission)) continue
+    permission.push({
+      permission: tool,
+      pattern: "*",
+      action: "deny",
+    })
+    tools[tool] = false
+  }
+
+  if (!hasTaskPermission) {
+    permission.push({
+      permission: "task",
+      pattern: "*",
+      action: "deny",
+    })
+    tools.task = false
+  }
+
+  for (const tool of input.config.experimental?.primary_tools ?? []) {
+    permission.push({
+      permission: tool,
+      pattern: "*",
+      action: "allow",
+    })
+    tools[tool] = false
+  }
+
+  return {
+    permission,
+    tools,
+  }
+}

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import path from "path"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
+import { ProviderID } from "../../src/provider/schema"
 import { SystemPrompt } from "../../src/session/system"
 import { tmpdir } from "../fixture/fixture"
 
@@ -55,5 +56,20 @@ description: ${description}
     } finally {
       process.env.OPENCODE_TEST_HOME = home
     }
+  })
+
+  test("anthropic prompt only includes todo instructions when todowrite is available", () => {
+    const model = {
+      providerID: ProviderID.make("anthropic"),
+      api: { id: "claude-sonnet-4-5" },
+    } as any
+
+    const withoutTodo = SystemPrompt.provider(model, { tools: [] }).join("\n")
+    expect(withoutTodo).not.toContain("Use these tools VERY frequently")
+    expect(withoutTodo).not.toContain("Always use the TodoWrite tool")
+
+    const withTodo = SystemPrompt.provider(model, { tools: ["todowrite", "todoread"] }).join("\n")
+    expect(withTodo).toContain("Use these tools VERY frequently")
+    expect(withTodo).toContain("Always use the TodoWrite tool")
   })
 })

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config/config"
 import { Instance } from "../../src/project/instance"
-import { TaskTool } from "../../src/tool/task"
+import { resolveSubagentToolAccess, TaskTool } from "../../src/tool/task"
 import { tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
@@ -43,6 +44,66 @@ describe("tool.task", () => {
         expect(explore).toBeGreaterThan(alpha)
         expect(general).toBeGreaterThan(explore)
         expect(zebra).toBeGreaterThan(general)
+      },
+    })
+  })
+
+  test("subagents keep todo tools disabled unless explicitly enabled", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        agent: {
+          default_subagent: {
+            description: "No explicit todo access",
+            mode: "subagent",
+          },
+          explicit_todo_subagent: {
+            description: "Explicit todo access",
+            mode: "subagent",
+            tools: {
+              todowrite: true,
+              todoread: true,
+            },
+            permission: {
+              todowrite: "allow",
+              todoread: "allow",
+            },
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        const defaultSubagent = await Agent.get("default_subagent")
+        const explicitTodoSubagent = await Agent.get("explicit_todo_subagent")
+
+        const disabled = resolveSubagentToolAccess({
+          agent: defaultSubagent!,
+          config,
+        })
+        expect(disabled.tools.todowrite).toBe(false)
+        expect(disabled.tools.todoread).toBe(false)
+        expect(disabled.permission).toContainEqual({
+          permission: "todowrite",
+          pattern: "*",
+          action: "deny",
+        })
+        expect(disabled.permission).toContainEqual({
+          permission: "todoread",
+          pattern: "*",
+          action: "deny",
+        })
+
+        const enabled = resolveSubagentToolAccess({
+          agent: explicitTodoSubagent!,
+          config,
+        })
+        expect(enabled.tools.todowrite).toBeUndefined()
+        expect(enabled.tools.todoread).toBeUndefined()
+        expect(enabled.permission.some((rule) => rule.permission === "todowrite")).toBe(false)
+        expect(enabled.permission.some((rule) => rule.permission === "todoread")).toBe(false)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #18061

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a mismatch between subagent TodoWrite instructions and the tools that are actually available.

There were two related problems:
1. the provider/system prompt could still tell the model to use TodoWrite even when `todowrite` was not available
2. subagents were defaulting todo tools off in a way that could override explicit todo access

This PR makes the prompt conditional on the final resolved tool set, so TodoWrite-specific instructions are only included when `todowrite` is actually available.

It also keeps the default behavior of disabling todo tools for subagents, while preserving explicit `todowrite` / `todoread` access when it is intentionally enabled.

I believe this works because it removes the prompt/tooling mismatch from both sides:
- prompt generation now reflects the resolved tool availability
- subagent tool gating no longer blindly overrides explicit todo access

### How did you verify your code works?

I verified the patch scope and consistency by:
- checking the relevant code paths for prompt generation and subagent tool gating
- adding focused tests for prompt generation and subagent todo access behavior
- running `git diff --check`

I was not able to complete local test execution in this environment because the workspace dependency `zod` was missing when running the targeted `bun test` commands.

### Screenshots / recordings

N/A

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR