### PR TITLE
refactor(cli): allow custom config setting for cli network options and improve docs

### DIFF
--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -37,22 +37,26 @@ export function withNetworkOptions<T>(yargs: Argv<T>) {
 }
 
 export async function resolveNetworkOptions(args: NetworkOptions) {
-  const config = await Config.global()
+  const globalConfig = await Config.global()
+  const customConfig = await Config.custom()
+
   const portExplicitlySet = process.argv.includes("--port")
   const hostnameExplicitlySet = process.argv.includes("--hostname")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
   const corsExplicitlySet = process.argv.includes("--cors")
 
-  const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
-  const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
-  const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)
+  const serverConfig = customConfig?.server ?? globalConfig.server // Based on Precidence Order https://opencode.ai/docs/config#precedence-order
+
+  const mdns = mdnsExplicitlySet ? args.mdns : (serverConfig?.mdns ?? args.mdns)
+  const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (serverConfig?.mdnsDomain ?? args["mdns-domain"])
+  const port = portExplicitlySet ? args.port : (serverConfig?.port ?? args.port)
   const hostname = hostnameExplicitlySet
     ? args.hostname
-    : mdns && !config?.server?.hostname
+    : mdns && !serverConfig?.hostname
       ? "0.0.0.0"
-      : (config?.server?.hostname ?? args.hostname)
-  const configCors = config?.server?.cors ?? []
+      : (serverConfig?.hostname ?? args.hostname)
+  const configCors = serverConfig?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1264,6 +1264,19 @@ export namespace Config {
     return result
   })
 
+  export const custom = async () => {
+    let result: Info | undefined = undefined
+
+    if (Flag.OPENCODE_CONFIG) {
+      result = await loadFile(Flag.OPENCODE_CONFIG)
+      log.debug("loaded custom config", { path: Flag.OPENCODE_CONFIG })
+      log.debug("loaded custom config value", { result: result})
+
+    }
+
+    return result
+  }
+
   export const { readFile } = ConfigPaths
 
   async function loadFile(filepath: string): Promise<Info> {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -186,6 +186,8 @@ Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and
 
 You can configure server settings for the `opencode serve` and `opencode web` commands through the `server` option.
 
+Server settings are only read from the [`Global Config`](/docs/config/#global), or from a custom config specified with the [`OPENCODE_CONFIG`](/docs/config/#custom-path) environment variable.
+
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",


### PR DESCRIPTION
### Issue for this PR

Closes #19078

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds support for custom config set by `OPENCODE_CONFIG` var when setting network options for cli commands like `serve` and `web`.

Improves the docs stating the places where config for `serve` and `web` comes from. The global config and the custom config.

### How did you verify your code works?

Tested on my local machine with he dev changes and check the docs frontend as well.

### Screenshots / recordings

<img width="900" height="504" alt="Screenshot 2026-03-25 at 13 15 30" src="https://github.com/user-attachments/assets/b3685112-c673-4aa3-800a-1bdafe7a57f7" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR