### PR TITLE
fix(shell): resolve short path names when finding bash.exe on Windows

### DIFF
--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -2,8 +2,9 @@ import { Flag } from "@/flag/flag"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "@/util/filesystem"
 import { which } from "@/util/which"
-import path from "path"
+import path, { resolve as pathResolve } from "path"
 import { spawn, type ChildProcess } from "child_process"
+import { realpathSync } from "fs"
 import { setTimeout as sleep } from "node:timers/promises"
 
 const SIGKILL_TIMEOUT_MS = 200
@@ -41,16 +42,47 @@ export namespace Shell {
   }
   const BLACKLIST = new Set(["fish", "nu"])
 
+  function winbash() {
+    const bash = which("bash.exe") || which("bash")
+    if (bash && Filesystem.stat(bash)?.size) {
+      try {
+        return realpathSync.native(bash)
+      } catch {
+        return bash
+      }
+    }
+    const git = which("git")
+    if (!git) return null
+    const list = [git]
+    try {
+      list.push(realpathSync.native(git))
+    } catch {}
+    for (const item of list) {
+      const direct = pathResolve(item, "..", "bash.exe")
+      if (Filesystem.stat(direct)?.size) {
+        try {
+          return realpathSync.native(direct)
+        } catch {
+          return direct
+        }
+      }
+      const bin = pathResolve(item, "..", "..", "bin", "bash.exe")
+      if (Filesystem.stat(bin)?.size) {
+        try {
+          return realpathSync.native(bin)
+        } catch {
+          return bin
+        }
+      }
+    }
+    return null
+  }
+
   function fallback() {
     if (process.platform === "win32") {
       if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
-      const git = which("git")
-      if (git) {
-        // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
-        // bash.exe is at: C:\Program Files\Git\bin\bash.exe
-        const bash = path.join(git, "..", "..", "bin", "bash.exe")
-        if (Filesystem.stat(bash)?.size) return bash
-      }
+      const bash = winbash()
+      if (bash) return bash
       return process.env.COMSPEC || "cmd.exe"
     }
     if (process.platform === "darwin") return "/bin/zsh"


### PR DESCRIPTION
### Issue for this PR

Closes #19413

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `which("git")` can return a path containing 8.3 short names (e.g. `C:\PROGRA~1\Git\cmd\git.exe`). The old code used `path.join` to derive the `bash.exe` path from that location, producing an unnormalized path like `C:\PROGRA~1\Git\cmd\..\..` which was passed directly to `uv_spawn`. `uv_spawn` does not resolve `..` segments or expand 8.3 short names, so it fails with `No such file in directory`.

The fix:
- Extracts bash resolution into a dedicated `winbash()` helper
- Tries `which("bash.exe")` / `which("bash")` first before deriving from git location
- Uses `path.resolve` instead of `path.join` to normalize `..` segments eagerly
- Calls `realpathSync.native` on all returned paths to expand 8.3 short names to their full form (e.g. `PROGRA~1` → `Program Files`)

### How did you verify your code works?

Reviewed the code path. The fix is straightforward: `path.resolve` normalizes `..` segments, and `realpathSync.native` is the standard Node.js API for expanding Windows short paths to long paths.

### Screenshots / recordings

_N/A - not a UI change._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR