### PR TITLE
feat(tui): add per-tool output visibility via show_tool_output config

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,9 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  show_tool_output: z
+    .array(z.string())
+    .optional()
 })
 
 export const TuiInfo = z

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1612,7 +1612,7 @@ function GenericTool(props: ToolProps<any>) {
   const { theme } = useTheme()
   const ctx = use()
   const output = createMemo(() => props.output?.trim() ?? "")
-  const [expanded, setExpanded] = createSignal(false)
+  const [expanded, setExpanded] = createSignal(ctx.tui?.show_tool_output?.includes(props.tool) ?? false)
   const lines = createMemo(() => output().split("\n"))
   const maxLines = 3
   const overflow = createMemo(() => lines().length > maxLines)
@@ -1623,7 +1623,7 @@ function GenericTool(props: ToolProps<any>) {
 
   return (
     <Show
-      when={props.output && ctx.showGenericToolOutput()}
+      when={props.output && (ctx.showGenericToolOutput() || ctx.tui?.show_tool_output?.includes(props.tool))}
       fallback={
         <InlineTool icon="⚙" pending="Writing command..." complete={true} part={props.part}>
           {props.tool} {input(props.input)}

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -369,7 +369,8 @@ You can customize TUI behavior through `tui.json` (or `tui.jsonc`).
     "enabled": true
   },
   "diff_style": "auto",
-  "mouse": true
+  "mouse": true,
+  "show_tool_output": ["bash", "read"]
 }
 ```
 
@@ -383,6 +384,7 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `0.001`, supports decimal values). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
+- `show_tool_output` - List of tool names whose output is always shown and expanded, even when generic tool output is hidden. Useful for selectively surfacing output from specific tools (e.g. `["bash", "read"]`) while keeping others collapsed.
 
 Use `OPENCODE_TUI_CONFIG` to load a custom TUI config path.
 


### PR DESCRIPTION
### Issue for this PR

Closes #17250 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `show_tool_output` string array to `tui.json` that lists tool names whose output should always be shown (and expanded), even when the global generic tool output toggle is off.

This addresses the use case where users want to hide noisy tool outputs (file reads, shell commands) but still see rich, formatted output from specific tools like plugins (e.g., project_status, todo_read, todo_edit or any custom tool which output is meant to be read).
                                                                                                                                                                                                               
**Changes:**
- Added `show_tool_output` field to `TuiOptions` in `tui-schema.ts`
- Modified GenericTool component to check if a tool is in the list and:
  - Show output block even when global toggle is off
  - Default to expanded state for tools in the list

**Usage:** in `tui.json`
```json
{
  "show_tool_output": ["project_status", "todo_edit", "todo_write"]
}
```

### How did you verify your code works?

I've been using it locally for 3 weeks, to allow my subagents use my `todo_edit`, `todo_write` and `todo_read` tools, and occasionally a work-only variant of the generic `project_status` tool that I mentioned in the issue.

### Screenshots / recordings

Here's an example of using `show_tool_output` inside a subagent

<img width="581" height="667" alt="image" src="https://github.com/user-attachments/assets/06cd4583-b550-44a3-93cc-0314a2321ec7" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

