### PR TITLE
ci: cancel stale nix-hashes runs

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -17,6 +17,10 @@ on:
       - "patches/**"
       - ".github/workflows/nix-hashes.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Native runners required: bun install cross-compilation flags (--os/--cpu)
   # do not produce byte-identical node_modules as native installs.


### PR DESCRIPTION
## Summary
- Add workflow-level concurrency to `nix-hashes`.
- Cancel older in-progress runs on the same ref when a newer run starts.
- Stop superseded Intel macOS hash jobs from continuing after newer pushes.

## Testing
- `bun turbo typecheck` ran successfully during `git push`.
