### PR TITLE
fix(app): prefer dropped files over file URIs

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -6,6 +6,7 @@ import { uuid } from "@/utils/uuid"
 import { getCursorPosition } from "./editor-dom"
 import { attachmentMime } from "./files"
 import { normalizePaste, pasteMode } from "./paste"
+import { getDroppedPromptData } from "./drop"
 
 function dataUrl(file: File, mime: string) {
   return new Promise<string>((resolve) => {
@@ -165,19 +166,17 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     event.preventDefault()
     input.setDraggingType(null)
 
-    const plainText = event.dataTransfer?.getData("text/plain")
-    const filePrefix = "file:"
-    if (plainText?.startsWith(filePrefix)) {
-      const filePath = plainText.slice(filePrefix.length)
-      input.focusEditor()
-      input.addPart({ type: "file", path: filePath, content: "@" + filePath, start: 0, end: 0 })
+    const dropped = getDroppedPromptData(event.dataTransfer)
+    if (dropped.files.length > 0) {
+      await addAttachments(dropped.files)
       return
     }
 
-    const dropped = event.dataTransfer?.files
-    if (!dropped) return
-
-    await addAttachments(Array.from(dropped))
+    if (dropped.filePath) {
+      input.focusEditor()
+      input.addPart({ type: "file", path: dropped.filePath, content: "@" + dropped.filePath, start: 0, end: 0 })
+      return
+    }
   }
 
   onMount(() => {

--- a/packages/app/src/components/prompt-input/drop.test.ts
+++ b/packages/app/src/components/prompt-input/drop.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { getDroppedPromptData } from "./drop"
+
+describe("getDroppedPromptData", () => {
+  test("prefers dropped files over file uri text", () => {
+    const file = new File(["png"], "drop.png", { type: "image/png" })
+    const dataTransfer = {
+      files: [file] as unknown as FileList,
+      getData: () => "file:/tmp/drop.png",
+    }
+
+    const result = getDroppedPromptData(dataTransfer)
+    expect(result.files).toEqual([file])
+    expect(result.filePath).toBeUndefined()
+  })
+
+  test("falls back to file uri text when no files are present", () => {
+    const dataTransfer = {
+      files: [] as unknown as FileList,
+      getData: () => "file:/tmp/drop.png",
+    }
+
+    expect(getDroppedPromptData(dataTransfer)).toEqual({
+      files: [],
+      filePath: "/tmp/drop.png",
+    })
+  })
+})

--- a/packages/app/src/components/prompt-input/drop.ts
+++ b/packages/app/src/components/prompt-input/drop.ts
@@ -1,0 +1,17 @@
+type DropDataTransfer = Pick<DataTransfer, "files" | "getData">
+
+export function getDroppedPromptData(dataTransfer: DropDataTransfer | null | undefined): {
+  files: File[]
+  filePath?: string
+} {
+  const files = Array.from(dataTransfer?.files ?? [])
+  if (files.length > 0) return { files }
+
+  const plainText = dataTransfer?.getData("text/plain")
+  const filePrefix = "file:"
+  if (plainText?.startsWith(filePrefix)) {
+    return { files: [], filePath: plainText.slice(filePrefix.length) }
+  }
+
+  return { files: [] }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #4668

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This changes prompt drag-and-drop handling to prefer real dropped files over `text/plain` `file:` fallbacks. That fixes image drops that were being turned into file references instead of attachments, while keeping the file-path fallback when no real files are present.

### How did you verify your code works?

- Ran `bun test --preload ./happydom.ts ./src/components/prompt-input/attachments.test.ts ./src/components/prompt-input/drop.test.ts`
- Ran `bun run test:e2e:local -- e2e/prompt/prompt-drop-file.spec.ts e2e/prompt/prompt-drop-file-uri.spec.ts`
- Ran `bun run typecheck` in `packages/app`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
