### PR TITLE
fix(session): stop prompt loop after model completion

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -696,8 +696,14 @@ export namespace SessionPrompt {
         break
       }
 
-      // Check if model finished (finish reason is not "tool-calls" or "unknown")
-      const modelFinished = processor.message.finish && !["tool-calls", "unknown"].includes(processor.message.finish)
+      const parts = await MessageV2.parts(processor.message.id)
+      const hasToolActivity = parts.some((part) => part.type === "tool")
+      const modelFinished =
+        !!processor.message.finish &&
+        (![
+          "tool-calls",
+          "unknown",
+        ].includes(processor.message.finish) || (processor.message.finish === "unknown" && !hasToolActivity))
 
       if (modelFinished && !processor.message.error) {
         if (format.type === "json_schema") {
@@ -709,6 +715,8 @@ export namespace SessionPrompt {
           await Session.updateMessage(processor.message)
           break
         }
+
+        break
       }
 
       if (result === "stop") break


### PR DESCRIPTION
### Issue for this PR

Closes #17982
Refs #18096
Refs #11153

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a session loop termination bug after model completion.

- stop prompt-loop continuation when the model has already completed and no tool activity remains
- treat `finish=unknown` as terminal only for non-tool responses
- keep json-schema/tool-call paths unchanged

Why this works:
- terminal completion state is handled explicitly so the loop cannot emit extra assistant messages in the same turn
- tool-related paths are excluded from the terminal shortcut, preserving existing tool execution flow

### How did you verify your code works?

- `bun test ./packages/opencode/test/session/session.test.ts` (3 passed, 0 failed)
- repeated local reproduction with anthropic/claude-sonnet-4-6 no longer produced multi-assistant emissions after one user ping

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
