### PR TITLE
docs(ja): fix missing phrase on GitLab CI/CD page

### DIFF
--- a/packages/web/src/content/docs/ja/gitlab.mdx
+++ b/packages/web/src/content/docs/ja/gitlab.mdx
@@ -13,7 +13,7 @@ OpenCode は、GitLab CI/CD パイプラインまたは GitLab Duo を通じて 
 
 OpenCode は通常の GitLab パイプラインで動作します。 [CI コンポーネント](https://docs.gitlab.com/ee/ci/components/) としてパイプラインに組み込むことができます。
 
-ここでは、コミュニティが作成した OpenCode 用の CI/CD コンポーネント — [nagyv/gitlab-opencode](https://gitlab.com/nagyv/gitlab-opencode).
+ここでは、コミュニティが作成した OpenCode 用の CI/CD コンポーネント — [nagyv/gitlab-opencode](https://gitlab.com/nagyv/gitlab-opencode) を使用しています。
 
 ---
 


### PR DESCRIPTION
Clarified the usage of the CI/CD component for OpenCode.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Japanese GitLab CI/CD documentation was missing 「を使用しています」 in the sentence referring to the community-created component (nagyv/gitlab-opencode).  
This PR adds the missing phrase to make the Japanese text match the intent of the English documentation.

### How did you verify your code works?

Checked the rendered page locally / in preview to confirm the sentence reads naturally and MDX builds without errors.

### Screenshots / recordings

N/A (text-only documentation change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
