### PR TITLE
feat(read): support docx/pptx via MarkItDown CLI

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -4,6 +4,7 @@ import { Tool } from "./tool"
 import { Filesystem } from "../util/filesystem"
 import { Ripgrep } from "../file/ripgrep"
 import { Process } from "../util/process"
+import { convertOfficeToMarkdown, isOfficeDocumentPath } from "../util/markitdown"
 
 import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
@@ -11,6 +12,14 @@ import path from "path"
 import { assertExternalDirectory } from "./external-directory"
 
 const MAX_LINE_LENGTH = 2000
+const OFFICE_FILE_SCAN_LIMIT = 20
+
+type Match = {
+  path: string
+  modTime: number
+  lineNum: number
+  lineText: string
+}
 
 export const GrepTool = Tool.define("grep", {
   description: DESCRIPTION,
@@ -79,7 +88,7 @@ export const GrepTool = Tool.define("grep", {
 
     // Handle both Unix (\n) and Windows (\r\n) line endings
     const lines = output.trim().split(/\r?\n/)
-    const matches = []
+    const matches: Match[] = []
 
     for (const line of lines) {
       if (!line) continue
@@ -100,6 +109,14 @@ export const GrepTool = Tool.define("grep", {
         lineText,
       })
     }
+
+    const officeSearch = await findOfficeMatches({
+      searchPath,
+      pattern: params.pattern,
+      include: params.include,
+      abort: ctx.abort,
+    })
+    matches.push(...officeSearch.matches)
 
     matches.sort((a, b) => b.modTime - a.modTime)
 
@@ -144,13 +161,104 @@ export const GrepTool = Tool.define("grep", {
       outputLines.push("(Some paths were inaccessible and skipped)")
     }
 
+    if (officeSearch.filesSkipped > 0) {
+      outputLines.push("")
+      outputLines.push(
+        `(Some office files were skipped after conversion errors: ${officeSearch.filesSkipped}${officeSearch.skipPreview ? `; e.g. ${officeSearch.skipPreview}` : ""})`,
+      )
+    }
+
+    if (officeSearch.filesCapped) {
+      outputLines.push("")
+      outputLines.push(
+        `(Office-file scanning capped at ${OFFICE_FILE_SCAN_LIMIT} files. Narrow the path/include filter for exhaustive results.)`,
+      )
+    }
+
+    if (officeSearch.regexUnsupported) {
+      outputLines.push("")
+      outputLines.push("(Office-file search skipped: pattern is unsupported by JS RegExp)")
+    }
+
     return {
       title: params.pattern,
       metadata: {
         matches: totalMatches,
         truncated,
+        officeMatches: officeSearch.matches.length,
       },
       output: outputLines.join("\n"),
     }
   },
 })
+
+async function findOfficeMatches(input: {
+  searchPath: string
+  pattern: string
+  include?: string
+  abort: AbortSignal
+}) {
+  let matcher: RegExp
+  try {
+    matcher = new RegExp(input.pattern)
+  } catch {
+    return {
+      matches: [] as Match[],
+      filesSkipped: 0,
+      filesCapped: false,
+      skipPreview: "",
+      regexUnsupported: true,
+    }
+  }
+
+  const officeFiles: string[] = []
+  for await (const relativePath of Ripgrep.files({
+    cwd: input.searchPath,
+    glob: input.include ? [input.include] : undefined,
+    signal: input.abort,
+  })) {
+    const absolutePath = path.join(input.searchPath, relativePath)
+    if (!isOfficeDocumentPath(absolutePath)) continue
+    officeFiles.push(absolutePath)
+    if (officeFiles.length >= OFFICE_FILE_SCAN_LIMIT) break
+  }
+
+  const matches: Match[] = []
+  let filesSkipped = 0
+  const skippedPaths: string[] = []
+
+  for (const officePath of officeFiles) {
+    let converted = ""
+    try {
+      converted = await convertOfficeToMarkdown(officePath, { abort: input.abort })
+    } catch {
+      filesSkipped += 1
+      if (skippedPaths.length < 3) skippedPaths.push(officePath)
+      continue
+    }
+
+    const lines = converted.replace(/\r\n/g, "\n").split("\n")
+    const stats = Filesystem.stat(officePath)
+    const modTime = stats?.mtime.getTime() ?? 0
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      matcher.lastIndex = 0
+      if (!matcher.test(line)) continue
+      matches.push({
+        path: officePath,
+        modTime,
+        lineNum: i + 1,
+        lineText: line,
+      })
+    }
+  }
+
+  return {
+    matches,
+    filesSkipped,
+    filesCapped: officeFiles.length >= OFFICE_FILE_SCAN_LIMIT,
+    skipPreview: skippedPaths.join(", "),
+    regexUnsupported: false,
+  }
+}

--- a/packages/opencode/src/tool/grep.txt
+++ b/packages/opencode/src/tool/grep.txt
@@ -2,6 +2,7 @@
 - Searches file contents using regular expressions
 - Supports full regex syntax (eg. "log.*Error", "function\s+\w+", etc.)
 - Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
+- Can search `.docx` and `.pptx` files by converting them to markdown text via MarkItDown
 - Returns file paths and line numbers with at least one match sorted by modification time
 - Use this tool when you need to find files containing specific patterns
 - If you need to identify/count the number of matches within files, use the Bash tool with `rg` (ripgrep) directly. Do NOT use `grep`.

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -3,7 +3,6 @@ import { createReadStream } from "fs"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { createInterface } from "readline"
-import { spawn } from "node:child_process"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
 import { FileTime } from "../file/time"
@@ -12,14 +11,13 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
 import { InstructionPrompt } from "../session/instruction"
 import { Filesystem } from "../util/filesystem"
+import { convertOfficeToMarkdown, isOfficeDocumentPath } from "../util/markitdown"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
 const MAX_BYTES = 50 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
-const MARKITDOWN_TIMEOUT_MS = 30_000
-const MARKITDOWN_EXTENSIONS = new Set([".docx", ".pptx"])
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
@@ -144,9 +142,8 @@ export const ReadTool = Tool.define("read", {
       }
     }
 
-    const ext = path.extname(filepath).toLowerCase()
-    if (MARKITDOWN_EXTENSIONS.has(ext)) {
-      const converted = await convertWithMarkItDown(filepath)
+    if (isOfficeDocumentPath(filepath)) {
+      const converted = await convertOfficeToMarkdown(filepath, { abort: ctx.abort })
       const rendered = renderTextOutput(converted, offsetAndLimit(params))
 
       let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
@@ -331,63 +328,6 @@ function renderTextOutput(text: string, options: { offset: number; limit: number
     preview,
     truncated,
   }
-}
-
-async function convertWithMarkItDown(filepath: string): Promise<string> {
-  const configured = process.env.OPENCODE_MARKITDOWN_CMD?.trim()
-  if (configured) {
-    return runCommand(configured, [filepath])
-  }
-
-  try {
-    return await runCommand("markitdown", [filepath])
-  } catch (error) {
-    if (!isCommandMissing(error)) throw error
-  }
-
-  try {
-    return await runCommand("python3", ["-m", "markitdown", filepath])
-  } catch (error) {
-    if (!isCommandMissing(error)) throw error
-  }
-
-  throw new Error(
-    "Unable to run MarkItDown. Install the 'markitdown' CLI or set OPENCODE_MARKITDOWN_CMD to a working executable.",
-  )
-}
-
-function isCommandMissing(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  return /not found|ENOENT|spawn/i.test(error.message)
-}
-
-function runCommand(command: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] })
-    const stdout: Buffer[] = []
-    const stderr: Buffer[] = []
-
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM")
-      reject(new Error(`Command timed out after ${MARKITDOWN_TIMEOUT_MS}ms: ${command} ${args.join(" ")}`))
-    }, MARKITDOWN_TIMEOUT_MS)
-
-    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)))
-    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)))
-    child.on("error", (error) => {
-      clearTimeout(timer)
-      reject(new Error(`Failed to execute ${command}: ${error.message}`))
-    })
-    child.on("close", (code) => {
-      clearTimeout(timer)
-      if (code === 0) {
-        resolve(Buffer.concat(stdout).toString("utf-8"))
-        return
-      }
-      const err = Buffer.concat(stderr).toString("utf-8").trim()
-      reject(new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${err}`))
-    })
-  })
 }
 
 async function isBinaryFile(filepath: string, fileSize: number): Promise<boolean> {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -3,6 +3,7 @@ import { createReadStream } from "fs"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { createInterface } from "readline"
+import { spawn } from "node:child_process"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
 import { FileTime } from "../file/time"
@@ -17,6 +18,8 @@ const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
 const MAX_BYTES = 50 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
+const MARKITDOWN_TIMEOUT_MS = 30_000
+const MARKITDOWN_EXTENSIONS = new Set([".docx", ".pptx"])
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
@@ -141,6 +144,34 @@ export const ReadTool = Tool.define("read", {
       }
     }
 
+    const ext = path.extname(filepath).toLowerCase()
+    if (MARKITDOWN_EXTENSIONS.has(ext)) {
+      const converted = await convertWithMarkItDown(filepath)
+      const rendered = renderTextOutput(converted, offsetAndLimit(params))
+
+      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
+      output += rendered.content
+      output += rendered.footer
+      output += "\n</content>"
+
+      LSP.touchFile(filepath, false)
+      await FileTime.read(ctx.sessionID, filepath)
+
+      if (instructions.length > 0) {
+        output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
+      }
+
+      return {
+        title,
+        output,
+        metadata: {
+          preview: rendered.preview,
+          truncated: rendered.truncated,
+          loaded: instructions.map((i) => i.filepath),
+        },
+      }
+    }
+
     const isBinary = await isBinaryFile(filepath, Number(stat.size))
     if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
 
@@ -231,6 +262,133 @@ export const ReadTool = Tool.define("read", {
     }
   },
 })
+
+function offsetAndLimit(params: { offset?: number; limit?: number }) {
+  return {
+    offset: params.offset ?? 1,
+    limit: params.limit ?? DEFAULT_READ_LIMIT,
+  }
+}
+
+function renderTextOutput(text: string, options: { offset: number; limit: number }) {
+  const normalized = text.replace(/\r\n/g, "\n")
+  const allLines = normalized.length === 0 ? [] : normalized.split("\n")
+  if (normalized.endsWith("\n") && allLines.length > 0 && allLines[allLines.length - 1] === "") {
+    allLines.pop()
+  }
+
+  const totalLines = allLines.length
+  const offset = options.offset
+  const limit = options.limit
+  if (totalLines < offset && !(totalLines === 0 && offset === 1)) {
+    throw new Error(`Offset ${offset} is out of range for this file (${totalLines} lines)`)
+  }
+
+  const start = offset - 1
+  const raw: string[] = []
+  let bytes = 0
+  let truncatedByBytes = false
+  let hasMoreLines = false
+
+  for (let i = start; i < totalLines; i++) {
+    if (raw.length >= limit) {
+      hasMoreLines = true
+      break
+    }
+
+    const textLine = allLines[i]
+    const line =
+      textLine.length > MAX_LINE_LENGTH ? textLine.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : textLine
+    const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+    if (bytes + size > MAX_BYTES) {
+      truncatedByBytes = true
+      hasMoreLines = true
+      break
+    }
+
+    raw.push(line)
+    bytes += size
+  }
+
+  const content = raw.map((line, index) => `${index + offset}: ${line}`).join("\n")
+  const preview = raw.slice(0, 20).join("\n")
+  const lastReadLine = offset + raw.length - 1
+  const nextOffset = lastReadLine + 1
+  const truncated = hasMoreLines || truncatedByBytes
+
+  let footer = ""
+  if (truncatedByBytes) {
+    footer += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
+  } else if (hasMoreLines) {
+    footer += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
+  } else {
+    footer += `\n\n(End of file - total ${totalLines} lines)`
+  }
+
+  return {
+    content,
+    footer,
+    preview,
+    truncated,
+  }
+}
+
+async function convertWithMarkItDown(filepath: string): Promise<string> {
+  const configured = process.env.OPENCODE_MARKITDOWN_CMD?.trim()
+  if (configured) {
+    return runCommand(configured, [filepath])
+  }
+
+  try {
+    return await runCommand("markitdown", [filepath])
+  } catch (error) {
+    if (!isCommandMissing(error)) throw error
+  }
+
+  try {
+    return await runCommand("python3", ["-m", "markitdown", filepath])
+  } catch (error) {
+    if (!isCommandMissing(error)) throw error
+  }
+
+  throw new Error(
+    "Unable to run MarkItDown. Install the 'markitdown' CLI or set OPENCODE_MARKITDOWN_CMD to a working executable.",
+  )
+}
+
+function isCommandMissing(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return /not found|ENOENT|spawn/i.test(error.message)
+}
+
+function runCommand(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM")
+      reject(new Error(`Command timed out after ${MARKITDOWN_TIMEOUT_MS}ms: ${command} ${args.join(" ")}`))
+    }, MARKITDOWN_TIMEOUT_MS)
+
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)))
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)))
+    child.on("error", (error) => {
+      clearTimeout(timer)
+      reject(new Error(`Failed to execute ${command}: ${error.message}`))
+    })
+    child.on("close", (code) => {
+      clearTimeout(timer)
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString("utf-8"))
+        return
+      }
+      const err = Buffer.concat(stderr).toString("utf-8").trim()
+      reject(new Error(`Command failed (${code}): ${command} ${args.join(" ")}\n${err}`))
+    })
+  })
+}
 
 async function isBinaryFile(filepath: string, fileSize: number): Promise<boolean> {
   const ext = path.extname(filepath).toLowerCase()

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -12,3 +12,4 @@ Usage:
 - Call this tool in parallel when you know there are multiple files you want to read.
 - Avoid tiny repeated slices (30 line chunks). If you need more context, read a larger window.
 - This tool can read image files and PDFs and return them as file attachments.
+- This tool can read `.docx` and `.pptx` files by converting them to markdown text via MarkItDown before applying offset/limit.

--- a/packages/opencode/src/util/markitdown.ts
+++ b/packages/opencode/src/util/markitdown.ts
@@ -1,0 +1,139 @@
+import path from "path"
+import { abortAfterAny } from "./abort"
+import { Process } from "./process"
+
+const MARKITDOWN_TIMEOUT_MS = 30_000
+const OFFICE_EXTENSIONS = new Set([".docx", ".pptx"])
+
+type ConvertOptions = {
+  abort?: AbortSignal
+  timeoutMs?: number
+}
+
+type ParsedCommand = {
+  argv: string[]
+  fromEnv: boolean
+}
+
+export function isOfficeDocumentPath(filepath: string) {
+  return OFFICE_EXTENSIONS.has(path.extname(filepath).toLowerCase())
+}
+
+export async function convertOfficeToMarkdown(filepath: string, options: ConvertOptions = {}) {
+  const commands = resolveCommands()
+  let fallbackMissing = false
+
+  for (const command of commands) {
+    try {
+      return await runCommand(command.argv, filepath, options)
+    } catch (error) {
+      if (command.fromEnv) throw error
+      if (isCommandMissing(error)) {
+        fallbackMissing = true
+        continue
+      }
+      throw error
+    }
+  }
+
+  if (fallbackMissing) {
+    throw new Error(
+      "Unable to run MarkItDown. Install the 'markitdown' CLI (with required extras) or set OPENCODE_MARKITDOWN_CMD.",
+    )
+  }
+
+  throw new Error("Unable to run MarkItDown.")
+}
+
+function resolveCommands(): ParsedCommand[] {
+  const configured = process.env.OPENCODE_MARKITDOWN_CMD?.trim()
+  if (configured) {
+    const argv = splitCommand(configured)
+    if (argv.length === 0) {
+      throw new Error("OPENCODE_MARKITDOWN_CMD is set but empty")
+    }
+    return [{ argv, fromEnv: true }]
+  }
+
+  return [
+    { argv: ["markitdown"], fromEnv: false },
+    { argv: ["python3", "-m", "markitdown"], fromEnv: false },
+  ]
+}
+
+function splitCommand(command: string) {
+  const parts: string[] = []
+  let current = ""
+  let quote: '"' | "'" | undefined
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]
+
+    if (quote) {
+      if (ch === quote) {
+        quote = undefined
+      } else {
+        current += ch
+      }
+      continue
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      continue
+    }
+
+    if (/\s/.test(ch)) {
+      if (current) {
+        parts.push(current)
+        current = ""
+      }
+      continue
+    }
+
+    current += ch
+  }
+
+  if (quote) {
+    throw new Error("OPENCODE_MARKITDOWN_CMD has an unmatched quote")
+  }
+
+  if (current) parts.push(current)
+  return parts
+}
+
+async function runCommand(argv: string[], filepath: string, options: ConvertOptions) {
+  const timeout = options.timeoutMs ?? MARKITDOWN_TIMEOUT_MS
+  const { signal, clearTimeout } = options.abort ? abortAfterAny(timeout, options.abort) : abortAfterAny(timeout)
+  try {
+    const result = await Process.text([...argv, filepath], {
+      abort: signal,
+    })
+    return result.text
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`MarkItDown timed out after ${timeout}ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout()
+  }
+}
+
+function isCommandMissing(error: unknown): boolean {
+  if (error && typeof error === "object" && "code" in error && (error as any).code === "ENOENT") {
+    return true
+  }
+
+  if (error instanceof Process.RunFailedError) {
+    const stderr = error.stderr.toString("utf-8")
+    if (error.code === 127) return true
+    return /not found|ENOENT|command not found/i.test(stderr)
+  }
+
+  if (error instanceof Error) {
+    return /not found|ENOENT|spawn|command not found/i.test(error.message)
+  }
+
+  return false
+}

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -84,6 +84,57 @@ describe("tool.grep", () => {
       },
     })
   })
+
+  test("searches pptx via MarkItDown and combines with text file matches", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "slides.pptx"), Buffer.from([0x50, 0x4b, 0x03, 0x04]))
+        await Bun.write(path.join(dir, "notes.txt"), "keyword in notes")
+
+        const mockCmd = path.join(dir, "mock-markitdown.mjs")
+        await Bun.write(
+          mockCmd,
+          [
+            "const filepath = process.argv[process.argv.length - 1]",
+            "if (!filepath.endsWith('.pptx') && !filepath.endsWith('.docx')) process.exit(2)",
+            "console.log('slide title')",
+            "console.log('keyword in slide')",
+          ].join("\n"),
+        )
+        await Bun.$`chmod +x ${mockCmd}`
+      },
+    })
+
+    const oldCmd = process.env.OPENCODE_MARKITDOWN_CMD
+    process.env.OPENCODE_MARKITDOWN_CMD = `${process.execPath} ${path.join(tmp.path, "mock-markitdown.mjs")}`
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const grep = await GrepTool.init()
+          const result = await grep.execute(
+            {
+              pattern: "keyword",
+              path: tmp.path,
+            },
+            ctx,
+          )
+
+          expect(result.output).toContain(path.join(tmp.path, "slides.pptx"))
+          expect(result.output).toContain(path.join(tmp.path, "notes.txt"))
+          expect(result.metadata.matches).toBeGreaterThanOrEqual(2)
+          expect(result.metadata.officeMatches).toBeGreaterThanOrEqual(1)
+        },
+      })
+    } finally {
+      if (oldCmd === undefined) {
+        delete process.env.OPENCODE_MARKITDOWN_CMD
+      } else {
+        process.env.OPENCODE_MARKITDOWN_CMD = oldCmd
+      }
+    }
+  })
 })
 
 describe("CRLF regex handling", () => {

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -448,6 +448,59 @@ root_type Monster;`
   })
 })
 
+describe("tool.read office documents", () => {
+  test("reads pptx content through MarkItDown and respects offset/limit", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "deck.pptx"), Buffer.from([0x50, 0x4b, 0x03, 0x04]))
+
+        const mockCmd = path.join(dir, "mock-markitdown.mjs")
+        await Bun.write(
+          mockCmd,
+          [
+            "const filepath = process.argv[process.argv.length - 1]",
+            "if (!filepath.endsWith('.pptx') && !filepath.endsWith('.docx')) process.exit(2)",
+            "console.log('alpha')",
+            "console.log('beta keyword')",
+            "console.log('gamma')",
+          ].join("\n"),
+        )
+        await Bun.$`chmod +x ${mockCmd}`
+      },
+    })
+
+    const oldCmd = process.env.OPENCODE_MARKITDOWN_CMD
+    process.env.OPENCODE_MARKITDOWN_CMD = `${process.execPath} ${path.join(tmp.path, "mock-markitdown.mjs")}`
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const read = await ReadTool.init()
+          const result = await read.execute(
+            {
+              filePath: path.join(tmp.path, "deck.pptx"),
+              offset: 2,
+              limit: 2,
+            },
+            ctx,
+          )
+
+          expect(result.output).toContain("2: beta keyword")
+          expect(result.output).toContain("3: gamma")
+          expect(result.output).not.toContain("1: alpha")
+        },
+      })
+    } finally {
+      if (oldCmd === undefined) {
+        delete process.env.OPENCODE_MARKITDOWN_CMD
+      } else {
+        process.env.OPENCODE_MARKITDOWN_CMD = oldCmd
+      }
+    }
+  })
+})
+
 describe("tool.read loaded instructions", () => {
   test("loads AGENTS.md from parent directory and includes in metadata", async () => {
     await using tmp = await tmpdir({


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR extends local Office document support so `.pptx` and `.docx` can be used more like text files in the agent workflow.

Changes included:
- add a shared MarkItDown utility used by tools to detect/convert Office files
- update `read` so Office files are converted to markdown then processed with existing offset/limit and truncation behavior
- update `grep` to include Office-file keyword matching by converting Office files and merging matches with ripgrep results
- add focused tests for read/grep Office behavior and update tool descriptions

Why this works:
- conversion is centralized in one utility with timeout + command fallback handling
- read/grep keep their original output contracts and only add an Office conversion branch
- tests verify both conversion flow and mixed Office+text search behavior

### How did you verify your code works?

I verified with both automated tests and a real sample file.

- Automated tests:
  - `cd packages/opencode && bun test test/tool/read.test.ts test/tool/grep.test.ts`
  - result: 43 passing, 0 failing
- Manual end-to-end checks:
  - converted and read `/home/hexay/temp/第一周_软件工程课程介绍.pptx`
  - confirmed `read` returns line-numbered converted text with truncation metadata
  - confirmed `grep` can find keywords in Office-converted content and regular text files together

Note: the repo currently has unrelated existing typecheck failures in app/desktop packages that predate this PR.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR