### PR TITLE
fix(opencode): strip file extension from Bedrock DocumentBlock name

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -275,9 +275,24 @@ export namespace ProviderTransform {
     })
   }
 
+  function sanitizeBedrockFilenames(msgs: ModelMessage[]): ModelMessage[] {
+    return msgs.map((msg) => {
+      if (msg.role !== "user" || !Array.isArray(msg.content)) return msg
+      const content = msg.content.map((part) => {
+        if (part.type !== "file" || !part.filename) return part
+        const sanitized = part.filename.replace(/\.[^.]+$/, "").replace(/[^a-zA-Z0-9\s\-()[\]]/g, "-")
+        return { ...part, filename: sanitized || "file" }
+      })
+      return { ...msg, content }
+    })
+  }
+
   export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
     msgs = unsupportedParts(msgs, model)
     msgs = normalizeMessages(msgs, model, options)
+    if (model.providerID.includes("bedrock") || model.api.npm === "@ai-sdk/amazon-bedrock") {
+      msgs = sanitizeBedrockFilenames(msgs)
+    }
     if (
       (model.providerID === "anthropic" ||
         model.api.id.includes("anthropic") ||


### PR DESCRIPTION
### Issue for this PR

Closes #19964

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bedrock's Converse API rejects DocumentBlock names containing dots or underscores. When sending file attachments like "report.pdf", the filename was passed as-is and Bedrock rejected it. Added a sanitize step in `transform.ts` that strips the file extension and removes disallowed characters from the filename, only for Bedrock providers.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` -- no errors. The sanitize function strips extensions with a regex and replaces invalid chars. Verified the Bedrock API spec allows only alphanumeric, spaces, hyphens, parentheses, and brackets in the name field.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR