### PR TITLE
feat: mistral enterprise endpoint

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -8,6 +8,7 @@ import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
+import { MistralAuthPlugin } from "./mistral"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
 import { PoeAuthPlugin } from "opencode-poe-auth"
 import { Effect, Layer, ServiceMap, Stream } from "effect"
@@ -65,7 +66,13 @@ export namespace Plugin {
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
+  const INTERNAL_PLUGINS: PluginInstance[] = [
+    CodexAuthPlugin,
+    CopilotAuthPlugin,
+    MistralAuthPlugin,
+    GitlabAuthPlugin,
+    PoeAuthPlugin,
+  ]
 
   function isServerPlugin(value: unknown): value is PluginInstance {
     return typeof value === "function"

--- a/packages/opencode/src/plugin/mistral.ts
+++ b/packages/opencode/src/plugin/mistral.ts
@@ -1,0 +1,86 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+function normalizeUrl(url: string) {
+  return url.replace(/\/$/, "")
+}
+
+export async function MistralAuthPlugin(input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "mistral",
+      async loader(getAuth) {
+        const info = await getAuth()
+        if (!info || info.type !== "api") return {}
+
+        const endpoint = info.endpoint
+        const baseURL = endpoint ? normalizeUrl(endpoint) : undefined
+
+        return {
+          baseURL,
+          apiKey: info.key ?? "",
+        }
+      },
+      methods: [
+        {
+          type: "api",
+          label: "Mistral API Key (api.mistral.ai)",
+          prompts: [
+            {
+              type: "secret",
+              key: "key",
+              message: "Enter your Mistral API key",
+              validate: (value) => {
+                if (!value) return "API key is required"
+                return undefined
+              },
+            },
+          ],
+          authorize(inputs) {
+            return {
+              type: "success",
+              key: inputs.key,
+            }
+          },
+        },
+        {
+          type: "api",
+          label: "Mistral Enterprise (custom endpoint)",
+          prompts: [
+            {
+              type: "text",
+              key: "endpoint",
+              message: "Enter your Mistral Enterprise endpoint URL",
+              placeholder: "https://mistral.enterprise.com",
+              validate: (value) => {
+                if (!value) return "Endpoint URL is required"
+                try {
+                  const url = value.includes("://") ? new URL(value) : new URL(`https://${value}`)
+                  if (!url.hostname) return "Please enter a valid URL"
+                  return undefined
+                } catch {
+                  return "Please enter a valid URL (e.g., https://mistral.enterprise.com)"
+                }
+              },
+            },
+            {
+              type: "secret",
+              key: "key",
+              message: "Enter your Mistral API key",
+              validate: (value) => {
+                if (!value) return "API key is required"
+                return undefined
+              },
+            },
+          ],
+          authorize(inputs) {
+            return {
+              type: "success",
+              key: inputs.key,
+              endpoint: normalizeUrl(inputs.endpoint),
+            }
+          },
+        },
+      ],
+    },
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add support for configuring custom Mistral API endpoints (e.g., Mistral Enterprise deployments) via an interactive auth flow, modeled after the GitHub Copilot provider pattern.

- Add `MistralAuthPlugin` with two auth methods: public API and Enterprise (custom endpoint)
- Update plugin registry to include the new Mistral plugin

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
