### PR TITLE
refactor(prompt): remove variant cycle display from footer

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1189,11 +1189,6 @@ export function Prompt(props: PromptProps) {
                       )}
                     </Match>
                     <Match when={true}>
-                      <Show when={local.model.variant.list().length > 0}>
-                        <text fg={theme.text}>
-                          {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>variants</span>
-                        </text>
-                      </Show>
                       <text fg={theme.text}>
                         {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>agents</span>
                       </text>


### PR DESCRIPTION
Removes the variant cycle display from the prompt footer footer when there are variants available. This simplifies the UI by removing unused functionality.