### PR TITLE
fix(opencode): keep dynamic user.system separate for prompt caching

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -94,24 +94,26 @@ export namespace LLM {
         ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
         // any custom prompt passed into this call
         ...input.system,
-        // any custom prompt from last user message
-        ...(input.user.system ? [input.user.system] : []),
       ]
         .filter((x) => x)
         .join("\n"),
     )
+    if (input.user.system) {
+      system.push(input.user.system)
+    }
 
-    const header = system[0]
+    const count = system.length
+    const head = system[0]
     await Plugin.trigger(
       "experimental.chat.system.transform",
       { sessionID: input.sessionID, model: input.model },
       { system },
     )
     // rejoin to maintain 2-part structure for caching if header unchanged
-    if (system.length > 2 && system[0] === header) {
+    if (system.length > count && system[0] === head) {
       const rest = system.slice(1)
       system.length = 0
-      system.push(header, rest.join("\n"))
+      system.push(head, rest.join("\n"))
     }
 
     const variant =

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -777,6 +777,137 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("keeps dynamic Anthropic system content in a separate message", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "anthropic"
+    const modelID = "claude-3-5-sonnet-20241022"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const chunks = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg-2",
+          model: model.id,
+          usage: {
+            input_tokens: 3,
+            cache_creation_input_tokens: null,
+            cache_read_input_tokens: null,
+          },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello" },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null, container: null },
+        usage: {
+          input_tokens: 3,
+          output_tokens: 2,
+          cache_creation_input_tokens: null,
+          cache_read_input_tokens: null,
+        },
+      },
+      { type: "message_stop" },
+    ]
+    const request = waitRequest("/messages", createEventResponse(chunks))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-anthropic-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-4")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-4"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+          system: "Dynamic caller context.",
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant.", "Stay concise."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const system = capture.body.system
+
+        expect(capture.url.pathname.endsWith("/messages")).toBe(true)
+        expect(Array.isArray(system)).toBe(true)
+        if (!Array.isArray(system)) {
+          throw new Error("Expected Anthropic system payload to be an array")
+        }
+
+        const text = system
+          .map((item) => {
+            if (typeof item === "string") return item
+            if (!item || typeof item !== "object") return
+            const text = Reflect.get(item, "text")
+            if (typeof text === "string") return text
+          })
+          .filter((item): item is string => item !== undefined)
+
+        expect(text).toHaveLength(2)
+        expect(text[0]).toContain("You are a helpful assistant.")
+        expect(text[0]).toContain("Stay concise.")
+        expect(text[1]).toBe("Dynamic caller context.")
+      },
+    })
+  })
+
   test("sends Google API payload for Gemini models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Closes #20110

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic prompt caching misses because `packages/opencode/src/session/llm.ts` merges the session-static system prefix with per-turn `user.system` content before building the request. This PR keeps the static prefix in the first system message, sends dynamic `user.system` text as a separate second system message, and preserves that two-part shape after plugin system transforms. It also adds a regression test for the outbound Anthropic `/messages` payload.

This overlaps with #14203, #14743, and #19961. The scope here is intentionally narrow: only the `session/llm.ts` split plus the matching regression test.

### How did you verify your code works?

- `bun test test/session/llm.test.ts`
- `bun run typecheck`

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
