### PR TITLE
fix(custom-tools): preserve arg descriptions and enforce validation

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -119,11 +119,37 @@ export const layer: Layer.Layer<
       Effect.fn("ToolRegistry.state")(function* (ctx) {
         const custom: Tool.Def[] = []
 
+        // custom tools can load a different zod instance whose per-instance
+        // .describe()/.meta() registry won't survive z.toJSONSchema(). walk
+        // schemas once and copy metadata into this runtime's registry.
+        function rehydrateZodMeta(value: unknown, seen = new WeakSet<object>()): void {
+          if (!value || typeof value !== "object" || seen.has(value)) return
+          seen.add(value)
+
+          if ("_zod" in value) {
+            const schema = value as z.ZodType
+            const metaFn = Reflect.get(schema, "meta")
+            const meta = metaFn instanceof Function ? Reflect.apply(metaFn, schema, []) : undefined
+            const base = {} as Record<string, unknown>
+            if (meta && typeof meta === "object" && !("_zod" in meta))
+              Object.assign(base, meta as Record<string, unknown>)
+            const description = Reflect.get(schema, "description")
+            if (typeof description === "string" && base.description === undefined) base.description = description
+            if (Object.keys(base).length > 0) z.globalRegistry.add(schema, base)
+            rehydrateZodMeta(Reflect.get(Reflect.get(schema, "_zod") as object, "def"), seen)
+            return
+          }
+
+          const items = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>)
+          for (const item of items) rehydrateZodMeta(item, seen)
+        }
+
         function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
           // Plugin tools define their args as a raw Zod shape. Wrap the
           // derived Zod object in a `Schema.declare` so it slots into the
           // Schema-typed framework, and annotate with `ZodOverride` so the
           // walker emits the original Zod object for LLM JSON Schema.
+          for (const value of Object.values(def.args)) rehydrateZodMeta(value)
           const zodParams = z.object(def.args)
           const parameters = Schema.declare<unknown>((u): u is unknown => zodParams.safeParse(u).success).annotate({
             [ZodOverride]: zodParams,
@@ -134,13 +160,18 @@ export const layer: Layer.Layer<
             description: def.description,
             execute: (args, toolCtx) =>
               Effect.gen(function* () {
+                const validated = zodParams.safeParse(args)
+                if (!validated.success)
+                  throw new Error(
+                    `The ${id} tool was called with invalid arguments: ${validated.error}.\nPlease rewrite the input so it satisfies the expected schema.`,
+                  )
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
                   ask: (req) => toolCtx.ask(req),
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }
-                const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
+                const result = yield* Effect.promise(() => def.execute(validated.data as any, pluginCtx))
                 const output = typeof result === "string" ? result : result.output
                 const metadata = typeof result === "string" ? {} : (result.metadata ?? {})
                 const info = yield* agent.get(toolCtx.agent)

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
+import z from "zod"
 import { Effect, Layer } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { ToolRegistry } from "@/tool/registry"
@@ -184,5 +185,51 @@ describe("tool.registry", () => {
       const ids = yield* registry.ids()
       expect(ids).toContain("cowsay")
     }),
+  )
+
+  it.live("preserves described arg metadata for plugin tools", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const opencode = path.join(dir, ".opencode")
+        const tools = path.join(opencode, "tools")
+        yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+        yield* Effect.promise(() =>
+          Bun.write(
+            path.join(tools, "search.ts"),
+            [
+              "import { tool } from '@opencode-ai/plugin'",
+              "",
+              "export default tool({",
+              "  description: 'search custom docs',",
+              "  args: {",
+              "    query: tool.schema.string().describe('query to search for'),",
+              "    type: tool.schema",
+              "      .union([tool.schema.literal('regex'), tool.schema.literal('text')])",
+              "      .describe('regex or text mode'),",
+              "  },",
+              "  async execute() {",
+              "    return 'ok'",
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          ),
+        )
+        const registry = yield* ToolRegistry.Service
+        const list = yield* registry.tools({
+          providerID: "openai" as any,
+          modelID: "gpt-5" as any,
+          agent: { name: "build", mode: "primary", permission: [], options: {} },
+        })
+        const search = list.find((item) => item.id === "search")
+        expect(search).toBeDefined()
+
+        const schema = z.toJSONSchema(search!.parameters) as {
+          properties?: { query?: { description?: string }; type?: { description?: string } }
+        }
+        expect(schema.properties?.query?.description).toBe("query to search for")
+        expect(schema.properties?.type?.description).toBe("regex or text mode")
+      }),
+    ),
   )
 })


### PR DESCRIPTION
rehydrate cross-instance zod metadata so .describe() survives JSON schema export, and validate tool input at runtime before execute.

based on https://github.com/anomalyco/opencode/pull/15957 by @ashleytowner but rebased against latest dev branch.

### Issue for this PR

Closes #4357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

resolve an issue where custom tools created by plugins do not have their parameter descriptions passed through to the LLM.

### How did you verify your code works?

i tested my custom plugin with it: https://github.com/khimaros/opencode-evolve and descriptions on params are now present.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR