### PR TITLE
feat(tui): add heap snapshot functionality for TUI and server

### DIFF
--- a/.opencode/command/changelog.md
+++ b/.opencode/command/changelog.md
@@ -1,5 +1,17 @@
+create UPCOMING_CHANGELOG.md
+
+it should have sections
+
+```
+# TUI
+
+# Desktop
+
+# Core
+
+# Misc
+```
+
 go through each PR merged since the last tag
 
-for each PR spawn a subagent to summarize what the PR was about. focus on user facing changes. if it was entirely internal or code related you can ignore it. also skip docs updates. each subagent should append its summary to UPCOMING_CHANGELOG.md
-
-once that is done, read UPCOMING_CHANGELOG.md and group it into sections for better readability. make sure all PR references are preserved
+for each PR spawn a subagent to summarize what the PR was about. focus on user facing changes. if it was entirely internal or code related you can ignore it. also skip docs updates. each subagent should append its summary to UPCOMING_CHANGELOG.md into the appropriate section.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -110,6 +110,7 @@ export function tui(input: {
   url: string
   args: Args
   config: TuiConfig.Info
+  onSnapshot?: () => Promise<string[]>
   directory?: string
   fetch?: typeof fetch
   headers?: RequestInit["headers"]
@@ -160,7 +161,7 @@ export function tui(input: {
                                         <FrecencyProvider>
                                           <PromptHistoryProvider>
                                             <PromptRefProvider>
-                                              <App />
+                                              <App onSnapshot={input.onSnapshot} />
                                             </PromptRefProvider>
                                           </PromptHistoryProvider>
                                         </FrecencyProvider>
@@ -201,7 +202,7 @@ export function tui(input: {
   })
 }
 
-function App() {
+function App(props: { onSnapshot?: () => Promise<string[]> }) {
   const route = useRoute()
   const dimensions = useTerminalDimensions()
   const renderer = useRenderer()
@@ -627,11 +628,11 @@ function App() {
       title: "Write heap snapshot",
       category: "System",
       value: "app.heap_snapshot",
-      onSelect: (dialog) => {
-        const path = writeHeapSnapshot()
+      onSelect: async (dialog) => {
+        const files = await props.onSnapshot?.()
         toast.show({
           variant: "info",
-          message: `Heap snapshot written to ${path}`,
+          message: `Heap snapshot written to ${files?.join(", ")}`,
           duration: 5000,
         })
         dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -14,6 +14,7 @@ import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
+import { writeHeapSnapshot } from "v8"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -201,6 +202,11 @@ export const TuiThreadCommand = cmd({
       try {
         await tui({
           url: transport.url,
+          async onSnapshot() {
+            const tui = writeHeapSnapshot("tui.heapsnapshot")
+            const server = await client.call("snapshot", undefined)
+            return [tui, server]
+          },
           config,
           directory: cwd,
           fetch: transport.fetch,

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -10,6 +10,7 @@ import { GlobalBus } from "@/bus/global"
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
 import { Flag } from "@/flag/flag"
 import { setTimeout as sleep } from "node:timers/promises"
+import { writeHeapSnapshot } from "node:v8"
 
 await Log.init({
   print: process.argv.includes("--print-logs"),
@@ -116,6 +117,10 @@ export const rpc = {
       headers: Object.fromEntries(response.headers.entries()),
       body,
     }
+  },
+  snapshot() {
+    const result = writeHeapSnapshot("server.heapsnapshot")
+    return result
   },
   async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
     if (server) await server.stop(true)


### PR DESCRIPTION
## Summary
This PR adds heap snapshot functionality to the TUI, allowing users to capture memory snapshots of both the TUI process and the server process simultaneously.

## Changes
- Added `onSnapshot` callback prop to the TUI app component
- Modified the "Write heap snapshot" command to capture both TUI and server heap snapshots
- Added new RPC `snapshot` method in the worker to write server heap snapshot
- Updated thread.ts to implement the snapshot callback that coordinates both snapshots

## How it works
When the user triggers the "Write heap snapshot" command from the command palette:
1. The TUI writes its own heap snapshot to `tui.heapsnapshot`
2. An RPC call is made to the worker to write the server heap snapshot to `server.heapsnapshot`
3. A toast notification displays both file paths