### PR TITLE
fix(project): use git common dir for bare repo project cache

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -207,13 +207,11 @@ export const layer: Layer.Layer<
             vcs: fakeVcs,
           }
         }
-        const worktree = (() => {
-          const common = resolveGitPath(sandbox, commonDir.text.trim())
-          return common === sandbox ? sandbox : pathSvc.dirname(common)
-        })()
+        const common = resolveGitPath(sandbox, commonDir.text.trim())
+        const worktree = common === sandbox ? sandbox : pathSvc.dirname(common)
 
         if (id == null) {
-          id = yield* readCachedProjectId(pathSvc.join(worktree, ".git"))
+          id = yield* readCachedProjectId(common)
         }
 
         if (!id) {
@@ -226,7 +224,7 @@ export const layer: Layer.Layer<
 
           id = roots[0] ? ProjectID.make(roots[0]) : undefined
           if (id) {
-            yield* fs.writeFileString(pathSvc.join(worktree, ".git", "opencode"), id).pipe(Effect.ignore)
+            yield* fs.writeFileString(pathSvc.join(common, "opencode"), id).pipe(Effect.ignore)
           }
         }
 

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -208,7 +208,9 @@ export const layer: Layer.Layer<
           }
         }
         const common = resolveGitPath(sandbox, commonDir.text.trim())
-        const worktree = common === sandbox ? sandbox : pathSvc.dirname(common)
+        const bareCheck = yield* git(["config", "--bool", "core.bare"], { cwd: sandbox })
+        const isBareRepo = bareCheck.code === 0 && bareCheck.text.trim() === "true"
+        const worktree = common === sandbox ? sandbox : isBareRepo ? common : pathSvc.dirname(common)
 
         if (id == null) {
           id = yield* readCachedProjectId(common)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -472,3 +472,63 @@ describe("Project.addSandbox and Project.removeSandbox", () => {
     expect(events.some((e) => e.payload.type === Project.Event.Updated.type)).toBe(true)
   })
 })
+
+describe("Project.fromDirectory with bare repos", () => {
+  test("worktree from bare repo should cache in bare repo, not parent", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const parentDir = path.dirname(tmp.path)
+    const barePath = path.join(parentDir, `bare-${Date.now()}.git`)
+    const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+
+    try {
+      await $`git clone --bare ${tmp.path} ${barePath}`.quiet()
+      await $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet()
+
+      const { project } = await run((svc) => svc.fromDirectory(worktreePath))
+
+      expect(project.id).not.toBe(ProjectID.global)
+
+      const correctCache = path.join(barePath, "opencode")
+      const wrongCache = path.join(parentDir, ".git", "opencode")
+
+      expect(await Bun.file(correctCache).exists()).toBe(true)
+      expect(await Bun.file(wrongCache).exists()).toBe(false)
+    } finally {
+      await $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()
+    }
+  })
+
+  test("different bare repos under same parent should not share project ID", async () => {
+    await using tmp1 = await tmpdir({ git: true })
+    await using tmp2 = await tmpdir({ git: true })
+
+    const parentDir = path.dirname(tmp1.path)
+    const bareA = path.join(parentDir, `bare-a-${Date.now()}.git`)
+    const bareB = path.join(parentDir, `bare-b-${Date.now()}.git`)
+    const worktreeA = path.join(parentDir, `wt-a-${Date.now()}`)
+    const worktreeB = path.join(parentDir, `wt-b-${Date.now()}`)
+
+    try {
+      await $`git clone --bare ${tmp1.path} ${bareA}`.quiet()
+      await $`git clone --bare ${tmp2.path} ${bareB}`.quiet()
+      await $`git worktree add ${worktreeA} HEAD`.cwd(bareA).quiet()
+      await $`git worktree add ${worktreeB} HEAD`.cwd(bareB).quiet()
+
+      const { project: projA } = await run((svc) => svc.fromDirectory(worktreeA))
+      const { project: projB } = await run((svc) => svc.fromDirectory(worktreeB))
+
+      expect(projA.id).not.toBe(projB.id)
+
+      const cacheA = path.join(bareA, "opencode")
+      const cacheB = path.join(bareB, "opencode")
+      const wrongCache = path.join(parentDir, ".git", "opencode")
+
+      expect(await Bun.file(cacheA).exists()).toBe(true)
+      expect(await Bun.file(cacheB).exists()).toBe(true)
+      expect(await Bun.file(wrongCache).exists()).toBe(false)
+    } finally {
+      await $`rm -rf ${bareA} ${bareB} ${worktreeA} ${worktreeB}`.quiet().nothrow()
+    }
+  })
+})

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -488,6 +488,7 @@ describe("Project.fromDirectory with bare repos", () => {
       const { project } = await run((svc) => svc.fromDirectory(worktreePath))
 
       expect(project.id).not.toBe(ProjectID.global)
+      expect(project.worktree).toBe(barePath)
 
       const correctCache = path.join(barePath, "opencode")
       const wrongCache = path.join(parentDir, ".git", "opencode")
@@ -529,6 +530,29 @@ describe("Project.fromDirectory with bare repos", () => {
       expect(await Bun.file(wrongCache).exists()).toBe(false)
     } finally {
       await $`rm -rf ${bareA} ${bareB} ${worktreeA} ${worktreeB}`.quiet().nothrow()
+    }
+  })
+
+  test("bare repo without .git suffix is still detected via core.bare", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const parentDir = path.dirname(tmp.path)
+    const barePath = path.join(parentDir, `bare-no-suffix-${Date.now()}`)
+    const worktreePath = path.join(parentDir, `worktree-${Date.now()}`)
+
+    try {
+      await $`git clone --bare ${tmp.path} ${barePath}`.quiet()
+      await $`git worktree add ${worktreePath} HEAD`.cwd(barePath).quiet()
+
+      const { project } = await run((svc) => svc.fromDirectory(worktreePath))
+
+      expect(project.id).not.toBe(ProjectID.global)
+      expect(project.worktree).toBe(barePath)
+
+      const correctCache = path.join(barePath, "opencode")
+      expect(await Bun.file(correctCache).exists()).toBe(true)
+    } finally {
+      await $`rm -rf ${barePath} ${worktreePath}`.quiet().nothrow()
     }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #18045

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes project ID cache placement for bare-repo-backed worktrees.

Before this change, cache read/write used `worktree/.git/opencode`. In bare repo setups, `worktree` resolves to the parent of the bare repo, so cache could be written to a shared parent path like `<parent>/.git/opencode`.

This PR reads and writes cache at `git rev-parse --git-common-dir` (`common/opencode`) instead. That is the correct git metadata location for normal repos, worktrees, and bare repos.

I also added regression tests for:
- bare repo worktree cache path (must be in `<bare>.git/opencode`, not parent)
- sibling bare repos under one parent (must not share IDs via parent cache)

### How did you verify your code works?

- Ran `bun test --timeout 30000 test/project/` in `packages/opencode`
- New bare-repo tests fail on old behavior and pass with this fix
- Manually validated no cache is created at the incorrect parent `.git/opencode` path

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
