### PR TITLE
fix: use condom to undo circumcision

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -39,7 +39,7 @@ export function Tips() {
       <text flexShrink={0} style={{ fg: theme.warning }}>
         ● Tip{" "}
       </text>
-      <text flexShrink={1}>
+      <text flexShrink={1} wrapMode="word">
         <For each={parts}>
           {(part) => <span style={{ fg: part.highlight ? theme.text : theme.textMuted }}>{part.text}</span>}
         </For>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips.tsx
@@ -6,7 +6,7 @@ const id = "internal:home-tips"
 
 function View(props: { show: boolean }) {
   return (
-    <box height={4} minHeight={0} width="100%" maxWidth={75} alignItems="center" paddingTop={3} flexShrink={1}>
+    <box minHeight={4} width="100%" maxWidth={75} alignItems="center" paddingTop={3} flexShrink={1}>
       <Show when={props.show}>
         <Tips />
       </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #11154

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

wraps the tip so it isnt cut off

the tip presented when a user opens opencode on a project is sometimes cut off if it is too long - adds word wrapping to it and removes the height=4 (forcing 3 lines of padding + 1 line of tip)

### How did you verify your code works?

set tip to not be random (for testing) and verified wrapping and eventual disappearing at very small window size

note: large tips now cause slight layout shift when toggled at a very small window size vs prev impl

### Screenshots / recordings

After/Before

Too small
<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/7c826146-0fa7-4ed4-8219-700ab741ccf6" />

Medium
<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/de2c8d9e-9a11-4f75-8b74-204dd3d0b428" />

Normal
<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/3562b8ab-4879-4d3e-92f4-1ec9216e3467" />

Large
<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/c677cfcb-82bb-423c-b8bc-07890a5b919d" />



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
