### PR TITLE
fix(provider): align providerOptions namespace in bundled Responses SDK

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
@@ -183,7 +183,7 @@ export async function convertToOpenAIResponsesInput({
 
             case "reasoning": {
               const providerOptions = await parseProviderOptions({
-                provider: "copilot",
+                provider: "openai",
                 providerOptions: part.providerOptions,
                 schema: openaiResponsesReasoningProviderOptionsSchema,
               })

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -194,7 +194,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     }
 
     const openaiOptions = await parseProviderOptions({
-      provider: "copilot",
+      provider: "openai",
       providerOptions,
       schema: openaiResponsesProviderOptionsSchema,
     })


### PR DESCRIPTION
### Issue for this PR

Closes #17926

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

> Authorship: Claude 90%, Dulani 10%

The bundled Responses SDK writes reasoning metadata under `"openai"` but reads it back under `"copilot"`. On turn 2+, `providerOptions["copilot"]` is undefined, the reasoning item gets dropped, and the server 400s.

Fix: `provider: "copilot"` → `provider: "openai"` in two `parseProviderOptions` calls.

Copilot unaffected — with `store: true` (default), reasoning replays via `item_reference` and never hits these calls. Only `store: false` (inline replay) exercises this path.

### How did you verify your code works?

Running locally for several weeks against four GPT-5 models on Microsoft Azure via `@ai-sdk/openai-compatible` + `useResponses: true`. Multi-turn reasoning works. Without the fix, every conversation fails on the second message.

Not tested against Copilot directly — `store: true` means these code paths aren't exercised.

### Screenshots / recordings

N/A — backend-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR