### PR TITLE
docs: add opencode-omoc-swarm to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                 |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
+| [opencode-omoc-swarm](https://github.com/Delqhi/opencode-omoc-swarm)                               | Subagent workflow plugin with tmux side-by-side sessions, parallel fan-out, messaging, and MAX-mode git worktrees |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |


### PR DESCRIPTION
## Why
Add `opencode-omoc-swarm` to the official OpenCode ecosystem list so OpenCode users can discover another community-built plugin workflow layer.

## What
- adds `opencode-omoc-swarm` to `packages/web/src/content/docs/ecosystem.mdx`
- uses a short factual description centered on tmux side-by-side sessions, parallel fan-out, messaging, and MAX-mode git worktrees

## Notes
This keeps the entry concise and product-scope accurate for the ecosystem page.