### PR TITLE
fix(openrouter): prevent reasoning block signature corruption with extended thinking

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -83,7 +83,7 @@ export namespace SessionProcessor {
                   if (value.id in reasoningMap) {
                     const part = reasoningMap[value.id]
                     part.text += value.text
-                    if (value.providerMetadata) part.metadata = value.providerMetadata
+                    if (value.providerMetadata) Object.assign((part.metadata ??= {}), value.providerMetadata)
                     await Session.updatePartDelta({
                       sessionID: part.sessionID,
                       messageID: part.messageID,
@@ -97,13 +97,11 @@ export namespace SessionProcessor {
                 case "reasoning-end":
                   if (value.id in reasoningMap) {
                     const part = reasoningMap[value.id]
-                    part.text = part.text.trimEnd()
-
                     part.time = {
                       ...part.time,
                       end: Date.now(),
                     }
-                    if (value.providerMetadata) part.metadata = value.providerMetadata
+                    if (value.providerMetadata) Object.assign((part.metadata ??= {}), value.providerMetadata)
                     await Session.updatePart(part)
                     delete reasoningMap[value.id]
                   }
@@ -306,7 +304,7 @@ export namespace SessionProcessor {
                 case "text-delta":
                   if (currentText) {
                     currentText.text += value.text
-                    if (value.providerMetadata) currentText.metadata = value.providerMetadata
+                    if (value.providerMetadata) Object.assign((currentText.metadata ??= {}), value.providerMetadata)
                     await Session.updatePartDelta({
                       sessionID: currentText.sessionID,
                       messageID: currentText.messageID,
@@ -334,7 +332,7 @@ export namespace SessionProcessor {
                       start: Date.now(),
                       end: Date.now(),
                     }
-                    if (value.providerMetadata) currentText.metadata = value.providerMetadata
+                    if (value.providerMetadata) Object.assign((currentText.metadata ??= {}), value.providerMetadata)
                     await Session.updatePart(currentText)
                   }
                   currentText = undefined

--- a/patches/@openrouter%2Fai-sdk-provider@1.5.4.patch
+++ b/patches/@openrouter%2Fai-sdk-provider@1.5.4.patch
@@ -1,8 +1,21 @@
 diff --git a/dist/index.js b/dist/index.js
-index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..e887a60352c0c08ab794b1e6821854dfeefd20cc 100644
+index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..e24c02ad1884018fdb214a1e380bc74f5c2fdb2b 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -2110,7 +2110,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -1319,12 +1319,6 @@ function convertToOpenRouterChatMessages(prompt) {
+               break;
+             }
+             case "tool-call": {
+-              const partReasoningDetails = (_c = part.providerOptions) == null ? void 0 : _c.openrouter;
+-              if ((partReasoningDetails == null ? void 0 : partReasoningDetails.reasoning_details) && Array.isArray(partReasoningDetails.reasoning_details)) {
+-                accumulatedReasoningDetails.push(
+-                  ...partReasoningDetails.reasoning_details
+-                );
+-              }
+               toolCalls.push({
+                 id: part.toolCallId,
+                 type: "function",
+@@ -2110,7 +2104,12 @@ var OpenRouterChatLanguageModel = class {
                if (reasoningStarted && !textStarted) {
                  controller.enqueue({
                    type: "reasoning-end",
@@ -16,7 +29,7 @@ index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..e887a60352c0c08ab794b1e6821854df
                  });
                  reasoningStarted = false;
                }
-@@ -2307,7 +2312,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -2307,7 +2306,12 @@ var OpenRouterChatLanguageModel = class {
              if (reasoningStarted) {
                controller.enqueue({
                  type: "reasoning-end",
@@ -31,10 +44,23 @@ index f33510a50d11a2cb92a90ea70cc0ac84c89f29b9..e887a60352c0c08ab794b1e6821854df
              }
              if (textStarted) {
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 8a688331b88b4af738ee4ca8062b5f24124d3d81..6310cb8b7c8d0a728d86e1eed09906c6b4c91ae2 100644
+index 8a688331b88b4af738ee4ca8062b5f24124d3d81..a9488ff73c09eda1ef0247eb62430261719c8ec3 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -2075,7 +2075,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -1284,12 +1284,6 @@ function convertToOpenRouterChatMessages(prompt) {
+               break;
+             }
+             case "tool-call": {
+-              const partReasoningDetails = (_c = part.providerOptions) == null ? void 0 : _c.openrouter;
+-              if ((partReasoningDetails == null ? void 0 : partReasoningDetails.reasoning_details) && Array.isArray(partReasoningDetails.reasoning_details)) {
+-                accumulatedReasoningDetails.push(
+-                  ...partReasoningDetails.reasoning_details
+-                );
+-              }
+               toolCalls.push({
+                 id: part.toolCallId,
+                 type: "function",
+@@ -2075,7 +2069,12 @@ var OpenRouterChatLanguageModel = class {
                if (reasoningStarted && !textStarted) {
                  controller.enqueue({
                    type: "reasoning-end",
@@ -48,7 +74,7 @@ index 8a688331b88b4af738ee4ca8062b5f24124d3d81..6310cb8b7c8d0a728d86e1eed09906c6
                  });
                  reasoningStarted = false;
                }
-@@ -2272,7 +2277,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -2272,7 +2271,12 @@ var OpenRouterChatLanguageModel = class {
              if (reasoningStarted) {
                controller.enqueue({
                  type: "reasoning-end",
@@ -63,10 +89,23 @@ index 8a688331b88b4af738ee4ca8062b5f24124d3d81..6310cb8b7c8d0a728d86e1eed09906c6
              }
              if (textStarted) {
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index d40fa66125941155ac13a4619503caba24d89f8a..8dd86d1b473f2fa31c1acd9881d72945b294a197 100644
+index d40fa66125941155ac13a4619503caba24d89f8a..efd3cee459b8b917fe8ff1a97ed384d066ac0682 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -2064,7 +2064,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -1273,12 +1273,6 @@ function convertToOpenRouterChatMessages(prompt) {
+               break;
+             }
+             case "tool-call": {
+-              const partReasoningDetails = (_c = part.providerOptions) == null ? void 0 : _c.openrouter;
+-              if ((partReasoningDetails == null ? void 0 : partReasoningDetails.reasoning_details) && Array.isArray(partReasoningDetails.reasoning_details)) {
+-                accumulatedReasoningDetails.push(
+-                  ...partReasoningDetails.reasoning_details
+-                );
+-              }
+               toolCalls.push({
+                 id: part.toolCallId,
+                 type: "function",
+@@ -2064,7 +2058,12 @@ var OpenRouterChatLanguageModel = class {
                if (reasoningStarted && !textStarted) {
                  controller.enqueue({
                    type: "reasoning-end",
@@ -80,7 +119,7 @@ index d40fa66125941155ac13a4619503caba24d89f8a..8dd86d1b473f2fa31c1acd9881d72945
                  });
                  reasoningStarted = false;
                }
-@@ -2261,7 +2266,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -2261,7 +2260,12 @@ var OpenRouterChatLanguageModel = class {
              if (reasoningStarted) {
                controller.enqueue({
                  type: "reasoning-end",
@@ -95,10 +134,23 @@ index d40fa66125941155ac13a4619503caba24d89f8a..8dd86d1b473f2fa31c1acd9881d72945
              }
              if (textStarted) {
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index b0ed9d113549c5c55ea3b1e08abb3db6f92ae5a7..5695930a8e038facc071d58a4179a369a29be9c7 100644
+index b0ed9d113549c5c55ea3b1e08abb3db6f92ae5a7..75f7fc4d95b661fcee97f0e1b185c49deb6d92b6 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -2030,7 +2030,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -1239,12 +1239,6 @@ function convertToOpenRouterChatMessages(prompt) {
+               break;
+             }
+             case "tool-call": {
+-              const partReasoningDetails = (_c = part.providerOptions) == null ? void 0 : _c.openrouter;
+-              if ((partReasoningDetails == null ? void 0 : partReasoningDetails.reasoning_details) && Array.isArray(partReasoningDetails.reasoning_details)) {
+-                accumulatedReasoningDetails.push(
+-                  ...partReasoningDetails.reasoning_details
+-                );
+-              }
+               toolCalls.push({
+                 id: part.toolCallId,
+                 type: "function",
+@@ -2030,7 +2024,12 @@ var OpenRouterChatLanguageModel = class {
                if (reasoningStarted && !textStarted) {
                  controller.enqueue({
                    type: "reasoning-end",
@@ -112,7 +164,7 @@ index b0ed9d113549c5c55ea3b1e08abb3db6f92ae5a7..5695930a8e038facc071d58a4179a369
                  });
                  reasoningStarted = false;
                }
-@@ -2227,7 +2232,12 @@ var OpenRouterChatLanguageModel = class {
+@@ -2227,7 +2226,12 @@ var OpenRouterChatLanguageModel = class {
              if (reasoningStarted) {
                controller.enqueue({
                  type: "reasoning-end",


### PR DESCRIPTION
### Issue for this PR

Fixes #18078

Related: #18254

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes three bugs that corrupt reasoning block data when using Claude models via OpenRouter with extended thinking enabled:

1. `trimEnd()` on reasoning text mutates the text after Anthropic signs it, causing "thinking blocks cannot be modified" on subsequent turns.

2. Both the tool-call and reasoning cases push into `accumulatedReasoningDetails` in the OpenRouter SDK message converter, producing duplicate thinking blocks that Anthropic rejects.

3. `providerMetadata` assignment (`=`) overwrites previously stored signature data when later delta/end events arrive with different metadata, causing "Invalid signature in thinking block".

Fixes: remove `trimEnd` from the reasoning-end handler, disable the tool-call case push in the SDK patch (the reasoning case is the canonical source), and use `Object.assign` to merge `providerMetadata` instead of overwriting it.

### How did you verify your code works?

Tested multi-turn conversations with Claude via OpenRouter with extended thinking enabled. Verified that reasoning signatures are preserved correctly across streaming events and that conversation history replays no longer produce signature validation errors.

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR