### PR TITLE
fix(zen): gate safety identifier by provider config

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -471,7 +471,7 @@ export async function handler(
           reqModel,
           providerModel: modelProvider.model,
           adjustCacheUsage: providerProps.adjustCacheUsage,
-          safetyIdentifier: ip,
+          safetyIdentifier: providerProps.safetyIdentifier ? ip : undefined,
           workspaceID: authInfo?.workspaceID,
         }
         if (format === "anthropic") return anthropicHelper(opts)


### PR DESCRIPTION
## Summary
- honor the existing provider-level safetyIdentifier flag when building Zen provider options
- stop sending safety_identifier to OpenAI-compatible providers like Kimi K2.5 unless that provider explicitly opts in
- keep the fix minimal by aligning safetyIdentifier with the existing djustCacheUsage config pattern