### PR TITLE
fix(auth): skip OAuth loader when direct API key is configured

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1076,6 +1076,12 @@ export namespace Provider {
       if (!auth) continue
       if (!plugin.auth.loader) continue
 
+      // Skip OAuth plugin loader when a direct API key is already configured
+      // (from environment variable or explicit config). This prevents stale
+      // OAuth auth from hijacking the direct key path.
+      const existingSource = providers[providerID]?.source
+      if (existingSource === "env" || existingSource === "api") continue
+
       if (auth) {
         const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
         const opts = options ?? {}


### PR DESCRIPTION
## Summary

Fixes #18862

When `openai` has stale OAuth auth stored, `Provider.state()` applies the Codex OAuth plugin loader even when the user has explicitly configured a direct API key via `OPENAI_API_KEY` or `provider.openai.options.apiKey`. This injects a dummy OAuth key and fetch override, effectively overriding the direct key path and making the OpenAI provider unusable for direct API-key users.

## Root Cause

In the plugin auth loader loop in `provider.ts`, the check `if (auth)` runs the OAuth loader whenever stored auth exists — without verifying whether the provider already has an explicit direct key source.

## Fix

Skip the plugin OAuth loader when the provider's source is already `"env"` (from environment variable) or `"api"` (from direct config). This preserves explicit direct key configuration and prevents stale OAuth from hijacking it.

```ts
// Skip OAuth plugin loader when a direct API key is already configured
const existingSource = providers[providerID]?.source
if (existingSource === "env" || existingSource === "api") continue
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Existing provider tests pass (`70 pass, 0 fail`)
- Plugin auth-override tests pass (`2 pass, 0 fail`)
