### PR TITLE
make variant modal less annoying

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -581,10 +581,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: "Switch model variant",
+      title: "Variant cycle",
       value: "variant.cycle",
       keybind: "variant_cycle",
       category: "Agent",
+      onSelect: () => {
+        local.model.variant.cycle()
+      },
+    },
+    {
+      title: "Switch model variant",
+      value: "variant.list",
+      category: "Agent",
+      hidden: local.model.variant.list().length === 0,
+      slash: {
+        name: "variants",
+      },
       onSelect: () => {
         dialog.replace(() => <DialogVariant />)
       },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -136,7 +136,13 @@ export function DialogModel(props: { providerID?: string }) {
 
   function onSelect(providerID: string, modelID: string) {
     local.model.set({ providerID, modelID }, { recent: true })
-    if (local.model.variant.list().length > 0) {
+    const list = local.model.variant.list()
+    const cur = local.model.variant.selected()
+    if (cur === "default" || (cur && list.includes(cur))) {
+      dialog.clear()
+      return
+    }
+    if (list.length > 0) {
       dialog.replace(() => <DialogVariant />)
       return
     }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-variant.tsx
@@ -8,21 +8,31 @@ export function DialogVariant() {
   const dialog = useDialog()
 
   const options = createMemo(() => {
-    return local.model.variant.list().map((variant) => ({
-      value: variant,
-      title: variant,
-      onSelect: () => {
-        dialog.clear()
-        local.model.variant.set(variant)
+    return [
+      {
+        value: "default",
+        title: "Default",
+        onSelect: () => {
+          dialog.clear()
+          local.model.variant.set(undefined)
+        },
       },
-    }))
+      ...local.model.variant.list().map((variant) => ({
+        value: variant,
+        title: variant,
+        onSelect: () => {
+          dialog.clear()
+          local.model.variant.set(variant)
+        },
+      })),
+    ]
   })
 
   return (
     <DialogSelect<string>
       options={options()}
       title={"Select variant"}
-      current={local.model.variant.current()}
+      current={local.model.variant.selected()}
       flat={true}
     />
   )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -632,7 +632,7 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
-    const variant = local.model.variant.selected()
+    const variant = local.model.variant.current()
 
     if (store.mode === "shell") {
       sdk.client.session.shell({

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -632,7 +632,7 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
-    const variant = local.model.variant.current()
+    const variant = local.model.variant.selected()
 
     if (store.mode === "shell") {
       sdk.client.session.shell({

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -351,12 +351,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           cycle() {
             const variants = this.list()
             if (variants.length === 0) return
-            const cur = this.current()
-            if (!cur) {
+            const current = this.current()
+            if (!current) {
               this.set(variants[0])
               return
             }
-            const index = variants.indexOf(cur)
+            const index = variants.indexOf(current)
             if (index === -1 || index === variants.length - 1) {
               this.set(undefined)
               return

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -321,11 +321,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
         },
         variant: {
-          current() {
+          selected() {
             const m = currentModel()
             if (!m) return undefined
             const key = `${m.providerID}/${m.modelID}`
             return modelStore.variant[key]
+          },
+          current() {
+            const v = this.selected()
+            if (!v) return undefined
+            if (!this.list().includes(v)) return undefined
+            return v
           },
           list() {
             const m = currentModel()
@@ -339,18 +345,18 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             const m = currentModel()
             if (!m) return
             const key = `${m.providerID}/${m.modelID}`
-            setModelStore("variant", key, value)
+            setModelStore("variant", key, value ?? "default")
             save()
           },
           cycle() {
             const variants = this.list()
             if (variants.length === 0) return
-            const current = this.current()
-            if (!current) {
+            const cur = this.current()
+            if (!cur) {
               this.set(variants[0])
               return
             }
-            const index = variants.indexOf(current)
+            const index = variants.indexOf(cur)
             if (index === -1 || index === variants.length - 1) {
               this.set(undefined)
               return


### PR DESCRIPTION
## Summary
- remember the variant choice per model, including choosing the default
- only prompt for a variant once per model; after that `ctrl+t` cycles variants and `/variants` opens the modal manually