### PR TITLE
fix(github): guard against null headRepository on fork PRs

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -72,7 +72,7 @@ type GitHubPullRequest = {
   }
   headRepository: {
     nameWithOwner: string
-  }
+  } | null
   commits: {
     totalCount: number
     nodes: Array<{
@@ -163,8 +163,8 @@ try {
   // 3. Fork PR
   if (isPullRequest()) {
     const prData = await fetchPR()
-    // Local PR
-    if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner) {
+    // Local PR (headRepository is null when the fork has been deleted)
+    if (prData.headRepository?.nameWithOwner === prData.baseRepository.nameWithOwner) {
       await checkoutLocalBranch(prData)
       const dataPrompt = buildPromptDataForPR(prData)
       const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
@@ -699,6 +699,9 @@ async function checkoutForkBranch(pr: GitHubPullRequest) {
   const localBranch = generateBranchName("pr")
   const depth = Math.max(pr.commits.totalCount, 20)
 
+  if (!pr.headRepository?.nameWithOwner) {
+    throw new Error("Cannot checkout fork branch: headRepository is not available (the fork may have been deleted)")
+  }
   await $`git remote add fork https://github.com/${pr.headRepository.nameWithOwner}.git`
   await $`git fetch fork --depth=${depth} ${remoteBranch}`
   await $`git checkout -b ${localBranch} fork/${remoteBranch}`

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -94,7 +94,7 @@ type GitHubPullRequest = {
   }
   headRepository: {
     nameWithOwner: string
-  }
+  } | null
   commits: {
     totalCount: number
     nodes: Array<{
@@ -606,8 +606,8 @@ export const GithubRunCommand = cmd({
           issueEvent?.issue.pull_request
         ) {
           const prData = await fetchPR()
-          // Local PR
-          if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner) {
+          // Local PR (headRepository is null when the fork has been deleted)
+          if (prData.headRepository?.nameWithOwner === prData.baseRepository.nameWithOwner) {
             await checkoutLocalBranch(prData)
             const head = await gitText(["rev-parse", "HEAD"])
             const dataPrompt = buildPromptDataForPR(prData)
@@ -1114,6 +1114,9 @@ export const GithubRunCommand = cmd({
         const localBranch = generateBranchName("pr")
         const depth = Math.max(pr.commits.totalCount, 20)
 
+        if (!pr.headRepository?.nameWithOwner) {
+          throw new Error("Cannot checkout fork branch: headRepository is not available (the fork may have been deleted)")
+        }
         await gitRun(["remote", "add", "fork", `https://github.com/${pr.headRepository.nameWithOwner}.git`])
         await gitRun(["fetch", "fork", `--depth=${depth}`, remoteBranch])
         await gitRun(["checkout", "-b", localBranch, `fork/${remoteBranch}`])


### PR DESCRIPTION
### Issue for this PR

Closes #19019

### Type of change

- [x] Bug fix

### What does this PR do?

When a PR comes from a fork (especially one that has been deleted), the GitHub GraphQL API can return `null` for `headRepository`. Both the standalone GitHub Action (`github/index.ts`) and the CLI github command (`packages/opencode/src/cli/cmd/github.ts`) accessed `headRepository.nameWithOwner` without a null check, causing a crash:

```
null is not an object (evaluating 'prData.headRepository.nameWithOwner')
```

This PR:

1. Updates the `GitHubPullRequest` type to mark `headRepository` as nullable (`| null`)
2. Adds optional chaining (`?.`) on the local-vs-fork comparison so deleted-fork PRs fall through to the fork branch
3. Adds an explicit guard with a clear error message in `checkoutForkBranch()` when `headRepository` is missing

The fix is applied consistently in both files (`github/index.ts` and `github.ts`).

### How did you verify your code works?

- Typecheck passes (all packages) — the `| null` type change correctly propagates through TypeScript
- The existing null-guard pattern in `packages/opencode/src/cli/cmd/pr.ts:64` (`prInfo.headRepository &&`) was used as reference
- The reporter provided a failing GitHub Actions run link confirming the crash

### Screenshots / recordings

N/A — null guard change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR