### PR TITLE
fix: preserve file parts in subtask prompts for multimodal subagents

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1935,9 +1935,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               providerID: taskModel.providerID,
               modelID: taskModel.modelID,
             },
-            // TODO: how can we make task tool accept a more complex input?
             prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
           },
+          // Preserve file parts (images, PDFs) so multimodal subagents can
+          // receive visual content passed via input.parts.
+          ...(input.parts?.filter((p) => p.type === "file") ?? []),
         ]
       : [...templateParts, ...(input.parts ?? [])]
 


### PR DESCRIPTION
### Issue for this PR

Closes #20001

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `isSubtask` is true in `prompt.ts`, the prompt assembly discards all non-text parts from `input.parts`. This means file content blocks (images, PDFs) passed by callers like the `look_at` tool are silently dropped before the subagent ever sees them.

The fix adds one line: filter `input.parts` for `type === "file"` entries and append them after the subtask part. The existing `toModelMessages` in `message-v2.ts` already handles file parts in user messages (lines 655-668), so no other changes are needed.

I hit this while building a plugin that delegates product image analysis to `multimodal-looker`. The agent always responded with "Could not access the image file" because the image content block was stripped. Traced it to the `isSubtask` gate at `prompt.ts:1927-1942`. The existing TODO comment on line 1938 acknowledges this gap.

### How did you verify your code works?

- All 146 session tests pass (`bun test test/session/`)
- TypeScript typecheck passes across all 13 packages (`bun turbo typecheck`)
- Manual test: called `look_at` with a product image → `multimodal-looker` received the image and returned structured analysis

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR