### PR TITLE
fix(tui): restore terminal modes on exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
@@ -4,6 +4,7 @@ import { Clipboard } from "@tui/util/clipboard"
 import { createSignal } from "solid-js"
 import { Installation } from "@/installation"
 import { win32FlushInputBuffer } from "../win32"
+import { Terminal } from "../util/terminal"
 
 export function ErrorComponent(props: {
   error: Error
@@ -18,7 +19,9 @@ export function ErrorComponent(props: {
   const handleExit = async () => {
     await props.onBeforeExit?.()
     renderer.setTerminalTitle("")
+    Terminal.restore()
     renderer.destroy()
+    Terminal.restore()
     win32FlushInputBuffer()
     await props.onExit()
   }

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -2,6 +2,7 @@ import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { win32FlushInputBuffer } from "../win32"
+import { Terminal } from "../util/terminal"
 type Exit = ((reason?: unknown) => Promise<void>) & {
   message: {
     set: (value?: string) => () => void
@@ -36,7 +37,9 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
           await input.onBeforeExit?.()
           // Reset window title before destroying renderer
           renderer.setTerminalTitle("")
+          Terminal.restore()
           renderer.destroy()
+          Terminal.restore()
           win32FlushInputBuffer()
           if (reason) {
             const formatted = FormatError(reason) ?? FormatUnknownError(reason)

--- a/packages/opencode/src/cli/cmd/tui/util/terminal.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/terminal.ts
@@ -1,7 +1,16 @@
 import { RGBA } from "@opentui/core"
 
 export namespace Terminal {
+  const RESET =
+    "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1004l\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1016l\x1b[?2004l\x1b[?25h"
+
   export type Colors = Awaited<ReturnType<typeof colors>>
+
+  export function restore() {
+    if (!process.stdout.isTTY) return
+    process.stdout.write(RESET)
+  }
+
   /**
    * Query terminal colors including background, foreground, and palette (0-15).
    * Uses OSC escape sequences to retrieve actual terminal color values.


### PR DESCRIPTION
### Issue for this PR

Closes #20207

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a TUI shutdown cleanup bug that can leave terminal mouse-reporting modes enabled after exit.

The change adds a shared terminal restore step that disables common mouse modes, disables bracketed paste, and restores cursor visibility. That restore step now runs around renderer teardown in both the normal exit path and the fatal-error exit path.

This matches the Linux issue in #20207 and is closely related to the Windows report in #11748. It also complements #18902, which resets leaked mouse tracking on startup after hard-kill scenarios.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck` passes
- verified locally against the reported symptom: stray mouse-report style codes appearing after TUI exit

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR