### PR TITLE
fix(tui): strip leaked system/internal tags from assistant message text

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -70,6 +70,7 @@ import { Toast, useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv.tsx"
 import { Editor } from "../../util/editor"
 import stripAnsi from "strip-ansi"
+import { sanitize } from "../../util/sanitize"
 import { usePromptRef } from "../../context/prompt"
 import { useExit } from "../../context/exit"
 import { Filesystem } from "@/util/filesystem"
@@ -1449,15 +1450,16 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const content = createMemo(() => sanitize(props.part.text))
   return (
-    <Show when={props.part.text.trim()}>
+    <Show when={content()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
               streaming={true}
-              content={props.part.text.trim()}
+              content={content()}
               conceal={ctx.conceal()}
               fg={theme.markdownText}
               bg={theme.background}
@@ -1469,7 +1471,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={content()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />

--- a/packages/opencode/src/cli/cmd/tui/util/sanitize.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/sanitize.ts
@@ -1,0 +1,19 @@
+// Patterns for tags injected by system prompts / wrappers that
+// the model sometimes echoes back in its response text.
+const tag = (name: string) =>
+  new RegExp("<" + name + ">[\\s\\S]*?</" + name + ">", "g")
+
+const PATTERNS: RegExp[] = [
+  tag("system-reminder"),
+  tag("dcp-" + "message-id"),
+  tag("dcp-" + "system-reminder"),
+  new RegExp("<" + "!--\\s*OMO_INTERNAL[\\s\\S]*?--" + ">", "g"),
+]
+
+export function sanitize(text: string): string {
+  let result = text
+  for (const pattern of PATTERNS) {
+    result = result.replace(pattern, "")
+  }
+  return result.trim()
+}

--- a/packages/opencode/test/tui/sanitize.test.ts
+++ b/packages/opencode/test/tui/sanitize.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import { sanitize } from "../../src/cli/cmd/tui/util/sanitize"
+
+describe("sanitize", () => {
+  test("returns text unchanged when no tags present", () => {
+    expect(sanitize("Hello world")).toBe("Hello world")
+  })
+
+  test("returns empty string for empty input", () => {
+    expect(sanitize("")).toBe("")
+    expect(sanitize("   ")).toBe("")
+  })
+
+  test("strips system-reminder tags", () => {
+    expect(sanitize("before <system-reminder>hidden</system-reminder> after")).toBe("before  after")
+  })
+
+  test("strips multiline system-reminder blocks", () => {
+    const input = [
+      "<system-reminder>",
+      "[BACKGROUND TASK COMPLETED]",
+      "**ID:** bg_123",
+      "</system-reminder>",
+      "Actual response",
+    ].join("\n")
+    expect(sanitize(input)).toBe("Actual response")
+  })
+
+  test("strips HTML comments with OMO_INTERNAL", () => {
+    expect(sanitize("text <!-- OMO_INTERNAL_INITIATOR --> more text")).toBe("text  more text")
+  })
+
+  test("strips multiple different tag types in one string", () => {
+    const input = [
+      "<system-reminder>reminder content</system-reminder>",
+      "<!-- OMO_INTERNAL_INITIATOR -->",
+      "Visible content here",
+    ].join("\n")
+    expect(sanitize(input)).toBe("Visible content here")
+  })
+
+  test("strips multiple occurrences of the same tag", () => {
+    const input = "<system-reminder>a</system-reminder> middle <system-reminder>b</system-reminder>"
+    expect(sanitize(input)).toBe("middle")
+  })
+
+  test("preserves normal HTML that is not a known injected tag", () => {
+    expect(sanitize("use <code>foo</code> here")).toBe("use <code>foo</code> here")
+  })
+
+  test("preserves normal HTML comments", () => {
+    expect(sanitize("<!-- normal comment -->")).toBe("<!-- normal comment -->")
+  })
+
+  test("handles tags at start and end of string", () => {
+    expect(sanitize("<system-reminder>x</system-reminder>")).toBe("")
+  })
+
+  test("handles only whitespace remaining after strip", () => {
+    expect(sanitize("  <system-reminder>x</system-reminder>  ")).toBe("")
+  })
+})
+
+describe("sanitize - dcp tags", () => {
+  const dcpMsg = "<" + "dcp-message-id" + ">m1234</" + "dcp-message-id" + ">"
+  const dcpSys = "<" + "dcp-system-reminder" + ">reminder</" + "dcp-system-reminder" + ">"
+
+  test("strips dcp-message-id tags", () => {
+    expect(sanitize("text " + dcpMsg + " more")).toBe("text  more")
+  })
+
+  test("strips dcp-system-reminder tags", () => {
+    expect(sanitize("text " + dcpSys + " more")).toBe("text  more")
+  })
+
+  test("strips all dcp tags combined", () => {
+    expect(sanitize(dcpMsg + " visible " + dcpSys)).toBe("visible")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #20148

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `TextPart` component in `routes/session/index.tsx` renders `props.part.text.trim()` directly. When the LLM echoes back injected XML tags (`<system-reminder>`, `<dcp-message-id>`, `<dcp-system-reminder>`, `<!-- OMO_INTERNAL_INITIATOR -->`), they show up as raw text in the TUI.

This adds a `sanitize()` utility that strips these known injected tag patterns from assistant text before rendering. The function constructs regexes dynamically (string concatenation) so the tags themselves aren't processed by intermediate rendering layers.

`TextPart` now wraps text through `sanitize()` via `createMemo` — same pattern used by `ReasoningPart` for its `[REDACTED]` replacement.

**Files changed:**
- `packages/opencode/src/cli/cmd/tui/util/sanitize.ts` — new sanitize utility
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` — integrate sanitize into TextPart
- `packages/opencode/test/tui/sanitize.test.ts` — 14 unit tests

### How did you verify your code works?

- 14 unit tests covering: all tag patterns, multiline blocks, multiple occurrences, edge cases (empty input, whitespace-only result), and preservation of normal HTML tags/comments
- Full test suite: 1715 pass, 0 fail (8 pre-existing skips)
- TypeScript typecheck: 0 new errors across all 13 packages

### Screenshots / recordings

_N/A — the fix strips invisible markup from text. No visual UI component changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR