### PR TITLE
fix: clean up orphaned processes and LSP state on shutdown

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -35,6 +35,7 @@ import { JsonMigration } from "./storage/json-migration"
 import { Database } from "./storage/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
+import { registerSignals } from "./signal"
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {
@@ -47,6 +48,8 @@ process.on("uncaughtException", (e) => {
     e: errorMessage(e),
   })
 })
+
+registerSignals()
 
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -238,6 +238,8 @@ export namespace LSPClient {
       },
       async shutdown() {
         l.info("shutting down")
+        diagnostics.clear()
+        for (const key of Object.keys(files)) delete files[key]
         connection.end()
         connection.dispose()
         await Process.stop(input.server.process)

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -217,6 +217,9 @@ export namespace LSP {
           yield* Effect.addFinalizer(() =>
             Effect.promise(async () => {
               await Promise.all(s.clients.map((client) => client.shutdown()))
+              s.clients.length = 0
+              s.broken.clear()
+              s.spawning.clear()
             }),
           )
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -712,6 +712,7 @@ export namespace SessionPrompt {
         model,
         toolChoice: format.type === "json_schema" ? "required" : undefined,
       })
+      msgs.length = 0
 
       // If structured output was captured, save it and exit immediately
       // This takes priority because the StructuredOutput tool was called successfully

--- a/packages/opencode/src/signal.ts
+++ b/packages/opencode/src/signal.ts
@@ -1,0 +1,40 @@
+import { Instance } from "./project/instance"
+import { Log } from "./util/log"
+
+const timeout = 5000
+const code = {
+  SIGHUP: 129,
+  SIGPIPE: 141,
+  SIGTERM: 143,
+} as const
+
+let exiting = false
+
+async function shutdown(sig: keyof typeof code) {
+  if (exiting) return
+  exiting = true
+  const log = Log.create({ service: "signal" })
+  log.info("shutdown", { sig })
+  const timer = setTimeout(() => {
+    log.warn("shutdown timeout", { sig, timeout })
+    process.exit(code[sig])
+  }, timeout)
+  timer.unref()
+
+  try {
+    await Instance.disposeAll()
+  } catch (err) {
+    log.error("shutdown failed", { err })
+  } finally {
+    clearTimeout(timer)
+    process.exit(code[sig])
+  }
+}
+
+export function registerSignals() {
+  for (const sig of Object.keys(code) as (keyof typeof code)[]) {
+    process.on(sig, () => {
+      void shutdown(sig)
+    })
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #12767
Related to #18632

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two shutdown paths that still look leaky on current `dev`.

First, `packages/opencode/src/index.ts` does not register process-level handlers for `SIGTERM`, `SIGHUP`, or `SIGPIPE`. The TUI has its own `SIGHUP` handling, but commands like `opencode run`, `opencode acp`, and `opencode serve` do not. This PR adds a small `signal.ts` helper that calls `Instance.disposeAll()` and then exits, with a 5 second timeout in case cleanup hangs.

Second, LSP shutdown was stopping the child process but keeping in-memory state alive. This clears the LSP diagnostics map, file version map, and the top-level LSP client caches during shutdown.

I also clear the prompt `msgs` array right after `processor.process(...)` returns, since that array can get large and is not needed for the rest of the loop iteration.

I did not copy over older PR changes around plugin subscriptions or processor cleanup because current `dev` already uses scoped Effect subscriptions there, and `SessionProcessor` already runs cleanup through `Effect.ensuring(cleanup())`.

### How did you verify your code works?

I tested the signal path locally with the ACP command, since it is a long-running non-TUI entrypoint:

- started `bun run ./src/index.ts acp`
- sent `SIGHUP`
- confirmed the process exited
- started it again
- sent `SIGTERM`
- confirmed the process exited

I also tried to run `bun typecheck` in `packages/opencode`, but this checkout currently does not have `tsgo` installed in `node_modules/.bin`, so the script exits before typechecking starts.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR