### PR TITLE
feat: open dialog for model variant selection instead of cycling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -121,6 +121,7 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
 }
 
 import type { EventSource } from "./context/sdk"
+import { DialogVariant } from "./component/dialog-variant"
 
 function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   return {
@@ -580,12 +581,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Variant cycle",
+      title: "Switch model variant",
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
       onSelect: () => {
-        local.model.variant.cycle()
+        dialog.replace(() => <DialogVariant />)
       },
     },
     {


### PR DESCRIPTION
Replaces the variant cycle action with a dialog that allows users to select a specific model variant rather than cycling through them.