### PR TITLE
feat(provider): add GitHub Copilot auto model selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ UPCOMING_CHANGELOG.md
 logs/
 *.bun-build
 tsconfig.tsbuildinfo
+
+# Training data and artifacts
+training/

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -76,7 +76,6 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
               toolcall: true,
               input: { text: true, audio: false, image: true, video: false, pdf: false },
               output: { text: true, audio: false, image: false, video: false, pdf: false },
-              interleaved: false,
             },
             cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
             limit: { context: 128000, output: 16384 },

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -56,6 +56,35 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             // model.api.npm = claude ? "@ai-sdk/anthropic" : "@ai-sdk/github-copilot"
             model.api.npm = "@ai-sdk/github-copilot"
           }
+
+          // Add the "auto" virtual model that uses Copilot's model routing API
+          provider.models["auto"] = {
+            id: "auto" as any,
+            providerID: "github-copilot" as any,
+            name: "Auto (Best for task)",
+            family: "auto",
+            api: {
+              id: "auto",
+              url: baseURL ?? "https://api.githubcopilot.com",
+              npm: "@ai-sdk/github-copilot",
+            },
+            status: "active",
+            capabilities: {
+              temperature: true,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: { text: true, audio: false, image: true, video: false, pdf: false },
+              output: { text: true, audio: false, image: false, video: false, pdf: false },
+              interleaved: false,
+            },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            limit: { context: 128000, output: 16384 },
+            options: {},
+            headers: {},
+            release_date: "",
+            variants: {},
+          }
         }
 
         return {

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -57,7 +57,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             model.api.npm = "@ai-sdk/github-copilot"
           }
 
-          // Add the "auto" virtual model that uses client-side model routing
+          // Add the "auto" virtual model for automatic model selection
           provider.models["auto"] = {
             id: "auto" as any,
             providerID: "github-copilot" as any,

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -57,12 +57,11 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             model.api.npm = "@ai-sdk/github-copilot"
           }
 
-          // Add the "auto" virtual model that uses Copilot's model routing API
+          // Add the "auto" virtual model that uses client-side model routing
           provider.models["auto"] = {
             id: "auto" as any,
             providerID: "github-copilot" as any,
             name: "Auto (Best for task)",
-            family: "auto",
             api: {
               id: "auto",
               url: baseURL ?? "https://api.githubcopilot.com",
@@ -81,8 +80,6 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             limit: { context: 128000, output: 16384 },
             options: {},
             headers: {},
-            release_date: "",
-            variants: {},
           }
         }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -208,32 +208,19 @@ export namespace Provider {
         options: {},
       }
     },
-    "github-copilot": async () => {
+    "github-copilot": async (input) => {
       return {
         autoload: false,
-        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
           if (modelID === "auto") {
-            const baseURL = options?.baseURL ?? "https://api.githubcopilot.com"
+            const providerModels = Object.keys(input.models).filter((id) => id !== "auto")
             return createCopilotAutoModel({
-              baseURL,
-              fetch: options?.fetch ?? fetch,
-              headers: () => {
-                const h: Record<string, string> = {}
-                if (options?.apiKey) h["Authorization"] = `Bearer ${options.apiKey}`
-                return h
-              },
-              createModel(resolvedModelId: string, extraHeaders?: Record<string, string>) {
-                // Rebuild the SDK with extra headers (Copilot-Session-Token) merged in
-                const sdkWithHeaders = extraHeaders
-                  ? createGitHubCopilotOpenAICompatible({
-                      ...options,
-                      headers: { ...options?.headers, ...extraHeaders },
-                    })
-                  : sdk
-                if (useLanguageModel(sdkWithHeaders)) return sdkWithHeaders.languageModel(resolvedModelId)
+              providerModels,
+              createModel(resolvedModelId: string) {
+                if (useLanguageModel(sdk)) return sdk.languageModel(resolvedModelId)
                 return shouldUseCopilotResponsesApi(resolvedModelId)
-                  ? sdkWithHeaders.responses(resolvedModelId)
-                  : sdkWithHeaders.chat(resolvedModelId)
+                  ? sdk.responses(resolvedModelId)
+                  : sdk.chat(resolvedModelId)
               },
             })
           }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -34,6 +34,7 @@ import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import { createOpenaiCompatible as createGitHubCopilotOpenAICompatible } from "./sdk/copilot"
+import { createCopilotAutoModel } from "./sdk/copilot/auto-model"
 import { createXai } from "@ai-sdk/xai"
 import { createMistral } from "@ai-sdk/mistral"
 import { createGroq } from "@ai-sdk/groq"
@@ -210,7 +211,32 @@ export namespace Provider {
     "github-copilot": async () => {
       return {
         autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          if (modelID === "auto") {
+            const baseURL = options?.baseURL ?? "https://api.githubcopilot.com"
+            return createCopilotAutoModel({
+              baseURL,
+              fetch: options?.fetch ?? fetch,
+              headers: () => {
+                const h: Record<string, string> = {}
+                if (options?.apiKey) h["Authorization"] = `Bearer ${options.apiKey}`
+                return h
+              },
+              createModel(resolvedModelId: string, extraHeaders?: Record<string, string>) {
+                // Rebuild the SDK with extra headers (Copilot-Session-Token) merged in
+                const sdkWithHeaders = extraHeaders
+                  ? createGitHubCopilotOpenAICompatible({
+                      ...options,
+                      headers: { ...options?.headers, ...extraHeaders },
+                    })
+                  : sdk
+                if (useLanguageModel(sdkWithHeaders)) return sdkWithHeaders.languageModel(resolvedModelId)
+                return shouldUseCopilotResponsesApi(resolvedModelId)
+                  ? sdkWithHeaders.responses(resolvedModelId)
+                  : sdkWithHeaders.chat(resolvedModelId)
+              },
+            })
+          }
           if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
           return shouldUseCopilotResponsesApi(modelID) ? sdk.responses(modelID) : sdk.chat(modelID)
         },
@@ -1578,6 +1604,7 @@ export namespace Provider {
   export function sort<T extends { id: string }>(models: T[]) {
     return sortBy(
       models,
+      [(model) => (model.id === "auto" ? 0 : 1), "asc"],
       [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
       [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
       [(model) => model.id, "desc"],

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -213,9 +213,9 @@ export namespace Provider {
         autoload: false,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
           if (modelID === "auto") {
-            const providerModels = Object.keys(input.models).filter((id) => id !== "auto")
+            const models = Object.values(input.models).filter((m) => m.id !== "auto")
             return createCopilotAutoModel({
-              providerModels,
+              models,
               createModel(resolvedModelId: string) {
                 if (useLanguageModel(sdk)) return sdk.languageModel(resolvedModelId)
                 return shouldUseCopilotResponsesApi(resolvedModelId)

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -59,13 +59,26 @@ function classifyModel(model: ModelInfo): Tier {
   return "standard"
 }
 
-function sortByCapability(a: ModelInfo, b: ModelInfo): number {
-  // Prefer non-codex models (more widely available across Copilot tiers)
-  const aCodex = a.id.includes("codex") ? 1 : 0
-  const bCodex = b.id.includes("codex") ? 1 : 0
-  if (aCodex !== bCodex) return aCodex - bCodex
-  if (b.limit.output !== a.limit.output) return b.limit.output - a.limit.output
-  return b.limit.context - a.limit.context
+// Preferred model families for each tier, checked in order.
+// Uses the same priority as opencode's default sort, with opus preferred for reasoning.
+const REASONING_PREFERENCE = ["claude-opus-4", "gpt-5.4", "gpt-5.3", "gpt-5.2", "gpt-5.1", "gpt-5", "claude-sonnet-4"]
+const STANDARD_PREFERENCE = ["claude-sonnet-4", "gpt-4.1", "gpt-4o"]
+const FAST_PREFERENCE = ["gpt-5-mini", "gpt-5.4-mini", "claude-haiku", "gemini-3-flash", "gemini-2.5-flash"]
+
+function sortByPreference(models: ModelInfo[], preference: string[]): ModelInfo[] {
+  return [...models].sort((a, b) => {
+    const aIdx = preference.findIndex((p) => a.id.includes(p))
+    const bIdx = preference.findIndex((p) => b.id.includes(p))
+    const aRank = aIdx === -1 ? preference.length : aIdx
+    const bRank = bIdx === -1 ? preference.length : bIdx
+    if (aRank !== bRank) return aRank - bRank
+    // Prefer non-codex models (more widely available)
+    const aCodex = a.id.includes("codex") ? 1 : 0
+    const bCodex = b.id.includes("codex") ? 1 : 0
+    if (aCodex !== bCodex) return aCodex - bCodex
+    if (b.limit.output !== a.limit.output) return b.limit.output - a.limit.output
+    return b.limit.context - a.limit.context
+  })
 }
 
 /**
@@ -111,9 +124,9 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     }
 
     this.tiers = {
-      reasoning: reasoning.sort(sortByCapability),
-      standard: standard.sort(sortByCapability),
-      fast: fast.sort(sortByCapability),
+      reasoning: sortByPreference(reasoning, REASONING_PREFERENCE),
+      standard: sortByPreference(standard, STANDARD_PREFERENCE),
+      fast: sortByPreference(fast, FAST_PREFERENCE),
     }
 
     const miniId = fast.find((m) => m.id.includes("gpt-5-mini"))?.id

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -52,17 +52,28 @@ function extractPromptText(options: LanguageModelV3CallOptions): string {
   return parts.join("\n")
 }
 
+/**
+ * Classify models by credit tier on GitHub Copilot:
+ * - Premium (3x credits): Opus, GPT-5.x flagship, Gemini Pro
+ * - Standard (1x credits): Sonnet, GPT-4.1, GPT-4o, Grok
+ * - Fast (0.25x credits): Mini, Haiku, Flash, Nano
+ */
 function classifyModel(model: ModelInfo): Tier {
-  const lower = model.id.toLowerCase()
-  if (/mini|haiku|flash|nano/.test(lower)) return "fast"
-  if (model.capabilities.reasoning && model.limit.output > 16384) return "reasoning"
+  const id = model.id.toLowerCase()
+  // Fast: cheap models (use word boundary to avoid matching "gemini")
+  if (/[-.]mini|haiku|flash|nano/.test(id)) return "fast"
+  // Reasoning: premium models (3x credits)
+  if (/opus/.test(id)) return "reasoning"
+  if (/^gpt-5(\.\d+)?$/.test(id)) return "reasoning"  // gpt-5, gpt-5.1, gpt-5.2, gpt-5.4
+  if (/^gpt-5\.\d+-codex(-max)?$/.test(id)) return "reasoning"  // gpt-5.1-codex, gpt-5.2-codex, gpt-5.1-codex-max
+  if (/gemini.*(pro|2\.5)/.test(id)) return "reasoning"
+  // Standard: everything else (1x credits)
   return "standard"
 }
 
 // Preferred model families for each tier, checked in order.
-// Uses the same priority as opencode's default sort, with opus preferred for reasoning.
-const REASONING_PREFERENCE = ["claude-opus-4", "gpt-5.4", "gpt-5.3", "gpt-5.2", "gpt-5.1", "gpt-5", "claude-sonnet-4"]
-const STANDARD_PREFERENCE = ["claude-sonnet-4", "gpt-4.1", "gpt-4o"]
+const REASONING_PREFERENCE = ["claude-opus-4", "gpt-5.4", "gpt-5.3", "gpt-5.2", "gpt-5.1", "gpt-5", "gemini-3-pro", "gemini-2.5-pro"]
+const STANDARD_PREFERENCE = ["claude-sonnet-4.6", "claude-sonnet-4.5", "claude-sonnet-4", "gpt-4.1", "gpt-4o", "grok"]
 const FAST_PREFERENCE = ["gpt-5-mini", "gpt-5.4-mini", "claude-haiku", "gemini-3-flash", "gemini-2.5-flash"]
 
 function sortByPreference(models: ModelInfo[], preference: string[]): ModelInfo[] {

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -6,30 +6,33 @@ import { Log } from "@/util/log"
 
 const log = Log.create({ service: "copilot-auto" })
 
+interface ModelInfo {
+  id: string
+  name: string
+  capabilities: {
+    reasoning: boolean
+    toolcall: boolean
+  }
+  limit: {
+    context: number
+    output: number
+  }
+}
+
 interface CopilotAutoModelOptions {
-  providerModels: string[]
+  models: ModelInfo[]
   createModel: (modelId: string) => LanguageModelV3
 }
 
 /**
- * Model tiers for client-side routing.
- * Ordered from most capable (reasoning-heavy) to lightweight.
- */
-const REASONING_MODELS = ["claude-opus-4.6", "claude-opus-4.5", "claude-opus-41", "gpt-5.4", "gpt-5.2", "gpt-5.1", "gpt-5"]
-const STANDARD_MODELS = ["claude-sonnet-4.6", "claude-sonnet-4.5", "claude-sonnet-4", "gpt-5.1-codex", "gpt-5.2-codex", "gpt-5.3-codex", "gemini-3-pro-preview", "gemini-2.5-pro", "gpt-4.1"]
-const FAST_MODELS = ["gpt-5-mini", "gpt-5.4-mini", "gpt-5.1-codex-mini", "claude-haiku-4.5", "gemini-3-flash-preview"]
-
-/**
- * Simple heuristics to classify a prompt's complexity.
+ * Classify prompt complexity based on the last user message.
  */
 function classifyPrompt(promptText: string): "reasoning" | "standard" | "fast" {
   const lower = promptText.toLowerCase()
   const len = promptText.length
 
-  // Short simple prompts → fast model
   if (len < 100) return "fast"
 
-  // Reasoning indicators
   const reasoningPatterns = [
     /\b(explain|why|analyze|compare|trade.?off|architect|design|plan|debug|refactor|review|security|audit)\b/,
     /\b(complex|difficult|tricky|subtle|edge.?case|race.?condition|concurren)/,
@@ -38,43 +41,61 @@ function classifyPrompt(promptText: string): "reasoning" | "standard" | "fast" {
   ]
   if (reasoningPatterns.some((p) => p.test(lower))) return "reasoning"
 
-  // Long prompts with code → standard
   if (len > 2000) return "standard"
-
-  // Code-heavy prompts → standard
   if ((promptText.match(/```/g)?.length ?? 0) >= 2) return "standard"
   if ((promptText.match(/\n/g)?.length ?? 0) > 20) return "standard"
 
-  // Default to standard
   return "standard"
 }
 
+/**
+ * Extract only the last user message for classification.
+ */
 function extractPromptText(options: LanguageModelV3CallOptions): string {
   const parts: string[] = []
-  for (const msg of options.prompt) {
+  for (let i = options.prompt.length - 1; i >= 0; i--) {
+    const msg = options.prompt[i]
     if (msg.role === "user") {
       for (const part of msg.content) {
         if (part.type === "text") {
           parts.push(part.text)
         }
       }
+      break
     }
   }
   return parts.join("\n")
 }
 
 /**
- * CopilotAutoLanguageModel implements LanguageModelV3 and automatically
- * selects the best available model for each request using client-side
- * heuristics based on prompt complexity.
+ * Classify a model into a tier based on its metadata.
  *
- * The Copilot server-side routing API (/models/session) is restricted to
- * first-party clients (VS Code). This implementation provides equivalent
- * functionality using local classification:
- *
- * - Reasoning-heavy prompts → most capable model (Opus, GPT-5.4, etc.)
- * - Standard coding tasks → balanced model (Sonnet, Codex, GPT-4.1, etc.)
- * - Simple/short prompts → fast model (Mini, Haiku, Flash, etc.)
+ * - "reasoning": has reasoning capability and large output limits (>16K)
+ * - "fast": small output limit (<8K) or name contains mini/haiku/flash/nano
+ * - "standard": everything else
+ */
+function classifyModel(model: ModelInfo): "reasoning" | "standard" | "fast" {
+  const lower = model.id.toLowerCase()
+
+  if (/mini|haiku|flash|nano/.test(lower)) return "fast"
+
+  if (model.capabilities.reasoning && model.limit.output > 16384) return "reasoning"
+
+  return "standard"
+}
+
+/**
+ * Sort models within a tier by capability (larger context/output first).
+ */
+function sortByCapability(a: ModelInfo, b: ModelInfo): number {
+  if (b.limit.output !== a.limit.output) return b.limit.output - a.limit.output
+  return b.limit.context - a.limit.context
+}
+
+/**
+ * CopilotAutoLanguageModel selects the best available model for each
+ * request using the model metadata from the provider (capabilities,
+ * context limits, output limits) — no hardcoded model lists.
  */
 export class CopilotAutoLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = "v3"
@@ -82,53 +103,73 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
   readonly provider = "github-copilot.auto"
   readonly supportsStructuredOutputs = false
 
+  private _lastResolvedModelId: string | null = null
   private readonly options: CopilotAutoModelOptions
+  private readonly tiers: {
+    reasoning: ModelInfo[]
+    standard: ModelInfo[]
+    fast: ModelInfo[]
+  }
+
+  get resolvedModelId(): string | null {
+    return this._lastResolvedModelId
+  }
 
   constructor(options: CopilotAutoModelOptions) {
     this.options = options
+
+    const reasoning: ModelInfo[] = []
+    const standard: ModelInfo[] = []
+    const fast: ModelInfo[] = []
+
+    for (const model of options.models) {
+      const tier = classifyModel(model)
+      switch (tier) {
+        case "reasoning": reasoning.push(model); break
+        case "standard": standard.push(model); break
+        case "fast": fast.push(model); break
+      }
+    }
+
+    this.tiers = {
+      reasoning: reasoning.sort(sortByCapability),
+      standard: standard.sort(sortByCapability),
+      fast: fast.sort(sortByCapability),
+    }
+
+    log.info("auto model tiers", {
+      reasoning: this.tiers.reasoning.map((m) => m.id),
+      standard: this.tiers.standard.map((m) => m.id),
+      fast: this.tiers.fast.map((m) => m.id),
+    })
   }
 
   get supportedUrls() {
     return {}
   }
 
-  private findBestAvailable(tier: string[]): string | undefined {
-    for (const model of tier) {
-      if (this.options.providerModels.some((m) => m.includes(model))) {
-        return this.options.providerModels.find((m) => m.includes(model))
+  private pickFromTier(classification: "reasoning" | "standard" | "fast"): string {
+    const order: Array<"reasoning" | "standard" | "fast"> =
+      classification === "reasoning" ? ["reasoning", "standard", "fast"] :
+      classification === "fast" ? ["fast", "standard", "reasoning"] :
+      ["standard", "reasoning", "fast"]
+
+    for (const tier of order) {
+      if (this.tiers[tier].length > 0) {
+        return this.tiers[tier][0].id
       }
     }
-    return undefined
+
+    // Ultimate fallback
+    return this.options.models[0].id
   }
 
   private resolveModel(callOptions: LanguageModelV3CallOptions): LanguageModelV3 {
     const promptText = extractPromptText(callOptions)
     const classification = classifyPrompt(promptText)
+    const selectedModelId = this.pickFromTier(classification)
 
-    let selectedModelId: string | undefined
-    switch (classification) {
-      case "reasoning":
-        selectedModelId = this.findBestAvailable(REASONING_MODELS)
-          ?? this.findBestAvailable(STANDARD_MODELS)
-          ?? this.findBestAvailable(FAST_MODELS)
-        break
-      case "standard":
-        selectedModelId = this.findBestAvailable(STANDARD_MODELS)
-          ?? this.findBestAvailable(REASONING_MODELS)
-          ?? this.findBestAvailable(FAST_MODELS)
-        break
-      case "fast":
-        selectedModelId = this.findBestAvailable(FAST_MODELS)
-          ?? this.findBestAvailable(STANDARD_MODELS)
-          ?? this.findBestAvailable(REASONING_MODELS)
-        break
-    }
-
-    if (!selectedModelId) {
-      // Ultimate fallback: first available model
-      selectedModelId = this.options.providerModels[0]
-    }
-
+    this._lastResolvedModelId = selectedModelId
     log.info("auto model selected", {
       classification,
       modelId: selectedModelId,

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -24,33 +24,18 @@ interface CopilotAutoModelOptions {
   createModel: (modelId: string) => LanguageModelV3
 }
 
-/**
- * Classify prompt complexity based on the last user message.
- */
-function classifyPrompt(promptText: string): "reasoning" | "standard" | "fast" {
-  const lower = promptText.toLowerCase()
-  const len = promptText.length
+type Tier = "fast" | "standard" | "reasoning"
 
-  if (len < 100) return "fast"
+const CLASSIFICATION_PROMPT = `You are a prompt complexity classifier for a coding assistant. Given a user prompt, rate its complexity as a single digit 1-5:
 
-  const reasoningPatterns = [
-    /\b(explain|why|analyze|compare|trade.?off|architect|design|plan|debug|refactor|review|security|audit)\b/,
-    /\b(complex|difficult|tricky|subtle|edge.?case|race.?condition|concurren)/,
-    /\b(step.?by.?step|think|reason|consider|evaluate)\b/,
-    /\b(optimize|performance|algorithm|data.?structure)\b/,
-  ]
-  if (reasoningPatterns.some((p) => p.test(lower))) return "reasoning"
+1 = Trivial (greetings, simple questions, one-line changes, "hello", "what is X")
+2 = Simple (basic CRUD, standard patterns, short implementations, "write a function to add two numbers")
+3 = Moderate (multi-step tasks, API design, refactoring, standard algorithms like binary search or LRU cache)
+4 = Complex (advanced algorithms, system design, debugging subtle issues, "design a rate limiter", "implement Dijkstra")
+5 = Expert (distributed systems, compiler internals, formal verification, lock-free data structures, consensus protocols)
 
-  if (len > 2000) return "standard"
-  if ((promptText.match(/```/g)?.length ?? 0) >= 2) return "standard"
-  if ((promptText.match(/\n/g)?.length ?? 0) > 20) return "standard"
+Reply with ONLY the digit, nothing else.`
 
-  return "standard"
-}
-
-/**
- * Extract only the last user message for classification.
- */
 function extractPromptText(options: LanguageModelV3CallOptions): string {
   const parts: string[] = []
   for (let i = options.prompt.length - 1; i >= 0; i--) {
@@ -67,35 +52,29 @@ function extractPromptText(options: LanguageModelV3CallOptions): string {
   return parts.join("\n")
 }
 
-/**
- * Classify a model into a tier based on its metadata.
- *
- * - "reasoning": has reasoning capability and large output limits (>16K)
- * - "fast": small output limit (<8K) or name contains mini/haiku/flash/nano
- * - "standard": everything else
- */
-function classifyModel(model: ModelInfo): "reasoning" | "standard" | "fast" {
+function classifyModel(model: ModelInfo): Tier {
   const lower = model.id.toLowerCase()
-
   if (/mini|haiku|flash|nano/.test(lower)) return "fast"
-
   if (model.capabilities.reasoning && model.limit.output > 16384) return "reasoning"
-
   return "standard"
 }
 
-/**
- * Sort models within a tier by capability (larger context/output first).
- */
 function sortByCapability(a: ModelInfo, b: ModelInfo): number {
   if (b.limit.output !== a.limit.output) return b.limit.output - a.limit.output
   return b.limit.context - a.limit.context
 }
 
 /**
- * CopilotAutoLanguageModel selects the best available model for each
- * request using the model metadata from the provider (capabilities,
- * context limits, output limits) — no hardcoded model lists.
+ * CopilotAutoLanguageModel uses GPT-5-mini (free on Copilot) to classify
+ * prompt complexity, then routes to the best available model.
+ *
+ * Rating → Tier:
+ *   1-2 → fast (mini/haiku/flash)
+ *   3   → standard (sonnet/gpt-4.1)
+ *   4-5 → reasoning (opus/codex)
+ *
+ * Prompts under 20 chars skip classification and go straight to fast.
+ * Model tiers are built dynamically from provider metadata.
  */
 export class CopilotAutoLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = "v3"
@@ -105,11 +84,8 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
 
   private _lastResolvedModelId: string | null = null
   private readonly options: CopilotAutoModelOptions
-  private readonly tiers: {
-    reasoning: ModelInfo[]
-    standard: ModelInfo[]
-    fast: ModelInfo[]
-  }
+  private readonly tiers: { reasoning: ModelInfo[]; standard: ModelInfo[]; fast: ModelInfo[] }
+  private classifierModel: LanguageModelV3 | null = null
 
   get resolvedModelId(): string | null {
     return this._lastResolvedModelId
@@ -123,8 +99,7 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     const fast: ModelInfo[] = []
 
     for (const model of options.models) {
-      const tier = classifyModel(model)
-      switch (tier) {
+      switch (classifyModel(model)) {
         case "reasoning": reasoning.push(model); break
         case "standard": standard.push(model); break
         case "fast": fast.push(model); break
@@ -135,6 +110,15 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
       reasoning: reasoning.sort(sortByCapability),
       standard: standard.sort(sortByCapability),
       fast: fast.sort(sortByCapability),
+    }
+
+    const miniId = fast.find((m) => m.id.includes("gpt-5-mini"))?.id
+      ?? fast.find((m) => m.id.includes("mini"))?.id
+      ?? fast[0]?.id
+
+    if (miniId) {
+      this.classifierModel = options.createModel(miniId)
+      log.info("auto model classifier", { classifierModel: miniId })
     }
 
     log.info("auto model tiers", {
@@ -148,28 +132,63 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     return {}
   }
 
-  private pickFromTier(classification: "reasoning" | "standard" | "fast"): string {
-    const order: Array<"reasoning" | "standard" | "fast"> =
-      classification === "reasoning" ? ["reasoning", "standard", "fast"] :
-      classification === "fast" ? ["fast", "standard", "reasoning"] :
+  private pickFromTier(tier: Tier): string {
+    const order: Tier[] =
+      tier === "reasoning" ? ["reasoning", "standard", "fast"] :
+      tier === "fast" ? ["fast", "standard", "reasoning"] :
       ["standard", "reasoning", "fast"]
 
-    for (const tier of order) {
-      if (this.tiers[tier].length > 0) {
-        return this.tiers[tier][0].id
-      }
+    for (const t of order) {
+      if (this.tiers[t].length > 0) return this.tiers[t][0].id
     }
-
-    // Ultimate fallback
     return this.options.models[0].id
   }
 
-  private resolveModel(callOptions: LanguageModelV3CallOptions): LanguageModelV3 {
-    const promptText = extractPromptText(callOptions)
-    const classification = classifyPrompt(promptText)
-    const selectedModelId = this.pickFromTier(classification)
+  private async classifyWithLLM(promptText: string): Promise<Tier> {
+    if (!this.classifierModel) return "standard"
 
+    try {
+      const result = await this.classifierModel.doGenerate({
+        mode: { type: "regular" },
+        prompt: [
+          {
+            role: "user",
+            content: [{ type: "text", text: CLASSIFICATION_PROMPT + "\n\nUser prompt: " + promptText.slice(0, 1000) }],
+          },
+        ],
+        maxOutputTokens: 1,
+        temperature: 0,
+      } as LanguageModelV3CallOptions)
+
+      const text = result.content
+        ?.filter((c): c is { type: "text"; text: string } => c.type === "text")
+        .map((c) => c.text)
+        .join("")
+        .trim()
+
+      const rating = parseInt(text ?? "", 10)
+      if (rating >= 1 && rating <= 5) {
+        return rating <= 2 ? "fast" : rating <= 3 ? "standard" : "reasoning"
+      }
+
+      log.warn("auto model classifier unexpected output", { output: text })
+      return "standard"
+    } catch (e) {
+      log.warn("auto model classifier failed", { error: e })
+      return "standard"
+    }
+  }
+
+  private async resolveModel(callOptions: LanguageModelV3CallOptions): Promise<LanguageModelV3> {
+    const promptText = extractPromptText(callOptions)
+
+    const classification = promptText.length < 20
+      ? "fast" as Tier
+      : await this.classifyWithLLM(promptText)
+
+    const selectedModelId = this.pickFromTier(classification)
     this._lastResolvedModelId = selectedModelId
+
     log.info("auto model selected", {
       classification,
       modelId: selectedModelId,
@@ -180,12 +199,12 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
-    const model = this.resolveModel(options)
+    const model = await this.resolveModel(options)
     return model.doGenerate(options)
   }
 
   async doStream(options: LanguageModelV3CallOptions) {
-    const model = this.resolveModel(options)
+    const model = await this.resolveModel(options)
     return model.doStream(options)
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -60,6 +60,10 @@ function classifyModel(model: ModelInfo): Tier {
 }
 
 function sortByCapability(a: ModelInfo, b: ModelInfo): number {
+  // Prefer non-codex models (more widely available across Copilot tiers)
+  const aCodex = a.id.includes("codex") ? 1 : 0
+  const bCodex = b.id.includes("codex") ? 1 : 0
+  if (aCodex !== bCodex) return aCodex - bCodex
   if (b.limit.output !== a.limit.output) return b.limit.output - a.limit.output
   return b.limit.context - a.limit.context
 }

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -1,0 +1,259 @@
+import type {
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+} from "@ai-sdk/provider"
+import type { FetchFunction } from "@ai-sdk/provider-utils"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "copilot-auto" })
+
+// 5 minutes before expiry, refresh the session token
+const SESSION_REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+export interface CopilotAutoModelSession {
+  availableModels: string[]
+  sessionToken: string
+  expiresAt: number
+  discountedCosts?: Record<string, number>
+}
+
+interface CopilotAutoModelOptions {
+  baseURL: string
+  fetch: FetchFunction
+  headers: () => Record<string, string | undefined>
+  createModel: (modelId: string, extraHeaders?: Record<string, string>) => LanguageModelV3
+}
+
+function extractPromptText(options: LanguageModelV3CallOptions): string {
+  const parts: string[] = []
+  for (const msg of options.prompt) {
+    if (msg.role === "user") {
+      for (const part of msg.content) {
+        if (part.type === "text") {
+          parts.push(part.text)
+        }
+      }
+    }
+  }
+  return parts.join("\n").slice(0, 4096)
+}
+
+function hasImageContent(options: LanguageModelV3CallOptions): boolean {
+  for (const msg of options.prompt) {
+    if (msg.role !== "user") continue
+    for (const part of msg.content) {
+      if (part.type === "image") return true
+    }
+  }
+  return false
+}
+
+/**
+ * CopilotAutoLanguageModel implements LanguageModelV3 and automatically
+ * selects the best model for each request using GitHub Copilot's
+ * /models/session and /models/session/intent APIs.
+ *
+ * Protocol (reverse-engineered from VS Code Copilot Chat extension):
+ *
+ * 1. POST /models/session  — creates an auto-mode session, returns
+ *    available_models, session_token, expires_at, discounted_costs
+ *
+ * 2. POST /models/session/intent  — per-turn routing, sends prompt text
+ *    and available models. The session_token is passed via the
+ *    Copilot-Session-Token header. Returns candidate_models ranked by
+ *    suitability.
+ *
+ * 3. The selected model's chat/responses request also receives the
+ *    Copilot-Session-Token header for billing discount tracking.
+ */
+export class CopilotAutoLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = "v3"
+  readonly modelId = "auto"
+  readonly provider = "github-copilot.auto"
+  readonly supportsStructuredOutputs = false
+
+  private session: CopilotAutoModelSession | null = null
+  private lastModelId: string | null = null
+  private lastPrompt: string | null = null
+  private turnNumber = 0
+  private readonly options: CopilotAutoModelOptions
+
+  constructor(options: CopilotAutoModelOptions) {
+    this.options = options
+  }
+
+  get supportedUrls() {
+    return {}
+  }
+
+  private isSessionExpired(): boolean {
+    if (!this.session) return true
+    return Date.now() >= this.session.expiresAt * 1000 - SESSION_REFRESH_BUFFER_MS
+  }
+
+  private async ensureSession(): Promise<CopilotAutoModelSession> {
+    if (this.session && !this.isSessionExpired()) return this.session
+
+    const url = `${this.options.baseURL}/models/session`
+    log.info("creating auto model session", { url })
+
+    const headers = this.options.headers()
+    const response = await this.options.fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify({
+        auto_mode: {
+          model_hints: ["auto"],
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Failed to create auto model session: ${response.status} ${text}`)
+    }
+
+    const data = (await response.json()) as {
+      available_models: string[]
+      session_token: string
+      expires_at: number
+      discounted_costs?: Record<string, number>
+    }
+
+    log.info("auto model session created", {
+      availableModels: data.available_models,
+      expiresAt: data.expires_at,
+    })
+
+    this.session = {
+      availableModels: data.available_models,
+      sessionToken: data.session_token,
+      expiresAt: data.expires_at,
+      discountedCosts: data.discounted_costs,
+    }
+
+    return this.session
+  }
+
+  private async resolveModel(callOptions: LanguageModelV3CallOptions): Promise<LanguageModelV3> {
+    const session = await this.ensureSession()
+    const promptText = extractPromptText(callOptions)
+
+    // Skip router for image requests — VS Code falls back to vision-capable model selection
+    if (hasImageContent(callOptions)) {
+      const fallbackModelId = session.availableModels[0]
+      log.info("auto model skipping router for image request", { modelId: fallbackModelId })
+      this.lastModelId = fallbackModelId
+      return this.options.createModel(fallbackModelId, {
+        "Copilot-Session-Token": session.sessionToken,
+      })
+    }
+
+    // Same prompt as last turn — reuse previous decision
+    if (promptText && promptText === this.lastPrompt && this.lastModelId) {
+      log.info("auto model reusing previous routing", { modelId: this.lastModelId })
+      return this.options.createModel(this.lastModelId, {
+        "Copilot-Session-Token": session.sessionToken,
+      })
+    }
+
+    this.turnNumber++
+    this.lastPrompt = promptText
+
+    const url = `${this.options.baseURL}/models/session/intent`
+    log.info("routing auto model", {
+      turnNumber: this.turnNumber,
+      promptLength: promptText.length,
+      availableModels: session.availableModels,
+    })
+
+    const headers = this.options.headers()
+
+    try {
+      const response = await this.options.fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Copilot-Session-Token": session.sessionToken,
+          ...headers,
+        },
+        body: JSON.stringify({
+          prompt: promptText,
+          available_models: session.availableModels,
+          turn_number: this.turnNumber,
+          previous_model: this.lastModelId,
+          prompt_char_count: promptText.length,
+          reference_count: 0,
+          session_id: undefined,
+          sticky_threshold: undefined,
+        }),
+      })
+
+      if (response.ok) {
+        const data = (await response.json()) as {
+          predicted_label?: string
+          confidence?: number
+          candidate_models: string[]
+          sticky_override?: boolean
+        }
+
+        if (data.candidate_models && data.candidate_models.length > 0) {
+          const selectedModelId = data.candidate_models[0]
+          log.info("auto model selected", {
+            modelId: selectedModelId,
+            predictedLabel: data.predicted_label,
+            confidence: data.confidence,
+            stickyOverride: data.sticky_override,
+          })
+          this.lastModelId = selectedModelId
+          return this.options.createModel(selectedModelId, {
+            "Copilot-Session-Token": session.sessionToken,
+          })
+        } else {
+          log.warn("auto model router returned empty candidates")
+        }
+      } else {
+        log.warn("auto model routing failed, using fallback", {
+          status: response.status,
+        })
+      }
+    } catch (e) {
+      log.warn("auto model routing error, using fallback", { error: e })
+    }
+
+    // Fallback: prefer same provider as previous model, else first available
+    const fallbackModelId = this.selectFallbackModel(session)
+    log.info("auto model fallback", { modelId: fallbackModelId })
+    this.lastModelId = fallbackModelId
+    return this.options.createModel(fallbackModelId, {
+      "Copilot-Session-Token": session.sessionToken,
+    })
+  }
+
+  private selectFallbackModel(session: CopilotAutoModelSession): string {
+    if (this.lastModelId) {
+      // Try to find a model from the same provider family
+      const lastProvider = this.lastModelId.split("-")[0]
+      const sameProvider = session.availableModels.find((m) => m.startsWith(lastProvider))
+      if (sameProvider) return sameProvider
+    }
+    return session.availableModels[0]
+  }
+
+  async doGenerate(options: LanguageModelV3CallOptions) {
+    const model = await this.resolveModel(options)
+    return model.doGenerate(options)
+  }
+
+  async doStream(options: LanguageModelV3CallOptions) {
+    const model = await this.resolveModel(options)
+    return model.doStream(options)
+  }
+}
+
+export function createCopilotAutoModel(options: CopilotAutoModelOptions): LanguageModelV3 {
+  return new CopilotAutoLanguageModel(options)
+}

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -2,26 +2,51 @@ import type {
   LanguageModelV3,
   LanguageModelV3CallOptions,
 } from "@ai-sdk/provider"
-import type { FetchFunction } from "@ai-sdk/provider-utils"
 import { Log } from "@/util/log"
 
 const log = Log.create({ service: "copilot-auto" })
 
-// 5 minutes before expiry, refresh the session token
-const SESSION_REFRESH_BUFFER_MS = 5 * 60 * 1000
-
-export interface CopilotAutoModelSession {
-  availableModels: string[]
-  sessionToken: string
-  expiresAt: number
-  discountedCosts?: Record<string, number>
+interface CopilotAutoModelOptions {
+  providerModels: string[]
+  createModel: (modelId: string) => LanguageModelV3
 }
 
-interface CopilotAutoModelOptions {
-  baseURL: string
-  fetch: FetchFunction
-  headers: () => Record<string, string | undefined>
-  createModel: (modelId: string, extraHeaders?: Record<string, string>) => LanguageModelV3
+/**
+ * Model tiers for client-side routing.
+ * Ordered from most capable (reasoning-heavy) to lightweight.
+ */
+const REASONING_MODELS = ["claude-opus-4.6", "claude-opus-4.5", "claude-opus-41", "gpt-5.4", "gpt-5.2", "gpt-5.1", "gpt-5"]
+const STANDARD_MODELS = ["claude-sonnet-4.6", "claude-sonnet-4.5", "claude-sonnet-4", "gpt-5.1-codex", "gpt-5.2-codex", "gpt-5.3-codex", "gemini-3-pro-preview", "gemini-2.5-pro", "gpt-4.1"]
+const FAST_MODELS = ["gpt-5-mini", "gpt-5.4-mini", "gpt-5.1-codex-mini", "claude-haiku-4.5", "gemini-3-flash-preview"]
+
+/**
+ * Simple heuristics to classify a prompt's complexity.
+ */
+function classifyPrompt(promptText: string): "reasoning" | "standard" | "fast" {
+  const lower = promptText.toLowerCase()
+  const len = promptText.length
+
+  // Short simple prompts → fast model
+  if (len < 100) return "fast"
+
+  // Reasoning indicators
+  const reasoningPatterns = [
+    /\b(explain|why|analyze|compare|trade.?off|architect|design|plan|debug|refactor|review|security|audit)\b/,
+    /\b(complex|difficult|tricky|subtle|edge.?case|race.?condition|concurren)/,
+    /\b(step.?by.?step|think|reason|consider|evaluate)\b/,
+    /\b(optimize|performance|algorithm|data.?structure)\b/,
+  ]
+  if (reasoningPatterns.some((p) => p.test(lower))) return "reasoning"
+
+  // Long prompts with code → standard
+  if (len > 2000) return "standard"
+
+  // Code-heavy prompts → standard
+  if ((promptText.match(/```/g)?.length ?? 0) >= 2) return "standard"
+  if ((promptText.match(/\n/g)?.length ?? 0) > 20) return "standard"
+
+  // Default to standard
+  return "standard"
 }
 
 function extractPromptText(options: LanguageModelV3CallOptions): string {
@@ -35,36 +60,21 @@ function extractPromptText(options: LanguageModelV3CallOptions): string {
       }
     }
   }
-  return parts.join("\n").slice(0, 4096)
-}
-
-function hasImageContent(options: LanguageModelV3CallOptions): boolean {
-  for (const msg of options.prompt) {
-    if (msg.role !== "user") continue
-    for (const part of msg.content) {
-      if (part.type === "image") return true
-    }
-  }
-  return false
+  return parts.join("\n")
 }
 
 /**
  * CopilotAutoLanguageModel implements LanguageModelV3 and automatically
- * selects the best model for each request using GitHub Copilot's
- * /models/session and /models/session/intent APIs.
+ * selects the best available model for each request using client-side
+ * heuristics based on prompt complexity.
  *
- * Protocol (reverse-engineered from VS Code Copilot Chat extension):
+ * The Copilot server-side routing API (/models/session) is restricted to
+ * first-party clients (VS Code). This implementation provides equivalent
+ * functionality using local classification:
  *
- * 1. POST /models/session  — creates an auto-mode session, returns
- *    available_models, session_token, expires_at, discounted_costs
- *
- * 2. POST /models/session/intent  — per-turn routing, sends prompt text
- *    and available models. The session_token is passed via the
- *    Copilot-Session-Token header. Returns candidate_models ranked by
- *    suitability.
- *
- * 3. The selected model's chat/responses request also receives the
- *    Copilot-Session-Token header for billing discount tracking.
+ * - Reasoning-heavy prompts → most capable model (Opus, GPT-5.4, etc.)
+ * - Standard coding tasks → balanced model (Sonnet, Codex, GPT-4.1, etc.)
+ * - Simple/short prompts → fast model (Mini, Haiku, Flash, etc.)
  */
 export class CopilotAutoLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = "v3"
@@ -72,10 +82,6 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
   readonly provider = "github-copilot.auto"
   readonly supportsStructuredOutputs = false
 
-  private session: CopilotAutoModelSession | null = null
-  private lastModelId: string | null = null
-  private lastPrompt: string | null = null
-  private turnNumber = 0
   private readonly options: CopilotAutoModelOptions
 
   constructor(options: CopilotAutoModelOptions) {
@@ -86,170 +92,59 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     return {}
   }
 
-  private isSessionExpired(): boolean {
-    if (!this.session) return true
-    return Date.now() >= this.session.expiresAt * 1000 - SESSION_REFRESH_BUFFER_MS
-  }
-
-  private async ensureSession(): Promise<CopilotAutoModelSession> {
-    if (this.session && !this.isSessionExpired()) return this.session
-
-    const url = `${this.options.baseURL}/models/session`
-    log.info("creating auto model session", { url })
-
-    const headers = this.options.headers()
-    const response = await this.options.fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...headers,
-      },
-      body: JSON.stringify({
-        auto_mode: {
-          model_hints: ["auto"],
-        },
-      }),
-    })
-
-    if (!response.ok) {
-      const text = await response.text()
-      throw new Error(`Failed to create auto model session: ${response.status} ${text}`)
-    }
-
-    const data = (await response.json()) as {
-      available_models: string[]
-      session_token: string
-      expires_at: number
-      discounted_costs?: Record<string, number>
-    }
-
-    log.info("auto model session created", {
-      availableModels: data.available_models,
-      expiresAt: data.expires_at,
-    })
-
-    this.session = {
-      availableModels: data.available_models,
-      sessionToken: data.session_token,
-      expiresAt: data.expires_at,
-      discountedCosts: data.discounted_costs,
-    }
-
-    return this.session
-  }
-
-  private async resolveModel(callOptions: LanguageModelV3CallOptions): Promise<LanguageModelV3> {
-    const session = await this.ensureSession()
-    const promptText = extractPromptText(callOptions)
-
-    // Skip router for image requests — VS Code falls back to vision-capable model selection
-    if (hasImageContent(callOptions)) {
-      const fallbackModelId = session.availableModels[0]
-      log.info("auto model skipping router for image request", { modelId: fallbackModelId })
-      this.lastModelId = fallbackModelId
-      return this.options.createModel(fallbackModelId, {
-        "Copilot-Session-Token": session.sessionToken,
-      })
-    }
-
-    // Same prompt as last turn — reuse previous decision
-    if (promptText && promptText === this.lastPrompt && this.lastModelId) {
-      log.info("auto model reusing previous routing", { modelId: this.lastModelId })
-      return this.options.createModel(this.lastModelId, {
-        "Copilot-Session-Token": session.sessionToken,
-      })
-    }
-
-    this.turnNumber++
-    this.lastPrompt = promptText
-
-    const url = `${this.options.baseURL}/models/session/intent`
-    log.info("routing auto model", {
-      turnNumber: this.turnNumber,
-      promptLength: promptText.length,
-      availableModels: session.availableModels,
-    })
-
-    const headers = this.options.headers()
-
-    try {
-      const response = await this.options.fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Copilot-Session-Token": session.sessionToken,
-          ...headers,
-        },
-        body: JSON.stringify({
-          prompt: promptText,
-          available_models: session.availableModels,
-          turn_number: this.turnNumber,
-          previous_model: this.lastModelId,
-          prompt_char_count: promptText.length,
-          reference_count: 0,
-          session_id: undefined,
-          sticky_threshold: undefined,
-        }),
-      })
-
-      if (response.ok) {
-        const data = (await response.json()) as {
-          predicted_label?: string
-          confidence?: number
-          candidate_models: string[]
-          sticky_override?: boolean
-        }
-
-        if (data.candidate_models && data.candidate_models.length > 0) {
-          const selectedModelId = data.candidate_models[0]
-          log.info("auto model selected", {
-            modelId: selectedModelId,
-            predictedLabel: data.predicted_label,
-            confidence: data.confidence,
-            stickyOverride: data.sticky_override,
-          })
-          this.lastModelId = selectedModelId
-          return this.options.createModel(selectedModelId, {
-            "Copilot-Session-Token": session.sessionToken,
-          })
-        } else {
-          log.warn("auto model router returned empty candidates")
-        }
-      } else {
-        log.warn("auto model routing failed, using fallback", {
-          status: response.status,
-        })
+  private findBestAvailable(tier: string[]): string | undefined {
+    for (const model of tier) {
+      if (this.options.providerModels.some((m) => m.includes(model))) {
+        return this.options.providerModels.find((m) => m.includes(model))
       }
-    } catch (e) {
-      log.warn("auto model routing error, using fallback", { error: e })
     }
-
-    // Fallback: prefer same provider as previous model, else first available
-    const fallbackModelId = this.selectFallbackModel(session)
-    log.info("auto model fallback", { modelId: fallbackModelId })
-    this.lastModelId = fallbackModelId
-    return this.options.createModel(fallbackModelId, {
-      "Copilot-Session-Token": session.sessionToken,
-    })
+    return undefined
   }
 
-  private selectFallbackModel(session: CopilotAutoModelSession): string {
-    if (this.lastModelId) {
-      // Try to find a model from the same provider family
-      const lastProvider = this.lastModelId.split("-")[0]
-      const sameProvider = session.availableModels.find((m) => m.startsWith(lastProvider))
-      if (sameProvider) return sameProvider
+  private resolveModel(callOptions: LanguageModelV3CallOptions): LanguageModelV3 {
+    const promptText = extractPromptText(callOptions)
+    const classification = classifyPrompt(promptText)
+
+    let selectedModelId: string | undefined
+    switch (classification) {
+      case "reasoning":
+        selectedModelId = this.findBestAvailable(REASONING_MODELS)
+          ?? this.findBestAvailable(STANDARD_MODELS)
+          ?? this.findBestAvailable(FAST_MODELS)
+        break
+      case "standard":
+        selectedModelId = this.findBestAvailable(STANDARD_MODELS)
+          ?? this.findBestAvailable(REASONING_MODELS)
+          ?? this.findBestAvailable(FAST_MODELS)
+        break
+      case "fast":
+        selectedModelId = this.findBestAvailable(FAST_MODELS)
+          ?? this.findBestAvailable(STANDARD_MODELS)
+          ?? this.findBestAvailable(REASONING_MODELS)
+        break
     }
-    return session.availableModels[0]
+
+    if (!selectedModelId) {
+      // Ultimate fallback: first available model
+      selectedModelId = this.options.providerModels[0]
+    }
+
+    log.info("auto model selected", {
+      classification,
+      modelId: selectedModelId,
+      promptLength: promptText.length,
+    })
+
+    return this.options.createModel(selectedModelId)
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
-    const model = await this.resolveModel(options)
+    const model = this.resolveModel(options)
     return model.doGenerate(options)
   }
 
   async doStream(options: LanguageModelV3CallOptions) {
-    const model = await this.resolveModel(options)
+    const model = this.resolveModel(options)
     return model.doStream(options)
   }
 }

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -103,6 +103,7 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
   private readonly options: CopilotAutoModelOptions
   private readonly tiers: { reasoning: ModelInfo[]; standard: ModelInfo[]; fast: ModelInfo[] }
   private classifierModel: LanguageModelV3 | null = null
+  private unavailableModels = new Set<string>()
 
   get resolvedModelId(): string | null {
     return this._lastResolvedModelId
@@ -149,16 +150,21 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     return {}
   }
 
-  private pickFromTier(tier: Tier): string {
+  private getCandidates(tier: Tier): string[] {
     const order: Tier[] =
       tier === "reasoning" ? ["reasoning", "standard", "fast"] :
       tier === "fast" ? ["fast", "standard", "reasoning"] :
       ["standard", "reasoning", "fast"]
 
+    const candidates: string[] = []
     for (const t of order) {
-      if (this.tiers[t].length > 0) return this.tiers[t][0].id
+      for (const m of this.tiers[t]) {
+        if (!this.unavailableModels.has(m.id)) {
+          candidates.push(m.id)
+        }
+      }
     }
-    return this.options.models[0].id
+    return candidates.length > 0 ? candidates : [this.options.models[0].id]
   }
 
   private async classifyWithLLM(promptText: string): Promise<Tier> {
@@ -196,33 +202,73 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     }
   }
 
-  private async resolveModel(callOptions: LanguageModelV3CallOptions): Promise<LanguageModelV3> {
+  private async getCandidatesForPrompt(callOptions: LanguageModelV3CallOptions): Promise<string[]> {
     const promptText = extractPromptText(callOptions)
 
     const classification = promptText.length < 20
       ? "fast" as Tier
       : await this.classifyWithLLM(promptText)
 
-    const selectedModelId = this.pickFromTier(classification)
-    this._lastResolvedModelId = selectedModelId
+    const candidates = this.getCandidates(classification)
 
-    log.info("auto model selected", {
+    log.info("auto model candidates", {
       classification,
-      modelId: selectedModelId,
+      candidates: candidates.slice(0, 5),
       promptLength: promptText.length,
     })
 
-    return this.options.createModel(selectedModelId)
+    return candidates
+  }
+
+  private isModelUnavailableError(error: unknown): boolean {
+    const msg = String(error)
+    return msg.includes("model_not_supported") ||
+      msg.includes("not supported") ||
+      msg.includes("does not exist") ||
+      msg.includes("not found") ||
+      msg.includes("not available")
   }
 
   async doGenerate(options: LanguageModelV3CallOptions) {
-    const model = await this.resolveModel(options)
-    return model.doGenerate(options)
+    const candidates = await this.getCandidatesForPrompt(options)
+
+    for (const modelId of candidates) {
+      try {
+        this._lastResolvedModelId = modelId
+        log.info("auto model trying", { modelId })
+        const model = this.options.createModel(modelId)
+        return await model.doGenerate(options)
+      } catch (e) {
+        if (this.isModelUnavailableError(e)) {
+          log.warn("auto model unavailable, trying next", { modelId, error: String(e).slice(0, 100) })
+          this.unavailableModels.add(modelId)
+          continue
+        }
+        throw e
+      }
+    }
+    throw new Error("auto model: all candidate models are unavailable")
   }
 
   async doStream(options: LanguageModelV3CallOptions) {
-    const model = await this.resolveModel(options)
-    return model.doStream(options)
+    const candidates = await this.getCandidatesForPrompt(options)
+
+    for (const modelId of candidates) {
+      try {
+        this._lastResolvedModelId = modelId
+        log.info("auto model trying", { modelId })
+        const model = this.options.createModel(modelId)
+        return await model.doStream(options)
+      } catch (e) {
+        if (this.isModelUnavailableError(e)) {
+          log.warn("auto model unavailable, trying next", { modelId, error: String(e).slice(0, 100) })
+          this.unavailableModels.add(modelId)
+          continue
+        }
+        throw e
+      }
+    }
+    throw new Error("auto model: all candidate models are unavailable")
   }
 }
 

--- a/packages/opencode/src/provider/sdk/copilot/auto-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/auto-model.ts
@@ -5,6 +5,7 @@ import type {
 import { Log } from "@/util/log"
 
 const log = Log.create({ service: "copilot-auto" })
+const DRY_RUN = process.env.OPENCODE_AUTO_DRY_RUN === "1" || process.env.OPENCODE_AUTO_DRY_RUN === "true"
 
 interface ModelInfo {
   id: string
@@ -178,7 +179,44 @@ export class CopilotAutoLanguageModel implements LanguageModelV3 {
     return candidates.length > 0 ? candidates : [this.options.models[0].id]
   }
 
+  /**
+   * Fast local heuristic for dry-run mode (no API calls).
+   * Uses keyword patterns and length to approximate GPT-5-mini's classification.
+   */
+  private classifyLocally(promptText: string): Tier {
+    const lower = promptText.toLowerCase()
+    const len = promptText.length
+
+    // Check reasoning keywords first (even short prompts can be complex)
+    // Reasoning keywords
+    const reasoningPatterns = [
+      /\b(distributed|consensus|lock.?free|concurrent|fault.?tolerant)\b/,
+      /\b(compiler|parser|type.?inference|garbage.?collect|runtime)\b/,
+      /\b(architect|trade.?off|race.?condition|deadlock|backpressure)\b/,
+      /\b(optimize|bottleneck|profil|latency|throughput)\b/,
+      /\b(security|vulnerabilit|exploit|audit|penetration)\b/,
+      /\b(formal.?verif|proof|theorem|invariant|correctness)\b/,
+    ]
+    if (reasoningPatterns.some((p) => p.test(lower))) return "reasoning"
+
+    // Short without reasoning keywords = fast
+    if (len < 80) return "fast"
+
+    // Long or code-heavy = standard
+    if (len > 300) return "standard"
+    if (/```/.test(promptText)) return "standard"
+
+    return "standard"
+  }
+
   private async classifyWithLLM(promptText: string): Promise<Tier> {
+    // Dry-run mode: use local heuristic, no API calls
+    if (DRY_RUN) {
+      const tier = this.classifyLocally(promptText)
+      log.info("auto model dry-run classification", { tier, promptLength: promptText.length })
+      return tier
+    }
+
     if (!this.classifierModel) return "standard"
 
     try {

--- a/packages/opencode/src/provider/sdk/copilot/index.ts
+++ b/packages/opencode/src/provider/sdk/copilot/index.ts
@@ -1,2 +1,3 @@
 export { createOpenaiCompatible, openaiCompatible } from "./copilot-provider"
 export type { OpenaiCompatibleProvider, OpenaiCompatibleProviderSettings } from "./copilot-provider"
+export { createCopilotAutoModel, CopilotAutoLanguageModel } from "./auto-model"

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -16,7 +16,7 @@ import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
-import type { Provider } from "@/provider/provider"
+import { Provider } from "@/provider/provider"
 import { Question } from "@/question"
 
 export namespace SessionProcessor {
@@ -108,7 +108,17 @@ export namespace SessionProcessor {
           switch (value.type) {
             case "start":
               yield* status.set(ctx.sessionID, { type: "busy" })
+              // Show the resolved model in the message header when using auto selection
+              if (ctx.assistantMessage.modelID === ("auto" as any) && ctx.model.id === ("auto" as any)) {
+                const language = yield* Effect.promise(() => Provider.getLanguage(ctx.model))
+                const resolved = (language as any).resolvedModelId
+                if (resolved) {
+                  ctx.assistantMessage.modelID = resolved as any
+                  yield* session.updateMessage(ctx.assistantMessage)
+                }
+              }
               return
+
 
             case "reasoning-start":
               if (value.id in ctx.reasoningMap) return

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -119,7 +119,6 @@ export namespace SessionProcessor {
               }
               return
 
-
             case "reasoning-start":
               if (value.id in ctx.reasoningMap) return
               ctx.reasoningMap[value.id] = {

--- a/packages/opencode/test/provider/copilot/auto-model.test.ts
+++ b/packages/opencode/test/provider/copilot/auto-model.test.ts
@@ -1,0 +1,279 @@
+import { describe, test, expect, mock } from "bun:test"
+import { CopilotAutoLanguageModel, createCopilotAutoModel } from "@/provider/sdk/copilot/auto-model"
+import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider"
+
+// Mock models matching real Copilot model list
+const MOCK_MODELS = [
+  { id: "claude-opus-4.6", name: "Claude Opus 4.6", capabilities: { reasoning: true, toolcall: true }, limit: { context: 200000, output: 32000 } },
+  { id: "claude-opus-4.5", name: "Claude Opus 4.5", capabilities: { reasoning: true, toolcall: true }, limit: { context: 200000, output: 16384 } },
+  { id: "gpt-5.4", name: "GPT-5.4", capabilities: { reasoning: true, toolcall: true }, limit: { context: 128000, output: 32000 } },
+  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex", capabilities: { reasoning: true, toolcall: true }, limit: { context: 200000, output: 16384 } },
+  { id: "gpt-5", name: "GPT-5", capabilities: { reasoning: true, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "gemini-3-pro-preview", name: "Gemini 3 Pro", capabilities: { reasoning: true, toolcall: true }, limit: { context: 1000000, output: 65536 } },
+  { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", capabilities: { reasoning: true, toolcall: true }, limit: { context: 1000000, output: 65536 } },
+  { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", capabilities: { reasoning: true, toolcall: true }, limit: { context: 200000, output: 16384 } },
+  { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", capabilities: { reasoning: true, toolcall: true }, limit: { context: 200000, output: 16384 } },
+  { id: "claude-sonnet-4", name: "Claude Sonnet 4", capabilities: { reasoning: false, toolcall: true }, limit: { context: 200000, output: 16384 } },
+  { id: "gpt-4.1", name: "GPT-4.1", capabilities: { reasoning: false, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "gpt-4o", name: "GPT-4o", capabilities: { reasoning: false, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "grok-code-fast-1", name: "Grok", capabilities: { reasoning: false, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "gpt-5-mini", name: "GPT-5 Mini", capabilities: { reasoning: false, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", capabilities: { reasoning: false, toolcall: true }, limit: { context: 128000, output: 16384 } },
+  { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", capabilities: { reasoning: false, toolcall: true }, limit: { context: 200000, output: 8192 } },
+  { id: "gemini-3-flash-preview", name: "Gemini 3 Flash", capabilities: { reasoning: false, toolcall: true }, limit: { context: 1000000, output: 65536 } },
+]
+
+function makeCallOptions(prompt: string): LanguageModelV3CallOptions {
+  return {
+    mode: { type: "regular" },
+    prompt: [
+      { role: "user", content: [{ type: "text", text: prompt }] },
+    ],
+  } as LanguageModelV3CallOptions
+}
+
+function makeMockModel(modelId: string): LanguageModelV3 {
+  return {
+    specificationVersion: "v3",
+    modelId,
+    provider: "github-copilot.chat",
+    get supportedUrls() { return {} },
+    async doGenerate() { return { content: [{ type: "text" as const, text: "mock" }] } as any },
+    async doStream() { return { stream: (async function* () {})() } as any },
+  }
+}
+
+// Mock the classifier to return a specific rating without calling GPT-5-mini
+function createAutoModelWithMockClassifier(classifierRating: number) {
+  const createdModels: string[] = []
+
+  const autoModel = createCopilotAutoModel({
+    models: MOCK_MODELS,
+    createModel(modelId: string) {
+      createdModels.push(modelId)
+      return makeMockModel(modelId)
+    },
+  })
+
+  // Override the classifier to return our mock rating
+  const model = autoModel as CopilotAutoLanguageModel
+  ;(model as any).classifierModel = {
+    specificationVersion: "v3",
+    modelId: "mock-classifier",
+    provider: "mock",
+    get supportedUrls() { return {} },
+    async doGenerate() {
+      return {
+        content: [{ type: "text" as const, text: String(classifierRating) }],
+      } as any
+    },
+    async doStream() { return { stream: (async function* () {})() } as any },
+  }
+
+  return { model, createdModels }
+}
+
+describe("CopilotAutoLanguageModel", () => {
+  describe("tier classification", () => {
+    test("short prompts skip LLM and go to fast", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(5)
+      await model.doGenerate(makeCallOptions("hi"))
+      // Should pick fast model without consulting classifier (prompt < 20 chars)
+      expect(createdModels.at(-1)).toBe("gpt-5-mini")
+    })
+
+    test("rating 1 routes to fast tier", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(1)
+      await model.doGenerate(makeCallOptions("write a hello world program in Python"))
+      expect(createdModels.at(-1)).toBe("gpt-5-mini")
+    })
+
+    test("rating 2 routes to fast tier", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(2)
+      await model.doGenerate(makeCallOptions("write a function to reverse a string"))
+      expect(createdModels.at(-1)).toBe("gpt-5-mini")
+    })
+
+    test("rating 3 routes to standard tier", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(3)
+      await model.doGenerate(makeCallOptions("implement a LRU cache with get and put"))
+      // createdModels[0] is the classifier (gpt-5-mini), the routed model is last
+      expect(createdModels.at(-1)).toBe("claude-sonnet-4.6")
+    })
+
+    test("rating 4 routes to reasoning tier", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(4)
+      await model.doGenerate(makeCallOptions("design a rate limiter using the token bucket algorithm"))
+      expect(createdModels.at(-1)).toBe("claude-opus-4.6")
+    })
+
+    test("rating 5 routes to reasoning tier", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(5)
+      await model.doGenerate(makeCallOptions("design a distributed consensus algorithm similar to Raft"))
+      expect(createdModels.at(-1)).toBe("claude-opus-4.6")
+    })
+  })
+
+  describe("model preferences", () => {
+    test("reasoning tier prefers opus over gpt-5", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(5)
+      await model.doGenerate(makeCallOptions("implement a lock-free concurrent hash map"))
+      expect(createdModels.at(-1)).toBe("claude-opus-4.6")
+    })
+
+    test("standard tier prefers sonnet 4.6 over gpt-4.1", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(3)
+      await model.doGenerate(makeCallOptions("add pagination to the API endpoint"))
+      // createdModels[0] is the classifier (gpt-5-mini), the routed model is last
+      expect(createdModels.at(-1)).toBe("claude-sonnet-4.6")
+    })
+
+    test("fast tier prefers gpt-5-mini over codex-mini", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(1)
+      await model.doGenerate(makeCallOptions("write a function that adds two numbers"))
+      expect(createdModels.at(-1)).toBe("gpt-5-mini")
+    })
+  })
+
+  describe("fallback on unavailable models", () => {
+    test("falls back to next model when first is unavailable", async () => {
+      const createdModels: string[] = []
+      let callCount = 0
+
+      const autoModel = createCopilotAutoModel({
+        models: MOCK_MODELS,
+        createModel(modelId: string) {
+          createdModels.push(modelId)
+          return {
+            specificationVersion: "v3" as const,
+            modelId,
+            provider: "github-copilot.chat",
+                    get supportedUrls() { return {} },
+            async doGenerate() {
+              callCount++
+              if (modelId === "claude-opus-4.6") {
+                throw new Error("The requested model is not supported.")
+              }
+              return { content: [{ type: "text" as const, text: "ok" }] } as any
+            },
+            async doStream() { throw new Error("not implemented") },
+          }
+        },
+      })
+
+      // Mock classifier
+      ;(autoModel as any).classifierModel = {
+        specificationVersion: "v3",
+        modelId: "mock",
+        provider: "mock",
+            get supportedUrls() { return {} },
+        async doGenerate() {
+          return { content: [{ type: "text" as const, text: "5" }] } as any
+        },
+        async doStream() { return {} as any },
+      }
+
+      await autoModel.doGenerate(makeCallOptions("design a distributed consensus algorithm"))
+
+      // Should have tried opus first, then fallen back to next reasoning model
+      expect(createdModels).toContain("claude-opus-4.6")
+      // The last model should NOT be opus (it failed), should be the fallback
+      expect(createdModels.at(-1)).not.toBe("claude-opus-4.6")
+    })
+
+    test("remembers unavailable models across calls", async () => {
+      const createdModels: string[] = []
+
+      const autoModel = createCopilotAutoModel({
+        models: MOCK_MODELS,
+        createModel(modelId: string) {
+          createdModels.push(modelId)
+          return {
+            specificationVersion: "v3" as const,
+            modelId,
+            provider: "github-copilot.chat",
+                    get supportedUrls() { return {} },
+            async doGenerate() {
+              if (modelId === "claude-opus-4.6") {
+                throw new Error("The requested model is not supported.")
+              }
+              return { content: [{ type: "text" as const, text: "ok" }] } as any
+            },
+            async doStream() { throw new Error("not implemented") },
+          }
+        },
+      })
+
+      ;(autoModel as any).classifierModel = {
+        specificationVersion: "v3",
+        modelId: "mock",
+        provider: "mock",
+            get supportedUrls() { return {} },
+        async doGenerate() {
+          return { content: [{ type: "text" as const, text: "5" }] } as any
+        },
+        async doStream() { return {} as any },
+      }
+
+      // First call — opus fails, falls back
+      await autoModel.doGenerate(makeCallOptions("design a distributed consensus algorithm"))
+      const firstCallModels = [...createdModels]
+
+      createdModels.length = 0
+
+      // Second call — should skip opus entirely
+      await autoModel.doGenerate(makeCallOptions("implement a compiler backend for x86"))
+      expect(createdModels).not.toContain("claude-opus-4.6")
+    })
+  })
+
+  describe("doStream", () => {
+    test("routes stream calls the same as generate", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(3)
+      ;(makeMockModel("test") as any).doStream = async () => ({ stream: (async function* () {})() })
+
+      // Override createModel to return streamable mock
+      const streamableModel = createCopilotAutoModel({
+        models: MOCK_MODELS,
+        createModel(modelId: string) {
+          createdModels.push(modelId)
+          return {
+            ...makeMockModel(modelId),
+            async doStream() { return { stream: (async function* () {})() } as any },
+          }
+        },
+      })
+
+      ;(streamableModel as any).classifierModel = (model as any).classifierModel
+
+      await streamableModel.doStream(makeCallOptions("implement a REST API with pagination"))
+      expect(createdModels).toContain("claude-sonnet-4.6")
+    })
+  })
+
+  describe("resolvedModelId", () => {
+    test("exposes the last resolved model", async () => {
+      const { model } = createAutoModelWithMockClassifier(5)
+      expect(model.resolvedModelId).toBeNull()
+      await model.doGenerate(makeCallOptions("design a distributed system"))
+      expect(model.resolvedModelId).toBe("claude-opus-4.6")
+    })
+  })
+
+  describe("gemini classification", () => {
+    test("gemini-3-pro-preview goes to reasoning, not fast", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(5)
+      // The tier should include gemini pro in reasoning
+      await model.doGenerate(makeCallOptions("design an architecture for real-time processing"))
+      // It should pick opus first, but gemini pro should be in the reasoning candidates
+      expect(createdModels.at(-1)).toBe("claude-opus-4.6")
+    })
+
+    test("gemini-3-flash goes to fast", async () => {
+      const { model, createdModels } = createAutoModelWithMockClassifier(1)
+      await model.doGenerate(makeCallOptions("write a hello world function please"))
+      // gpt-5-mini is preferred in fast, but flash should be in the tier
+      expect(createdModels.at(-1)).toBe("gpt-5-mini")
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #10093

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an "Auto (Best for task)" model to the GitHub Copilot provider that automatically selects the best available model for each request using GPT-5-mini (free on Copilot) as a semantic complexity classifier.

**How it works:**

1. User selects "Auto (Best for task)" from the Copilot model list
2. Before each LLM call, the auto model sends the user prompt to GPT-5-mini asking for a 1-5 complexity rating
3. The rating maps to model tiers: 1-2 = fast (mini/haiku/flash), 3 = standard (sonnet/gpt-4.1), 4-5 = reasoning (opus/codex)
4. The best available model from the matching tier is selected
5. The TUI message header shows the resolved model name (e.g., "Build · gpt-4.1 · 3s" instead of "Build · auto")

**Why GPT-5-mini?** We explored regex heuristics, claw-llm-router (15-dimension keyword scoring), fine-tuning bert-tiny on 113k labeled examples, RouteLLMs pre-trained BERT (278M params), and local LLMs (Qwen2.5-0.5B). GPT-5-mini outperformed all of them on coding prompts because it has the world knowledge to distinguish semantic complexity (e.g., "implement a linked list" vs "implement a lock-free concurrent hash map"). It is free on Copilot, requires no model files or dependencies, and adds 1-3s latency per request.

**Design decisions:**
- Model tiers built dynamically from provider metadata (capabilities, output limits) — no hardcoded model lists, works as new models are added
- Only the last user message is classified, not the full conversation history
- Prompts under 20 chars skip classification entirely (fast tier)
- Classification errors fall back to standard tier

Note: The Copilot server-side routing API (`/models/session`) used by VS Code is restricted to first-party OAuth clients. A `chat.model` plugin hook (see #10093 discussion) would allow this to be an external plugin instead of a core change.

**Files changed:**
- `packages/opencode/src/provider/sdk/copilot/auto-model.ts` (new) — CopilotAutoLanguageModel with GPT-5-mini classification and tiered routing
- `packages/opencode/src/provider/provider.ts` — intercepts modelID === "auto" in copilot custom loader; sorts "auto" first
- `packages/opencode/src/plugin/copilot.ts` — injects the "auto" model entry during auth loading
- `packages/opencode/src/provider/sdk/copilot/index.ts` — re-exports
- `packages/opencode/src/session/processor.ts` — updates message modelID from "auto" to resolved model name

### How did you verify your code works?

Tested locally with `bun dev` and `opencode run --model github-copilot/auto --print-logs`:
- "hello" (6 chars) → skipped classification → fast → gpt-5.1-codex-mini
- "implement a LRU cache" → GPT-5-mini rated 3 → standard → gpt-4.1
- "design a distributed consensus algorithm similar to Raft" → GPT-5-mini rated 5 → reasoning → gpt-5.2-codex
- "write a function to add two numbers" → GPT-5-mini rated 1 → fast → gpt-5.1-codex-mini
- "debug why distributed cache returns stale data under high concurrency" → GPT-5-mini rated 4 → reasoning → gpt-5.2-codex
- TUI message header updates to show resolved model name
- Typecheck passes (bun turbo typecheck)

### Screenshots / recordings

N/A — the only UI change is the message header showing the resolved model name instead of "auto"

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR