### PR TITLE
fix(github): create PRs from agent-selected custom branches

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -189,6 +189,22 @@ export function formatPromptTooLargeError(files: { filename: string; content: st
   return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
 }
 
+export function branchState(input: {
+  before: string
+  expect: string
+  current: string
+  head: string
+  status: string
+}) {
+  const uncommitted = input.status.trim().length > 0
+  return {
+    branch: input.current,
+    dirty: uncommitted || input.head !== input.before,
+    uncommittedChanges: uncommitted,
+    switched: input.current !== input.expect,
+  }
+}
+
 export const GithubCommand = cmd({
   command: "github",
   describe: "manage GitHub agent",
@@ -650,18 +666,13 @@ export const GithubRunCommand = cmd({
           const issueData = await fetchIssue()
           const dataPrompt = buildPromptDataForIssue(issueData)
           const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-          const { dirty, uncommittedChanges, switched } = await branchIsDirty(head, branch)
-          if (switched) {
-            // Agent switched branches (likely created its own branch/PR).
-            // Don't push the stale infrastructure branch — just comment.
-            await createComment(`${response}${footer({ image: true })}`)
-            await removeReaction(commentType)
-          } else if (dirty) {
+          const state = await branchIsDirty(head, branch)
+          if (state.dirty) {
             const summary = await summarize(response)
-            await pushToNewBranch(summary, branch, uncommittedChanges, false)
+            await pushToNewBranch(summary, state.branch, state.uncommittedChanges, false)
             const pr = await createPR(
               repoData.data.default_branch,
-              branch,
+              state.branch,
               summary,
               `${response}\n\nCloses #${issueId}${footer({ image: true })}`,
             )
@@ -1172,22 +1183,19 @@ export const GithubRunCommand = cmd({
         // Detect if the agent switched branches during chat (e.g. created
         // its own branch, committed, and possibly pushed/created a PR).
         const current = await gitText(["rev-parse", "--abbrev-ref", "HEAD"])
-        if (current !== expectedBranch) {
-          console.log(`Branch changed during chat: expected ${expectedBranch}, now on ${current}`)
-          return { dirty: true, uncommittedChanges: false, switched: true }
-        }
-
         const ret = await gitStatus(["status", "--porcelain"])
-        const status = ret.stdout.toString().trim()
-        if (status.length > 0) {
-          return { dirty: true, uncommittedChanges: true, switched: false }
-        }
         const head = await gitText(["rev-parse", "HEAD"])
-        return {
-          dirty: head !== originalHead,
-          uncommittedChanges: false,
-          switched: false,
+        const state = branchState({
+          before: originalHead,
+          expect: expectedBranch,
+          current,
+          head,
+          status: ret.stdout.toString(),
+        })
+        if (state.switched) {
+          console.log(`Branch changed during chat: expected ${expectedBranch}, now on ${state.branch}`)
         }
+        return state
       }
 
       // Verify commits exist between base ref and a branch using rev-list.

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
+import { branchState, extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
@@ -194,5 +194,58 @@ describe("formatPromptTooLargeError", () => {
     expect(result).toInclude("img1.png (3 KB)")
     expect(result).toInclude("img2.jpg (6 KB)")
     expect(result).toInclude("img3.gif (9 KB)")
+  })
+})
+
+describe("branchState", () => {
+  test("uses the current custom branch after the agent switches and commits", () => {
+    expect(
+      branchState({
+        before: "base",
+        expect: "opencode/issue19070-20260326",
+        current: "1758-no-rename-extension",
+        head: "custom",
+        status: "",
+      }),
+    ).toEqual({
+      branch: "1758-no-rename-extension",
+      dirty: true,
+      uncommittedChanges: false,
+      switched: true,
+    })
+  })
+
+  test("stays clean when the agent only switches branches without changes", () => {
+    expect(
+      branchState({
+        before: "base",
+        expect: "opencode/issue19070-20260326",
+        current: "1758-no-rename-extension",
+        head: "base",
+        status: "",
+      }),
+    ).toEqual({
+      branch: "1758-no-rename-extension",
+      dirty: false,
+      uncommittedChanges: false,
+      switched: true,
+    })
+  })
+
+  test("marks uncommitted changes on the expected branch", () => {
+    expect(
+      branchState({
+        before: "base",
+        expect: "opencode/issue19070-20260326",
+        current: "opencode/issue19070-20260326",
+        head: "base",
+        status: " M github.ts\n",
+      }),
+    ).toEqual({
+      branch: "opencode/issue19070-20260326",
+      dirty: true,
+      uncommittedChanges: true,
+      switched: false,
+    })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #19070

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the issue where the GitHub issue action could create and use the default generated branch, but failed once the agent switched to a custom branch name before opening the PR.

The problem was that the issue flow only trusted the initially generated branch. If the agent changed to a user-named branch during the run, the action either stopped the infrastructure PR flow or kept using the wrong branch name for push / PR creation.

This change makes the issue flow use the actual current branch after the chat finishes. It also distinguishes between:

- switching branches with real changes or commits
- switching branches without any actual changes

That keeps the default flow unchanged, while allowing custom agent-selected branches to continue through push and PR creation correctly.

I also added focused regression tests for the branch state logic.

### How did you verify your code works?

I verified this locally with:

- `bun test test/cli/github-action.test.ts`
- `bun typecheck`

The new tests cover:
- switching to a custom branch with committed changes
- switching branches without any changes
- staying on the expected branch with uncommitted changes

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR