### PR TITLE
fix(app): reduce session navigation blocking by wiring timeline staging

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -458,21 +458,19 @@ export default function Page() {
     return sync.session.history.loading(id)
   })
 
-  const userMessages = createMemo(
-    () => messages().filter((m) => m.role === "user") as UserMessage[],
-    emptyUserMessages,
-    { equals: same },
-  )
   const visibleUserMessages = createMemo(
     () => {
       const revert = revertMessageID()
-      if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
+      const result: UserMessage[] = []
+      for (const m of messages()) {
+        if (m.role !== "user") continue
+        if (revert && m.id >= revert) continue
+        result.push(m as UserMessage)
+      }
+      return result
     },
     emptyUserMessages,
-    {
-      equals: same,
-    },
+    { equals: same },
   )
   const lastUserMessage = createMemo(() => visibleUserMessages().at(-1))
 
@@ -1558,7 +1556,7 @@ export default function Page() {
       const sessionID = params.id
       if (!sessionID) return
 
-      const next = userMessages().find((item) => item.id > id)
+      const next = messages().find((item): item is UserMessage => item.role === "user" && item.id > id)
       const prev = prompt.current().slice()
       const last = info()?.revert
 
@@ -1610,8 +1608,8 @@ export default function Page() {
   const rolled = createMemo(() => {
     const id = revertMessageID()
     if (!id) return []
-    return userMessages()
-      .filter((item) => item.id >= id)
+    return messages()
+      .filter((item): item is UserMessage => item.role === "user" && item.id >= id)
       .map((item) => ({ id: item.id, text: line(item.id) }))
   })
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,15 @@
-import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
+import {
+  For,
+  createComputed,
+  createEffect,
+  createMemo,
+  on,
+  onCleanup,
+  Show,
+  Index,
+  type JSX,
+  createSignal,
+} from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
@@ -125,11 +136,18 @@ function createTimelineStaging(input: TimelineStageInput) {
     count: 0,
   })
 
+  createComputed((prev: string) => {
+    const key = input.sessionKey()
+    if (prev && key !== prev) setState("completedSession", "")
+    return key
+  }, input.sessionKey())
+
   const stagedCount = createMemo(() => {
     const total = input.messages().length
     if (input.turnStart() <= 0) return total
     if (state.completedSession === input.sessionKey()) return total
     const init = Math.min(total, input.config.init)
+    if (state.activeSession !== input.sessionKey()) return init
     if (state.count <= init) return init
     if (state.count >= total) return total
     return state.count
@@ -172,10 +190,10 @@ function createTimelineStaging(input: TimelineStageInput) {
             frame = undefined
             return
           }
-          const currentTotal = input.messages().length
-          count = Math.min(currentTotal, count + input.config.batch)
+          const current = input.messages().length
+          count = Math.min(current, count + input.config.batch)
           setState("count", count)
-          if (count >= currentTotal) {
+          if (count >= current) {
             setState({ completedSession: sessionKey, activeSession: "" })
             frame = undefined
             return
@@ -231,18 +249,21 @@ export function MessageTimeline(props: {
   const { params, sessionKey } = useSessionKey()
   const platform = usePlatform()
 
-  const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
   const sessionID = createMemo(() => params.id)
   const sessionMessages = createMemo(() => {
     const id = sessionID()
     if (!id) return emptyMessages
     return sync.data.message[id] ?? emptyMessages
   })
-  const pending = createMemo(() =>
-    sessionMessages().findLast(
-      (item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number",
-    ),
-  )
+  const pending = createMemo(() => {
+    const msgs = sessionMessages()
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const item = msgs[i]
+      if (item.role === "user") return undefined
+      if (item.role === "assistant" && typeof item.time.completed !== "number") return item as AssistantMessage
+    }
+    return undefined
+  })
   const sessionStatus = createMemo(() => {
     const id = sessionID()
     if (!id) return idle
@@ -295,13 +316,14 @@ export function MessageTimeline(props: {
   const shareEnabled = createMemo(() => sync.data.config.share !== "disabled")
   const parentID = createMemo(() => info()?.parentID)
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
-  const stageCfg = { init: 1, batch: 3 }
+  const stageCfg = { init: 0, batch: 3 }
   const staging = createTimelineStaging({
     sessionKey,
     turnStart: () => props.turnStart,
     messages: () => props.renderedUserMessages,
     config: stageCfg,
   })
+  const rendered = createMemo(() => staging.messages().map((message) => message.id))
 
   const [title, setTitle] = createStore({
     draft: "",


### PR DESCRIPTION
### Issue for this PR

Fixes #19793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`createTimelineStaging` was built to progressively mount turns across frames, but its output (`staging.messages()`) was never connected to the `rendered` memo that feeds the `<For>` loop. All turns mounted synchronously in one frame during session navigation.

Three fixes:

1. **Wire staging output into `rendered`** — `rendered` now reads from `staging.messages()` instead of `props.renderedUserMessages` directly. With `init: 0`, zero turns mount in the navigation frame; turns mount in subsequent rAF frames (`batch: 3`).

2. **Fix stale staging state on session switch** — Added a `createComputed` that clears `completedSession` synchronously when `sessionKey` changes, and an `activeSession` guard in `stagedCount`. Without this, revisiting a completed session skips staging and mounts all turns at once.

3. **Single-pass user message filter** — Merged the `userMessages` and `visibleUserMessages` memos into one O(n) pass. Replaced `pending`'s `findLast` with an early-exit reverse loop.

### How did you verify your code works?

Benchmarked with `agent-browser` navigating between two sessions (495 and 312 messages). Measured sync frame cost and PerformanceObserver long tasks across 5 round trips.

| Metric | Before | After |
|--------|--------|-------|
| Sync navigation cost | 50-223ms | **1.2-2.3ms** |
| Max long task (worst) | **223ms** | 59ms |
| Total blocking (avg) | 47ms | 5ms |

`bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR