### PR TITLE
feat(tool): add experimental team tool for parallel subagents

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1056,6 +1056,7 @@ export namespace Config {
         .object({
           disable_paste_summary: z.boolean().optional(),
           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
+          team_tool: z.boolean().optional().describe("Enable the team tool"),
           openTelemetry: z
             .boolean()
             .optional()

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,6 +27,7 @@ import { Log } from "@/util/log"
 import { LspTool } from "./lsp"
 import { Truncate } from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
+import { TeamTool } from "./team"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
 import { Effect, Layer, ServiceMap } from "effect"
@@ -133,6 +134,7 @@ export namespace ToolRegistry {
           ApplyPatchTool,
           ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
           ...(cfg.experimental?.batch_tool === true ? [BatchTool] : []),
+          ...(cfg.experimental?.team_tool === true ? [TeamTool] : []),
           ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool] : []),
           ...custom,
         ]

--- a/packages/opencode/src/tool/team.ts
+++ b/packages/opencode/src/tool/team.ts
@@ -1,0 +1,189 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { TaskTool } from "./task"
+import DESCRIPTION from "./team.txt"
+
+const task = z.object({
+  id: z.string().optional(),
+  description: z.string().describe("A short (3-5 words) description of the task"),
+  prompt: z.string().describe("The task for the sub-agent to perform"),
+  subagent_type: z.string().describe("The type of specialized agent to use for this task"),
+  task_id: z.string().describe("Resume an existing sub-agent session if provided").optional(),
+})
+
+const parameters = z.object({
+  description: z.string().describe("A short (3-5 words) description of the team execution"),
+  tasks: z.array(task).min(1).max(10).describe("Sub-agent tasks to execute"),
+  concurrency: z
+    .number()
+    .int()
+    .min(1)
+    .max(8)
+    .optional()
+    .describe("Maximum number of child tasks to run concurrently (default: 4)"),
+})
+
+function parse(input: string) {
+  const key = "task_id:"
+  const idx = input.indexOf(key)
+  if (idx < 0) return
+  const line = input
+    .slice(idx + key.length)
+    .split("\n")[0]
+    ?.trim()
+  if (!line) return
+  const first = line.split(" ")[0]
+  return first || undefined
+}
+
+function getErr(err: unknown) {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+export const TeamTool = Tool.define("team", async (ctx) => {
+  const subtask = await TaskTool.init(ctx)
+
+  return {
+    description: DESCRIPTION,
+    parameters,
+    async execute(params: z.infer<typeof parameters>, ctx) {
+      const started = Date.now()
+      const jobs = params.tasks
+      const limit = params.concurrency ?? 4
+      const asks = Array.from(new Set(jobs.map((item) => item.subagent_type)))
+      const denied = new Map<string, string>()
+
+      for (const subagent_type of asks) {
+        try {
+          await ctx.ask({
+            permission: "task",
+            patterns: [subagent_type],
+            always: [subagent_type],
+            metadata: {
+              description: params.description,
+              subagent_type,
+              team: true,
+            },
+          })
+        } catch (err) {
+          denied.set(subagent_type, getErr(err))
+        }
+      }
+
+      const out = await Promise.all(
+        jobs.map(async (item, i) => ({
+          i,
+          item,
+          run: async () => {
+            const start = Date.now()
+            try {
+              if (denied.has(item.subagent_type)) {
+                return {
+                  id: item.id ?? `task_${i + 1}`,
+                  description: item.description,
+                  subagent_type: item.subagent_type,
+                  status: "error" as const,
+                  error: denied.get(item.subagent_type),
+                  task_id: item.task_id,
+                  duration_ms: Date.now() - start,
+                }
+              }
+
+              const result = await subtask.execute(
+                {
+                  description: item.description,
+                  prompt: item.prompt,
+                  subagent_type: item.subagent_type,
+                  task_id: item.task_id,
+                },
+                {
+                  ...ctx,
+                  extra: {
+                    ...ctx.extra,
+                    bypassAgentCheck: true,
+                  },
+                },
+              )
+
+              return {
+                id: item.id ?? `task_${i + 1}`,
+                description: item.description,
+                subagent_type: item.subagent_type,
+                status: "completed" as const,
+                output: result.output,
+                task_id:
+                  (typeof result.metadata?.sessionId === "string" && result.metadata.sessionId) ||
+                  parse(result.output) ||
+                  item.task_id,
+                duration_ms: Date.now() - start,
+              }
+            } catch (err) {
+              return {
+                id: item.id ?? `task_${i + 1}`,
+                description: item.description,
+                subagent_type: item.subagent_type,
+                status: "error" as const,
+                error: getErr(err),
+                task_id: item.task_id,
+                duration_ms: Date.now() - start,
+              }
+            }
+          },
+        })),
+      )
+
+      const result = new Array<Awaited<ReturnType<(typeof out)[number]["run"]>>>(out.length)
+      let next = 0
+      const workers = Array.from({ length: Math.min(limit, out.length) }, async () => {
+        while (true) {
+          const idx = next
+          next += 1
+          const item = out[idx]
+          if (!item) return
+          if (ctx.abort.aborted) return
+          result[idx] = await item.run()
+        }
+      })
+      await Promise.all(workers)
+
+      const list = result.filter((item) => item !== undefined)
+
+      const good = list.filter((item) => item.status === "completed")
+      const bad = list.filter((item) => item.status === "error")
+
+      const body = [
+        `Team summary: ${good.length}/${list.length} tasks completed`,
+        ...list.map((item) =>
+          item.status === "completed"
+            ? [
+                ``,
+                `## ${item.id} (${item.subagent_type})`,
+                `status: completed`,
+                `task_id: ${item.task_id ?? "unknown"}`,
+                `${item.output}`,
+              ].join("\n")
+            : [
+                ``,
+                `## ${item.id} (${item.subagent_type})`,
+                `status: error`,
+                `task_id: ${item.task_id ?? "unknown"}`,
+                `error: ${item.error}`,
+              ].join("\n"),
+        ),
+      ].join("\n")
+
+      return {
+        title: params.description,
+        output: body,
+        metadata: {
+          total: result.length,
+          successful: good.length,
+          failed: bad.length,
+          duration_ms: Date.now() - started,
+          children: list,
+        },
+      }
+    },
+  }
+})

--- a/packages/opencode/src/tool/team.txt
+++ b/packages/opencode/src/tool/team.txt
@@ -1,0 +1,22 @@
+Run multiple sub-agent tasks in parallel as an ephemeral team.
+
+Use this tool when work can be safely split into independent subtasks that do not require strict ordering.
+
+Key behavior:
+- Spawns child sub-agent tasks and executes them concurrently (bounded by `concurrency`).
+- Aggregates all child outputs into one combined result.
+- Team state is ephemeral (runtime-only). Child sessions remain available via returned `task_id` values.
+- If one child fails, other children still continue (collect-all behavior).
+
+Use this tool for:
+- Parallel research across files/directories
+- Splitting implementation vs testing vs review work
+- Running multiple independent specialist agents at once
+
+Avoid this tool when:
+- Tasks have hard dependencies on each other (run those sequentially with `task`)
+- You need persistent shared memory between children
+
+Tips:
+- Keep each child task narrowly scoped.
+- Set `concurrency` to a reasonable value to control resource usage.

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -123,4 +123,40 @@ describe("tool.registry", () => {
       },
     })
   })
+
+  test("gates team tool behind experimental.team_tool", async () => {
+    await using off = await tmpdir({
+      git: true,
+      config: {
+        experimental: {
+          team_tool: false,
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: off.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).not.toContain("team")
+      },
+    })
+
+    await using on = await tmpdir({
+      git: true,
+      config: {
+        experimental: {
+          team_tool: true,
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: on.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).toContain("team")
+      },
+    })
+  })
 })

--- a/packages/opencode/test/tool/team.test.ts
+++ b/packages/opencode/test/tool/team.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Agent } from "../../src/agent/agent"
+import { Instance } from "../../src/project/instance"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { TaskTool } from "../../src/tool/task"
+import { TeamTool } from "../../src/tool/team"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("tool.team", () => {
+  test("executes child tasks and aggregates outputs", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const prior = TaskTool.init
+
+    ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = (async (ctx: Parameters<typeof prior>[0]) => {
+      const def = await prior(ctx)
+      return {
+        ...def,
+        async execute(input: Parameters<typeof def.execute>[0]) {
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          return {
+            title: input.description,
+            metadata: {
+              sessionId: SessionID.make("session_child"),
+              model: {
+                modelID: ModelID.make("gpt-5"),
+                providerID: ProviderID.make("openai"),
+              },
+            },
+            output: [
+              `task_id: child_${input.subagent_type}`,
+              "",
+              "<task_result>",
+              `ok: ${input.description}`,
+              "</task_result>",
+            ].join("\n"),
+          }
+        },
+      }
+    }) as unknown as typeof TaskTool.init
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const build = await Agent.get("build")
+          const team = await TeamTool.init({ agent: build ?? undefined })
+          const calls: string[] = []
+
+          const result = await team.execute(
+            {
+              description: "parallel checks",
+              concurrency: 2,
+              tasks: [
+                {
+                  id: "a",
+                  description: "research issue",
+                  subagent_type: "explore",
+                  prompt: "Find files related to session prompt.",
+                },
+                {
+                  id: "b",
+                  description: "read docs",
+                  subagent_type: "docs",
+                  prompt: "Summarize docs structure.",
+                },
+              ],
+            },
+            {
+              sessionID: SessionID.make("session_test"),
+              messageID: MessageID.make("msg_test"),
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata() {},
+              ask: async (input) => {
+                calls.push(input.permission)
+              },
+            },
+          )
+
+          expect(result.title).toBe("parallel checks")
+          expect(result.metadata.total).toBe(2)
+          expect(result.metadata.successful).toBe(2)
+          expect(result.metadata.failed).toBe(0)
+          expect(result.metadata.children).toHaveLength(2)
+          expect(result.output).toContain("Team summary")
+          expect(calls).toHaveLength(2)
+        },
+      })
+    } finally {
+      ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = prior
+    }
+  })
+
+  test("keeps collect-all behavior when a child fails", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const prior = TaskTool.init
+
+    ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = (async (ctx: Parameters<typeof prior>[0]) => {
+      const def = await prior(ctx)
+      return {
+        ...def,
+        async execute(input: Parameters<typeof def.execute>[0]) {
+          if (input.description.includes("fail")) throw new Error("boom")
+          return {
+            title: input.description,
+            metadata: {
+              sessionId: SessionID.make("session_child"),
+              model: {
+                modelID: ModelID.make("gpt-5"),
+                providerID: ProviderID.make("openai"),
+              },
+            },
+            output: `task_id: child_${input.subagent_type}`,
+          }
+        },
+      }
+    }) as unknown as typeof TaskTool.init
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const build = await Agent.get("build")
+          const team = await TeamTool.init({ agent: build ?? undefined })
+
+          const result = await team.execute(
+            {
+              description: "mixed checks",
+              tasks: [
+                {
+                  id: "ok",
+                  description: "good task",
+                  subagent_type: "explore",
+                  prompt: "ok",
+                },
+                {
+                  id: "bad",
+                  description: "fail task",
+                  subagent_type: "docs",
+                  prompt: "bad",
+                },
+              ],
+            },
+            {
+              sessionID: SessionID.make("session_test"),
+              messageID: MessageID.make("msg_test"),
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata() {},
+              ask: async () => undefined,
+            },
+          )
+
+          expect(result.metadata.total).toBe(2)
+          expect(result.metadata.successful).toBe(1)
+          expect(result.metadata.failed).toBe(1)
+          expect(result.output).toContain("status: error")
+        },
+      })
+    } finally {
+      ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = prior
+    }
+  })
+
+  test("keeps collect-all behavior when one subagent permission is denied", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const prior = TaskTool.init
+
+    ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = (async (ctx: Parameters<typeof prior>[0]) => {
+      const def = await prior(ctx)
+      return {
+        ...def,
+        async execute(input: Parameters<typeof def.execute>[0]) {
+          return {
+            title: input.description,
+            metadata: {
+              sessionId: SessionID.make("session_child"),
+              model: {
+                modelID: ModelID.make("gpt-5"),
+                providerID: ProviderID.make("openai"),
+              },
+            },
+            output: `task_id: child_${input.subagent_type}`,
+          }
+        },
+      }
+    }) as unknown as typeof TaskTool.init
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const build = await Agent.get("build")
+          const team = await TeamTool.init({ agent: build ?? undefined })
+
+          const result = await team.execute(
+            {
+              description: "permission checks",
+              tasks: [
+                {
+                  id: "deny",
+                  description: "blocked task",
+                  subagent_type: "docs",
+                  prompt: "blocked",
+                },
+                {
+                  id: "ok",
+                  description: "allowed task",
+                  subagent_type: "explore",
+                  prompt: "allowed",
+                },
+              ],
+            },
+            {
+              sessionID: SessionID.make("session_test"),
+              messageID: MessageID.make("msg_test"),
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata() {},
+              ask: async (input) => {
+                if (input.patterns[0] === "docs") throw new Error("denied docs")
+              },
+            },
+          )
+
+          expect(result.metadata.total).toBe(2)
+          expect(result.metadata.successful).toBe(1)
+          expect(result.metadata.failed).toBe(1)
+          expect(result.output).toContain("denied docs")
+        },
+      })
+    } finally {
+      ;(TaskTool as unknown as { init: typeof TaskTool.init }).init = prior
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19999

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Introduces an **experimental `team` tool** for ephemeral parallel sub-agent orchestration.

MVP scope in this PR:
- Adds new `team` tool (`packages/opencode/src/tool/team.ts`) and usage guidance (`team.txt`).
- Supports executing multiple sub-agent tasks in parallel with bounded `concurrency`.
- Uses collect-all behavior: child failures do not cancel sibling tasks.
- Preserves child `task_id` values in aggregated output (prefers structured metadata, falls back to output parsing).
- Implements per-subagent permission preflight while preserving collect-all semantics when one subagent is denied.
- Adds config gate `experimental.team_tool` and registers tool only when enabled.
- Adds tests for:
  - tool execution + aggregation,
  - collect-all on child failure,
  - collect-all when one subagent permission is denied,
  - registry gating behind `experimental.team_tool`.

### How did you verify your code works?

From `packages/opencode`:
- `bun test test/tool/team.test.ts`
- `bun test test/tool/registry.test.ts`
- `bun typecheck`

Additionally, push hook ran workspace typecheck successfully (`bun turbo typecheck`).

### Screenshots / recordings

N/A (tool/runtime feature).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR