### PR TITLE
fix(cli): print subagent output in run command mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -443,6 +443,7 @@ export const RunCommand = cmd({
 
       async function loop() {
         const toggles = new Map<string, boolean>()
+        const sessions = new Set([sessionID])
 
         for await (const event of events.stream) {
           if (
@@ -459,7 +460,7 @@ export const RunCommand = cmd({
 
           if (event.type === "message.part.updated") {
             const part = event.properties.part
-            if (part.sessionID !== sessionID) continue
+            if (!sessions.has(part.sessionID)) continue
 
             if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
               if (emit("tool_use", { part })) continue
@@ -474,12 +475,11 @@ export const RunCommand = cmd({
               UI.error(part.state.error)
             }
 
-            if (
-              part.type === "tool" &&
-              part.tool === "task" &&
-              part.state.status === "running" &&
-              args.format !== "json"
-            ) {
+            if (part.type === "tool" && part.tool === "task" && part.state.status === "running") {
+              // Track child session IDs so their output is also printed
+              const meta = "metadata" in part.state ? (part.state.metadata as Record<string, unknown>) : undefined
+              if (meta && typeof meta.sessionId === "string") sessions.add(meta.sessionId)
+              if (args.format === "json") continue
               if (toggles.get(part.id) === true) continue
               task(props<typeof TaskTool>(part))
               toggles.set(part.id, true)
@@ -523,7 +523,7 @@ export const RunCommand = cmd({
 
           if (event.type === "session.error") {
             const props = event.properties
-            if (props.sessionID !== sessionID || !props.error) continue
+            if (!sessions.has(props.sessionID) || !props.error) continue
             let err = String(props.error.name)
             if ("data" in props.error && props.error.data && "message" in props.error.data) {
               err = String(props.error.data.message)


### PR DESCRIPTION
## Summary
- Fix `opencode run` CLI mode to also print subagent (child session) output, tool calls, and errors
- Previously only the main agent's text was visible; subagent activity was silently discarded

## Problem
The CLI `run` command event loop filtered all `message.part.updated` events by comparing `part.sessionID !== sessionID` (the main session ID). When the main agent spawns subagents via the `task` tool, child sessions get different session IDs, causing all their events to be silently dropped.

## Fix
1. Track session IDs in a `Set` instead of comparing against a single string
2. When a `task` tool transitions to "running", extract the child session ID from `part.state.metadata.sessionId` (set by the task tool at line 116 of `task.ts`) and add it to the tracked set
3. Include child session events (text output, tool calls, errors) in CLI output
4. The main loop still only breaks when the **main** session goes idle, ensuring proper completion

## How to Test
```bash
opencode run --model <model> "Use @explore subagent to list files in current directory"
```
Before: Only main agent text visible. After: Subagent text, tool calls, and errors also printed.

Closes #19278