### PR TITLE
fix(session): treat unknown finishReason as terminal in prompt loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,16 @@ import { makeRuntime } from "@/effect/run-service"
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
 
+/**
+ * Returns true if the given finish reason indicates the model has finished
+ * and the prompt loop should not continue. Only "tool-calls" is non-terminal
+ * (the model needs tool results to continue). All other reasons — including
+ * "unknown" from non-standard providers — are treated as terminal.
+ */
+export function isTerminalFinishReason(reason: string): boolean {
+  return reason !== "tool-calls"
+}
+
 const STRUCTURED_OUTPUT_DESCRIPTION = `Use this tool to return your final response in the requested structured format.
 
 IMPORTANT:
@@ -1372,7 +1382,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
             if (
               lastAssistant?.finish &&
-              !["tool-calls"].includes(lastAssistant.finish) &&
+              isTerminalFinishReason(lastAssistant.finish) &&
               !hasToolCalls &&
               lastUser.id < lastAssistant.id
             ) {
@@ -1527,7 +1537,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   return "break" as const
                 }
 
-                const finished = handle.message.finish && !["tool-calls", "unknown"].includes(handle.message.finish)
+                const finished = handle.message.finish && isTerminalFinishReason(handle.message.finish)
                 if (finished && !handle.message.error) {
                   if (format.type === "json_schema") {
                     handle.message.error = new MessageV2.StructuredOutputError({

--- a/packages/opencode/test/session/finish-reason.test.ts
+++ b/packages/opencode/test/session/finish-reason.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { isTerminalFinishReason } from "../../src/session/prompt"
+
+describe("isTerminalFinishReason", () => {
+  test("tool-calls is non-terminal", () => {
+    expect(isTerminalFinishReason("tool-calls")).toBe(false)
+  })
+
+  test("stop is terminal", () => {
+    expect(isTerminalFinishReason("stop")).toBe(true)
+  })
+
+  test("length is terminal", () => {
+    expect(isTerminalFinishReason("length")).toBe(true)
+  })
+
+  test("content-filter is terminal", () => {
+    expect(isTerminalFinishReason("content-filter")).toBe(true)
+  })
+
+  test("error is terminal", () => {
+    expect(isTerminalFinishReason("error")).toBe(true)
+  })
+
+  test("other is terminal", () => {
+    expect(isTerminalFinishReason("other")).toBe(true)
+  })
+
+  test("unknown is terminal (non-standard providers like GLM-5 Turbo)", () => {
+    expect(isTerminalFinishReason("unknown")).toBe(true)
+  })
+
+  test("end_turn is terminal (Anthropic)", () => {
+    expect(isTerminalFinishReason("end_turn")).toBe(true)
+  })
+
+  test("empty string is terminal (defensive)", () => {
+    expect(isTerminalFinishReason("")).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19339

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Providers like GLM-5 Turbo (via OpenAI-compatible gateways) return `finishReason: "unknown"` instead of `"stop"`. The prompt loop treated `"unknown"` as non-terminal alongside `"tool-calls"`, causing an infinite loop when no tool calls were present.

This PR removes `"unknown"` from the non-terminal list so only `"tool-calls"` keeps the loop running. The check is extracted into `isTerminalFinishReason()` to make the invariant explicit and testable.

Note: the TUI has a similar pattern in `session/index.tsx` — will address in a follow-up.

### How did you verify your code works?

- Reproduced the infinite loop with GLM-5 Turbo (`finishReason: "unknown"`, step count reaching 100+)
- After fix, session exits cleanly on first turn
- `bun test test/session/finish-reason.test.ts` — 9 tests pass
- `bun typecheck` passes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR