### PR TITLE
docs: rename patch tool to apply_patch and clarify apply_patch behavior

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -95,7 +95,7 @@ Create new files or overwrite existing ones.
 Use this to allow the LLM to create new files. It will overwrite existing files if they already exist.
 
 :::note
-The `write` tool is controlled by the `edit` permission, which covers all file modifications (`edit`, `write`, `patch`, `multiedit`).
+The `write` tool is controlled by the `edit` permission, which covers all file modifications (`edit`, `write`, `apply_patch`, `multiedit`).
 :::
 
 ---
@@ -191,7 +191,7 @@ To configure which LSP servers are available for your project, see [LSP Servers]
 
 ---
 
-### patch
+### apply_patch
 
 Apply patches to files.
 
@@ -206,8 +206,12 @@ Apply patches to files.
 
 This tool applies patch files to your codebase. Useful for applying diffs and patches from various sources.
 
+When handling `tool.execute.before` or `tool.execute.after` hooks, check `input.tool === "apply_patch"` (not `"patch"`).
+
+`apply_patch` uses `output.args.patchText` instead of `output.args.filePath`. Paths are embedded in marker lines within `patchText` and are relative to the project root (for example: `*** Add File: src/new-file.ts`, `*** Update File: src/existing.ts`, `*** Move to: src/renamed.ts`, `*** Delete File: src/obsolete.ts`).
+
 :::note
-The `patch` tool is controlled by the `edit` permission, which covers all file modifications (`edit`, `write`, `patch`, `multiedit`).
+The `apply_patch` tool is controlled by the `edit` permission, which covers all file modifications (`edit`, `write`, `apply_patch`, `multiedit`).
 :::
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #19941

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR fixes the built-in tool naming mismatch in the Tools docs.

Previously, the docs listed the patching tool as `patch`, but the actual registered tool ID is `apply_patch`. That mismatch caused plugin hooks checking `input.tool === "patch"` to never fire.

Changes made:
- Renamed the built-in tool section heading from `patch` to `apply_patch`.
- Updated permission notes to reference `apply_patch` instead of `patch`.
- Added explicit hook guidance to use `input.tool === "apply_patch"`.
- Documented the `apply_patch` args shape:
  - Uses `output.args.patchText`
  - Does not expose `output.args.filePath`
  - Paths are embedded in marker lines and are relative to project root.

Why this works:
- It aligns documentation with the actual tool registry name in source.
- It prevents silent plugin hook failures due to incorrect tool ID checks.
- It clarifies how to parse file paths from `patchText`, matching runtime behavior.

### How did you verify your code works?

- Reviewed and updated the relevant section in `packages/web/src/content/docs/tools.mdx`.
- Verified all changed references consistently use `apply_patch`.

### Screenshots / recordings

Not applicable (documentation-only change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR