### PR TITLE
feat: add csharpier formatter for C# files

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -394,3 +394,12 @@ export const dfmt: Info = {
     return which("dfmt") !== null
   },
 }
+
+export const csharpier: Info = {
+  name: "csharpier",
+  command: ["dotnet", "csharpier", "$FILE"],
+  extensions: [".cs"],
+  async enabled() {
+    return which("dotnet") !== null
+  },
+}


### PR DESCRIPTION
### Issue for this PR

Closes #19002

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `csharpier` as a built-in formatter for C# (`.cs`) files. The project already has C# LSP support via the built-in `csharp` language server, but no formatter. CSharpier is the standard opinionated code formatter for C#.

Runs `dotnet csharpier $FILE` and is enabled when `dotnet` is found in PATH. Follows the same pattern as the other built-in formatters.

### How did you verify your code works?

Installed `dotnet csharpier` as a global tool and confirmed `.cs` files are formatted in place. Verified behavior remains unchanged when `dotnet` is not installed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
