### PR TITLE
fix(desktop): open local file paths with file:// scheme

### DIFF
--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process"
 import { BrowserWindow, Notification, app, clipboard, dialog, ipcMain, shell } from "electron"
+import * as path from "node:path"
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron"
 
 import type { InitStep, ServerReadyData, SqliteMigrationProgress, TitlebarTheme, WslConfig } from "../preload/types"
@@ -127,7 +128,16 @@ export function registerIpcHandlers(deps: Deps) {
   )
 
   ipcMain.on("open-link", (_event: IpcMainEvent, url: string) => {
-    void shell.openExternal(url)
+    // Convert local file paths to file:// URLs
+    // If the URL doesn't have a scheme (not http://, https://, file://, etc.),
+    // treat it as a local file path and convert to file://
+    let finalUrl = url
+    if (!url.match(/^[a-zA-Z][a-zA-Z\d+.-]*:/)) {
+      // Resolve relative paths to absolute paths
+      const absolutePath = path.resolve(url)
+      finalUrl = `file://${absolutePath}`
+    }
+    void shell.openExternal(finalUrl)
   })
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {


### PR DESCRIPTION
### Issue for this PR

Closes #19144

### Type of change

- [x] Bug fix

### What does this PR do?

When cmd+clicking on a local file path (e.g., `README.md`, `src/app.ts`) in a chat message, the `open-link` handler now converts bare paths to `file://` URLs with resolved absolute paths before calling `shell.openExternal()`.

**Root cause:** In `packages/desktop-electron/src/main/ipc.ts`, the `open-link` handler passed bare file paths directly to `shell.openExternal()`, which treated them as HTTP URLs and failed with "Unable to connect" error.

**Fix:** Check if the URL has a scheme. If not, treat it as a local file path, resolve to absolute path, and prepend `file://`.

### How did you verify your code works?

- Tested clicking `README.md` in a chat message - opens in default markdown viewer (mkdn)
- Tested clicking `src/app.ts` - opens in default text editor
- Verified `https://` URLs still open in browser
- Verified `file://` URLs still work correctly
- Verified paths are resolved to absolute before opening

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR