### PR TITLE
fix(opencode): preserve tool argument descriptions in schema conversion

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import os from "os"
 import z from "zod"
+import { zodToJsonSchema } from "zod-to-json-schema"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { Log } from "../util/log"
@@ -436,7 +437,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           { modelID: ModelID.make(input.model.api.id), providerID: input.model.providerID },
           input.agent,
         )) {
-          const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+          const schema = ProviderTransform.schema(input.model, zodToJsonSchema(item.parameters) as Record<string, unknown>)
           tools[item.id] = tool({
             id: item.id as any,
             description: item.description,


### PR DESCRIPTION
### Issue for this PR

Closes #4357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prompt.ts` used `z.toJSONSchema()` to convert tool parameter schemas, which drops `.describe()` metadata from Zod fields. The LLM never saw what each tool argument was for. Switched to `zodToJsonSchema()` from the `zod-to-json-schema` package, which is already a dependency and already used in `server.ts` for the same purpose.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` -- no errors. Confirmed that `zod-to-json-schema` is already used in `server/routes/experimental.ts` and correctly preserves `.describe()` metadata.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR