### PR TITLE
fix: Allow plugin hooks to mutate tool call args before context creation

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -826,19 +826,18 @@ export namespace SessionPrompt {
         description: item.description,
         inputSchema: jsonSchema(schema as any),
         async execute(args, options) {
-          const ctx = context(args, options)
+          const out = { args }
           await Plugin.trigger(
             "tool.execute.before",
             {
               tool: item.id,
-              sessionID: ctx.sessionID,
-              callID: ctx.callID,
+              sessionID: input.session.id,
+              callID: options.toolCallId,
             },
-            {
-              args,
-            },
+            out,
           )
-          const result = await item.execute(args, ctx)
+          const ctx = context(out.args, options)
+          const result = await item.execute(out.args, ctx)
           const output = {
             ...result,
             attachments: result.attachments?.map((attachment) => ({
@@ -854,7 +853,7 @@ export namespace SessionPrompt {
               tool: item.id,
               sessionID: ctx.sessionID,
               callID: ctx.callID,
-              args,
+              args: out.args,
             },
             output,
           )
@@ -872,19 +871,18 @@ export namespace SessionPrompt {
       item.inputSchema = jsonSchema(transformed)
       // Wrap execute to add plugin hooks and format output
       item.execute = async (args, opts) => {
-        const ctx = context(args, opts)
+        const out = { args }
 
         await Plugin.trigger(
           "tool.execute.before",
           {
             tool: key,
-            sessionID: ctx.sessionID,
+            sessionID: input.session.id,
             callID: opts.toolCallId,
           },
-          {
-            args,
-          },
+          out,
         )
+        const ctx = context(out.args, opts)
 
         await ctx.ask({
           permission: key,
@@ -893,7 +891,7 @@ export namespace SessionPrompt {
           always: ["*"],
         })
 
-        const result = await execute(args, opts)
+        const result = await execute(out.args, opts)
 
         await Plugin.trigger(
           "tool.execute.after",
@@ -901,7 +899,7 @@ export namespace SessionPrompt {
             tool: key,
             sessionID: ctx.sessionID,
             callID: opts.toolCallId,
-            args,
+            args: out.args,
           },
           result,
         )


### PR DESCRIPTION
### Issue for this PR

Closes #20013

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tool.execute.before` hooks receive `{ args }`, but tool execution continued with the original `args` reference captured before the hook ran. That meant hooks could mutate `output.args` without affecting the actual tool call.

This change routes both native tools and MCP tools through a mutable `out = { args }` object, triggers the before hook with that object, and then executes tools using `out.args`. It also passes `out.args` to `tool.execute.after` for consistency.

Why this works: the before hook can now replace or inject args by mutating the shared `out.args` object, and the execution path reads from the same object after the hook completes.

### How did you verify your code works?

- Ran `bun test test/plugin/trigger.test.ts` in `packages/opencode` (environment warning: missing preload module `@opentui/solid/preload`).
- Ran `bun typecheck` in `packages/opencode` (environment warning: `tsgo` not available in this container).

### Screenshots / recordings

Not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR