### PR TITLE
feat(session): expose context budget information to agents

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -31,6 +31,7 @@ import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
 import { pathToFileURL, fileURLToPath } from "url"
+import { Config } from "../config/config"
 import { ConfigMarkdown } from "../config/markdown"
 import { SessionSummary } from "./summary"
 import { NamedError } from "@opencode-ai/util/error"
@@ -48,6 +49,8 @@ import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { Database, and, eq, sql } from "@/storage/db"
+import { PartTable } from "./session.sql"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -87,6 +90,7 @@ export namespace SessionPrompt {
       const processor = yield* SessionProcessor.Service
       const compaction = yield* SessionCompaction.Service
       const plugin = yield* Plugin.Service
+      const config = yield* Config.Service
       const commands = yield* Command.Service
       const permission = yield* Permission.Service
       const fsys = yield* AppFileSystem.Service
@@ -1482,10 +1486,50 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
                 yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
+                const cfg = yield* config.get()
+                const used = lastFinished
+                  ? lastFinished.tokens.total ||
+                    lastFinished.tokens.input +
+                      lastFinished.tokens.output +
+                      lastFinished.tokens.cache.read +
+                      lastFinished.tokens.cache.write
+                  : 0
+                const reserved = cfg.compaction?.reserved ?? Math.min(20_000, ProviderTransform.maxOutputTokens(model))
+                const trigger = model.limit.input
+                  ? model.limit.input - reserved
+                  : model.limit.context - ProviderTransform.maxOutputTokens(model)
+                const cap = Math.max(0, trigger)
+                const ratio = model.limit.context > 0 ? Math.max(0, Math.min(1, cap / model.limit.context)) : 0
+                const compactions =
+                  Database.use(
+                    (db) =>
+                      db
+                        .select({ count: sql<number>`count(*)` })
+                        .from(PartTable)
+                        .where(
+                          and(
+                            eq(PartTable.session_id, sessionID),
+                            sql`json_extract(${PartTable.data}, '$.type') = 'compaction'`,
+                          ),
+                        )
+                        .get()?.count,
+                  ) ?? 0
+                const max = agent.steps ?? "unbounded"
+                const budget = {
+                  max_context_tokens: model.limit.context,
+                  used_tokens: used,
+                  remaining_context_tokens: Math.max(0, cap - used),
+                  compaction_threshold: Number(ratio.toFixed(4)),
+                  compaction_triggers_at: cap,
+                  compactions_total: compactions,
+                  current_step: step,
+                  max_steps: max,
+                } as const
+
                 const [skills, env, instructions, modelMsgs] = yield* Effect.promise(() =>
                   Promise.all([
                     SystemPrompt.skills(agent),
-                    SystemPrompt.environment(model),
+                    SystemPrompt.environment(model, { budget }),
                     InstructionPrompt.system(),
                     MessageV2.toModelMessages(msgs, model),
                   ]),
@@ -1712,6 +1756,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         Layer.provide(Session.defaultLayer),
         Layer.provide(Agent.defaultLayer),
         Layer.provide(Bus.layer),
+        Layer.provide(Config.defaultLayer),
       ),
     ),
   )

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -16,6 +16,17 @@ import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 
 export namespace SystemPrompt {
+  type Budget = {
+    max_context_tokens: number
+    used_tokens: number
+    remaining_context_tokens: number
+    compaction_threshold: number
+    compaction_triggers_at: number
+    compactions_total: number
+    current_step: number
+    max_steps: number | "unbounded"
+  }
+
   export function provider(model: Provider.Model) {
     if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
       return [PROMPT_BEAST]
@@ -31,31 +42,50 @@ export namespace SystemPrompt {
     return [PROMPT_DEFAULT]
   }
 
-  export async function environment(model: Provider.Model) {
+  export async function environment(model: Provider.Model, input?: { budget?: Budget }) {
     const project = Instance.project
-    return [
-      [
-        `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
-        `Here is some useful information about the environment you are running in:`,
-        `<env>`,
-        `  Working directory: ${Instance.directory}`,
-        `  Workspace root folder: ${Instance.worktree}`,
-        `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
-        `  Platform: ${process.platform}`,
-        `  Today's date: ${new Date().toDateString()}`,
-        `</env>`,
-        `<directories>`,
-        `  ${
-          project.vcs === "git" && false
-            ? await Ripgrep.tree({
-                cwd: Instance.directory,
-                limit: 50,
-              })
-            : ""
-        }`,
-        `</directories>`,
-      ].join("\n"),
+    const budget = input?.budget
+    const lines = [
+      `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
+      `Here is some useful information about the environment you are running in:`,
+      `<env>`,
+      `  Working directory: ${Instance.directory}`,
+      `  Workspace root folder: ${Instance.worktree}`,
+      `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
+      `  Platform: ${process.platform}`,
+      `  Today's date: ${new Date().toDateString()}`,
+      `</env>`,
     ]
+
+    if (budget) {
+      lines.push(
+        `<context-budget>`,
+        `  max_context_tokens: ${budget.max_context_tokens}`,
+        `  used_tokens: ${budget.used_tokens}`,
+        `  remaining_context_tokens: ${budget.remaining_context_tokens}`,
+        `  compaction_threshold: ${budget.compaction_threshold}`,
+        `  compaction_triggers_at: ${budget.compaction_triggers_at}`,
+        `  compactions_total: ${budget.compactions_total}`,
+        `  current_step: ${budget.current_step}`,
+        `  max_steps: ${budget.max_steps}`,
+        `</context-budget>`,
+      )
+    }
+
+    lines.push(
+      `<directories>`,
+      `  ${
+        project.vcs === "git" && false
+          ? await Ripgrep.tree({
+              cwd: Instance.directory,
+              limit: 50,
+            })
+          : ""
+      }`,
+      `</directories>`,
+    )
+
+    return [lines.join("\n")]
   }
 
   export async function skills(agent: Agent.Info) {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import { Agent } from "../../src/agent/agent"
+import type { Provider } from "../../src/provider/provider"
 import { Instance } from "../../src/project/instance"
 import { SystemPrompt } from "../../src/session/system"
 import { tmpdir } from "../fixture/fixture"
@@ -55,5 +56,42 @@ description: ${description}
     } finally {
       process.env.OPENCODE_TEST_HOME = home
     }
+  })
+
+  test("environment includes context-budget block when provided", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const out = (
+          await SystemPrompt.environment(
+            {
+              providerID: "openai",
+              api: { id: "gpt-5" },
+            } as unknown as Provider.Model,
+            {
+              budget: {
+                max_context_tokens: 200000,
+                used_tokens: 47823,
+                remaining_context_tokens: 152177,
+                compaction_threshold: 0.9,
+                compaction_triggers_at: 180000,
+                compactions_total: 0,
+                current_step: 3,
+                max_steps: 25,
+              },
+            },
+          )
+        )[0]
+
+        expect(out).toContain("<context-budget>")
+        expect(out).toContain("max_context_tokens: 200000")
+        expect(out).toContain("used_tokens: 47823")
+        expect(out).toContain("remaining_context_tokens: 152177")
+        expect(out).toContain("compaction_triggers_at: 180000")
+        expect(out).toContain("current_step: 3")
+        expect(out).toContain("max_steps: 25")
+      },
+    })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #19471

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds agent-visible context budget information to the system prompt.

- Extends `SystemPrompt.environment()` with an optional `<context-budget>` block.
- Computes live budget values in `SessionPrompt` per loop turn and injects them into the system prompt:
  - `max_context_tokens`
  - `used_tokens`
  - `remaining_context_tokens`
  - `compaction_threshold`
  - `compaction_triggers_at`
  - `compactions_total`
  - `current_step`
  - `max_steps`
- Keeps the budget math aligned with compaction overflow logic (same fallback behavior for token totals).
- Computes `compactions_total` from session part storage so it reflects true session history instead of filtered in-memory message windows.
- Adds regression coverage for budget block rendering in `session.system` tests.

### How did you verify your code works?

From `packages/opencode`:
- `bun test test/session/system.test.ts`
- `bun test test/session`
- `bun typecheck`

Additionally, push hook ran workspace typecheck successfully (`bun turbo typecheck`).

### Screenshots / recordings

N/A (system prompt content feature).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR