### PR TITLE
fix(auth): restore anthropic api key flow

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -17,6 +17,10 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 
+function shouldOpen(provider: string, label: string) {
+  return provider === "anthropic" && label === "Create an API Key"
+}
+
 export function DialogConnectProvider(props: { provider: string }) {
   const dialog = useDialog()
   const globalSync = useGlobalSync()
@@ -47,7 +51,7 @@ export function DialogConnectProvider(props: { provider: string }) {
   )
   const fallback = createMemo<ProviderAuthMethod[]>(() => [
     {
-      type: "api" as const,
+      type: "api",
       label: language.t("provider.connect.method.apiKey"),
     },
   ])
@@ -63,7 +67,9 @@ export function DialogConnectProvider(props: { provider: string }) {
     },
   )
   const loading = createMemo(() => auth.loading && !globalSync.data.provider_auth[props.provider])
-  const methods = createMemo(() => auth.latest ?? globalSync.data.provider_auth[props.provider] ?? fallback())
+  const methods = createMemo<ProviderAuthMethod[]>(
+    () => auth.latest ?? globalSync.data.provider_auth[props.provider] ?? fallback(),
+  )
   const [store, setStore] = createStore({
     methodIndex: undefined as undefined | number,
     authorization: undefined as undefined | ProviderAuthAuthorization,
@@ -171,6 +177,9 @@ export function DialogConnectProvider(props: { provider: string }) {
         )
         .then((x) => {
           if (!alive.value) return
+          if (x.data?.url && shouldOpen(props.provider, method.label)) {
+            window.open(x.data.url, "_blank", "noopener,noreferrer")
+          }
           const elapsed = Date.now() - start
           const delay = 1000 - elapsed
 

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -13,8 +13,13 @@ import { Instance } from "../../project/instance"
 import type { Hooks } from "@opencode-ai/plugin"
 import { Process } from "../../util/process"
 import { text } from "node:stream/consumers"
+import open from "open"
 
 type PluginAuth = NonNullable<Hooks["auth"]>
+
+function shouldOpen(provider: string, label: string) {
+  return provider === "anthropic" && label === "Create an API Key"
+}
 
 async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, methodName?: string): Promise<boolean> {
   let index = 0
@@ -77,6 +82,7 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
 
     if (authorize.url) {
       prompts.log.info("Go to: " + authorize.url)
+      if (shouldOpen(provider, method.label)) await open(authorize.url).catch(() => {})
     }
 
     if (authorize.method === "auto") {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -13,6 +13,7 @@ import { DialogModel } from "./dialog-model"
 import { useKeyboard } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
+import open from "open"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   opencode: 0,
@@ -21,6 +22,9 @@ const PROVIDER_PRIORITY: Record<string, number> = {
   "github-copilot": 3,
   anthropic: 4,
   google: 5,
+}
+function shouldOpen(provider: string, label: string) {
+  return provider === "anthropic" && label === "Create an API Key"
 }
 
 export function createDialogProviderOptions() {
@@ -43,12 +47,13 @@ export function createDialogProviderOptions() {
         }[provider.id],
         category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Other",
         async onSelect() {
-          const methods = sync.data.provider_auth[provider.id] ?? [
+          const fallback: ProviderAuthMethod[] = [
             {
               type: "api",
               label: "API key",
             },
           ]
+          const methods = sync.data.provider_auth[provider.id] ?? fallback
           let index: number | null = 0
           if (methods.length > 1) {
             index = await new Promise<number | null>((resolve) => {
@@ -92,6 +97,9 @@ export function createDialogProviderOptions() {
               })
               dialog.clear()
               return
+            }
+            if (result.data?.url && shouldOpen(provider.id, method.label)) {
+              open(result.data.url).catch(() => {})
             }
             if (result.data?.method === "code") {
               dialog.replace(() => (

--- a/packages/opencode/src/plugin/anthropic.ts
+++ b/packages/opencode/src/plugin/anthropic.ts
@@ -1,0 +1,113 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const REDIRECT_URL = "https://console.anthropic.com/oauth/code/callback"
+const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+const CREATE_URL = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key"
+
+function rand(size: number) {
+  const text = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  const buf = crypto.getRandomValues(new Uint8Array(size))
+  return Array.from(buf)
+    .map((x) => text[x % text.length])
+    .join("")
+}
+
+function b64(buf: ArrayBuffer) {
+  return Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+async function pkce() {
+  const verifier = rand(43)
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))
+  return {
+    verifier,
+    challenge: b64(hash),
+  }
+}
+
+async function authorize() {
+  const code = await pkce()
+  const url = new URL("https://console.anthropic.com/oauth/authorize")
+  url.searchParams.set("code", "true")
+  url.searchParams.set("client_id", CLIENT_ID)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("redirect_uri", REDIRECT_URL)
+  url.searchParams.set("scope", "org:create_api_key user:profile user:inference")
+  url.searchParams.set("code_challenge", code.challenge)
+  url.searchParams.set("code_challenge_method", "S256")
+  url.searchParams.set("state", code.verifier)
+  return {
+    url: url.toString(),
+    verifier: code.verifier,
+  }
+}
+
+async function exchange(code: string, verifier: string) {
+  const [value, state] = code.split("#")
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      code: value,
+      state,
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URL,
+      code_verifier: verifier,
+    }),
+  })
+  if (!res.ok) return
+  return (await res.json()) as {
+    access_token: string
+  }
+}
+
+export async function AnthropicAuthPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "anthropic",
+      methods: [
+        {
+          label: "Create an API Key",
+          type: "oauth",
+          authorize: async () => {
+            const auth = await authorize()
+            return {
+              url: auth.url,
+              instructions: "Paste the authorization code here:",
+              method: "code" as const,
+              callback: async (code) => {
+                const token = await exchange(code, auth.verifier)
+                if (!token) return { type: "failed" as const }
+
+                const res = await fetch(CREATE_URL, {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                    authorization: `Bearer ${token.access_token}`,
+                  },
+                })
+                if (!res.ok) return { type: "failed" as const }
+
+                const json = (await res.json()) as { raw_key?: string }
+                if (!json.raw_key) return { type: "failed" as const }
+
+                return {
+                  type: "success" as const,
+                  key: json.raw_key,
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "API key",
+          type: "api",
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -9,6 +9,7 @@ import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
+import { AnthropicAuthPlugin } from "./anthropic"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
 import { PoeAuthPlugin } from "opencode-poe-auth"
 import { Effect, Layer, ServiceMap, Stream } from "effect"
@@ -44,7 +45,13 @@ export namespace Plugin {
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
+  const INTERNAL_PLUGINS: PluginInstance[] = [
+    CodexAuthPlugin,
+    CopilotAuthPlugin,
+    AnthropicAuthPlugin,
+    GitlabAuthPlugin,
+    PoeAuthPlugin,
+  ]
 
   // Old npm package names for plugins that are now built-in — skip if users still have them in config
   const DEPRECATED_PLUGIN_PACKAGES = ["opencode-openai-codex-auth", "opencode-copilot-auth"]


### PR DESCRIPTION
### Issue for this PR

Closes #19097

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This restores Anthropic's `Create an API Key` connect flow without bringing back the removed Claude Pro/Max auth path. It vendors the old create-key OAuth flow as a built-in Anthropic auth plugin, then wires the returned authorization URL through the CLI, TUI, and app so users can complete the browser flow and save the generated API key.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Ran `bun typecheck` in `packages/app`
- Ran `bun run dev -- providers login --provider anthropic --method \"Create an API Key\"` and verified it opened the Anthropic OAuth URL and prompted for the authorization code

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR