### PR TITLE
feat(web): prefill in-file search from current selection

### DIFF
--- a/packages/ui/src/pierre/file-find.ts
+++ b/packages/ui/src/pierre/file-find.ts
@@ -360,7 +360,10 @@ export function createFileFind(opts: CreateFileFindOptions) {
     if (current && current !== host) current.close()
     current = host
     target = host
+    const query = window.getSelection()?.toString()
     if (!open()) setState("open", true)
+    if (query) setState("query", query)
+
     requestAnimationFrame(() => {
       apply({ scroll: true })
       input?.focus()


### PR DESCRIPTION
### Issue for this PR

Closes [#19022](https://github.com/anomalyco/opencode/issues/19022)

### Type of change

- [x] New feature

### What does this PR do?

When pressing Ctrl+F inside a file, use the current text selection as the default search query.

### How did you verify your code works?

I ran the project; selected lines; ctrl + f and checked if the query was using my selection.

### Screenshots / recordings

## Before

https://github.com/user-attachments/assets/41d6344e-02ce-4cba-a0cf-5183390fb5aa

## After

https://github.com/user-attachments/assets/1ae70a3f-8e0d-489d-9510-6e6f975b2325

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
