### PR TITLE
feat: add OfoxAI as a native provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -748,6 +748,17 @@ export namespace Provider {
         },
       }
     },
+    ofoxai: async () => {
+      return {
+        autoload: false,
+        options: {
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
+          },
+        },
+      }
+    },
   }
 
   export const Model = z


### PR DESCRIPTION
### Issue for this PR

N/A - New provider addition

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds OfoxAI as a native provider. OfoxAI is an OpenAI-compatible API gateway (https://ofox.ai) that provides unified access to 73+ AI models from Anthropic, OpenAI, Google, DeepSeek, Qwen, MiniMax, Doubao, GLM, and Kimi through a single API key.

The implementation follows the exact same pattern as the Kilo provider — a `CUSTOM_LOADERS` entry using `@ai-sdk/openai-compatible` (already bundled) with standard attribution headers. No new dependencies are added.

The corresponding model definitions are submitted to models.dev in anomalyco/models.dev#1275.

### How did you verify your code works?

1. Ran the full provider test suite (`bun test test/provider/provider.test.ts`) — all 70 tests pass with no regressions
2. Ran `bun run validate` on models.dev with the OfoxAI provider TOML files — all validated successfully
3. Verified the OfoxAI `/v1/models` endpoint returns correct model data and `/v1/chat/completions` responds with proper error format (401 without key, confirming API connectivity)

### Screenshots / recordings

N/A - No UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR