### PR TITLE
fix(desktop): prevent duplicate external link opens

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -461,6 +461,7 @@ render(() => {
     const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
     if (link?.href) {
       e.preventDefault()
+      e.stopImmediatePropagation()
       platform.openLink(link.href)
     }
   }
@@ -472,9 +473,9 @@ render(() => {
   }
 
   onMount(() => {
-    document.addEventListener("click", handleClick)
+    document.addEventListener("click", handleClick, true)
     onCleanup(() => {
-      document.removeEventListener("click", handleClick)
+      document.removeEventListener("click", handleClick, true)
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #20048

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops desktop external links from being handled twice by intercepting the click earlier, so one click only opens one browser tab.

### How did you verify your code works?

Clicked a markdown link in the desktop app and confirmed it only opened once. Also ran un turbo typecheck locally.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR