### PR TITLE
fix(provider): add required OAuth scope for Google authentication

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -460,7 +460,9 @@ export namespace Provider {
           project,
           location,
           fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-            const auth = new GoogleAuth()
+            const auth = new GoogleAuth({
+              scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+            })
             const client = await auth.getApplicationDefault()
             const token = await client.credential.getAccessToken()
 


### PR DESCRIPTION
### Issue for this PR

Closes #20202

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Google Vertex provider was missing OAuth scopes when authenticating. This caused GLM models to fail with "invalid_scope" errors because Google didn't know what permissions were being requested.

Added the `https://www.googleapis.com/auth/cloud-platform` scope to the GoogleAuth configuration so Google knows we need access to Vertex AI.

### How did you verify your code works?

Tested locally with GLM models through the Google Vertex provider. The authentication now succeeds and models respond correctly.

### Screenshots / recordings


https://github.com/user-attachments/assets/338ab98d-4ffd-4f49-a097-7697d2e50d8b


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR