### PR TITLE
fix(app): guard against non-array diffs in session review

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -517,6 +517,75 @@ describe("applyDirectoryEvent", () => {
     expect(cacheStore.value).toEqual({ branch: "feature/test", default_branch: "main" })
   })
 
+  test("session.diff stores array diffs in session_diff", () => {
+    const [store, setStore] = createStore(baseState())
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.diff",
+        properties: {
+          sessionID: "ses_1",
+          diff: [{ file: "a.txt", before: "", after: "hello", additions: 1, deletions: 0, status: "added" }],
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(Array.isArray(store.session_diff.ses_1)).toBe(true)
+    expect(store.session_diff.ses_1?.length).toBe(1)
+    expect(store.session_diff.ses_1?.[0]?.file).toBe("a.txt")
+  })
+
+  test("session.diff handles undefined diff gracefully", () => {
+    const [store, setStore] = createStore(baseState())
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.diff",
+        properties: {
+          sessionID: "ses_1",
+          diff: undefined,
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    const result = store.session_diff.ses_1
+    expect(Array.isArray(result)).toBe(true)
+    expect(result?.length).toBe(0)
+  })
+
+  test("session.diff handles non-array diff gracefully", () => {
+    const [store, setStore] = createStore(baseState())
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.diff",
+        properties: {
+          sessionID: "ses_1",
+          diff: { file: "a.txt" } as any,
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    const result = store.session_diff.ses_1
+    expect(Array.isArray(result)).toBe(true)
+    expect(result?.length).toBe(0)
+  })
+
   test("routes disposal and lsp events to side-effect handlers", () => {
     const [store, setStore] = createStore(baseState())
     const pushes: string[] = []

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -162,7 +162,8 @@ export function applyDirectoryEvent(input: {
     }
     case "session.diff": {
       const props = event.properties as { sessionID: string; diff: FileDiff[] }
-      input.setStore("session_diff", props.sessionID, reconcile(props.diff, { key: "file" }))
+      const diff = Array.isArray(props.diff) ? props.diff : []
+      input.setStore("session_diff", props.sessionID, reconcile(diff, { key: "file" }))
       break
     }
     case "todo.updated": {

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -150,7 +150,8 @@ export const SessionReview = (props: SessionReviewProps) => {
   const opened = () => store.opened
 
   const open = () => props.open ?? store.open
-  const files = createMemo(() => props.diffs.map((diff) => diff.file))
+  const safeDiffs = () => (Array.isArray(props.diffs) ? props.diffs : [])
+  const files = createMemo(() => safeDiffs().map((diff) => diff.file))
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
   const hasDiffs = () => files().length > 0
 
@@ -281,7 +282,7 @@ export const SessionReview = (props: SessionReviewProps) => {
           <Show when={hasDiffs()} fallback={props.empty}>
             <div class="pb-6">
               <Accordion multiple value={open()} onChange={handleChange}>
-                <For each={props.diffs}>
+                <For each={safeDiffs()}>
                   {(diff) => {
                     let wrapper: HTMLDivElement | undefined
                     const file = diff.file


### PR DESCRIPTION
## Summary

- Add `Array.isArray` guard in event-reducer before passing diff data to `reconcile()`, preventing non-array values from being stored in `session_diff`
- Add `safeDiffs()` accessor in `SessionReview` component to normalize `props.diffs`, preventing `.map()` crash on non-array values
- Add 3 test cases for `session.diff` event handling: normal array, `undefined`, and non-array object payloads

## Problem

Users are seeing a common crash in the session review UI:

```
TypeError: e.diffs.map is not a function
    at Object.fn (session-BdJIdAn0.js:19:50326)
```

The root cause is in `event-reducer.ts` where `session.diff` event properties are cast with `as { sessionID: string; diff: FileDiff[] }` — an unsafe cast with no runtime validation. If the SSE event delivers malformed `diff` data (e.g., `undefined` or an object instead of an array), `reconcile()` stores a non-array value in the `session_diff` store. The `?? []` fallback in the memo doesn't catch truthy non-array values like `{}`, so the `SessionReview` component crashes when calling `.map()` on it.

## Test plan

- [x] All 302 existing tests pass
- [x] 3 new tests added for `session.diff` event edge cases (undefined, non-array)
- [x] TypeScript typecheck passes across all 13 packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)