### PR TITLE
feat(github): auto-extract issue prompt on assignment and opened events

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -770,13 +770,29 @@ export const GithubRunCommand = cmd({
 
       async function getUserPrompt() {
         const customPrompt = process.env["PROMPT"]
-        // For repo events and issues events, PROMPT is required since there's no comment to extract from
-        if (isRepoEvent || isIssuesEvent) {
+        // For repo events, PROMPT is required since there's no comment/issue to extract from
+        if (isRepoEvent) {
           if (!customPrompt) {
-            const eventType = isRepoEvent ? "scheduled and workflow_dispatch" : "issues"
-            throw new Error(`PROMPT input is required for ${eventType} events`)
+            throw new Error(`PROMPT input is required for scheduled and workflow_dispatch events`)
           }
           return { userPrompt: customPrompt, promptFiles: [] }
+        }
+        // For issues events: auto-extract issue title+body when assigned or opened, otherwise require PROMPT
+        if (isIssuesEvent) {
+          if (customPrompt) {
+            return { userPrompt: customPrompt, promptFiles: [] }
+          }
+          const issuesPayload = payload as IssuesEvent
+          if (issuesPayload.action === "assigned" || issuesPayload.action === "opened") {
+            const issue = issuesPayload.issue
+            const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
+            const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
+            return {
+              userPrompt: `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`,
+              promptFiles: [],
+            }
+          }
+          throw new Error(`PROMPT input is required for issues events with action "${issuesPayload.action}"`)
         }
 
         if (customPrompt) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -189,6 +189,21 @@ export function formatPromptTooLargeError(files: { filename: string; content: st
   return `PROMPT_TOO_LARGE: The prompt exceeds the model's context limit.${fileDetails}`
 }
 
+/**
+ * Builds a prompt string from a GitHub issue payload.
+ * Used when an issue is assigned or opened to auto-extract the issue context.
+ */
+export function buildIssuePrompt(issue: {
+  number: number
+  title: string
+  body?: string | null
+  labels?: (string | { name?: string })[]
+}): string {
+  const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
+  const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
+  return `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`
+}
+
 export const GithubCommand = cmd({
   command: "github",
   describe: "manage GitHub agent",
@@ -784,11 +799,8 @@ export const GithubRunCommand = cmd({
           }
           const issuesPayload = payload as IssuesEvent
           if (issuesPayload.action === "assigned" || issuesPayload.action === "opened") {
-            const issue = issuesPayload.issue
-            const labels = issue.labels?.map((l) => (typeof l === "string" ? l : l.name)).filter(Boolean)
-            const labelText = labels?.length ? `\nLabels: ${labels.join(", ")}` : ""
             return {
-              userPrompt: `Issue #${issue.number}: ${issue.title}${labelText}\n\n${issue.body || "No description provided."}`,
+              userPrompt: buildIssuePrompt(issuesPayload.issue),
               promptFiles: [],
             }
           }

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test"
-import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
+import { extractResponseText, formatPromptTooLargeError, buildIssuePrompt } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
@@ -194,5 +194,114 @@ describe("formatPromptTooLargeError", () => {
     expect(result).toInclude("img1.png (3 KB)")
     expect(result).toInclude("img2.jpg (6 KB)")
     expect(result).toInclude("img3.gif (9 KB)")
+  })
+})
+
+describe("buildIssuePrompt", () => {
+  test("builds prompt with title and body", () => {
+    const result = buildIssuePrompt({
+      number: 42,
+      title: "Fix login bug",
+      body: "Users cannot log in with SSO.",
+    })
+    expect(result).toBe("Issue #42: Fix login bug\n\nUsers cannot log in with SSO.")
+  })
+
+  test("uses fallback when body is null", () => {
+    const result = buildIssuePrompt({
+      number: 1,
+      title: "No body issue",
+      body: null,
+    })
+    expect(result).toInclude("No description provided.")
+    expect(result).toStartWith("Issue #1: No body issue")
+  })
+
+  test("uses fallback when body is undefined", () => {
+    const result = buildIssuePrompt({
+      number: 1,
+      title: "No body issue",
+    })
+    expect(result).toInclude("No description provided.")
+  })
+
+  test("uses fallback when body is empty string", () => {
+    const result = buildIssuePrompt({
+      number: 5,
+      title: "Empty body",
+      body: "",
+    })
+    expect(result).toInclude("No description provided.")
+  })
+
+  test("includes labels from string array", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Labeled issue",
+      body: "Some body",
+      labels: ["bug", "priority"],
+    })
+    expect(result).toInclude("Labels: bug, priority")
+  })
+
+  test("includes labels from object array", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Labeled issue",
+      body: "Some body",
+      labels: [{ name: "enhancement" }, { name: "help wanted" }],
+    })
+    expect(result).toInclude("Labels: enhancement, help wanted")
+  })
+
+  test("handles mixed label types (string and object)", () => {
+    const result = buildIssuePrompt({
+      number: 10,
+      title: "Mixed labels",
+      body: "Body",
+      labels: ["bug", { name: "urgent" }],
+    })
+    expect(result).toInclude("Labels: bug, urgent")
+  })
+
+  test("omits labels line when labels array is empty", () => {
+    const result = buildIssuePrompt({
+      number: 3,
+      title: "No labels",
+      body: "Body text",
+      labels: [],
+    })
+    expect(result).not.toInclude("Labels:")
+    expect(result).toBe("Issue #3: No labels\n\nBody text")
+  })
+
+  test("omits labels line when labels is undefined", () => {
+    const result = buildIssuePrompt({
+      number: 3,
+      title: "No labels",
+      body: "Body text",
+    })
+    expect(result).not.toInclude("Labels:")
+  })
+
+  test("filters out labels with missing name", () => {
+    const result = buildIssuePrompt({
+      number: 7,
+      title: "Partial labels",
+      body: "Body",
+      labels: [{ name: "valid" }, { name: undefined } as any, { name: "" }],
+    })
+    expect(result).toInclude("Labels: valid")
+  })
+
+  test("preserves markdown formatting in body", () => {
+    const body = "## Steps to reproduce\n\n1. Open the app\n2. Click login\n\n```js\nconsole.log('test')\n```"
+    const result = buildIssuePrompt({
+      number: 99,
+      title: "Markdown body",
+      body,
+    })
+    expect(result).toInclude("## Steps to reproduce")
+    expect(result).toInclude("```js")
   })
 })


### PR DESCRIPTION
## Summary

- Auto-extract issue title, body, and labels as the prompt when `issues` events fire with `assigned` or `opened` actions
- Removes the hard requirement for `PROMPT` env var on these issue actions
- Enables a "assign to bot → it works on it" workflow

## Changes

**`packages/opencode/src/cli/cmd/github.ts`**

The `getUserPrompt()` function previously required the `PROMPT` environment variable for all `issues` events. Now:

1. If `PROMPT` is set, it's used as an override (backward compatible)
2. For `assigned` and `opened` actions: auto-constructs prompt from `issue.title`, `issue.body`, and `issue.labels`
3. For other actions (e.g. `labeled`, `closed`): still requires `PROMPT`

The downstream issue handling flow (branch creation, work, PR/comment) is unchanged.

## Testing

- The change is self-contained in `getUserPrompt()` and doesn't affect any other code paths
- `PROMPT` env var override still works for all event types (backward compatible)
- The `assigned` and `opened` paths construct the same prompt format that `PROMPT` users would provide manually

Refs #19926