### PR TITLE
docs: fix undocumented behaviors and inaccuracies in skills, commands, and agents pages

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -587,7 +587,9 @@ export namespace Config {
       hidden: z
         .boolean()
         .optional()
-        .describe("Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)"),
+        .describe(
+          "Hide this agent from the UI — excludes primary agents from the agent switcher and subagents from the @ autocomplete menu (default: false)",
+        ),
       options: z.record(z.string(), z.any()).optional(),
       color: z
         .union([

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -547,24 +547,23 @@ The `mode` option can be set to `primary`, `subagent`, or `all`. If no `mode` is
 
 ### Hidden
 
-Hide a subagent from the `@` autocomplete menu with `hidden: true`. Useful for internal subagents that should only be invoked programmatically by other agents via the Task tool.
+Hide an agent from the UI with `hidden: true`.
+
+- **Primary agents**: excluded from the Tab-cycle agent switcher
+- **Subagents**: excluded from the `@` autocomplete menu
 
 ```json title="opencode.json"
 {
   "agent": {
-    "internal-helper": {
-      "mode": "subagent",
+    "internal-orchestrator": {
+      "mode": "primary",
       "hidden": true
     }
   }
 }
 ```
 
-This only affects user visibility in the autocomplete menu. Hidden agents can still be invoked by the model via the Task tool if permissions allow.
-
-:::note
-Only applies to `mode: subagent` agents.
-:::
+Hidden agents can still be invoked programmatically via the Task tool if permissions allow. A hidden agent cannot be set as the default agent.
 
 ---
 
@@ -598,6 +597,28 @@ Rules are evaluated in order, and the **last matching rule wins**. In the exampl
 :::tip
 Users can always invoke any subagent directly via the `@` autocomplete menu, even if the agent's task permissions would deny it.
 :::
+
+---
+
+### Expand Task prompts
+
+When a primary agent launches a subagent via the Task tool, `@` references in the `prompt` parameter are automatically expanded.
+
+- `@path/to/file` — the file contents are injected inline into the subagent's prompt context. The subagent receives the content without needing to read the file itself.
+- `@agent-name` — resolved as an agent mention, the same way `@` mentions work in user messages.
+
+This enables patterns where a parent agent writes shared context to a file, then launches multiple subagents with `@path/to/context.md` in their Task prompt. Each subagent receives the full context inline without the parent repeating it in every prompt.
+
+---
+
+### Subagent defaults
+
+Subagents spawned via the Task tool are created with restricted defaults:
+
+- `todowrite` and `todoread` are denied
+- If the invoking agent does not have `task` permission, the subagent also has `task` denied
+
+These defaults prevent subagents from modifying the parent's todo list or recursively spawning further subagents. The `experimental.primary_tools` config can override specific permissions.
 
 ---
 

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -159,6 +159,21 @@ This replaces:
 - `$2` with `src`
 - `$3` with `{ "key": "value" }`
 
+The highest-numbered positional parameter captures all remaining text, not just a single token.
+For example, if a template uses `$1` and `$2`:
+
+```bash frame="none"
+/my-command investigation Focus on the auth module
+```
+
+`$1` gets `investigation` and `$2` gets `Focus on the auth module`. This lets commands accept a selector plus free-text instructions.
+
+---
+
+### Auto-append
+
+If a template contains no `$N` or `$ARGUMENTS` placeholders but the user provides arguments, the arguments are appended to the end of the template automatically. This means commands without explicit argument handling still receive user input.
+
 ---
 
 ### Shell output

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -4,7 +4,7 @@ description: "Define reusable behavior via SKILL.md definitions"
 ---
 
 Agent skills let OpenCode discover reusable instructions from your repo or home directory.
-Skills are loaded on-demand via the native `skill` tool—agents see available skills and can load the full content when needed.
+Skills are loaded on-demand via the native `skill` tool, and are also available as [slash commands](#use-as-slash-commands) for direct invocation.
 
 ---
 
@@ -122,6 +122,76 @@ skill({ name: "git-release" })
 
 ---
 
+## Use as slash commands
+
+Every discovered skill is also registered as a slash command.
+A skill named `git-release` becomes `/git-release` in the TUI and Web UI, appearing alongside regular commands in the slash command popover.
+
+```bash frame="none"
+/git-release
+```
+
+This lets you invoke a skill directly without waiting for the agent to decide to load it via the `skill` tool.
+
+---
+
+## Pass arguments
+
+When invoked as a slash command, skills support the same argument placeholders as [commands](/docs/commands/#arguments).
+
+Use `$ARGUMENTS` for the full argument string, or `$1`, `$2`, etc. for positional parameters:
+
+```markdown
+---
+name: analyze-logs
+description: Analyze application logs for issues
+---
+
+Analyze the $1 logs and focus on:
+$2
+```
+
+Invoke it with:
+
+```bash frame="none"
+/analyze-logs production "errors in the auth module"
+```
+
+`$1` gets `production` and `$2` gets everything after. See [Commands — Arguments](/docs/commands/#arguments) for full placeholder syntax.
+
+---
+
+## Understand invocation paths
+
+Skills have two invocation paths with different behaviors:
+
+1. **Agent-initiated** — The agent calls `skill({ name: "..." })` during a conversation. The `SKILL.md` content is returned as tool output. No argument substitution occurs.
+
+2. **User-initiated** — You type `/skill-name args` in the prompt. The `SKILL.md` content goes through template expansion (`$1`, `$ARGUMENTS`, shell commands, `@file` references) and is sent as a user message.
+
+If you design a skill for both paths, avoid required `$N` parameters. They work as `/my-skill args` but appear as literal `$1` when loaded via the skill tool. Use `$ARGUMENTS` or `$N` only for skills designed primarily as slash commands.
+
+---
+
+## Configure paths and URLs
+
+Add extra skill directories or remote skill sources in `opencode.json`:
+
+```json title="opencode.json"
+{
+  "skills": {
+    "paths": ["./custom-skills", "~/shared-skills"],
+    "urls": ["https://example.com/skills"]
+  }
+}
+```
+
+`paths` are resolved relative to the config file location. `~` expands to your home directory.
+
+Remote `urls` must serve an `index.json` listing available skills and their files. OpenCode fetches the index and downloads matching skills to a local cache.
+
+---
+
 ## Configure permissions
 
 Control which skills agents can access using pattern-based permissions in `opencode.json`:
@@ -218,5 +288,5 @@ If a skill does not show up:
 
 1. Verify `SKILL.md` is spelled in all caps
 2. Check that frontmatter includes `name` and `description`
-3. Ensure skill names are unique across all locations
+3. Check for duplicate names — if two skills share the same name, the last one loaded takes precedence. Load order: global home → project (walking up to the worktree) → configured `paths` → configured `urls`
 4. Check permissions—skills with `deny` are hidden from agents


### PR DESCRIPTION
### Issue for this PR

No existing issue. These documentation gaps were found by reading source code and confirmed through manual testing:

- Skills are auto-registered as slash commands but only the `skill()` tool path is documented
- Skills support `$ARGUMENTS`/`$1`/`$2` when invoked as slash commands — not mentioned on the Skills page
- Last positional parameter captures all remaining text, not just one token — undocumented
- Arguments auto-append when template has no placeholders — undocumented
- Skills have two invocation paths (tool vs. slash command) with different behaviors — undocumented
- `@path` and `@agent` references in Task tool prompts are auto-expanded — undocumented
- `hidden` docs say "only applies to mode: subagent" but it works on primary agents too — inaccurate
- Subagent default permission restrictions (todowrite/todoread denied) — undocumented
- `skills.paths` and `skills.urls` config options — undocumented
- Skill name collision behavior (last loaded wins) — undocumented

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes undocumented behaviors and one inaccuracy across three doc pages and the config schema.

**`skills.mdx`:**
- New section "Use as slash commands" — skills are auto-registered as commands via `command/index.ts:142-153`
- New section "Pass arguments" — `$ARGUMENTS`/`$1`/`$2` work in skills through the shared template expansion in `session/prompt.ts:1793-1817`
- New section "Understand invocation paths" — documents the behavioral difference between agent-initiated (`tool/skill.ts:43-97`, no expansion) and user-initiated (`session/prompt.ts:1782+`, full expansion) paths
- New section "Configure paths and URLs" — documents `skills.paths` and `skills.urls` config options (`skill/index.ts:148-163`)
- Updated troubleshoot item for name collisions — last loaded wins (`skill/index.ts:87-93`)
- Updated page intro to reflect both invocation paths

**`commands.mdx`:**
- Documented "last positional swallows remaining" behavior (`session/prompt.ts:1802-1808`)
- New "Auto-append" subsection for the no-placeholder fallback (`session/prompt.ts:1815-1817`)

**`agents.mdx`:**
- Corrected `hidden` to apply to all modes, not just subagents — OpenCode's own `compaction`, `title`, `summary` are hidden primaries (`agent/agent.ts:158-189`). Removed incorrect "only applies to mode: subagent" note
- New section "Expand Task prompts" — `@path` and `@agent` references are auto-expanded (`tool/task.ts:128`, `session/prompt.ts:191-239`)
- New section "Subagent defaults" — todowrite/todoread denied, task denied if parent lacks it (`tool/task.ts:77-96`)

**`config.ts`:**
- Fixed `.describe()` string for `hidden` which incorrectly stated "only applies to mode: subagent" (line 590)

### How did you verify your code works?

All documented behaviors were verified by reading the source code at the referenced locations. Key behaviors (skills as slash commands, positional swallowing, `@path` in Task prompts, `hidden` on primary agents) were also confirmed through manual testing.

### Screenshots / recordings

N/A — documentation-only changes, no UI modifications.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR