### PR TITLE
feat(tui): add ctrl+/ shortcut for model selector

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -695,7 +695,7 @@ export namespace Config {
         .default("<leader>h")
         .describe("Toggle code block concealment in messages"),
       tool_details: z.string().optional().default("none").describe("Toggle tool details visibility"),
-      model_list: z.string().optional().default("<leader>m").describe("List available models"),
+      model_list: z.string().optional().default("ctrl+/,<leader>m").describe("List available models"),
       model_cycle_recent: z.string().optional().default("f2").describe("Next recently used model"),
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),
       model_cycle_favorite: z.string().optional().default("none").describe("Next favorite model"),

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -10,10 +10,19 @@ export namespace Keybind {
     leader: boolean // our custom field
   }
 
+  function normalize(info: Info) {
+    return {
+      ...info,
+      super: info.super ?? false,
+      // Many terminals report Ctrl+/ as Ctrl+_ (\x1F), so treat them as the same binding.
+      name: info.ctrl && info.name === "_" ? "/" : info.name,
+    }
+  }
+
   export function match(a: Info | undefined, b: Info): boolean {
     if (!a) return false
-    const normalizedA = { ...a, super: a.super ?? false }
-    const normalizedB = { ...b, super: b.super ?? false }
+    const normalizedA = normalize(a)
+    const normalizedB = normalize(b)
     return isDeepEqual(normalizedA, normalizedB)
   }
 

--- a/packages/opencode/test/keybind.test.ts
+++ b/packages/opencode/test/keybind.test.ts
@@ -168,6 +168,12 @@ describe("Keybind.match", () => {
     expect(Keybind.match(a, b)).toBe(true)
   })
 
+  test("should match ctrl+/ with ctrl+_ terminal form", () => {
+    const a = Keybind.parse("ctrl+/")[0]
+    const b: Keybind.Info = { ctrl: true, meta: false, shift: false, leader: false, name: "_" }
+    expect(Keybind.match(a, b)).toBe(true)
+  })
+
   test("should not match when only super differs", () => {
     const a: Keybind.Info = { ctrl: true, meta: true, shift: true, super: true, leader: false, name: "a" }
     const b: Keybind.Info = { ctrl: true, meta: true, shift: true, super: false, leader: false, name: "a" }

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -47,7 +47,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
     "messages_redo": "<leader>r",
     "messages_last_user": "none",
     "messages_toggle_conceal": "<leader>h",
-    "model_list": "<leader>m",
+    "model_list": "ctrl+/,<leader>m",
     "model_cycle_recent": "f2",
     "model_cycle_recent_reverse": "shift+f2",
     "model_cycle_favorite": "none",


### PR DESCRIPTION
### Issue for this PR

Closes #20157

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds `Ctrl+/` as a default shortcut for the existing model selector action.

OpenCode already has a global `model_list` action and an existing model selector dialog. This change does not add a new flow. It updates the default keybind for that existing action to `ctrl+/,<leader>m`, so the direct shortcut works while keeping the old leader shortcut available.

It also normalizes `Ctrl+_` when matching keybinds, because many terminals report `Ctrl+/` through that control-character path. Without that normalization, a `ctrl+/` binding is not reliable across terminals.

This PR also updates the English keybind docs so the published default matches the code.

### How did you verify your code works?

- `bun test test/keybind.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/opencode`
- `bun run build` in `packages/web`
- repo pre-push hook also passed `bun turbo typecheck`

### Screenshots / recordings

Not included. This change updates an existing keyboard shortcut and related docs.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR