### PR TITLE
feat(opencode): support Claude Code OAuth credentials for Anthropic provider

### DIFF
--- a/packages/opencode/src/provider/claude-code-credential.ts
+++ b/packages/opencode/src/provider/claude-code-credential.ts
@@ -1,0 +1,66 @@
+import os from "os"
+import path from "path"
+import { Filesystem } from "../util/filesystem"
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "claude-code-credential" })
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+export namespace ClaudeCodeCredential {
+  export interface Token {
+    accessToken: string
+    refreshToken: string
+    expiresAt: number
+  }
+
+  export type Status = "valid" | "expired" | "missing" | "error"
+
+  type Result =
+    | { token: Token; status: "valid" | "expired" }
+    | { token: undefined; status: "missing" | "error" }
+
+  let cache: { value: Token; readAt: number } | undefined
+
+  export async function get(): Promise<Result> {
+    const now = Date.now()
+
+    if (cache && now - cache.readAt < CACHE_TTL_MS) {
+      const status = now < cache.value.expiresAt ? "valid" : "expired"
+      if (status === "expired") {
+        log.warn("Claude Code OAuth token has expired. Run `claude` to re-authenticate.")
+      }
+      return { token: cache.value, status }
+    }
+
+    const credPath = path.join(os.homedir(), ".claude", ".credentials.json")
+
+    try {
+      const data = await Filesystem.readJson<Record<string, any>>(credPath)
+      const oauth = data?.claudeAiOauth
+      if (!oauth?.accessToken) {
+        return { token: undefined, status: "missing" }
+      }
+
+      const token: Token = {
+        accessToken: oauth.accessToken,
+        refreshToken: oauth.refreshToken ?? "",
+        expiresAt: typeof oauth.expiresAt === "number" ? oauth.expiresAt : 0,
+      }
+
+      cache = { value: token, readAt: now }
+
+      const status = now < token.expiresAt ? "valid" : "expired"
+      if (status === "expired") {
+        log.warn("Claude Code OAuth token has expired. Run `claude` to re-authenticate.")
+      }
+      return { token, status }
+    } catch (e: any) {
+      if (e?.code === "ENOENT") {
+        return { token: undefined, status: "missing" }
+      }
+      log.warn("Failed to read Claude Code credentials", { error: e?.message })
+      return { token: undefined, status: "error" }
+    }
+  }
+}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -52,6 +52,7 @@ import { GoogleAuth } from "google-auth-library"
 import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
+import { ClaudeCodeCredential } from "./claude-code-credential"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -154,12 +155,33 @@ export namespace Provider {
   }
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
-    async anthropic() {
+    async anthropic(input) {
+      const baseBetas = "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+
+      // Only try OAuth if no API key is already configured (env var or auth store)
+      const hasApiKey = input.env.some((e: string) => Env.all()[e]) || !!(await Auth.get("anthropic"))
+
+      if (!hasApiKey) {
+        const credential = await ClaudeCodeCredential.get()
+        if (credential.token && (credential.status === "valid" || credential.status === "expired")) {
+          log.info("using Claude Code OAuth credentials for Anthropic")
+          return {
+            autoload: true,
+            options: {
+              authToken: credential.token.accessToken,
+              headers: {
+                "anthropic-beta": baseBetas + ",claude-code-20250219,oauth-2025-04-20",
+              },
+            },
+          }
+        }
+      }
+
       return {
         autoload: false,
         options: {
           headers: {
-            "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+            "anthropic-beta": baseBetas,
           },
         },
       }
@@ -1247,6 +1269,8 @@ export namespace Provider {
 
       if (baseURL !== undefined) options["baseURL"] = baseURL
       if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
+      // When using OAuth authToken, ensure apiKey doesn't conflict
+      if (options["authToken"]) delete options["apiKey"]
       if (model.headers)
         options["headers"] = {
           ...options["headers"],
@@ -1298,6 +1322,32 @@ export namespace Provider {
             }
             opts.body = JSON.stringify(body)
           }
+        }
+
+        // Inject billing header and metadata for Anthropic OAuth requests
+        if (options["authToken"] && model.api.npm === "@ai-sdk/anthropic" && opts.body && opts.method === "POST") {
+          const body = JSON.parse(opts.body as string)
+          const billingText =
+            "x-anthropic-billing-header: cc_version=opencode; cc_entrypoint=cli; cch=opencode;"
+          const billingBlock = { type: "text", text: billingText }
+          if (Array.isArray(body.system)) {
+            body.system = [billingBlock, ...body.system.filter((b: any) => b?.text !== billingText)]
+          } else if (typeof body.system === "string") {
+            body.system = [billingBlock, { type: "text", text: body.system }]
+          } else {
+            body.system = [billingBlock]
+          }
+          if (!body.metadata) body.metadata = {}
+          if (!body.metadata.user_id) {
+            const hostname = os.hostname()
+            const deviceId = Hash.fast(`opencode-${hostname}`)
+            body.metadata.user_id = JSON.stringify({
+              device_id: deviceId,
+              account_uuid: "opencode",
+              session_id: crypto.randomUUID(),
+            })
+          }
+          opts.body = JSON.stringify(body)
         }
 
         const res = await fetchFn(input, {


### PR DESCRIPTION
### Issue for this PR

Closes #20079

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for authenticating with Anthropic using Claude Code OAuth credentials (`~/.claude/.credentials.json`) when no `ANTHROPIC_API_KEY` is set.

Two files changed:
- **New** `claude-code-credential.ts` — reads the credential file, caches the token (5 min TTL), checks expiry
- **Modified** `provider.ts` — the Anthropic custom loader detects the OAuth token, passes it via `authToken` to `createAnthropic()`, adds OAuth beta headers, and injects the billing header + metadata in the fetch wrapper

API key always takes precedence. No behavior change for users without Claude Code credentials.

### How did you verify your code works?

- `npx tsc --noEmit` — zero type errors
- `bun test test/provider/provider.test.ts` — 70/70 pass
- `bun test test/provider/transform.test.ts` — 119/119 pass
- Ran `bun dev` with only `~/.claude/.credentials.json` (no API key) — Claude Sonnet 4.6 loaded and responded successfully

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR