### PR TITLE
fix(plugin): restore automatic plan/build mode switching

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -51,6 +51,12 @@ const DEFAULT_VARIANT_VALUE = "default"
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
 
+  function modeFromTool(tool: string) {
+    if (tool === "plan_enter") return "plan"
+    if (tool === "plan_exit") return "build"
+    return
+  }
+
   async function getContextLimit(
     sdk: OpencodeClient,
     providerID: string,
@@ -326,6 +332,11 @@ export namespace ACP {
                 return
 
               case "completed": {
+                const mode = modeFromTool(part.tool)
+                if (mode) {
+                  this.sessionManager.setMode(sessionId, mode)
+                }
+
                 const kind = toToolKind(part.tool)
                 const content: ToolCallContent[] = [
                   {
@@ -838,6 +849,11 @@ export namespace ACP {
                 })
               break
             case "completed":
+              const mode = modeFromTool(part.tool)
+              if (mode) {
+                this.sessionManager.setMode(sessionId, mode)
+              }
+
               const kind = toToolKind(part.tool)
               const content: ToolCallContent[] = [
                 {

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -104,10 +104,29 @@ export namespace Agent {
             edit: {
               "*": "deny",
               [path.join(".opencode", "plans", "*.md")]: "allow",
+              [path.join(".opencode", "plans", "*.json")]: "allow",
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+              [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.json")))]: "allow",
             },
           }),
           user,
+        ),
+        mode: "primary",
+        native: true,
+      },
+      ask: {
+        name: "ask",
+        description: "Conversation mode. No tool calls are allowed.",
+        options: {},
+        permission: PermissionNext.merge(
+          defaults,
+          PermissionNext.fromConfig({
+            "*": "deny",
+            external_directory: {
+              "*": "deny",
+              [Truncate.GLOB]: "allow",
+            },
+          }),
         ),
         mode: "primary",
         native: true,

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -3,6 +3,12 @@ function truthy(key: string) {
   return value === "true" || value === "1"
 }
 
+function oneOf<T extends string>(key: string, list: readonly T[], fallback: T) {
+  const value = process.env[key]?.toLowerCase() as T | undefined
+  if (!value) return fallback
+  return list.includes(value) ? value : fallback
+}
+
 export namespace Flag {
   export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
@@ -50,6 +56,7 @@ export namespace Flag {
   export const OPENCODE_EXPERIMENTAL_LSP_TOOL = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_LSP_TOOL")
   export const OPENCODE_DISABLE_FILETIME_CHECK = truthy("OPENCODE_DISABLE_FILETIME_CHECK")
   export const OPENCODE_EXPERIMENTAL_PLAN_MODE = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_PLAN_MODE")
+  export const OPENCODE_PLAN_STYLE = oneOf("OPENCODE_PLAN_STYLE", ["legacy", "interrogative"], "interrogative")
   export const OPENCODE_EXPERIMENTAL_MARKDOWN = truthy("OPENCODE_EXPERIMENTAL_MARKDOWN")
   export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"]
   export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"]

--- a/packages/opencode/src/session/plan-guard.ts
+++ b/packages/opencode/src/session/plan-guard.ts
@@ -1,0 +1,43 @@
+function lines(text: string) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function hasHeading(text: string, test: RegExp) {
+  return lines(text).some((line) => /^#{1,6}\s+/.test(line) && test.test(line.toLowerCase()))
+}
+
+export function hasConfirmation(text: string) {
+  return hasHeading(text, /confirmed understanding|my understanding|confirmation|理解确认|确认/)
+}
+
+export function missingFields(text: string) {
+  const result = [] as string[]
+  const list = lines(text)
+  const titled = list.some((line) => line.startsWith("# "))
+  if (!titled && !hasHeading(text, /objective|goal|目标/)) result.push("objective")
+  if (!hasHeading(text, /scope|范围|in[\s-]?scope/)) result.push("scope")
+  if (!hasHeading(text, /constraints|限制|约束/)) result.push("constraints")
+  if (!hasHeading(text, /acceptance|success criteria|验收/)) result.push("acceptance_criteria")
+  if (!hasHeading(text, /steps|implementation|执行步骤/)) result.push("steps")
+  return result
+}
+
+export function nextQuestionCount(input: { missing: number; hasPlan: boolean }) {
+  if (!input.hasPlan) return 2
+  if (input.missing >= 3) return 3
+  if (input.missing >= 2) return 2
+  return 1
+}
+
+export function canFinalize(text: string) {
+  const missing = missingFields(text)
+  const confirmed = hasConfirmation(text)
+  return {
+    ok: missing.length === 0 && confirmed,
+    missing,
+    confirmed,
+  }
+}

--- a/packages/opencode/src/session/plan-persist.ts
+++ b/packages/opencode/src/session/plan-persist.ts
@@ -1,0 +1,119 @@
+import fs from "fs/promises"
+import path from "path"
+import { Flag } from "@/flag/flag"
+import { PlanArtifact, type PlanArtifactInfo } from "./plan-schema"
+import { hasConfirmation } from "./plan-guard"
+
+function lines(text: string) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function pickSection(list: string[], match: RegExp) {
+  const start = list.findIndex((line) => /^#{1,6}\s+/.test(line) && match.test(line.toLowerCase()))
+  if (start < 0) return [] as string[]
+  const out = [] as string[]
+  for (let idx = start + 1; idx < list.length; idx++) {
+    const line = list[idx]
+    if (/^#{1,6}\s+/.test(line)) break
+    if (/^(-|\*|\d+\.)\s+/.test(line)) {
+      out.push(line.replace(/^(-|\*|\d+\.)\s+/, ""))
+      continue
+    }
+    if (out.length === 0 && line) out.push(line)
+  }
+  return out
+}
+
+function score(item: Omit<PlanArtifactInfo, "metadata">) {
+  const checks = [
+    item.objective.length > 0,
+    item.in_scope.length > 0,
+    item.constraints.length > 0,
+    item.acceptance_criteria.length > 0,
+    item.steps.length > 0,
+  ]
+  const total = checks.filter(Boolean).length
+  return Number((total / checks.length).toFixed(2))
+}
+
+function fromMarkdown(md: string) {
+  const list = lines(md)
+  const objective =
+    list.find((line) => line.startsWith("# "))?.replace(/^#\s+/, "") ??
+    list.find((line) => !line.startsWith("#")) ??
+    "Implementation plan"
+
+  const inScope = pickSection(list, /in[\s-]?scope|scope/)
+  const outScope = pickSection(list, /out[\s-]?of[\s-]?scope|non[\s-]?goals/)
+  const constraints = pickSection(list, /constraints|limits/)
+  const assumptions = pickSection(list, /assumptions?/)
+  const acceptance = pickSection(list, /acceptance|success|validation/)
+  const risksRaw = pickSection(list, /risks?/)
+  const stepRaw = pickSection(list, /steps?|implementation|rollout|execution|phases?/)
+
+  const steps = (stepRaw.length ? stepRaw : list.filter((line) => /^\d+\.\s+/.test(line))).map((item, idx) => ({
+    id: `step-${idx + 1}`,
+    title: item.replace(/^\d+\.\s+/, ""),
+    dependencies: [] as string[],
+  }))
+
+  const risks = risksRaw.map((risk) => ({
+    risk,
+    mitigation: "TBD",
+  }))
+
+  return {
+    objective,
+    in_scope: inScope,
+    out_of_scope: outScope,
+    constraints,
+    assumptions,
+    acceptance_criteria: acceptance,
+    steps,
+    risks,
+  }
+}
+
+export function planJsonPath(markdownPath: string) {
+  if (markdownPath.endsWith(".md")) return markdownPath.slice(0, -3) + ".json"
+  return markdownPath + ".json"
+}
+
+export async function persistPlanArtifacts(input: {
+  sessionID: string
+  planPath: string
+  agent: string
+  questionRounds?: number
+}) {
+  const exists = await Bun.file(input.planPath).exists()
+  const markdown = exists ? await Bun.file(input.planPath).text() : ""
+  const parsed = fromMarkdown(markdown)
+  const jsonPath = planJsonPath(input.planPath)
+  const dir = path.dirname(jsonPath)
+  await fs.mkdir(dir, { recursive: true })
+
+  const artifact = PlanArtifact.parse({
+    ...parsed,
+    metadata: {
+      session_id: input.sessionID,
+      agent: input.agent,
+      created_at: Date.now(),
+      style: Flag.OPENCODE_PLAN_STYLE,
+      interaction_style: Flag.OPENCODE_PLAN_STYLE === "interrogative" ? "codex-like" : "legacy",
+      confirmed: hasConfirmation(markdown),
+      question_rounds: input.questionRounds ?? 0,
+      completeness_score: score(parsed),
+      markdown_path: input.planPath,
+      json_path: jsonPath,
+    },
+  })
+
+  await Bun.write(jsonPath, JSON.stringify(artifact, null, 2) + "\n")
+  return {
+    artifact,
+    jsonPath,
+  }
+}

--- a/packages/opencode/src/session/plan-schema.ts
+++ b/packages/opencode/src/session/plan-schema.ts
@@ -1,0 +1,39 @@
+import z from "zod"
+
+export const PlanStep = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  dependencies: z.array(z.string()),
+  verification: z.string().optional(),
+})
+
+export const PlanRisk = z.object({
+  risk: z.string(),
+  mitigation: z.string(),
+})
+
+export const PlanArtifact = z.object({
+  objective: z.string(),
+  in_scope: z.array(z.string()),
+  out_of_scope: z.array(z.string()),
+  constraints: z.array(z.string()),
+  assumptions: z.array(z.string()),
+  acceptance_criteria: z.array(z.string()),
+  steps: z.array(PlanStep),
+  risks: z.array(PlanRisk),
+  metadata: z.object({
+    session_id: z.string(),
+    agent: z.string(),
+    created_at: z.number(),
+    style: z.enum(["legacy", "interrogative"]),
+    interaction_style: z.enum(["codex-like", "legacy"]),
+    confirmed: z.boolean(),
+    question_rounds: z.number().int().min(0),
+    completeness_score: z.number().min(0).max(1),
+    markdown_path: z.string(),
+    json_path: z.string(),
+  }),
+})
+
+export type PlanArtifactInfo = z.infer<typeof PlanArtifact>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -45,6 +45,7 @@ import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
+import { missingFields, nextQuestionCount } from "./plan-guard"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1326,8 +1327,23 @@ export namespace SessionPrompt {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
     if (!userMessage) return input.messages
 
-    // Original logic when experimental plan mode is disabled
-    if (!Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE) {
+    if (input.agent.name === "ask") {
+      userMessage.parts.push({
+        id: Identifier.ascending("part"),
+        messageID: userMessage.info.id,
+        sessionID: userMessage.info.sessionID,
+        type: "text",
+        text: `<system-reminder>
+Ask mode is active.
+You are in conversation-only mode. Do not call tools, do not read files, do not run commands, and do not propose or perform implementation steps.
+Respond with direct conversational guidance only.
+</system-reminder>`,
+        synthetic: true,
+      })
+      return input.messages
+    }
+
+    if (Flag.OPENCODE_PLAN_STYLE === "legacy") {
       if (input.agent.name === "plan") {
         userMessage.parts.push({
           id: Identifier.ascending("part"),
@@ -1352,10 +1368,8 @@ export namespace SessionPrompt {
       return input.messages
     }
 
-    // New plan mode logic when flag is enabled
     const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
 
-    // Switching from plan mode to build mode
     if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
       const plan = Session.plan(input.session)
       const exists = await Bun.file(plan).exists()
@@ -1374,85 +1388,80 @@ export namespace SessionPrompt {
       return input.messages
     }
 
-    // Entering plan mode
     if (input.agent.name === "plan" && assistantMessage?.info.agent !== "plan") {
       const plan = Session.plan(input.session)
       const exists = await Bun.file(plan).exists()
       if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })
+      const markdown = exists ? await Bun.file(plan).text() : ""
+      const missing = missingFields(markdown).length
+      const questions = nextQuestionCount({ missing, hasPlan: exists })
       const part = await Session.updatePart({
         id: Identifier.ascending("part"),
         messageID: userMessage.info.id,
         sessionID: userMessage.info.sessionID,
         type: "text",
         text: `<system-reminder>
-Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+Plan mode is active. You are in planning-only mode and must not execute implementation work.
+You must run a codex-like conversation: clarify, confirm understanding, then finalize.
+Do not make edits outside plan artifacts.
 
 ## Plan File Info:
-${exists ? `A plan file already exists at ${plan}. You can read it and make incremental edits using the edit tool.` : `No plan file exists yet. You should create your plan at ${plan} using the write tool.`}
-You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
+${exists ? `A plan file already exists at ${plan}. You can read and update it.` : `No plan file exists yet. You should create it at ${plan}.`}
+You must produce two artifacts with the same file stem:
+1) Markdown plan at ${plan}
+2) JSON plan at ${plan.replace(/\.md$/, ".json")}
 
-## Plan Workflow
+## Required workflow (interrogative plan mode)
 
-### Phase 1: Initial Understanding
-Goal: Gain a comprehensive understanding of the user's request by reading through code and asking them questions. Critical: In this phase you should only use the explore subagent type.
+### Phase 1: Clarify intent
+Ask ${questions} high-impact question${questions > 1 ? "s" : ""} for this round.
+Prioritize missing details that affect implementation:
+- objective
+- in scope / out of scope
+- constraints
+- acceptance criteria
+IMPORTANT: You MUST ask these via the question tool so the client renders interactive cards.
+Do NOT ask clarification questions as plain assistant text.
 
-1. Focus on understanding the user's request and the code associated with their request
+### Phase 2: Evaluate completeness
+Stop asking questions when all required fields are known or when the user asks to proceed with assumptions.
+If assumptions are needed, record them explicitly.
 
-2. **Launch up to 3 explore agents IN PARALLEL** (single message, multiple tool calls) to efficiently explore the codebase.
-   - Use 1 agent when the task is isolated to known files, the user provided specific file paths, or you're making a small targeted change.
-   - Use multiple agents when: the scope is uncertain, multiple areas of the codebase are involved, or you need to understand existing patterns before planning.
-   - Quality over quantity - 3 agents maximum, but you should try to use the minimum number of agents necessary (usually just 1)
-   - If using multiple agents: Provide each agent with a specific search focus or area to explore. Example: One agent searches for existing implementations, another explores related components, a third investigates testing patterns
+### Phase 3: Confirm understanding (required)
+Before finalizing, add a section titled "## Confirmed Understanding" to the markdown plan.
+In chat, summarize your understanding and ask for explicit confirmation using the question tool.
+Only continue when the user confirms or explicitly asks you to proceed with assumptions.
+IMPORTANT: confirmation must use the question tool (card UI), not plain-text yes/no.
 
-3. After exploring the code, use the question tool to clarify ambiguities in the user request up front.
+### Phase 4: Produce final plan
+Write a complete, execution-ready plan to the Markdown file with:
+- summary
+- key changes
+- ordered steps
+- risks and mitigations
+- verification plan
 
-### Phase 2: Design
-Goal: Design an implementation approach.
+### Phase 5: Produce JSON artifact
+Write a JSON plan artifact to ${plan.replace(/\.md$/, ".json")} with fields:
+- objective
+- in_scope
+- out_of_scope
+- constraints
+- assumptions
+- acceptance_criteria
+- steps
+- risks
+- metadata (style=interrogative)
 
-Launch general agent(s) to design the implementation based on the user's intent and your exploration results from Phase 1.
+### Phase 6: Exit plan mode
+When both artifacts are complete, call plan_exit exactly once.
+plan_exit will automatically switch the session to the build agent.
 
-You can launch up to 1 agent(s) in parallel.
-
-**Guidelines:**
-- **Default**: Launch at least 1 Plan agent for most tasks - it helps validate your understanding and consider alternatives
-- **Skip agents**: Only for truly trivial tasks (typo fixes, single-line changes, simple renames)
-
-Examples of when to use multiple agents:
-- The task touches multiple parts of the codebase
-- It's a large refactor or architectural change
-- There are many edge cases to consider
-- You'd benefit from exploring different approaches
-
-Example perspectives by task type:
-- New feature: simplicity vs performance vs maintainability
-- Bug fix: root cause vs workaround vs prevention
-- Refactoring: minimal change vs clean architecture
-
-In the agent prompt:
-- Provide comprehensive background context from Phase 1 exploration including filenames and code path traces
-- Describe requirements and constraints
-- Request a detailed implementation plan
-
-### Phase 3: Review
-Goal: Review the plan(s) from Phase 2 and ensure alignment with the user's intentions.
-1. Read the critical files identified by agents to deepen your understanding
-2. Ensure that the plans align with the user's original request
-3. Use question tool to clarify any remaining questions with the user
-
-### Phase 4: Final Plan
-Goal: Write your final plan to the plan file (the only file you can edit).
-- Include only your recommended approach, not all alternatives
-- Ensure that the plan file is concise enough to scan quickly, but detailed enough to execute effectively
-- Include the paths of critical files to be modified
-- Include a verification section describing how to test the changes end-to-end (run the code, use MCP tools, run tests)
-
-### Phase 5: Call plan_exit tool
-At the very end of your turn, once you have asked the user questions and are happy with your final plan file - you should always call plan_exit to indicate to the user that you are done planning.
-This is critical - your turn should only end with either asking the user a question or calling plan_exit. Do not stop unless it's for these 2 reasons.
-
-**Important:** Use question tool to clarify requirements/approach, use plan_exit to request plan approval. Do NOT use question tool to ask "Is this plan okay?" - that's what plan_exit does.
-
-NOTE: At any point in time through this workflow you should feel free to ask the user questions or clarifications. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.
+## Question tool formatting rules (required)
+- Use 1-${questions} questions per round.
+- For each question, include 2-3 options with concise labels and one-line descriptions.
+- Set custom=true so the user can type their own answer.
+- Keep headers short and specific.
 </system-reminder>`,
         synthetic: true,
       })

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -7,6 +7,8 @@ import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Provider } from "../provider/provider"
 import { Instance } from "../project/instance"
+import { persistPlanArtifacts } from "../session/plan-persist"
+import { canFinalize } from "../session/plan-guard"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 import ENTER_DESCRIPTION from "./plan-enter.txt"
 
@@ -17,30 +19,38 @@ async function getLastModel(sessionID: string) {
   return Provider.defaultModel()
 }
 
+async function questionRounds(sessionID: string) {
+  let total = 0
+  for await (const item of MessageV2.stream(sessionID)) {
+    if (item.info.role !== "assistant") continue
+    if (item.info.agent !== "plan") continue
+    const has = item.parts.some((part) => part.type === "tool" && part.tool === "question")
+    if (has) total += 1
+  }
+  return total
+}
+
 export const PlanExitTool = Tool.define("plan_exit", {
   description: EXIT_DESCRIPTION,
   parameters: z.object({}),
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
-    const plan = path.relative(Instance.worktree, Session.plan(session))
-    const answers = await Question.ask({
+    const absolute = Session.plan(session)
+    const relative = path.relative(Instance.worktree, absolute)
+    const markdown = await Bun.file(absolute).text()
+    const guard = canFinalize(markdown)
+    if (!guard.ok) {
+      const list = guard.missing.length ? ` Missing sections: ${guard.missing.join(", ")}.` : ""
+      const confirm = guard.confirmed ? "" : " Add a 'Confirmed Understanding' section before finalizing."
+      throw new Error("Plan is not ready for finalize." + list + confirm)
+    }
+    const rounds = await questionRounds(ctx.sessionID)
+    const { artifact, jsonPath } = await persistPlanArtifacts({
       sessionID: ctx.sessionID,
-      questions: [
-        {
-          question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
-          header: "Build Agent",
-          custom: false,
-          options: [
-            { label: "Yes", description: "Switch to build agent and start implementing the plan" },
-            { label: "No", description: "Stay with plan agent to continue refining the plan" },
-          ],
-        },
-      ],
-      tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+      planPath: absolute,
+      agent: "plan",
+      questionRounds: rounds,
     })
-
-    const answer = answers[0]?.[0]
-    if (answer === "No") throw new Question.RejectedError()
 
     const model = await getLastModel(ctx.sessionID)
 
@@ -60,14 +70,21 @@ export const PlanExitTool = Tool.define("plan_exit", {
       messageID: userMsg.id,
       sessionID: ctx.sessionID,
       type: "text",
-      text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
+      text: [
+        `The plan artifacts are ready at ${relative} and ${path.relative(Instance.worktree, jsonPath)}.`,
+        `Plan completeness score: ${artifact.metadata.completeness_score}.`,
+        "Switch to build mode and execute the approved plan.",
+      ].join("\n"),
       synthetic: true,
     } satisfies MessageV2.TextPart)
 
     return {
       title: "Switching to build agent",
-      output: "User approved switching to build agent. Wait for further instructions.",
-      metadata: {},
+      output: "Plan finalized and build agent selected automatically.",
+      metadata: {
+        planPath: relative,
+        jsonPath: path.relative(Instance.worktree, jsonPath),
+      },
     }
   },
 })

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -114,7 +114,7 @@ export namespace ToolRegistry {
       ApplyPatchTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
-      ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),
+      ...(["cli", "desktop", "app"].includes(Flag.OPENCODE_CLIENT) ? [PlanExitTool, PlanEnterTool] : []),
       ...custom,
     ]
   }

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -435,4 +435,47 @@ describe("acp.agent event subscription", () => {
       },
     })
   })
+
+  test("plan tool completion updates ACP session mode", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+        ;(agent as any).sessionManager.setMode(sessionId, "plan")
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              sessionID: sessionId,
+              messageID: "msg_plan_exit",
+              part: {
+                callID: "call_plan_exit",
+                tool: "plan_exit",
+                type: "tool",
+                state: {
+                  status: "completed",
+                  title: "Switching to build agent",
+                  input: {},
+                  output: "ok",
+                  metadata: {},
+                },
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect((agent as any).sessionManager.get(sessionId).modeId).toBe("build")
+
+        stop()
+      },
+    })
+  })
 })

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -19,12 +19,30 @@ test("returns default native agents when no config", async () => {
       const agents = await Agent.list()
       const names = agents.map((a) => a.name)
       expect(names).toContain("build")
+      expect(names).toContain("ask")
       expect(names).toContain("plan")
       expect(names).toContain("general")
       expect(names).toContain("explore")
       expect(names).toContain("compaction")
       expect(names).toContain("title")
       expect(names).toContain("summary")
+    },
+  })
+})
+
+test("ask agent denies all tool permissions", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const ask = await Agent.get("ask")
+      expect(ask).toBeDefined()
+      expect(ask?.mode).toBe("primary")
+      expect(evalPerm(ask, "bash")).toBe("deny")
+      expect(evalPerm(ask, "read")).toBe("deny")
+      expect(evalPerm(ask, "edit")).toBe("deny")
+      expect(evalPerm(ask, "question")).toBe("deny")
+      expect(evalPerm(ask, "plan_exit")).toBe("deny")
     },
   })
 })
@@ -54,7 +72,9 @@ test("plan agent denies edits except .opencode/plans/*", async () => {
       // Wildcard is denied
       expect(evalPerm(plan, "edit")).toBe("deny")
       // But specific path is allowed
-      expect(PermissionNext.evaluate("edit", ".opencode/plans/foo.md", plan!.permission).action).toBe("allow")
+      expect(PermissionNext.evaluate("edit", path.join(".opencode", "plans", "foo.md"), plan!.permission).action).toBe(
+        "allow",
+      )
     },
   })
 })
@@ -661,6 +681,7 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
     config: {
       agent: {
         build: { disable: true },
+        ask: { disable: true },
         plan: { disable: true },
       },
     },

--- a/packages/opencode/test/session/plan-guard.test.ts
+++ b/packages/opencode/test/session/plan-guard.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { canFinalize, missingFields, nextQuestionCount } from "../../src/session/plan-guard"
+
+describe("session.plan-guard", () => {
+  test("returns missing fields for incomplete plan markdown", () => {
+    const markdown = ["# Plan", "", "## Steps", "1. Do work"].join("\n")
+    const missing = missingFields(markdown)
+    expect(missing).toContain("constraints")
+    expect(missing).toContain("acceptance_criteria")
+  })
+
+  test("requires confirmed understanding before finalize", () => {
+    const markdown = [
+      "# Plan",
+      "",
+      "## Scope",
+      "- API only",
+      "",
+      "## Constraints",
+      "- No breaking changes",
+      "",
+      "## Steps",
+      "1. Add route",
+      "",
+      "## Acceptance",
+      "- tests pass",
+    ].join("\n")
+    const guard = canFinalize(markdown)
+    expect(guard.confirmed).toBe(false)
+    expect(guard.ok).toBe(false)
+  })
+
+  test("passes finalize when required sections and confirmation exist", () => {
+    const markdown = [
+      "# Plan",
+      "",
+      "## Scope",
+      "- API only",
+      "",
+      "## Constraints",
+      "- No breaking changes",
+      "",
+      "## Steps",
+      "1. Add route",
+      "",
+      "## Acceptance",
+      "- tests pass",
+      "",
+      "## Confirmed Understanding",
+      "- User approved",
+    ].join("\n")
+    const guard = canFinalize(markdown)
+    expect(guard.missing).toHaveLength(0)
+    expect(guard.confirmed).toBe(true)
+    expect(guard.ok).toBe(true)
+  })
+
+  test("adapts question count based on missing fields", () => {
+    expect(nextQuestionCount({ missing: 4, hasPlan: true })).toBe(3)
+    expect(nextQuestionCount({ missing: 2, hasPlan: true })).toBe(2)
+    expect(nextQuestionCount({ missing: 1, hasPlan: true })).toBe(1)
+    expect(nextQuestionCount({ missing: 0, hasPlan: false })).toBe(2)
+  })
+})

--- a/packages/opencode/test/tool/plan.test.ts
+++ b/packages/opencode/test/tool/plan.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { PlanExitTool } from "../../src/tool/plan"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Provider } from "../../src/provider/provider"
+import { Question } from "../../src/question"
+
+const ctx = {
+  sessionID: "session_test",
+  messageID: "message_test",
+  callID: "call_test",
+  agent: "plan",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("tool.plan", () => {
+  const all = [] as { mockRestore: () => void }[]
+
+  beforeEach(() => {
+    all.length = 0
+  })
+
+  afterEach(() => {
+    for (const item of all) item.mockRestore()
+  })
+
+  test("plan_exit auto-switches to build and writes json artifact", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const file = path.join(dir, ".opencode", "plans", "123-demo.md")
+        await fs.mkdir(path.dirname(file), { recursive: true })
+        await Bun.write(
+          file,
+          [
+            "# Improve API plan",
+            "",
+            "## Scope",
+            "- API routes only",
+            "",
+            "## Constraints",
+            "- Keep backward compatibility",
+            "",
+            "## Steps",
+            "1. Add route",
+            "2. Add tests",
+            "",
+            "## Acceptance",
+            "- tests pass",
+            "",
+            "## Confirmed Understanding",
+            "- User approved the summarized intent",
+          ].join("\n"),
+        )
+        return file
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const file = tmp.extra as string
+        all.push(spyOn(Session, "get").mockResolvedValue({} as any))
+        all.push(spyOn(Session, "plan").mockReturnValue(file))
+        all.push(spyOn(Provider, "defaultModel").mockResolvedValue({ providerID: "openai", modelID: "gpt-5" } as any))
+        all.push(spyOn(MessageV2, "stream").mockReturnValue((async function* () {})() as any))
+
+        const updateMessage = spyOn(Session, "updateMessage").mockResolvedValue(undefined as any)
+        const updatePart = spyOn(Session, "updatePart").mockResolvedValue(undefined as any)
+        const ask = spyOn(Question, "ask").mockResolvedValue([])
+        all.push(updateMessage)
+        all.push(updatePart)
+        all.push(ask)
+
+        const tool = await PlanExitTool.init()
+        const result = await tool.execute({}, ctx)
+
+        expect(ask).not.toHaveBeenCalled()
+        expect(result.output).toContain("automatically")
+        expect(updateMessage).toHaveBeenCalled()
+        expect(updatePart).toHaveBeenCalled()
+        expect((updateMessage.mock.calls[0]?.[0] as any)?.agent).toBe("build")
+
+        const jsonPath = file.replace(/\.md$/, ".json")
+        const saved = await Bun.file(jsonPath).json()
+        expect(saved.objective).toBe("Improve API plan")
+        expect(saved.steps.length).toBeGreaterThan(0)
+        expect(saved.metadata.style).toBe("interrogative")
+        expect(saved.metadata.interaction_style).toBe("codex-like")
+        expect(saved.metadata.confirmed).toBe(true)
+      },
+    })
+  })
+
+  test("plan_exit rejects when confirmation section is missing", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const file = path.join(dir, ".opencode", "plans", "456-demo.md")
+        await fs.mkdir(path.dirname(file), { recursive: true })
+        await Bun.write(
+          file,
+          [
+            "# Improve API plan",
+            "",
+            "## Scope",
+            "- API routes only",
+            "",
+            "## Constraints",
+            "- Keep backward compatibility",
+            "",
+            "## Steps",
+            "1. Add route",
+            "",
+            "## Acceptance",
+            "- tests pass",
+          ].join("\n"),
+        )
+        return file
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const file = tmp.extra as string
+        all.push(spyOn(Session, "get").mockResolvedValue({} as any))
+        all.push(spyOn(Session, "plan").mockReturnValue(file))
+        all.push(spyOn(Provider, "defaultModel").mockResolvedValue({ providerID: "openai", modelID: "gpt-5" } as any))
+        all.push(spyOn(MessageV2, "stream").mockReturnValue((async function* () {})() as any))
+        all.push(spyOn(Session, "updateMessage").mockResolvedValue(undefined as any))
+        all.push(spyOn(Session, "updatePart").mockResolvedValue(undefined as any))
+        all.push(spyOn(Question, "ask").mockResolvedValue([]))
+
+        const tool = await PlanExitTool.init()
+        await expect(tool.execute({}, ctx)).rejects.toThrow("Plan is not ready for finalize.")
+      },
+    })
+  })
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -119,4 +119,42 @@ describe("tool.registry", () => {
       },
     })
   })
+
+  test("includes plan tools for desktop client", async () => {
+    await using tmp = await tmpdir()
+    const old = process.env.OPENCODE_CLIENT
+    process.env.OPENCODE_CLIENT = "desktop"
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).toContain("plan_enter")
+          expect(ids).toContain("plan_exit")
+        },
+      })
+    } finally {
+      if (old === undefined) delete process.env.OPENCODE_CLIENT
+      else process.env.OPENCODE_CLIENT = old
+    }
+  })
+
+  test("does not include plan tools for acp client", async () => {
+    await using tmp = await tmpdir()
+    const old = process.env.OPENCODE_CLIENT
+    process.env.OPENCODE_CLIENT = "acp"
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).not.toContain("plan_enter")
+          expect(ids).not.toContain("plan_exit")
+        },
+      })
+    } finally {
+      if (old === undefined) delete process.env.OPENCODE_CLIENT
+      else process.env.OPENCODE_CLIENT = old
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- fix ACP session mode synchronization so `plan_enter` and `plan_exit` tool completions immediately update session mode to `plan`/`build`
- keep mode state consistent for both live event handling and replayed assistant tool messages to prevent stale plan mode in plugin clients
- add regression coverage for ACP mode switching and interrogative plan flow artifacts/guards