### PR TITLE
fix: show error message for run --command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { errorMessage } from "../../util/error"
 
 type ToolProps<T extends Tool.Info> = {
   input: Tool.InferParameters<T>
@@ -47,6 +48,21 @@ type Inline = {
   icon: string
   title: string
   description?: string
+}
+
+export function unwrap<T>(res: { data: T; error?: undefined } | { data?: undefined; error: unknown }) {
+  if (res.error !== undefined) {
+    const err = res.error
+    if (err instanceof Error) throw err
+    if (typeof err === "object" && err !== null && "data" in err) {
+      const data = err.data
+      if (typeof data === "object" && data !== null && "message" in data && typeof data.message === "string") {
+        throw new Error(data.message)
+      }
+    }
+    throw new Error(errorMessage(err))
+  }
+  return res.data
 }
 
 function inline(info: Inline) {
@@ -632,23 +648,27 @@ export const RunCommand = cmd({
       })
 
       if (args.command) {
-        await sdk.session.command({
-          sessionID,
-          agent,
-          model: args.model,
-          command: args.command,
-          arguments: message,
-          variant: args.variant,
-        })
+        unwrap(
+          await sdk.session.command({
+            sessionID,
+            agent,
+            model: args.model,
+            command: args.command,
+            arguments: message,
+            variant: args.variant,
+          }),
+        )
       } else {
         const model = args.model ? Provider.parseModel(args.model) : undefined
-        await sdk.session.prompt({
-          sessionID,
-          agent,
-          model,
-          variant: args.variant,
-          parts: [...files, { type: "text", text: message }],
-        })
+        unwrap(
+          await sdk.session.prompt({
+            sessionID,
+            agent,
+            model,
+            variant: args.variant,
+            parts: [...files, { type: "text", text: message }],
+          }),
+        )
       }
     }
 

--- a/packages/opencode/test/cli/run.test.ts
+++ b/packages/opencode/test/cli/run.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { unwrap } from "../../src/cli/cmd/run"
+
+describe("run command request handling", () => {
+  test("returns data for successful responses", () => {
+    expect(unwrap({ data: { ok: true } })).toEqual({ ok: true })
+  })
+
+  test("throws sdk error responses instead of ignoring them", () => {
+    expect(() => unwrap({ data: undefined, error: { message: 'default agent "wrong_agent" not found' } })).toThrow(
+      'default agent "wrong_agent" not found',
+    )
+  })
+
+  test("throws nested sdk error messages from named error payloads", () => {
+    expect(() =>
+      unwrap({
+        data: undefined,
+        error: {
+          name: "UnknownError",
+          data: { message: 'default agent "wrong_agent" not found' },
+        },
+      }),
+    ).toThrow('default agent "wrong_agent" not found')
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19352 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When --command is present, the CLI uses sdk.session.command(...). That SDK call can return an error result object instead of throwing, and the previous CLI code did not handle that result, so the process could exit without printing anything.
There was also a related gap where assistant errors returned inside a successful response payload could be missed.


### How did you verify your code works?

Add test and check the proper error message after the changes.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
