### PR TITLE
fix: ensure wl-copy stdin is flushed before closing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -118,8 +118,15 @@ export namespace Clipboard {
         return async (text: string) => {
           const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           if (!proc.stdin) return
-          proc.stdin.write(text)
-          proc.stdin.end()
+          await new Promise<void>((resolve, reject) => {
+            proc.stdin!.write(text, (err) => {
+              if (err) reject(err)
+              else {
+                proc.stdin!.end()
+                resolve()
+              }
+            })
+          })
           await proc.exited.catch(() => {})
         }
       }


### PR DESCRIPTION
Fixes clipboard write on Wayland by properly awaiting the stdin write callback instead of calling write() and end() synchronously.

### Issue for this PR
Closes # N/A

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
The wl-copy command was being used incorrectly - stdin.write() and stdin.end() were called synchronously without waiting for the write callback to complete. This caused clipboard data to be lost on Wayland because the process would exit before the data was fully written.
The fix wraps the write operation in a Promise that resolves only after the write callback fires, ensuring the data is flushed before the stdin is closed.

### How did you verify your code works?
Tested locally on a Wayland system (Sway) where clipboard operations were previously failing. The fix ensures text is properly written to the clipboard.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR