### PR TITLE
fix(plugin): properly resolve entrypoints without leading dot

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -46,7 +46,7 @@ export function pluginSource(spec: string): PluginSource {
 
 function resolveExportPath(raw: string, dir: string) {
   if (raw.startsWith("file://")) return fileURLToPath(raw)
-  if (path.isAbsolute(raw) || /^[A-Za-z]:[\\/]/.test(raw)) return raw
+  if (path.isAbsolute(raw)) return raw
   return path.resolve(dir, raw)
 }
 
@@ -93,7 +93,7 @@ function resolvePackageEntrypoint(spec: string, kind: PluginKind, pkg: PluginPac
 
 function targetPath(target: string) {
   if (target.startsWith("file://")) return fileURLToPath(target)
-  if (path.isAbsolute(target) || /^[A-Za-z]:[\\/]/.test(target)) return target
+  if (path.isAbsolute(target)) return target
 }
 
 async function resolveDirectoryIndex(dir: string) {

--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -45,9 +45,9 @@ export function pluginSource(spec: string): PluginSource {
 }
 
 function resolveExportPath(raw: string, dir: string) {
-  if (raw.startsWith("./") || raw.startsWith("../")) return path.resolve(dir, raw)
   if (raw.startsWith("file://")) return fileURLToPath(raw)
-  return raw
+  if (path.isAbsolute(raw) || /^[A-Za-z]:[\\/]/.test(raw)) return raw
+  return path.resolve(dir, raw)
 }
 
 function extractExportValue(value: unknown): string | undefined {

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -331,6 +331,64 @@ describe("plugin.loader.shared", () => {
     }
   })
 
+  test("loads npm server plugin from package server export without leading dot", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const mod = path.join(dir, "mods", "acme-plugin")
+        const dist = path.join(mod, "dist")
+        const mark = path.join(dir, "server-called.txt")
+        await fs.mkdir(dist, { recursive: true })
+
+        await Bun.write(
+          path.join(mod, "package.json"),
+          JSON.stringify(
+            {
+              name: "acme-plugin",
+              type: "module",
+              exports: {
+                ".": "./index.js",
+                "./server": "dist/server.js",
+              },
+            },
+            null,
+            2,
+          ),
+        )
+        await Bun.write(path.join(mod, "index.js"), 'import "./main-throws.js"\nexport default {}\n')
+        await Bun.write(path.join(mod, "main-throws.js"), 'throw new Error("main loaded")\n')
+        await Bun.write(
+          path.join(dist, "server.js"),
+          [
+            "export default {",
+            "  server: async () => {",
+            `    await Bun.write(${JSON.stringify(mark)}, "called")`,
+            "    return {}",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: ["acme-plugin@1.0.0"] }, null, 2))
+
+        return {
+          mod,
+          mark,
+        }
+      },
+    })
+
+    const install = spyOn(BunProc, "install").mockResolvedValue(tmp.extra.mod)
+
+    try {
+      const errors = await errs(tmp.path)
+      expect(errors).toHaveLength(0)
+      expect(await Bun.file(tmp.extra.mark).text()).toBe("called")
+    } finally {
+      install.mockRestore()
+    }
+  })
+
   test("loads npm server plugin from package main without leading dot", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -331,6 +331,59 @@ describe("plugin.loader.shared", () => {
     }
   })
 
+  test("loads npm server plugin from package main without leading dot", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const mod = path.join(dir, "mods", "acme-plugin")
+        const dist = path.join(mod, "dist")
+        const mark = path.join(dir, "main-called.txt")
+        await fs.mkdir(dist, { recursive: true })
+
+        await Bun.write(
+          path.join(mod, "package.json"),
+          JSON.stringify(
+            {
+              name: "acme-plugin",
+              type: "module",
+              main: "dist/index.js",
+            },
+            null,
+            2,
+          ),
+        )
+        await Bun.write(
+          path.join(dist, "index.js"),
+          [
+            "export default {",
+            "  server: async () => {",
+            `    await Bun.write(${JSON.stringify(mark)}, "called")`,
+            "    return {}",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+
+        await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ plugin: ["acme-plugin@1.0.0"] }, null, 2))
+
+        return {
+          mod,
+          mark,
+        }
+      },
+    })
+
+    const install = spyOn(BunProc, "install").mockResolvedValue(tmp.extra.mod)
+
+    try {
+      const errors = await errs(tmp.path)
+      expect(errors).toHaveLength(0)
+      expect(await Bun.file(tmp.extra.mark).text()).toBe("called")
+    } finally {
+      install.mockRestore()
+    }
+  })
+
   test("does not use npm package exports dot for server entry", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## Summary
* Fixes npm plugin loading when package.json uses a bare relative main entry like dist/index.js.
* Keeps the plugin-directory safety check intact by resolving the path relative to the installed plugin before validating it stays inside the plugin root.
* Adds regression coverage for npm server plugins that rely on a bare main entry.

## Repro
* Reproduced manually with @cortexkit/opencode-magic-context@latest.
* Pre-fix code failed with Plugin @cortexkit/opencode-magic-context@latest resolved server entry outside plugin directory.
* Fixed code resolves ile:///C:/Users/Lukem/.cache/opencode/node_modules/@cortexkit/opencode-magic-context/dist/index.js.

## Verification
* un run test test/plugin/loader-shared.test.ts test/cli/tui/plugin-loader-entrypoint.test.ts (27 pass, 0 fail)