### PR TITLE
fix: include credentials when fetching site.webmanifest

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon-v3.svg" />
     <link rel="shortcut icon" href="/favicon-v3.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
     <meta name="theme-color" content="#F8F7F7" />
     <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="/social-share.png" />

--- a/packages/ui/src/components/favicon.tsx
+++ b/packages/ui/src/components/favicon.tsx
@@ -6,7 +6,7 @@ export const Favicon = () => {
       <Link rel="icon" type="image/png" href="/favicon-96x96-v3.png" sizes="96x96" />
       <Link rel="shortcut icon" href="/favicon-v3.ico" />
       <Link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v3.png" />
-      <Link rel="manifest" href="/site.webmanifest" />
+      <Link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
       <Meta name="apple-mobile-web-app-title" content="OpenCode" />
     </>
   )


### PR DESCRIPTION
### Issue for this PR

Closes #19301

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `<link rel="manifest">` tag fetches `/site.webmanifest` without credentials by default. When the web app is behind a Cloudflare proxy (e.g. Cloudflare Access), the request gets blocked because cookies aren't sent. Adding `crossorigin="use-credentials"` tells the browser to include cookies with the manifest fetch. For users not behind a proxy, this is a no-op since same-origin requests already include cookies.

Desktop app is left unchanged since it serves files locally.

### How did you verify your code works?

- `bun run test` in `packages/app`: 299 pass, 0 fail
- Typechecks pass across all 13 packages
- Verified the attribute is a no-op for same-origin requests without a proxy

### Screenshots / recordings

_N/A — no UI change, only an HTML attribute addition._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR