### PR TITLE
docs(keybinds): document Ctrl+V behavior in Windows Terminal + WSL

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -193,3 +193,47 @@ Add this to the root-level `keybindings` array:
 ```
 
 Save the file and restart Windows Terminal or open a new tab.
+
+---
+
+## Ctrl+V In Windows Terminal (WSL)
+
+If OpenCode is running inside WSL, Windows Terminal may intercept `ctrl+v` before the app can process clipboard events. This can cause inconsistent behavior where plain text paste works but image paste does not.
+
+You can keep using `ctrl+v` by binding it to a custom action that:
+
+1. performs normal paste, then
+2. sends an empty bracketed-paste marker (`\u001b[200~\u001b[201~`).
+
+Add this to the root-level `actions` array:
+
+```json
+"actions": [
+  {
+    "command": {
+      "action": "multipleActions",
+      "actions": [
+        "paste",
+        {
+          "action": "sendInput",
+          "input": "\u001b[200~\u001b[201~"
+        }
+      ]
+    },
+    "id": "User.pasteAndNotify"
+  }
+]
+```
+
+Then bind `ctrl+v` to that action in the root-level `keybindings` array:
+
+```json
+"keybindings": [
+  {
+    "keys": "ctrl+v",
+    "id": "User.pasteAndNotify"
+  }
+]
+```
+
+Save the file and restart Windows Terminal.


### PR DESCRIPTION
### Issue for this PR

Closes #19502.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a focused documentation section in `keybinds.mdx` for Windows Terminal + WSL `Ctrl+V` behavior.

The new section explains:
- why users can see text/image paste inconsistency in this setup,
- how to configure a Windows Terminal `multipleActions` binding,
- how to keep `Ctrl+V` while also sending an empty bracketed-paste marker.

This is a docs-only update; no runtime code changes are included.

### How did you verify your code works?

- Verified the docs diff includes only one file:
  - `packages/web/src/content/docs/keybinds.mdx`
- Confirmed examples are valid JSON snippets for Windows Terminal `actions` and `keybindings` blocks.
- Confirmed branch is docs-only and does not include unrelated code changes.

### Screenshots / recordings

N/A (documentation-only change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
