### PR TITLE
fix(opencode): ignore generated models snapshot files

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -2,4 +2,5 @@ research
 dist
 gen
 app.log
-src/provider/models-snapshot.ts
+src/provider/models-snapshot.js
+src/provider/models-snapshot.d.ts


### PR DESCRIPTION
## Summary
- align `packages/opencode/.gitignore` with the current snapshot generator, which writes `models-snapshot.js` and `models-snapshot.d.ts`
- stop ignoring the obsolete `models-snapshot.ts` artifact so stale local files do not make the snapshot flow look rolled back