### PR TITLE
feat(provider): support per-provider Google credentials for Vertex AI

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -443,6 +443,9 @@ export namespace Provider {
 
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
+
+      const authOptions = provider.options?.googleAuthOptions
+
       return {
         autoload: true,
         vars(_options: Record<string, any>) {
@@ -456,10 +459,11 @@ export namespace Provider {
         options: {
           project,
           location,
+          ...(authOptions && { googleAuthOptions: authOptions }),
           fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-            const auth = new GoogleAuth()
-            const client = await auth.getApplicationDefault()
-            const token = await client.credential.getAccessToken()
+            const auth = new GoogleAuth(authOptions ?? {})
+            const client = await auth.getClient()
+            const token = await client.getAccessToken()
 
             const headers = new Headers(init?.headers)
             headers.set("Authorization", `Bearer ${token.token}`)
@@ -473,16 +477,26 @@ export namespace Provider {
         },
       }
     },
-    "google-vertex-anthropic": async () => {
-      const project = Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
-      const location = Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "global"
+    "google-vertex-anthropic": async (provider) => {
+      const project =
+        provider.options?.project ??
+        Env.get("GOOGLE_CLOUD_PROJECT") ??
+        Env.get("GCP_PROJECT") ??
+        Env.get("GCLOUD_PROJECT")
+      const location = String(
+        provider.options?.location ?? Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "global",
+      )
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
+
+      const authOptions = provider.options?.googleAuthOptions
+
       return {
         autoload: true,
         options: {
           project,
           location,
+          ...(authOptions && { googleAuthOptions: authOptions }),
         },
         async getModel(sdk: any, modelID) {
           const id = String(modelID).trim()

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2282,3 +2282,105 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
     },
   })
 })
+
+test("google-vertex-anthropic: respects config-level project and location", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "config-project",
+                location: "us-east5",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "env-project")
+      Env.set("GOOGLE_CLOUD_LOCATION", "env-location")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const p = providers[ProviderID.make("google-vertex-anthropic")]
+      expect(p).toBeDefined()
+      expect(p.options.project).toBe("config-project")
+      expect(p.options.location).toBe("us-east5")
+    },
+  })
+})
+
+test("google-vertex: passes googleAuthOptions to provider options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex": {
+              options: {
+                project: "test-project",
+                location: "us-central1",
+                googleAuthOptions: { keyFilename: "/path/to/key.json" },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const p = providers[ProviderID.make("google-vertex")]
+      expect(p).toBeDefined()
+      expect(p.options.googleAuthOptions).toEqual({ keyFilename: "/path/to/key.json" })
+    },
+  })
+})
+
+test("google-vertex-anthropic: passes googleAuthOptions to provider options", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "google-vertex-anthropic": {
+              options: {
+                project: "test-project",
+                googleAuthOptions: { keyFilename: "/path/to/anthropic-key.json" },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GOOGLE_CLOUD_PROJECT", "test-project")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const p = providers[ProviderID.make("google-vertex-anthropic")]
+      expect(p).toBeDefined()
+      expect(p.options.googleAuthOptions).toEqual({ keyFilename: "/path/to/anthropic-key.json" })
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19930

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Passes `googleAuthOptions` from provider config through to the AI SDK for both
`google-vertex` and `google-vertex-anthropic`, so each provider can authenticate
with separate GCP credentials.

Changes to `google-vertex` loader:
- Extracts `googleAuthOptions` from config and spreads it into SDK options
- Passes it to `new GoogleAuth(...)` in the custom fetch for openai-compatible models
- Switches from `getApplicationDefault()` to `getClient()` (backward-compatible,
  falls back to ADC when no explicit credentials given)

Changes to `google-vertex-anthropic` loader:
- Fixes a bug where the function signature was `async () =>`, silently ignoring
  all config options (`project`, `location`, etc.)
- Now checks config options before env vars for `project` and `location`,
  matching the `google-vertex` pattern
- Passes `googleAuthOptions` through to SDK options

Both changes are backward-compatible. When `googleAuthOptions` is absent, behavior
is identical to before.

### How did you verify your code works?

- `bun typecheck` passes (exit 0)
- `bun test test/provider/provider.test.ts` passes (73 pass, 0 fail) including
  3 new tests:
  - `google-vertex-anthropic: respects config-level project and location`
  - `google-vertex: passes googleAuthOptions to provider options`
  - `google-vertex-anthropic: passes googleAuthOptions to provider options`

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR