### PR TITLE
fix(opencode): preserve tool execution start time on abort

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -405,7 +405,7 @@ export namespace SessionProcessor {
                 ...part.state,
                 status: "error",
                 error: "Tool execution aborted",
-                time: { start: Date.now(), end: Date.now() },
+                time: { start: "time" in part.state ? part.state.time.start : Date.now(), end: Date.now() },
               },
             })
           }


### PR DESCRIPTION
### Issue for this PR

Closes #19971

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a tool execution is aborted, both `time.start` and `time.end` were set to `Date.now()`, losing the original start time. Now the abort handler preserves the original start time from `part.state.time.start` when available, and falls back to `Date.now()` for tools still in pending state.

One-line change in `processor.ts`.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` with no errors. Reviewed the abort handler logic -- the `part.state` union type correctly distinguishes pending (no `time`) from running (has `time`), and the `"time" in part.state` guard handles both cases.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR