### PR TITLE
fix(config): correct directory config precedence so project overrides global

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -22,6 +22,13 @@ export namespace ConfigPaths {
   export async function directories(directory: string, worktree: string) {
     return [
       Global.Path.config,
+      ...(await Array.fromAsync(
+        Filesystem.up({
+          targets: [".opencode"],
+          start: Global.Path.home,
+          stop: Global.Path.home,
+        }),
+      )),
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? await Array.fromAsync(
             Filesystem.up({
@@ -31,13 +38,6 @@ export namespace ConfigPaths {
             }),
           )
         : []),
-      ...(await Array.fromAsync(
-        Filesystem.up({
-          targets: [".opencode"],
-          start: Global.Path.home,
-          stop: Global.Path.home,
-        }),
-      )),
       ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
     ]
   }


### PR DESCRIPTION
## Summary
- Fix config precedence order so project `.opencode` directory configs properly override home `~/.opencode` directory configs
- This restores the documented behavior where project configs take priority over global defaults

## Problem
The `ConfigPaths.directories()` function returned directories in this order:
1. `~/.config/opencode` (global XDG config)
2. **Project `.opencode` dirs** (loaded first)
3. **Home `~/.opencode` dir** (loaded last — overrides project!)

Since configs are merged sequentially with later values overriding earlier ones, the home `~/.opencode` config incorrectly took precedence over the project `.opencode` config. This contradicts the [documented precedence order](https://opencode.ai/docs/config/#precedence-order).

## Fix
Swap the order so home `~/.opencode` is loaded *before* project `.opencode`:
1. `~/.config/opencode` (global XDG config)
2. **Home `~/.opencode` dir** (loaded first — serves as base)
3. **Project `.opencode` dirs** (loaded last — overrides home)

This matches the documented precedence where project configs override global defaults.

## Reproduction
As described in the issue:
- Global restricted + local unrestricted → **Before**: asks for permission (wrong). **After**: allows (correct)
- Global unrestricted + local restricted → **Before**: no permission required (wrong). **After**: asks for permission (correct)

Closes #19296