### PR TITLE
fix(theme): darken muted text in catppuccin tui themes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
@@ -62,8 +62,8 @@
       "light": "frappeText"
     },
     "textMuted": {
-      "dark": "frappeSubtext1",
-      "light": "frappeSubtext1"
+      "dark": "frappeOverlay2",
+      "light": "frappeOverlay2"
     },
     "background": {
       "dark": "frappeBase",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
@@ -62,8 +62,8 @@
       "light": "macText"
     },
     "textMuted": {
-      "dark": "macSubtext1",
-      "light": "macSubtext1"
+      "dark": "macOverlay2",
+      "light": "macOverlay2"
     },
     "background": {
       "dark": "macBase",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
@@ -63,7 +63,7 @@
     "success": { "dark": "darkGreen", "light": "lightGreen" },
     "info": { "dark": "darkTeal", "light": "lightTeal" },
     "text": { "dark": "darkText", "light": "lightText" },
-    "textMuted": { "dark": "darkSubtext1", "light": "lightSubtext1" },
+    "textMuted": { "dark": "darkOverlay2", "light": "lightOverlay2" },
     "background": { "dark": "darkBase", "light": "lightBase" },
     "backgroundPanel": { "dark": "darkMantle", "light": "lightMantle" },
     "backgroundElement": { "dark": "darkCrust", "light": "lightCrust" },


### PR DESCRIPTION
**BEFORE**

<img width="962" height="282" alt="CleanShot 2026-03-30 at 20 58 43@2x" src="https://github.com/user-attachments/assets/b465fe9d-02fd-4df4-9173-64a2516bf9c9" />
<img width="908" height="420" alt="CleanShot 2026-03-30 at 20 58 51@2x" src="https://github.com/user-attachments/assets/88641f8f-3e85-4339-9a25-a326339f3331" />


**AFTER**
<img width="407" height="155" alt="image" src="https://github.com/user-attachments/assets/b3e46da4-be91-4663-99e9-0640380d9f64" />
<img width="616" height="386" alt="CleanShot 2026-03-30 at 20 58 57@2x" src="https://github.com/user-attachments/assets/e0a96d42-e6d7-450a-a16d-aa2999846f3d" />


## Summary
- darken `textMuted` in the Catppuccin, Frappe, and Macchiato TUI themes
- make the provider label in the prompt footer read as clearly secondary to the model name
- keep the existing prompt component semantics unchanged by adjusting only theme tokens

## Testing
- not run (theme JSON token change only)
