### PR TITLE
fix(opencode): normalize embedded WebUI paths on Windows

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -72,10 +72,10 @@ const createEmbeddedWebUIBundle = async () => {
   const allFiles = await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: path.join(appDir, "dist") }))
   const fileMap = `
     // Import all files as file_$i with type: "file" 
-    ${allFiles.map((filePath, i) => `import file_${i} from "${path.join(appDir, "dist", filePath)}" with { type: "file" };`).join("\n")}
+    ${allFiles.map((filePath, i) => `import file_${i} from "${path.join(appDir, "dist", filePath).replace(/\\/g, "/")}" with { type: "file" };`).join("\n")}
     // Export with original mappings
     export default {
-      ${allFiles.map((filePath, i) => `"${filePath}": file_${i},`).join("\n")}
+      ${allFiles.map((filePath, i) => `"${filePath.replace(/\\/g, "/")}": file_${i},`).join("\n")}
     }
     `.trim()
   return fileMap


### PR DESCRIPTION
### Issue for this PR

Closes #19332

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Windows desktop dev was failing after the embedded WebUI change because `packages/opencode/script/build.ts` generated `opencode-web-ui.gen.ts` with backslashes in string literals.

That broke generated code like `assets\xml-...` / `C:\...\assets\xml-...`, where `\x` is treated as the start of an escape sequence by Bun while parsing the generated module.

This changes the generated import paths and file map keys to use forward slashes, which keeps the generated module valid on Windows while preserving the same file mapping.

### How did you verify your code works?

I reproduced the failure on Windows by updating local `dev` to current `upstream/dev` and running `start_desktop.cmd`.

Before this change, desktop startup failed with a syntax error in generated `opencode-web-ui.gen.ts`.

After this change, `bun run dev:desktop` gets past that generated-file syntax error and desktop dev starts correctly.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR