### PR TITLE
Fix variant dialog filtering

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
@@ -24,7 +24,6 @@ export function DialogVariant() {
       title={"Select variant"}
       current={local.model.variant.current()}
       flat={true}
-      skipFilter={true}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Remove `skipFilter={true}` from the variant dialog (`DialogVariant`), so the search input actually filters the list when typing

## Context
Ctrl+T opens the variant selector which renders a search input, but `skipFilter={true}` was bypassing the fuzzysort filtering logic — typing had no effect on the displayed options.