### PR TITLE
fix: prevent stderr bleed on session cancel

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -261,7 +261,7 @@ export function Prompt(props: PromptProps) {
           if (store.interrupt >= 2) {
             sdk.client.session.abort({
               sessionID: props.sessionID,
-            })
+            }).catch(() => {})
             setStore("interrupt", 0)
           }
           dialog.clear()
@@ -665,7 +665,7 @@ export function Prompt(props: PromptProps) {
             id: PartID.ascending(),
             ...x,
           })),
-      })
+      }).catch(() => {})
     } else {
       sdk.client.session
         .prompt({

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -381,7 +381,7 @@ export const SessionRoutes = lazy(() =>
         }),
       ),
       async (c) => {
-        SessionPrompt.cancel(c.req.valid("param").sessionID)
+        await SessionPrompt.cancel(c.req.valid("param").sessionID).catch(() => {})
         return c.json(true)
       },
     )

--- a/packages/opencode/test/session/cancel.test.ts
+++ b/packages/opencode/test/session/cancel.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("SessionPrompt.cancel", () => {
+  test("does not produce unhandled rejections", async () => {
+    const rejections: unknown[] = []
+    const handler = (e: unknown) => rejections.push(e)
+    process.on("unhandledRejection", handler)
+
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })
+
+        const pending = SessionPrompt.loop({ sessionID: session.id })
+
+        await SessionPrompt.cancel(session.id)
+
+        await expect(pending).rejects.toThrow("Session cancelled")
+
+        await new Promise((r) => setTimeout(r, 50))
+
+        expect(rejections).toEqual([])
+      },
+    })
+
+    process.off("unhandledRejection", handler)
+  })
+
+  test("cancel on non-existent session does not throw", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await SessionPrompt.cancel("nonexistent" as any)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19855

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When you press Escape during active LLM generation, `SessionPrompt.cancel()` rejects pending callback promises. The abort endpoint at `session.ts:384` calls `cancel()` without `await` or `.catch()` — it fires the async function and immediately returns `c.json(true)`. The rejected promise has no handler, so Bun writes the stack trace to stderr. Since the TUI process has stderr pointed at the terminal (fd 2 → pts), the raw text renders over the TUI display.

Two additional SDK calls in the TUI prompt component also lack `.catch()`:
- `sdk.client.session.abort()` on double-Escape
- `sdk.client.session.command()` on slash commands

The fix adds `await` + `.catch(() => {})` to the abort endpoint handler, and `.catch(() => {})` to the two SDK calls. The cancel rejection is expected behavior (it's how the prompt loop knows to stop), so swallowing it is correct.

### How did you verify your code works?

- Added `test/session/cancel.test.ts` that creates a session, starts the prompt loop, calls cancel, and asserts no `unhandledRejection` event fires
- Traced the stack trace from user report (`at cancel(worker.js:231904)`) through source maps back to `SessionPrompt.cancel` in `prompt.ts`
- Verified all three call sites: abort endpoint returns before cancel completes (fire-and-forget), prompt abort has no catch, command has no catch

### Screenshots / recordings

Stack trace observed in TUI:
```
at cancel(/$bunfs/root/src/cli/cmd/tui/worker.js:231904:19)
at <anonymous> (/$bunfs/root/src/cli/cmd/tui/worker.js:306117:25)
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR