### PR TITLE
fix: join system messages into single message

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -349,12 +349,10 @@ export namespace Agent {
             },
             temperature: 0.3,
             messages: [
-              ...system.map(
-                (item): ModelMessage => ({
-                  role: "system",
-                  content: item,
-                }),
-              ),
+              {
+                role: "system" as const,
+                content: system.join("\n"),
+              },
               {
                 role: "user",
                 content: `Create an agent configuration based on this request: \"${input.description}\".\n\nIMPORTANT: The following identifiers already exist and must NOT be used: ${existing.map((i) => i.name).join(", ")}\n  Return ONLY the JSON object, no other text, do not wrap in backticks`,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -119,12 +119,10 @@ export namespace LLM {
       : isWorkflow
         ? input.messages
         : [
-            ...system.map(
-              (x): ModelMessage => ({
-                role: "system",
-                content: x,
-              }),
-            ),
+            {
+              role: "system" as const,
+              content: system.join("\n"),
+            },
             ...input.messages,
           ]
 


### PR DESCRIPTION
# PR Notice: fix/join-system-messages
## Title
fix: Join system messages into a single message
## Summary
This fix consolidates multiple system messages into a single system message by joining them with a newline separator. This resolves compatibility issues with LLM providers that handle multiple system messages differently or don't properly support them.
## Changes
### Files Modified
- `packages/opencode/src/agent/agent.ts` — Modified system message handling in agent creation
- `packages/opencode/src/session/llm.ts` — Modified system message handling in LLM message construction
### Before (problematic)
```typescript
messages: [
  ...system.map(
    (item): ModelMessage => ({
      role: "system",
      content: item,
    }),
  ),
  // ... other messages
]
```
### After (fixed)
```typescript
messages: [
  {
    role: "system" as const,
    content: system.join("\n"),
  },
  // ... other messages
]
```
## Motivation
Different LLM providers handle multiple system messages in different ways:
- Some concatenate them unexpectedly
- Some treat them as separate prompts with different behavior
- Some may not properly merge them
By joining all system messages into a single message, we ensure consistent behavior across all LLM providers.
## Benefits
1. **Provider compatibility**: Works consistently across all LLM providers (OpenAI, Anthropic, Google, etc.)
2. **Predictable behavior**: System prompts are always processed as a single unit
3. **Cleaner message history**: Reduces message count in the conversation
4. **Maintains functionality**: All system message content is preserved
## Testing
- The change preserves all system message content (just joins with newlines)
- No functional changes to what the system prompts contain
- Compatible with existing agent and LLM configurations
## Related
- Closes  https://github.com/obra/superpowers/issues/894 ( fix in opencode is better global engineering)