### PR TITLE
fix(tui): allow theme mode override

### DIFF
--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -19,6 +19,7 @@ Example:
 {
   "$schema": "https://opencode.ai/tui.json",
   "theme": "smoke-theme",
+  "theme_mode": "light",
   "plugin": ["@acme/opencode-plugin@1.2.3", ["./plugins/demo.tsx", { "label": "demo" }]],
   "plugin_enabled": {
     "acme.demo": false
@@ -27,6 +28,7 @@ Example:
 ```
 
 - `plugin` entries can be either a string spec or `[spec, options]`.
+- `theme_mode` can be `system`, `light`, or `dark` to override terminal light/dark detection when a multiplexer or IDE terminal reports the wrong mode.
 - Plugin specs can be npm specs, `file://` URLs, relative paths, or absolute paths.
 - Relative path specs are resolved relative to the config file that declared them.
 - A file module listed in `tui.json` must be a TUI module (`default export { id?, tui }`) and must not export `server`.

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -163,6 +163,42 @@ export function allThemes() {
   return store.themes
 }
 
+type ThemeMode = State["mode"]
+type ThemeModeConfig = ThemeMode | "system"
+
+function pickThemeMode(value: unknown): ThemeMode | undefined {
+  if (value === "dark" || value === "light") return value
+  return
+}
+
+export function resolveThemeModeState(input: {
+  detected: ThemeMode
+  config?: ThemeModeConfig
+  persisted?: unknown
+  lock?: unknown
+}) {
+  if (input.config === "dark" || input.config === "light") {
+    return {
+      mode: input.config,
+      lock: input.config,
+    }
+  }
+
+  if (input.config === "system") {
+    return {
+      mode: input.detected,
+      lock: undefined,
+    }
+  }
+
+  const lock = pickThemeMode(input.lock)
+  const mode = pickThemeMode(input.persisted) ?? input.detected
+  return {
+    mode: lock ?? mode,
+    lock,
+  }
+}
+
 function isTheme(theme: unknown): theme is ThemeJson {
   if (!isRecord(theme)) return false
   if (!isRecord(theme.theme)) return false
@@ -294,17 +330,17 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const renderer = useRenderer()
     const config = useTuiConfig()
     const kv = useKV()
-    const pick = (value: unknown) => {
-      if (value === "dark" || value === "light") return value
-      return
-    }
 
     setStore(
       produce((draft) => {
-        const lock = pick(kv.get("theme_mode_lock"))
-        const mode = pick(kv.get("theme_mode", props.mode))
-        draft.mode = lock ?? mode ?? props.mode
-        draft.lock = lock
+        const resolved = resolveThemeModeState({
+          detected: props.mode,
+          config: config.theme_mode,
+          persisted: kv.get("theme_mode", props.mode),
+          lock: kv.get("theme_mode_lock"),
+        })
+        draft.mode = resolved.mode
+        draft.lock = resolved.lock
         const active = config.theme ?? kv.get("theme", "opencode")
         draft.active = typeof active === "string" ? active : "opencode"
         draft.ready = false

--- a/packages/opencode/src/config/migrate-tui-config.ts
+++ b/packages/opencode/src/config/migrate-tui-config.ts
@@ -19,6 +19,7 @@ const LegacyRecord = z.record(z.string(), z.unknown()).optional()
 
 const TuiLegacy = z
   .object({
+    theme_mode: TuiOptions.shape.theme_mode.catch(undefined),
     scroll_speed: TuiOptions.shape.scroll_speed.catch(undefined),
     scroll_acceleration: TuiOptions.shape.scroll_acceleration.catch(undefined),
     diff_style: TuiOptions.shape.diff_style.catch(undefined),
@@ -90,6 +91,7 @@ export async function migrateTuiConfig(input: MigrateInput) {
 function normalizeTui(data: Record<string, unknown>) {
   const parsed = TuiLegacy.parse(data)
   if (
+    parsed.theme_mode === undefined &&
     parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
     parsed.scroll_acceleration === undefined

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -11,6 +11,10 @@ const KeybindOverride = z
   .strict()
 
 export const TuiOptions = z.object({
+  theme_mode: z
+    .enum(["system", "light", "dark"])
+    .optional()
+    .describe("Override terminal light/dark mode detection"),
   scroll_speed: z.number().min(0.001).optional().describe("TUI scroll speed"),
   scroll_acceleration: z
     .object({

--- a/packages/opencode/test/cli/tui/theme-store.test.ts
+++ b/packages/opencode/test/cli/tui/theme-store.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 
-const { DEFAULT_THEMES, allThemes, addTheme, hasTheme, resolveTheme } = await import(
+const { DEFAULT_THEMES, allThemes, addTheme, hasTheme, resolveTheme, resolveThemeModeState } = await import(
   "../../../src/cli/cmd/tui/context/theme"
 )
 
@@ -48,4 +48,32 @@ test("resolveTheme rejects circular color refs", () => {
   item.theme.primary = "one"
 
   expect(() => resolveTheme(item, "dark")).toThrow("Circular color reference")
+})
+
+test("resolveThemeModeState lets tui config force light mode", () => {
+  expect(
+    resolveThemeModeState({
+      detected: "dark",
+      config: "light",
+      persisted: "dark",
+      lock: "dark",
+    }),
+  ).toEqual({
+    mode: "light",
+    lock: "light",
+  })
+})
+
+test("resolveThemeModeState lets tui config reset back to system detection", () => {
+  expect(
+    resolveThemeModeState({
+      detected: "light",
+      config: "system",
+      persisted: "dark",
+      lock: "dark",
+    }),
+  ).toEqual({
+    mode: "light",
+    lock: undefined,
+  })
 })

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -40,6 +40,22 @@ test("loads tui config with the same precedence order as server config paths", a
   })
 })
 
+test("loads theme_mode from tui config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "tui.json"), JSON.stringify({ theme_mode: "light" }, null, 2))
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await TuiConfig.get()
+      expect(config.theme_mode).toBe("light")
+    },
+  })
+})
+
 test("migrates tui-specific keys from opencode.json when tui.json does not exist", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
@@ -141,6 +157,36 @@ test("drops unknown legacy tui keys during migration", async () => {
       const migrated = JSON.parse(text)
       expect(migrated.scroll_speed).toBe(2)
       expect(migrated.foo).toBeUndefined()
+    },
+  })
+})
+
+test("migrates legacy theme_mode from nested tui config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify(
+          {
+            tui: { theme_mode: "light" },
+          },
+          null,
+          2,
+        ),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await TuiConfig.get()
+      expect(config.theme_mode).toBe("light")
+
+      const text = await Filesystem.readText(path.join(tmp.path, "tui.json"))
+      expect(JSON.parse(text)).toMatchObject({
+        theme_mode: "light",
+      })
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #4464

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a `theme_mode` override to `tui.json` so terminals like Zellij do not get stuck in dark mode when automatic detection is wrong. It also migrates legacy nested `tui.theme_mode` settings into `tui.json` and wires the override into the TUI theme initialization.

### How did you verify your code works?

- Ran `bun test test/config/tui.test.ts test/cli/tui/theme-store.test.ts`
- Ran `bun run typecheck` in `packages/opencode`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
