### PR TITLE
fix: omit toolChoice field when tool calls are disabled

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -186,7 +186,8 @@ export namespace LLM {
         ? undefined
         : ProviderTransform.maxOutputTokens(input.model)
 
-    const tools = await resolveTools(input)
+    const canTool = input.model.capabilities.toolcall
+    const tools = canTool ? await resolveTools(input) : {}
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.
@@ -203,7 +204,7 @@ export namespace LLM {
     // calls but no tools param is present. When there are no active tools (e.g.
     // during compaction), inject a stub tool to satisfy the validation requirement.
     // The stub description explicitly tells the model not to call it.
-    if (isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
+    if (canTool && isLiteLLMProxy && Object.keys(tools).length === 0 && hasToolCalls(input.messages)) {
       tools["_noop"] = tool({
         description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
         inputSchema: jsonSchema({
@@ -276,9 +277,13 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-      tools,
-      toolChoice: input.toolChoice,
+      ...(canTool
+        ? {
+            activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+            tools,
+          }
+        : {}),
+      ...(canTool ? { toolChoice: input.toolChoice } : {}),
       maxOutputTokens,
       abortSignal: input.abort,
       headers: {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -414,6 +414,99 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("does not send tools when model toolcall is disabled", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-no-tools")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-no-tools"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: {
+            ...resolved,
+            capabilities: {
+              ...resolved.capabilities,
+              toolcall: false,
+            },
+          },
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            question: tool({
+              description: "Ask a question",
+              inputSchema: z.object({}),
+              execute: async () => ({ output: "" }),
+            }),
+          },
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        expect(capture.body.tools).toBeUndefined()
+        expect(capture.body.tool_choice).toBeUndefined()
+      },
+    })
+  })
+
   test("sends responses API payload for OpenAI models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Closes #19966

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a compatibility bug where OpenCode still sent tool-related payload fields even when a model advertises `capabilities.toolcall=false`.

Changes made:
- Gate tool resolution in `LLM.stream` behind `input.model.capabilities.toolcall`.
- Skip LiteLLM noop tool injection when tool calling is disabled.
- Omit both `tools` and `activeTools` from the request payload when tool calling is disabled.
- Add a regression test that forces `toolcall=false` and verifies `body.tools` is not sent.

Why this works:
- The provider request builder now conditionally spreads tool fields only when tool calling is enabled.
- With tool fields omitted, openai-compatible backends that reject unsupported `tools` payloads can accept the request.

### How did you verify your code works?

- Added test: `does not send tools when model toolcall is disabled` in `test/session/llm.test.ts`.
- Attempted to run:
  - `bun test test/session/llm.test.ts` (fails in this environment because preload module `@opentui/solid/preload` is missing)
  - `bun typecheck` (fails in this environment because `tsgo` is not installed)

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
