### PR TITLE
fix(desktop): restore the main window on relaunch

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2.9.5", features = ["macos-private-api"] }
+tauri = { version = "2.9.5", features = ["macos-private-api", "test"] }
 tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2.4.6"
 tauri-plugin-shell = "2"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tauri::{AppHandle, Listener, Manager, RunEvent, State, ipc::Channel};
+use tauri::{AppHandle, Listener, Manager, RunEvent, Runtime, State, ipc::Channel};
 #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_specta::Event;
@@ -33,7 +33,13 @@ use tokio::{
 
 use crate::cli::{sqlite_migration::SqliteMigrationProgress, sync_cli};
 use crate::constants::*;
-use crate::windows::{LoadingWindow, MainWindow};
+use crate::windows::{LOADING_WINDOW_LABEL, MAIN_WINDOW_LABEL, LoadingWindow, MainWindow};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MainAction {
+    Focused,
+    Created,
+}
 
 #[derive(Clone, serde::Serialize, specta::Type, Debug)]
 struct ServerReadyData {
@@ -89,6 +95,19 @@ fn kill_sidecar(app: AppHandle) {
     let _ = server_state.kill();
 
     tracing::info!("Killed server");
+}
+
+fn restore_main<R: Runtime>(app: &AppHandle<R>) -> Result<MainAction, tauri::Error> {
+    let existing = app.get_webview_window(MAIN_WINDOW_LABEL).is_some();
+    let window = MainWindow::create(app)?;
+    let _ = window.show();
+    let _ = window.set_focus();
+    let _ = window.unminimize();
+    Ok(if existing {
+        MainAction::Focused
+    } else {
+        MainAction::Created
+    })
 }
 
 #[tauri::command]
@@ -312,10 +331,16 @@ pub fn run() {
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            // Focus existing window when another instance is launched
-            if let Some(window) = app.get_webview_window(MainWindow::LABEL) {
-                let _ = window.set_focus();
-                let _ = window.unminimize();
+            match restore_main(app) {
+                Ok(MainAction::Focused) => {
+                    tracing::info!("Focused main window for relaunch");
+                }
+                Ok(MainAction::Created) => {
+                    tracing::warn!("Recreated missing main window for relaunch");
+                }
+                Err(err) => {
+                    tracing::error!(?err, "Failed to restore main window for relaunch");
+                }
             }
         }))
         .plugin(tauri_plugin_deep_link::init())
@@ -323,7 +348,7 @@ pub fn run() {
         .plugin(
             tauri_plugin_window_state::Builder::new()
                 .with_state_flags(window_state_flags())
-                .with_denylist(&[LoadingWindow::LABEL])
+                .with_denylist(&[LOADING_WINDOW_LABEL])
                 .build(),
         )
         .plugin(tauri_plugin_store::Builder::new().build())
@@ -362,6 +387,26 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|app, event| {
+            #[cfg(target_os = "macos")]
+            if let RunEvent::Reopen {
+                has_visible_windows: false,
+                ..
+            } = event
+            {
+                match restore_main(&app) {
+                    Ok(MainAction::Focused) => {
+                        tracing::info!("Focused main window for reopen");
+                    }
+                    Ok(MainAction::Created) => {
+                        tracing::warn!("Recreated missing main window for reopen");
+                    }
+                    Err(err) => {
+                        tracing::error!(?err, "Failed to restore main window for reopen");
+                    }
+                }
+                return;
+            }
+
             if let RunEvent::Exit = event {
                 tracing::info!("Received Exit");
 
@@ -410,6 +455,21 @@ fn export_types(builder: &tauri_specta::Builder<tauri::Wry>) {
 fn test_export_types() {
     let builder = make_specta_builder();
     export_types(&builder);
+}
+
+#[cfg(test)]
+#[test]
+fn test_restore_main_reuses_existing_window() {
+    let app = tauri::test::mock_builder()
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .unwrap();
+
+    let first = restore_main(app.handle()).unwrap();
+    let second = restore_main(app.handle()).unwrap();
+
+    assert_eq!(first, MainAction::Created);
+    assert_eq!(second, MainAction::Focused);
+    assert!(app.get_webview_window(MAIN_WINDOW_LABEL).is_some());
 }
 
 #[derive(tauri_specta::Event, serde::Deserialize, specta::Type)]

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -55,6 +55,10 @@ pub async fn set_default_server_url(app: AppHandle, url: Option<String>) -> Resu
 #[tauri::command]
 #[specta::specta]
 pub fn get_wsl_config(_app: AppHandle) -> Result<WslConfig, String> {
+    load_wsl(_app)
+}
+
+pub(crate) fn load_wsl<R: tauri::Runtime>(_app: AppHandle<R>) -> Result<WslConfig, String> {
     // let store = app
     //     .store(SETTINGS_STORE)
     //     .map_err(|e| format!("Failed to open settings store: {}", e))?;

--- a/packages/desktop/src-tauri/src/windows.rs
+++ b/packages/desktop/src-tauri/src/windows.rs
@@ -1,11 +1,14 @@
 use crate::{
     constants::{UPDATER_ENABLED, window_state_flags},
-    server::get_wsl_config,
+    server::load_wsl,
 };
 use std::{ops::Deref, time::Duration};
 use tauri::{AppHandle, Manager, Runtime, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 use tauri_plugin_window_state::AppHandleExt;
 use tokio::sync::mpsc;
+
+pub const MAIN_WINDOW_LABEL: &str = "main";
+pub const LOADING_WINDOW_LABEL: &str = "loading";
 
 #[cfg(target_os = "linux")]
 use std::sync::OnceLock;
@@ -23,33 +26,31 @@ fn use_decorations() -> bool {
     true
 }
 
-pub struct MainWindow(WebviewWindow);
+pub struct MainWindow<R: Runtime = tauri::Wry>(WebviewWindow<R>);
 
-impl Deref for MainWindow {
-    type Target = WebviewWindow;
+impl<R: Runtime> Deref for MainWindow<R> {
+    type Target = WebviewWindow<R>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl MainWindow {
-    pub const LABEL: &str = "main";
-
-    pub fn create(app: &AppHandle) -> Result<Self, tauri::Error> {
-        if let Some(window) = app.get_webview_window(Self::LABEL) {
+impl<R: Runtime> MainWindow<R> {
+    pub fn create(app: &AppHandle<R>) -> Result<Self, tauri::Error> {
+        if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
             let _ = window.set_focus();
             let _ = window.unminimize();
-            return Ok(Self(window));
+            return Ok(MainWindow(window));
         }
 
-        let wsl_enabled = get_wsl_config(app.clone())
+        let wsl_enabled = load_wsl(app.clone())
             .ok()
             .map(|v| v.enabled)
             .unwrap_or(false);
         let decorations = use_decorations();
         let window_builder = base_window_config(
-            WebviewWindowBuilder::new(app, Self::LABEL, WebviewUrl::App("/".into())),
+            WebviewWindowBuilder::new(app, MAIN_WINDOW_LABEL, WebviewUrl::App("/".into())),
             app,
             decorations,
         )
@@ -71,7 +72,9 @@ impl MainWindow {
         // Ensure window is focused after creation (e.g., after update/relaunch)
         let _ = window.set_focus();
 
-        setup_window_state_listener(app, &window);
+        if tokio::runtime::Handle::try_current().is_ok() {
+            setup_window_state_listener(app, &window);
+        }
 
         #[cfg(windows)]
         {
@@ -79,11 +82,11 @@ impl MainWindow {
             let _ = window.create_overlay_titlebar();
         }
 
-        Ok(Self(window))
+        Ok(MainWindow(window))
     }
 }
 
-fn setup_window_state_listener(app: &AppHandle, window: &WebviewWindow) {
+fn setup_window_state_listener<R: Runtime>(app: &AppHandle<R>, window: &WebviewWindow<R>) {
     let (tx, mut rx) = mpsc::channel::<()>(1);
 
     window.on_window_event(move |event| {
@@ -115,24 +118,22 @@ fn setup_window_state_listener(app: &AppHandle, window: &WebviewWindow) {
     });
 }
 
-pub struct LoadingWindow(WebviewWindow);
+pub struct LoadingWindow<R: Runtime = tauri::Wry>(WebviewWindow<R>);
 
-impl Deref for LoadingWindow {
-    type Target = WebviewWindow;
+impl<R: Runtime> Deref for LoadingWindow<R> {
+    type Target = WebviewWindow<R>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl LoadingWindow {
-    pub const LABEL: &str = "loading";
-
-    pub fn create(app: &AppHandle) -> Result<Self, tauri::Error> {
+impl<R: Runtime> LoadingWindow<R> {
+    pub fn create(app: &AppHandle<R>) -> Result<Self, tauri::Error> {
         let decorations = use_decorations();
 
         let window_builder = base_window_config(
-            WebviewWindowBuilder::new(app, Self::LABEL, tauri::WebviewUrl::App("/loading".into())),
+            WebviewWindowBuilder::new(app, LOADING_WINDOW_LABEL, tauri::WebviewUrl::App("/loading".into())),
             app,
             decorations,
         )
@@ -141,13 +142,13 @@ impl LoadingWindow {
         .inner_size(640.0, 480.0)
         .visible(true);
 
-        Ok(Self(window_builder.build()?))
+        Ok(LoadingWindow(window_builder.build()?))
     }
 }
 
 fn base_window_config<'a, R: Runtime, M: Manager<R>>(
     window_builder: WebviewWindowBuilder<'a, R, M>,
-    _app: &AppHandle,
+    _app: &AppHandle<R>,
     decorations: bool,
 ) -> WebviewWindowBuilder<'a, R, M> {
     let window_builder = window_builder.decorations(decorations);


### PR DESCRIPTION
### Issue for this PR

Closes #20222

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Desktop relaunches could no-op when an existing single-instance process was still alive but had no visible `main` window to focus. This updates the relaunch path to restore the main window instead of assuming it already exists, adds log lines so we can see whether we focused or recreated the window, and handles macOS reopen events the same way.

I also added a small regression test around the restore helper. The internal window creation path is runtime-generic so the test can use Tauri's mock runtime without changing the desktop startup flow.

### How did you verify your code works?

- Ran `cargo check --no-default-features` in `packages/desktop/src-tauri`
- Ran `cargo test --no-default-features test_restore_main_reuses_existing_window` in `packages/desktop/src-tauri`
- Ran `bun run dev:desktop` and confirmed the app reached desktop initialization successfully after the stale-process fix
- Pre-push hook also ran `bun turbo typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
