### PR TITLE
docs: add edenai provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -420,6 +420,115 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    edenai: Effect.fnUntraced(function* (input: Info) {
+      const envKey = yield* dep.get("EDENAI_API_KEY")
+      const auth = yield* dep.auth(input.id)
+      const apiKey = envKey ?? (auth?.type === "api" ? auth.key : undefined)
+
+      if (!apiKey) return { autoload: false }
+
+      return {
+        autoload: true,
+        options: {
+          apiKey,
+          baseURL: "https://api.edenai.run/v3/llm",
+        },
+        async discoverModels(): Promise<Record<string, Model>> {
+          try {
+            log.info("edenai model discovery starting")
+            const response = await fetch("https://api.edenai.run/v3/models", {
+              headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+              },
+            })
+
+            if (!response.ok) {
+              log.warn("edenai model discovery failed", { status: response.status })
+              return {}
+            }
+
+            const data = (await response.json()) as {
+              object: string
+              data: Array<{
+                id?: string
+                model_name?: string
+                owned_by?: string
+                context_length?: number
+                capabilities?: Record<string, boolean>
+                pricing?: {
+                  input?: number
+                  output?: number
+                  cache_read?: number
+                  cache_write?: number
+                }
+              }>
+            }
+
+            const items = Array.isArray(data?.data) ? data.data : []
+            const models: Record<string, Model> = {}
+            for (const m of items) {
+              const modelId = m.id
+              if (!modelId) continue
+              if (input.models[modelId]) continue
+
+              models[modelId] = {
+                id: ModelID.make(modelId),
+                providerID: ProviderID.edenai,
+                name: m.model_name ?? modelId,
+                family: m.owned_by,
+                api: {
+                  id: modelId,
+                  url: "https://api.edenai.run/v3/llm",
+                  npm: "@ai-sdk/openai-compatible",
+                },
+                status: "active",
+                headers: {},
+                options: {},
+                cost: {
+                  input: m.pricing?.input ?? 0,
+                  output: m.pricing?.output ?? 0,
+                  cache: {
+                    read: m.pricing?.cache_read ?? 0,
+                    write: m.pricing?.cache_write ?? 0,
+                  },
+                },
+                limit: {
+                  context: m.context_length ?? 128000,
+                  output: 4096,
+                },
+                capabilities: {
+                  temperature: true,
+                  reasoning: m.capabilities?.["reasoning"] ?? false,
+                  attachment: m.capabilities?.["vision"] ?? false,
+                  toolcall: m.capabilities?.["tool_choice"] ?? true,
+                  input: {
+                    text: true,
+                    audio: false,
+                    image: m.capabilities?.["vision"] ?? false,
+                    video: false,
+                    pdf: false,
+                  },
+                  output: { text: true, audio: false, image: false, video: false, pdf: false },
+                  interleaved: false,
+                },
+                release_date: "",
+                variants: {},
+              }
+            }
+
+            log.info("edenai model discovery complete", {
+              count: Object.keys(models).length,
+              models: Object.keys(models).slice(0, 10),
+            })
+            return models
+          } catch (e) {
+            log.warn("edenai model discovery failed", { error: e })
+            return {}
+          }
+        },
+      }
+    }),
     vercel: () =>
       Effect.succeed({
         autoload: false,
@@ -1296,6 +1405,22 @@ const layer: Layer.Layer<
               }
             } catch (e) {
               log.warn("state discovery error", { id: "gitlab", error: e })
+            }
+          })
+        }
+
+        const edenai = ProviderID.edenai
+        if (discoveryLoaders[edenai] && providers[edenai] && isProviderAllowed(edenai)) {
+          yield* Effect.promise(async () => {
+            try {
+              const discovered = await discoveryLoaders[edenai]()
+              for (const [modelID, model] of Object.entries(discovered)) {
+                if (!providers[edenai].models[modelID]) {
+                  providers[edenai].models[modelID] = model
+                }
+              }
+            } catch (e) {
+              log.warn("state discovery error", { id: "edenai", error: e })
             }
           })
         }

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -22,6 +22,7 @@ export const ProviderID = providerIdSchema.pipe(
     openrouter: schema.make("openrouter"),
     mistral: schema.make("mistral"),
     gitlab: schema.make("gitlab"),
+    edenai: schema.make("edenai"),
   })),
 )
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1672,6 +1672,56 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### Eden AI
+
+[Eden AI](https://app.edenai.run) is a European LLM gateway providing access to 500+ models from
+OpenAI, Anthropic, Google, Mistral, Meta, xAI, and more — through a single API key. All infrastructure
+is hosted in Europe, making it a strong choice for teams with data residency or compliance requirements.
+
+1. Head over to [app.edenai.run](https://app.edenai.run) → **API Keys**, create a key, and copy it.
+
+2. Run the `/connect` command and search for **Eden AI**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Eden AI API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command — Eden AI's available models are fetched automatically from their API.
+
+   ```txt
+   /models
+   ```
+
+Eden AI supports **automatic model fallbacks** via their API. You can configure fallbacks in your opencode config:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "edenai": {
+      "models": {
+        "openai/gpt-4o": {
+          "options": {
+            "fallbacks": "openai/gpt-4o-mini,anthropic/claude-haiku-4-5"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

  Adds Eden AI to the providers documentation. Eden AI is a European LLM aggregator — you get access to 500+ models (OpenAI, Anthropic, Google, Mistral, Meta, xAI…) through a single API key, with infrastructure hosted in Europe.

  The setup follows the exact same pattern as the other OpenAI-compatible gateway providers already documented (@ai-sdk/openai-compatible + baseURL). I also documented the fallback feature, which lets you automatically reroute to a backup model if the primary one is unavailable.

### How did you verify your code works?

  Tested locally with opencode — ran /connect, selected Eden AI, entered the API key, then /models to confirm the models appear. Made a request with edenai/openai/gpt-4o-mini and it responded correctly.

### Screenshots / recordings

 N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
