### PR TITLE
chore: update diff package version to 8.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "@pierre/diffs": "1.1.0-beta.18",
       "@solid-primitives/storage": "4.3.3",
       "@tailwindcss/vite": "4.1.11",
-      "diff": "8.0.2",
+      "diff": "8.0.3",
       "dompurify": "3.3.1",
       "drizzle-kit": "1.0.0-beta.19-d95b7a4",
       "drizzle-orm": "1.0.0-beta.19-d95b7a4",


### PR DESCRIPTION
Update `diff` package version from `8.0.2` to `8.0.3`
[jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch](https://github.com/advisories/GHSA-73rr-hh4g-fpgx)