### PR TITLE
file: use Effect.cached for scan deduplication

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -2,7 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRunPromise } from "@/effect/run-service"
 import { Git } from "@/git"
-import { Effect, Fiber, Layer, Scope, ServiceMap } from "effect"
+import { Effect, Layer, ServiceMap } from "effect"
 import { formatPatch, structuredPatch } from "diff"
 import fs from "fs"
 import fuzzysort from "fuzzysort"
@@ -323,7 +323,6 @@ export namespace File {
 
   interface State {
     cache: Entry
-    fiber: Fiber.Fiber<void> | undefined
   }
 
   export interface Interface {
@@ -348,7 +347,6 @@ export namespace File {
         Effect.fn("File.state")(() =>
           Effect.succeed({
             cache: { files: [], dirs: [] } as Entry,
-            fiber: undefined as Fiber.Fiber<void> | undefined,
           }),
         ),
       )
@@ -406,21 +404,15 @@ export namespace File {
         s.cache = next
       })
 
-      const scope = yield* Scope.Scope
+      let cachedScan = yield* Effect.cached(
+        scan().pipe(Effect.catchCause(() => Effect.void)),
+      )
 
       const ensure = Effect.fn("File.ensure")(function* () {
-        const s = yield* InstanceState.get(state)
-        if (!s.fiber)
-          s.fiber = yield* scan().pipe(
-            Effect.catchCause(() => Effect.void),
-            Effect.ensuring(
-              Effect.sync(() => {
-                s.fiber = undefined
-              }),
-            ),
-            Effect.forkIn(scope),
-          )
-        yield* Fiber.join(s.fiber)
+        yield* cachedScan
+        cachedScan = yield* Effect.cached(
+          scan().pipe(Effect.catchCause(() => Effect.void)),
+        )
       })
 
       const init = Effect.fn("File.init")(function* () {


### PR DESCRIPTION
## Summary

- Replace `Fiber.Fiber<void> | undefined` + manual fork/join with `Effect.cached` for deduplicating concurrent `scan()` calls
- Removes `Fiber`, `Scope` imports and `fiber` field from state
- Concurrent `ensure()` callers share the same in-flight fiber instead of racing

## Test plan

- [x] `bun run typecheck` passes
- [x] No test regressions