### PR TITLE
fix(opencode): support compound file extensions in formatter matching

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -100,12 +100,24 @@ export namespace Format {
             return checks.filter((x) => x.enabled).map((x) => x.item)
           }
 
+          function extensions(filepath: string) {
+            const parts = path.basename(filepath).split(".")
+            return parts.slice(1).map((_, i) => "." + parts.slice(i + 1).join("."))
+          }
+
           function formatFile(filepath: string) {
             return Effect.gen(function* () {
               log.info("formatting", { file: filepath })
-              const ext = path.extname(filepath)
+              const exts = extensions(filepath)
+              const matches = yield* Effect.promise(async () => {
+                for (const ext of exts) {
+                  const found = await getFormatter(ext)
+                  if (found.length > 0) return found
+                }
+                return []
+              })
 
-              for (const item of yield* Effect.promise(() => getFormatter(ext))) {
+              for (const item of matches) {
                 log.info("running", { command: item.command })
                 const cmd = item.command.map((x) => x.replace("$FILE", filepath))
                 const code = yield* spawner


### PR DESCRIPTION
### Issue for this PR

Closes #3431

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`path.extname()` only returns the last extension, so `template.blade.php` matched `.php` formatters but never `.blade.php` ones. Now the formatter extracts all possible extensions from most-specific to least-specific and uses the first match. For `template.blade.php` it tries `.blade.php` first, then `.php`. Existing single-extension configs are unaffected.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` -- no errors. Manually traced the logic: `"template.blade.php".split(".")` gives `["template", "blade", "php"]`, producing extensions `[".blade.php", ".php"]` in the right priority order.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR