### PR TITLE
fix(app): guard diffs with Array.isArray to prevent .map crash

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -162,7 +162,8 @@ export function applyDirectoryEvent(input: {
     }
     case "session.diff": {
       const props = event.properties as { sessionID: string; diff: FileDiff[] }
-      input.setStore("session_diff", props.sessionID, reconcile(props.diff, { key: "file" }))
+      const diff = Array.isArray(props.diff) ? props.diff : []
+      input.setStore("session_diff", props.sessionID, reconcile(diff, { key: "file" }))
       break
     }
     case "todo.updated": {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -426,7 +426,11 @@ export default function Page() {
   }
 
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
-  const diffs = createMemo(() => (params.id ? (sync.data.session_diff[params.id] ?? []) : []))
+  const diffs = createMemo(() => {
+    if (!params.id) return []
+    const d = sync.data.session_diff[params.id]
+    return Array.isArray(d) ? d : []
+  })
   const sessionCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
   const hasSessionReview = createMemo(() => sessionCount() > 0)
   const canReview = createMemo(() => !!params.id)
@@ -636,7 +640,10 @@ export default function Page() {
     return open
   }, desktopReviewOpen())
 
-  const turnDiffs = createMemo(() => lastUserMessage()?.summary?.diffs ?? [])
+  const turnDiffs = createMemo(() => {
+    const d = lastUserMessage()?.summary?.diffs
+    return Array.isArray(d) ? d : []
+  })
   const changesOptions = createMemo<ChangeMode[]>(() => {
     const list: ChangeMode[] = []
     if (sync.project?.vcs === "git") list.push("git")

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -150,7 +150,8 @@ export const SessionReview = (props: SessionReviewProps) => {
   const opened = () => store.opened
 
   const open = () => props.open ?? store.open
-  const files = createMemo(() => props.diffs.map((diff) => diff.file))
+  const safe = () => (Array.isArray(props.diffs) ? props.diffs : [])
+  const files = createMemo(() => safe().map((diff) => diff.file))
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
 
@@ -281,7 +282,7 @@ export const SessionReview = (props: SessionReviewProps) => {
           <Show when={hasDiffs()} fallback={props.empty}>
             <div class="pb-6">
               <Accordion multiple value={open()} onChange={handleChange}>
-                <For each={props.diffs}>
+                <For each={safe()}>
                   {(diff) => {
                     let wrapper: HTMLDivElement | undefined
                     const file = diff.file


### PR DESCRIPTION
### Issue for this PR

Closes #19217

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`props.diffs.map` in `SessionReview` crashes when `diffs` is not an array. This happens when reopening old browser sessions because the SSE event reducer passes `event.properties.diff` directly to `reconcile()` without validating it's an array. If the data is malformed or missing, `reconcile(undefined, { key: "file" })` can corrupt the store value into a non-array. The existing `?? []` fallback only catches `null`/`undefined` — a truthy non-array (like `{}`) passes through.

The fix adds `Array.isArray` guards at four points:

1. **event-reducer.ts** — validate `props.diff` before `reconcile()` (root cause fix, matches the pattern already used in `sync.tsx`)
2. **session.tsx** — guard `session_diff[id]` read with `Array.isArray` instead of `?? []`
3. **session.tsx** — guard `summary.diffs` read with `Array.isArray` instead of `?? []`
4. **session-review.tsx** — guard `props.diffs` access in the UI component as last-resort defense

### How did you verify your code works?

- `bun typecheck` passes across all 13 packages
- Traced the full data flow from backend SSE events through `reconcile()` to the `SessionReview` component to confirm all paths now guarantee an array

### Screenshots / recordings

_N/A — no UI changes, this is a runtime crash fix._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR