### PR TITLE
fix(session): ensure aborted tool executions keep start time

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -405,7 +405,10 @@ export namespace SessionProcessor {
                 ...part.state,
                 status: "error",
                 error: "Tool execution aborted",
-                time: { start: Date.now(), end: Date.now() },
+                time: {
+                  start: "time" in part.state ? part.state.time.start : Date.now(),
+                  end: Date.now(),
+                },
               },
             })
           }


### PR DESCRIPTION
Fixes #19971

### Type of change

- [x] Bug fix

### What does this PR do?

When a tool execution is aborted, both `time.start` and `time.end` were being set to `Date.now()`, losing the original start time. This means aborted tool calls appear to have taken zero time rather than reflecting their actual duration.

The fix checks whether `time` already exists on `part.state` before setting `time.start`, preserving the original value if present.

### How did you verify your code works?

Triggered a tool execution and aborted it mid-run; confirmed the reported start time matches when the tool actually began rather than when it was aborted.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR