### PR TITLE
fix(tui): dock session sidebar without overlapping content on narrow terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -158,15 +158,19 @@ export function Session() {
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
-  const wide = createMemo(() => dimensions().width > 120)
+  const SIDEBAR_WIDTH = 42
+  const SIDEBAR_GAP = 4
+  const DOCKED_SIDEBAR_MIN_WIDTH = 110
+  const wide = createMemo(() => dimensions().width >= DOCKED_SIDEBAR_MIN_WIDTH)
   const sidebarVisible = createMemo(() => {
     if (session()?.parentID) return false
     if (sidebarOpen()) return true
     if (sidebar() === "auto" && wide()) return true
     return false
   })
+  const dockedSidebar = createMemo(() => sidebarVisible() && wide())
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => dimensions().width - (dockedSidebar() ? SIDEBAR_WIDTH : 0) - SIDEBAR_GAP)
 
   const scrollAcceleration = createMemo(() => {
     const tui = tuiConfig
@@ -1035,7 +1039,15 @@ export function Session() {
       }}
     >
       <box flexDirection="row">
-        <box flexGrow={1} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box
+          flexGrow={1}
+          flexShrink={1}
+          width={contentWidth()}
+          paddingBottom={1}
+          paddingLeft={2}
+          paddingRight={2}
+          gap={1}
+        >
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}


### PR DESCRIPTION
### Issue for this PR

Fixes #19450.
Related to #8447.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a TUI layout regression where the session sidebar can feel broken on narrower laptop terminals:

- auto-docking kicked in too late, so the sidebar often stayed hidden unless opened manually
- when the sidebar was visible, the main session column did not reliably shrink with it
- in that state the sidebar could cover the chat area instead of behaving like a docked panel

The change is intentionally small:

- lower the docked-sidebar width threshold a bit for laptop-sized terminals
- only subtract sidebar width from the content column when the sidebar is actually docked
- make the main session column shrink to the computed content width

That keeps the sidebar usable without it sitting on top of the conversation area.

### How did you verify your code works?

- built `packages/opencode` locally from latest `dev`
- ran the patched TUI against an existing real session in `~/projects/SAP_CCP`
- confirmed the sidebar now stays visible in the same narrow-terminal scenario
- confirmed the chat/input area shrinks with the sidebar instead of being blocked by it

### Screenshots / recordings

I validated this against a real narrow-terminal session before opening the PR.

Before: sidebar visible but overlapping the active session content.
<img width="1919" height="1078" alt="image" src="https://github.com/user-attachments/assets/48d9ca7c-930e-41b4-921b-1cd4cd0b96ca" />

After: sidebar remains visible and the main content column shrinks correctly.
<img width="1919" height="1082" alt="image" src="https://github.com/user-attachments/assets/fcea89a0-eaf5-4711-bc94-7d191b86e1df" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR