### PR TITLE
docs: add opencode-llm-proxy to ecosystem plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -50,6 +50,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [opencode-llm-proxy](https://github.com/KochC/opencode-llm-proxy)                                 | Local HTTP gateway — use any OpenCode model via OpenAI, Anthropic, or Gemini API format           |
 
 ---
 


### PR DESCRIPTION
## What is this?

[opencode-llm-proxy](https://github.com/KochC/opencode-llm-proxy) is an OpenCode plugin that starts a local HTTP server (`http://127.0.0.1:4010`) translating between multiple LLM API formats and any model configured in OpenCode.

**npm:** [`opencode-llm-proxy`](https://www.npmjs.com/package/opencode-llm-proxy)

## Supported API formats

| Format | Endpoint |
|---|---|
| OpenAI Chat Completions | `POST /v1/chat/completions` |
| OpenAI Responses API | `POST /v1/responses` |
| Anthropic Messages API | `POST /v1/messages` |
| Google Gemini | `POST /v1beta/models/:model:generateContent` |

## Why it belongs in the ecosystem list

- It's an OpenCode plugin — loaded via `"plugin": ["opencode-llm-proxy"]` in `opencode.json`
- Lets users route any OpenAI/Anthropic/Gemini-compatible tool (Open WebUI, LangChain, Chatbox, Continue, Zed, etc.) through their existing OpenCode model config without reconfiguring each tool
- MIT licensed, 112 tests, actively maintained

## Quickstart

```bash
npm install opencode-llm-proxy
```

```json
{ "plugin": ["opencode-llm-proxy"] }
```

Start OpenCode — the proxy starts automatically on `http://127.0.0.1:4010`.