### PR TITLE
fix(tui): use roots filter instead of time-based filter for session list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -357,9 +357,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     async function bootstrap() {
       console.log("bootstrapping")
-      const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
-        .list({ start: start })
+        .list({ roots: true })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session


### PR DESCRIPTION
## Summary

- The TUI `/sessions` picker shows far fewer sessions than expected for users with heavy subagent usage
- Root cause: hardcoded 30-day time filter + no `roots` filter + default limit of 100 = most slots consumed by child sessions
- Fix: replace `{ start: 30days }` with `{ roots: true }` so the server returns only root sessions

## Problem

`bootstrap()` in `sync.tsx` fetches sessions with a 30-day time filter but no `roots` filter:

```ts
const start = Date.now() - 30 * 24 * 60 * 60 * 1000
sdk.client.session.list({ start: start })
```

With the default `limit: 100`, most returned sessions are child/subagent sessions. The UI then filters for root sessions only (`parentID === undefined` in `dialog-session-list.tsx`), leaving very few visible — often only ~2 days worth.

Data from a real database (3170 project sessions, 248 root):

| Query | Total returned | Root sessions visible in UI |
|---|---|---|
| `{ start: 30days }` (current) | 100 | 10 |
| `{ roots: true }` (this PR) | 100 | 100 |

## Fix

Replace the time-based filter with `roots: true`. The server already supports this (`session/index.ts` adds `WHERE parent_id IS NULL`), and the default limit of 100 provides a reasonable cap.

Fixes #16733