### PR TITLE
fix(opencode): remove 150-line cap from /init AGENTS.md generation

### DIFF
--- a/packages/opencode/src/command/template/initialize.txt
+++ b/packages/opencode/src/command/template/initialize.txt
@@ -2,7 +2,7 @@ Please analyze this codebase and create an AGENTS.md file containing:
 1. Build/lint/test commands - especially for running a single test
 2. Code style guidelines including imports, formatting, types, naming conventions, error handling, etc.
 
-The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Make it about 150 lines long.
+The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Be comprehensive — include all relevant project context, but stay concise and avoid filler. Aim for completeness over brevity.
 If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (in .github/copilot-instructions.md), make sure to include them.
 
 If there's already an AGENTS.md, improve it if it's located in ${path}


### PR DESCRIPTION
﻿## Summary
- Remove the hard-coded "Make it about 150 lines long" instruction from the `/init` command template
- Replace with guidance to be comprehensive while staying concise, allowing the generated AGENTS.md to fully capture project context

## Problem
The `/init` command generates AGENTS.md by instructing the LLM to create a file "about 150 lines long". For medium-to-large projects, this causes important context (testing patterns, deployment config, architectural decisions) to be silently truncated.

## Fix
Changed the template instruction in `packages/opencode/src/command/template/initialize.txt` from a hard 150-line limit to guidance that encourages completeness over brevity.

Closes #19341
