### PR TITLE
feat(ui): add copy format options -- Markdown and Email-ready HTML

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -49,12 +49,111 @@ import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/pa
 import { checksum } from "@opencode-ai/util/encode"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
+import { DropdownMenu } from "./dropdown-menu"
+import { marked } from "marked"
+import DOMPurify from "dompurify"
 import { TextShimmer } from "./text-shimmer"
 import { AnimatedCountList } from "./tool-count-summary"
 import { ToolStatusTitle } from "./tool-status-title"
 import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
+
+// DOMPurify config matching Markdown.tsx -- sanitize before any DOM manipulation
+const purifyConfig = {
+  USE_PROFILES: { html: true, mathMl: true },
+  SANITIZE_NAMED_PROPS: true,
+  FORBID_TAGS: ["style", "img", "video", "audio", "iframe", "script"],
+  FORBID_CONTENTS: ["style", "script"],
+}
+
+/**
+ * Convert markdown to sanitized HTML suitable for email clients.
+ * Sanitizes via DOMPurify first (prevents XSS and network loads),
+ * then strips all classes/styles and inlines email-safe CSS.
+ */
+async function markdownToEmailHtml(markdown: string): Promise<string> {
+  const rawHtml = await marked.parse(markdown)
+  const safeHtml = DOMPurify.sanitize(rawHtml, purifyConfig)
+  const div = document.createElement("div")
+  div.innerHTML = safeHtml
+
+  // Strip all class and style attributes
+  div.querySelectorAll("*").forEach((el) => {
+    ;(el as HTMLElement).removeAttribute("class")
+    ;(el as HTMLElement).removeAttribute("style")
+  })
+
+  // Ensure safe anchor attributes
+  div.querySelectorAll("a").forEach((a) => {
+    a.setAttribute("style", "color: #1a73e8; text-decoration: underline;")
+    if (a.target === "_blank") {
+      a.setAttribute("rel", "noopener noreferrer")
+    }
+  })
+  div.querySelectorAll("code").forEach((code) => {
+    if (code.parentElement?.tagName !== "PRE") {
+      code.setAttribute(
+        "style",
+        "background: #f1f3f4; padding: 1px 4px; border-radius: 3px; font-family: monospace; font-size: 0.9em;",
+      )
+    }
+  })
+  div.querySelectorAll("pre").forEach((pre) => {
+    pre.setAttribute(
+      "style",
+      "background: #f8f9fa; padding: 12px; border-radius: 4px; overflow-x: auto; font-family: monospace; font-size: 0.85em;",
+    )
+  })
+  div.querySelectorAll("blockquote").forEach((bq) => {
+    bq.setAttribute("style", "border-left: 3px solid #dadce0; padding-left: 12px; margin-left: 0; color: #5f6368;")
+  })
+  div.querySelectorAll("table").forEach((table) => {
+    table.setAttribute("style", "border-collapse: collapse; margin: 8px 0;")
+  })
+  div.querySelectorAll("th, td").forEach((cell) => {
+    cell.setAttribute("style", "border: 1px solid #dadce0; padding: 6px 10px; text-align: left;")
+  })
+  div.querySelectorAll("th").forEach((th) => {
+    const s = th.getAttribute("style") || ""
+    th.setAttribute("style", s + " background: #f8f9fa; font-weight: 600;")
+  })
+
+  return `<div style="font-family: Arial, Helvetica, sans-serif; font-size: 14px; line-height: 1.5; color: #202124;">${div.innerHTML}</div>`
+}
+
+/**
+ * Write content to clipboard with format support and fallbacks.
+ * Tries ClipboardItem API first (for HTML), falls back to writeText.
+ */
+async function writeClipboard(options: { html?: string; text: string }): Promise<void> {
+  if (options.html && typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([options.html], { type: "text/html" }),
+          "text/plain": new Blob([options.text], { type: "text/plain" }),
+        }),
+      ])
+      return
+    } catch {
+      // ClipboardItem failed, fall through to writeText
+    }
+  }
+  try {
+    await navigator.clipboard.writeText(options.text)
+  } catch {
+    // Last resort: textarea fallback
+    const textarea = document.createElement("textarea")
+    textarea.value = options.text
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand("copy")
+    document.body.removeChild(textarea)
+  }
+}
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -1370,13 +1469,39 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     return isLastTextPart()
   })
   const [copied, setCopied] = createSignal(false)
+  const [copiedLabel, setCopiedLabel] = createSignal("")
 
-  const handleCopy = async () => {
+  const flashCopied = (label: string) => {
+    setCopied(true)
+    setCopiedLabel(label)
+    setTimeout(() => {
+      setCopied(false)
+      setCopiedLabel("")
+    }, 2000)
+  }
+
+  const handleCopyText = async () => {
     const content = displayText()
     if (!content) return
-    await navigator.clipboard.writeText(content)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    await writeClipboard({ text: content })
+    flashCopied(i18n.t("ui.message.copied"))
+  }
+
+  const handleCopyMarkdown = async () => {
+    const content = displayText()
+    if (!content) return
+    const rawHtml = await marked.parse(content)
+    const safeHtml = DOMPurify.sanitize(rawHtml, purifyConfig)
+    await writeClipboard({ html: safeHtml, text: content })
+    flashCopied(i18n.t("ui.message.copied"))
+  }
+
+  const handleCopyEmail = async () => {
+    const content = displayText()
+    if (!content) return
+    const emailHtml = await markdownToEmailHtml(content)
+    await writeClipboard({ html: emailHtml, text: content })
+    flashCopied(i18n.t("ui.message.copied"))
   }
 
   return (
@@ -1387,20 +1512,29 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
         </div>
         <Show when={showCopy()}>
           <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
-            <Tooltip
-              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              placement="top"
-              gutter={4}
-            >
-              <IconButton
+            <DropdownMenu gutter={4} placement="top-end">
+              <DropdownMenu.Trigger
+                as={IconButton}
                 icon={copied() ? "check" : "copy"}
                 size="normal"
                 variant="ghost"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={handleCopy}
-                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+                onMouseDown={(e: MouseEvent) => e.preventDefault()}
+                aria-label={copied() ? copiedLabel() : i18n.t("ui.message.copyResponse")}
               />
-            </Tooltip>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content>
+                  <DropdownMenu.Item onSelect={handleCopyText}>
+                    <DropdownMenu.ItemLabel>{i18n.t("ui.message.copyResponse")}</DropdownMenu.ItemLabel>
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item onSelect={handleCopyMarkdown}>
+                    <DropdownMenu.ItemLabel>{i18n.t("ui.message.copyMarkdown")}</DropdownMenu.ItemLabel>
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item onSelect={handleCopyEmail}>
+                    <DropdownMenu.ItemLabel>{i18n.t("ui.message.copyEmail")}</DropdownMenu.ItemLabel>
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu>
             <Show when={meta()}>
               <span data-slot="text-part-meta" class="text-12-regular text-text-weak cursor-default">
                 {meta()}

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -141,6 +141,8 @@ export const dict: Record<string, string> = {
   "ui.message.forkMessage": "Fork to new session",
   "ui.message.revertMessage": "Revert message",
   "ui.message.copyResponse": "Copy response",
+  "ui.message.copyMarkdown": "Copy as Markdown",
+  "ui.message.copyEmail": "Copy for Email",
   "ui.message.copied": "Copied",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",


### PR DESCRIPTION
### Issue for this PR

Closes #14041
Relates to #10693

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces the single copy `IconButton` on assistant text parts with a `DropdownMenu` offering three copy modes:

| Mode | Clipboard format | Use case |
|---|---|---|
| **Copy response** | `text/plain` | Current behavior, unchanged |
| **Copy as Markdown** | `text/html` + `text/plain` | Paste into Notion, Obsidian, GitHub -- formatting preserved |
| **Copy for Email** | `text/html` (inline styles) + `text/plain` | Paste into Gmail, Outlook, Apple Mail -- renders correctly |

The email HTML sanitization strips all classes/styles from rendered HTML and inlines email-safe CSS on key elements (monospace code blocks, bordered tables, styled blockquotes, blue links, Arial 14px base font).

**Security:**
- All HTML sanitized via DOMPurify before DOM parsing or clipboard write (matches `Markdown.tsx` config)
- Media tags forbidden (`img`, `video`, `audio`, `iframe`) to prevent network loads from untrusted content
- Safe anchor attributes enforced (`rel="noopener noreferrer"`)
- Centralized `writeClipboard()` with `ClipboardItem` → `writeText` → `textarea` fallback chain

**Scope:** `packages/ui/src/components/message-part.tsx` and `packages/ui/src/i18n/en.ts` (2 new i18n keys). Uses the existing `DropdownMenu` component. No API changes.

### How to test

1. Start a session and get an assistant response with code blocks, tables, and links
2. Click the copy button on the response -- should show a dropdown with three options
3. "Copy response" -- paste into a text editor, should be plain text (unchanged behavior)
4. "Copy as Markdown" -- paste into GitHub comment or Notion, should render with formatting
5. "Copy for Email" -- paste into Gmail compose, should render with proper styling (monospace code, bordered tables, blue links)

### i18n note

Two new keys added to `en.ts`. Other locale files will need translations added in a follow-up.