### PR TITLE
fix: improve @ path autocomplete for spaced file paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -87,6 +87,7 @@ export function Autocomplete(props: {
     selected: 0,
     visible: false as AutocompleteRef["visible"],
     input: "keyboard" as "keyboard" | "mouse",
+    browsing: false,
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -470,6 +471,7 @@ export function Autocomplete(props: {
     const endCursor = input.logicalCursor
 
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+    setStore("browsing", true)
     input.insertText("@" + path)
 
     setStore("selected", 0)
@@ -495,6 +497,7 @@ export function Autocomplete(props: {
     }
     command.keybinds(true)
     setStore("visible", false)
+    setStore("browsing", false)
   }
 
   onMount(() => {
@@ -508,7 +511,8 @@ export function Autocomplete(props: {
             // Typed text before the trigger
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
-            props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
+            // When browsing directories via tab-complete, allow spaces in file paths
+            props.input().getTextRange(store.index, props.input().cursorOffset).match(store.browsing ? /[\n\r\t]/ : /\s/) ||
             // "/<command>" is not the sole content
             (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
           ) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -19,9 +19,8 @@ function removeLineRange(input: string) {
   return hashIndex !== -1 ? input.substring(0, hashIndex) : input
 }
 
-export function ended(query: string, prefix: string) {
-  const rest = query.startsWith(prefix) ? query.slice(prefix.length) : query
-  return /\s/.test(rest)
+export function ended(query: string) {
+  return /[\n\r\t]/.test(query) || query.endsWith(" ")
 }
 
 function extractLineRange(input: string) {
@@ -92,7 +91,6 @@ export function Autocomplete(props: {
     selected: 0,
     visible: false as AutocompleteRef["visible"],
     input: "keyboard" as "keyboard" | "mouse",
-    prefix: "",
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -477,8 +475,6 @@ export function Autocomplete(props: {
 
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
     input.insertText("@" + path)
-
-    setStore("prefix", path)
     setStore("selected", 0)
   }
 
@@ -487,7 +483,6 @@ export function Autocomplete(props: {
     setStore({
       visible: mode,
       index: props.input().cursorOffset,
-      prefix: "",
     })
   }
 
@@ -503,7 +498,6 @@ export function Autocomplete(props: {
     }
     command.keybinds(true)
     setStore("visible", false)
-    setStore("prefix", "")
   }
 
   onMount(() => {
@@ -517,8 +511,8 @@ export function Autocomplete(props: {
           if (
             // Typed text before the trigger
             props.input().cursorOffset <= store.index ||
-            // Allow spaces in accepted path segments, but not in new input after them.
-            ended(query, store.prefix) ||
+            // Allow internal spaces in path queries, but close on delimiter whitespace.
+            ended(query) ||
             // "/<command>" is not the sole content
             (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
           ) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -19,6 +19,11 @@ function removeLineRange(input: string) {
   return hashIndex !== -1 ? input.substring(0, hashIndex) : input
 }
 
+export function ended(query: string, prefix: string) {
+  const rest = query.startsWith(prefix) ? query.slice(prefix.length) : query
+  return /\s/.test(rest)
+}
+
 function extractLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
   if (hashIndex === -1) {
@@ -87,7 +92,7 @@ export function Autocomplete(props: {
     selected: 0,
     visible: false as AutocompleteRef["visible"],
     input: "keyboard" as "keyboard" | "mouse",
-    browsing: false,
+    prefix: "",
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -471,9 +476,9 @@ export function Autocomplete(props: {
     const endCursor = input.logicalCursor
 
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
-    setStore("browsing", true)
     input.insertText("@" + path)
 
+    setStore("prefix", path)
     setStore("selected", 0)
   }
 
@@ -482,6 +487,7 @@ export function Autocomplete(props: {
     setStore({
       visible: mode,
       index: props.input().cursorOffset,
+      prefix: "",
     })
   }
 
@@ -497,7 +503,7 @@ export function Autocomplete(props: {
     }
     command.keybinds(true)
     setStore("visible", false)
-    setStore("browsing", false)
+    setStore("prefix", "")
   }
 
   onMount(() => {
@@ -507,12 +513,12 @@ export function Autocomplete(props: {
       },
       onInput(value) {
         if (store.visible) {
+          const query = props.input().getTextRange(store.index + 1, props.input().cursorOffset)
           if (
             // Typed text before the trigger
             props.input().cursorOffset <= store.index ||
-            // There is a space between the trigger and the cursor
-            // When browsing directories via tab-complete, allow spaces in file paths
-            props.input().getTextRange(store.index, props.input().cursorOffset).match(store.browsing ? /[\n\r\t]/ : /\s/) ||
+            // Allow spaces in accepted path segments, but not in new input after them.
+            ended(query, store.prefix) ||
             // "/<command>" is not the sole content
             (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
           ) {

--- a/packages/opencode/test/cli/cmd/tui/autocomplete.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete.test.ts
@@ -14,17 +14,19 @@ async function load() {
 describe("autocomplete", () => {
   test("allows spaces inside an accepted path prefix", async () => {
     const { ended } = await load()
-    expect(ended("dir with space/", "dir with space/")).toBe(false)
-    expect(ended("dir with space/file.ts", "dir with space/")).toBe(false)
+    expect(ended("dir with space/")).toBe(false)
+    expect(ended("dir with space/file.ts")).toBe(false)
   })
 
-  test("ends once whitespace appears after an accepted path prefix", async () => {
+  test("allows editing a spaced path after tab completion", async () => {
     const { ended } = await load()
-    expect(ended("dir with space/ note", "dir with space/")).toBe(true)
+    expect(ended("dir with space")).toBe(false)
+    expect(ended("dir with spce/")).toBe(false)
   })
 
-  test("ends when the query no longer matches the accepted prefix", async () => {
+  test("ends when a delimiter space is typed at the end", async () => {
     const { ended } = await load()
-    expect(ended("dir with space", "dir with space/")).toBe(true)
+    expect(ended("dir with space/ ")).toBe(true)
+    expect(ended("foobar ")).toBe(true)
   })
 })

--- a/packages/opencode/test/cli/cmd/tui/autocomplete.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/autocomplete.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from "bun:test"
+
+mock.module("@opentui/solid/jsx-runtime", () => ({
+  Fragment: Symbol("Fragment"),
+  jsx: () => null,
+  jsxs: () => null,
+  jsxDEV: () => null,
+}))
+
+async function load() {
+  return import("../../../../src/cli/cmd/tui/component/prompt/autocomplete")
+}
+
+describe("autocomplete", () => {
+  test("allows spaces inside an accepted path prefix", async () => {
+    const { ended } = await load()
+    expect(ended("dir with space/", "dir with space/")).toBe(false)
+    expect(ended("dir with space/file.ts", "dir with space/")).toBe(false)
+  })
+
+  test("ends once whitespace appears after an accepted path prefix", async () => {
+    const { ended } = await load()
+    expect(ended("dir with space/ note", "dir with space/")).toBe(true)
+  })
+
+  test("ends when the query no longer matches the accepted prefix", async () => {
+    const { ended } = await load()
+    expect(ended("dir with space", "dir with space/")).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19152

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Before this change, when a path contained spaces, the suggestion table could close at the wrong time while using `@` autocomplete.

This PR updates the autocomplete logic so spaces inside a path are allowed, but the suggestion table still closes when the user finishes the path and types a trailing space to continue writing. It also adds a regression test for this behavior.


### How did you verify your code works?

- Ran `bun test test/cli/cmd/tui/autocomplete.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`
- Pre-push `bun turbo typecheck` passed

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
