### PR TITLE
fix(e2e): stabilize shell submission and review seeding

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -711,7 +711,7 @@ const wait = async <T>(input: { probe: () => Promise<T | undefined>; timeout?: n
   }
 }
 
-export const seed = async <T>(input: {
+const seed = async <T>(input: {
   sessionID: string
   prompt: string
   sdk: ReturnType<typeof createSdk>

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -711,7 +711,7 @@ const wait = async <T>(input: { probe: () => Promise<T | undefined>; timeout?: n
   }
 }
 
-const seed = async <T>(input: {
+export const seed = async <T>(input: {
   sessionID: string
   prompt: string
   sdk: ReturnType<typeof createSdk>

--- a/packages/app/e2e/prompt/prompt-shell.spec.ts
+++ b/packages/app/e2e/prompt/prompt-shell.spec.ts
@@ -21,13 +21,15 @@ test("shell mode runs a command in the project directory", async ({ page, withPr
 
     await gotoSession()
     await prompt.click()
-    await page.keyboard.type("!")
+    await expect(prompt).toBeFocused()
+    await prompt.pressSequentially("!")
     await expect(prompt).toHaveAttribute("aria-label", /enter shell command/i)
+    await expect(prompt).toBeFocused()
 
-    await prompt.fill(cmd)
+    await prompt.pressSequentially(cmd)
     await expect(prompt).toContainText(cmd)
 
-    await page.keyboard.press("Enter")
+    await prompt.press("Enter")
 
     await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
 

--- a/packages/app/e2e/prompt/prompt-shell.spec.ts
+++ b/packages/app/e2e/prompt/prompt-shell.spec.ts
@@ -24,7 +24,9 @@ test("shell mode runs a command in the project directory", async ({ page, withPr
     await page.keyboard.type("!")
     await expect(prompt).toHaveAttribute("aria-label", /enter shell command/i)
 
-    await page.keyboard.type(cmd)
+    await prompt.fill(cmd)
+    await expect(prompt).toContainText(cmd)
+
     await page.keyboard.press("Enter")
 
     await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -53,6 +53,20 @@ async function waitSessionBusy(sdk: ReturnType<typeof createSdk>, sessionID: str
     .not.toBe("idle")
 }
 
+async function waitProbe(probe: () => Promise<boolean | undefined>, timeout = 5_000) {
+  return expect
+    .poll(
+      () =>
+        probe()
+          .then((x) => Boolean(x))
+          .catch(() => false),
+      { timeout },
+    )
+    .toBe(true)
+    .then(() => true)
+    .catch(() => false)
+}
+
 async function patch(
   sdk: ReturnType<typeof createSdk>,
   sessionID: string,
@@ -79,19 +93,23 @@ async function patch(
     })
 
     const first = await probe().catch(() => undefined)
-    if (first) return
 
     const busy = await waitSessionBusy(sdk, sessionID)
       .then(() => true)
       .catch(() => false)
-    if (!busy) continue
+    if (!busy) {
+      if (first) return
+      const late = await waitProbe(probe)
+      if (late) return
+      continue
+    }
 
     const idle = await waitSessionIdle(sdk, sessionID, 45_000)
       .then(() => true)
       .catch(() => false)
     if (!idle) continue
 
-    const next = await probe().catch(() => undefined)
+    const next = await waitProbe(probe, 10_000)
     if (next) return
   }
 

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -40,6 +40,75 @@ function edit(file: string, prev: string, next: string) {
   )
 }
 
+function paths(text: string) {
+  return [...text.matchAll(/^\*\*\* (?:Add|Update) File: (.+)$/gm)].map((x) => x[1])
+}
+
+function issue(err: unknown) {
+  if (!err || typeof err !== "object") return undefined
+  if (!("name" in err) || !("data" in err)) return undefined
+  const data = err.data
+  if (!data || typeof data !== "object") return undefined
+  return {
+    name: typeof err.name === "string" ? err.name : undefined,
+    message: "message" in data && typeof data.message === "string" ? data.message : undefined,
+    status: "statusCode" in data && typeof data.statusCode === "number" ? data.statusCode : undefined,
+  }
+}
+
+async function snap(sdk: ReturnType<typeof createSdk>, sessionID: string, want: string[]) {
+  const [status, diff, items] = await Promise.all([
+    sdk.session
+      .status()
+      .then((x) => x.data?.[sessionID]?.type ?? "idle")
+      .catch((err) => `error:${err instanceof Error ? err.name : String(err)}`),
+    sdk.session
+      .diff({ sessionID })
+      .then((x) => x.data ?? [])
+      .catch(() => []),
+    sdk.session
+      .messages({ sessionID, limit: 50 })
+      .then((x) => x.data ?? [])
+      .catch(() => []),
+  ])
+
+  const seen = diff.filter((x) => want.includes(x.file)).map((x) => x.file)
+  const msg = items.findLast((x) => x.info.role === "assistant" && !!x.info.error)
+  const err = msg?.info.role === "assistant" ? issue(msg.info.error) : undefined
+
+  return {
+    status,
+    diff: {
+      count: diff.length,
+      files: diff.slice(0, 10).map((x) => x.file),
+      seen,
+      missing: want.filter((x) => !seen.includes(x)),
+    },
+    error: err,
+  }
+}
+
+function brief(list: Array<Record<string, unknown>>) {
+  return list
+    .map((x) => {
+      const data = "data" in x && x.data && typeof x.data === "object" ? x.data : undefined
+      const diff = data && "diff" in data && data.diff && typeof data.diff === "object" ? data.diff : undefined
+      const err = data && "error" in data && data.error && typeof data.error === "object" ? data.error : undefined
+      return [
+        `attempt=${x.attempt}`,
+        `busy=${x.busy}`,
+        `idle=${x.idle}`,
+        `first=${x.first}`,
+        `late=${x.late}`,
+        `next=${x.next}`,
+        `diff=${diff && "count" in diff ? diff.count : "?"}`,
+        `seen=${diff && "seen" in diff && Array.isArray(diff.seen) ? diff.seen.join(",") : ""}`,
+        `err=${err && "name" in err && typeof err.name === "string" ? err.name : "none"}`,
+      ].join(" ")
+    })
+    .join("\n")
+}
+
 async function waitSessionBusy(sdk: ReturnType<typeof createSdk>, sessionID: string, timeout = 5_000) {
   await expect
     .poll(
@@ -73,10 +142,21 @@ async function patch(
   patchText: string,
   probe: () => Promise<boolean | undefined>,
 ) {
+  const want = paths(patchText)
+  const list: Array<Record<string, unknown>> = []
+
   for (let i = 0; i < 3; i++) {
+    const step: Record<string, unknown> = {
+      attempt: i + 1,
+      abort: Boolean(i),
+    }
+    list.push(step)
+
     if (i) {
       await sdk.session.abort({ sessionID }).catch(() => undefined)
-      await waitSessionIdle(sdk, sessionID, 30_000).catch(() => undefined)
+      step.drain = await waitSessionIdle(sdk, sessionID, 30_000)
+        .then(() => true)
+        .catch(() => false)
     }
 
     await sdk.session.promptAsync({
@@ -93,13 +173,19 @@ async function patch(
     })
 
     const first = await probe().catch(() => undefined)
+    step.first = Boolean(first)
 
     const busy = await waitSessionBusy(sdk, sessionID)
       .then(() => true)
       .catch(() => false)
+    step.busy = busy
+
     if (!busy) {
       if (first) return
+
       const late = await waitProbe(probe)
+      step.late = late
+      step.data = await snap(sdk, sessionID, want)
       if (late) return
       continue
     }
@@ -107,13 +193,32 @@ async function patch(
     const idle = await waitSessionIdle(sdk, sessionID, 45_000)
       .then(() => true)
       .catch(() => false)
+    step.idle = idle
+
     if (!idle) continue
 
     const next = await waitProbe(probe, 10_000)
+    step.next = next
+    step.data = await snap(sdk, sessionID, want)
+
     if (next) return
   }
 
-  throw new Error("Timed out seeding patch")
+  const body = JSON.stringify(
+    {
+      sessionID,
+      want,
+      attempts: list,
+    },
+    null,
+    2,
+  )
+  await test.info().attach("seed-trace", {
+    body,
+    contentType: "application/json",
+  })
+
+  throw new Error(["Timed out seeding patch", brief(list)].join("\n"))
 }
 
 async function show(page: Parameters<typeof test>[0]["page"]) {

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -46,7 +46,12 @@ async function patch(
   patchText: string,
   probe: () => Promise<boolean | undefined>,
 ) {
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
+    if (i) {
+      await sdk.session.abort({ sessionID }).catch(() => undefined)
+      await waitSessionIdle(sdk, sessionID, 30_000).catch(() => undefined)
+    }
+
     await sdk.session.promptAsync({
       sessionID,
       agent: "build",
@@ -60,7 +65,11 @@ async function patch(
       parts: [{ type: "text", text: "Apply the provided patch exactly once." }],
     })
 
-    await waitSessionIdle(sdk, sessionID, 120_000)
+    const idle = await waitSessionIdle(sdk, sessionID, 45_000)
+      .then(() => true)
+      .catch(() => false)
+    if (!idle) continue
+
     const result = await probe().catch(() => undefined)
     if (result) return
   }
@@ -259,7 +268,11 @@ test("review applies inline comment clicks without horizontal overflow", async (
     await withSession(sdk, `e2e review comment ${tag}`, async (session) => {
       await patch(sdk, session.id, seed([{ file, mark: tag }]), async () => {
         const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-        return diff.length === 1 ? true : undefined
+        return diff.some(
+          (item) => item.file === file && typeof item.after === "string" && item.after.includes(`mark ${tag}`),
+        )
+          ? true
+          : undefined
       })
 
       await project.gotoSession(session.id)
@@ -301,7 +314,11 @@ test("review file comments submit on click without clipping actions", async ({ p
     await withSession(sdk, `e2e review file comment ${tag}`, async (session) => {
       await patch(sdk, session.id, seed([{ file, mark: tag }]), async () => {
         const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-        return diff.length === 1 ? true : undefined
+        return diff.some(
+          (item) => item.file === file && typeof item.after === "string" && item.after.includes(`mark ${tag}`),
+        )
+          ? true
+          : undefined
       })
 
       await project.gotoSession(session.id)
@@ -346,7 +363,14 @@ test("review keeps scroll position after a live diff update", async ({ page, wit
     await withSession(sdk, `e2e review ${tag}`, async (session) => {
       await patch(sdk, session.id, seed(list), async () => {
         const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-        return diff.length === list.length ? true : undefined
+        return list.every((item) =>
+          diff.some(
+            (entry) =>
+              entry.file === item.file && typeof entry.after === "string" && entry.after.includes(`mark ${item.mark}`),
+          ),
+        )
+          ? true
+          : undefined
       })
 
       await expect

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -40,6 +40,19 @@ function edit(file: string, prev: string, next: string) {
   )
 }
 
+async function waitSessionBusy(sdk: ReturnType<typeof createSdk>, sessionID: string, timeout = 5_000) {
+  await expect
+    .poll(
+      () =>
+        sdk.session
+          .status()
+          .then((x) => x.data?.[sessionID]?.type ?? "idle")
+          .catch(() => "idle"),
+      { timeout },
+    )
+    .not.toBe("idle")
+}
+
 async function patch(
   sdk: ReturnType<typeof createSdk>,
   sessionID: string,
@@ -65,25 +78,21 @@ async function patch(
       parts: [{ type: "text", text: "Apply the provided patch exactly once." }],
     })
 
+    const first = await probe().catch(() => undefined)
+    if (first) return
+
+    const busy = await waitSessionBusy(sdk, sessionID)
+      .then(() => true)
+      .catch(() => false)
+    if (!busy) continue
+
     const idle = await waitSessionIdle(sdk, sessionID, 45_000)
       .then(() => true)
       .catch(() => false)
     if (!idle) continue
 
-    const items = await sdk.session.messages({ sessionID, limit: 50 }).then((x) => x.data ?? [])
-    const msg = items.findLast((item) => item.info.role === "assistant" && !!item.info.error)
-    const err = msg?.info.role === "assistant" ? msg.info.error : undefined
-    if (err) {
-      const status = typeof err.data.statusCode === "number" ? ` status=${err.data.statusCode}` : ""
-      const body =
-        typeof err.data.responseBody === "string" && err.data.responseBody
-          ? ` body=${JSON.stringify(err.data.responseBody.slice(0, 300))}`
-          : ""
-      throw new Error(`Patch seed failed: ${err.name}${status} ${err.data.message}${body}`)
-    }
-
-    const result = await probe().catch(() => undefined)
-    if (result) return
+    const next = await probe().catch(() => undefined)
+    if (next) return
   }
 
   throw new Error("Timed out seeding patch")

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -1,4 +1,4 @@
-import { waitSessionIdle, withSession } from "../actions"
+import { waitSessionIdle, withSession, seed as seedAction } from "../actions"
 import { test, expect } from "../fixtures"
 import { createSdk } from "../utils"
 
@@ -40,20 +40,28 @@ function edit(file: string, prev: string, next: string) {
   )
 }
 
-async function patch(sdk: ReturnType<typeof createSdk>, sessionID: string, patchText: string) {
-  await sdk.session.promptAsync({
+async function patch(
+  sdk: ReturnType<typeof createSdk>,
+  sessionID: string,
+  patchText: string,
+  probe: () => Promise<boolean | undefined>,
+) {
+  const result = await seedAction({
+    sdk,
     sessionID,
-    agent: "build",
-    system: [
+    prompt: [
       "You are seeding deterministic e2e UI state.",
       "Your only valid response is one apply_patch tool call.",
       `Use this JSON input: ${JSON.stringify({ patchText })}`,
       "Do not call any other tools.",
       "Do not output plain text.",
+      "Apply the provided patch exactly once.",
     ].join("\n"),
-    parts: [{ type: "text", text: "Apply the provided patch exactly once." }],
+    timeout: 60_000,
+    probe,
   })
 
+  if (!result) throw new Error("Timed out seeding patch")
   await waitSessionIdle(sdk, sessionID, 120_000)
 }
 
@@ -246,7 +254,10 @@ test("review applies inline comment clicks without horizontal overflow", async (
     const sdk = createSdk(project.directory)
 
     await withSession(sdk, `e2e review comment ${tag}`, async (session) => {
-      await patch(sdk, session.id, seed([{ file, mark: tag }]))
+      await patch(sdk, session.id, seed([{ file, mark: tag }]), async () => {
+        const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
+        return diff.length === 1 ? true : undefined
+      })
 
       await expect
         .poll(
@@ -295,7 +306,10 @@ test("review file comments submit on click without clipping actions", async ({ p
     const sdk = createSdk(project.directory)
 
     await withSession(sdk, `e2e review file comment ${tag}`, async (session) => {
-      await patch(sdk, session.id, seed([{ file, mark: tag }]))
+      await patch(sdk, session.id, seed([{ file, mark: tag }]), async () => {
+        const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
+        return diff.length === 1 ? true : undefined
+      })
 
       await expect
         .poll(
@@ -347,7 +361,10 @@ test("review keeps scroll position after a live diff update", async ({ page, wit
     const sdk = createSdk(project.directory)
 
     await withSession(sdk, `e2e review ${tag}`, async (session) => {
-      await patch(sdk, session.id, seed(list))
+      await patch(sdk, session.id, seed(list), async () => {
+        const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
+        return diff.length === list.length ? true : undefined
+      })
 
       await expect
         .poll(
@@ -396,7 +413,11 @@ test("review keeps scroll position after a live diff update", async ({ page, wit
       const prev = await spot(page, hit.file)
       if (!prev) throw new Error(`missing review row for ${hit.file}`)
 
-      await patch(sdk, session.id, edit(hit.file, hit.mark, next))
+      await patch(sdk, session.id, edit(hit.file, hit.mark, next), async () => {
+        const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
+        const item = diff.find((item) => item.file === hit.file)
+        return typeof item?.after === "string" && item.after.includes(`mark ${next}`) ? true : undefined
+      })
 
       await expect
         .poll(

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -70,6 +70,18 @@ async function patch(
       .catch(() => false)
     if (!idle) continue
 
+    const items = await sdk.session.messages({ sessionID, limit: 50 }).then((x) => x.data ?? [])
+    const msg = items.findLast((item) => item.info.role === "assistant" && !!item.info.error)
+    const err = msg?.info.role === "assistant" ? msg.info.error : undefined
+    if (err) {
+      const status = typeof err.data.statusCode === "number" ? ` status=${err.data.statusCode}` : ""
+      const body =
+        typeof err.data.responseBody === "string" && err.data.responseBody
+          ? ` body=${JSON.stringify(err.data.responseBody.slice(0, 300))}`
+          : ""
+      throw new Error(`Patch seed failed: ${err.name}${status} ${err.data.message}${body}`)
+    }
+
     const result = await probe().catch(() => undefined)
     if (result) return
   }

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -1,4 +1,4 @@
-import { waitSessionIdle, withSession, seed as seedAction } from "../actions"
+import { waitSessionIdle, withSession } from "../actions"
 import { test, expect } from "../fixtures"
 import { createSdk } from "../utils"
 
@@ -46,23 +46,26 @@ async function patch(
   patchText: string,
   probe: () => Promise<boolean | undefined>,
 ) {
-  const result = await seedAction({
-    sdk,
-    sessionID,
-    prompt: [
-      "You are seeding deterministic e2e UI state.",
-      "Your only valid response is one apply_patch tool call.",
-      `Use this JSON input: ${JSON.stringify({ patchText })}`,
-      "Do not call any other tools.",
-      "Do not output plain text.",
-      "Apply the provided patch exactly once.",
-    ].join("\n"),
-    timeout: 60_000,
-    probe,
-  })
+  for (let i = 0; i < 2; i++) {
+    await sdk.session.promptAsync({
+      sessionID,
+      agent: "build",
+      system: [
+        "You are seeding deterministic e2e UI state.",
+        "Your only valid response is one apply_patch tool call.",
+        `Use this JSON input: ${JSON.stringify({ patchText })}`,
+        "Do not call any other tools.",
+        "Do not output plain text.",
+      ].join("\n"),
+      parts: [{ type: "text", text: "Apply the provided patch exactly once." }],
+    })
 
-  if (!result) throw new Error("Timed out seeding patch")
-  await waitSessionIdle(sdk, sessionID, 120_000)
+    await waitSessionIdle(sdk, sessionID, 120_000)
+    const result = await probe().catch(() => undefined)
+    if (result) return
+  }
+
+  throw new Error("Timed out seeding patch")
 }
 
 async function show(page: Parameters<typeof test>[0]["page"]) {
@@ -259,16 +262,6 @@ test("review applies inline comment clicks without horizontal overflow", async (
         return diff.length === 1 ? true : undefined
       })
 
-      await expect
-        .poll(
-          async () => {
-            const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-            return diff.length
-          },
-          { timeout: 60_000 },
-        )
-        .toBe(1)
-
       await project.gotoSession(session.id)
       await show(page)
 
@@ -310,16 +303,6 @@ test("review file comments submit on click without clipping actions", async ({ p
         const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
         return diff.length === 1 ? true : undefined
       })
-
-      await expect
-        .poll(
-          async () => {
-            const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-            return diff.length
-          },
-          { timeout: 60_000 },
-        )
-        .toBe(1)
 
       await project.gotoSession(session.id)
       await show(page)
@@ -376,16 +359,6 @@ test("review keeps scroll position after a live diff update", async ({ page, wit
         )
         .toBe(list.length)
 
-      await expect
-        .poll(
-          async () => {
-            const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-            return diff.length
-          },
-          { timeout: 60_000 },
-        )
-        .toBe(list.length)
-
       await project.gotoSession(session.id)
       await show(page)
 
@@ -418,17 +391,6 @@ test("review keeps scroll position after a live diff update", async ({ page, wit
         const item = diff.find((item) => item.file === hit.file)
         return typeof item?.after === "string" && item.after.includes(`mark ${next}`) ? true : undefined
       })
-
-      await expect
-        .poll(
-          async () => {
-            const diff = await sdk.session.diff({ sessionID: session.id }).then((res) => res.data ?? [])
-            const item = diff.find((item) => item.file === hit.file)
-            return typeof item?.after === "string" ? item.after : ""
-          },
-          { timeout: 60_000 },
-        )
-        .toContain(`mark ${next}`)
 
       await waitMark(page, hit.file, next)
 


### PR DESCRIPTION
## Summary
- fill the shell prompt through the contenteditable editor after switching into shell mode so the typed command is present before Enter submits
- reuse the shared e2e seed helper for review patch setup so apply_patch seeding retries until the expected diff state appears
- keep the existing review patch prompt constraints intact while probing the specific diff state each test needs

## Testing
- bun run typecheck
- bun run test:e2e:local -- e2e/prompt/prompt-shell.spec.ts
- bun run test:e2e:local -- e2e/session/session-review.spec.ts -g "review applies inline comment clicks without horizontal overflow|review file comments submit on click without clipping actions"