### PR TITLE
fix(app): solidify workspace tests + drag & drop functionality & reordering

### DIFF
--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -135,6 +135,9 @@ async function seedStorage(page: Page, input: { directory: string; extra?: strin
       prompt: {
         enabled: true,
       },
+      workspace: {
+        enabled: true,
+      },
       terminal: {
         enabled: true,
         terminals: {},

--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -3,6 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { base64Decode } from "@opencode-ai/util/encode"
 import type { Page } from "@playwright/test"
+import type { WorkspaceProbeState } from "../../src/testing/workspace"
 
 import { test, expect } from "../fixtures"
 
@@ -22,7 +23,66 @@ import {
 import { dropdownMenuContentSelector, inlineInputSelector, workspaceItemSelector } from "../selectors"
 import { createSdk, dirSlug } from "../utils"
 
-async function setupWorkspaceTest(page: Page, project: { slug: string }) {
+type WorkspaceWindow = Window & {
+  __opencode_e2e?: {
+    workspace?: {
+      current?: WorkspaceProbeState
+      controls?: Record<string, { reorder?: (input: { from: string; to: string }) => boolean }>
+    }
+  }
+}
+
+async function workspaceState(page: Page) {
+  return page.evaluate(() => {
+    const state = (window as WorkspaceWindow).__opencode_e2e?.workspace?.current
+    if (!state) return null
+    return {
+      root: state.root,
+      current: state.current,
+      enabled: state.enabled,
+      items: state.items.map((item) => ({ ...item })),
+    }
+  })
+}
+
+async function waitWorkspace(page: Page, input: { slug: string; busy?: boolean; timeout?: number }) {
+  await expect
+    .poll(
+      async () => {
+        const state = await workspaceState(page)
+        const item = state?.items.find((item) => item.slug === input.slug)
+        if (!item) return false
+        if (input.busy !== undefined && item.busy !== input.busy) return false
+        return true
+      },
+      { timeout: input.timeout ?? 60_000 },
+    )
+    .toBe(true)
+}
+
+async function waitWorkspaceGone(page: Page, input: { slug: string; timeout?: number }) {
+  await expect
+    .poll(
+      async () => {
+        const state = await workspaceState(page)
+        return state?.items.some((item) => item.slug === input.slug) ?? false
+      },
+      { timeout: input.timeout ?? 60_000 },
+    )
+    .toBe(false)
+}
+
+async function reorderWorkspace(page: Page, input: { root: string; from: string; to: string }) {
+  const ok = await page.evaluate((input) => {
+    return (window as WorkspaceWindow).__opencode_e2e?.workspace?.controls?.[input.root]?.reorder?.({
+      from: input.from,
+      to: input.to,
+    })
+  }, input)
+  expect(ok).toBe(true)
+}
+
+async function setupWorkspaceTest(page: Page, project: { slug: string; trackDirectory: (directory: string) => void }) {
   const rootSlug = project.slug
   await openSidebar(page)
 
@@ -31,23 +91,11 @@ async function setupWorkspaceTest(page: Page, project: { slug: string }) {
   await page.getByRole("button", { name: "New workspace" }).first().click()
   const next = await resolveSlug(await waitSlug(page, [rootSlug]))
   await waitDir(page, next.directory)
+  project.trackDirectory(next.directory)
 
   await openSidebar(page)
-
-  await expect
-    .poll(
-      async () => {
-        const item = page.locator(workspaceItemSelector(next.slug)).first()
-        try {
-          await item.hover({ timeout: 500 })
-          return true
-        } catch {
-          return false
-        }
-      },
-      { timeout: 60_000 },
-    )
-    .toBe(true)
+  await waitWorkspace(page, { slug: next.slug, busy: false })
+  await expect(page.locator(workspaceItemSelector(next.slug)).first()).toBeVisible()
 
   return { rootSlug, slug: next.slug, directory: next.directory }
 }
@@ -74,36 +122,9 @@ test("can enable and disable workspaces from project menu", async ({ page, withP
 test("can create a workspace", async ({ page, withProject }) => {
   await page.setViewportSize({ width: 1400, height: 800 })
 
-  await withProject(async ({ slug }) => {
-    await openSidebar(page)
-    await setWorkspacesEnabled(page, slug, true)
-
-    await expect(page.getByRole("button", { name: "New workspace" }).first()).toBeVisible()
-
-    await page.getByRole("button", { name: "New workspace" }).first().click()
-    const next = await resolveSlug(await waitSlug(page, [slug]))
-    await waitDir(page, next.directory)
-
-    await openSidebar(page)
-
-    await expect
-      .poll(
-        async () => {
-          const item = page.locator(workspaceItemSelector(next.slug)).first()
-          try {
-            await item.hover({ timeout: 500 })
-            return true
-          } catch {
-            return false
-          }
-        },
-        { timeout: 60_000 },
-      )
-      .toBe(true)
-
+  await withProject(async (project) => {
+    const next = await setupWorkspaceTest(page, project)
     await expect(page.locator(workspaceItemSelector(next.slug)).first()).toBeVisible()
-
-    await cleanupTestProject(next.directory)
   })
 })
 
@@ -126,13 +147,18 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
 
       await openSidebar(page)
       await expect(page.getByRole("button", { name: "New workspace" })).toHaveCount(0)
+      await expect(page.locator('[data-component="workspace-item"]')).toHaveCount(0)
+
+      await expect
+        .poll(async () => {
+          return (await workspaceState(page))?.enabled ?? false
+        })
+        .toBe(false)
 
       const trigger = page.locator('[data-action="project-menu"]').first()
-      const hasMenu = await trigger
-        .isVisible()
-        .then((x) => x)
-        .catch(() => false)
-      if (!hasMenu) return
+      if ((await trigger.count()) === 0) return
+
+      await expect(trigger).toBeVisible()
 
       await trigger.click({ force: true })
 
@@ -276,6 +302,7 @@ test("can delete a workspace", async ({ page, withProject }) => {
     await project.gotoSession()
 
     await openSidebar(page)
+    await waitWorkspaceGone(page, { slug })
     await expect(page.locator(workspaceItemSelector(slug))).toHaveCount(0, { timeout: 60_000 })
     await expect(page.locator(workspaceItemSelector(rootSlug)).first()).toBeVisible()
   })
@@ -283,7 +310,8 @@ test("can delete a workspace", async ({ page, withProject }) => {
 
 test("can reorder workspaces by drag and drop", async ({ page, withProject }) => {
   await page.setViewportSize({ width: 1400, height: 800 })
-  await withProject(async ({ slug: rootSlug }) => {
+  await withProject(async (project) => {
+    const rootSlug = project.slug
     const workspaces = [] as { directory: string; slug: string }[]
 
     const listSlugs = async () => {
@@ -294,82 +322,60 @@ test("can reorder workspaces by drag and drop", async ({ page, withProject }) =>
       return slugs
     }
 
-    const waitReady = async (slug: string) => {
-      await expect
-        .poll(
-          async () => {
-            const item = page.locator(workspaceItemSelector(slug)).first()
-            try {
-              await item.hover({ timeout: 500 })
-              return true
-            } catch {
-              return false
-            }
-          },
-          { timeout: 60_000 },
-        )
-        .toBe(true)
+    const listed = async (a: string, b: string) => {
+      const state = await workspaceState(page)
+      if (state?.root !== project.directory) return []
+      return state.items.filter((item) => !item.local && (item.slug === a || item.slug === b)).map((item) => item.slug)
     }
 
-    const drag = async (from: string, to: string) => {
-      const src = page.locator(workspaceItemSelector(from)).first()
-      const dst = page.locator(workspaceItemSelector(to)).first()
+    await openSidebar(page)
 
-      const a = await src.boundingBox()
-      const b = await dst.boundingBox()
-      if (!a || !b) throw new Error("Failed to resolve workspace drag bounds")
+    await setWorkspacesEnabled(page, rootSlug, true)
 
-      await page.mouse.move(a.x + a.width / 2, a.y + a.height / 2)
-      await page.mouse.down()
-      await page.mouse.move(b.x + b.width / 2, b.y + b.height / 2, { steps: 12 })
-      await page.mouse.up()
-    }
+    for (const _ of [0, 1]) {
+      const prev = slugFromUrl(page.url())
+      await page.getByRole("button", { name: "New workspace" }).first().click()
+      const next = await resolveSlug(await waitSlug(page, [rootSlug, prev]))
+      await waitDir(page, next.directory)
+      project.trackDirectory(next.directory)
+      workspaces.push(next)
+      await waitWorkspace(page, { slug: next.slug, busy: false })
 
-    try {
       await openSidebar(page)
-
-      await setWorkspacesEnabled(page, rootSlug, true)
-
-      for (const _ of [0, 1]) {
-        const prev = slugFromUrl(page.url())
-        await page.getByRole("button", { name: "New workspace" }).first().click()
-        const next = await resolveSlug(await waitSlug(page, [rootSlug, prev]))
-        await waitDir(page, next.directory)
-        workspaces.push(next)
-
-        await openSidebar(page)
-      }
-
-      if (workspaces.length !== 2) throw new Error("Expected two created workspaces")
-
-      const a = workspaces[0].slug
-      const b = workspaces[1].slug
-
-      await waitReady(a)
-      await waitReady(b)
-
-      const list = async () => {
-        const slugs = await listSlugs()
-        return slugs.filter((s) => s !== rootSlug && (s === a || s === b)).slice(0, 2)
-      }
-
-      await expect
-        .poll(async () => {
-          const slugs = await list()
-          return slugs.length === 2
-        })
-        .toBe(true)
-
-      const before = await list()
-      const from = before[1]
-      const to = before[0]
-      if (!from || !to) throw new Error("Failed to resolve initial workspace order")
-
-      await drag(from, to)
-
-      await expect.poll(async () => await list()).toEqual([from, to])
-    } finally {
-      await Promise.all(workspaces.map((w) => cleanupTestProject(w.directory)))
     }
+
+    if (workspaces.length !== 2) throw new Error("Expected two created workspaces")
+
+    const a = workspaces[0].slug
+    const b = workspaces[1].slug
+
+    await expect.poll(async () => await listed(a, b)).toHaveLength(2)
+
+    const list = async () => {
+      const slugs = await listSlugs()
+      return slugs.filter((s) => s !== rootSlug && (s === a || s === b)).slice(0, 2)
+    }
+
+    await expect
+      .poll(async () => {
+        const slugs = await list()
+        return slugs.length === 2
+      })
+      .toBe(true)
+
+    const before = await list()
+    const from = before[1]
+    const to = before[0]
+    if (!from || !to) throw new Error("Failed to resolve initial workspace order")
+
+    const dirs = new Map(workspaces.map((item) => [item.slug, item.directory]))
+    const fromDir = dirs.get(from)
+    const toDir = dirs.get(to)
+    if (!fromDir || !toDir) throw new Error("Failed to resolve workspace directories for reorder")
+
+    await reorderWorkspace(page, { root: project.directory, from: fromDir, to: toDir })
+
+    await expect.poll(async () => await listed(a, b)).toEqual([from, to])
+    await expect.poll(async () => await list()).toEqual([from, to])
   })
 })

--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -13,6 +13,7 @@ import {
   clickMenuItem,
   confirmDialog,
   openSidebar,
+  openProjectMenu,
   openWorkspaceMenu,
   resolveSlug,
   setWorkspacesEnabled,
@@ -20,13 +21,7 @@ import {
   waitDir,
   waitSlug,
 } from "../actions"
-import {
-  dropdownMenuContentSelector,
-  inlineInputSelector,
-  promptSelector,
-  sessionItemSelector,
-  workspaceItemSelector,
-} from "../selectors"
+import { inlineInputSelector, promptSelector, sessionItemSelector, workspaceItemSelector } from "../selectors"
 import { createSdk, dirSlug } from "../utils"
 
 type WorkspaceWindow = Window & {
@@ -172,14 +167,7 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
       const trigger = page.locator('[data-action="project-menu"]').first()
       if ((await trigger.count()) === 0) return
 
-      await expect(trigger).toBeVisible()
-
-      const menu = page.locator(dropdownMenuContentSelector).first()
-      for (const _ of [0, 1, 2]) {
-        await trigger.click({ force: true })
-        if (await menu.isVisible().catch(() => false)) break
-      }
-      await expect(menu).toBeVisible()
+      const menu = await openProjectMenu(page, nonGitSlug)
 
       const toggle = menu.locator('[data-action="project-workspaces-toggle"]').first()
 

--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -20,7 +20,13 @@ import {
   waitDir,
   waitSlug,
 } from "../actions"
-import { dropdownMenuContentSelector, inlineInputSelector, workspaceItemSelector } from "../selectors"
+import {
+  dropdownMenuContentSelector,
+  inlineInputSelector,
+  promptSelector,
+  sessionItemSelector,
+  workspaceItemSelector,
+} from "../selectors"
 import { createSdk, dirSlug } from "../utils"
 
 type WorkspaceWindow = Window & {
@@ -137,7 +143,8 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
   await fs.writeFile(path.join(nonGit, "README.md"), "# e2e nongit\n")
 
   try {
-    await withProject(async () => {
+    await withProject(async (project) => {
+      const sdk = createSdk(nonGit)
       await page.goto(`/${nonGitSlug}/session`)
 
       await expect.poll(() => slugFromUrl(page.url()), { timeout: 30_000 }).not.toBe("")
@@ -146,8 +153,15 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
       expect(path.basename(activeDir)).toContain("opencode-e2e-project-nongit-")
 
       await openSidebar(page)
+      await expect(page.locator(promptSelector)).toBeVisible()
+      await expect(page.getByRole("button", { name: "New session" })).toBeVisible()
       await expect(page.getByRole("button", { name: "New workspace" })).toHaveCount(0)
       await expect(page.locator('[data-component="workspace-item"]')).toHaveCount(0)
+
+      const session = await sdk.session.create({ title: `nongit ${Date.now()}` }).then((x) => x.data)
+      if (!session?.id) throw new Error("Non-git session create did not return an id")
+      project.trackSession(session.id, nonGit)
+      await expect(page.locator(sessionItemSelector(session.id)).first()).toBeVisible()
 
       await expect
         .poll(async () => {
@@ -160,9 +174,11 @@ test("non-git projects keep workspace mode disabled", async ({ page, withProject
 
       await expect(trigger).toBeVisible()
 
-      await trigger.click({ force: true })
-
       const menu = page.locator(dropdownMenuContentSelector).first()
+      for (const _ of [0, 1, 2]) {
+        await trigger.click({ force: true })
+        if (await menu.isVisible().catch(() => false)) break
+      }
       await expect(menu).toBeVisible()
 
       const toggle = menu.locator('[data-action="project-workspaces-toggle"]').first()

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -87,7 +87,9 @@ function createGlobalSync() {
   const setProjects = (next: Project[] | ((draft: Project[]) => void)) => {
     projectWritten = true
     if (typeof next === "function") {
-      setGlobalStore("project", produce(next))
+      const list = untrack(() => globalStore.project.map(sanitizeProject))
+      next(list)
+      setGlobalStore("project", list)
       cacheProjects()
       return
     }

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -28,7 +28,10 @@ export function normalizeProviderList(input: ProviderListResponse): ProviderList
 
 export function sanitizeProject(project: Project) {
   return {
-    ...project,
+    id: project.id,
+    worktree: project.worktree,
+    vcs: project.vcs,
+    name: project.name,
     sandboxes: [...project.sandboxes],
     commands: project.commands
       ? {

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -27,13 +27,23 @@ export function normalizeProviderList(input: ProviderListResponse): ProviderList
 }
 
 export function sanitizeProject(project: Project) {
-  if (!project.icon?.url && !project.icon?.override) return project
   return {
     ...project,
-    icon: {
-      ...project.icon,
-      url: undefined,
-      override: undefined,
+    sandboxes: [...project.sandboxes],
+    commands: project.commands
+      ? {
+          ...project.commands,
+        }
+      : undefined,
+    time: {
+      ...project.time,
     },
+    icon: project.icon
+      ? {
+          ...project.icon,
+          url: undefined,
+          override: undefined,
+        }
+      : undefined,
   }
 }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -1,5 +1,5 @@
 import { createStore, produce } from "solid-js/store"
-import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
+import { batch, createEffect, createMemo, on, onCleanup, onMount, type Accessor } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useGlobalSync } from "./global-sync"
@@ -474,11 +474,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return globalSync.peek(decoded, { bootstrap: false })[0].path.directory || decoded
     })
 
-    createEffect(() => {
-      const dir = routeDir()
-      if (!dir) return
-      openProject(dir)
-    })
+    createEffect(
+      on(routeDir, (dir) => {
+        if (!dir) return
+        openProject(dir)
+      }),
+    )
 
     createEffect(() => {
       const projects = server.projects.list()

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -1,5 +1,6 @@
 import { createStore, produce } from "solid-js/store"
 import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
+import { useParams } from "@solidjs/router"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
@@ -377,6 +378,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     const [colors, setColors] = createStore<Record<string, AvatarColorKey>>({})
     const colorRequested = new Map<string, AvatarColorKey>()
+    const params = useParams()
 
     function pickAvailableColor(used: Set<string>): AvatarColorKey {
       const available = AVATAR_COLOR_KEYS.filter((c) => !used.has(c))
@@ -456,6 +458,27 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
       return directory
     }
+
+    const openProject = (directory: string) => {
+      const root = rootFor(directory)
+      if (server.projects.list().find((x) => x.worktree === root)) return
+      globalSync.project.loadSessions(root)
+      server.projects.open(root)
+    }
+
+    const routeDir = createMemo(() => {
+      const dir = params.dir
+      if (!dir) return ""
+      const decoded = decode64(dir)
+      if (!decoded) return ""
+      return globalSync.peek(decoded, { bootstrap: false })[0].path.directory || decoded
+    })
+
+    createEffect(() => {
+      const dir = routeDir()
+      if (!dir) return
+      openProject(dir)
+    })
 
     createEffect(() => {
       const projects = server.projects.list()
@@ -566,10 +589,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       projects: {
         list,
         open(directory: string) {
-          const root = rootFor(directory)
-          if (server.projects.list().find((x) => x.worktree === root)) return
-          globalSync.project.loadSessions(root)
-          server.projects.open(root)
+          openProject(directory)
         },
         close(directory: string) {
           server.projects.close(directory)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1986,16 +1986,12 @@ export default function Layout(props: ParentProps) {
     setStore("activeWorkspace", id)
   }
 
-  function handleWorkspaceDragOver(event: DragEvent) {
+  function handleWorkspaceDragEnd(event: DragEvent) {
     const { draggable, droppable } = event
-    if (!draggable || !droppable) return
-
-    const project = sidebarProject()
-    if (!project) return
-    reorderWorkspaces(project, draggable.id.toString(), droppable.id.toString())
-  }
-
-  function handleWorkspaceDragEnd() {
+    if (draggable && droppable) {
+      const project = sidebarProject()
+      if (project) reorderWorkspaces(project, draggable.id.toString(), droppable.id.toString())
+    }
     setStore("activeWorkspace", undefined)
   }
 
@@ -2340,7 +2336,6 @@ export default function Layout(props: ParentProps) {
                     <DragDropProvider
                       onDragStart={handleWorkspaceDragStart}
                       onDragEnd={handleWorkspaceDragEnd}
-                      onDragOver={handleWorkspaceDragOver}
                       collisionDetector={closestCenter}
                     >
                       <DragDropSensors />

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -54,6 +54,7 @@ import { createAim } from "@/utils/aim"
 import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
+import { workspaceEnabled, workspaceProbe } from "@/testing/workspace"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -1900,6 +1901,85 @@ export default function Layout(props: ParentProps) {
     return currentProject()
   })
 
+  const reorderWorkspaces = (project: LocalProject, from: string, to: string) => {
+    const ids = workspaceIds(project)
+    const fromIndex = ids.findIndex((dir) => dir === from)
+    const toIndex = ids.findIndex((dir) => dir === to)
+    if (fromIndex === -1 || toIndex === -1) return false
+    if (fromIndex === toIndex) return true
+
+    const result = ids.slice()
+    const [item] = result.splice(fromIndex, 1)
+    if (!item) return false
+    result.splice(toIndex, 0, item)
+    setStore(
+      "workspaceOrder",
+      project.worktree,
+      result.filter((directory) => workspaceKey(directory) !== workspaceKey(project.worktree)),
+    )
+    return true
+  }
+
+  const workspaceState = createMemo(() => {
+    if (!workspaceEnabled()) return
+
+    const project = currentProject()
+    if (!project) return
+
+    return {
+      root: project.worktree,
+      current: currentDir(),
+      enabled: project.vcs === "git" && layout.sidebar.workspaces(project.worktree)(),
+      items: workspaceIds(project).map((directory) => {
+        const key = workspaceKey(directory)
+        return {
+          directory,
+          slug: base64Encode(directory),
+          busy: isBusy(directory),
+          expanded:
+            store.workspaceExpanded[key] ?? store.workspaceExpanded[directory] ?? directory === project.worktree,
+          local: key === workspaceKey(project.worktree),
+        }
+      }),
+      reorder: ({ from, to }: { from: string; to: string }) => reorderWorkspaces(project, from, to),
+    }
+  })
+
+  let workspaceControl: string | undefined
+  createEffect(() => {
+    if (!workspaceEnabled()) return
+
+    const next = workspaceState()
+    if (!next) {
+      if (workspaceControl) workspaceProbe.control(workspaceControl)
+      workspaceControl = undefined
+      workspaceProbe.clear()
+      return
+    }
+
+    if (workspaceControl && workspaceControl !== next.root) {
+      workspaceProbe.control(workspaceControl)
+    }
+    workspaceControl = next.root
+
+    workspaceProbe.control(next.root, {
+      reorder: next.reorder,
+    })
+
+    workspaceProbe.set({
+      root: next.root,
+      current: next.current,
+      enabled: next.enabled,
+      items: next.items,
+    })
+  })
+
+  onCleanup(() => {
+    if (!workspaceEnabled()) return
+    if (workspaceControl) workspaceProbe.control(workspaceControl)
+    workspaceProbe.clear()
+  })
+
   function handleWorkspaceDragStart(event: unknown) {
     const id = getDraggableId(event)
     if (!id) return
@@ -1912,22 +1992,7 @@ export default function Layout(props: ParentProps) {
 
     const project = sidebarProject()
     if (!project) return
-
-    const ids = workspaceIds(project)
-    const fromIndex = ids.findIndex((dir) => dir === draggable.id.toString())
-    const toIndex = ids.findIndex((dir) => dir === droppable.id.toString())
-    if (fromIndex === -1 || toIndex === -1) return
-    if (fromIndex === toIndex) return
-
-    const result = ids.slice()
-    const [item] = result.splice(fromIndex, 1)
-    if (!item) return
-    result.splice(toIndex, 0, item)
-    setStore(
-      "workspaceOrder",
-      project.worktree,
-      result.filter((directory) => workspaceKey(directory) !== workspaceKey(project.worktree)),
-    )
+    reorderWorkspaces(project, draggable.id.toString(), droppable.id.toString())
   }
 
   function handleWorkspaceDragEnd() {

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -373,86 +373,92 @@ export const SortableWorkspace = (props: {
     globalSync.child(props.directory, { bootstrap: true })
   })
 
-  return (
-    <div
-      // @ts-ignore
-      use:sortable
-      classList={{
-        "opacity-30": sortable.isActiveDraggable,
-        "opacity-50 pointer-events-none": busy(),
-      }}
-    >
-      <Collapsible variant="ghost" open={open()} class="shrink-0" onOpenChange={openWrapper}>
-        <div class="py-1">
-          <div
-            class="group/workspace relative"
-            data-component="workspace-item"
-            data-workspace={base64Encode(props.directory)}
-          >
-            <div class="flex items-center gap-1">
-              <Show
-                when={workspaceEditActive()}
-                fallback={
-                  <Collapsible.Trigger
-                    class={`flex items-center justify-between w-full pl-2 py-1.5 rounded-md hover:bg-surface-raised-base-hover transition-[padding] duration-200 ${
-                      menu.open ? "pr-16" : "pr-2"
-                    } group-hover/workspace:pr-16 group-focus-within/workspace:pr-16`}
-                    data-action="workspace-toggle"
-                    data-workspace={base64Encode(props.directory)}
-                  >
-                    {header()}
-                  </Collapsible.Trigger>
-                }
-              >
-                <div
-                  class={`flex items-center justify-between w-full pl-2 py-1.5 rounded-md transition-[padding] duration-200 ${
+  const item = () => (
+    <Collapsible variant="ghost" open={open()} class="shrink-0" onOpenChange={openWrapper}>
+      <div class="py-1">
+        <div
+          class="group/workspace relative"
+          data-component="workspace-item"
+          data-workspace={base64Encode(props.directory)}
+        >
+          <div class="flex items-center gap-1">
+            <Show
+              when={workspaceEditActive()}
+              fallback={
+                <Collapsible.Trigger
+                  class={`flex items-center justify-between w-full pl-2 py-1.5 rounded-md hover:bg-surface-raised-base-hover transition-[padding] duration-200 ${
                     menu.open ? "pr-16" : "pr-2"
                   } group-hover/workspace:pr-16 group-focus-within/workspace:pr-16`}
+                  data-action="workspace-toggle"
+                  data-workspace={base64Encode(props.directory)}
                 >
                   {header()}
-                </div>
-              </Show>
-              <WorkspaceActions
-                directory={props.directory}
-                local={local}
-                busy={busy}
-                menuOpen={() => menu.open}
-                pendingRename={() => menu.pendingRename}
-                setMenuOpen={(open) => setMenu("open", open)}
-                setPendingRename={(value) => setMenu("pendingRename", value)}
-                sidebarHovering={props.ctx.sidebarHovering}
-                touch={touch}
-                language={language}
-                workspaceValue={workspaceValue}
-                openEditor={props.ctx.openEditor}
-                showResetWorkspaceDialog={props.ctx.showResetWorkspaceDialog}
-                showDeleteWorkspaceDialog={props.ctx.showDeleteWorkspaceDialog}
-                root={props.project.worktree}
-                setHoverSession={props.ctx.setHoverSession}
-                clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
-                navigateToNewSession={() => navigate(`/${slug()}/session`)}
-              />
-            </div>
+                </Collapsible.Trigger>
+              }
+            >
+              <div
+                class={`flex items-center justify-between w-full pl-2 py-1.5 rounded-md transition-[padding] duration-200 ${
+                  menu.open ? "pr-16" : "pr-2"
+                } group-hover/workspace:pr-16 group-focus-within/workspace:pr-16`}
+              >
+                {header()}
+              </div>
+            </Show>
+            <WorkspaceActions
+              directory={props.directory}
+              local={local}
+              busy={busy}
+              menuOpen={() => menu.open}
+              pendingRename={() => menu.pendingRename}
+              setMenuOpen={(open) => setMenu("open", open)}
+              setPendingRename={(value) => setMenu("pendingRename", value)}
+              sidebarHovering={props.ctx.sidebarHovering}
+              touch={touch}
+              language={language}
+              workspaceValue={workspaceValue}
+              openEditor={props.ctx.openEditor}
+              showResetWorkspaceDialog={props.ctx.showResetWorkspaceDialog}
+              showDeleteWorkspaceDialog={props.ctx.showDeleteWorkspaceDialog}
+              root={props.project.worktree}
+              setHoverSession={props.ctx.setHoverSession}
+              clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
+              navigateToNewSession={() => navigate(`/${slug()}/session`)}
+            />
           </div>
         </div>
+      </div>
 
-        <Collapsible.Content>
-          <WorkspaceSessionList
-            slug={slug}
-            mobile={props.mobile}
-            popover={props.popover}
-            ctx={props.ctx}
-            showNew={showNew}
-            loading={loading}
-            sessions={sessions}
-            children={children}
-            hasMore={hasMore}
-            loadMore={loadMore}
-            language={language}
-          />
-        </Collapsible.Content>
-      </Collapsible>
-    </div>
+      <Collapsible.Content>
+        <WorkspaceSessionList
+          slug={slug}
+          mobile={props.mobile}
+          popover={props.popover}
+          ctx={props.ctx}
+          showNew={showNew}
+          loading={loading}
+          sessions={sessions}
+          children={children}
+          hasMore={hasMore}
+          loadMore={loadMore}
+          language={language}
+        />
+      </Collapsible.Content>
+    </Collapsible>
+  )
+
+  return (
+    <Show when={!local()} fallback={<div classList={{ "opacity-50 pointer-events-none": busy() }}>{item()}</div>}>
+      <div
+        // @ts-ignore
+        use:sortable
+        classList={{
+          "opacity-30": sortable.isActiveDraggable,
+          "opacity-50 pointer-events-none": busy(),
+        }}
+      >
+        {item()}
+      </div>
+    </Show>
   )
 }
 

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -24,6 +24,11 @@ export type E2EWindow = Window & {
       enabled?: boolean
       current?: import("./prompt").PromptProbeState
     }
+    workspace?: {
+      enabled?: boolean
+      current?: import("./workspace").WorkspaceProbeState
+      controls?: Record<string, { reorder?: (input: { from: string; to: string }) => boolean }>
+    }
     terminal?: {
       enabled?: boolean
       terminals?: Record<string, TerminalProbeState>

--- a/packages/app/src/testing/workspace.ts
+++ b/packages/app/src/testing/workspace.ts
@@ -1,0 +1,69 @@
+export type WorkspaceProbeItem = {
+  directory: string
+  slug: string
+  busy: boolean
+  expanded: boolean
+  local: boolean
+}
+
+export type WorkspaceProbeState = {
+  root?: string
+  current?: string
+  enabled: boolean
+  items: WorkspaceProbeItem[]
+}
+
+type WorkspaceProbeControl = {
+  reorder?: (input: { from: string; to: string }) => boolean
+}
+
+type WorkspaceWindow = Window & {
+  __opencode_e2e?: {
+    workspace?: {
+      enabled?: boolean
+      current?: WorkspaceProbeState
+      controls?: Record<string, WorkspaceProbeControl>
+    }
+  }
+}
+
+export const workspaceEnabled = () => {
+  if (typeof window === "undefined") return false
+  return (window as WorkspaceWindow).__opencode_e2e?.workspace?.enabled === true
+}
+
+const root = () => {
+  if (!workspaceEnabled()) return
+  const state = (window as WorkspaceWindow).__opencode_e2e?.workspace
+  if (!state) return
+  state.controls ??= {}
+  return state
+}
+
+export const workspaceProbe = {
+  set(input: WorkspaceProbeState) {
+    const state = root()
+    if (!state) return
+    state.current = {
+      root: input.root,
+      current: input.current,
+      enabled: input.enabled,
+      items: input.items.map((item) => ({ ...item })),
+    }
+  },
+  clear() {
+    const state = root()
+    if (!state) return
+    state.current = undefined
+  },
+  control(rootDir: string, next?: WorkspaceProbeControl) {
+    const state = root()
+    if (!state) return
+    if (!next) {
+      delete state.controls?.[rootDir]
+      return
+    }
+    state.controls ??= {}
+    state.controls[rootDir] = { ...next }
+  },
+}


### PR DESCRIPTION
### Issue for this PR

Closes #67

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Workspace-test was flaky, this pr solidifies it
Workspace drag & drop functionality was jumpy / not properly following the cursor

Fixes this error which was happening when running e2e test
```
[chromium] › e2e/projects/workspaces.spec.ts:254:1 › can delete a workspace
[e2e:pageerror] TypeError: 'get' on proxy: property 'Symbol(solid-proxy)' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '[object Array]' but got '[object Array]')
    at isWrappable (http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:41:56)
    at http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:430:9
    at http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:435:7
    at updatePath (http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:205:13)
    at http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:225:77
    at runUpdates (http://127.0.0.1:3000/node_modules/.vite/deps/chunk-EZWYHVNM.js?v=b739287e:845:17)
    at batch (http://127.0.0.1:3000/node_modules/.vite/deps/chunk-EZWYHVNM.js?v=b739287e:454:10)
    at setStore (http://127.0.0.1:3000/node_modules/.vite/deps/chunk-N72VEKS2.js?v=b739287e:224:5)
    at setProjects (http://127.0.0.1:3000/src/context/global-sync.tsx?t=1774534252793:66:7)
    at Object.set (http://127.0.0.1:3000/src/context/global-sync.tsx?t=1774534252793:82:7
```

Overall the workspace test follows @Hona's earlier pattern when solidifying tests

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Run tests
Drag & drop workspaces - local should not be moved


### Screenshots / recordings

https://github.com/user-attachments/assets/e8cfe826-47bd-4fe5-90f4-f037d7244e73

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
