### PR TITLE
fix: show config api keys in auth list

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -225,6 +225,29 @@ export const ProvidersListCommand = cmd({
 
     prompts.outro(`${results.length} credentials`)
 
+    const config = await Config.get()
+    const configEntries: Array<{ provider: string; providerID: string }> = []
+
+    for (const [providerID, provider] of Object.entries(config.provider ?? {})) {
+      if (results.some(([id]) => id === providerID)) continue
+      if (!provider.options?.apiKey) continue
+      configEntries.push({
+        provider: database[providerID]?.name || provider.name || providerID,
+        providerID,
+      })
+    }
+
+    if (configEntries.length > 0) {
+      UI.empty()
+      prompts.intro("Config")
+
+      for (const { provider, providerID } of configEntries) {
+        prompts.log.info(`${provider} ${UI.Style.TEXT_DIM}config (${providerID})`)
+      }
+
+      prompts.outro(`${configEntries.length} config credential` + (configEntries.length === 1 ? "" : "s"))
+    }
+
     const activeEnvVars: Array<{ provider: string; envVar: string }> = []
 
     for (const [providerID, provider] of Object.entries(database)) {


### PR DESCRIPTION
### Issue for this PR

Closes #4533

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode auth list` only shows credentials from `auth.json` and environment variables, but ignores API keys set via `provider.options.apiKey` in `opencode.json`. This causes confusion when users configure providers through config — the command shows nothing despite valid configuration.

This fix reads `config.provider` entries after displaying auth.json credentials. It skips providers already shown from auth.json to avoid duplicates, and only includes entries that have `options.apiKey` set. These are displayed in a new "Config" section between "Credentials" and "Environment".

Note: PRs #11822 and #15806 target `auth.ts` which no longer contains the auth list command — it was moved to `providers.ts`. This PR targets the current file.

### How did you verify your code works?

1. Added a custom provider with `apiKey` in `opencode.json`
2. Ran `opencode auth list` — the provider now appears under a "Config" section
3. Verified no duplicate entries when the same provider exists in both auth.json and config
4. All CI checks pass (typecheck, unit tests, e2e tests)

### Screenshots / recordings

_CLI output change, not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR