### PR TITLE
feat(model): add preserveInterruptedResponse option for KV cache consistency

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -393,6 +393,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               input: { text: true, audio: false, image: true, video: false, pdf: false },
               output: { text: true, audio: false, image: false, video: false, pdf: false },
               interleaved: false,
+              preserveInterruptedResponse: false,
             },
             cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
             limit: { context: 400_000, input: 272_000, output: 128_000 },

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -34,6 +34,13 @@ export namespace ModelsDev {
           .strict(),
       ])
       .optional(),
+    preserveInterruptedResponse: z
+      .boolean()
+      .optional()
+      .describe(
+        "When enabled, interrupted responses are saved with their partial content instead of being discarded. " +
+          "This preserves the token sequence for local inference backends with KV cache, avoiding expensive reprocessing.",
+      ),
     cost: z
       .object({
         input: z.number(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -643,6 +643,7 @@ export namespace Provider {
                       pdf: false,
                     },
                     interleaved: false,
+                    preserveInterruptedResponse: false,
                   },
                   release_date: "",
                   variants: {},
@@ -807,6 +808,7 @@ export namespace Provider {
             field: z.enum(["reasoning_content", "reasoning_details"]),
           }),
         ]),
+        preserveInterruptedResponse: z.boolean(),
       }),
       cost: z.object({
         input: z.number(),
@@ -914,6 +916,7 @@ export namespace Provider {
           pdf: model.modalities?.output?.includes("pdf") ?? false,
         },
         interleaved: model.interleaved ?? false,
+        preserveInterruptedResponse: model.preserveInterruptedResponse ?? false,
       },
       release_date: model.release_date,
       variants: {},
@@ -1034,6 +1037,10 @@ export namespace Provider {
               pdf: model.modalities?.output?.includes("pdf") ?? existingModel?.capabilities.output.pdf ?? false,
             },
             interleaved: model.interleaved ?? false,
+            preserveInterruptedResponse:
+              model.preserveInterruptedResponse ??
+              existingModel?.capabilities.preserveInterruptedResponse ??
+              false,
           },
           cost: {
             input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -48,9 +48,10 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          // Moved outside try block so they're accessible in catch for preserveInterruptedResponse
+          let currentText: MessageV2.TextPart | undefined
+          let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
           try {
-            let currentText: MessageV2.TextPart | undefined
-            let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
             const stream = await LLM.stream(streamInput)
 
             for await (const value of stream.fullStream) {
@@ -383,6 +384,34 @@ export namespace SessionProcessor {
                 error: input.assistantMessage.error,
               })
               await SessionStatus.set(input.sessionID, { type: "idle" })
+            }
+
+            // Preserve partial response content when interrupted and option is enabled
+            // This maintains token sequence consistency for local inference backends with KV cache
+            if (input.abort.aborted && input.model.capabilities.preserveInterruptedResponse) {
+              log.info("preserving interrupted response", { sessionID: input.sessionID })
+
+              // Finalize any partial text with interrupt marker
+              if (currentText && currentText.text) {
+                currentText.text = currentText.text.trimEnd() + "\n\n[interrupted]"
+                currentText.time = {
+                  start: currentText.time?.start ?? Date.now(),
+                  end: Date.now(),
+                }
+                await Session.updatePart(currentText)
+              }
+
+              // Finalize any pending reasoning parts with interrupt marker
+              for (const [id, part] of Object.entries(reasoningMap)) {
+                if (part.text) {
+                  part.text = part.text.trimEnd() + "\n\n[interrupted]"
+                  part.time = {
+                    start: part.time?.start ?? Date.now(),
+                    end: Date.now(),
+                  }
+                  await Session.updatePart(part)
+                }
+              }
             }
           }
           if (snapshot) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -24,6 +24,7 @@ describe("ProviderTransform.options - setCacheKey", () => {
       input: { text: true, audio: false, image: true, video: false, pdf: true },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
       interleaved: false,
+          preserveInterruptedResponse: false,
     },
     cost: {
       input: 0.003,
@@ -125,6 +126,7 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: true },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: {
         input: 0.001,
@@ -191,6 +193,7 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: false },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
       limit: { context: 128000, output: 4096 },
@@ -263,6 +266,7 @@ describe("ProviderTransform.options - gateway", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: true },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: {
         input: 0.001,
@@ -309,6 +313,7 @@ describe("ProviderTransform.providerOptions", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: false },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: {
         input: 0.001,
@@ -825,6 +830,7 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           interleaved: {
             field: "reasoning_content",
           },
+          preserveInterruptedResponse: false,
         },
         cost: {
           input: 0.001,
@@ -885,6 +891,7 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
           input: { text: true, audio: false, image: true, video: false, pdf: false },
           output: { text: true, audio: false, image: false, video: false, pdf: false },
           interleaved: false,
+          preserveInterruptedResponse: false,
         },
         cost: {
           input: 0.03,
@@ -929,6 +936,7 @@ describe("ProviderTransform.message - empty image handling", () => {
       input: { text: true, audio: false, image: true, video: false, pdf: true },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
       interleaved: false,
+          preserveInterruptedResponse: false,
     },
     cost: {
       input: 0.003,
@@ -1032,6 +1040,7 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
       input: { text: true, audio: false, image: true, video: false, pdf: true },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
       interleaved: false,
+          preserveInterruptedResponse: false,
     },
     cost: {
       input: 0.003,
@@ -1239,6 +1248,7 @@ describe("ProviderTransform.message - strip openai metadata when store=false", (
       input: { text: true, audio: false, image: true, video: false, pdf: false },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
       interleaved: false,
+          preserveInterruptedResponse: false,
     },
     cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
     limit: { context: 128000, output: 4096 },
@@ -1531,6 +1541,7 @@ describe("ProviderTransform.message - providerOptions key remapping", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: true },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
       limit: { context: 128000, output: 8192 },
@@ -1685,6 +1696,7 @@ describe("ProviderTransform.message - cache control on gateway", () => {
         input: { text: true, audio: false, image: true, video: false, pdf: true },
         output: { text: true, audio: false, image: false, video: false, pdf: false },
         interleaved: false,
+          preserveInterruptedResponse: false,
       },
       cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
       limit: { context: 200_000, output: 8192 },
@@ -1783,6 +1795,7 @@ describe("ProviderTransform.variants", () => {
       input: { text: true, audio: false, image: true, video: false, pdf: false },
       output: { text: true, audio: false, image: false, video: false, pdf: false },
       interleaved: false,
+          preserveInterruptedResponse: false,
     },
     cost: {
       input: 0.001,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -37,6 +37,7 @@ const model: Provider.Model = {
       pdf: false,
     },
     interleaved: false,
+    preserveInterruptedResponse: false,
   },
   cost: {
     input: 0,


### PR DESCRIPTION
### Issue for this PR

Closes #19081

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `preserveInterruptedResponse` model capability. When enabled, interrupted responses are saved with their partial content (marked with `[interrupted]`) instead of being discarded.

**Why this matters for local models:**
When users interrupt a streaming response, OpenCode discards it. For local inference backends with KV cache (llama.cpp), this causes a token sequence mismatch - the cache has tokens that the next request doesn't include. This forces expensive full context reprocessing (can be minutes for large contexts).

By preserving the partial response, the token sequence stays consistent and the KV cache remains valid.

**Config:**
```json
{
  "provider": {
    "my-local": {
      "models": {
        "my-model": {
          "preserveInterruptedResponse": true
        }
      }
    }
  }
}
```

### How did you verify your code works?

Tested with llama.cpp backend (Qwen3.5-27B) with KV cache enabled.

**Before (without option):** After interrupt, cache similarity dropped dramatically
```
[interrupted]
sim_best = 0.445
n_past = 18122  ← cache dropped to 18k tokens
prompt eval time = 157716.70 ms / 22201 tokens  ← had to reprocess 22k tokens (~2.5 min)
```

**After (with option enabled):** Cache remains valid after interrupt
```
[interrupted]...
sim_best = 0.998  ← 99.8% cache hit!
n_past = 30131   ← cache retained 30k tokens
prompt eval time = 2418.69 ms / 305 tokens  ← only 305 new tokens (~2.4s)
```

Result: **~65x faster** response after interrupt (2.4s vs 157s)

### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Developed with assistance from Claude Opus 4.5