### PR TITLE
feat(tool): configurable timeout protection for tool and task execution

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1074,6 +1074,20 @@ export namespace Config {
             .positive()
             .optional()
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+          task_timeout: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              "Default timeout in milliseconds for Task tool sub-agent execution (default: 14400000 = 4 hours)",
+            ),
+          tool_timeout: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Global timeout in milliseconds for individual tool executions (default: 900000 = 15 minutes)"),
         })
         .optional(),
     })

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,10 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { Permission } from "@/permission"
+import { abortAfterAny, raceSignal } from "@/util/abort"
+
+const DEFAULT_TIMEOUT = 14_400_000 // 4 hours — zombie/stall protection, not performance pressure
+const MIN_TIMEOUT = 1_800_000 // 30 minutes — floor for LLM-specified values
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -23,7 +27,80 @@ const parameters = z.object({
     )
     .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
+  timeout: z
+    .number()
+    .optional()
+    .describe(
+      "Optional timeout in seconds for zombie/stall protection. Default: 4 hours. Minimum: 30 minutes. You almost never need to set this \u2014 only override if you have a specific reason.",
+    ),
 })
+
+export async function childText(
+  result: Awaited<ReturnType<typeof SessionPrompt.prompt>>,
+  id: string,
+  opts?: { skipAbort?: boolean; parentAborted?: boolean; deadlineAborted?: boolean },
+) {
+  if (result.info.role !== "assistant") return ""
+  const error = result.info.error
+  if (error?.name === "MessageAbortedError" && !opts?.skipAbort) {
+    if (opts?.deadlineAborted) return ""
+    if (opts?.parentAborted) return "Task was cancelled by user."
+    return [
+      `WATCHDOG: Subagent session (${id}) was killed \u2014 tool execution exceeded maximum allowed duration.`,
+      `task_id: ${id}`,
+      "",
+      "The subagent stalled (likely waiting on an external resource or internal deadlock).",
+      "Recommended: retry this task with a simpler or more focused prompt.",
+      "You can resume by passing the task_id above.",
+    ].join("\n")
+  }
+  const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+  if (text) return text
+  if (!error) return ""
+
+  // The child errored with no text output. Recover substantive work from
+  // the session history so the parent doesn't lose everything.
+  const lines: string[] = []
+
+  // 1. Collect completed tool outputs from the errored message itself
+  for (const p of result.parts) {
+    if (p.type !== "tool" || p.state.status !== "completed") continue
+    lines.push(`[${p.state.title}]\n${p.state.output}`)
+  }
+
+  // 2. Walk backwards through earlier messages for the last substantive text
+  if (!lines.length) {
+    const msgs = await Session.messages({ sessionID: SessionID.make(id), limit: 10 })
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i]
+      if (m.info.role !== "assistant" || m.info.id === result.info.id) continue
+      const prior = m.parts.findLast((x) => x.type === "text")?.text
+      if (prior) {
+        lines.push(prior)
+        break
+      }
+    }
+  }
+
+  const msg = error.data && "message" in error.data ? (error.data as { message: string }).message : error.name
+  const code =
+    error.data && "statusCode" in error.data ? ` (status ${(error.data as { statusCode: number }).statusCode})` : ""
+  const header = `ERROR: The subagent session (${id}) failed with: ${error.name}${code}\n${msg}`
+
+  if (!lines.length) {
+    return [header, "", "You can retry this task by passing the task_id above, or try a different approach."].join("\n")
+  }
+
+  return [
+    "NOTE: The subagent errored after completing some work. Partial output below:",
+    "",
+    ...lines,
+    "",
+    header,
+    "",
+    "You can retry this task by passing the task_id above, or try a different approach.",
+  ].join("\n")
+}
 
 export const TaskTool = Tool.define("task", async (ctx) => {
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
@@ -127,39 +204,122 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
 
-      const result = await SessionPrompt.prompt({
-        messageID,
-        sessionID: session.id,
-        model: {
-          modelID: model.modelID,
-          providerID: model.providerID,
-        },
-        agent: agent.name,
-        tools: {
-          ...(hasTodoWritePermission ? {} : { todowrite: false }),
-          ...(hasTaskPermission ? {} : { task: false }),
-          ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
-        },
-        parts: promptParts,
-      })
+      const cfg_timeout = config.experimental?.task_timeout
+      const raw = params.timeout ? params.timeout * 1000 : (cfg_timeout ?? DEFAULT_TIMEOUT)
+      // MIN_TIMEOUT guards against LLM-specified timeouts that are too short.
+      // When the user explicitly configures task_timeout, they control timeout
+      // policy and the floor is not applied.
+      const ms = params.timeout && !cfg_timeout ? Math.max(MIN_TIMEOUT, raw) : raw
+      const deadline = abortAfterAny(ms, ctx.abort)
+      deadline.signal.addEventListener("abort", cancel)
 
-      const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+      try {
+        const result = await raceSignal(
+          SessionPrompt.prompt({
+            messageID,
+            sessionID: session.id,
+            model: {
+              modelID: model.modelID,
+              providerID: model.providerID,
+            },
+            agent: agent.name,
+            tools: {
+              ...(hasTodoWritePermission ? {} : { todowrite: false }),
+              ...(hasTaskPermission ? {} : { task: false }),
+              ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
+            },
+            parts: promptParts,
+          }),
+          deadline.signal,
+          `Task exceeded ${Math.round(ms / 1000)}s deadline`,
+        )
 
-      const output = [
-        `task_id: ${session.id} (for resuming to continue this task if needed)`,
-        "",
-        "<task_result>",
-        text,
-        "</task_result>",
-      ].join("\n")
+        deadline.clearTimeout()
 
-      return {
-        title: params.description,
-        metadata: {
-          sessionId: session.id,
-          model,
-        },
-        output,
+        // Detect timeout: deadline fired but parent wasn't cancelled
+        if (deadline.signal.aborted && !ctx.abort.aborted) {
+          const limit = Math.round(ms / 1000)
+          const partial = await childText(result, session.id, { skipAbort: true })
+          const output = [
+            `TIMEOUT: Task exceeded ${limit}s deadline and was cancelled.`,
+            `task_id: ${session.id}`,
+            "",
+            ...(partial ? ["Partial output recovered from the timed-out session:", "", partial, ""] : []),
+            "You can resume this task by passing the task_id above.",
+            "Recommended: retry with a simpler or more focused prompt. Break large tasks into smaller sub-tasks.",
+          ].join("\n")
+          return {
+            title: params.description,
+            metadata: {
+              sessionId: session.id,
+              model,
+            },
+            output,
+          }
+        }
+
+        const text = await childText(result, session.id, {
+          parentAborted: ctx.abort.aborted,
+          deadlineAborted: deadline.signal.aborted,
+        })
+
+        const output = [
+          `task_id: ${session.id} (for resuming to continue this task if needed)`,
+          "",
+          "<task_result>",
+          text,
+          "</task_result>",
+        ].join("\n")
+
+        return {
+          title: params.description,
+          metadata: {
+            sessionId: session.id,
+            model,
+          },
+          output,
+        }
+      } catch (e) {
+        deadline.clearTimeout()
+        // If parent was aborted (user Ctrl+C), re-throw — don't mask it
+        if (ctx.abort.aborted) throw e
+        // If the deadline fired, it's a real timeout — cancel child and return structured error
+        if (deadline.signal.aborted) {
+          cancel()
+          return {
+            title: params.description,
+            metadata: {
+              sessionId: session.id,
+              model,
+            },
+            output: [
+              `TIMEOUT: Task exceeded ${ms / 1000}s deadline and was cancelled.`,
+              `task_id: ${session.id}`,
+              "",
+              "You can resume this task by passing the task_id above.",
+              "If this task is important, retry with a longer timeout or a simpler prompt.",
+              "Recommended: retry with a simpler or more focused prompt. Break large tasks into smaller sub-tasks.",
+            ].join("\n"),
+          }
+        }
+        // Non-timeout, non-abort error — surface the actual failure
+        cancel()
+        const reason = e instanceof Error ? e.message : String(e)
+        return {
+          title: params.description,
+          metadata: {
+            sessionId: session.id,
+            model,
+          },
+          output: [
+            `ERROR: Task failed: ${reason}`,
+            `task_id: ${session.id}`,
+            "",
+            "You can resume this task by passing the task_id above, or try a different approach.",
+          ].join("\n"),
+        }
+      } finally {
+        deadline.signal.removeEventListener("abort", cancel)
       }
     },
   }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -4,6 +4,15 @@ import type { Agent } from "../agent/agent"
 import type { Permission } from "../permission"
 import type { SessionID, MessageID } from "../session/schema"
 import { Truncate } from "./truncate"
+import { abortAfterAny, raceSignal } from "../util/abort"
+import { Config } from "../config/config"
+
+const TOOL_TIMEOUT = 15 * 60 * 1000
+
+/** Compute the effective timeout for a non-task tool execution. Exported for testing. */
+export function timeout(input: { tool?: number }): number {
+  return input.tool ?? TOOL_TIMEOUT
+}
 
 export namespace Tool {
   interface Metadata {
@@ -69,20 +78,53 @@ export namespace Tool {
               { cause: error },
             )
           }
-          const result = await execute(args, ctx)
-          // skip truncation for tools that handle it themselves
-          if (result.metadata.truncated !== undefined) {
-            return result
+          // Task tool manages its own deadline inside task.ts — skip the
+          // outer raceSignal wrapper so nested tasks aren't starved of time.
+          if (id === "task") {
+            const result = await execute(args, ctx)
+            if (result.metadata.truncated !== undefined) return result
+            const truncated = await Truncate.output(result.output, {}, initCtx?.agent)
+            return {
+              ...result,
+              output: truncated.content,
+              metadata: {
+                ...result.metadata,
+                truncated: truncated.truncated,
+                ...(truncated.truncated && { outputPath: truncated.outputPath }),
+              },
+            }
           }
-          const truncated = await Truncate.output(result.output, {}, initCtx?.agent)
-          return {
-            ...result,
-            output: truncated.content,
-            metadata: {
-              ...result.metadata,
-              truncated: truncated.truncated,
-              ...(truncated.truncated && { outputPath: truncated.outputPath }),
-            },
+
+          let ms = TOOL_TIMEOUT
+          try {
+            const cfg = await Config.get()
+            ms = timeout({ tool: cfg.experimental?.tool_timeout })
+          } catch {
+            // No Instance context (e.g., unit tests) — use hardcoded default
+          }
+          const deadline = abortAfterAny(ms, ctx.abort)
+          try {
+            const result = await raceSignal(
+              execute(args, { ...ctx, abort: deadline.signal }),
+              deadline.signal,
+              `Tool execution exceeded ${Math.round(ms / 1000)}s global timeout`,
+            )
+            // skip truncation for tools that handle it themselves
+            if (result.metadata.truncated !== undefined) {
+              return result
+            }
+            const truncated = await Truncate.output(result.output, {}, initCtx?.agent)
+            return {
+              ...result,
+              output: truncated.content,
+              metadata: {
+                ...result.metadata,
+                truncated: truncated.truncated,
+                ...(truncated.truncated && { outputPath: truncated.outputPath }),
+              },
+            }
+          } finally {
+            deadline.clearTimeout()
           }
         }
         return toolInfo

--- a/packages/opencode/src/util/abort.ts
+++ b/packages/opencode/src/util/abort.ts
@@ -33,3 +33,26 @@ export function abortAfterAny(ms: number, ...signals: AbortSignal[]) {
     clearTimeout: timeout.clearTimeout,
   }
 }
+
+/**
+ * Races a promise against an AbortSignal, rejecting when the signal fires.
+ * Properly cleans up the abort listener when the promise settles first,
+ * avoiding unhandled rejection issues that occur with naive Promise.race patterns.
+ */
+export function raceSignal<T>(promise: Promise<T>, signal: AbortSignal, msg = "Aborted"): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error(msg))
+  return new Promise<T>((resolve, reject) => {
+    const handler = () => reject(new Error(msg))
+    signal.addEventListener("abort", handler, { once: true })
+    promise.then(
+      (v) => {
+        signal.removeEventListener("abort", handler)
+        resolve(v)
+      },
+      (e) => {
+        signal.removeEventListener("abort", handler)
+        reject(e)
+      },
+    )
+  })
+}

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -599,6 +599,7 @@ it.live(
               subagent_type: z.string(),
               task_id: z.string().optional(),
               command: z.string().optional(),
+              timeout: z.number().optional(),
             }),
             execute: async (_args, ctx) => {
               ready.resolve()

--- a/packages/opencode/test/tool/timeout.test.ts
+++ b/packages/opencode/test/tool/timeout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { timeout } from "../../src/tool/tool"
+
+/**
+ * Tests for the tool timeout computation extracted from Tool.define.
+ *
+ * The `timeout()` function computes the effective deadline for non-task tool
+ * executions. Task tools are exempt from the outer wrapper entirely — their
+ * deadline is managed inside task.ts.
+ */
+
+describe("tool.timeout", () => {
+  const DEFAULT = 15 * 60 * 1000 // 900_000ms = 15 min
+
+  test("uses hardcoded default when no config", () => {
+    expect(timeout({})).toBe(DEFAULT)
+  })
+
+  test("respects tool_timeout config", () => {
+    expect(timeout({ tool: 300_000 })).toBe(300_000)
+  })
+
+  test("error message uses seconds", () => {
+    const ms = timeout({})
+    expect(Math.round(ms / 1000)).toBe(900)
+    const msg = `Tool execution exceeded ${Math.round(ms / 1000)}s global timeout`
+    expect(msg).toBe("Tool execution exceeded 900s global timeout")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #15080

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds configurable timeout protection for both normal tool execution and subagent task execution to prevent indefinite hangs.

Key changes:

1. **Shared abort utility**
   - Adds a `raceSignal(...)` helper that cleanly races async work against an abort signal.

2. **Global non-task tool timeout**
   - Adds a default timeout for non-task tools in the tool execution wrapper.
   - Supports config override via `experimental.tool_timeout`.
   - Keeps `task` excluded from this outer timeout so it can manage its own deadline.

3. **Task tool deadline management**
   - Adds task-level timeout behavior (default deadline + optional override).
   - Supports config via `experimental.task_timeout`.
   - On timeout, cancels child session execution and returns structured output with `task_id`.
   - Preserves partial-output recovery behavior where available.

4. **Config schema updates**
   - Adds timeout fields used by the above behavior.

Related overlap (not duplicates):

- #11865 (subagent sessions hanging forever)
- #13841 (explore subagent hang without timeout/recovery)
- #18378 (subagent hangs in high-concurrency paths)

### How did you verify your code works?

- Added and ran `packages/opencode/test/tool/timeout.test.ts`.
- Ran targeted tool/session tests to confirm timeout behavior and cancellation flow.
- Verified that task timeout behavior remains isolated from non-task global tool timeout.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
