### PR TITLE
fix: fix OAuth PKCE verifier overwrite and transport authProvider lookup

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -17,7 +17,7 @@ import { Instance } from "../project/instance"
 import { Installation } from "../installation"
 import { withTimeout } from "@/util/timeout"
 import { AppFileSystem } from "@/filesystem"
-import { McpOAuthProvider } from "./oauth-provider"
+import { McpOAuthProvider,normalizedOAuthFetch } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
 import { BusEvent } from "../bus/bus-event"
@@ -231,6 +231,7 @@ export namespace MCP {
           name: "StreamableHTTP",
           transport: new StreamableHTTPClientTransport(new URL(mcp.url), {
             authProvider,
+            fetch: normalizedOAuthFetch,
             requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
           }),
         },
@@ -238,6 +239,7 @@ export namespace MCP {
           name: "SSE",
           transport: new SSEClientTransport(new URL(mcp.url), {
             authProvider,
+            fetch: normalizedOAuthFetch,
             requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
           }),
         },
@@ -284,6 +286,11 @@ export namespace MCP {
               }).catch((e) => log.debug("failed to show toast", { error: e }))
             } else {
               // Store transport for later finishAuth call
+              if (pendingOAuthTransports.has(key)) {
+                log.info("oauth flow already in progress, skipping", { key })
+                status = { status: "needs_auth" as const }
+                break
+              }
               pendingOAuthTransports.set(key, transport)
               status = { status: "needs_auth" as const }
               // Show toast for needs_auth

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -58,6 +58,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
     const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    console.log("CLIENT INFO LOOKUP:", this.mcpName, this.serverUrl)
+    console.log("ENTRY:", JSON.stringify(entry, null, 2))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -127,16 +129,26 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await McpAuth.updateCodeVerifier(this.mcpName, codeVerifier)
+    // Use get() not getForUrl() — we want existing data regardless of URL
+    const existing = await McpAuth.get(this.mcpName)
+    if (existing?.codeVerifier) return
+    await McpAuth.set(this.mcpName, {
+      ...existing,
+      serverUrl: this.serverUrl,
+      codeVerifier,
+    })
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
-    if (!entry?.codeVerifier) {
-      throw new Error(`No code verifier saved for MCP server: ${this.mcpName}`)
-    }
-    return entry.codeVerifier
+  // Use get() not getForUrl() — verifier saved before URL was stored
+  const entry = await McpAuth.get(this.mcpName)
+  
+  if (!entry?.codeVerifier) {
+    throw new Error(`No code verifier found for ${this.mcpName}`)
   }
+  
+  return entry.codeVerifier
+}
 
   async saveState(state: string): Promise<void> {
     await McpAuth.updateOAuthState(this.mcpName, state)
@@ -180,6 +192,62 @@ export class McpOAuthProvider implements OAuthClientProvider {
         break
     }
   }
+}
+
+/**
+ * Normalized fetch that handles non-standard OAuth error responses.
+ * Some servers (e.g. Datadog) return {"errors": [...]} instead of
+ * the RFC 6749 standard {"error": "...", "error_description": "..."}.
+ * This normalizes those responses before the MCP SDK parses them.
+ */
+export async function normalizedOAuthFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+
+  
+  const response = await fetch(input, init)
+
+  
+
+  if (!response.ok) {
+    const body = await response.text()
+
+    try {
+      const json = JSON.parse(body)
+
+      if (!json.error && Array.isArray(json.errors)) {
+        const firstError: string = json.errors[0] ?? ""
+        
+        // Extract OAuth error code from "error_code - description" format
+        // e.g. "invalid_grant - Invalid authorization code" → "invalid_grant"
+        const dashIndex = firstError.indexOf(" - ")
+        const errorCode = dashIndex > 0 
+          ? firstError.substring(0, dashIndex).trim()
+          : "invalid_request"
+      
+        const normalized = {
+          error: errorCode,
+          error_description: json.errors.join(", "),
+        }
+      
+        return new Response(JSON.stringify(normalized), {
+          status: response.status,
+          headers: response.headers,
+        })
+      }
+    } catch {
+      // not JSON → passthrough
+    }
+
+
+    return new Response(body, {
+      status: response.status,
+      headers: response.headers,
+    })
+  }
+
+  return response
 }
 
 export { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -58,8 +58,6 @@ export class McpOAuthProvider implements OAuthClientProvider {
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
     const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
-    console.log("CLIENT INFO LOOKUP:", this.mcpName, this.serverUrl)
-    console.log("ENTRY:", JSON.stringify(entry, null, 2))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {

--- a/packages/opencode/test/mcp/normalized-oauth-fetch.test.ts
+++ b/packages/opencode/test/mcp/normalized-oauth-fetch.test.ts
@@ -1,0 +1,88 @@
+import { test, expect, spyOn } from "bun:test"
+import { normalizedOAuthFetch } from "../../src/mcp/oauth-provider"
+
+function setupFetch(body: unknown, status: number, contentType = "application/json") {
+    const spy = spyOn(globalThis, "fetch").mockImplementation(
+      (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response(
+          typeof body === "string" ? body : JSON.stringify(body),
+          {
+            status,
+            headers: { "Content-Type": contentType },
+          },
+        )
+      }) as typeof fetch
+    )
+  
+    return spy
+  }
+
+test("passes through successful responses unchanged", async () => {
+  const spy = setupFetch({ access_token: "abc123" }, 200)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(200)
+  expect(body.access_token).toBe("abc123")
+  spy.mockRestore()
+})
+
+test("passes through standard RFC 6749 error responses unchanged", async () => {
+  const spy = setupFetch({ error: "invalid_grant", error_description: "Invalid authorization code" }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("Invalid authorization code")
+  spy.mockRestore()
+})
+
+test("normalizes Datadog-style {errors: [...]} to standard {error, error_description}", async () => {
+  const spy = setupFetch({ errors: ["invalid_grant - Invalid authorization code or code verifier."] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("invalid_grant - Invalid authorization code or code verifier.")
+  expect(body.errors).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("normalizes multiple errors in array to comma-separated error_description", async () => {
+  const spy = setupFetch({ errors: ["invalid_grant - error one", "invalid_scope - error two"] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.error_description).toBe("invalid_grant - error one, invalid_scope - error two")
+  expect(body.errors).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("passes through non-JSON error responses unchanged", async () => {
+  const spy = setupFetch("Internal Server Error", 500, "text/plain")
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.text()
+  expect(response.status).toBe(500)
+  expect(body).toBe("Internal Server Error")
+  spy.mockRestore()
+})
+
+test("does not modify response when errors field is not an array", async () => {
+  const spy = setupFetch({ errors: "some string error" }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.errors).toBe("some string error")
+  expect(body.error).toBeUndefined()
+  spy.mockRestore()
+})
+
+test("does not modify response when both error and errors fields exist", async () => {
+  const spy = setupFetch({ error: "invalid_grant", errors: ["some extra field"] }, 400)
+  const response = await normalizedOAuthFetch("https://example.com/token")
+  const body = await response.json()
+  expect(response.status).toBe(400)
+  expect(body.error).toBe("invalid_grant")
+  expect(body.errors).toEqual(["some extra field"])
+  spy.mockRestore()
+})


### PR DESCRIPTION
### Issue for this PR

Closes #17822

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an issue where OAuth remained stuck in `needs_auth` after a successful login.

- Prevent duplicate `saveCodeVerifier` calls causing `invalid_grant`
- Fix incorrect `authProvider` access (`_authProvider`)
- Ensure transport is stored after redirect regardless of error type
- Add support for non-standard OAuth error responses

### How did you verify your code works?

Tested locally with Notion MCP and Atlassian MCP.  
OAuth flow completes successfully, tokens persist, and client is reused across runs.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR