### PR TITLE
fix(app): preserve macOS ctrl+f in file search

### DIFF
--- a/packages/app/e2e/files/file-viewer.spec.ts
+++ b/packages/app/e2e/files/file-viewer.spec.ts
@@ -102,6 +102,56 @@ test("cmd+f opens text viewer search while prompt is focused", async ({ page, go
   await expect(findInput).toBeFocused()
 })
 
+test("ctrl+f does not open text viewer search while prompt is focused on macos", async ({ page, gotoSession }) => {
+  test.skip(process.platform !== "darwin", "macos only")
+
+  await gotoSession()
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.type("/open")
+
+  const command = page.locator('[data-slash-id="file.open"]').first()
+  await expect(command).toBeVisible()
+  await page.keyboard.press("Enter")
+
+  const dialog = page
+    .getByRole("dialog")
+    .filter({ has: page.getByPlaceholder(/search files/i) })
+    .first()
+  await expect(dialog).toBeVisible()
+
+  const input = dialog.getByRole("textbox").first()
+  await input.fill("package.json")
+
+  const items = dialog.locator('[data-slot="list-item"][data-key^="file:"]')
+  let index = -1
+  await expect
+    .poll(
+      async () => {
+        const keys = await items.evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-key") ?? ""))
+        index = keys.findIndex((key) => /packages[\\/]+app[\\/]+package\.json$/i.test(key.replace(/^file:/, "")))
+        return index >= 0
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true)
+
+  const item = items.nth(index)
+  await expect(item).toBeVisible()
+  await item.click()
+
+  await expect(dialog).toHaveCount(0)
+
+  const tab = page.getByRole("tab", { name: "package.json" })
+  await expect(tab).toBeVisible()
+  await tab.click()
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.press("Control+f")
+
+  await expect(page.getByPlaceholder("Find")).toHaveCount(0)
+})
+
 test("cmd+f opens text viewer search while prompt is not focused", async ({ page, gotoSession }) => {
   await gotoSession()
 

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -19,6 +19,8 @@ import { getSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 
+const IS_MAC = typeof navigator === "object" && /(Mac|iPod|iPhone|iPad)/.test(navigator.platform)
+
 function FileCommentMenu(props: {
   moreLabel: string
   editLabel: string
@@ -224,7 +226,8 @@ export function FileTabContent(props: { tab: string }) {
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (activeFileTab() !== props.tab) return
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return
+      const mod = IS_MAC ? event.metaKey : event.ctrlKey
+      if (!mod || event.altKey || event.shiftKey) return
       if (event.key.toLowerCase() !== "f") return
 
       event.preventDefault()


### PR DESCRIPTION
### Issue for this PR

Closes #13990

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a file viewer is open, `Ctrl+F` on macOS is being treated like the file search shortcut even while typing in the prompt. That prevents the native cursor-forward behavior and moves focus into file search instead.

This changes the file search shortcut handling so macOS only opens file search on `Cmd+F`, while other platforms continue using `Ctrl+F`. I also added an e2e test to cover the macOS case where the prompt is focused, so `Ctrl+F` no longer regresses.

### How did you verify your code works?

- ran `bun --cwd packages/app test:e2e:local -- e2e/files/file-viewer.spec.ts`
- confirmed the file viewer shortcut tests pass with the new macOS-specific `Ctrl+F` coverage

### Screenshots / recordings

**Before**

https://github.com/user-attachments/assets/69da3d1d-2f16-4137-88e9-634888878d8b

**After**

https://github.com/user-attachments/assets/0ed2f916-3ce9-40db-a8c5-1630bb7a4f69



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
