### PR TITLE
fix: auto-re-read stale files in agent loop to prevent retry loops

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -16,6 +16,8 @@ import { Permission } from "@/permission"
 import { Question } from "@/question"
 import { PartID } from "./schema"
 import type { SessionID, MessageID } from "./schema"
+import { FileTime } from "@/file/time"
+import { Filesystem } from "@/util/filesystem"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -205,12 +207,28 @@ export namespace SessionProcessor {
                 case "tool-error": {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
+                    let errorStr = value.error instanceof Error ? value.error.message : String(value.error)
+                    const staleFileMatch =
+                      errorStr.match(/File (.+) has been modified since it was last read/) ??
+                      errorStr.match(/You must read file (.+) before overwriting it/)
+                    if (staleFileMatch) {
+                      const staleFilePath = staleFileMatch[1].trim()
+                      try {
+                        const freshContent = await Filesystem.readText(staleFilePath)
+                        FileTime.read(input.sessionID, staleFilePath)
+                        errorStr += `\n\nThe file has been auto-re-read. Here is the current content:\n<file path="${staleFilePath}">\n${freshContent}\n</file>`
+                        log.info("stale file auto-re-read", { file: staleFilePath, sessionID: input.sessionID })
+                      } catch (readErr) {
+                        log.warn("failed to auto-re-read stale file", { file: staleFilePath, error: readErr })
+                      }
+                    }
+
                     await Session.updatePart({
                       ...match,
                       state: {
                         status: "error",
                         input: value.input ?? match.state.input,
-                        error: value.error instanceof Error ? value.error.message : String(value.error),
+                        error: errorStr,
                         time: {
                           start: match.state.time.start,
                           end: Date.now(),


### PR DESCRIPTION
## Summary

Fixes #19040

When external formatters or linters modify files between a read and a write, the `FileTime.assert` safety check correctly rejects the write. However, the model has no way to recover except by calling the read tool again — and often it doesn't, leading to **hundreds of consecutive identical failures** (295 in the reported issue).

This PR adds agent-level recovery in the `tool-error` handler of the session processor:

- Detects stale-file errors via regex matching on the error string
- Auto-re-reads the file content using `Filesystem.readText`
- Updates `FileTime` so subsequent writes pass the staleness check
- Appends the fresh file content to the error message so the model's context is updated

## Why agent-level, not tool-level?

Doing this at the tool level (inside the write/edit tool) would silently retry without updating the model's context. The model would continue believing it has the old file content, leading to incorrect edits. By recovering at the agent level, we:

1. **Preserve the `FileTime.assert` safety check** — it still fires and prevents blind overwrites
2. **Update the model's context** — the fresh file content is included in the error message
3. **Let the model decide** — it sees the current file and can adjust its edit accordingly

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Existing tests pass (`bun test` — 1459 pass, 1 pre-existing timeout skip)
- [ ] Manual test: run a formatter that modifies a file mid-edit and verify the agent recovers in 1 retry instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)