### PR TITLE
fix(tui): fix prompt history clobber

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -4,7 +4,7 @@ import { Filesystem } from "@/util/filesystem"
 import { onMount } from "solid-js"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { createSimpleContext } from "../../context/helper"
-import { appendFile, writeFile } from "fs/promises"
+import { writeFile } from "fs/promises"
 import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
 
 export type PromptInfo = {
@@ -31,9 +31,8 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
   name: "PromptHistory",
   init: () => {
     const historyPath = path.join(Global.Path.state, "prompt-history.jsonl")
-    onMount(async () => {
-      const text = await Filesystem.readText(historyPath).catch(() => "")
-      const lines = text
+    const parse = (text: string) =>
+      text
         .split("\n")
         .filter(Boolean)
         .map((line) => {
@@ -44,7 +43,9 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
           }
         })
         .filter((line): line is PromptInfo => line !== null)
-        .slice(-MAX_HISTORY_ENTRIES)
+
+    onMount(async () => {
+      const lines = parse(await Filesystem.readText(historyPath).catch(() => "")).slice(-MAX_HISTORY_ENTRIES)
 
       setStore("history", lines)
 
@@ -83,25 +84,25 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       },
       append(item: PromptInfo) {
         const entry = structuredClone(unwrap(item))
-        let trimmed = false
         setStore(
           produce((draft) => {
             draft.history.push(entry)
             if (draft.history.length > MAX_HISTORY_ENTRIES) {
               draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
-              trimmed = true
             }
             draft.index = 0
           }),
         )
 
-        if (trimmed) {
-          const content = store.history.map((line) => JSON.stringify(line)).join("\n") + "\n"
-          writeFile(historyPath, content).catch(() => {})
-          return
-        }
-
-        appendFile(historyPath, JSON.stringify(entry) + "\n").catch(() => {})
+        Filesystem.readText(historyPath)
+          .catch(() => "")
+          .then((text) => {
+            const lines = parse(text)
+            const next = lines.length >= MAX_HISTORY_ENTRIES ? lines.slice(-(MAX_HISTORY_ENTRIES - 1)) : lines
+            const content = [...next, entry].map((line) => JSON.stringify(line)).join("\n") + "\n"
+            return writeFile(historyPath, content)
+          })
+          .catch(() => {})
       },
     }
   },


### PR DESCRIPTION
fix multiple instances of opencode overwriting prompt history

### Issue for this PR

Closes #19536

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Instead of using `store.history` to write prompt-history.jsonl which leads to overwriting data in file re-read prompt-history.jsonl and append new entry.

Still keeps max length of file at 50 entries.

Small simple fix that fixes this bug.

### How did you verify your code works?

Tested locally with
1. no prompt-history.jsonl
2. full prompt-history.jsonl (e.g. 50 entries)

### Screenshots / recordings

demo of bug fix

https://github.com/user-attachments/assets/0605bbf2-e40c-439b-8bc3-a876566d9dac

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

