### PR TITLE
fix(tui): client state clobbering

### DIFF
--- a/packages/opencode/client-migration/20260327120000_client_state/migration.sql
+++ b/packages/opencode/client-migration/20260327120000_client_state/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `kv` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`time_updated` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `prompt_history` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`data` text NOT NULL,
+	`time_created` integer NOT NULL
+);

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -30,35 +30,40 @@ await Bun.write(
 )
 console.log("Generated models-snapshot.js")
 
-// Load migrations from migration directories
-const migrationDirs = (
-  await fs.promises.readdir(path.join(dir, "migration"), {
-    withFileTypes: true,
-  })
-)
-  .filter((entry) => entry.isDirectory() && /^\d{4}\d{2}\d{2}\d{2}\d{2}\d{2}/.test(entry.name))
-  .map((entry) => entry.name)
-  .sort()
+async function load(root: string) {
+  const dirs = (
+    await fs.promises.readdir(path.join(dir, root), {
+      withFileTypes: true,
+    })
+  )
+    .filter((entry) => entry.isDirectory() && /^\d{4}\d{2}\d{2}\d{2}\d{2}\d{2}/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort()
 
-const migrations = await Promise.all(
-  migrationDirs.map(async (name) => {
-    const file = path.join(dir, "migration", name, "migration.sql")
-    const sql = await Bun.file(file).text()
-    const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(name)
-    const timestamp = match
-      ? Date.UTC(
-          Number(match[1]),
-          Number(match[2]) - 1,
-          Number(match[3]),
-          Number(match[4]),
-          Number(match[5]),
-          Number(match[6]),
-        )
-      : 0
-    return { sql, timestamp, name }
-  }),
-)
+  return Promise.all(
+    dirs.map(async (name) => {
+      const file = path.join(dir, root, name, "migration.sql")
+      const sql = await Bun.file(file).text()
+      const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(name)
+      const timestamp = match
+        ? Date.UTC(
+            Number(match[1]),
+            Number(match[2]) - 1,
+            Number(match[3]),
+            Number(match[4]),
+            Number(match[5]),
+            Number(match[6]),
+          )
+        : 0
+      return { sql, timestamp, name }
+    }),
+  )
+}
+
+const migrations = await load("migration")
+const clientMigrations = await load("client-migration")
 console.log(`Loaded ${migrations.length} migrations`)
+console.log(`Loaded ${clientMigrations.length} client migrations`)
 
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
@@ -226,6 +231,7 @@ for (const item of targets) {
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
+      OPENCODE_CLIENT_MIGRATIONS: JSON.stringify(clientMigrations),
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
       OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -1,10 +1,12 @@
-import path from "path"
+import { ClientDatabase } from "@/storage/db"
+import { ClientPromptHistoryTable } from "@/storage/client-db.schema"
 import { Global } from "@/global"
-import { Filesystem } from "@/util/filesystem"
+import { desc, lt } from "drizzle-orm"
+import { existsSync, readFileSync } from "fs"
+import path from "path"
 import { onMount } from "solid-js"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { createSimpleContext } from "../../context/helper"
-import { appendFile, writeFile } from "fs/promises"
 import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
 
 export type PromptInfo = {
@@ -30,29 +32,11 @@ const MAX_HISTORY_ENTRIES = 50
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
   init: () => {
-    const historyPath = path.join(Global.Path.state, "prompt-history.jsonl")
-    onMount(async () => {
-      const text = await Filesystem.readText(historyPath).catch(() => "")
-      const lines = text
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => {
-          try {
-            return JSON.parse(line)
-          } catch {
-            return null
-          }
-        })
-        .filter((line): line is PromptInfo => line !== null)
-        .slice(-MAX_HISTORY_ENTRIES)
+    const file = path.join(Global.Path.state, "prompt-history.jsonl")
 
-      setStore("history", lines)
-
-      // Rewrite file with only valid entries to self-heal corruption
-      if (lines.length > 0) {
-        const content = lines.map((line) => JSON.stringify(line)).join("\n") + "\n"
-        writeFile(historyPath, content).catch(() => {})
-      }
+    onMount(() => {
+      seed(file)
+      setStore("history", list())
     })
 
     const [store, setStore] = createStore({
@@ -83,26 +67,81 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       },
       append(item: PromptInfo) {
         const entry = structuredClone(unwrap(item))
-        let trimmed = false
         setStore(
           produce((draft) => {
             draft.history.push(entry)
             if (draft.history.length > MAX_HISTORY_ENTRIES) {
               draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
-              trimmed = true
             }
             draft.index = 0
           }),
         )
-
-        if (trimmed) {
-          const content = store.history.map((line) => JSON.stringify(line)).join("\n") + "\n"
-          writeFile(historyPath, content).catch(() => {})
-          return
-        }
-
-        appendFile(historyPath, JSON.stringify(entry) + "\n").catch(() => {})
+        write(entry)
       },
     }
   },
 })
+
+function seed(file: string) {
+  ClientDatabase.transaction((db) => {
+    const row = db.select({ id: ClientPromptHistoryTable.id }).from(ClientPromptHistoryTable).limit(1).get()
+    if (row) return
+    if (!existsSync(file)) return
+
+    const now = Date.now()
+    const rows = readFileSync(file, "utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line)
+        } catch {
+          return null
+        }
+      })
+      .filter((item): item is PromptInfo => item !== null)
+      .slice(-MAX_HISTORY_ENTRIES)
+      .map((data) => ({
+        data,
+        time_created: now,
+      }))
+
+    if (rows.length === 0) return
+    db.insert(ClientPromptHistoryTable).values(rows).run()
+  })
+}
+
+function list() {
+  return ClientDatabase.use((db) =>
+    db
+      .select({ data: ClientPromptHistoryTable.data })
+      .from(ClientPromptHistoryTable)
+      .orderBy(desc(ClientPromptHistoryTable.id))
+      .limit(MAX_HISTORY_ENTRIES)
+      .all(),
+  )
+    .reverse()
+    .map((row) => row.data as PromptInfo)
+}
+
+function write(data: PromptInfo) {
+  ClientDatabase.transaction((db) => {
+    db.insert(ClientPromptHistoryTable)
+      .values({
+        data,
+        time_created: Date.now(),
+      })
+      .run()
+
+    const row = db
+      .select({ id: ClientPromptHistoryTable.id })
+      .from(ClientPromptHistoryTable)
+      .orderBy(desc(ClientPromptHistoryTable.id))
+      .offset(MAX_HISTORY_ENTRIES - 1)
+      .limit(1)
+      .get()
+    if (!row) return
+
+    db.delete(ClientPromptHistoryTable).where(lt(ClientPromptHistoryTable.id, row.id)).run()
+  })
+}

--- a/packages/opencode/src/cli/cmd/tui/context/kv.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/kv.tsx
@@ -1,25 +1,86 @@
+import { ClientDatabase } from "@/storage/db"
+import { ClientKVTable } from "@/storage/client-db.schema"
 import { Global } from "@/global"
-import { Filesystem } from "@/util/filesystem"
+import { eq } from "drizzle-orm"
+import { existsSync, readFileSync } from "fs"
+import path from "path"
 import { createSignal, type Setter } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
-import path from "path"
+
+function seed(file: string) {
+  ClientDatabase.transaction((db) => {
+    const row = db.select({ key: ClientKVTable.key }).from(ClientKVTable).limit(1).get()
+    if (row) return
+    if (!existsSync(file)) return
+
+    const data = (() => {
+      try {
+        return JSON.parse(readFileSync(file, "utf-8"))
+      } catch {
+        return null
+      }
+    })()
+    if (data === null || typeof data !== "object" || Array.isArray(data)) return
+
+    const now = Date.now()
+    const rows = Object.entries(data)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => ({
+        key,
+        value,
+        time_updated: now,
+      }))
+
+    if (rows.length === 0) return
+    db.insert(ClientKVTable).values(rows).onConflictDoNothing().run()
+  })
+}
+
+function list() {
+  return Object.fromEntries(
+    ClientDatabase.use((db) =>
+      db.select({ key: ClientKVTable.key, value: ClientKVTable.value }).from(ClientKVTable).all(),
+    ).map((row) => [row.key, row.value]),
+  )
+}
+
+function write(key: string, value: unknown) {
+  ClientDatabase.transaction((db) => {
+    if (value === undefined) {
+      db.delete(ClientKVTable).where(eq(ClientKVTable.key, key)).run()
+      return
+    }
+
+    const now = Date.now()
+
+    db.insert(ClientKVTable)
+      .values({
+        key,
+        value,
+        time_updated: now,
+      })
+      .onConflictDoUpdate({
+        target: ClientKVTable.key,
+        set: {
+          value,
+          time_updated: now,
+        },
+      })
+      .run()
+  })
+}
 
 export const { use: useKV, provider: KVProvider } = createSimpleContext({
   name: "KV",
   init: () => {
     const [ready, setReady] = createSignal(false)
     const [store, setStore] = createStore<Record<string, any>>()
-    const filePath = path.join(Global.Path.state, "kv.json")
+    const file = path.join(Global.Path.state, "kv.json")
 
-    Filesystem.readJson(filePath)
-      .then((x) => {
-        setStore(x)
-      })
-      .catch(() => {})
-      .finally(() => {
-        setReady(true)
-      })
+    seed(file)
+    setStore(list())
+    setReady(true)
 
     const result = {
       get ready() {
@@ -44,7 +105,7 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
       },
       set(key: string, value: any) {
         setStore(key, value)
-        Filesystem.writeJson(filePath, store)
+        write(key, store[key])
       },
     }
     return result

--- a/packages/opencode/src/storage/client-db.schema.ts
+++ b/packages/opencode/src/storage/client-db.schema.ts
@@ -1,0 +1,13 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
+
+export const ClientKVTable = sqliteTable("kv", {
+  key: text().primaryKey(),
+  value: text({ mode: "json" }).notNull().$type<unknown>(),
+  time_updated: integer().notNull(),
+})
+
+export const ClientPromptHistoryTable = sqliteTable("prompt_history", {
+  id: integer().primaryKey({ autoIncrement: true }),
+  data: text({ mode: "json" }).notNull().$type<unknown>(),
+  time_created: integer().notNull(),
+})

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -16,6 +16,7 @@ import { iife } from "@/util/iife"
 import { init } from "#db"
 
 declare const OPENCODE_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
+declare const OPENCODE_CLIENT_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
 
 export const NotFoundError = NamedError.create(
   "NotFoundError",
@@ -24,68 +25,64 @@ export const NotFoundError = NamedError.create(
   }),
 )
 
-const log = Log.create({ service: "db" })
+type Journal = { sql: string; timestamp: number; name: string }[]
+type Client = SQLiteBunDatabase
+type Transaction = SQLiteTransaction<"sync", void>
+type TxOrDb = Transaction | Client
+type NotPromise<T> = T extends Promise<any> ? never : T
 
-export namespace Database {
-  export function getChannelPath() {
-    const channel = Installation.CHANNEL
-    if (["latest", "beta"].includes(channel) || Flag.OPENCODE_DISABLE_CHANNEL_DB)
-      return path.join(Global.Path.data, "opencode.db")
-    const safe = channel.replace(/[^a-zA-Z0-9._-]/g, "-")
-    return path.join(Global.Path.data, `opencode-${safe}.db`)
+function time(tag: string) {
+  const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(tag)
+  if (!match) return 0
+  return Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5]),
+    Number(match[6]),
+  )
+}
+
+function migrations(dir: string): Journal {
+  const dirs = readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+
+  const sql = dirs
+    .map((name) => {
+      const file = path.join(dir, name, "migration.sql")
+      if (!existsSync(file)) return
+      return {
+        sql: readFileSync(file, "utf-8"),
+        timestamp: time(name),
+        name,
+      }
+    })
+    .filter(Boolean) as Journal
+
+  return sql.sort((a, b) => a.timestamp - b.timestamp)
+}
+
+function make(input: {
+  service: string
+  path: string
+  context: string
+  source: () => {
+    entries: Journal
+    mode: "bundled" | "dev"
   }
+}) {
+  const log = Log.create({ service: input.service })
+  const ctx = Context.create<{
+    tx: TxOrDb
+    effects: (() => void | Promise<void>)[]
+  }>(input.context)
 
-  export const Path = iife(() => {
-    if (Flag.OPENCODE_DB) {
-      if (Flag.OPENCODE_DB === ":memory:" || path.isAbsolute(Flag.OPENCODE_DB)) return Flag.OPENCODE_DB
-      return path.join(Global.Path.data, Flag.OPENCODE_DB)
-    }
-    return getChannelPath()
-  })
+  const Client = lazy(() => {
+    log.info("opening database", { path: input.path })
 
-  export type Transaction = SQLiteTransaction<"sync", void>
-
-  type Client = SQLiteBunDatabase
-
-  type Journal = { sql: string; timestamp: number; name: string }[]
-
-  function time(tag: string) {
-    const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(tag)
-    if (!match) return 0
-    return Date.UTC(
-      Number(match[1]),
-      Number(match[2]) - 1,
-      Number(match[3]),
-      Number(match[4]),
-      Number(match[5]),
-      Number(match[6]),
-    )
-  }
-
-  function migrations(dir: string): Journal {
-    const dirs = readdirSync(dir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
-
-    const sql = dirs
-      .map((name) => {
-        const file = path.join(dir, name, "migration.sql")
-        if (!existsSync(file)) return
-        return {
-          sql: readFileSync(file, "utf-8"),
-          timestamp: time(name),
-          name,
-        }
-      })
-      .filter(Boolean) as Journal
-
-    return sql.sort((a, b) => a.timestamp - b.timestamp)
-  }
-
-  export const Client = lazy(() => {
-    log.info("opening database", { path: Path })
-
-    const db = init(Path)
+    const db = init(input.path)
 
     db.run("PRAGMA journal_mode = WAL")
     db.run("PRAGMA synchronous = NORMAL")
@@ -94,40 +91,29 @@ export namespace Database {
     db.run("PRAGMA foreign_keys = ON")
     db.run("PRAGMA wal_checkpoint(PASSIVE)")
 
-    // Apply schema migrations
-    const entries =
-      typeof OPENCODE_MIGRATIONS !== "undefined"
-        ? OPENCODE_MIGRATIONS
-        : migrations(path.join(import.meta.dirname, "../../migration"))
-    if (entries.length > 0) {
+    const source = input.source()
+    if (source.entries.length > 0) {
       log.info("applying migrations", {
-        count: entries.length,
-        mode: typeof OPENCODE_MIGRATIONS !== "undefined" ? "bundled" : "dev",
+        count: source.entries.length,
+        mode: source.mode,
       })
       if (Flag.OPENCODE_SKIP_MIGRATIONS) {
-        for (const item of entries) {
+        for (const item of source.entries) {
           item.sql = "select 1;"
         }
       }
-      migrate(db, entries)
+      migrate(db, source.entries)
     }
 
     return db
   })
 
-  export function close() {
+  function close() {
     Client().$client.close()
     Client.reset()
   }
 
-  export type TxOrDb = Transaction | Client
-
-  const ctx = Context.create<{
-    tx: TxOrDb
-    effects: (() => void | Promise<void>)[]
-  }>("database")
-
-  export function use<T>(callback: (trx: TxOrDb) => T): T {
+  function use<T>(callback: (trx: TxOrDb) => T): T {
     try {
       return callback(ctx.use().tx)
     } catch (err) {
@@ -141,7 +127,7 @@ export namespace Database {
     }
   }
 
-  export function effect(fn: () => any | Promise<any>) {
+  function effect(fn: () => any | Promise<any>) {
     try {
       ctx.use().effects.push(fn)
     } catch {
@@ -149,9 +135,7 @@ export namespace Database {
     }
   }
 
-  type NotPromise<T> = T extends Promise<any> ? never : T
-
-  export function transaction<T>(
+  function transaction<T>(
     callback: (tx: TxOrDb) => NotPromise<T>,
     options?: {
       behavior?: "deferred" | "immediate" | "exclusive"
@@ -174,4 +158,88 @@ export namespace Database {
       throw err
     }
   }
+
+  return {
+    Client,
+    close,
+    use,
+    effect,
+    transaction,
+  }
+}
+
+export namespace Database {
+  export function getChannelPath() {
+    const channel = Installation.CHANNEL
+    if (["latest", "beta"].includes(channel) || Flag.OPENCODE_DISABLE_CHANNEL_DB)
+      return path.join(Global.Path.data, "opencode.db")
+    const safe = channel.replace(/[^a-zA-Z0-9._-]/g, "-")
+    return path.join(Global.Path.data, `opencode-${safe}.db`)
+  }
+
+  export const Path = iife(() => {
+    if (Flag.OPENCODE_DB) {
+      if (Flag.OPENCODE_DB === ":memory:" || path.isAbsolute(Flag.OPENCODE_DB)) return Flag.OPENCODE_DB
+      return path.join(Global.Path.data, Flag.OPENCODE_DB)
+    }
+    return getChannelPath()
+  })
+
+  const db = make({
+    service: "db",
+    path: Path,
+    context: "database",
+    source: () => {
+      if (typeof OPENCODE_MIGRATIONS !== "undefined") {
+        return {
+          entries: OPENCODE_MIGRATIONS,
+          mode: "bundled" as const,
+        }
+      }
+      return {
+        entries: migrations(path.join(import.meta.dirname, "../../migration")),
+        mode: "dev" as const,
+      }
+    },
+  })
+
+  export type Transaction = SQLiteTransaction<"sync", void>
+  export type TxOrDb = Transaction | SQLiteBunDatabase
+
+  export const Client = db.Client
+  export const close = db.close
+  export const use = db.use
+  export const effect = db.effect
+  export const transaction = db.transaction
+}
+
+export namespace ClientDatabase {
+  export const Path = path.join(Global.Path.state, "client.db")
+
+  const db = make({
+    service: "client-db",
+    path: Path,
+    context: "client-database",
+    source: () => {
+      if (typeof OPENCODE_CLIENT_MIGRATIONS !== "undefined") {
+        return {
+          entries: OPENCODE_CLIENT_MIGRATIONS,
+          mode: "bundled" as const,
+        }
+      }
+      return {
+        entries: migrations(path.join(import.meta.dirname, "../../client-migration")),
+        mode: "dev" as const,
+      }
+    },
+  })
+
+  export type Transaction = SQLiteTransaction<"sync", void>
+  export type TxOrDb = Transaction | SQLiteBunDatabase
+
+  export const Client = db.Client
+  export const close = db.close
+  export const use = db.use
+  export const effect = db.effect
+  export const transaction = db.transaction
 }

--- a/packages/opencode/test/fixture/db.ts
+++ b/packages/opencode/test/fixture/db.ts
@@ -1,11 +1,15 @@
 import { rm } from "fs/promises"
 import { Instance } from "../../src/project/instance"
-import { Database } from "../../src/storage/db"
+import { Database, ClientDatabase } from "../../src/storage/db"
 
 export async function resetDatabase() {
   await Instance.disposeAll().catch(() => undefined)
   Database.close()
+  ClientDatabase.close()
   await rm(Database.Path, { force: true }).catch(() => undefined)
   await rm(`${Database.Path}-wal`, { force: true }).catch(() => undefined)
   await rm(`${Database.Path}-shm`, { force: true }).catch(() => undefined)
+  await rm(ClientDatabase.Path, { force: true }).catch(() => undefined)
+  await rm(`${ClientDatabase.Path}-wal`, { force: true }).catch(() => undefined)
+  await rm(`${ClientDatabase.Path}-shm`, { force: true }).catch(() => undefined)
 }

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -10,8 +10,9 @@ import { afterAll } from "bun:test"
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 afterAll(async () => {
-  const { Database } = await import("../src/storage/db")
+  const { Database, ClientDatabase } = await import("../src/storage/db")
   Database.close()
+  ClientDatabase.close()
   const busy = (error: unknown) =>
     typeof error === "object" && error !== null && "code" in error && error.code === "EBUSY"
   const rm = async (left: number): Promise<void> => {

--- a/packages/opencode/test/storage/client-db.test.ts
+++ b/packages/opencode/test/storage/client-db.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, afterEach, describe, expect, test } from "bun:test"
+import { rm } from "fs/promises"
+import path from "path"
+import { desc, eq, lt } from "drizzle-orm"
+import { Global } from "../../src/global"
+import { ClientDatabase } from "../../src/storage/db"
+import { ClientKVTable, ClientPromptHistoryTable } from "../../src/storage/client-db.schema"
+
+async function clear() {
+  ClientDatabase.close()
+  await rm(ClientDatabase.Path, { force: true }).catch(() => undefined)
+  await rm(`${ClientDatabase.Path}-wal`, { force: true }).catch(() => undefined)
+  await rm(`${ClientDatabase.Path}-shm`, { force: true }).catch(() => undefined)
+  await rm(path.join(Global.Path.state, "kv.json"), { force: true }).catch(() => undefined)
+  await rm(path.join(Global.Path.state, "prompt-history.jsonl"), { force: true }).catch(() => undefined)
+}
+
+function kv() {
+  return Object.fromEntries(
+    ClientDatabase.use((db) =>
+      db.select({ key: ClientKVTable.key, value: ClientKVTable.value }).from(ClientKVTable).all(),
+    ).map((row) => [row.key, row.value]),
+  ) as Record<string, unknown>
+}
+
+function prompt(limit: number) {
+  return ClientDatabase.use((db) =>
+    db
+      .select({ data: ClientPromptHistoryTable.data })
+      .from(ClientPromptHistoryTable)
+      .orderBy(desc(ClientPromptHistoryTable.id))
+      .limit(limit)
+      .all(),
+  )
+    .reverse()
+    .map((row) => row.data) as { input: string; parts: unknown[] }[]
+}
+
+function setKV(key: string, value: unknown) {
+  ClientDatabase.transaction((db) => {
+    if (value === undefined) {
+      db.delete(ClientKVTable).where(eq(ClientKVTable.key, key)).run()
+      return
+    }
+
+    db.insert(ClientKVTable)
+      .values({
+        key,
+        value,
+        time_updated: Date.now(),
+      })
+      .onConflictDoUpdate({
+        target: ClientKVTable.key,
+        set: {
+          value,
+          time_updated: Date.now(),
+        },
+      })
+      .run()
+  })
+}
+
+function appendPrompt(data: unknown, limit: number) {
+  ClientDatabase.transaction((db) => {
+    db.insert(ClientPromptHistoryTable)
+      .values({
+        data,
+        time_created: Date.now(),
+      })
+      .run()
+
+    const row = db
+      .select({ id: ClientPromptHistoryTable.id })
+      .from(ClientPromptHistoryTable)
+      .orderBy(desc(ClientPromptHistoryTable.id))
+      .offset(limit - 1)
+      .limit(1)
+      .get()
+    if (!row) return
+
+    db.delete(ClientPromptHistoryTable).where(lt(ClientPromptHistoryTable.id, row.id)).run()
+  })
+}
+
+describe("ClientDatabase", () => {
+  beforeEach(async () => {
+    await clear()
+  })
+
+  afterEach(async () => {
+    await clear()
+  })
+
+  test("does not import legacy files in db layer", async () => {
+    await Bun.write(path.join(Global.Path.state, "kv.json"), JSON.stringify({ alpha: 1, beta: "x" }))
+    await Bun.write(
+      path.join(Global.Path.state, "prompt-history.jsonl"),
+      `${JSON.stringify({ input: "one", parts: [] })}\nnot-json\n${JSON.stringify({ input: "two", parts: [] })}\n`,
+    )
+
+    const first = kv()
+    expect(first.alpha).toBeUndefined()
+    expect(first.beta).toBeUndefined()
+
+    const prompts = prompt(50)
+    expect(prompts.length).toBe(0)
+  })
+
+  test("keeps prompt history capped", () => {
+    for (let i = 0; i < 60; i++) {
+      appendPrompt({ input: `${i}`, parts: [] }, 50)
+    }
+
+    const rows = prompt(50)
+    expect(rows.length).toBe(50)
+    expect(rows[0].input).toBe("10")
+    expect(rows[49].input).toBe("59")
+  })
+
+  test("upserts and deletes kv values", () => {
+    setKV("key", { ok: true })
+    const first = kv()
+    expect(first.key).toEqual({ ok: true })
+
+    setKV("key", undefined)
+    const second = kv()
+    expect("key" in second).toBe(false)
+  })
+})


### PR DESCRIPTION
fix client state clobbering when multiple instances of opencode are open add client sqlite db to save prompt-history and kv

### Issue for this PR

Closes #19436

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add a client state sqlite database (I know I know I know, just hang with me for a second).

This allows prompt-history.jsonl and kv.json (other client state json files to follow in followup PR I am trying to keep this one small) to be saved to the client.db. This resolves all issues related to multiple instances clobbering state.

This is the best approach to solving this class of bugs + it will make adding additional client state features easier and robust.

I CAN probably resolve these bugs with a pattern on save of re-reading the file, merging the store and re-read file values, and then saving that. It is just sort of ugly/clunky and prone to breakages and after playing around with this I think this is a better approach.

### How did you verify your code works?

I tested it and kept change minimal.

### Screenshots / recordings

Bug demo
https://github.com/user-attachments/assets/a9fe26e4-9a3c-4a09-a395-5f260e71b353

Bug fix demo
https://github.com/user-attachments/assets/8fc15e07-9c9f-494f-8e93-e6e11418082d


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
