### PR TITLE
fix(server): harden embedded web UI serving

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -65,17 +65,26 @@ const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
 
+// Exclude optional font files — only keep core UI fonts (Inter + IBM Plex Mono).
+// This saves ~27MB since users only use one of 12+ optional monospace fonts.
+// Excluded fonts fall through to the CDN proxy at runtime.
+const CORE_FONT = /\/(inter|BlexMono)/i
+const OPTIONAL_FONT = /\.(woff2|woff|ttf)$/
+
 const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
   const appDir = path.join(import.meta.dirname, "../../app")
   await $`bun run --cwd ${appDir} build`
   const allFiles = await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: path.join(appDir, "dist") }))
+  const filtered = allFiles.filter((f) => !OPTIONAL_FONT.test(f) || CORE_FONT.test(f))
+  const excluded = allFiles.length - filtered.length
+  console.log(`Embedding ${filtered.length} web UI assets (${excluded} optional fonts externalized to CDN)`)
   const fileMap = `
-    // Import all files as file_$i with type: "file" 
-    ${allFiles.map((filePath, i) => `import file_${i} from "${path.join(appDir, "dist", filePath)}" with { type: "file" };`).join("\n")}
+    // Import all files as file_$i with type: "file"
+    ${filtered.map((filePath, i) => `import file_${i} from "${path.join(appDir, "dist", filePath)}" with { type: "file" };`).join("\n")}
     // Export with original mappings
     export default {
-      ${allFiles.map((filePath, i) => `"${filePath}": file_${i},`).join("\n")}
+      ${filtered.map((filePath, i) => `"${filePath}": file_${i},`).join("\n")}
     }
     `.trim()
   return fileMap

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -70,6 +70,7 @@ export namespace Flag {
   export const OPENCODE_EXPERIMENTAL_MARKDOWN = !falsy("OPENCODE_EXPERIMENTAL_MARKDOWN")
   export const OPENCODE_MODELS_URL = process.env["OPENCODE_MODELS_URL"]
   export const OPENCODE_MODELS_PATH = process.env["OPENCODE_MODELS_PATH"]
+  export const OPENCODE_APP_DIR = process.env["OPENCODE_APP_DIR"]
   export const OPENCODE_DISABLE_EMBEDDED_WEB_UI = truthy("OPENCODE_DISABLE_EMBEDDED_WEB_UI")
   export const OPENCODE_DB = process.env["OPENCODE_DB"]
   export const OPENCODE_DISABLE_CHANNEL_DB = truthy("OPENCODE_DISABLE_CHANNEL_DB")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -56,12 +56,119 @@ initProjectors()
 
 export namespace Server {
   const log = Log.create({ service: "server" })
-  const DEFAULT_CSP =
+  const CSP =
     "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
   const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
     ? Promise.resolve(null)
     : // @ts-expect-error - generated file at build time
       import("opencode-web-ui.gen.ts").then((module) => module.default as Record<string, string>).catch(() => null)
+
+  const MIME: Record<string, string> = {
+    html: "text/html; charset=utf-8",
+    js: "application/javascript",
+    mjs: "application/javascript",
+    css: "text/css",
+    json: "application/json",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    svg: "image/svg+xml",
+    ico: "image/x-icon",
+    woff: "font/woff",
+    woff2: "font/woff2",
+    ttf: "font/ttf",
+    wasm: "application/wasm",
+    txt: "text/plain",
+    webmanifest: "application/manifest+json",
+  }
+
+  // Resolve the local app directory. Resolution order:
+  //   1. OPENCODE_APP_DIR env var (explicit override for dev)
+  //   2. Auto-detect packages/app/dist relative to this file (monorepo dev)
+  // Embedded assets are handled separately via embeddedUIPromise.
+  let _appDir: string | false | undefined
+  function resolveAppDir(): string | undefined {
+    if (_appDir !== undefined) return _appDir || undefined
+
+    if (Flag.OPENCODE_APP_DIR) {
+      _appDir = Flag.OPENCODE_APP_DIR
+      return _appDir
+    }
+
+    try {
+      const url = new URL("../../../app/dist", import.meta.url)
+      if (url.protocol === "file:") {
+        if (Bun.file(url.pathname + "/index.html").size > 0) {
+          _appDir = url.pathname
+          return _appDir
+        }
+      }
+    } catch {}
+
+    _appDir = false
+    return undefined
+  }
+
+  function mime(path: string) {
+    return MIME[path.split(".").pop() ?? ""] ?? "application/octet-stream"
+  }
+
+  // Serve an embedded asset from the $bunfs manifest.
+  function serveEmbedded(reqPath: string, manifest: Record<string, string>): Response | undefined {
+    const key = reqPath === "/" ? "index.html" : reqPath.replace(/^\//, "")
+    const bunfs = manifest[key]
+    if (!bunfs) return undefined
+    const file = Bun.file(bunfs)
+    if (file.size > 0) {
+      return new Response(file, {
+        headers: { "Content-Type": mime(key), "Content-Security-Policy": CSP },
+      })
+    }
+    return undefined
+  }
+
+  // Serve a static file from a local directory.
+  function serveFile(reqPath: string, dir: string): Response | undefined {
+    const rel = reqPath === "/" ? "/index.html" : reqPath
+    const file = Bun.file(dir + rel)
+    if (file.size > 0) {
+      return new Response(file, {
+        headers: { "Content-Type": mime(rel), "Content-Security-Policy": CSP },
+      })
+    }
+    return undefined
+  }
+
+  // Serve a static file or fall back to index.html for SPA page routes.
+  // Paths with file extensions (e.g. .woff2, .js) are asset requests that
+  // should NOT get the SPA fallback — they fall through to CDN proxy.
+  function serveLocal(
+    reqPath: string,
+    manifest: Record<string, string> | null,
+    dir: string | undefined,
+  ): Response | undefined {
+    if (manifest) {
+      const res = serveEmbedded(reqPath, manifest)
+      if (res) return res
+    }
+    if (dir) {
+      const res = serveFile(reqPath, dir)
+      if (res) return res
+    }
+    // SPA fallback for page routes (no extension)
+    if (!/\.[a-zA-Z0-9]+$/.test(reqPath)) {
+      if (manifest) {
+        const idx = serveEmbedded("/index.html", manifest)
+        if (idx) return idx
+      }
+      if (dir) {
+        const idx = serveFile("/index.html", dir)
+        if (idx) return idx
+      }
+    }
+    return undefined
+  }
 
   export const Default = lazy(() => createApp({}))
 
@@ -202,6 +309,22 @@ export namespace Server {
           return c.json(true)
         },
       )
+      .use(async (c, next) => {
+        // Serve static assets before Instance.provide() to avoid DB migration
+        // checks on every asset request. Only exact file matches — no SPA fallback
+        // here so API routes like /agent, /health are not intercepted.
+        const embedded = await embeddedUIPromise
+        if (embedded) {
+          const res = serveEmbedded(c.req.path, embedded)
+          if (res) return res
+        }
+        const dir = resolveAppDir()
+        if (dir) {
+          const res = serveFile(c.req.path, dir)
+          if (res) return res
+        }
+        return next()
+      })
       .use(async (c, next) => {
         if (c.req.path === "/log") return next()
         const rawWorkspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")
@@ -510,39 +633,28 @@ export namespace Server {
         },
       )
       .all("/*", async (c) => {
-        const embeddedWebUI = await embeddedUIPromise
-        const path = c.req.path
+        // Try local/embedded assets with SPA fallback
+        const embedded = await embeddedUIPromise
+        const dir = resolveAppDir()
+        const local = serveLocal(c.req.path, embedded, dir)
+        if (local) return local
 
-        if (embeddedWebUI) {
-          const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
-          if (!match) return c.json({ error: "Not Found" }, 404)
-          const file = Bun.file(match)
-          if (await file.exists()) {
-            c.header("Content-Type", file.type)
-            if (file.type.startsWith("text/html")) {
-              c.header("Content-Security-Policy", DEFAULT_CSP)
-            }
-            return c.body(await file.arrayBuffer())
-          } else {
-            return c.json({ error: "Not Found" }, 404)
-          }
-        } else {
-          const response = await proxy(`https://app.opencode.ai${path}`, {
-            ...c.req,
-            headers: {
-              ...c.req.raw.headers,
-              host: "app.opencode.ai",
-            },
-          })
-          const match = response.headers.get("content-type")?.includes("text/html")
-            ? (await response.clone().text()).match(
-                /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
-              )
-            : undefined
-          const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
-          response.headers.set("Content-Security-Policy", csp(hash))
-          return response
-        }
+        // Fall through to CDN proxy for missing assets (e.g. excluded fonts)
+        const response = await proxy(`https://app.opencode.ai${c.req.path}`, {
+          ...c.req,
+          headers: {
+            ...c.req.raw.headers,
+            host: "app.opencode.ai",
+          },
+        })
+        const match = response.headers.get("content-type")?.includes("text/html")
+          ? (await response.clone().text()).match(
+              /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
+            )
+          : undefined
+        const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
+        response.headers.set("Content-Security-Policy", csp(hash))
+        return response
       }) as unknown as Hono
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #19313

Builds on #19299 by @thdxr (now merged) and supersedes #15721. 

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hardens the embedded web UI feature from #19299 with five improvements:

**1. Font filtering (~27MB binary savings)**
Only embeds core fonts (Inter + IBM Plex Mono). The 12+ optional monospace fonts are excluded and fall through to the CDN proxy at runtime. Users only ever use one monospace font.

**2. Pre-bootstrap static middleware**
Inserts a `.use()` middleware *before* `Instance.provide()` that serves exact static file matches. Without this, every asset request (CSS, JS, images, fonts) triggers `Instance.provide()` → `InstanceBootstrap` → DB migration checks. This was a known production issue documented in AGENTS.md.

**3. SPA fallback routing**
Page routes (no file extension) now fall back to `index.html` for client-side routing. Asset requests (`.js`, `.woff2`, etc.) do *not* get the SPA fallback — they fall through to CDN proxy if not found locally.

**4. `OPENCODE_APP_DIR` env var**
Lets developers point at a local `packages/app/dist` without compiling a binary. Auto-detects the monorepo layout in dev mode.

**5. CDN proxy fallback**
Assets not found in the embedded bundle (e.g. excluded optional fonts) fall through to the existing CDN proxy instead of returning 404.

### How did you verify your code works?

- Binary builds successfully with font filtering (confirmed ~27MB reduction)
- Asset requests bypass Instance.provide() (pre-bootstrap middleware)
- SPA routes return index.html; asset 404s fall through to CDN
- `OPENCODE_APP_DIR=/path/to/dist` serves local files correctly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR