### PR TITLE
fix(xai): patch the finish-reason for ai-sdk/xai

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -602,6 +602,7 @@
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",
+    "@ai-sdk/xai@3.0.74": "patches/@ai-sdk%2Fxai@3.0.74.patch",
     "@ai-sdk/provider-utils@4.0.21": "patches/@ai-sdk%2Fprovider-utils@4.0.21.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@ai-sdk/provider-utils@4.0.21": "patches/@ai-sdk%2Fprovider-utils@4.0.21.patch",
-    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch"
+    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",
+    "@ai-sdk/xai@3.0.74": "patches/@ai-sdk%2Fxai@3.0.74.patch"
   }
 }

--- a/patches/@ai-sdk%2Fxai@3.0.74.patch
+++ b/patches/@ai-sdk%2Fxai@3.0.74.patch
@@ -1,0 +1,104 @@
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2105,6 +2105,7 @@
+       fetch: this.config.fetch
+     });
+     const content = [];
++    let hasFunctionCall = false;
+     const webSearchSubTools = [
+       "web_search",
+       "web_search_with_snippets",
+@@ -2189,6 +2190,7 @@
+           break;
+         }
+         case "function_call": {
++          hasFunctionCall = true;
+           content.push({
+             type: "tool-call",
+             toolCallId: part.call_id,
+@@ -2231,7 +2233,7 @@
+     return {
+       content,
+       finishReason: {
+-        unified: mapXaiResponsesFinishReason(response.status),
++        unified: hasFunctionCall ? "tool-calls" : mapXaiResponsesFinishReason(response.status),
+         raw: (_m = response.status) != null ? _m : void 0
+       },
+       usage: response.usage ? convertXaiResponsesUsage(response.usage) : {
+@@ -2283,6 +2285,7 @@
+     const seenToolCalls = /* @__PURE__ */ new Set();
+     const ongoingToolCalls = {};
+     const activeReasoning = {};
++    let hasFunctionCall = false;
+     const self = this;
+     return {
+       stream: response.pipeThrough(
+@@ -2421,7 +2424,7 @@
+               }
+               if (response2.status) {
+                 finishReason = {
+-                  unified: mapXaiResponsesFinishReason(response2.status),
++                  unified: hasFunctionCall ? "tool-calls" : mapXaiResponsesFinishReason(response2.status),
+                   raw: response2.status
+                 };
+               }
+@@ -2614,6 +2617,7 @@
+                     toolName: part.name
+                   });
+                 } else if (event.type === "response.output_item.done") {
++                  hasFunctionCall = true;
+                   ongoingToolCalls[event.output_index] = void 0;
+                   controller.enqueue({
+                     type: "tool-input-end",
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -2126,6 +2126,7 @@
+       fetch: this.config.fetch
+     });
+     const content = [];
++    let hasFunctionCall = false;
+     const webSearchSubTools = [
+       "web_search",
+       "web_search_with_snippets",
+@@ -2210,6 +2211,7 @@
+           break;
+         }
+         case "function_call": {
++          hasFunctionCall = true;
+           content.push({
+             type: "tool-call",
+             toolCallId: part.call_id,
+@@ -2252,7 +2254,7 @@
+     return {
+       content,
+       finishReason: {
+-        unified: mapXaiResponsesFinishReason(response.status),
++        unified: hasFunctionCall ? "tool-calls" : mapXaiResponsesFinishReason(response.status),
+         raw: (_m = response.status) != null ? _m : void 0
+       },
+       usage: response.usage ? convertXaiResponsesUsage(response.usage) : {
+@@ -2304,6 +2306,7 @@
+     const seenToolCalls = /* @__PURE__ */ new Set();
+     const ongoingToolCalls = {};
+     const activeReasoning = {};
++    let hasFunctionCall = false;
+     const self = this;
+     return {
+       stream: response.pipeThrough(
+@@ -2442,7 +2445,7 @@
+               }
+               if (response2.status) {
+                 finishReason = {
+-                  unified: mapXaiResponsesFinishReason(response2.status),
++                  unified: hasFunctionCall ? "tool-calls" : mapXaiResponsesFinishReason(response2.status),
+                   raw: response2.status
+                 };
+               }
+@@ -2635,6 +2638,7 @@
+                     toolName: part.name
+                   });
+                 } else if (event.type === "response.output_item.done") {
++                  hasFunctionCall = true;
+                   ongoingToolCalls[event.output_index] = void 0;
+                   controller.enqueue({
+                     type: "tool-input-end",


### PR DESCRIPTION
This will allow ai-sdk/xai correctly report `tool-calls` if there are tool calls from the model and send the next request.

### Issue for this PR

Closes #19622 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add the patch for the ai-sdk/xai to correctly report the finish-reason for xai-model when there are tool calls from the model response.

### How did you verify your code works?

```
bun install
bun run dev
```

OpenCode now is able to use grok models to do the agentic coding.


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
