### PR TITLE
fix(app): persist queued followups across project switches

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -57,6 +57,7 @@ import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
+import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
@@ -74,6 +75,13 @@ type SessionHistoryWindowInput = {
   loadMore: (sessionID: string) => Promise<void>
   userScrolled: () => boolean
   scroller: () => HTMLDivElement | undefined
+}
+
+type FollowupState = {
+  items: Record<string, (FollowupDraft & { id: string })[] | undefined>
+  failed: Record<string, string | undefined>
+  paused: Record<string, boolean | undefined>
+  edit: Record<string, { id: string; prompt: FollowupDraft["prompt"]; context: FollowupDraft["context"] } | undefined>
 }
 
 /**
@@ -512,15 +520,15 @@ export default function Page() {
     deferRender: false,
   })
 
-  const [followup, setFollowup] = createStore({
-    items: {} as Record<string, (FollowupDraft & { id: string })[] | undefined>,
-    failed: {} as Record<string, string | undefined>,
-    paused: {} as Record<string, boolean | undefined>,
-    edit: {} as Record<
-      string,
-      { id: string; prompt: FollowupDraft["prompt"]; context: FollowupDraft["context"] } | undefined
-    >,
-  })
+  const [followup, setFollowup] = persisted(
+    Persist.workspace(sdk.directory, "followup", ["followup.v1"]),
+    createStore<FollowupState>({
+      items: {},
+      failed: {},
+      paused: {},
+      edit: {},
+    }),
+  )
 
   createComputed((prev) => {
     const key = sessionKey()

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -63,7 +63,9 @@ import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
 
 const emptyUserMessages: UserMessage[] = []
-const emptyFollowups: (FollowupDraft & { id: string })[] = []
+type FollowupItem = FollowupDraft & { id: string }
+type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
+const emptyFollowups: FollowupItem[] = []
 
 type SessionHistoryWindowInput = {
   sessionID: () => string | undefined
@@ -75,13 +77,6 @@ type SessionHistoryWindowInput = {
   loadMore: (sessionID: string) => Promise<void>
   userScrolled: () => boolean
   scroller: () => HTMLDivElement | undefined
-}
-
-type FollowupState = {
-  items: Record<string, (FollowupDraft & { id: string })[] | undefined>
-  failed: Record<string, string | undefined>
-  paused: Record<string, boolean | undefined>
-  edit: Record<string, { id: string; prompt: FollowupDraft["prompt"]; context: FollowupDraft["context"] } | undefined>
 }
 
 /**
@@ -522,7 +517,12 @@ export default function Page() {
 
   const [followup, setFollowup] = persisted(
     Persist.workspace(sdk.directory, "followup", ["followup.v1"]),
-    createStore<FollowupState>({
+    createStore<{
+      items: Record<string, FollowupItem[] | undefined>
+      failed: Record<string, string | undefined>
+      paused: Record<string, boolean | undefined>
+      edit: Record<string, FollowupEdit | undefined>
+    }>({
       items: {},
       failed: {},
       paused: {},


### PR DESCRIPTION
## summary
- persist the session followup queue in workspace storage instead of keeping it only in `Session` component memory
- preserve queued followups when switching projects in the shared app code used by both web and desktop
- keep existing queue send behavior unchanged once the user returns to the session

## testing
- `bun test src/utils/persist.test.ts`
- `bun typecheck` in `packages/app` currently fails due to an unrelated existing `remend` module/types error in `packages/ui/src/components/markdown-stream.ts`