### PR TITLE
fix: restore streamed tool response rendering

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -635,7 +635,7 @@ export namespace Session {
         field: string
         delta: string
       }) {
-        yield* bus.publish(MessageV2.Event.PartDelta, input)
+        yield* Effect.sync(() => SyncEvent.run(MessageV2.Event.PartDelta, input))
       })
 
       const initialize = Effect.fn("Session.initialize")(function* (input: {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -483,16 +483,18 @@ export namespace MessageV2 {
         time: z.number(),
       }),
     }),
-    PartDelta: BusEvent.define(
-      "message.part.delta",
-      z.object({
+    PartDelta: SyncEvent.define({
+      type: "message.part.delta",
+      version: 1,
+      aggregate: "sessionID",
+      schema: z.object({
         sessionID: SessionID.zod,
         messageID: MessageID.zod,
         partID: PartID.zod,
         field: z.string(),
         delta: z.string(),
       }),
-    ),
+    }),
     PartRemoved: SyncEvent.define({
       type: "message.part.removed",
       version: 1,
@@ -601,8 +603,9 @@ export namespace MessageV2 {
       return false
     })()
 
-    const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
-      const output = options.output
+    const toModelOutput = (value: unknown) => {
+      const output =
+        value && typeof value === "object" && "output" in value ? (value as { output: unknown }).output : value
       if (typeof output === "string") {
         return { type: "text", value: output }
       }

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -6,6 +6,8 @@ import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { ProjectTable } from "../project/project.sql"
 import { Log } from "../util/log"
 
+type PartData = typeof PartTable.$inferSelect.data
+
 const log = Log.create({ service: "session.projector" })
 
 function foreign(err: unknown) {
@@ -136,9 +138,9 @@ export default [
   SyncEvent.project(MessageV2.Event.PartDelta, (db, data) => {
     const row = db.select().from(PartTable).where(eq(PartTable.id, data.partID)).get()
     if (!row) throw new NotFoundError({ message: `Part not found: ${data.partID}` })
-    const next = structuredClone(row.data) as Record<string, unknown>
+    const next = structuredClone(row.data) as PartData & Record<string, unknown>
     const prev = next[data.field]
     next[data.field] = (typeof prev === "string" ? prev : "") + data.delta
-    db.update(PartTable).set({ data: next }).where(eq(PartTable.id, data.partID)).run()
+    db.update(PartTable).set({ data: next as PartData }).where(eq(PartTable.id, data.partID)).run()
   }),
 ]

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -132,4 +132,13 @@ export default [
       log.warn("ignored late part update", { partID: id, messageID, sessionID })
     }
   }),
+
+  SyncEvent.project(MessageV2.Event.PartDelta, (db, data) => {
+    const row = db.select().from(PartTable).where(eq(PartTable.id, data.partID)).get()
+    if (!row) throw new NotFoundError({ message: `Part not found: ${data.partID}` })
+    const next = structuredClone(row.data) as Record<string, unknown>
+    const prev = next[data.field]
+    next[data.field] = (typeof prev === "string" ? prev : "") + data.delta
+    db.update(PartTable).set({ data: next }).where(eq(PartTable.id, data.partID)).run()
+  }),
 ]

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -788,6 +788,73 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ])
   })
+
+  test("serializes completed tool output when tool output is passed directly", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-complete",
+            tool: "mcp_fetch",
+            state: {
+              status: "completed",
+              input: { query: "status" },
+              output: "done",
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-complete",
+            toolName: "mcp_fetch",
+            input: { query: "status" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-complete",
+            toolName: "mcp_fetch",
+            output: { type: "text", value: "done" },
+          },
+        ],
+      },
+    ])
+  })
 })
 
 describe("session.message-v2.fromError", () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -816,6 +816,8 @@ describe("session.message-v2.toModelMessage", () => {
               status: "completed",
               input: { query: "status" },
               output: "done",
+              title: "",
+              metadata: {},
               time: { start: 0, end: 1 },
             },
           },

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -140,3 +140,68 @@ describe("step-finish token propagation via Bus event", () => {
     { timeout: 30000 },
   )
 })
+
+describe("part delta persistence", () => {
+  test("persists text deltas into the stored part", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const messageID = MessageID.ascending()
+        await Session.updateMessage({
+          id: messageID,
+          sessionID: session.id,
+          role: "assistant",
+          parentID: MessageID.ascending(),
+          time: { created: Date.now() },
+          agent: "test",
+          modelID: "test",
+          providerID: "test",
+          mode: "",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+        } as unknown as MessageV2.Info)
+
+        const partID = PartID.ascending()
+        await Session.updatePart({
+          id: partID,
+          messageID,
+          sessionID: session.id,
+          type: "text",
+          text: "",
+          time: { start: Date.now() },
+        })
+
+        await Session.updatePartDelta({
+          sessionID: session.id,
+          messageID,
+          partID,
+          field: "text",
+          delta: "hello",
+        })
+        await Session.updatePartDelta({
+          sessionID: session.id,
+          messageID,
+          partID,
+          field: "text",
+          delta: " world",
+        })
+
+        const parts = await MessageV2.parts(messageID)
+        const part = parts.find((item) => item.id === partID) as MessageV2.TextPart | undefined
+
+        expect(part?.type).toBe("text")
+        expect(part?.text).toBe("hello world")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20050

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two regressions introduced in v1.3.4 that can make assistant responses disappear during local MCP tool turns.

It makes `message.part.delta` sync-backed again so streamed text is not lost when the event stream starts late or reconnects, and it makes tool output serialization accept both raw output and `{ output, ... }` inputs so completed tool results still serialize correctly.

### How did you verify your code works?

I added focused regression tests for:
- completed tool output serialization in `packages/opencode/test/session/message-v2.test.ts`
- persisted text deltas in `packages/opencode/test/session/session.test.ts`

I could not run the package checks successfully in this environment:
- `bun test` fails here because preload `@opentui/solid/preload` is missing
- `bun typecheck` fails here because `tsgo` is unavailable

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
