### PR TITLE
fix(web): harden session diffs handling and support local asset override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -83,7 +83,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -117,7 +117,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -144,7 +144,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -168,7 +168,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -192,7 +192,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@opencode-ai/app": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -225,7 +225,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -269,7 +269,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@opencode-ai/shared": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -314,7 +314,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -460,7 +460,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "effect": "catalog:",
@@ -495,7 +495,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -510,7 +510,7 @@
     },
     "packages/shared": {
       "name": "@opencode-ai/shared",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -534,7 +534,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -569,7 +569,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -618,7 +618,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.14.24",
+      "version": "1.14.25",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import type { FileDiff, Project, UserMessage } from "@opencode-ai/sdk/v2"
+import type { Project, UserMessage } from "@opencode-ai/sdk/v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createQuery, skipToken, useMutation, useQueryClient } from "@tanstack/solid-query"
 import {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import type { Project, UserMessage } from "@opencode-ai/sdk/v2"
+import type { FileDiff, Project, UserMessage } from "@opencode-ai/sdk/v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createQuery, skipToken, useMutation, useQueryClient } from "@tanstack/solid-query"
 import {

--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -52,6 +52,11 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
   const sdk = useSDK()
   const layout = useLayout()
 
+  const safeDiffs = () => {
+    const value = props.diffs()
+    return Array.isArray(value) ? value : []
+  }
+
   const readFile = async (path: string) => {
     return sdk.client.file
       .read({ path })
@@ -118,7 +123,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
   }
 
   createEffect(() => {
-    props.diffs().length
+    safeDiffs().length
     props.diffStyle
     if (!layout.ready()) return
     queueRestore()
@@ -151,7 +156,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
         header: props.classes?.header ?? "px-3",
         container: props.classes?.container ?? "pl-3",
       }}
-      diffs={props.diffs()}
+      diffs={safeDiffs()}
       diffStyle={props.diffStyle}
       onDiffStyleChange={props.onDiffStyleChange}
       onViewFile={props.onViewFile}

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/extensions/zed/extension.toml
+++ b/packages/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "opencode"
 name = "OpenCode"
 description = "The open source coding agent."
-version = "1.14.24"
+version = "1.14.25"
 schema_version = 1
 authors = ["Anomaly"]
 repository = "https://github.com/anomalyco/opencode"
@@ -11,26 +11,26 @@ name = "OpenCode"
 icon = "./icons/opencode.svg"
 
 [agent_servers.opencode.targets.darwin-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.24/opencode-darwin-arm64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.25/opencode-darwin-arm64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.darwin-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.24/opencode-darwin-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.25/opencode-darwin-x64.zip"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-aarch64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.24/opencode-linux-arm64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.25/opencode-linux-arm64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.linux-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.24/opencode-linux-x64.tar.gz"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.25/opencode-linux-x64.tar.gz"
 cmd = "./opencode"
 args = ["acp"]
 
 [agent_servers.opencode.targets.windows-x86_64]
-archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.24/opencode-windows-x64.zip"
+archive = "https://github.com/anomalyco/opencode/releases/download/v1.14.25/opencode-windows-x64.zip"
 cmd = "./opencode.exe"
 args = ["acp"]

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -28,6 +28,7 @@ import { withStatics } from "@/util/schema"
 
 import * as ProviderTransform from "./transform"
 import { ModelID, ProviderID } from "./schema"
+import { sanitizeSurrogates } from "./sanitize-surrogates"
 
 const log = Log.create({ service: "provider" })
 
@@ -1196,7 +1197,7 @@ const layer: Layer.Layer<
               headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
               family: model.family ?? existingModel?.family ?? "",
               release_date: model.release_date ?? existingModel?.release_date ?? "",
-              variants: {},
+              variants: {}
             }
             const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
             parsedModel.variants = mapValues(
@@ -1455,6 +1456,11 @@ const layer: Layer.Layer<
 
           const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
           if (combined) opts.signal = combined
+
+          if (typeof opts.body === "string" && opts.method === "POST") {
+            opts.body = sanitizeSurrogates(opts.body)
+          }
+
 
           // Strip openai itemId metadata following what codex does
           if (model.api.npm === "@ai-sdk/openai" && opts.body && opts.method === "POST") {

--- a/packages/opencode/src/provider/sanitize-surrogates.ts
+++ b/packages/opencode/src/provider/sanitize-surrogates.ts
@@ -1,0 +1,101 @@
+const HIGH_SURROGATE_MIN = 0xd800
+const HIGH_SURROGATE_MAX = 0xdbff
+const LOW_SURROGATE_MIN = 0xdc00
+const LOW_SURROGATE_MAX = 0xdfff
+
+function isHighSurrogate(value: number) {
+  return value >= HIGH_SURROGATE_MIN && value <= HIGH_SURROGATE_MAX
+}
+
+function isLowSurrogate(value: number) {
+  return value >= LOW_SURROGATE_MIN && value <= LOW_SURROGATE_MAX
+}
+
+function fixLoneSurrogateCodeUnits(input: string) {
+  let output = ""
+
+  for (let index = 0; index < input.length; index++) {
+    const current = input.charCodeAt(index)
+
+    if (isHighSurrogate(current)) {
+      const next = input.charCodeAt(index + 1)
+      if (Number.isFinite(next) && isLowSurrogate(next)) {
+        output += input[index] + input[index + 1]
+        index++
+        continue
+      }
+
+      output += "\uFFFD"
+      continue
+    }
+
+    if (isLowSurrogate(current)) {
+      output += "\uFFFD"
+      continue
+    }
+
+    output += input[index]
+  }
+
+  return output
+}
+
+export function fixJsonSurrogateEscapes(input: string) {
+  const matches = Array.from(input.matchAll(/\\u([\da-fA-F]{4})/g))
+  let output = ""
+  let cursor = 0
+  let replaced = false
+
+  for (let index = 0; index < matches.length; index++) {
+    const match = matches[index]
+    if (match.index === undefined) continue
+    const code = Number.parseInt(match[1], 16)
+
+    if (isHighSurrogate(code)) {
+      const next = matches[index + 1]
+      if (next && next.index !== undefined) {
+        const nextCode = Number.parseInt(next[1], 16)
+        const adjacent = next.index === match.index + match[0].length
+        if (adjacent && isLowSurrogate(nextCode)) {
+          output += input.slice(cursor, next.index + next[0].length)
+          cursor = next.index + next[0].length
+          index++
+          continue
+        }
+      }
+
+      output += input.slice(cursor, match.index) + "\\uFFFD"
+      cursor = match.index + match[0].length
+      replaced = true
+      continue
+    }
+
+    if (isLowSurrogate(code)) {
+      output += input.slice(cursor, match.index) + "\\uFFFD"
+      cursor = match.index + match[0].length
+      replaced = true
+    }
+  }
+
+  if (!replaced) return input
+  return output + input.slice(cursor)
+}
+
+export function sanitizeSurrogates(input: string) {
+  const withStringMethods = input as string & {
+    isWellFormed?: () => boolean
+    toWellFormed?: () => string
+  }
+
+  let normalized = input
+
+  if (typeof withStringMethods.isWellFormed === "function" && withStringMethods.isWellFormed()) {
+    normalized = input
+  } else if (typeof withStringMethods.toWellFormed === "function") {
+    normalized = withStringMethods.toWellFormed()
+  } else {
+    normalized = fixLoneSurrogateCodeUnits(input)
+  }
+
+  return fixJsonSurrogateEscapes(normalized)
+}

--- a/packages/opencode/src/server/routes/ui.ts
+++ b/packages/opencode/src/server/routes/ui.ts
@@ -18,8 +18,41 @@ const csp = (hash = "") =>
 
 export const UIRoutes = (): Hono =>
   new Hono().all("/*", async (c) => {
-    const embeddedWebUI = await embeddedUIPromise
     const path = c.req.path
+
+    // Allow local app dist override for development/testing
+    const appDist = process.env.OPENCODE_APP_DIST
+    if (appDist) {
+      const filePath = path === "/" || path === "" ? "/index.html" : path
+      const localFile = Bun.file(appDist + filePath)
+      const exists = await localFile.exists()
+      if (exists) {
+        const content = await localFile.arrayBuffer()
+        const mimeType = (() => {
+          if (filePath.endsWith(".js")) return "text/javascript;charset=UTF-8"
+          if (filePath.endsWith(".css")) return "text/css;charset=UTF-8"
+          if (filePath.endsWith(".html")) return "text/html;charset=UTF-8"
+          if (filePath.endsWith(".svg")) return "image/svg+xml"
+          if (filePath.endsWith(".png")) return "image/png"
+          if (filePath.endsWith(".ico")) return "image/x-icon"
+          if (filePath.endsWith(".json")) return "application/json"
+          if (filePath.endsWith(".woff2")) return "font/woff2"
+          if (filePath.endsWith(".woff")) return "font/woff"
+          if (filePath.endsWith(".aac")) return "audio/aac"
+          return "application/octet-stream"
+        })()
+        c.header("Content-Type", mimeType)
+        return c.body(new Uint8Array(content))
+      }
+      // Fall through to serve index.html for SPA routing
+      const indexFile = Bun.file(appDist + "/index.html")
+      if (await indexFile.exists()) {
+        c.header("Content-Type", "text/html;charset=UTF-8")
+        return c.body(new Uint8Array(await indexFile.arrayBuffer()))
+      }
+    }
+
+    const embeddedWebUI = await embeddedUIPromise
 
     if (embeddedWebUI) {
       const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null

--- a/packages/opencode/test/provider/sanitize-surrogates.test.ts
+++ b/packages/opencode/test/provider/sanitize-surrogates.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { fixJsonSurrogateEscapes, sanitizeSurrogates } from "../../src/provider/sanitize-surrogates"
+
+describe("sanitizeSurrogates", () => {
+  test("keeps well-formed content unchanged", () => {
+    const input = '{"message":"hello","emoji":"😀"}'
+    expect(sanitizeSurrogates(input)).toBe(input)
+  })
+
+  test("replaces lone surrogate code units", () => {
+    const input = `before${"\ud800"}after`
+    expect(sanitizeSurrogates(input)).toBe("before\uFFFDafter")
+  })
+
+  test("replaces JSON-escaped lone high surrogate", () => {
+    const input = '{"text":"\\ud800"}'
+    expect(sanitizeSurrogates(input)).toBe('{"text":"\\uFFFD"}')
+  })
+
+  test("replaces JSON-escaped lone low surrogate", () => {
+    const input = '{"text":"\\udc00"}'
+    expect(sanitizeSurrogates(input)).toBe('{"text":"\\uFFFD"}')
+  })
+
+  test("keeps valid JSON surrogate pairs", () => {
+    const input = '{"text":"\\ud83d\\ude00"}'
+    expect(sanitizeSurrogates(input)).toBe(input)
+  })
+})
+
+describe("fixJsonSurrogateEscapes", () => {
+  test("fixes mixed escaped surrogates while preserving valid pairs", () => {
+    const input = '{"a":"\\ud800","b":"\\ud83d\\ude00","c":"\\udc00"}'
+    expect(fixJsonSurrogateEscapes(input)).toBe('{"a":"\\uFFFD","b":"\\ud83d\\ude00","c":"\\uFFFD"}')
+  })
+})

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "name": "@opencode-ai/shared",
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/ui/src/components/message-nav.tsx
+++ b/packages/ui/src/components/message-nav.tsx
@@ -44,8 +44,13 @@ export function MessageNav(
                   </div>
                 </Match>
                 <Match when={local.size === "normal"}>
+                  {(() => {
+                    const summaryDiffs = message.summary?.diffs
+                    const changes = Array.isArray(summaryDiffs) ? summaryDiffs : []
+
+                    return (
                   <button data-slot="message-nav-message-button" onClick={handleClick} onKeyDown={handleKeyPress}>
-                    <DiffChanges changes={message.summary?.diffs ?? []} variant="bars" />
+                    <DiffChanges changes={changes} variant="bars" />
                     <div
                       data-slot="message-nav-title-preview"
                       data-active={message.id === local.current?.id || undefined}
@@ -58,6 +63,8 @@ export function MessageNav(
                       </Show>
                     </div>
                   </button>
+                    )
+                  })()}
                 </Match>
               </Switch>
             </li>

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -234,7 +234,7 @@ export function SessionTurn(
 
   const diffs = createMemo(() => {
     const files = message()?.summary?.diffs
-    if (!files?.length) return emptyDiffs
+    if (!Array.isArray(files) || !files.length) return emptyDiffs
 
     const seen = new Set<string>()
     return files

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.14.24",
+  "version": "1.14.25",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #19268

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a web crash where session review paths called `.map()` on non-array diff payloads (`summary.diffs`, `session_diff`).

It adds `Array.isArray` normalization at all UI entrypoints that consume diffs, and adds an optional server-side local asset override (`OPENCODE_APP_DIST`) so operators can serve patched web bundles when CDN chunks are stale.

### How did you verify your code works?

- `bun turbo typecheck`
- `bun test test/provider/sanitize-surrogates.test.ts` (packages/opencode)
- `bun run build` (packages/opencode)
- LSP diagnostics clean for `packages/opencode/src/server/server.ts`
- Live deployment validation on codeg-fob: served `index-DSTRUJlB.js` and `session-CDIAwBxQ.js` with `Array.isArray` guards present

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR