### PR TITLE
fix(tui): hide prompt usage when sidebar is visible

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -41,6 +41,7 @@ export type PromptProps = {
   workspaceID?: string
   visible?: boolean
   disabled?: boolean
+  showUsage?: boolean
   onSubmit?: () => void
   ref?: (ref: PromptRef) => void
   hint?: JSX.Element
@@ -153,6 +154,7 @@ export function Prompt(props: PromptProps) {
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })
+  const footer = createMemo(() => (props.showUsage === false ? undefined : usage()))
 
   const [store, setStore] = createStore<{
     prompt: PromptInfo
@@ -1193,7 +1195,7 @@ export function Prompt(props: PromptProps) {
               <Switch>
                 <Match when={store.mode === "normal"}>
                   <Switch>
-                    <Match when={usage()}>
+                    <Match when={footer()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
                           {[item().context, item().cost].filter(Boolean).join(" · ")}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1173,6 +1173,7 @@ export function Session() {
                   }
                 }}
                 disabled={permissions().length > 0 || questions().length > 0}
+                showUsage={!sidebarVisible()}
                 onSubmit={() => {
                   toBottom()
                 }}


### PR DESCRIPTION
### Issue for this PR

Closes #20145

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the session sidebar is visible, OpenCode currently shows context usage in two places:
- the sidebar `Context` block
- the bottom prompt footer context/cost label

This PR only hides the bottom prompt footer label while the sidebar is visible. It does not remove or change the sidebar `Context` block.

When the sidebar is hidden, the bottom prompt footer label still shows.

Implementation-wise, this adds a small `showUsage` prop to the prompt component and sets it from the session route based on `sidebarVisible()`.

### How did you verify your code works?

- `bun typecheck`
- `bun test test/cli/cmd/tui/prompt-part.test.ts`

### Screenshots / recordings

<img width="1470" height="956" alt="Screenshot 2026-03-30 at 6 08 38 PM" src="https://github.com/user-attachments/assets/6dea074f-8850-452c-b1c9-3578921ca41c" />

Intended behavior:
- keep the sidebar `Context` panel visible
- hide only the bottom prompt footer context/cost label while the sidebar is showing
- show the bottom label again when the sidebar is hidden

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR