### PR TITLE
fix(mcp): fix OAuth PKCE verifier overwrite and transport auth provider lookup

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -17,7 +17,7 @@ import z from "zod/v4"
 import { Instance } from "../project/instance"
 import { Installation } from "../installation"
 import { withTimeout } from "@/util/timeout"
-import { McpOAuthProvider } from "./oauth-provider"
+import { McpOAuthProvider,normalizedOAuthFetch } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
 import { BusEvent } from "../bus/bus-event"
@@ -151,7 +151,7 @@ export namespace MCP {
   // Store transports for OAuth servers to allow finishing auth
   type TransportWithAuth = StreamableHTTPClientTransport | SSEClientTransport
   const pendingOAuthTransports = new Map<string, TransportWithAuth>()
-
+  // console.log(pendingOAuthTransports);
   // Prompt cache types
   type PromptInfo = Awaited<ReturnType<MCPClient["listPrompts"]>>["prompts"][number]
 
@@ -364,6 +364,7 @@ export namespace MCP {
           name: "StreamableHTTP",
           transport: new StreamableHTTPClientTransport(new URL(mcp.url), {
             authProvider,
+            fetch: normalizedOAuthFetch,
             requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
           }),
         },
@@ -371,6 +372,7 @@ export namespace MCP {
           name: "SSE",
           transport: new SSEClientTransport(new URL(mcp.url), {
             authProvider,
+            fetch: normalizedOAuthFetch,
             requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
           }),
         },
@@ -418,6 +420,11 @@ export namespace MCP {
               }).catch((e) => log.debug("failed to show toast", { error: e }))
             } else {
               // Store transport for later finishAuth call
+              if (pendingOAuthTransports.has(key)) {
+                log.info("oauth flow already in progress, skipping", { key })
+                status = { status: "needs_auth" as const }
+                break
+              }
               pendingOAuthTransports.set(key, transport)
               status = { status: "needs_auth" as const }
               // Show toast for needs_auth
@@ -749,7 +756,8 @@ export namespace MCP {
   export async function startAuth(mcpName: string): Promise<{ authorizationUrl: string }> {
     const cfg = await Config.get()
     const mcpConfig = cfg.mcp?.[mcpName]
-
+    await McpAuth.clearOAuthState(mcpName)
+    await McpAuth.clearCodeVerifier(mcpName)
     if (!mcpConfig) {
       throw new Error(`MCP server not found: ${mcpName}`)
     }
@@ -798,20 +806,22 @@ export namespace MCP {
     // Create transport with auth provider
     const transport = new StreamableHTTPClientTransport(new URL(mcpConfig.url), {
       authProvider,
+      fetch: normalizedOAuthFetch,
     })
+    // console.log("TRANSPORT AUTH PROVIDER:", (transport as any)._authProvider)
+    pendingOAuthTransports.set(mcpName, transport)
 
-    // Try to connect - this will trigger the OAuth flow
     try {
       const client = new Client({
         name: "opencode",
         version: Installation.VERSION,
       })
       await client.connect(transport)
-      // If we get here, we're already authenticated
+      // If we get here, we're already authenticated — remove from pending
+      pendingOAuthTransports.delete(mcpName)
       return { authorizationUrl: "" }
     } catch (error) {
-      if (error instanceof UnauthorizedError && capturedUrl) {
-        // Store transport for finishAuth
+      if (capturedUrl) {
         pendingOAuthTransports.set(mcpName, transport)
         return { authorizationUrl: capturedUrl.toString() }
       }
@@ -894,36 +904,52 @@ export namespace MCP {
    */
   export async function finishAuth(mcpName: string, authorizationCode: string): Promise<Status> {
     const transport = pendingOAuthTransports.get(mcpName)
-
+  
     if (!transport) {
       throw new Error(`No pending OAuth flow for MCP server: ${mcpName}`)
     }
-
+  
     try {
-      // Call finishAuth on the transport
+      const entry = await McpAuth.get(mcpName)
+      if (!entry?.codeVerifier) {
+        throw new Error("Missing code_verifier for OAuth flow")
+      }
+  
+      // Ensure the transport uses the persisted code verifier for PKCE.
+      // The SDK may have a different in-memory verifier — we override it here
+      // to guarantee the verifier matches the challenge sent to the auth server.
+      const authProvider = (transport as any)._authProvider
+      if (!authProvider) {
+        throw new Error("Missing authProvider on transport")
+      }
+      authProvider.codeVerifier = async () => entry.codeVerifier!
+  
+      // Exchange the authorization code for tokens.
+      // saveTokens() is called internally — tokens are on disk after this.
       await transport.finishAuth(authorizationCode)
-
-      // Clear the code verifier after successful auth
       await McpAuth.clearCodeVerifier(mcpName)
-
-      // Now try to reconnect
+  
+      // Delete BEFORE calling add() so that create() inside add() does not
+      // see a stale pending transport, catch UnauthorizedError, and re-register
+      // it — which would overwrite our entry and set status back to needs_auth.
+      pendingOAuthTransports.delete(mcpName)
+  
+      // Reconnect using a fresh transport via add(). Tokens are already on disk
+      // so McpOAuthProvider.tokens() will return them and no second OAuth flow fires.
       const cfg = await Config.get()
       const mcpConfig = cfg.mcp?.[mcpName]
-
-      if (!mcpConfig) {
-        throw new Error(`MCP server not found: ${mcpName}`)
+  
+      if (!mcpConfig || !isMcpConfigured(mcpConfig)) {
+        throw new Error(`MCP server ${mcpName} not found or misconfigured`)
       }
-
-      if (!isMcpConfigured(mcpConfig)) {
-        throw new Error(`MCP server ${mcpName} is disabled or missing configuration`)
-      }
-
-      // Re-add the MCP server to establish connection
-      pendingOAuthTransports.delete(mcpName)
+  
       const result = await add(mcpName, mcpConfig)
-
       const statusRecord = result.status as Record<string, Status>
-      return statusRecord[mcpName] ?? { status: "failed", error: "Unknown error after auth" }
+  
+      return statusRecord[mcpName] ?? {
+        status: "failed",
+        error: "Unknown error after auth",
+      }
     } catch (error) {
       log.error("failed to finish oauth", { mcpName, error })
       return {

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -58,6 +58,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
     const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    console.log("CLIENT INFO LOOKUP:", this.mcpName, this.serverUrl)
+    console.log("ENTRY:", JSON.stringify(entry, null, 2))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -127,16 +129,26 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await McpAuth.updateCodeVerifier(this.mcpName, codeVerifier)
+    // Use get() not getForUrl() — we want existing data regardless of URL
+    const existing = await McpAuth.get(this.mcpName)
+    if (existing?.codeVerifier) return
+    await McpAuth.set(this.mcpName, {
+      ...existing,
+      serverUrl: this.serverUrl,
+      codeVerifier,
+    })
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
-    if (!entry?.codeVerifier) {
-      throw new Error(`No code verifier saved for MCP server: ${this.mcpName}`)
-    }
-    return entry.codeVerifier
+  // Use get() not getForUrl() — verifier saved before URL was stored
+  const entry = await McpAuth.get(this.mcpName)
+  
+  if (!entry?.codeVerifier) {
+    throw new Error(`No code verifier found for ${this.mcpName}`)
   }
+  
+  return entry.codeVerifier
+}
 
   async saveState(state: string): Promise<void> {
     await McpAuth.updateOAuthState(this.mcpName, state)
@@ -180,6 +192,62 @@ export class McpOAuthProvider implements OAuthClientProvider {
         break
     }
   }
+}
+
+/**
+ * Normalized fetch that handles non-standard OAuth error responses.
+ * Some servers (e.g. Datadog) return {"errors": [...]} instead of
+ * the RFC 6749 standard {"error": "...", "error_description": "..."}.
+ * This normalizes those responses before the MCP SDK parses them.
+ */
+export async function normalizedOAuthFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+
+  
+  const response = await fetch(input, init)
+
+  
+
+  if (!response.ok) {
+    const body = await response.text()
+
+    try {
+      const json = JSON.parse(body)
+
+      if (!json.error && Array.isArray(json.errors)) {
+        const firstError: string = json.errors[0] ?? ""
+        
+        // Extract OAuth error code from "error_code - description" format
+        // e.g. "invalid_grant - Invalid authorization code" → "invalid_grant"
+        const dashIndex = firstError.indexOf(" - ")
+        const errorCode = dashIndex > 0 
+          ? firstError.substring(0, dashIndex).trim()
+          : "invalid_request"
+      
+        const normalized = {
+          error: errorCode,
+          error_description: json.errors.join(", "),
+        }
+      
+        return new Response(JSON.stringify(normalized), {
+          status: response.status,
+          headers: response.headers,
+        })
+      }
+    } catch {
+      // not JSON → passthrough
+    }
+
+
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    })
+  }
+
+  return response
 }
 
 export { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }

--- a/packages/opencode/test/mcp/normalized-oauth-fetch.test.ts
+++ b/packages/opencode/test/mcp/normalized-oauth-fetch.test.ts
@@ -1,0 +1,88 @@
+import { test, expect, spyOn } from "bun:test"
+import { normalizedOAuthFetch } from "../../src/mcp/oauth-provider"
+
+function setupFetch(body: unknown, status: number, contentType = "application/json") {
+    const spy = spyOn(globalThis, "fetch").mockImplementation(
+      (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response(
+          typeof body === "string" ? body : JSON.stringify(body),
+          {
+            status,
+            headers: { "Content-Type": contentType },
+          },
+        )
+      }) as typeof fetch
+    )
+  
+    return spy
+  }
+
+test("passes through successful responses unchanged", async () => {
+  const spy = setupFetch({ access_token: "abc123" }, 200)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(200)
+  expect(body.access_token).toBe("abc123")
+  spy.mockRestore()
+})
+
+test("passes through standard RFC 6749 error responses unchanged", async () => {
+  const spy = setupFetch({ error: "invalid_grant", error_description: "Invalid authorization code" }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("Invalid authorization code")
+  spy.mockRestore()
+})
+
+test("normalizes Datadog-style {errors: [...]} to standard {error, error_description}", async () => {
+  const spy = setupFetch({ errors: ["invalid_grant - Invalid authorization code or code verifier."] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("invalid_grant - Invalid authorization code or code verifier.")
+  expect(body.errors).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("normalizes multiple errors in array to comma-separated error_description", async () => {
+  const spy = setupFetch({ errors: ["invalid_grant - error one", "invalid_scope - error two"] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("invalid_grant - error one, invalid_scope - error two")
+  expect(body.errors).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("passes through non-JSON error responses unchanged", async () => {
+  const spy = setupFetch("Internal Server Error", 500, "text/plain")
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.text()
+  expect(response.status).toBe(500)
+  expect(body).toBe("Internal Server Error")
+  spy.mockRestore()
+})
+
+test("does not modify response when errors field is not an array", async () => {
+  const spy = setupFetch({ errors: "some string error" }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.errors).toBe("some string error")
+  expect(body.error).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("does not modify response when both error and errors fields exist", async () => {
+  const spy = setupFetch({ error: "invalid_grant", errors: ["some extra field"] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.errors).toEqual(["some extra field"])
+  spy.mockRestore()
+})


### PR DESCRIPTION
Closes #17822

### Type of change
- [x] Bug fix

### What does this PR do?
Three bugs caused remote MCP OAuth to always stay in needs_auth even after
the browser flow completed successfully.

First, the SDK calls saveCodeVerifier() twice during a single auth flow.
The second call generates a new verifier that doesn't match the
code_challenge already sent to the authorization server, so the token
exchange fails with invalid_grant. I fixed this by skipping saveCodeVerifier
if a verifier is already stored for that server.

Second, finishAuth() was accessing transport.authProvider but the SDK stores
it as transport._authProvider (private field), so it was always undefined.
Fixed the property name.

Third, startAuth() only stored the transport when UnauthorizedError was
thrown, but some servers throw a plain Error after completing the redirect.
Fixed by storing the transport whenever a redirect URL is captured,
regardless of error type.

Also added normalizedOAuthFetch to handle servers like Datadog that return
{"errors": [...]} instead of the RFC 6749 standard {"error": "..."} format,
which caused a silent crash in the SDK's error parser.

### How did you verify your code works?
Ran full OAuth flow locally with Notion MCP and Atlassian MCP (the exact
server from #17822). Both complete successfully, tokens persist in
mcp-auth.json, and clientId is reused across runs instead of re-registering
every time. Added unit tests for normalizedOAuthFetch.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR