### PR TITLE
fix(task): ignore invalid task_id when spawning subagents

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -67,9 +67,11 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const hasTodoWritePermission = agent.permission.some((rule) => rule.permission === "todowrite")
 
       const session = await iife(async () => {
-        if (params.task_id) {
-          const found = await Session.get(SessionID.make(params.task_id)).catch(() => {})
-          if (found) return found
+        const id = params.task_id ? SessionID.zod.safeParse(params.task_id) : undefined
+        const found = id?.success ? await Session.get(id.data).catch(() => undefined) : undefined
+
+        if (found) {
+          return found
         }
 
         return await Session.create({

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,10 +1,27 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { TaskTool } from "../../src/tool/task"
 import { tmpdir } from "../fixture/fixture"
 
+const ctx = {
+  sessionID: SessionID.make("ses_test-task-session"),
+  messageID: MessageID.make("msg_test-task-message"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
 afterEach(async () => {
+  mock.restore()
   await Instance.disposeAll()
 })
 
@@ -43,6 +60,150 @@ describe("tool.task", () => {
         expect(explore).toBeGreaterThan(alpha)
         expect(general).toBeGreaterThan(explore)
         expect(zebra).toBeGreaterThan(general)
+      },
+    })
+  })
+
+  test("creates a fresh session when task_id is invalid", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await Agent.get("build")
+        const tool = await TaskTool.init({ agent: build })
+        const msg = MessageV2.WithParts.parse({
+          info: {
+            id: MessageID.make("msg_test-task-parent"),
+            sessionID: ctx.sessionID,
+            role: "assistant",
+            time: { created: 0 },
+            parentID: MessageID.make("msg_test-task-user"),
+            modelID: ModelID.make("test-model"),
+            providerID: ProviderID.opencode,
+            mode: "build",
+            agent: "build",
+            path: {
+              cwd: tmp.path,
+              root: tmp.path,
+            },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: {
+                read: 0,
+                write: 0,
+              },
+            },
+          },
+          parts: [],
+        })
+        const out = MessageV2.WithParts.parse({
+          info: msg.info,
+          parts: [
+            {
+              id: PartID.make("prt_test-task-reply"),
+              sessionID: ctx.sessionID,
+              messageID: msg.info.id,
+              type: "text",
+              text: "done",
+            },
+          ],
+        })
+
+        const get = spyOn(MessageV2, "get").mockResolvedValue(msg)
+        const parts = spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "run" }])
+        const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue(out)
+
+        const result = await tool.execute(
+          {
+            description: "Run task",
+            prompt: "run",
+            subagent_type: "general",
+            task_id: "invalid-task-id",
+          },
+          ctx,
+        )
+
+        expect(get).toHaveBeenCalledTimes(1)
+        expect(parts).toHaveBeenCalledTimes(1)
+        expect(prompt).toHaveBeenCalledTimes(1)
+        expect(result.output).toMatch(/^task_id: ses_/)
+        expect(result.output).toContain("<task_result>\ndone\n</task_result>")
+      },
+    })
+  })
+
+  test("reuses an existing session when task_id is valid", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await Agent.get("build")
+        const tool = await TaskTool.init({ agent: build })
+        const child = await Session.create({
+          parentID: ctx.sessionID,
+          title: "child",
+        })
+        const msg = MessageV2.WithParts.parse({
+          info: {
+            id: MessageID.make("msg_test-task-parent"),
+            sessionID: ctx.sessionID,
+            role: "assistant",
+            time: { created: 0 },
+            parentID: MessageID.make("msg_test-task-user"),
+            modelID: ModelID.make("test-model"),
+            providerID: ProviderID.opencode,
+            mode: "build",
+            agent: "build",
+            path: {
+              cwd: tmp.path,
+              root: tmp.path,
+            },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: {
+                read: 0,
+                write: 0,
+              },
+            },
+          },
+          parts: [],
+        })
+        const out = MessageV2.WithParts.parse({
+          info: msg.info,
+          parts: [
+            {
+              id: PartID.make("prt_test-task-reply"),
+              sessionID: child.id,
+              messageID: msg.info.id,
+              type: "text",
+              text: "done",
+            },
+          ],
+        })
+
+        spyOn(MessageV2, "get").mockResolvedValue(msg)
+        spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "run" }])
+        spyOn(SessionPrompt, "prompt").mockResolvedValue(out)
+
+        const result = await tool.execute(
+          {
+            description: "Run task",
+            prompt: "run",
+            subagent_type: "general",
+            task_id: child.id,
+          },
+          ctx,
+        )
+
+        expect(result.output).toContain(`task_id: ${child.id}`)
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #19239

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `task` tool tried to resume an existing subagent session by calling `Session.get(SessionID.make(params.task_id)).catch(...)`.

That was not safe for malformed `task_id` values. If `task_id` was not a valid session id, the validation path could fail before the fallback logic had a chance to run, so the subagent would not continue and no fresh session would be created.

This change validates `task_id` first with `SessionID.zod.safeParse(...)`. If the id is valid, the tool still tries to reuse the existing session. If the id is invalid, it skips reuse and falls back to creating a fresh subagent session.

I also added regression coverage for both paths:
- invalid `task_id` falls back to a new session
- valid `task_id` still reuses the existing session

### How did you verify your code works?

- Ran the focused regression test:
  - `bun test test/tool/task.test.ts --timeout 30000`
- Ran typecheck successfully:
  - `bun turbo typecheck`

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR