### PR TITLE
fix: support ACP question prompts via extMethod

### DIFF
--- a/packages/opencode/src/acp/README.md
+++ b/packages/opencode/src/acp/README.md
@@ -54,6 +54,51 @@ OPENCODE_ENABLE_QUESTION_TOOL=1 opencode acp
 
 Enable this only for ACP clients that support interactive question prompts.
 
+Question support also requires the ACP client to advertise the following capability at initialize time:
+
+```json
+{
+  "clientCapabilities": {
+    "_meta": {
+      "opencode/question": {
+        "version": 1
+      }
+    }
+  }
+}
+```
+
+When enabled, opencode sends question requests over the ACP extension method `opencode/question`:
+
+```json
+{
+  "requestId": "que_123",
+  "sessionId": "ses_123",
+  "questions": [
+    {
+      "header": "Build Agent",
+      "question": "Start implementing now?",
+      "options": [
+        { "label": "Yes", "description": "Switch to build agent and start implementing" },
+        { "label": "No", "description": "Stay in the current mode" }
+      ]
+    }
+  ]
+}
+```
+
+The client should return either:
+
+```json
+{ "answers": [["Yes"]] }
+```
+
+or:
+
+```json
+{ "rejected": true }
+```
+
 ### Programmatic
 
 ```typescript

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -42,13 +42,24 @@ import { Config } from "@/config/config"
 import { Todo } from "@/session/todo"
 import { z } from "zod"
 import { LoadAPIKeyError } from "ai"
-import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
+import type {
+  AssistantMessage,
+  Event,
+  OpencodeClient,
+  QuestionRequest,
+  SessionMessageResponse,
+  ToolPart,
+} from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
+import { Flag } from "@/flag/flag"
 
 type ModeOption = { id: string; name: string; description?: string }
 type ModelOption = { modelId: string; name: string }
 
 const DEFAULT_VARIANT_VALUE = "default"
+const QuestionCap = z.union([z.literal(true), z.object({ version: z.number().int().positive().optional() })])
+const QuestionReply = z.object({ answers: z.array(z.array(z.string())) })
+const QuestionReject = z.object({ rejected: z.literal(true) })
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
@@ -136,9 +147,11 @@ export namespace ACP {
     private sessionManager: ACPSessionManager
     private eventAbort = new AbortController()
     private eventStarted = false
+    private question = false
     private bashSnapshots = new Map<string, string>()
     private toolStarts = new Set<string>()
     private permissionQueues = new Map<string, Promise<void>>()
+    private questionQueues = new Map<string, Promise<void>>()
     private permissionOptions: PermissionOption[] = [
       { optionId: "once", kind: "allow_once", name: "Allow once" },
       { optionId: "always", kind: "allow_always", name: "Always allow" },
@@ -259,6 +272,86 @@ export namespace ACP {
               }
             })
           this.permissionQueues.set(permission.sessionID, next)
+          return
+        }
+
+        case "question.asked": {
+          const question = event.properties as QuestionRequest
+          const session = this.sessionManager.tryGet(question.sessionID)
+          if (!session) return
+
+          const prev = this.questionQueues.get(question.sessionID) ?? Promise.resolve()
+          const next = prev
+            .then(async () => {
+              const directory = session.cwd
+
+              if (!this.question) {
+                log.warn("question requested without ACP question support", {
+                  questionID: question.id,
+                  sessionID: question.sessionID,
+                })
+                await this.sdk.question.reject({
+                  requestID: question.id,
+                  directory,
+                })
+                return
+              }
+
+              const res = await this.connection
+                .extMethod("opencode/question", {
+                  requestId: question.id,
+                  sessionId: question.sessionID,
+                  questions: question.questions,
+                  tool: question.tool,
+                })
+                .catch((error) => {
+                  log.error("failed to request question response from ACP", {
+                    error,
+                    questionID: question.id,
+                    sessionID: question.sessionID,
+                  })
+                  return undefined
+                })
+
+              const reply = QuestionReply.safeParse(res)
+              if (reply.success) {
+                await this.sdk.question.reply({
+                  requestID: question.id,
+                  answers: reply.data.answers,
+                  directory,
+                })
+                return
+              }
+
+              const reject = QuestionReject.safeParse(res)
+              if (reject.success) {
+                await this.sdk.question.reject({
+                  requestID: question.id,
+                  directory,
+                })
+                return
+              }
+
+              log.error("ACP question response was invalid", {
+                questionID: question.id,
+                sessionID: question.sessionID,
+                response: res,
+              })
+              await this.sdk.question.reject({
+                requestID: question.id,
+                directory,
+              })
+            })
+            .catch((error) => {
+              log.error("failed to handle question", { error, questionID: question.id })
+            })
+            .finally(() => {
+              if (this.questionQueues.get(question.sessionID) === next) {
+                this.questionQueues.delete(question.sessionID)
+              }
+            })
+
+          this.questionQueues.set(question.sessionID, next)
           return
         }
 
@@ -517,6 +610,10 @@ export namespace ACP {
 
     async initialize(params: InitializeRequest): Promise<InitializeResponse> {
       log.info("initialize", { protocolVersion: params.protocolVersion })
+      this.question =
+        Flag.OPENCODE_ENABLE_QUESTION_TOOL &&
+        QuestionCap.safeParse(params.clientCapabilities?._meta?.["opencode/question"]).success
+      process.env.OPENCODE_ENABLE_QUESTION_TOOL = this.question ? "1" : "0"
 
       const authMethod: AuthMethod = {
         description: "Run `opencode auth login` in the terminal",

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -36,7 +36,7 @@ export namespace Flag {
   export declare const OPENCODE_CLIENT: string
   export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
-  export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
+  export declare const OPENCODE_ENABLE_QUESTION_TOOL: boolean
 
   // Experimental
   export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")
@@ -111,6 +111,14 @@ Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
 Object.defineProperty(Flag, "OPENCODE_CLIENT", {
   get() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+Object.defineProperty(Flag, "OPENCODE_ENABLE_QUESTION_TOOL", {
+  get() {
+    return truthy("OPENCODE_ENABLE_QUESTION_TOOL")
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "../fixture/fixture"
 type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
 type RequestPermissionParams = Parameters<AgentSideConnection["requestPermission"]>[0]
 type RequestPermissionResult = Awaited<ReturnType<AgentSideConnection["requestPermission"]>>
+type ExtMethodResult = Awaited<ReturnType<AgentSideConnection["extMethod"]>>
 
 type GlobalEventEnvelope = {
   directory?: string
@@ -143,6 +144,9 @@ function createFakeAgent() {
     async requestPermission(_params: RequestPermissionParams): Promise<RequestPermissionResult> {
       return { outcome: { outcome: "selected", optionId: "once" } } as RequestPermissionResult
     },
+    async extMethod(_method: string, _params: Record<string, unknown>): Promise<ExtMethodResult> {
+      return { rejected: true }
+    },
   } as unknown as AgentSideConnection
 
   const { controller, stream } = createEventStream()
@@ -199,6 +203,14 @@ function createFakeAgent() {
     },
     permission: {
       respond: async () => {
+        return { data: true }
+      },
+    },
+    question: {
+      reply: async () => {
+        return { data: true }
+      },
+      reject: async () => {
         return { data: true }
       },
     },
@@ -491,6 +503,176 @@ describe("acp.agent event subscription", () => {
         stop()
       },
     })
+  })
+
+  test("question.asked events use ACP extMethod replies when enabled", async () => {
+    await using tmp = await tmpdir()
+    const prev = process.env.OPENCODE_ENABLE_QUESTION_TOOL
+    process.env.OPENCODE_ENABLE_QUESTION_TOOL = "1"
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const replies: any[] = []
+        const ext: any[] = []
+        const { agent, controller, stop, sdk, connection } = createFakeAgent()
+        sdk.question.reply = async (params: any) => {
+          replies.push(params)
+          return { data: true }
+        }
+        connection.extMethod = async (method: string, params: Record<string, unknown>) => {
+          ext.push({ method, params })
+          return { answers: [["Yes"]] }
+        }
+
+        await agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            _meta: {
+              "opencode/question": {
+                version: 1,
+              },
+            },
+          },
+        } as any)
+
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "question.asked",
+            properties: {
+              id: "que_1",
+              sessionID: sessionId,
+              questions: [
+                {
+                  header: "Build",
+                  question: "Start implementing?",
+                  options: [
+                    { label: "Yes", description: "Start implementing now" },
+                    { label: "No", description: "Keep planning" },
+                  ],
+                },
+              ],
+              tool: {
+                messageID: "msg_1",
+                callID: "call_1",
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(ext).toEqual([
+          {
+            method: "opencode/question",
+            params: {
+              requestId: "que_1",
+              sessionId,
+              questions: [
+                {
+                  header: "Build",
+                  question: "Start implementing?",
+                  options: [
+                    { label: "Yes", description: "Start implementing now" },
+                    { label: "No", description: "Keep planning" },
+                  ],
+                },
+              ],
+              tool: {
+                messageID: "msg_1",
+                callID: "call_1",
+              },
+            },
+          },
+        ])
+        expect(replies).toEqual([
+          {
+            requestID: "que_1",
+            answers: [["Yes"]],
+            directory: cwd,
+          },
+        ])
+
+        stop()
+      },
+    })
+
+    if (prev === undefined) delete process.env.OPENCODE_ENABLE_QUESTION_TOOL
+    else process.env.OPENCODE_ENABLE_QUESTION_TOOL = prev
+  })
+
+  test("question.asked events reject when ACP client declines", async () => {
+    await using tmp = await tmpdir()
+    const prev = process.env.OPENCODE_ENABLE_QUESTION_TOOL
+    process.env.OPENCODE_ENABLE_QUESTION_TOOL = "1"
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const rejects: any[] = []
+        const { agent, controller, stop, sdk, connection } = createFakeAgent()
+        sdk.question.reject = async (params: any) => {
+          rejects.push(params)
+          return { data: true }
+        }
+        connection.extMethod = async () => {
+          return { rejected: true }
+        }
+
+        await agent.initialize({
+          protocolVersion: 1,
+          clientCapabilities: {
+            _meta: {
+              "opencode/question": {
+                version: 1,
+              },
+            },
+          },
+        } as any)
+
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "question.asked",
+            properties: {
+              id: "que_2",
+              sessionID: sessionId,
+              questions: [
+                {
+                  header: "Build",
+                  question: "Start implementing?",
+                  options: [
+                    { label: "Yes", description: "Start implementing now" },
+                    { label: "No", description: "Keep planning" },
+                  ],
+                },
+              ],
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(rejects).toEqual([
+          {
+            requestID: "que_2",
+            directory: cwd,
+          },
+        ])
+
+        stop()
+      },
+    })
+
+    if (prev === undefined) delete process.env.OPENCODE_ENABLE_QUESTION_TOOL
+    else process.env.OPENCODE_ENABLE_QUESTION_TOOL = prev
   })
 
   test("streams running bash output snapshots and de-dupes identical snapshots", async () => {


### PR DESCRIPTION
## Summary\n- gate ACP question support on both \ and a client-advertised \ capability\n- bridge internal \ events to ACP clients over \ and reply/reject through the existing question API\n- document the extension contract and cover the new flow in ACP event-subscription tests\n\n## Validation\n- bun test ./test/acp/event-subscription.test.ts\n- bun test ./test/tool/question.test.ts\n- bun test ./test/acp/agent-interface.test.ts\n- bun run typecheck