### PR TITLE
fix(session): preserve tool metadata across pending→running transition

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -30,6 +30,7 @@ export namespace SessionProcessor {
   export interface Handle {
     readonly message: MessageV2.Assistant
     readonly partFromToolCall: (toolCallID: string) => MessageV2.ToolPart | undefined
+    readonly setToolMetadata: (toolCallID: string, val: { title?: string; metadata?: Record<string, any> }) => void
     readonly abort: () => Effect.Effect<void>
     readonly process: (streamInput: LLM.StreamInput) => Effect.Effect<Result>
   }
@@ -46,6 +47,7 @@ export namespace SessionProcessor {
 
   interface ProcessorContext extends Input {
     toolcalls: Record<string, MessageV2.ToolPart>
+    toolMetadata: Record<string, { title?: string; metadata?: Record<string, any> }>
     shouldBreak: boolean
     snapshot: string | undefined
     blocked: boolean
@@ -89,6 +91,7 @@ export namespace SessionProcessor {
           sessionID: input.sessionID,
           model: input.model,
           toolcalls: {},
+          toolMetadata: {},
           shouldBreak: false,
           snapshot: undefined,
           blocked: false,
@@ -173,10 +176,18 @@ export namespace SessionProcessor {
               }
               const match = ctx.toolcalls[value.toolCallId]
               if (!match) return
+              const pending = ctx.toolMetadata[value.toolCallId]
+              delete ctx.toolMetadata[value.toolCallId]
               ctx.toolcalls[value.toolCallId] = yield* session.updatePart({
                 ...match,
                 tool: value.toolName,
-                state: { status: "running", input: value.input, time: { start: Date.now() } },
+                state: {
+                  status: "running",
+                  input: value.input,
+                  time: { start: Date.now() },
+                  title: pending?.title,
+                  metadata: pending?.metadata,
+                },
                 metadata: value.providerMetadata,
               } satisfies MessageV2.ToolPart)
 
@@ -224,6 +235,7 @@ export namespace SessionProcessor {
                 },
               })
               delete ctx.toolcalls[value.toolCallId]
+              delete ctx.toolMetadata[value.toolCallId]
               return
             }
 
@@ -243,6 +255,7 @@ export namespace SessionProcessor {
                 ctx.blocked = ctx.shouldBreak
               }
               delete ctx.toolcalls[value.toolCallId]
+              delete ctx.toolMetadata[value.toolCallId]
               return
             }
 
@@ -493,6 +506,9 @@ export namespace SessionProcessor {
           },
           partFromToolCall(toolCallID: string) {
             return ctx.toolcalls[toolCallID]
+          },
+          setToolMetadata(toolCallID: string, val: { title?: string; metadata?: Record<string, any> }) {
+            ctx.toolMetadata[toolCallID] = val
           },
           abort,
           process,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -384,7 +384,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         model: Provider.Model
         session: Session.Info
         tools?: Record<string, boolean>
-        processor: Pick<SessionProcessor.Handle, "message" | "partFromToolCall">
+        processor: Pick<SessionProcessor.Handle, "message" | "partFromToolCall" | "setToolMetadata">
         bypassAgentCheck: boolean
         messages: MessageV2.WithParts[]
       }) {
@@ -399,23 +399,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck },
           agent: input.agent.name,
           messages: input.messages,
-          metadata: (val) =>
-            Effect.runPromise(
+          metadata: (val) => {
+            input.processor.setToolMetadata(options.toolCallId, val)
+            return Effect.runPromise(
               Effect.gen(function* () {
                 const match = input.processor.partFromToolCall(options.toolCallId)
                 if (!match || match.state.status !== "running") return
                 yield* sessions.updatePart({
                   ...match,
                   state: {
+                    ...match.state,
                     title: val.title,
                     metadata: val.metadata,
-                    status: "running",
-                    input: args,
-                    time: { start: Date.now() },
                   },
                 })
               }),
-            ),
+            )
+          },
           ask: (req) =>
             Effect.runPromise(
               permission.ask({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -149,6 +149,7 @@ function fake(
         state: { status: "pending", input: {}, raw: "" },
       }
     },
+    setToolMetadata() {},
     process: Effect.fn("TestSessionProcessor.process")(() => Effect.succeed(result)),
   } satisfies SessionProcessorModule.SessionProcessor.Handle
 }

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -870,3 +870,188 @@ it.effect("session.processor effect tests mark interruptions aborted without man
     { git: true },
   )
 })
+
+// Regression: the Anthropic AI SDK adapter fires tool execute() before yielding
+// the tool-call stream event. ctx.metadata({sessionId}) writes to the DB while
+// the part is still pending. The processor's tool-call handler then overwrites
+// with a fresh running state that has no metadata — clobbering sessionId.
+// The TUI reads state.metadata.sessionId for click navigation, so subagent
+// sessions become unclickable while running.
+
+it.effect("tool-call handler clobbers metadata written to DB during pending state without side-channel", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const test = yield* TestLLM
+        const processors = yield* SessionProcessor.Service
+        const session = yield* Session.Service
+
+        const gate = defer<void>()
+        yield* test.push(
+          stream(start(), toolInputStart("task-1", "task")).pipe(
+            Stream.concat(
+              Stream.fromEffect(
+                Effect.promise<LLM.Event>(() =>
+                  gate.promise.then(() => toolCall("task-1", "task", { description: "test" })),
+                ),
+              ),
+            ),
+            Stream.concat(stream(finishStep(), finish())),
+          ),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = model(100)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const input = {
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        } satisfies LLM.StreamInput
+
+        // Start processing — blocks after tool-input-start (part is pending)
+        const fiber = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Effect.promise(() => new Promise<void>((r) => setTimeout(r, 100)))
+
+        // Verify part is pending in DB
+        const pending = handle.partFromToolCall("task-1")
+        expect(pending).toBeDefined()
+        expect(pending?.state.status).toBe("pending")
+
+        // Simulate ctx.metadata() writing to DB while part is still pending.
+        // This is what happens with the Anthropic adapter.
+        yield* session.updatePart({
+          ...pending!,
+          state: {
+            status: "running",
+            input: {},
+            time: { start: Date.now() },
+            title: "test task",
+            metadata: { sessionId: "child-session" },
+          },
+        })
+
+        // Confirm the DB has the metadata
+        const dbBefore = yield* Effect.promise(() => MessageV2.parts(msg.id))
+        const before = dbBefore.find((p): p is MessageV2.ToolPart => p.type === "tool" && p.callID === "task-1")
+        expect(before?.state.status).toBe("running")
+        if (before?.state.status === "running") {
+          expect(before.state.metadata?.sessionId).toBe("child-session")
+        }
+
+        // Release gate — tool-call handler reads from ctx.toolcalls (stale pending
+        // copy without metadata) and overwrites DB with fresh running state.
+        gate.resolve()
+        yield* Fiber.join(fiber)
+
+        // The processor's in-memory copy has no metadata — the DB write is lost.
+        const part = handle.partFromToolCall("task-1")
+        expect(part).toBeDefined()
+        if (!part) return
+        expect(part.state.status).toBe("running")
+        if (part.state.status !== "running") return
+        // Without the side-channel fix, metadata is clobbered:
+        expect(part.state.metadata?.sessionId).toBeUndefined()
+      }),
+    { git: true },
+  ),
+)
+
+it.effect("tool-call handler preserves metadata via setToolMetadata side-channel", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const test = yield* TestLLM
+        const processors = yield* SessionProcessor.Service
+        const session = yield* Session.Service
+
+        const gate = defer<void>()
+        yield* test.push(
+          stream(start(), toolInputStart("task-1", "task")).pipe(
+            Stream.concat(
+              Stream.fromEffect(
+                Effect.promise<LLM.Event>(() =>
+                  gate.promise.then(() => toolCall("task-1", "task", { description: "test" })),
+                ),
+              ),
+            ),
+            Stream.concat(stream(finishStep(), finish())),
+          ),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = model(100)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const input = {
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies MessageV2.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        } satisfies LLM.StreamInput
+
+        // Start processing — blocks after tool-input-start (part is pending)
+        const fiber = yield* handle.process(input).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Effect.promise(() => new Promise<void>((r) => setTimeout(r, 100)))
+
+        expect(handle.partFromToolCall("task-1")?.state.status).toBe("pending")
+
+        // Simulate the fix path: ctx.metadata() buffers in the side-channel
+        // so tool-call handler can merge it into the running state.
+        handle.setToolMetadata("task-1", {
+          title: "test task",
+          metadata: { sessionId: "child-session" },
+        })
+
+        // Release gate — tool-call merges from side-channel
+        gate.resolve()
+        yield* Fiber.join(fiber)
+
+        // Metadata survives the pending→running transition
+        const part = handle.partFromToolCall("task-1")
+        expect(part).toBeDefined()
+        if (!part) return
+        expect(part.state.status).toBe("running")
+        if (part.state.status !== "running") return
+        expect(part.state.title).toBe("test task")
+        expect(part.state.metadata?.sessionId).toBe("child-session")
+      }),
+    { git: true },
+  ),
+)


### PR DESCRIPTION
## Summary

- Fixes #20184
- Related: #20183

Regression from c5442d418 (effectify SessionPrompt): clicking a running subagent
in the TUI does nothing because `state.metadata.sessionId` is never populated
while the tool is running.

## Root Cause

`ctx.metadata({sessionId})` fires while the part is still `pending`. The
processor's `tool-call` handler then transitions the part to `running` with a
fresh state object — clobbering the metadata. The TUI reads
`state.metadata.sessionId` for click navigation, so it's always empty.

## Fix

Synchronous side-channel (`toolMetadata` map) on the processor context:

- `setToolMetadata()` writes immediately when the metadata callback fires
- `tool-call` handler merges `title`/`metadata` from the map into the running state
- Entries cleaned up in `tool-result` and `tool-error`

Uses an in-memory side-channel rather than a DB read, so the metadata is
guaranteed to be available regardless of async scheduling.