### PR TITLE
docs: Add occtl CLI and skill to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -68,6 +68,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [occtl](https://github.com/colinmollenhour/opencode-occtl)                                 | CLI and skill for controlling OpenCode sessions.                 |
 
 ---
 


### PR DESCRIPTION
https://github.com/colinmollenhour/opencode-occtl

occtl simply exposes more of the OpenCode SDK to a command line so agents can easily watch and wait on other sessions, spawn sessions in other projects, etc.

### Issue for this PR

There is no related bug/feature, just adding a tool to the ecosystem page.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `occtl` to the Ecosystem page.

### How did you verify your code works?

Manual and AI testing.

### Screenshots / recordings

None

### Checklist

[x] I have tested my changes locally
[x] I have not included unrelated changes in this PR