### PR TITLE
fix(opencode): current directory highlighting in sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/directory.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/directory.ts
@@ -2,12 +2,23 @@ import { createMemo } from "solid-js"
 import { useSync } from "./sync"
 import { Global } from "@/global"
 
-export function useDirectory() {
+export function useDirectoryDetails() {
   const sync = useSync()
   return createMemo(() => {
     const directory = sync.data.path.directory || process.cwd()
     const result = directory.replace(Global.Path.home, "~")
-    if (sync.data.vcs?.branch) return result + ":" + sync.data.vcs.branch
-    return result
+    const branch = sync.data.vcs?.branch
+    const parts = result.split("/")
+    const lastPart = parts.pop()
+    const parentPath = parts.length === 0 ? "" : `${parts.join("/")}/`
+    return { directory: result, parentPath, name: branch ? lastPart : `${lastPart}:${branch}` }
+  })
+}
+
+export function useDirectory() {
+  const dir = useDirectoryDetails()
+  return createMemo(() => {
+    const { parentPath, name } = dir()
+    return `${parentPath}${name}`
   })
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -8,7 +8,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
 import { Installation } from "@/installation"
 import { useKeybind } from "../../context/keybind"
-import { useDirectory } from "../../context/directory"
+import { useDirectory, useDirectoryDetails } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
@@ -61,6 +61,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   })
 
   const directory = useDirectory()
+  const directoryDetails = useDirectoryDetails()
   const kv = useKV()
 
   const hasProviders = createMemo(() =>
@@ -304,8 +305,8 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
             </box>
           </Show>
           <text>
-            <span style={{ fg: theme.textMuted }}>{directory().split("/").slice(0, -1).join("/")}/</span>
-            <span style={{ fg: theme.text }}>{directory().split("/").at(-1)}</span>
+            <span style={{ fg: theme.textMuted }}>{directoryDetails().parentPath}</span>
+            <span style={{ fg: theme.text }}>{directoryDetails().name}</span>
           </text>
           <text fg={theme.textMuted}>
             <span style={{ fg: theme.success }}>•</span> <b>Open</b>


### PR DESCRIPTION
### Issue for this PR

Closes #17392 

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR extracts the logic from the `useDirectory` hook into a lower level `useDirectoryInfo` hook, which returns an object for further processing. This causes the root folder to be calculated before appending the branch name, so that the current directory is always accurate. This resolves the part after the slash in the branch name as being treated as the directory name.

Additionally, the code conditionally appends a forward slash to the parent path so long as it is not empty, instead of always appending it, which resolves having the cwd as `~` mistakenly show as `/~` in the sidebar.

EDIT: this was also attempted in #17390, but that implementation, on the other hand, breaks if the cwd path were to contain `:`. This approach works both with paths containing `:` as well as branches containing `/`.

### How did you verify your code works?

Ran the development build using `bun run` in various directories and branches, such as `~`, the project location, other folders, without a git branch, with branches containing `/` and without.

### Screenshots

| directory | branch | before | after |
| --- | --- | --- | --- |
| ~/coding/opencode/packages/opencode | fix/slashed-branch-highlighting | <img width="324" height="99" alt="Screenshot 2026-03-25 at 18 12 32" src="https://github.com/user-attachments/assets/744a5fad-d585-476f-a575-aa70a8bac1f8" /> | <img width="320" height="96" alt="Screenshot 2026-03-25 at 18 39 02" src="https://github.com/user-attachments/assets/78c51aef-717e-4715-a0ac-fac1f1dbc5af" /> |
| ~ | `<none>` | <img width="169" height="73" alt="Screenshot 2026-03-25 at 18 42 10" src="https://github.com/user-attachments/assets/5cee4414-6f28-48fc-8947-6ae465aac3d8" /> | <img width="164" height="76" alt="Screenshot 2026-03-25 at 18 41 00" src="https://github.com/user-attachments/assets/e64f2ffd-be6d-4f74-9a43-63f06908ae12" /> |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR