### PR TITLE
fix(opencode): run transformParams middleware unconditionally for all call types

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -295,11 +295,8 @@ export namespace LLM {
           {
             specificationVersion: "v3" as const,
             async transformParams(args) {
-              if (args.type === "stream") {
-                // TODO: verify that LanguageModelV3Prompt is still compat here!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-                // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
-              }
+              // @ts-expect-error LanguageModelV3Prompt compat — prompt shape matches ModelMessage[]
+              args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
               return args.params
             },
           },


### PR DESCRIPTION
### Issue for this PR

Fixes #19557

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `transformParams` middleware in `llm.ts` wraps `ProviderTransform.message()` behind an `if (args.type === "stream")` guard. Non-stream call types skip the entire normalization pipeline — `normalizeMessages()`, `applyCaching()`, and tool-call ID scrubbing all get bypassed.

The prompt shape is the same regardless of `args.type`, so the guard has no purpose. This removes it so the middleware runs unconditionally. The existing TODO comment on the line suggests this was already known to be questionable.

### How did you verify your code works?

- Typecheck clean across all 13 packages (`bun turbo typecheck`)
- All existing tests pass
- Manually confirmed `ProviderTransform.message()` is called for both stream and non-stream paths by adding a temporary log and running `bun dev`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR