### PR TITLE
fix: update opencode-gitlab-auth to 2.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -369,7 +369,7 @@
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
         "open": "10.1.2",
-        "opencode-gitlab-auth": "2.0.0",
+        "opencode-gitlab-auth": "2.0.1",
         "opencode-poe-auth": "0.0.1",
         "opentui-spinner": "0.0.6",
         "partial-json": "0.1.7",
@@ -3801,7 +3801,7 @@
 
     "opencode": ["opencode@workspace:packages/opencode"],
 
-    "opencode-gitlab-auth": ["opencode-gitlab-auth@2.0.0", "", { "dependencies": { "@fastify/rate-limit": "^10.2.0", "@opencode-ai/plugin": "*", "fastify": "^5.2.0", "open": "^10.0.0" } }, "sha512-jmZOOvYIurRScQCtdBqIW5HbP1JbmIiq7UtI7NGgn2vjke46g9d4NVPBg5/ZmFFVIBwZcgyFgJ7b8kGEOR9ujA=="],
+    "opencode-gitlab-auth": ["opencode-gitlab-auth@2.0.1", "", { "dependencies": { "@fastify/rate-limit": "^10.2.0", "@opencode-ai/plugin": "*", "fastify": "^5.2.0", "open": "^10.0.0" } }, "sha512-1EMZHdbADLMVaTVLQ6C/V8uVMDr6MP++osj2lmOecowtn46AafP/w6ADkV4AN/ddjA1rob5cWpMuf/iME6DI6A=="],
 
     "opencode-poe-auth": ["opencode-poe-auth@0.0.1", "", { "dependencies": { "open": "^10.0.0", "poe-oauth": "*" }, "peerDependencies": { "@opencode-ai/plugin": "*" } }, "sha512-cXqTlS6AXHzo1oBdosnxbT47ZJEZ9WXn050X8Re6wZ1vaNnTpB/l2fMQt90evT7RBK0fB8UjXQUDMKyd7bbiqg=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -133,7 +133,7 @@
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
     "open": "10.1.2",
-    "opencode-gitlab-auth": "2.0.0",
+    "opencode-gitlab-auth": "2.0.1",
     "opencode-poe-auth": "0.0.1",
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",


### PR DESCRIPTION
### Issue for this PR

Closes #19554

### Type of change

- [x] Bug fix

### What does this PR do?

The GitLab auth dialog (both OAuth and PAT methods) had an "Instance URL" text prompt with a required validator. Pressing Enter without typing triggered `"Instance URL is required"`, blocking login for anyone connecting to the default gitlab.com.

The fix is in `opencode-gitlab-auth` 2.0.1: the instance URL prompt is removed from both auth methods. The URL is now resolved automatically via `GITLAB_INSTANCE_URL` env var → `instanceUrl` plugin option → `https://gitlab.com` default. This PR bumps the dependency from 2.0.0 to 2.0.1.

### How did you verify your code works?

`bun turbo typecheck` passes. The fix is in the upstream plugin — changelog: https://gitlab.com/vglafirov/opencode-gitlab-auth/-/blob/main/CHANGELOG.md

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR