### PR TITLE
fix: intercept plugin console output to prevent TUI corruption

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,21 @@ import { makeRunPromise } from "@/effect/run-service"
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
+  // Intercept global console to prevent plugins from corrupting TUI output.
+  // Plugin console.log/warn/error calls are routed through the structured
+  // Log system, respecting the configured logLevel.
+  const pluginConsole = Log.create({ service: "plugin:console" })
+
+  function interceptConsole() {
+    const format = (...args: unknown[]) =>
+      args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")
+    console.log = (...args: unknown[]) => pluginConsole.info(format(...args))
+    console.info = (...args: unknown[]) => pluginConsole.info(format(...args))
+    console.warn = (...args: unknown[]) => pluginConsole.warn(format(...args))
+    console.error = (...args: unknown[]) => pluginConsole.error(format(...args))
+    console.debug = (...args: unknown[]) => pluginConsole.debug(format(...args))
+  }
+
   type State = {
     hooks: Hooks[]
   }
@@ -79,6 +94,9 @@ export namespace Plugin {
               },
               $: Bun.$,
             }
+
+            // Intercept console before loading any plugins to prevent TUI corruption
+            interceptConsole()
 
             for (const plugin of INTERNAL_PLUGINS) {
               log.info("loading internal plugin", { name: plugin.name })


### PR DESCRIPTION
### Issue for this PR

Closes #19108

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins and their npm dependencies call `console.log/warn/error` which writes directly to stdout, corrupting the TUI display. The `logLevel` config only controls OpenCode's own slog-based logging and has zero effect on plugin console output.

This is a problem I hit daily with `@rehydra/opencode` (its dependency `rehydra` calls `console.warn("Validation warnings:", ...)` on every anonymization pass) and custom `.opencode/plugins/` scripts. The TUI becomes unreadable with JSON objects and warning messages mixed into the chat.

The fix adds `interceptConsole()` in `packages/opencode/src/plugin/index.ts` that replaces global `console` methods right before plugins load. All output is routed through `Log.create({ service: "plugin:console" })`, so it respects `logLevel` and goes to the log file instead of stdout.

This works because plugins run in the same Bun process — they share the global `console` object. Intercepting it once catches both plugin code and their transitive dependencies (which is why adding a `log` property to `PluginInput` alone wouldn't solve this — third-party deps will always use `console.*`).

Related to #12931 but distinct: that issue covers uncaught errors in event handlers, this covers normal console output from working plugins.

### How did you verify your code works?

1. Identified the spam sources by reading plugin code (`rehydra/dist/core/anonymizer.js:315` and `.opencode/plugins/memorix.js`)
2. Verified that `console.warn` in plugins goes directly to TUI stdout (confirmed by screenshot evidence)
3. Traced the plugin loading path in `plugin/index.ts` — plugins are loaded via `import()` with no console interception
4. The `Log.create()` API is already used throughout the codebase (e.g. `const log = Log.create({ service: "plugin" })` on the same file's line 17)

### Screenshots / recordings

Before (TUI corrupted by plugin console output):
```
{ cValidation warnings: [tool.execute.after leak(s)",
{ cValidation warnings: "AK", potential PII leak(s)",
{ c[memorix] hook fired: session.idleal PII leak(s)",
  code: "POTENTIAL_PII_LEAK", potential PII leak(s)",
  message: "Leak scan found 2 potential PII leak(s)",
}
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR