### PR TITLE
fix(project): disambiguate submodule identities and selection

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -17,6 +17,7 @@ import { useLanguage } from "@/context/language"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { decode64 } from "@/utils/base64"
+import { projectForDirectory } from "@/utils/project"
 import { getRelativeTime } from "@/utils/time"
 
 type EntryType = "command" | "file" | "session"
@@ -280,7 +281,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
   const project = createMemo(() => {
     const directory = projectDirectory()
     if (!directory) return
-    return layout.projects.list().find((p) => p.worktree === directory || p.sandboxes?.includes(directory))
+    return projectForDirectory(layout.projects.list(), directory)
   })
   const workspaces = createMemo(() => {
     const directory = projectDirectory()

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -22,6 +22,7 @@ import { focusTerminalById } from "@/pages/session/helpers"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { messageAgentColor } from "@/utils/agent"
 import { decode64 } from "@/utils/base64"
+import { projectForDirectory } from "@/utils/project"
 import { Persist, persisted } from "@/utils/persist"
 import { StatusPopover } from "../status-popover"
 
@@ -142,7 +143,7 @@ export function SessionHeader() {
   const project = createMemo(() => {
     const directory = projectDirectory()
     if (!directory) return
-    return layout.projects.list().find((p) => p.worktree === directory || p.sandboxes?.includes(directory))
+    return projectForDirectory(layout.projects.list(), directory)
   })
   const name = createMemo(() => {
     const current = project()

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -18,6 +18,7 @@ import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
 import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
+import { projectForDirectory } from "@/utils/project"
 
 type GlobalStore = {
   ready: boolean
@@ -148,7 +149,7 @@ function groupBySession<T extends { id: string; sessionID: string }>(input: T[])
 }
 
 function projectID(directory: string, projects: Project[]) {
-  return projects.find((project) => project.worktree === directory || project.sandboxes?.includes(directory))?.id
+  return projectForDirectory(projects, directory)?.id
 }
 
 function mergeSession(setStore: SetStoreFunction<State>, session: Session) {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -8,6 +8,7 @@ import { usePlatform } from "./platform"
 import { Project } from "@opencode-ai/sdk/v2"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { decode64 } from "@/utils/base64"
+import { sandboxRoots } from "@/utils/project"
 import { same } from "@/utils/same"
 import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
@@ -425,14 +426,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     }
 
     const roots = createMemo(() => {
-      const map = new Map<string, string>()
-      for (const project of globalSync.data.project) {
-        const sandboxes = project.sandboxes ?? []
-        for (const sandbox of sandboxes) {
-          map.set(sandbox, project.worktree)
-        }
-      }
-      return map
+      return sandboxRoots(globalSync.data.project)
     })
 
     const rootFor = (directory: string) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -52,6 +52,7 @@ import { retry } from "@opencode-ai/util/retry"
 import { playSoundById } from "@/utils/sound"
 import { createAim } from "@/utils/aim"
 import { setNavigate } from "@/utils/notification-click"
+import { projectForDirectory } from "@/utils/project"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
 
@@ -569,11 +570,11 @@ export default function Layout(props: ParentProps) {
 
     const projects = layout.projects.list()
 
-    const sandbox = projects.find((p) => p.sandboxes?.some((item) => workspaceKey(item) === key))
-    if (sandbox) return sandbox
-
     const direct = projects.find((p) => workspaceKey(p.worktree) === key)
     if (direct) return direct
+
+    const sandbox = projects.find((p) => p.sandboxes?.some((item) => workspaceKey(item) === key))
+    if (sandbox) return sandbox
 
     const [child] = globalSync.child(directory, { bootstrap: false })
     const id = child.project
@@ -1231,12 +1232,7 @@ export default function Layout(props: ParentProps) {
 
   function projectRoot(directory: string) {
     const key = workspaceKey(directory)
-    const project = layout.projects
-      .list()
-      .find(
-        (item) =>
-          workspaceKey(item.worktree) === key || item.sandboxes?.some((sandbox) => workspaceKey(sandbox) === key),
-      )
+    const project = projectForDirectory(layout.projects.list(), directory, workspaceKey)
     if (project) return project.worktree
 
     const known = Object.entries(store.workspaceOrder).find(

--- a/packages/app/src/utils/project.test.ts
+++ b/packages/app/src/utils/project.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { projectForDirectory, sandboxRoots } from "./project"
+
+describe("utils.project", () => {
+  test("prefers a direct worktree match over a sandbox match", () => {
+    const projects = [
+      { worktree: "/root", sandboxes: ["/root/deps/right"] },
+      { worktree: "/root/deps/right", sandboxes: [] },
+    ]
+
+    expect(projectForDirectory(projects, "/root/deps/right")?.worktree).toBe("/root/deps/right")
+  })
+
+  test("skips sandbox roots that are also project worktrees", () => {
+    const projects = [
+      { worktree: "/root", sandboxes: ["/root/deps/right", "/root/wt"] },
+      { worktree: "/root/deps/right", sandboxes: [] },
+    ]
+
+    const roots = sandboxRoots(projects)
+
+    expect(roots.get("/root/deps/right")).toBeUndefined()
+    expect(roots.get("/root/wt")).toBe("/root")
+  })
+})

--- a/packages/app/src/utils/project.ts
+++ b/packages/app/src/utils/project.ts
@@ -1,0 +1,28 @@
+type ProjectLike = {
+  worktree: string
+  sandboxes?: string[]
+}
+
+export function projectForDirectory<T extends ProjectLike>(
+  projects: T[],
+  directory: string,
+  norm = (value: string) => value,
+) {
+  const key = norm(directory)
+  const direct = projects.find((project) => norm(project.worktree) === key)
+  if (direct) return direct
+  return projects.find((project) => project.sandboxes?.some((sandbox) => norm(sandbox) === key))
+}
+
+export function sandboxRoots<T extends ProjectLike>(projects: T[], norm = (value: string) => value) {
+  const worktrees = new Set(projects.map((project) => norm(project.worktree)))
+  const map = new Map<string, string>()
+  for (const project of projects) {
+    for (const sandbox of project.sandboxes ?? []) {
+      const key = norm(sandbox)
+      if (worktrees.has(key)) continue
+      map.set(key, project.worktree)
+    }
+  }
+  return map
+}

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -14,6 +14,7 @@ import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { makeRuntime } from "@/effect/run-service"
 import { AppFileSystem } from "@/filesystem"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
+import { Hash } from "@/util/hash"
 
 export namespace Project {
   const log = Log.create({ service: "project" })
@@ -162,6 +163,29 @@ export namespace Project {
         )
       })
 
+      const rootsFor = Effect.fnUntraced(function* (cwd: string) {
+        const result = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd })
+        if (result.code !== 0) return [] as string[]
+        return result.text
+          .split("\n")
+          .filter(Boolean)
+          .map((x) => x.trim())
+          .toSorted()
+      })
+
+      const chainFor = Effect.fnUntraced(function* (cwd: string, supertree: string) {
+        const chain: { roots: string[]; rel: string }[] = []
+        let child = cwd
+        let dir: string | undefined = supertree
+        while (dir) {
+          chain.push({ roots: yield* rootsFor(dir), rel: pathSvc.relative(dir, child) })
+          const next: GitResult = yield* git(["rev-parse", "--show-superproject-working-tree"], { cwd: dir })
+          child = dir
+          dir = next.text.trim() ? resolveGitPath(child, next.text.trim()) : undefined
+        }
+        return chain
+      })
+
       const fromDirectory = Effect.fn("Project.fromDirectory")(function* (directory: string) {
         log.info("fromDirectory", { directory })
 
@@ -194,8 +218,15 @@ export namespace Project {
             }
           }
 
-          const commonDir = yield* git(["rev-parse", "--git-common-dir"], { cwd: sandbox })
-          if (commonDir.code !== 0) {
+          const [commonDir, gitDir, superDir] = yield* Effect.all(
+            [
+              git(["rev-parse", "--git-common-dir"], { cwd: sandbox }),
+              git(["rev-parse", "--git-dir"], { cwd: sandbox }),
+              git(["rev-parse", "--show-superproject-working-tree"], { cwd: sandbox }),
+            ],
+            { concurrency: 3 },
+          )
+          if (commonDir.code !== 0 || gitDir.code !== 0) {
             return {
               id: id ?? ProjectID.global,
               worktree: sandbox,
@@ -203,26 +234,26 @@ export namespace Project {
               vcs: fakeVcs,
             }
           }
-          const worktree = (() => {
-            const common = resolveGitPath(sandbox, commonDir.text.trim())
-            return common === sandbox ? sandbox : pathSvc.dirname(common)
-          })()
+          const common = resolveGitPath(sandbox, commonDir.text.trim())
+          const gitdir = resolveGitPath(sandbox, gitDir.text.trim())
+          const cache = common === gitdir ? gitdir : common
+          const worktree = common === gitdir ? sandbox : pathSvc.dirname(common)
+          const supertree = superDir.text.trim() ? resolveGitPath(sandbox, superDir.text.trim()) : undefined
 
-          if (id == null) {
-            id = yield* readCachedProjectId(pathSvc.join(worktree, ".git"))
+          if (id == null && !supertree) {
+            id = yield* readCachedProjectId(cache)
           }
 
           if (!id) {
-            const revList = yield* git(["rev-list", "--max-parents=0", "HEAD"], { cwd: sandbox })
-            const roots = revList.text
-              .split("\n")
-              .filter(Boolean)
-              .map((x) => x.trim())
-              .toSorted()
+            const roots = yield* rootsFor(sandbox)
 
-            id = roots[0] ? ProjectID.make(roots[0]) : undefined
+            if (roots[0] && supertree) {
+              id = ProjectID.make(Hash.fast(JSON.stringify({ roots, chain: yield* chainFor(sandbox, supertree) })))
+            }
+
+            if (!id) id = roots[0] ? ProjectID.make(roots[0]) : undefined
             if (id) {
-              yield* fsys.writeFileString(pathSvc.join(worktree, ".git", "opencode"), id).pipe(Effect.ignore)
+              yield* fsys.writeFileString(pathSvc.join(cache, "opencode"), id).pipe(Effect.ignore)
             }
           }
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -242,6 +242,157 @@ describe("Project.fromDirectory with worktrees", () => {
   })
 })
 
+describe("Project.fromDirectory with submodules", () => {
+  test("should set worktree to the submodule root", async () => {
+    await using root = await tmpdir({ git: true })
+    await using sub = await tmpdir({ git: true })
+
+    const rel = path.join("deps", "sub")
+    const dir = path.join(root.path, rel)
+    await $`git -c protocol.file.allow=always submodule add ${sub.path} ${rel}`.cwd(root.path).quiet()
+
+    const { project, sandbox } = await Project.fromDirectory(dir)
+
+    expect(project.worktree).toBe(dir)
+    expect(sandbox).toBe(dir)
+  })
+
+  test("should keep two top-level submodules as separate projects", async () => {
+    await using root = await tmpdir({ git: true })
+    await using leftSrc = await tmpdir({ git: true })
+    await using rightSrc = await tmpdir({ git: true })
+
+    const leftRel = path.join("deps", "left")
+    const rightRel = path.join("deps", "right")
+    const left = path.join(root.path, leftRel)
+    const right = path.join(root.path, rightRel)
+
+    // Root repo with two submodules. Open both repos and ensure they stay distinct.
+    await $`git -c protocol.file.allow=always submodule add ${leftSrc.path} ${leftRel}`.cwd(root.path).quiet()
+    await $`git -c protocol.file.allow=always submodule add ${rightSrc.path} ${rightRel}`.cwd(root.path).quiet()
+
+    const a = await Project.fromDirectory(left)
+    const b = await Project.fromDirectory(right)
+
+    expect(a.project.worktree).toBe(left)
+    expect(b.project.worktree).toBe(right)
+    expect(a.project.id).not.toBe(b.project.id)
+  })
+
+  test("should keep sibling submodules as separate projects", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const seed = root.path + "-seed"
+    const bare = root.path + "-bare"
+    const leftRel = path.join("deps", "left")
+    const rightRel = path.join("deps", "right")
+    const left = path.join(root.path, leftRel)
+    const right = path.join(root.path, rightRel)
+
+    try {
+      await $`git clone ${root.path} ${seed}`.quiet()
+      await $`git clone --bare ${seed} ${bare}`.quiet()
+
+      await $`git -c protocol.file.allow=always submodule add ${bare} ${leftRel}`.cwd(root.path).quiet()
+      await $`git -c protocol.file.allow=always submodule add ${bare} ${rightRel}`.cwd(root.path).quiet()
+
+      const a = await Project.fromDirectory(left)
+      const b = await Project.fromDirectory(right)
+
+      expect(a.project.worktree).toBe(left)
+      expect(b.project.worktree).toBe(right)
+      expect(a.project.id).not.toBe(b.project.id)
+    } finally {
+      await $`rm -rf ${seed} ${bare}`.quiet().nothrow()
+    }
+  })
+
+  test("should ignore stale cached ids for submodules", async () => {
+    await using root = await tmpdir({ git: true })
+
+    const seed = root.path + "-seed"
+    const bare = root.path + "-bare"
+    const leftRel = path.join("deps", "left")
+    const rightRel = path.join("deps", "right")
+    const left = path.join(root.path, leftRel)
+    const right = path.join(root.path, rightRel)
+
+    try {
+      await $`git clone ${root.path} ${seed}`.quiet()
+      await $`git clone --bare ${seed} ${bare}`.quiet()
+
+      await $`git -c protocol.file.allow=always submodule add ${bare} ${leftRel}`.cwd(root.path).quiet()
+      await $`git -c protocol.file.allow=always submodule add ${bare} ${rightRel}`.cwd(root.path).quiet()
+
+      const leftGit = (await $`git rev-parse --git-dir`.cwd(left).text()).trim()
+      const rightGit = (await $`git rev-parse --git-dir`.cwd(right).text()).trim()
+      await Bun.write(path.join(left, leftGit, "opencode"), "stale")
+      await Bun.write(path.join(right, rightGit, "opencode"), "stale")
+
+      const a = await Project.fromDirectory(left)
+      const b = await Project.fromDirectory(right)
+
+      expect(a.project.id).not.toBe("stale")
+      expect(b.project.id).not.toBe("stale")
+      expect(a.project.id).not.toBe(b.project.id)
+    } finally {
+      await $`rm -rf ${seed} ${bare}`.quiet().nothrow()
+    }
+  })
+
+  test("should keep repeated nested submodules as separate projects", async () => {
+    await using root = await tmpdir({ git: true })
+    await using parent = await tmpdir({ git: true })
+    await using grand = await tmpdir({ git: true })
+
+    const left = path.join(root.path, "deps", "left", "nested", "grand")
+    const right = path.join(root.path, "deps", "right", "nested", "grand")
+
+    await $`git -c protocol.file.allow=always submodule add ${grand.path} nested/grand`.cwd(parent.path).quiet()
+    await $`git add .gitmodules nested/grand && git commit -m add-nested`.cwd(parent.path).quiet()
+    await $`git -c protocol.file.allow=always submodule add ${parent.path} deps/left`.cwd(root.path).quiet()
+    await $`git -c protocol.file.allow=always submodule add ${parent.path} deps/right`.cwd(root.path).quiet()
+    await $`git -c protocol.file.allow=always submodule update --init --recursive`.cwd(root.path).quiet()
+
+    const a = await Project.fromDirectory(left)
+    const b = await Project.fromDirectory(right)
+
+    expect(a.project.worktree).toBe(left)
+    expect(b.project.worktree).toBe(right)
+    expect(a.project.id).not.toBe(b.project.id)
+  })
+
+  test("should keep separate submodules distinct inside a project submodule", async () => {
+    await using root = await tmpdir({ git: true })
+    await using parent = await tmpdir({ git: true })
+    await using leftSrc = await tmpdir({ git: true })
+    await using rightSrc = await tmpdir({ git: true })
+
+    const parentRel = path.join("deps", "parent")
+    const parentDir = path.join(root.path, parentRel)
+    const left = path.join(parentDir, "nested", "left")
+    const right = path.join(parentDir, "nested", "right")
+
+    await $`git -c protocol.file.allow=always submodule add ${leftSrc.path} nested/left`.cwd(parent.path).quiet()
+    await $`git -c protocol.file.allow=always submodule add ${rightSrc.path} nested/right`.cwd(parent.path).quiet()
+    await $`git add .gitmodules nested/left nested/right && git commit -m add-nested`.cwd(parent.path).quiet()
+
+    await $`git -c protocol.file.allow=always submodule add ${parent.path} ${parentRel}`.cwd(root.path).quiet()
+    await $`git -c protocol.file.allow=always submodule update --init --recursive`.cwd(parentDir).quiet()
+
+    const parentProject = await Project.fromDirectory(parentDir)
+    const a = await Project.fromDirectory(left)
+    const b = await Project.fromDirectory(right)
+
+    expect(parentProject.project.worktree).toBe(parentDir)
+    expect(a.project.worktree).toBe(left)
+    expect(b.project.worktree).toBe(right)
+    expect(parentProject.project.id).not.toBe(a.project.id)
+    expect(parentProject.project.id).not.toBe(b.project.id)
+    expect(a.project.id).not.toBe(b.project.id)
+  })
+})
+
 describe("Project.discover", () => {
   test("should discover favicon.png in root", async () => {
     await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
### Issue for this PR

When opening two submodules of a Git repository, the project identity gets resolved to the parent directory. This prevents the submodules from being opened in the desktop app.

Closes #19095

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR disambiguates the submodule identities so that submodules of a repository can be added as projects to opencode desktop

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR