### PR TITLE
fix(app): reset contenteditable formatting state when clearing prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -477,6 +477,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const clearEditor = () => {
     editorRef.innerHTML = ""
+    // Ensure a clean text node exists to break any inherited formatting
+    // (e.g., browser link mode from previously typed URLs)
+    editorRef.appendChild(document.createTextNode(""))
   }
 
   const setEditorText = (text: string) => {


### PR DESCRIPTION
## Summary
- Fix the chat input box retaining link formatting after sending a message that contained a URL
- After clearing, the empty input no longer shows hoverable link styling

## Problem
When a user types a URL in the prompt input (a `contenteditable` div), the browser auto-detects links and enters "link mode". After the message is sent:
1. `clearEditor()` sets `innerHTML = ""`
2. `renderEditor()` calls `createTextFragment("")` which produces an **empty fragment** (no nodes)
3. The editor has zero child nodes, so the browser retains the previous formatting context (link mode)
4. The input box shows a hoverable underline/tooltip even though it appears empty

## Fix
Append an empty text node after clearing `innerHTML` in `clearEditor()`. This gives the browser a fresh text context node, breaking any inherited formatting (link mode, bold, italic, etc.).

```diff
  const clearEditor = () => {
    editorRef.innerHTML = ""
+   // Ensure a clean text node exists to break any inherited formatting
+   // (e.g., browser link mode from previously typed URLs)
+   editorRef.appendChild(document.createTextNode(""))
  }
```

## How to Verify
1. Type a URL (e.g., `https://example.com`) in the input box
2. Send the message
3. Hover over the now-empty input box
4. **Before**: Link underline/tooltip visible. **After**: Clean empty input, no formatting artifacts

Closes #19201