### PR TITLE
fix(docs): desktop-electron documentation is incorrect

### DIFF
--- a/packages/desktop-electron/README.md
+++ b/packages/desktop-electron/README.md
@@ -1,6 +1,11 @@
-# OpenCode Desktop
+# OpenCode Desktop (Electron)
 
-Native OpenCode desktop app, built with Tauri v2.
+Native OpenCode desktop app, built with Electron.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) v1.3.11+
+- Node.js v22+ (optional, Bun is preferred)
 
 ## Development
 
@@ -8,25 +13,50 @@ From the repo root:
 
 ```bash
 bun install
-bun run --cwd packages/desktop tauri dev
+bun run --cwd packages/desktop-electron dev
 ```
 
-This starts the Vite dev server on http://localhost:1420 and opens the native window.
-
-If you only want the web dev server (no native shell):
-
-```bash
-bun run --cwd packages/desktop dev
-```
+This starts the Electron app in development mode with hot reload.
 
 ## Build
 
-To create a production `dist/` and build the native app bundle:
+### Step 1: Build the CLI
+
+The desktop app requires the OpenCode CLI as a sidecar. Build it first:
 
 ```bash
-bun run --cwd packages/desktop tauri build
+cd packages/opencode
+bun run build --single
 ```
 
-## Prerequisites
+### Step 2: Copy CLI to resources
 
-Running the desktop app requires additional Tauri dependencies (Rust toolchain, platform-specific libraries). See the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for setup instructions.
+```bash
+mkdir -p ../desktop-electron/resources
+cp dist/opencode-darwin-arm64/bin/opencode ../desktop-electron/resources/opencode-cli
+```
+
+### Step 3: Package the app
+
+The following example is for macOS. For other platforms, see [Platform-specific Commands](#platform-specific-commands).
+
+```bash
+cd ../desktop-electron
+bun run build && bun run prebuild && bun run package:mac
+```
+
+The packaged app will be in `packages/desktop-electron/dist/`.
+
+## Platform-specific Commands
+
+- `bun run package:mac` - Package for macOS
+- `bun run package:win` - Package for Windows
+- `bun run package:linux` - Package for Linux
+
+## Architecture
+
+The desktop app consists of:
+
+1. **Electron main process** - Handles app lifecycle, window management, and CLI sidecar
+2. **Renderer process** - SolidJS-based UI (shared with the web app)
+3. **CLI sidecar** - The OpenCode CLI runs as a local server that the UI connects to

--- a/packages/desktop-electron/README_CN.md
+++ b/packages/desktop-electron/README_CN.md
@@ -1,0 +1,85 @@
+# OpenCode 桌面应用 (Electron)
+
+基于 Electron 构建的 OpenCode 原生桌面应用。
+
+## 环境要求
+
+- [Bun](https://bun.sh/) v1.3.11+
+- Node.js v22+（可选，推荐使用 Bun）
+
+## 开发调试
+
+在项目根目录运行：
+
+```bash
+bun install
+bun run --cwd packages/desktop-electron dev
+```
+
+这将启动 Electron 应用并开启热重载。
+
+## 构建打包
+
+### 第一步：编译 CLI
+
+桌面应用需要 OpenCode CLI 作为后端服务。首先编译 CLI：
+
+```bash
+cd packages/opencode
+bun run build --single
+```
+
+> 注意：`--single` 参数表示只编译当前平台的版本，加快编译速度。
+
+### 第二步：复制 CLI 到资源目录
+
+将编译好的 CLI 复制到 Electron 的资源目录：
+
+**macOS (Apple Silicon):**
+```bash
+mkdir -p ../desktop-electron/resources
+cp dist/opencode-darwin-arm64/bin/opencode ../desktop-electron/resources/opencode-cli
+```
+
+**macOS (Intel):**
+```bash
+mkdir -p ../desktop-electron/resources
+cp dist/opencode-darwin-x64/bin/opencode ../desktop-electron/resources/opencode-cli
+```
+
+**Windows:**
+```bash
+mkdir ..\desktop-electron\resources
+copy dist\opencode-windows-x64\bin\opencode.exe ..\desktop-electron\resources\opencode-cli.exe
+```
+
+**Linux:**
+```bash
+mkdir -p ../desktop-electron/resources
+cp dist/opencode-linux-x64/bin/opencode ../desktop-electron/resources/opencode-cli
+```
+
+### 第三步：打包应用
+
+以下以 macOS 为例，其他平台请参考[各平台打包命令](#各平台打包命令)。
+
+```bash
+cd ../desktop-electron
+bun run build && bun run prebuild && bun run package:mac
+```
+
+打包完成后，安装包位于 `packages/desktop-electron/dist/` 目录。
+
+## 各平台打包命令
+
+- `bun run package:mac` - 打包 macOS 应用（.dmg）
+- `bun run package:win` - 打包 Windows 应用（.exe）
+- `bun run package:linux` - 打包 Linux 应用（.AppImage, .deb）
+
+**## 应用架构
+
+桌面应用由以下部分组成：
+
+1. **Electron 主进程** - 负责应用生命周期、窗口管理和 CLI 后端服务
+2. **渲染进程** - 基于 SolidJS 的 UI 界面（与 Web 应用共用）
+3. **CLI 后端服务** - OpenCode CLI 作为本地服务器运行，UI 通过 HTTP 连接


### PR DESCRIPTION
### Issue for this PR

Closes #19395 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The README in desktop-electron was incorrect; it mistakenly used the README from desktop, which prevented proper packaging. I have corrected it.

### How did you verify your code works?
Only the packaging method in the documentation was modified, and packaging verification has been completed.


### Screenshots / recordings
_If this is a UI change, please include a screenshot or recording._  
No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
