### PR TITLE
feat(acp): move reasoning level to a separate switcher

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -12,15 +12,21 @@ import {
   type ListSessionsRequest,
   type ListSessionsResponse,
   type LoadSessionRequest,
+  type LoadSessionResponse,
   type NewSessionRequest,
+  type NewSessionResponse,
   type PermissionOption,
   type PlanEntry,
   type PromptRequest,
   type ResumeSessionRequest,
   type ResumeSessionResponse,
+  type SessionConfigOption,
   type Role,
   type SessionInfo,
+  type SetSessionConfigOptionRequest,
+  type SetSessionConfigOptionResponse,
   type SetSessionModelRequest,
+  type SetSessionModelResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
   type ToolCallContent,
@@ -48,8 +54,13 @@ import { applyPatch } from "diff"
 
 type ModeOption = { id: string; name: string; description?: string }
 type ModelOption = { modelId: string; name: string }
+type ProviderEntry = { id: string; name: string; models: Record<string, any> }
+type VariantEntry = { id: string; models: Record<string, { variants?: Record<string, any> }> }
 
 const DEFAULT_VARIANT_VALUE = "default"
+const MODE_CONFIG_ID = "mode"
+const MODEL_CONFIG_ID = "model"
+const REASONING_CONFIG_ID = "reasoning_effort"
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
@@ -567,7 +578,7 @@ export namespace ACP {
       throw new Error("Authentication not implemented")
     }
 
-    async newSession(params: NewSessionRequest) {
+    async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
       const directory = params.cwd
       try {
         const model = await defaultModel(this.config, directory)
@@ -586,6 +597,7 @@ export namespace ACP {
 
         return {
           sessionId,
+          configOptions: load.configOptions,
           models: load.models,
           modes: load.modes,
           _meta: load._meta,
@@ -601,7 +613,7 @@ export namespace ACP {
       }
     }
 
-    async loadSession(params: LoadSessionRequest) {
+    async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
       const directory = params.cwd
       const sessionId = params.sessionId
 
@@ -635,11 +647,28 @@ export namespace ACP {
           })
 
         const lastUser = messages?.findLast((m) => m.info.role === "user")?.info
-        if (lastUser?.role === "user") {
+        if (lastUser?.role === "user" && result.models) {
           result.models.currentModelId = `${lastUser.model.providerID}/${lastUser.model.modelID}`
           this.sessionManager.setModel(sessionId, {
             providerID: ProviderID.make(lastUser.model.providerID),
             modelID: ModelID.make(lastUser.model.modelID),
+          })
+          this.sessionManager.setVariant(sessionId, lastUser.variant)
+          result.configOptions = buildConfigOptions({
+            providers: await this.sdk.config
+              .providers({ directory }, { throwOnError: true })
+              .then((x) => sortProvidersByName(x.data!.providers)),
+            modes: (result.modes?.availableModes ?? []).map((mode) => ({
+              id: mode.id,
+              name: mode.name,
+              description: mode.description ?? undefined,
+            })),
+            currentModeId: result.modes?.currentModeId,
+            model: {
+              providerID: ProviderID.make(lastUser.model.providerID),
+              modelID: ModelID.make(lastUser.model.modelID),
+            },
+            variant: lastUser.variant,
           })
           if (result.modes?.availableModes.some((m) => m.id === lastUser.agent)) {
             result.modes.currentModeId = lastUser.agent
@@ -1147,7 +1176,7 @@ export namespace ACP {
       return { availableModes, currentModeId }
     }
 
-    private async loadSessionMode(params: LoadSessionRequest) {
+    private async loadSessionMode(params: LoadSessionRequest): Promise<LoadSessionResponse & { sessionId: string }> {
       const directory = params.cwd
       const model = await defaultModel(this.config, directory)
       const sessionId = params.sessionId
@@ -1156,10 +1185,11 @@ export namespace ACP {
       const entries = sortProvidersByName(providers)
       const availableVariants = modelVariantsFromProviders(entries, model)
       const currentVariant = this.sessionManager.getVariant(sessionId)
-      if (currentVariant && !availableVariants.includes(currentVariant)) {
+      const variant = currentVariant && availableVariants.includes(currentVariant) ? currentVariant : undefined
+      if (currentVariant && !variant) {
         this.sessionManager.setVariant(sessionId, undefined)
       }
-      const availableModels = buildAvailableModels(entries, { includeVariants: true })
+      const availableModels = buildAvailableModels(entries)
       const modeState = await this.resolveModeState(directory, sessionId)
       const currentModeId = modeState.currentModeId
       const modes = currentModeId
@@ -1168,6 +1198,13 @@ export namespace ACP {
             currentModeId,
           }
         : undefined
+      const configOptions = buildConfigOptions({
+        providers: entries,
+        modes: modeState.availableModes,
+        currentModeId,
+        model,
+        variant,
+      })
 
       const commands = await this.config.sdk.command
         .list(
@@ -1241,20 +1278,21 @@ export namespace ACP {
 
       return {
         sessionId,
+        configOptions,
         models: {
-          currentModelId: formatModelIdWithVariant(model, currentVariant, availableVariants, true),
+          currentModelId: formatModelIdWithVariant(model, undefined, availableVariants, false),
           availableModels,
         },
         modes,
         _meta: buildVariantMeta({
           model,
-          variant: this.sessionManager.getVariant(sessionId),
+          variant,
           availableVariants,
         }),
       }
     }
 
-    async unstable_setSessionModel(params: SetSessionModelRequest) {
+    async unstable_setSessionModel(params: SetSessionModelRequest): Promise<SetSessionModelResponse> {
       const session = this.sessionManager.get(params.sessionId)
       const providers = await this.sdk.config
         .providers({ directory: session.cwd }, { throwOnError: true })
@@ -1266,12 +1304,106 @@ export namespace ACP {
 
       const entries = sortProvidersByName(providers)
       const availableVariants = modelVariantsFromProviders(entries, selection.model)
+      const variant = selection.variant && availableVariants.includes(selection.variant) ? selection.variant : undefined
+
+      if (selection.variant && !variant) {
+        this.sessionManager.setVariant(session.id, undefined)
+      }
+
+      setTimeout(() => {
+        this.connection.sessionUpdate({
+          sessionId: session.id,
+          update: {
+            sessionUpdate: "config_option_update",
+            configOptions: buildConfigOptions({
+              providers: entries,
+              modes: [],
+              currentModeId: this.sessionManager.get(session.id).modeId,
+              model: selection.model,
+              variant,
+            }),
+          },
+        })
+      }, 0)
 
       return {
         _meta: buildVariantMeta({
           model: selection.model,
-          variant: selection.variant,
+          variant,
           availableVariants,
+        }),
+      }
+    }
+
+    async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
+      const session = this.sessionManager.get(params.sessionId)
+      const current = session.model ?? (await defaultModel(this.config, session.cwd))
+      if (!session.model) {
+        this.sessionManager.setModel(session.id, current)
+      }
+
+      const providers = await this.sdk.config
+        .providers({ directory: session.cwd }, { throwOnError: true })
+        .then((x) => x.data!.providers)
+      const entries = sortProvidersByName(providers)
+      const modes = await this.loadAvailableModes(session.cwd)
+      const modeId = session.modeId ?? (await AgentModule.defaultAgent())
+
+      if (params.configId === MODE_CONFIG_ID) {
+        if (!modes.some((mode) => mode.id === params.value)) {
+          throw RequestError.invalidParams(JSON.stringify({ error: `Invalid config value: ${params.value}` }))
+        }
+        this.sessionManager.setMode(session.id, params.value)
+        return {
+          configOptions: buildConfigOptions({
+            providers: entries,
+            modes,
+            currentModeId: params.value,
+            model: current,
+            variant: this.sessionManager.getVariant(session.id),
+          }),
+        }
+      }
+
+      if (params.configId === MODEL_CONFIG_ID) {
+        const selection = parseModelSelection(params.value, entries)
+        const variants = modelVariantsFromProviders(entries, selection.model)
+        const variant = this.sessionManager.getVariant(session.id)
+        const next = variant && variants.includes(variant) ? variant : undefined
+        this.sessionManager.setModel(session.id, selection.model)
+        this.sessionManager.setVariant(session.id, next)
+        return {
+          configOptions: buildConfigOptions({
+            providers: entries,
+            modes,
+            currentModeId: session.modeId ?? modeId,
+            model: selection.model,
+            variant: next,
+          }),
+        }
+      }
+
+      if (params.configId !== REASONING_CONFIG_ID) {
+        throw RequestError.invalidParams(JSON.stringify({ error: `Unknown config option: ${params.configId}` }))
+      }
+
+      const variants = [
+        DEFAULT_VARIANT_VALUE,
+        ...modelVariantsFromProviders(entries, current).filter((variant) => variant !== DEFAULT_VARIANT_VALUE),
+      ]
+      if (!variants.includes(params.value)) {
+        throw RequestError.invalidParams(JSON.stringify({ error: `Invalid config value: ${params.value}` }))
+      }
+
+      this.sessionManager.setVariant(session.id, params.value === DEFAULT_VARIANT_VALUE ? undefined : params.value)
+
+      return {
+        configOptions: buildConfigOptions({
+          providers: entries,
+          modes,
+          currentModeId: session.modeId ?? modeId,
+          model: current,
+          variant: this.sessionManager.getVariant(session.id),
         }),
       }
     }
@@ -1648,7 +1780,7 @@ export namespace ACP {
   }
 
   function modelVariantsFromProviders(
-    providers: Array<{ id: string; models: Record<string, { variants?: Record<string, any> }> }>,
+    providers: VariantEntry[],
     model: { providerID: ProviderID; modelID: ModelID },
   ): string[] {
     const provider = providers.find((entry) => entry.id === model.providerID)
@@ -1658,11 +1790,7 @@ export namespace ACP {
     return Object.keys(modelInfo.variants)
   }
 
-  function buildAvailableModels(
-    providers: Array<{ id: string; name: string; models: Record<string, any> }>,
-    options: { includeVariants?: boolean } = {},
-  ): ModelOption[] {
-    const includeVariants = options.includeVariants ?? false
+  function buildAvailableModels(providers: ProviderEntry[]): ModelOption[] {
     return providers.flatMap((provider) => {
       const unsorted: Array<{ id: string; name: string; variants?: Record<string, any> }> = Object.values(
         provider.models,
@@ -1673,15 +1801,84 @@ export namespace ACP {
           modelId: `${provider.id}/${model.id}`,
           name: `${provider.name}/${model.name}`,
         }
-        if (!includeVariants || !model.variants) return [base]
-        const variants = Object.keys(model.variants).filter((variant) => variant !== DEFAULT_VARIANT_VALUE)
-        const variantOptions = variants.map((variant) => ({
-          modelId: `${provider.id}/${model.id}/${variant}`,
-          name: `${provider.name}/${model.name} (${variant})`,
-        }))
-        return [base, ...variantOptions]
+        return [base]
       })
     })
+  }
+
+  function buildReasoning(input: {
+    providers: VariantEntry[]
+    model: { providerID: ProviderID; modelID: ModelID }
+    variant?: string
+  }): SessionConfigOption[] {
+    const base = modelVariantsFromProviders(input.providers, input.model)
+    if (!base.length) return []
+    const variants = [DEFAULT_VARIANT_VALUE, ...base.filter((variant) => variant !== DEFAULT_VARIANT_VALUE)]
+    const current = input.variant && variants.includes(input.variant) ? input.variant : DEFAULT_VARIANT_VALUE
+    return [
+      {
+        type: "select",
+        id: REASONING_CONFIG_ID,
+        name: "Reasoning effort",
+        category: "thought_level",
+        currentValue: current,
+        options: variants.map((variant) => ({
+          value: variant,
+          name: variant === DEFAULT_VARIANT_VALUE ? "Default" : variant,
+        })),
+      },
+    ]
+  }
+
+  function buildModeConfig(input: { modes: ModeOption[]; currentModeId?: string }): SessionConfigOption[] {
+    if (!input.modes.length || !input.currentModeId) return []
+    return [
+      {
+        type: "select",
+        id: MODE_CONFIG_ID,
+        name: "Mode",
+        category: "mode",
+        currentValue: input.currentModeId,
+        options: input.modes.map((mode) => ({
+          value: mode.id,
+          name: mode.name,
+          description: mode.description,
+        })),
+      },
+    ]
+  }
+
+  function buildModelConfig(input: {
+    providers: ProviderEntry[]
+    model: { providerID: ProviderID; modelID: ModelID }
+  }): SessionConfigOption[] {
+    return [
+      {
+        type: "select",
+        id: MODEL_CONFIG_ID,
+        name: "Model",
+        category: "model",
+        currentValue: `${input.model.providerID}/${input.model.modelID}`,
+        options: buildAvailableModels(input.providers).map((model) => ({
+          value: model.modelId,
+          name: model.name,
+        })),
+      },
+    ]
+  }
+
+  function buildConfigOptions(input: {
+    providers: ProviderEntry[]
+    modes: ModeOption[]
+    currentModeId?: string
+    model: { providerID: ProviderID; modelID: ModelID }
+    variant?: string
+  }) {
+    return [
+      ...buildModeConfig({ modes: input.modes, currentModeId: input.currentModeId }),
+      ...buildModelConfig({ providers: input.providers, model: input.model }),
+      ...buildReasoning({ providers: input.providers, model: input.model, variant: input.variant }),
+    ]
   }
 
   function formatModelIdWithVariant(
@@ -1711,8 +1908,11 @@ export namespace ACP {
 
   function parseModelSelection(
     modelId: string,
-    providers: Array<{ id: string; models: Record<string, { variants?: Record<string, any> }> }>,
-  ): { model: { providerID: ProviderID; modelID: ModelID }; variant?: string } {
+    providers: VariantEntry[],
+  ): {
+    model: { providerID: ProviderID; modelID: ModelID }
+    variant?: string
+  } {
     const parsed = Provider.parseModel(modelId)
     const provider = providers.find((p) => p.id === parsed.providerID)
     if (!provider) {

--- a/packages/opencode/test/acp/agent-interface.test.ts
+++ b/packages/opencode/test/acp/agent-interface.test.ts
@@ -33,6 +33,7 @@ describe("acp.agent interface compliance", () => {
     // Optional but checked by SDK router
     "loadSession",
     "setSessionMode",
+    "setSessionConfigOption",
     "authenticate",
     // Unstable - SDK checks these with unstable_ prefix
     "unstable_listSessions",

--- a/packages/opencode/test/acp/config-option.test.ts
+++ b/packages/opencode/test/acp/config-option.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import { ACP } from "../../src/acp/agent"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+function createAgent() {
+  const stream = async function* (signal?: AbortSignal) {
+    await new Promise<void>((resolve) => {
+      signal?.addEventListener("abort", () => resolve(), { once: true })
+    })
+  }
+
+  const connection = {
+    async sessionUpdate() {},
+    async requestPermission() {
+      return { outcome: { outcome: "selected", optionId: "once" } }
+    },
+  } as unknown as AgentSideConnection
+
+  const sdk = {
+    global: {
+      event: async (opts?: { signal?: AbortSignal }) => ({ stream: stream(opts?.signal) }),
+    },
+    session: {
+      create: async () => ({
+        data: {
+          id: "ses_1",
+          time: { created: new Date().toISOString() },
+        },
+      }),
+    },
+    config: {
+      providers: async () => ({
+        data: {
+          providers: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              models: {
+                "gpt-5.4-mini": {
+                  id: "gpt-5.4-mini",
+                  name: "gpt-5.4-mini",
+                  variants: {
+                    default: {},
+                    low: {},
+                    medium: {},
+                    high: {},
+                    xhigh: {},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    },
+    app: {
+      agents: async () => ({
+        data: [
+          {
+            name: "build",
+            description: "build",
+            mode: "agent",
+          },
+          {
+            name: "plan",
+            description: "plan",
+            mode: "agent",
+          },
+        ],
+      }),
+    },
+    command: {
+      list: async () => ({ data: [] }),
+    },
+    mcp: {
+      add: async () => ({ data: true }),
+    },
+  } as any
+
+  const agent = new ACP.Agent(connection, {
+    sdk,
+    defaultModel: { providerID: "openai", modelID: "gpt-5.4-mini" },
+  } as any)
+
+  return { agent, stop: () => (agent as any).eventAbort.abort() }
+}
+
+describe("acp.agent config options", () => {
+  test("exposes reasoning effort separately from model names", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop } = createAgent()
+
+        const result = await agent.newSession({ cwd: tmp.path, mcpServers: [] } as any)
+
+        expect(result.models?.availableModels).toEqual([
+          { modelId: "openai/gpt-5.4-mini", name: "OpenAI/gpt-5.4-mini" },
+        ])
+        expect(result.configOptions).toEqual([
+          {
+            type: "select",
+            id: "mode",
+            name: "Mode",
+            category: "mode",
+            currentValue: "build",
+            options: [
+              { value: "build", name: "build", description: "build" },
+              { value: "plan", name: "plan", description: "plan" },
+            ],
+          },
+          {
+            type: "select",
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "openai/gpt-5.4-mini",
+            options: [{ value: "openai/gpt-5.4-mini", name: "OpenAI/gpt-5.4-mini" }],
+          },
+          {
+            type: "select",
+            id: "reasoning_effort",
+            name: "Reasoning effort",
+            category: "thought_level",
+            currentValue: "default",
+            options: [
+              { value: "default", name: "Default" },
+              { value: "low", name: "low" },
+              { value: "medium", name: "medium" },
+              { value: "high", name: "high" },
+              { value: "xhigh", name: "xhigh" },
+            ],
+          },
+        ])
+
+        stop()
+      },
+    })
+  })
+
+  test("allows switching reasoning effort back to default", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop } = createAgent()
+
+        const result = await agent.newSession({ cwd: tmp.path, mcpServers: [] } as any)
+        const changed = await agent.setSessionConfigOption({
+          sessionId: result.sessionId,
+          configId: "reasoning_effort",
+          value: "high",
+        } as any)
+        const reset = await agent.setSessionConfigOption({
+          sessionId: result.sessionId,
+          configId: "reasoning_effort",
+          value: "default",
+        } as any)
+
+        expect(changed.configOptions.find((x) => x.id === "reasoning_effort")?.currentValue).toBe("high")
+        expect(reset.configOptions.find((x) => x.id === "reasoning_effort")?.currentValue).toBe("default")
+
+        stop()
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #16543

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR moves the reasoning level/model variants to a separate switcher, so the model selector is easier to use in IDEs which use ACP (Zed, JetBrains, neovim, etc.). Currently, every model variants appears as a separate model, which results in hard to use switcher. GPT-5.4 is 6 separate models right now.

After the change, it's just one model with a separate switcher.

I based the changes on how [zed-industries/codex-acp](https://github.com/zed-industries/codex-acp) handles it.

### How did you verify your code works?

I tested the changes by adding a custom ACP in Zed 0.229.0 (macOS 26.4, brew install). I checked it on an actual codebase and compared the `none`, `default` and `xhigh` variants to compare how they work. It clearly has a different reasoning budget.

Also, I wrote test cases for it.

Didn't test in other editors.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

(before)

<img width="446" height="40" alt="image" src="https://github.com/user-attachments/assets/9209eb80-1c7c-4d2f-b72e-18dbe2018bfc" />
<img width="355" height="397" alt="image" src="https://github.com/user-attachments/assets/db6629fd-103b-430e-aac8-1c33af1f90d3" />

(after)

<img width="447" height="42" alt="image" src="https://github.com/user-attachments/assets/6299bc51-e54e-4595-8040-fbf902641327" />
<img width="354" height="187" alt="image" src="https://github.com/user-attachments/assets/193a0920-1f43-4f2e-bd8e-77d476886eb3" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
