### PR TITLE
feat(tui): add /clear command to clear session messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -477,7 +477,6 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       category: "Session",
       slash: {
         name: "new",
-        aliases: ["clear"],
       },
       onSelect: () => {
         const current = promptRef.current
@@ -492,6 +491,45 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         })
         dialog.clear()
       },
+    },
+    {
+      title: "Clear session",
+      value: "session.clear",
+      category: "Session",
+      slash: {
+        name: "clear",
+      },
+      onSelect: async () => {
+        try {
+        const choice = await DialogConfirm.show(
+          dialog,
+          "Clear Session",
+          "Are you sure you want to clear the current session? All messages with it's context will be deleted.This cannot be undone.",
+          "cancel",
+        )
+        if (choice !== true) return
+
+        
+        if (route.data.type !== "session") return
+        const sessionID=route.data.sessionID
+        const messages=await sdk.client.session.messages({sessionID})
+        if (!messages.data?.length) return
+        const results=await Promise.all(
+          messages.data.map((m) =>
+            sdk.client.session.deleteMessage({
+              sessionID,
+              messageID: m.info.id,
+            }).then(() => ({ok: true}))
+              .catch(()=>({ok: false}))
+          )
+        )
+        const success=results.filter(r=>r.ok).length
+        toast.show({variant:"info",message: `Cleared ${success} messages`,duration: 3000})
+        dialog.clear()
+      } finally{
+        dialog.clear()
+      }
+    },
     },
     {
       title: "Switch model",


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It add /clear command to the tui which removes all messages and context in the session without changing the session id.
It uses the existing session.deleteMessage API ,it  has a dialog for confirmation before clearing all messages and a toast message after clearing indicating number of messages cleared.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tested it locally for every use case and flow. Tested with multiple messages by confirming and not confirming in the dialog box.

### Screenshots / recordings


https://github.com/user-attachments/assets/e3acf31b-b5f5-4204-bbea-b59a9a2e19e0

<img width="1715" height="932" alt="Screenshot From 2026-03-28 22-29-16" src="https://github.com/user-attachments/assets/26f8700f-32eb-443f-92d4-13bede1e130b" />

<img width="1715" height="932" alt="Screenshot From 2026-03-28 22-29-27" src="https://github.com/user-attachments/assets/2b513401-ed5a-40dd-9c8a-2b95fb9518e0" />

<img width="1715" height="932" alt="Screenshot From 2026-03-28 22-29-34" src="https://github.com/user-attachments/assets/df0b9790-27e2-40e2-ba09-59701b6949bd" />

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
