### PR TITLE
feat: add /subagents command with list dialog

### DIFF
--- a/packages/app/src/components/dialog-list-subagents.tsx
+++ b/packages/app/src/components/dialog-list-subagents.tsx
@@ -1,0 +1,40 @@
+import { Component, createMemo } from "solid-js"
+import { useSync } from "@/context/sync"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { List } from "@opencode-ai/ui/list"
+import { useLanguage } from "@/context/language"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+
+export const DialogListSubagents: Component = () => {
+  const sync = useSync()
+  const language = useLanguage()
+  const dialog = useDialog()
+
+  const subagents = createMemo(() =>
+    sync.data.agent
+      .filter((item) => item.mode === "subagent" && !item.hidden)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  )
+
+  return (
+    <Dialog title={language.t("dialog.subagent.title")}>
+      <List
+        class="flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0"
+        search={{ placeholder: language.t("dialog.subagent.search.placeholder"), autofocus: true }}
+        emptyMessage={language.t("dialog.subagent.empty")}
+        key={(x) => x.name}
+        items={subagents}
+        filterKeys={["name", "description"]}
+        sortBy={(a, b) => a.name.localeCompare(b.name)}
+        onSelect={() => dialog.close()}
+      >
+        {(item) => (
+          <div class="w-full flex items-center gap-x-2 text-13-regular">
+            <span class="text-text-strong whitespace-nowrap">{item.name}</span>
+            <span class="text-text-weak truncate">{item.description}</span>
+          </div>
+        )}
+      </List>
+    </Dialog>
+  )
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -65,6 +65,8 @@ export const dict = {
   "command.model.choose.description": "Select a different model",
   "command.mcp.toggle": "Toggle MCPs",
   "command.mcp.toggle.description": "Toggle MCPs",
+  "command.subagent.list": "List subagents",
+  "command.subagent.list.description": "Browse available subagents",
   "command.agent.cycle": "Cycle agent",
   "command.agent.cycle.description": "Switch to the next agent",
   "command.agent.cycle.reverse": "Cycle agent backwards",
@@ -292,6 +294,9 @@ export const dict = {
   "prompt.toast.promptSendFailed.title": "Failed to send prompt",
   "prompt.toast.promptSendFailed.description": "Unable to retrieve session",
 
+  "dialog.subagent.title": "Subagents",
+  "dialog.subagent.search.placeholder": "Search subagents",
+  "dialog.subagent.empty": "No subagents configured",
   "dialog.mcp.title": "MCPs",
   "dialog.mcp.description": "{{enabled}} of {{total}} enabled",
   "dialog.mcp.empty": "No MCPs configured",

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -370,6 +370,17 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         },
       }),
       agentCommand({
+        id: "subagent.list",
+        title: language.t("command.subagent.list"),
+        description: language.t("command.subagent.list.description"),
+        slash: "subagents",
+        onSelect: () => {
+          void import("@/components/dialog-list-subagents").then((x) => {
+            dialog.show(() => <x.DialogListSubagents />)
+          })
+        },
+      }),
+      agentCommand({
         id: "agent.cycle",
         title: language.t("command.agent.cycle"),
         description: language.t("command.agent.cycle.description"),

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -19,6 +19,7 @@ import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
+import { DialogSubagent } from "@tui/component/dialog-subagent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { DialogWorkspaceList } from "@tui/component/dialog-workspace-list"
 import { KeybindProvider } from "@tui/context/keybind"
@@ -478,6 +479,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       onSelect: () => {
         dialog.replace(() => <DialogAgent />)
+      },
+    },
+    {
+      title: "List subagents",
+      value: "subagent.list",
+      category: "Agent",
+      slash: {
+        name: "subagents",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogSubagent />)
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-subagent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-subagent.tsx
@@ -1,0 +1,19 @@
+import { createMemo } from "solid-js"
+import { useSync } from "@tui/context/sync"
+import { DialogSelect } from "@tui/ui/dialog-select"
+
+export function DialogSubagent() {
+  const sync = useSync()
+
+  const options = createMemo(() =>
+    sync.data.agent
+      .filter((item) => item.mode === "subagent" && !item.hidden)
+      .map((item) => ({
+        value: item.name,
+        title: item.name,
+        description: item.description,
+      })),
+  )
+
+  return <DialogSelect title="Subagents" options={options()} />
+}


### PR DESCRIPTION
## Summary

- Adds `/subagents` slash command that opens a searchable list dialog showing all configured subagents
- Implemented for both TUI and web app, following existing patterns exactly

Closes #19415

## Changes

- **TUI**: New `dialog-subagent.tsx` using `DialogSelect` (same as `/agents`)
- **Web**: New `dialog-list-subagents.tsx` using `Dialog` + `List` (same as `/mcps`)
- **Commands**: Registered as `subagent.list` under the Agent category
- **i18n**: English strings only (5 keys)

## Testing

- `/subagents` in TUI → opens searchable list of subagent-mode agents
- `/subagents` in web → opens dialog with filterable list
- No impact on existing `/agents`, `/mcps`, or agent cycling commands