### PR TITLE
fix: bound session sidebar prefetch

### DIFF
--- a/packages/app/src/context/global-sync/session-prefetch.test.ts
+++ b/packages/app/src/context/global-sync/session-prefetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  SESSION_PAGE_SIZE,
   clearSessionPrefetch,
   clearSessionPrefetchDirectory,
   getSessionPrefetch,
@@ -67,8 +68,8 @@ describe("session prefetch", () => {
     expect(
       shouldSkipSessionPrefetch({
         message: true,
-        info: { limit: 200, cursor: "x", complete: false, at: 1 },
-        chunk: 200,
+        info: { limit: SESSION_PAGE_SIZE, cursor: "x", complete: false, at: 1 },
+        chunk: SESSION_PAGE_SIZE,
         now: 1 + 15_001,
       }),
     ).toBe(false)
@@ -78,8 +79,8 @@ describe("session prefetch", () => {
     expect(
       shouldSkipSessionPrefetch({
         message: true,
-        info: { limit: 400, cursor: "x", complete: false, at: 1 },
-        chunk: 200,
+        info: { limit: SESSION_PAGE_SIZE * 2, cursor: "x", complete: false, at: 1 },
+        chunk: SESSION_PAGE_SIZE,
         now: 1 + 15_001,
       }),
     ).toBe(true)
@@ -88,7 +89,7 @@ describe("session prefetch", () => {
       shouldSkipSessionPrefetch({
         message: true,
         info: { limit: 120, complete: true, at: 1 },
-        chunk: 200,
+        chunk: SESSION_PAGE_SIZE,
         now: 1 + 15_001,
       }),
     ).toBe(true)

--- a/packages/app/src/context/global-sync/session-prefetch.ts
+++ b/packages/app/src/context/global-sync/session-prefetch.ts
@@ -1,5 +1,7 @@
 const key = (directory: string, sessionID: string) => `${directory}\n${sessionID}`
 
+export const SESSION_PAGE_SIZE = 80
+
 export const SESSION_PREFETCH_TTL = 15_000
 
 type Meta = {

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -4,6 +4,7 @@ import { Binary } from "@opencode-ai/util/binary"
 import { retry } from "@opencode-ai/util/retry"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import {
+  SESSION_PAGE_SIZE,
   clearSessionPrefetch,
   getSessionPrefetch,
   getSessionPrefetchPromise,
@@ -180,7 +181,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       return globalSync.child(directory)
     }
     const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
-    const initialMessagePageSize = 80
+    const initialMessagePageSize = SESSION_PAGE_SIZE
     const historyMessagePageSize = 200
     const inflight = new Map<string, Promise<void>>()
     const inflightDiff = new Map<string, Promise<void>>()

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -37,6 +37,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { clearWorkspaceTerminals } from "@/context/terminal"
 import { dropSessionCaches, pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
 import {
+  SESSION_PAGE_SIZE,
   clearSessionPrefetchInflight,
   clearSessionPrefetch,
   getSessionPrefetch,
@@ -68,6 +69,7 @@ import {
   effectiveWorkspaceOrder,
   errorMessage,
   latestRootSession,
+  sessionPrefetchCandidates,
   sortedRootSessions,
   workspaceKey,
 } from "./layout/helpers"
@@ -685,10 +687,9 @@ export default function Layout(props: ParentProps) {
     running: number
   }
 
-  const prefetchChunk = 200
+  const prefetchChunk = SESSION_PAGE_SIZE
   const prefetchConcurrency = 2
   const prefetchPendingLimit = 10
-  const span = 4
   const prefetchToken = { value: 0 }
   const prefetchQueues = new Map<string, PrefetchQueue>()
 
@@ -901,13 +902,9 @@ export default function Layout(props: ParentProps) {
     pumpPrefetch(directory)
   }
 
-  const warm = (sessions: Session[], index: number) => {
-    for (let offset = 1; offset <= span; offset++) {
-      const next = sessions[index + offset]
-      if (next) prefetchSession(next, offset === 1 ? "high" : "low")
-
-      const prev = sessions[index - offset]
-      if (prev) prefetchSession(prev, offset === 1 ? "high" : "low")
+  const warm = (sessions: Session[], index: number, opts?: { current?: boolean; span?: number }) => {
+    for (const item of sessionPrefetchCandidates(sessions, index, opts)) {
+      prefetchSession(item.session, item.priority)
     }
   }
 
@@ -918,12 +915,7 @@ export default function Layout(props: ParentProps) {
     const index = params.id ? sessions.findIndex((s) => s.id === params.id) : 0
     if (index === -1) return
 
-    if (!params.id) {
-      const first = sessions[index]
-      if (first) prefetchSession(first, "high")
-    }
-
-    warm(sessions, index)
+    if (!params.id) warm(sessions, index)
   })
 
   function navigateSessionByOffset(offset: number) {
@@ -942,7 +934,6 @@ export default function Layout(props: ParentProps) {
     const session = sessions[targetIndex]
     if (!session) return
 
-    prefetchSession(session, "high")
     warm(sessions, targetIndex)
 
     navigateToSession(session)
@@ -986,7 +977,6 @@ export default function Layout(props: ParentProps) {
       if (!session) continue
       if (notification.session.unseenCount(session.id) === 0) continue
 
-      prefetchSession(session, "high")
       warm(sessions, index)
 
       navigateToSession(session)

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  sessionPrefetchCandidates,
   workspaceKey,
 } from "./helpers"
 
@@ -207,5 +208,46 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+
+  test("prefetch candidates default to the selected session", () => {
+    const list = [
+      session({ id: "one", directory: "/tmp/app" }),
+      session({ id: "two", directory: "/tmp/app" }),
+      session({ id: "three", directory: "/tmp/app" }),
+    ]
+
+    expect(sessionPrefetchCandidates(list, 1)).toEqual([{ session: list[1], priority: "high" }])
+  })
+
+  test("prefetch candidates can expand to nearby sessions", () => {
+    const list = [
+      session({ id: "one", directory: "/tmp/app" }),
+      session({ id: "two", directory: "/tmp/app" }),
+      session({ id: "three", directory: "/tmp/app" }),
+      session({ id: "four", directory: "/tmp/app" }),
+      session({ id: "five", directory: "/tmp/app" }),
+    ]
+
+    expect(sessionPrefetchCandidates(list, 2, { span: 2 })).toEqual([
+      { session: list[2], priority: "high" },
+      { session: list[3], priority: "high" },
+      { session: list[1], priority: "high" },
+      { session: list[4], priority: "low" },
+      { session: list[0], priority: "low" },
+    ])
+  })
+
+  test("prefetch candidates can omit the selected session", () => {
+    const list = [
+      session({ id: "one", directory: "/tmp/app" }),
+      session({ id: "two", directory: "/tmp/app" }),
+      session({ id: "three", directory: "/tmp/app" }),
+    ]
+
+    expect(sessionPrefetchCandidates(list, 1, { current: false, span: 1 })).toEqual([
+      { session: list[2], priority: "high" },
+      { session: list[0], priority: "high" },
+    ])
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -60,6 +60,29 @@ export const childMapByParent = (sessions: Session[] | undefined) => {
   return map
 }
 
+export const sessionPrefetchCandidates = (
+  sessions: Session[],
+  index: number,
+  opts: { current?: boolean; span?: number } = {},
+) => {
+  const root = sessions[index]
+  if (!root) return [] as Array<{ session: Session; priority: "high" | "low" }>
+
+  const span = opts.span ?? 0
+  const items: Array<{ session: Session; priority: "high" | "low" }> =
+    opts.current === false ? [] : [{ session: root, priority: "high" }]
+
+  for (let step = 1; step <= span; step++) {
+    const priority = step === 1 ? "high" : "low"
+    const next = sessions[index + step]
+    if (next) items.push({ session: next, priority })
+    const prev = sessions[index - step]
+    if (prev) items.push({ session: prev, priority })
+  }
+
+  return items
+}
+
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree)
 

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -9,7 +9,7 @@ import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
 import { A, useNavigate, useParams } from "@solidjs/router"
-import { type Accessor, createMemo, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js"
+import { type Accessor, createMemo, For, type JSX, Match, Show, Switch } from "solid-js"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { getAvatarColors, type LocalProject, useLayout } from "@/context/layout"
@@ -17,7 +17,7 @@ import { useNotification } from "@/context/notification"
 import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
-import { hasProjectPermissions } from "./helpers"
+import { hasProjectPermissions, sessionPrefetchCandidates } from "./helpers"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -100,14 +100,12 @@ const SessionRow = (props: {
   warmHover: () => void
   warmPress: () => void
   warmFocus: () => void
-  cancelHoverPrefetch: () => void
 }): JSX.Element => (
   <A
     href={`/${props.slug}/session/${props.session.id}`}
     class={`flex items-center gap-1 min-w-0 w-full text-left focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
     onPointerDown={props.warmPress}
     onPointerEnter={props.warmHover}
-    onPointerLeave={props.cancelHoverPrefetch}
     onFocus={props.warmFocus}
     onClick={() => {
       props.setHoverSession(undefined)
@@ -241,44 +239,19 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const hoverEnabled = createMemo(() => (props.popover ?? true) && hoverAllowed())
   const isActive = createMemo(() => props.session.id === params.id)
 
-  const warm = (span: number, priority: "high" | "low") => {
+  const warm = () => {
     const nav = props.navList?.()
     const list = nav?.some((item) => item.id === props.session.id && item.directory === props.session.directory)
       ? nav
       : props.list
 
-    props.prefetchSession(props.session, priority)
-
     const idx = list.findIndex((item) => item.id === props.session.id && item.directory === props.session.directory)
     if (idx === -1) return
 
-    for (let step = 1; step <= span; step++) {
-      const next = list[idx + step]
-      if (next) props.prefetchSession(next, step === 1 ? "high" : priority)
-
-      const prev = list[idx - step]
-      if (prev) props.prefetchSession(prev, step === 1 ? "high" : priority)
+    for (const item of sessionPrefetchCandidates(list, idx)) {
+      props.prefetchSession(item.session, item.priority)
     }
   }
-
-  const hoverPrefetch = {
-    current: undefined as ReturnType<typeof setTimeout> | undefined,
-  }
-  const cancelHoverPrefetch = () => {
-    if (hoverPrefetch.current === undefined) return
-    clearTimeout(hoverPrefetch.current)
-    hoverPrefetch.current = undefined
-  }
-  const scheduleHoverPrefetch = () => {
-    warm(1, "high")
-    if (hoverPrefetch.current !== undefined) return
-    hoverPrefetch.current = setTimeout(() => {
-      hoverPrefetch.current = undefined
-      warm(2, "low")
-    }, 80)
-  }
-
-  onCleanup(cancelHoverPrefetch)
 
   const messageLabel = (message: Message) => {
     const parts = sessionStore.part[message.id] ?? []
@@ -299,10 +272,9 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       setHoverSession={props.setHoverSession}
       clearHoverProjectSoon={props.clearHoverProjectSoon}
       sidebarOpened={layout.sidebar.opened}
-      warmHover={scheduleHoverPrefetch}
-      warmPress={() => warm(2, "high")}
-      warmFocus={() => warm(2, "high")}
-      cancelHoverPrefetch={cancelHoverPrefetch}
+      warmHover={warm}
+      warmPress={warm}
+      warmFocus={warm}
     />
   )
 

--- a/specs/project.md
+++ b/specs/project.md
@@ -35,6 +35,8 @@ POST /project/:projectID/session/:sessionID/compact
 
 GET /project/:projectID/session/:sessionID/message -> { info: Message, parts: Part[] }[]
 
+Session open and sidebar prefetch should request a bounded first page from this endpoint and lazy-load older history instead of eagerly hydrating deep message ranges.
+
 GET /project/:projectID/session/:sessionID/message/:messageID -> { info: Message, parts: Part[] }
 
 POST /project/:projectID/session/:sessionID/message -> { info: Message, parts: Part[] }


### PR DESCRIPTION
## Summary
- bound sidebar session prefetch to the same first-page size the session view already uses so heavy sessions do not eagerly hydrate a deeper slice than the page needs
- stop warming adjacent sessions from sidebar hover/focus and session navigation helpers, keeping prefetch scoped to the selected session only
- add regression coverage for the shared page-size contract and the current-only prefetch candidate policy, and document the bounded first-page expectation in `specs/project.md`

## Testing
- `bun test --preload ./happydom.ts ./src/context/global-sync/session-prefetch.test.ts ./src/pages/layout/helpers.test.ts`
- `bun typecheck`
- `bun run build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:47999 PLAYWRIGHT_SERVER_PORT=4096 bun test:e2e -- app/session.spec.ts` after starting `packages/opencode` on `4096` and `packages/app` on `47999`