### PR TITLE
fix: ensure enterprise url is set properly during auth flow

### DIFF
--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -215,12 +215,13 @@ export namespace ProviderAuth {
         }
 
         if ("refresh" in result) {
+          const { type: _, provider: __, refresh, access, expires, ...extra } = result
           yield* auth.set(input.providerID, {
             type: "oauth",
-            access: result.access,
-            refresh: result.refresh,
-            expires: result.expires,
-            ...(result.accountId ? { accountId: result.accountId } : {}),
+            access,
+            refresh,
+            expires,
+            ...extra,
           })
         }
       })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -129,6 +129,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
+                enterpriseUrl?: string
               }
             | { key: string }
           ))
@@ -149,6 +150,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
+                enterpriseUrl?: string
               }
             | { key: string }
           ))


### PR DESCRIPTION
Closes #13740

## caveat

This solution is kinda ugly we should have a generic key to go off of instead of these hardcoded ones

