### PR TITLE
fix(desktop): add timeout guards to prevent Windows startup hang

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -150,7 +150,10 @@ async function initialize() {
     })
 
     if (needsMigration) {
-      await sqliteDone?.promise
+      await Promise.race([
+        sqliteDone?.promise,
+        delay(30_000),
+      ])
     }
 
     await Promise.race([
@@ -182,7 +185,10 @@ async function initialize() {
   setInitStep({ phase: "done" })
 
   if (overlay) {
-    await loadingComplete.promise
+    await Promise.race([
+      loadingComplete.promise,
+      delay(10_000),
+    ])
   }
 
   mainWindow = createMainWindow(globals)
@@ -301,8 +307,14 @@ async function getSidecarPort() {
 
 function sqliteFileExists() {
   const xdg = process.env.XDG_DATA_HOME
-  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-  return existsSync(join(base, "opencode", "opencode.db"))
+  const base =
+    xdg && xdg.length > 0
+      ? xdg
+      : process.platform === "win32"
+        ? join(process.env.APPDATA || homedir(), "opencode")
+        : join(homedir(), ".local", "share", "opencode")
+  const dbPath = process.platform === "win32" ? join(base, "opencode.db") : join(base, "opencode", "opencode.db")
+  return existsSync(dbPath)
 }
 
 function setupAutoUpdater() {


### PR DESCRIPTION
### Issue for this PR

Closes #631

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Electron desktop app hangs forever on "Just a moment..." loading screen on Windows when the sidecar is slow to start (e.g. in offline/intranet environments).

Two issues cause this:

1. `sqliteFileExists()` checks `~/.local/share/opencode/opencode.db` — a Linux-only path that never exists on Windows. So `needsMigration` is always `true` on Windows, and the app waits for a `sqlite-migration:done` event from the sidecar.

2. Both `sqliteDone?.promise` and `loadingComplete.promise` are awaited with no timeout. When the sidecar blocks on network requests (models.dev fetch, plugin installs) before emitting the migration event, the app hangs indefinitely.

This is masked on internet-connected Windows because the sidecar finishes network init fast enough to emit the event. On macOS/Linux the path check is correct so `needsMigration` is `false` and the whole code path is skipped.

Fixes:
- `sqliteFileExists()` now uses `%APPDATA%\opencode\opencode.db` on Windows
- `sqliteDone` wait gets a 30s timeout
- `loadingComplete` wait gets a 10s timeout

### How did you verify your code works?

Tested on Windows in an intranet environment (no internet access). Before the fix, the app hung permanently on loading screen. After the fix, the app starts within seconds.

### Screenshots / recordings

_N/A — not a UI change, fixes a startup hang._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
