### PR TITLE
fix(session): use MCP tool name in permission patterns

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -889,8 +889,8 @@ export namespace SessionPrompt {
         await ctx.ask({
           permission: key,
           metadata: {},
-          patterns: ["*"],
-          always: ["*"],
+          patterns: [key],
+          always: [key],
         })
 
         const result = await execute(args, opts)


### PR DESCRIPTION
MCP tools were showing '*' instead of the actual tool name in permission dialogs. This fixes the patterns and always arrays to use the actual tool key instead of '*', allowing users to see which specific tool is requesting permission.

Fixes #19549