### PR TITLE
fix(session): ignore control messages in real user history

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -634,8 +634,8 @@ export namespace ACP {
             return undefined
           })
 
-        const lastUser = messages?.findLast((m) => m.info.role === "user")?.info
-        if (lastUser?.role === "user") {
+        const lastUser = messages?.findLast((m) => MessageV2.isRealUserMessage(m))?.info
+        if (lastUser) {
           result.models.currentModelId = `${lastUser.model.providerID}/${lastUser.model.modelID}`
           this.sessionManager.setModel(sessionId, {
             providerID: ProviderID.make(lastUser.model.providerID),

--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -229,7 +229,7 @@ export const make = Effect.gen(function* () {
           evaluate: () => proc.stdin!,
           onError: (err) => toPlatformError("fromWritable(stdin)", toError(err), command),
           endOnDone: cfg.endOnDone,
-          encoding: cfg.encoding,
+          encoding: cfg.encoding === "utf-16le" ? "utf16le" : cfg.encoding,
         })
       }
       if (Stream.isStream(cfg.stream)) return Effect.as(Effect.forkScoped(Stream.run(cfg.stream, sink)), sink)

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -526,9 +526,9 @@ export const SessionRoutes = lazy(() =>
         const msgs = await Session.messages({ sessionID })
         let currentAgent = await Agent.defaultAgent()
         for (let i = msgs.length - 1; i >= 0; i--) {
-          const info = msgs[i].info
-          if (info.role === "user") {
-            currentAgent = info.agent || (await Agent.defaultAgent())
+          const msg = msgs[i]
+          if (MessageV2.isRealUserMessage(msg)) {
+            currentAgent = msg.info.agent || (await Agent.defaultAgent())
             break
           }
         }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -73,7 +73,7 @@ export namespace SessionCompaction {
 
     loop: for (let msgIndex = msgs.length - 1; msgIndex >= 0; msgIndex--) {
       const msg = msgs[msgIndex]
-      if (msg.info.role === "user") turns++
+      if (MessageV2.isRealUserMessage(msg)) turns++
       if (turns < 2) continue
       if (msg.info.role === "assistant" && msg.info.summary) break loop
       for (let partIndex = msg.parts.length - 1; partIndex >= 0; partIndex--) {
@@ -120,14 +120,14 @@ export namespace SessionCompaction {
       const idx = input.messages.findIndex((m) => m.info.id === input.parentID)
       for (let i = idx - 1; i >= 0; i--) {
         const msg = input.messages[i]
-        if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "compaction")) {
+        if (MessageV2.isRealUserMessage(msg) && !msg.parts.some((p) => p.type === "compaction")) {
           replay = msg
           messages = input.messages.slice(0, i)
           break
         }
       }
       const hasContent =
-        replay && messages.some((m) => m.info.role === "user" && !m.parts.some((p) => p.type === "compaction"))
+        replay && messages.some((m) => MessageV2.isRealUserMessage(m) && !m.parts.some((p) => p.type === "compaction"))
       if (!hasContent) {
         replay = undefined
         messages = input.messages

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -34,7 +34,12 @@ export namespace MessageV2 {
   export function isRealUserMessage(msg: { info: { role: string }; parts: readonly unknown[] }) {
     return (
       msg.info.role === "user" &&
-      !msg.parts.every((part) => typeof part === "object" && part !== null && "synthetic" in part && part.synthetic)
+      msg.parts.some((part) => {
+        if (typeof part !== "object" || part === null || !("type" in part)) return false
+        if (part.type === "compaction" || part.type === "subtask") return false
+        if ("synthetic" in part && part.synthetic) return false
+        return true
+      })
     )
   }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -27,6 +27,17 @@ export namespace MessageV2 {
     return mime.startsWith("image/") || mime === "application/pdf"
   }
 
+  export function isRealUserMessage(msg: MessageV2.WithParts): msg is MessageV2.WithParts & { info: MessageV2.User }
+  export function isRealUserMessage<T extends { info: { role: string }; parts: readonly unknown[] }>(
+    msg: T,
+  ): msg is T & { info: T["info"] & { role: "user" } }
+  export function isRealUserMessage(msg: { info: { role: string }; parts: readonly unknown[] }) {
+    return (
+      msg.info.role === "user" &&
+      !msg.parts.every((part) => typeof part === "object" && part !== null && "synthetic" in part && part.synthetic)
+    )
+  }
+
   export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))
   export const AbortedError = NamedError.create("MessageAbortedError", z.object({ message: z.string() }))
   export const StructuredOutputError = NamedError.create(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -307,10 +307,9 @@ export namespace SessionPrompt {
       let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
       for (let i = msgs.length - 1; i >= 0; i--) {
         const msg = msgs[i]
-        if (!lastUser && msg.info.role === "user") lastUser = msg.info as MessageV2.User
+        if (!lastUser && MessageV2.isRealUserMessage(msg)) lastUser = msg.info as MessageV2.User
         if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info as MessageV2.Assistant
-        if (!lastFinished && msg.info.role === "assistant" && msg.info.finish)
-          lastFinished = msg.info as MessageV2.Assistant
+        if (!lastFinished && msg.info.role === "assistant" && msg.info.finish) lastFinished = msg.info as MessageV2.Assistant
         if (lastUser && lastFinished) break
         const task = msg.parts.filter((part) => part.type === "compaction" || part.type === "subtask")
         if (task && !lastFinished) {
@@ -621,7 +620,7 @@ export namespace SessionPrompt {
       using _ = defer(() => InstructionPrompt.clear(processor.message.id))
 
       // Check if user explicitly invoked an agent via @ in this turn
-      const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
+      const lastUserMsg = msgs.findLast((m) => MessageV2.isRealUserMessage(m))
       const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
       const tools = await resolveTools({
@@ -654,7 +653,7 @@ export namespace SessionPrompt {
       // Ephemerally wrap queued user messages with a reminder to stay on track
       if (step > 1 && lastFinished) {
         for (const msg of msgs) {
-          if (msg.info.role !== "user" || msg.info.id <= lastFinished.id) continue
+          if (!MessageV2.isRealUserMessage(msg) || msg.info.id <= lastFinished.id) continue
           for (const part of msg.parts) {
             if (part.type !== "text" || part.ignored || part.synthetic) continue
             if (!part.text.trim()) continue
@@ -757,7 +756,7 @@ export namespace SessionPrompt {
 
   async function lastModel(sessionID: SessionID) {
     for await (const item of MessageV2.stream(sessionID)) {
-      if (item.info.role === "user" && item.info.model) return item.info.model
+      if (MessageV2.isRealUserMessage(item) && item.info.model) return item.info.model
     }
     return Provider.defaultModel()
   }
@@ -1387,7 +1386,7 @@ export namespace SessionPrompt {
   }
 
   async function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info; session: Session.Info }) {
-    const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
+    const userMessage = input.messages.findLast((msg) => MessageV2.isRealUserMessage(msg))
     if (!userMessage) return input.messages
 
     // Original logic when experimental plan mode is disabled
@@ -1982,14 +1981,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     if (!Session.isDefaultTitle(input.session.title)) return
 
     // Find first non-synthetic user message
-    const firstRealUserIdx = input.history.findIndex(
-      (m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic),
-    )
+    const firstRealUserIdx = input.history.findIndex((m) => MessageV2.isRealUserMessage(m))
     if (firstRealUserIdx === -1) return
 
     const isFirst =
-      input.history.filter((m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic))
-        .length === 1
+      input.history.filter((m) => MessageV2.isRealUserMessage(m)).length === 1
     if (!isFirst) return
 
     // Gather all messages up to and including the first real user message for context

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -29,7 +29,7 @@ export namespace SessionRevert {
     let revert: Session.Info["revert"]
     const patches: Snapshot.Patch[] = []
     for (const msg of all) {
-      if (msg.info.role === "user") lastUser = msg.info
+      if (MessageV2.isRealUserMessage(msg)) lastUser = msg.info
       const remaining = []
       for (const part of msg.parts) {
         if (revert) {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -83,20 +83,20 @@ export namespace ShareNext {
           data: evt.properties.info,
         },
       ])
-      if (info.role === "user") {
-        await sync(info.sessionID, [
-          {
-            type: "model",
-            data: [await Provider.getModel(info.model.providerID, info.model.modelID).then((m) => m)],
-          },
-        ])
-      }
     })
     Bus.subscribe(MessageV2.Event.PartUpdated, async (evt) => {
       await sync(evt.properties.part.sessionID, [
         {
           type: "part",
           data: evt.properties.part,
+        },
+      ])
+      const msg = await MessageV2.get({ sessionID: evt.properties.part.sessionID, messageID: evt.properties.part.messageID })
+      if (!MessageV2.isRealUserMessage(msg)) return
+      await sync(evt.properties.part.sessionID, [
+        {
+          type: "model",
+          data: [await Provider.getModel(msg.info.model.providerID, msg.info.model.modelID).then((m) => m)],
         },
       ])
     })

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -258,7 +258,7 @@ export namespace ShareNext {
       Array.from(
         new Map(
           messages
-            .filter((m) => m.info.role === "user")
+            .filter((m) => MessageV2.isRealUserMessage(m))
             .map((m) => (m.info as SDK.UserMessage).model)
             .map((m) => [`${m.providerID}/${m.modelID}`, m] as const),
         ).values(),

--- a/packages/opencode/src/storage/node-sqlite.d.ts
+++ b/packages/opencode/src/storage/node-sqlite.d.ts
@@ -1,0 +1,5 @@
+declare module "node:sqlite" {
+  export class DatabaseSync {
+    constructor(path: string)
+  }
+}

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -11,7 +11,7 @@ import EXIT_DESCRIPTION from "./plan-exit.txt"
 
 async function getLastModel(sessionID: SessionID) {
   for await (const item of MessageV2.stream(sessionID)) {
-    if (item.info.role === "user" && item.info.model) return item.info.model
+    if (MessageV2.isRealUserMessage(item) && item.info.model) return item.info.model
   }
   return Provider.defaultModel()
 }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -108,6 +108,52 @@ function basePart(messageID: string, id: string) {
 }
 
 describe("session.message-v2.toModelMessage", () => {
+  test("detects real user messages", () => {
+    const realUser: MessageV2.WithParts = {
+      info: userInfo("m-real"),
+      parts: [
+        {
+          ...basePart("m-real", "p-real"),
+          type: "text",
+          text: "hello",
+        } as MessageV2.Part,
+      ],
+    }
+
+    const syntheticUser: MessageV2.WithParts = {
+      info: userInfo("m-synth"),
+      parts: [
+        {
+          ...basePart("m-synth", "p-synth"),
+          type: "text",
+          text: "synthetic",
+          synthetic: true,
+        } as MessageV2.Part,
+      ],
+    }
+
+    const emptyUser: MessageV2.WithParts = {
+      info: userInfo("m-empty"),
+      parts: [],
+    }
+
+    const assistant: MessageV2.WithParts = {
+      info: assistantInfo("m-assistant", "m-real"),
+      parts: [
+        {
+          ...basePart("m-assistant", "p-assistant"),
+          type: "text",
+          text: "assistant",
+        } as MessageV2.Part,
+      ],
+    }
+
+    expect(MessageV2.isRealUserMessage(realUser)).toBe(true)
+    expect(MessageV2.isRealUserMessage(syntheticUser)).toBe(false)
+    expect(MessageV2.isRealUserMessage(emptyUser)).toBe(false)
+    expect(MessageV2.isRealUserMessage(assistant)).toBe(false)
+  })
+
   test("filters out messages with no parts", () => {
     const input: MessageV2.WithParts[] = [
       {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -137,6 +137,30 @@ describe("session.message-v2.toModelMessage", () => {
       parts: [],
     }
 
+    const compactionUser: MessageV2.WithParts = {
+      info: userInfo("m-compaction"),
+      parts: [
+        {
+          ...basePart("m-compaction", "p-compaction"),
+          type: "compaction",
+          auto: true,
+        } as MessageV2.Part,
+      ],
+    }
+
+    const subtaskUser: MessageV2.WithParts = {
+      info: userInfo("m-subtask"),
+      parts: [
+        {
+          ...basePart("m-subtask", "p-subtask"),
+          type: "subtask",
+          agent: "general",
+          description: "run task",
+          prompt: "do thing",
+        } as MessageV2.Part,
+      ],
+    }
+
     const assistant: MessageV2.WithParts = {
       info: assistantInfo("m-assistant", "m-real"),
       parts: [
@@ -151,6 +175,8 @@ describe("session.message-v2.toModelMessage", () => {
     expect(MessageV2.isRealUserMessage(realUser)).toBe(true)
     expect(MessageV2.isRealUserMessage(syntheticUser)).toBe(false)
     expect(MessageV2.isRealUserMessage(emptyUser)).toBe(false)
+    expect(MessageV2.isRealUserMessage(compactionUser)).toBe(false)
+    expect(MessageV2.isRealUserMessage(subtaskUser)).toBe(false)
     expect(MessageV2.isRealUserMessage(assistant)).toBe(false)
   })
 

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -349,4 +349,61 @@ describe("revert + compact workflow", () => {
       },
     })
   })
+
+  test("uses latest real user for revert anchor when compaction message is selected", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const sessionID = session.id
+
+        const userMsg = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID,
+          type: "text",
+          text: "hello",
+        })
+
+        await SessionCompaction.create({
+          sessionID,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          auto: true,
+        })
+
+        const messages = await Session.messages({ sessionID })
+        const compaction = messages.findLast((msg) => msg.parts.some((part) => part.type === "compaction"))
+        expect(compaction).toBeDefined()
+
+        await SessionRevert.revert({
+          sessionID,
+          messageID: compaction!.info.id,
+        })
+
+        const sessionInfo = await Session.get(sessionID)
+        expect(sessionInfo.revert?.messageID).toBe(userMsg.id)
+
+        await Session.remove(sessionID)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -283,4 +283,70 @@ describe("revert + compact workflow", () => {
       },
     })
   })
+
+  test("uses latest real user for revert anchor when synthetic message is selected", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const sessionID = session.id
+
+        const userMsg = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID,
+          type: "text",
+          text: "hello",
+        })
+
+        const synthetic = await Session.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          time: {
+            created: Date.now(),
+          },
+        })
+
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: synthetic.id,
+          sessionID,
+          type: "text",
+          text: "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.",
+          synthetic: true,
+        })
+
+        await SessionRevert.revert({
+          sessionID,
+          messageID: synthetic.id,
+        })
+
+        const sessionInfo = await Session.get(sessionID)
+        expect(sessionInfo.revert?.messageID).toBe(userMsg.id)
+
+        await Session.remove(sessionID)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/share/share-next.test.ts
+++ b/packages/opencode/test/share/share-next.test.ts
@@ -2,6 +2,13 @@ import { test, expect, mock } from "bun:test"
 import { ShareNext } from "../../src/share/share-next"
 import { AccessToken, Account, AccountID, OrgID } from "../../src/account"
 import { Config } from "../../src/config/config"
+import { Session } from "../../src/session"
+import { SessionCompaction } from "../../src/session/compaction"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Instance } from "../../src/project/instance"
+import { Database } from "../../src/storage/db"
+import { SessionShareTable } from "../../src/share/share.sql"
+import { tmpdir } from "../fixture/fixture"
 
 test("ShareNext.request uses legacy share API without active org account", async () => {
   const originalActive = Account.active
@@ -72,5 +79,61 @@ test("ShareNext.request fails when org account has no token", async () => {
   } finally {
     Account.active = originalActive
     Account.token = originalToken
+  }
+})
+
+test("ShareNext.init does not sync model metadata for compaction messages", async () => {
+  const originalFetch = globalThis.fetch
+  const calls: any[] = []
+
+  globalThis.fetch = mock(async (_input, init) => {
+    calls.push(JSON.parse(String(init?.body ?? "{}")))
+    return new Response(null, { status: 200 })
+  }) as unknown as typeof fetch
+
+  await using tmp = await tmpdir({ git: true })
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const sessionID = session.id
+
+        Database.use((db) =>
+          db
+            .insert(SessionShareTable)
+            .values({
+              session_id: sessionID,
+              id: "shr_test",
+              secret: "sec_test",
+              url: "https://share.example.com/share/shr_test",
+            })
+            .run(),
+        )
+
+        await ShareNext.init()
+
+        await SessionCompaction.create({
+          sessionID,
+          agent: "default",
+          model: {
+            providerID: ProviderID.make("openai"),
+            modelID: ModelID.make("gpt-4"),
+          },
+          auto: true,
+        })
+
+        await Bun.sleep(1100)
+
+        const payload = calls.find((item) => Array.isArray(item.data))
+        expect(payload).toBeDefined()
+        expect(payload.data.some((item: { type: string }) => item.type === "message")).toBe(true)
+        expect(payload.data.some((item: { type: string }) => item.type === "part")).toBe(true)
+        expect(payload.data.some((item: { type: string }) => item.type === "model")).toBe(false)
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
   }
 })


### PR DESCRIPTION
### Issue for this PR

Closes #19319

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a bug where internal control turns stored as `role: "user"` were still being read back as if they were fresh human input.

Concrete examples from this branch:

- **Revert:** if the selected message is a synthetic continuation turn or a compaction-only user turn, revert should anchor to the latest real user request, not to the control message itself.
- **Prompt / model / agent recovery:** subtask-only and compaction-only user turns should not become the `last user` for prompt loop state, compact route agent selection, ACP session restore, or plan/model recovery.
- **Share sync:** a compaction control message should still sync the message/part, but it should not emit model metadata as if a human user changed the model.

The implementation adds `MessageV2.isRealUserMessage()` and replaces the history-sensitive `role === "user"` reads in those flows with the helper. The helper keeps real user turns, but rejects synthetic text shims and pure compaction/subtask control turns.

The new regression coverage checks the concrete cases above:

- synthetic / empty / compaction-only / subtask-only user-message classification
- revert anchoring when the selected message is a synthetic continuation or a compaction control turn
- share sync avoiding model updates for compaction-only user turns

I also included two narrow compatibility fixes that were needed to get the repo's current typecheck/pre-push path green locally: normalize `utf-16le` to Node's `utf16le` spelling and add a minimal `node:sqlite` declaration for the node storage entrypoint.

### How did you verify your code works?

- `cd packages/opencode && bun test test/share/share-next.test.ts test/session/message-v2.test.ts test/session/revert-compact.test.ts`
- `cd packages/opencode && bun typecheck`
- `bun turbo typecheck`

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR