### PR TITLE
fix(write): enforce explicit file mode despite umask

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -41,7 +41,7 @@ export const WriteTool = Tool.define("write", {
       },
     })
 
-    await Filesystem.write(filepath, params.content)
+    await Filesystem.write(filepath, params.content, 0o644)
     await Bus.publish(File.Event.Edited, {
       file: filepath,
     })

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -55,6 +55,9 @@ export namespace Filesystem {
     try {
       if (mode) {
         await writeFile(p, content, { mode })
+        // writeFile mode is still filtered by process umask for newly created files,
+        // and won't update mode for existing files. Force the requested mode explicitly.
+        await chmod(p, mode)
       } else {
         await writeFile(p, content)
       }
@@ -63,6 +66,7 @@ export namespace Filesystem {
         await mkdir(dirname(p), { recursive: true })
         if (mode) {
           await writeFile(p, content, { mode })
+          await chmod(p, mode)
         } else {
           await writeFile(p, content)
         }


### PR DESCRIPTION
### Issue for this PR

Closes #19076

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes file mode handling in write paths so `tool.write` consistently produces `0644` files even under strict umask settings.

Changes:
- `WriteTool` now writes with explicit mode `0o644`.
- `Filesystem.write` now applies `chmod` after write when `mode` is provided.
  - This avoids umask-filtered permissions on new files.
  - It also normalizes permissions for existing files (where `writeFile(..., { mode })` does not update mode).

### How did you verify your code works?

- Reproduced failing test locally in `packages/opencode/test/tool/write.test.ts` (`Expected 0644, Received 0600`).
- Ran targeted test after fix:
  - `bun --cwd packages/opencode test test/tool/write.test.ts`
- Ran full package tests after fix:
  - `bun --cwd packages/opencode test`

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._