### PR TITLE
fix: show config api keys in auth list

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -225,6 +225,29 @@ export const ProvidersListCommand = cmd({
 
     prompts.outro(`${results.length} credentials`)
 
+    const config = await Config.get()
+    const configEntries: Array<{ provider: string; providerID: string }> = []
+
+    for (const [providerID, provider] of Object.entries(config.provider ?? {})) {
+      if (results.some(([id]) => id === providerID)) continue
+      if (!provider.options?.apiKey) continue
+      configEntries.push({
+        provider: database[providerID]?.name || provider.name || providerID,
+        providerID,
+      })
+    }
+
+    if (configEntries.length > 0) {
+      UI.empty()
+      prompts.intro("Config")
+
+      for (const { provider, providerID } of configEntries) {
+        prompts.log.info(`${provider} ${UI.Style.TEXT_DIM}config (${providerID})`)
+      }
+
+      prompts.outro(`${configEntries.length} config credential` + (configEntries.length === 1 ? "" : "s"))
+    }
+
     const activeEnvVars: Array<{ provider: string; envVar: string }> = []
 
     for (const [providerID, provider] of Object.entries(database)) {


### PR DESCRIPTION
Fixes #4533

## What changed

`opencode auth list` now shows providers configured via `opencode.json` with `provider.options.apiKey` under a new "Config" section. Previously these credentials were not displayed, causing confusion when users configured providers through config but saw no output from `auth list`.

## How it works

- Reads `config.provider` entries after displaying auth.json credentials
- Skips providers already shown from auth.json (no duplicates)
- Only shows entries that have `options.apiKey` set
- Displays in a separate "Config" section between "Credentials" and "Environment"

## Verification

Configured a custom provider with `apiKey` in `opencode.json` and ran `opencode auth list` — the provider now appears under the "Config" section.