### PR TITLE
docs: clarify that config file is not auto-created

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -22,6 +22,8 @@ OpenCode supports both **JSON** and **JSONC** (JSON with Comments) formats.
 }
 ```
 
+> **Note:** OpenCode works out of the box without any config file. The `opencode.json` file is **not auto-created** — you only need to create one when you want to customize OpenCode's behavior.
+
 ---
 
 ## Locations
@@ -101,6 +103,8 @@ Place your global OpenCode config in `~/.config/opencode/opencode.json`. Use glo
 For TUI-specific settings, use `~/.config/opencode/tui.json`.
 
 Global config overrides remote organizational defaults.
+
+> **Tip:** Runtime UI preferences like your theme selection (via `/theme`) are stored in `~/.local/state/opencode/kv.json` and persist across restarts.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #4208

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Issue #4208 reports that after installing OpenCode (via brew or npm), users cannot find the `opencode.json` config file at `~/.config/opencode/`. The config docs describe where to place the file (e.g. "Place your global OpenCode config in `~/.config/opencode/opencode.json`") but never clarify that this file needs to be manually created — it is not auto-generated. The user also noticed that their theme selection persists across restarts but had no way of knowing where that preference was being saved.

The root cause is twofold:

1. **OpenCode does not auto-create a config file.** It works entirely with defaults out of the box. The config directories (`~/.config/opencode/`, etc.) are created at startup, but no `opencode.json` or `tui.json` is generated. Users only need to create these files manually when they want to customize behavior. The existing docs never stated this, which can lead users to believe something is broken.

2. **Runtime UI preferences are stored in a separate KV store.** When a user selects a theme via `/theme`, that preference is saved to `~/.local/state/opencode/kv.json` — a runtime state file that is not mentioned anywhere in the config docs. This explains why the user's theme persisted despite no config file existing.

This PR adds two blockquote callouts to `config.mdx`:

- A **Note** after the "Format" section clarifying that `opencode.json` is not auto-created and only needs to be manually created when customizing.
- A **Tip** in the "Global" section explaining that runtime UI preferences (like theme) are stored in `~/.local/state/opencode/kv.json` and persist across restarts.

### How did you verify your code works?

Reviewed the config loading code in `packages/opencode/src/config/config.ts` to confirm that `opencode.json` is indeed never auto-created — the `loadFile` function catches `ENOENT` silently and proceeds with an empty config. Also verified the KV store path in `packages/opencode/src/cli/cmd/tui/context/kv.tsx` (line 13) which confirms `~/.local/state/opencode/kv.json` as the storage location for runtime TUI preferences.

### Screenshots / recordings

N/A — text-only documentation change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR