### PR TITLE
fix(provider): normalize wrapped rate_limit_error chunks in Responses stream

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -1277,6 +1277,22 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
               }
             } else if (isErrorChunk(value)) {
               controller.enqueue({ type: "error", error: value })
+            } else if (isWrappedErrorChunk(value)) {
+              // Normalise wrapped error shape { error: { type, message } } into
+              // a provider error. Rate-limit errors are retryable.
+              const wrappedError = value.error
+              const isRetryable = RETRYABLE_WRAPPED_ERROR_TYPES.has(wrappedError.type)
+              controller.enqueue({
+                type: "error",
+                error: new APICallError({
+                  message: wrappedError.message,
+                  url: "",
+                  requestBodyValues: {},
+                  statusCode: isRetryable ? 429 : 400,
+                  responseBody: JSON.stringify(value),
+                  isRetryable,
+                }),
+              })
             }
           },
 
@@ -1336,6 +1352,20 @@ const errorChunkSchema = z.object({
   message: z.string(),
   param: z.string().nullish(),
   sequence_number: z.number(),
+})
+
+// Some Responses API paths (e.g. rate limit errors) return a wrapped error
+// shape without a top-level `type` field:
+//   { "error": { "type": "rate_limit_error", "message": "..." } }
+// This schema captures that shape so it can be normalised into a retryable
+// provider error instead of failing Zod union validation.
+const wrappedErrorChunkSchema = z.object({
+  error: z.object({
+    type: z.string(),
+    message: z.string(),
+    code: z.string().nullish(),
+    param: z.string().nullish(),
+  }),
 })
 
 const responseFinishedChunkSchema = z.object({
@@ -1528,6 +1558,7 @@ const openaiResponsesChunkSchema = z.union([
   responseReasoningSummaryPartAddedSchema,
   responseReasoningSummaryTextDeltaSchema,
   errorChunkSchema,
+  wrappedErrorChunkSchema,
   z.object({ type: z.string() }).loose(), // fallback for unknown chunks
 ])
 
@@ -1623,6 +1654,19 @@ function isResponseReasoningSummaryTextDeltaChunk(
 function isErrorChunk(chunk: z.infer<typeof openaiResponsesChunkSchema>): chunk is z.infer<typeof errorChunkSchema> {
   return chunk.type === "error"
 }
+
+function isWrappedErrorChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof wrappedErrorChunkSchema> {
+  return (
+    "error" in chunk &&
+    typeof (chunk as any).error === "object" &&
+    (chunk as any).error !== null &&
+    typeof (chunk as any).error.type === "string"
+  )
+}
+
+const RETRYABLE_WRAPPED_ERROR_TYPES = new Set(["rate_limit_error", "concurrency_limit_exceeded"])
 
 type ResponsesModelConfig = {
   isReasoningModel: boolean


### PR DESCRIPTION
## Summary

Fixes #18897

Some Responses API paths (e.g. concurrency/rate limit errors) return stream chunks in a wrapped shape without a top-level `type` field:

```json
{"error":{"type":"rate_limit_error","message":"Concurrency limit exceeded for user, please retry later"}}
```

OpenCode's stream chunk schema union expects either a `type: "error"` event or one of the `response.*` events. This wrapped shape has no `type` key, so it falls through to the loose fallback `z.object({ type: z.string() })` — which also fails because `type` is missing — surfacing as a confusing `Type validation failed` Zod error instead of a retryable provider error.

## Changes

- `openai-responses-language-model.ts`: Add `wrappedErrorChunkSchema` for the `{ error: { type, message } }` shape
- Add `isWrappedErrorChunk()` type guard
- Handle wrapped error chunks in the transform pipeline, mapping `rate_limit_error` and `concurrency_limit_exceeded` to a retryable `APICallError` (HTTP 429); other wrapped error types are treated as non-retryable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Existing provider tests pass (`70 pass, 0 fail`). The fix is narrowly scoped to stream chunk parsing and does not affect the happy path.
