### PR TITLE
fix(snapshot): migrate objects from pre-v1.3.3 flat snapshot layout

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -83,10 +83,11 @@ export namespace Snapshot {
 
       const state = yield* InstanceState.make<State>(
         Effect.fn("Snapshot.state")(function* (ctx) {
+          const legacy = path.join(Global.Path.data, "snapshot", ctx.project.id)
           const state = {
             directory: ctx.directory,
             worktree: ctx.worktree,
-            gitdir: path.join(Global.Path.data, "snapshot", ctx.project.id, Hash.fast(ctx.worktree)),
+            gitdir: path.join(legacy, Hash.fast(ctx.worktree)),
             vcs: ctx.project.vcs,
           }
 
@@ -121,6 +122,16 @@ export namespace Snapshot {
           const read = (file: string) => fs.readFileString(file).pipe(Effect.catch(() => Effect.succeed("")))
           const remove = (file: string) => fs.remove(file).pipe(Effect.catch(() => Effect.void))
           const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
+
+          // #19437: import tree objects from pre-v1.3.3 flat snapshot layout
+          if (state.gitdir !== legacy) {
+            yield* Effect.gen(function* () {
+              if (!(yield* exists(path.join(legacy, "HEAD")))) return
+              if (!(yield* exists(state.gitdir))) return
+              const result = yield* git(["--git-dir", state.gitdir, "fetch", legacy, "--no-tags"])
+              if (result.code === 0) log.info("migrated legacy snapshot objects", { from: legacy })
+            }).pipe(Effect.catchAll(() => Effect.void))
+          }
 
           const enabled = Effect.fnUntraced(function* () {
             if (state.vcs !== "git") return false

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -130,7 +130,7 @@ export namespace Snapshot {
               if (!(yield* exists(state.gitdir))) return
               const result = yield* git(["--git-dir", state.gitdir, "fetch", legacy, "--no-tags"])
               if (result.code === 0) log.info("migrated legacy snapshot objects", { from: legacy })
-            }).pipe(Effect.catchAll(() => Effect.void))
+            }).pipe(Effect.catch(() => Effect.void))
           }
 
           const enabled = Effect.fnUntraced(function* () {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -126,10 +126,13 @@ export namespace Snapshot {
           // #19437: import tree objects from pre-v1.3.3 flat snapshot layout
           if (state.gitdir !== legacy) {
             yield* Effect.gen(function* () {
-              if (!(yield* exists(path.join(legacy, "HEAD")))) return
+              if (!(yield* exists(path.join(legacy, "objects")))) return
               if (!(yield* exists(state.gitdir))) return
-              const result = yield* git(["--git-dir", state.gitdir, "fetch", legacy, "--no-tags"])
-              if (result.code === 0) log.info("migrated legacy snapshot objects", { from: legacy })
+              const alt = path.join(state.gitdir, "objects", "info", "alternates")
+              if (yield* exists(alt)) return
+              yield* fs.ensureDir(path.join(state.gitdir, "objects", "info")).pipe(Effect.orDie)
+              yield* fs.writeFileString(alt, path.join(legacy, "objects") + "\n").pipe(Effect.orDie)
+              log.info("linked legacy snapshot objects", { from: legacy })
             }).pipe(Effect.catch(() => Effect.void))
           }
 


### PR DESCRIPTION
### Issue for this PR

Closes #19437

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #19163 changed the snapshot gitdir from `<data>/snapshot/<projectID>/` to `<data>/snapshot/<projectID>/<Hash.fast(worktree)>/` but didn't migrate existing objects. Sessions created before v1.3.3 have step-start/step-finish hashes pointing at tree objects in the old directory. When `diffFull()` tries to diff across those hashes, git returns `fatal: bad object` and the Review tab shows nothing.

This PR sets up a `git alternates` file when both old and new snapshot repos exist, allowing git to read objects from the old location transparently. The migration runs once during snapshot service initialization and is safe (errors are caught silently).

**Note for users**: Sessions affected by this bug will automatically work after this fix is deployed. The Review tab may appear empty initially due to cached `summary_files=0` in the database. This will self-heal when:
- The session receives a new message (triggers diff recomputation), or
- The user restarts the desktop app (clears frontend cache)

No manual intervention or data migration is required.

### How did you verify your code works?

1. Tested on a local machine with multiple sessions affected by this bug (portal-service, x-portal projects)
2. Verified git alternates setup allows `git diff` between old and new snapshot hashes
3. Confirmed Review tabs populate correctly after app restart
4. Tested across 11 affected sessions in 3 different projects

### Screenshots / recordings

N/A — backend-only change, no UI modifications.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR