### PR TITLE
feat(server): add GET /tui/prompt endpoint

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -141,6 +141,20 @@ export function Prompt(props: PromptProps) {
 
   createEffect(
     on(
+      () => store.prompt.input,
+      (value) => {
+        sdk.fetch(sdk.url + "/tui/prompt", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ input: value }),
+        })
+      },
+      { defer: true },
+    ),
+  )
+
+  createEffect(
+    on(
       () => props.sessionID,
       () => {
         setStore("placeholder", Math.floor(Math.random() * PLACEHOLDERS.length))

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -145,7 +145,10 @@ export function Prompt(props: PromptProps) {
       (value) => {
         sdk.fetch(sdk.url + "/tui/prompt", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...sdk.headers,
+          },
           body: JSON.stringify({ input: value }),
         })
       },

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -115,6 +115,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       directory: props.directory,
       event: emitter,
       fetch: props.fetch ?? fetch,
+      headers: props.headers,
       setWorkspace(next?: string) {
         if (workspaceID === next) return
         workspaceID = next

--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -18,6 +18,12 @@ type TuiRequest = z.infer<typeof TuiRequest>
 const request = new AsyncQueue<TuiRequest>()
 const response = new AsyncQueue<any>()
 
+const PromptState = z.object({
+  input: z.string(),
+})
+
+let prompt: z.infer<typeof PromptState> = { input: "" }
+
 export async function callTui(ctx: Context) {
   const body = await ctx.req.json()
   request.push({
@@ -77,6 +83,51 @@ const TuiControlRoutes = new Hono()
 
 export const TuiRoutes = lazy(() =>
   new Hono()
+    .get(
+      "/prompt",
+      describeRoute({
+        summary: "Get TUI prompt",
+        description: "Get the current prompt content.",
+        operationId: "tui.prompt",
+        responses: {
+          200: {
+            description: "Current prompt content",
+            content: {
+              "application/json": {
+                schema: resolver(PromptState),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(prompt)
+      },
+    )
+    .post(
+      "/prompt",
+      describeRoute({
+        summary: "Update TUI prompt",
+        description: "Update the current prompt content.",
+        operationId: "tui.updatePrompt",
+        responses: {
+          200: {
+            description: "Prompt updated successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", PromptState),
+      async (c) => {
+        prompt = c.req.valid("json")
+        return c.json(true)
+      },
+    )
     .post(
       "/append-prompt",
       describeRoute({
@@ -97,7 +148,9 @@ export const TuiRoutes = lazy(() =>
       }),
       validator("json", TuiEvent.PromptAppend.properties),
       async (c) => {
-        await Bus.publish(TuiEvent.PromptAppend, c.req.valid("json"))
+        const body = c.req.valid("json")
+        prompt = { input: prompt.input + body.text }
+        await Bus.publish(TuiEvent.PromptAppend, body)
         return c.json(true)
       },
     )
@@ -215,6 +268,7 @@ export const TuiRoutes = lazy(() =>
         },
       }),
       async (c) => {
+        prompt = { input: "" }
         await Bus.publish(TuiEvent.CommandExecute, {
           command: "prompt.submit",
         })
@@ -239,6 +293,7 @@ export const TuiRoutes = lazy(() =>
         },
       }),
       async (c) => {
+        prompt = { input: "" }
         await Bus.publish(TuiEvent.CommandExecute, {
           command: "prompt.clear",
         })


### PR DESCRIPTION
### Issue for this PR

Closes #19233
Partially addresses #18111 (just the read-only prompt endpoint bit, not the session-scoping stuff)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

adds `GET /tui/prompt` that returns whats currently in the prompt as `{"input": "..."}`. right now the `/tui/` API is write-only — you can append/clear/submit but theres no way to read what's actually in the prompt. this fixes that.

server side: `GET /tui/prompt` and `POST /tui/prompt` in `tui.ts` with a module-level cache. the existing append-prompt, submit-prompt, and clear-prompt handlers also update the cache so it stays in sync.

tui side: one `createEffect` in the prompt component watching `store.prompt.input` that syncs to the server whenever it changes. catches typing, pasting, clearing, history nav, stash pop, etc — everything goes through the store so one effect handles all of it. uses `sdk.fetch` so it works both in-process (default) and with `--port`.

### How did you verify your code works?

- typecheck passes across all 13 packages
- ran `bun dev -- --port 4096`, typed a bunch of multiline stuff in the prompt, curled `GET /tui/prompt` and it returned exactly what was in the prompt
- tested append-prompt, clear-prompt etc all keep the GET in sync too

### Screenshots / recordings

n/a, no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR