### PR TITLE
fix: ensure OPENCODE_DISABLE_CLAUDE_CODE_PROMPT is respected for project lvl CLAUDE.md

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -13,7 +13,7 @@ const log = Log.create({ service: "instruction" })
 
 const FILES = [
   "AGENTS.md",
-  "CLAUDE.md",
+  ...(Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT ? [] : ["CLAUDE.md"]),
   "CONTEXT.md", // deprecated
 ]
 


### PR DESCRIPTION
By default opencode reads ~/.claude/CLAUDE.md and CLAUDE.md if you do not have AGENTS.md

We have OPENCODE_DISABLE_CLAUDE_CODE_PROMPT to disable this behavior but it was only respected for the global claude.md.

This fixes it for project level too.