### PR TITLE
fix(opentui): add default option to variant selector

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
@@ -8,7 +8,15 @@ export function DialogVariant() {
   const dialog = useDialog()
 
   const options = createMemo(() => {
-    return local.model.variant.list().map((variant) => ({
+    const none = {
+      value: "",
+      title: "default",
+      onSelect: () => {
+        dialog.clear()
+        local.model.variant.set(undefined)
+      },
+    }
+    const variants = local.model.variant.list().map((variant) => ({
       value: variant,
       title: variant,
       onSelect: () => {
@@ -16,13 +24,14 @@ export function DialogVariant() {
         local.model.variant.set(variant)
       },
     }))
+    return [none, ...variants]
   })
 
   return (
     <DialogSelect<string>
       options={options()}
       title={"Select variant"}
-      current={local.model.variant.current()}
+      current={local.model.variant.current() ?? ""}
       flat={true}
     />
   )


### PR DESCRIPTION
### Issue for this PR

Closes #19696

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The variant selector dialog only listed model-defined variants like "thinking" with no way to deselect back to the default mode. Added a "default" entry at the top of the option list that clears the variant. The `cycle()` method already supported cycling back to undefined, but the dialog UI was missing this option.

### How did you verify your code works?

Ran `bun typecheck` in `packages/opencode` -- no errors. The "default" option calls `local.model.variant.set(undefined)` which is the same path used by `cycle()` when it wraps around.

### Screenshots / recordings

_Not a UI change (TUI component). The variant selector dialog now shows "default" as the first option above the existing variants._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR