### PR TITLE
fix(provider): honor useCompletionUrls in openai and xai loaders

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -185,7 +185,9 @@ export namespace Provider {
     openai: async () => {
       return {
         autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          if (options?.["useCompletionUrls"] && sdk.chat) return sdk.chat(modelID)
           return sdk.responses(modelID)
         },
         options: {},
@@ -194,7 +196,9 @@ export namespace Provider {
     xai: async () => {
       return {
         autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          if (options?.["useCompletionUrls"] && sdk.chat) return sdk.chat(modelID)
           return sdk.responses(modelID)
         },
         options: {},


### PR DESCRIPTION
Fixes #19228

The `openai` and `xai` loaders ignored the `options` parameter (`_options` — unused). The `azure` and `azure-cognitive-services` loaders already support `useCompletionUrls: true` to force `sdk.chat()` instead of `sdk.responses()`. This PR brings the same behavior to `openai` and `xai`.

No change to default behavior — Responses API is still used unless `useCompletionUrls: true` is set in provider options.