### PR TITLE
fix: keep revert controls visible for attachment-only messages

### DIFF
--- a/packages/ui/src/components/message-part-actions.ts
+++ b/packages/ui/src/components/message-part-actions.ts
@@ -1,0 +1,4 @@
+export function showUserActions(input: { text: string; attachments: number }) {
+  if (input.text) return true
+  return input.attachments > 0
+}

--- a/packages/ui/src/components/message-part.test.ts
+++ b/packages/ui/src/components/message-part.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test"
+import { showUserActions } from "./message-part-actions"
+
+describe("message-part", () => {
+  test("shows actions for attachment-only user messages", () => {
+    expect(showUserActions({ text: "", attachments: 1 })).toBe(true)
+    expect(showUserActions({ text: "hello", attachments: 0 })).toBe(true)
+    expect(showUserActions({ text: "", attachments: 0 })).toBe(false)
+  })
+})

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -38,6 +38,7 @@ import { Accordion } from "./accordion"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 import { Card } from "./card"
 import { Collapsible } from "./collapsible"
+import { showUserActions } from "./message-part-actions"
 import { FileIcon } from "./file-icon"
 import { Icon } from "./icon"
 import { ToolErrorCard } from "./tool-error-card"
@@ -936,6 +937,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const files = createMemo(() => (props.parts?.filter((p) => p.type === "file") as FilePart[]) ?? [])
 
   const attachments = createMemo(() => files().filter(attached))
+  const actions = createMemo(() => showUserActions({ text: text(), attachments: attachments().length }))
 
   const inlineFiles = createMemo(() => files().filter(inline))
 
@@ -1033,42 +1035,46 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
               <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>
-          <div data-slot="user-message-copy-wrapper">
-            <Show when={metaHead() || metaTail()}>
-              <span data-slot="user-message-meta-wrap">
-                <Show when={metaHead()}>
-                  <span data-slot="user-message-meta" class="text-12-regular text-text-weak cursor-default">
-                    {metaHead()}
-                  </span>
-                </Show>
-                <Show when={metaHead() && metaTail()}>
-                  <span data-slot="user-message-meta-sep" class="text-12-regular text-text-weak cursor-default">
-                    {"\u00A0\u00B7\u00A0"}
-                  </span>
-                </Show>
-                <Show when={metaTail()}>
-                  <span data-slot="user-message-meta-tail" class="text-12-regular text-text-weak cursor-default">
-                    {metaTail()}
-                  </span>
-                </Show>
-              </span>
-            </Show>
-            <Show when={props.actions?.revert}>
-              <Tooltip value={i18n.t("ui.message.revertMessage")} placement="top" gutter={4}>
-                <IconButton
-                  icon="reset"
-                  size="normal"
-                  variant="ghost"
-                  disabled={!!busy()}
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    revert()
-                  }}
-                  aria-label={i18n.t("ui.message.revertMessage")}
-                />
-              </Tooltip>
-            </Show>
+        </>
+      </Show>
+      <Show when={actions()}>
+        <div data-slot="user-message-copy-wrapper">
+          <Show when={metaHead() || metaTail()}>
+            <span data-slot="user-message-meta-wrap">
+              <Show when={metaHead()}>
+                <span data-slot="user-message-meta" class="text-12-regular text-text-weak cursor-default">
+                  {metaHead()}
+                </span>
+              </Show>
+              <Show when={metaHead() && metaTail()}>
+                <span data-slot="user-message-meta-sep" class="text-12-regular text-text-weak cursor-default">
+                  {"\u00A0\u00B7\u00A0"}
+                </span>
+              </Show>
+              <Show when={metaTail()}>
+                <span data-slot="user-message-meta-tail" class="text-12-regular text-text-weak cursor-default">
+                  {metaTail()}
+                </span>
+              </Show>
+            </span>
+          </Show>
+          <Show when={props.actions?.revert}>
+            <Tooltip value={i18n.t("ui.message.revertMessage")} placement="top" gutter={4}>
+              <IconButton
+                icon="reset"
+                size="normal"
+                variant="ghost"
+                disabled={!!busy()}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  revert()
+                }}
+                aria-label={i18n.t("ui.message.revertMessage")}
+              />
+            </Tooltip>
+          </Show>
+          <Show when={text()}>
             <Tooltip
               value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyMessage")}
               placement="top"
@@ -1086,8 +1092,8 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
                 aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyMessage")}
               />
             </Tooltip>
-          </div>
-        </>
+          </Show>
+        </div>
       </Show>
     </div>
   )


### PR DESCRIPTION
﻿### Issue for this PR

Closes #20030

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a desktop regression where a user message that only contains an image does not show the existing "Reset to this point" action.

The user message action row was only rendered when the message had text. Image-only messages have attachments but no text, so the revert control never appeared. This change keeps that action row visible for attachment-only messages while still only showing the copy button when text exists.

### How did you verify your code works?

- `bun test src/components/message-part.test.ts src/components/message-file.test.ts` in `packages/ui`
- `bun typecheck` in `packages/ui`
- manually reproduced the bug flow and confirmed image-only messages now keep the revert control visible

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
