### PR TITLE
docs(skills): replace misleading skill example

### DIFF
--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -73,30 +73,28 @@ Keep it specific enough for the agent to choose correctly.
 
 ## Use an example
 
-Create `.opencode/skills/git-release/SKILL.md` like this:
+Create `.agents/skills/roll-dice/SKILL.md` like this:
 
-```markdown
+````markdown
 ---
-name: git-release
-description: Create consistent releases and changelogs
-license: MIT
-compatibility: opencode
-metadata:
-  audience: maintainers
-  workflow: github
+name: roll-dice
+description: Roll dice using a random number generator. Use when asked to roll a die (d6, d20, etc.), roll dice, or generate a random dice roll.
 ---
 
-## What I do
+To roll a die, use the following command that generates a random number from 1
+to the given number of sides:
 
-- Draft release notes from merged PRs
-- Propose a version bump
-- Provide a copy-pasteable `gh release create` command
-
-## When to use me
-
-Use this when you are preparing a tagged release.
-Ask clarifying questions if the target versioning scheme is unclear.
+```bash
+echo $((RANDOM % <sides> + 1))
 ```
+
+```powershell
+Get-Random -Minimum 1 -Maximum (<sides> + 1)
+```
+
+Replace `<sides>` with the number of sides on the die (e.g., 6 for a standard
+die, 20 for a d20).
+````
 
 ---
 
@@ -108,8 +106,8 @@ Each entry includes the skill name and description:
 ```xml
 <available_skills>
   <skill>
-    <name>git-release</name>
-    <description>Create consistent releases and changelogs</description>
+    <name>roll-dice</name>
+    <description>Roll dice using a random number generator. Use when asked to roll a die (d6, d20, etc.), roll dice, or generate a random dice roll.</description>
   </skill>
 </available_skills>
 ```
@@ -117,7 +115,7 @@ Each entry includes the skill name and description:
 The agent loads a skill by calling the tool:
 
 ```
-skill({ name: "git-release" })
+skill({ name: "roll-dice" })
 ```
 
 ---


### PR DESCRIPTION
### Issue for this PR

Related to #20091

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This updates the English `Agent Skills` docs page to replace the current `SKILL.md` example.

The previous example put the \"when to use\" guidance in the body of the skill, which is misleading for OpenCode. OpenCode discovers skills from their frontmatter `name` and `description`, so the example should show that activation guidance in `description` instead.

This swaps in the `roll-dice` quickstart example from the Agent Skills quickstart:
https://agentskills.io/skill-creation/quickstart#create-the-skill

It also updates the later `available_skills` and `skill({ name: ... })` snippets to match.

This PR only updates the English page. Localized `skills` docs are intentionally left for a separate follow-up.

### How did you verify your code works?

- `bun run build` in `packages/web`
- repo pre-push hook also passed `bun turbo typecheck`

### Screenshots / recordings

Not included. This change only updates the docs page content and example snippets.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR