### PR TITLE
test(e2e): experiment with authenticated opencode model in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,8 @@ jobs:
         run: bun --cwd packages/app test:e2e:local
         env:
           CI: true
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENCODE_E2E_MODEL: ${{ secrets.OPENCODE_API_KEY != '' && 'opencode/gpt-5' || 'opencode/gpt-5-nano' }}
         timeout-minutes: 30
 
       - name: Upload Playwright artifacts

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -5,7 +5,7 @@ import os from "node:os"
 import path from "node:path"
 import { execSync } from "node:child_process"
 import { terminalAttr, type E2EWindow } from "../src/testing/terminal"
-import { createSdk, modKey, resolveDirectory, serverUrl } from "./utils"
+import { createSdk, e2eModel, modKey, resolveDirectory, serverUrl } from "./utils"
 import {
   dropdownMenuTriggerSelector,
   dropdownMenuContentSelector,
@@ -719,9 +719,11 @@ const seed = async <T>(input: {
   timeout?: number
   attempts?: number
 }) => {
+  const model = e2eModel()
   for (let i = 0; i < (input.attempts ?? 2); i++) {
     await input.sdk.session.promptAsync({
       sessionID: input.sessionID,
+      ...(model && { model }),
       agent: "build",
       system: seedSystem,
       parts: [{ type: "text", text: input.prompt }],

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -11,7 +11,7 @@ import {
   waitSlug,
   waitSession,
 } from "./actions"
-import { createSdk, dirSlug, getWorktree, sessionPath } from "./utils"
+import { createSdk, dirSlug, e2eModel, getWorktree, sessionPath } from "./utils"
 
 export const settingsKey = "settings.v3"
 
@@ -125,30 +125,33 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 async function seedStorage(page: Page, input: { directory: string; extra?: string[] }) {
   await seedProjects(page, input)
-  await page.addInitScript(() => {
-    const win = window as E2EWindow
-    win.__opencode_e2e = {
-      ...win.__opencode_e2e,
-      model: {
-        enabled: true,
-      },
-      prompt: {
-        enabled: true,
-      },
-      terminal: {
-        enabled: true,
-        terminals: {},
-      },
-    }
-    localStorage.setItem(
-      "opencode.global.dat:model",
-      JSON.stringify({
-        recent: [{ providerID: "opencode", modelID: "big-pickle" }],
-        user: [],
-        variant: {},
-      }),
-    )
-  })
+  await page.addInitScript(
+    (model) => {
+      const win = window as E2EWindow
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        model: {
+          enabled: true,
+        },
+        prompt: {
+          enabled: true,
+        },
+        terminal: {
+          enabled: true,
+          terminals: {},
+        },
+      }
+      localStorage.setItem(
+        "opencode.global.dat:model",
+        JSON.stringify({
+          recent: [model],
+          user: [],
+          variant: {},
+        }),
+      )
+    },
+    e2eModel() ?? { providerID: "opencode", modelID: "big-pickle" },
+  )
 }
 
 export { expect }

--- a/packages/app/e2e/prompt/context.spec.ts
+++ b/packages/app/e2e/prompt/context.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../fixtures"
 import type { Page } from "@playwright/test"
 import { promptSelector } from "../selectors"
 import { withSession } from "../actions"
+import { e2eModel } from "../utils"
 
 function contextButton(page: Page) {
   return page
@@ -11,8 +12,10 @@ function contextButton(page: Page) {
 }
 
 async function seedContextSession(input: { sessionID: string; sdk: Parameters<typeof withSession>[0] }) {
+  const model = e2eModel()
   await input.sdk.session.promptAsync({
     sessionID: input.sessionID,
+    ...(model && { model }),
     noReply: true,
     parts: [
       {

--- a/packages/app/e2e/prompt/prompt-slash-share.spec.ts
+++ b/packages/app/e2e/prompt/prompt-slash-share.spec.ts
@@ -1,12 +1,15 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { withSession } from "../actions"
+import { e2eModel } from "../utils"
 
 const shareDisabled = process.env.OPENCODE_DISABLE_SHARE === "true" || process.env.OPENCODE_DISABLE_SHARE === "1"
 
 async function seed(sdk: Parameters<typeof withSession>[0], sessionID: string) {
+  const model = e2eModel()
   await sdk.session.promptAsync({
     sessionID,
+    ...(model && { model }),
     noReply: true,
     parts: [{ type: "text", text: "e2e share seed" }],
   })

--- a/packages/app/e2e/session/session-review.spec.ts
+++ b/packages/app/e2e/session/session-review.spec.ts
@@ -1,6 +1,6 @@
 import { waitSessionIdle, withSession } from "../actions"
 import { test, expect } from "../fixtures"
-import { createSdk } from "../utils"
+import { createSdk, e2eModel } from "../utils"
 
 const count = 14
 
@@ -41,8 +41,10 @@ function edit(file: string, prev: string, next: string) {
 }
 
 async function patch(sdk: ReturnType<typeof createSdk>, sessionID: string, patchText: string) {
+  const model = e2eModel()
   await sdk.session.promptAsync({
     sessionID,
+    ...(model && { model }),
     agent: "build",
     system: [
       "You are seeding deterministic e2e UI state.",

--- a/packages/app/e2e/session/session-undo-redo.spec.ts
+++ b/packages/app/e2e/session/session-undo-redo.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { withSession } from "../actions"
-import { createSdk, modKey } from "../utils"
+import { createSdk, e2eModel, modKey } from "../utils"
 import { promptSelector } from "../selectors"
 
 async function seedConversation(input: {
@@ -17,8 +17,10 @@ async function seedConversation(input: {
 
   const prompt = input.page.locator(promptSelector)
   await expect(prompt).toBeVisible()
+  const model = e2eModel()
   await input.sdk.session.promptAsync({
     sessionID: input.sessionID,
+    ...(model && { model }),
     noReply: true,
     parts: [{ type: "text", text: input.token }],
   })

--- a/packages/app/e2e/session/session.spec.ts
+++ b/packages/app/e2e/session/session.spec.ts
@@ -8,14 +8,17 @@ import {
   withSession,
 } from "../actions"
 import { sessionItemSelector, inlineInputSelector } from "../selectors"
+import { e2eModel } from "../utils"
 
 const shareDisabled = process.env.OPENCODE_DISABLE_SHARE === "true" || process.env.OPENCODE_DISABLE_SHARE === "1"
 
 type Sdk = Parameters<typeof withSession>[0]
 
 async function seedMessage(sdk: Sdk, sessionID: string) {
+  const model = e2eModel()
   await sdk.session.promptAsync({
     sessionID,
+    ...(model && { model }),
     noReply: true,
     parts: [{ type: "text", text: "e2e seed" }],
   })

--- a/packages/app/e2e/utils.ts
+++ b/packages/app/e2e/utils.ts
@@ -30,6 +30,15 @@ export function createSdk(directory?: string) {
   return createOpencodeClient({ baseUrl: serverUrl, directory, throwOnError: true })
 }
 
+export function e2eModel() {
+  const value = process.env.OPENCODE_E2E_MODEL
+  if (!value) return
+  const [providerID, ...rest] = value.split("/")
+  const modelID = rest.join("/")
+  if (!providerID || !modelID) return
+  return { providerID, modelID }
+}
+
 export async function resolveDirectory(directory: string) {
   return createSdk(directory)
     .path.get()

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -71,7 +71,7 @@ const serverEnv = {
   OPENCODE_E2E_PROJECT_DIR: repoDir,
   OPENCODE_E2E_SESSION_TITLE: "E2E Session",
   OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
-  OPENCODE_E2E_MODEL: "opencode/gpt-5-nano",
+  OPENCODE_E2E_MODEL: process.env.OPENCODE_E2E_MODEL || "opencode/gpt-5-nano",
   OPENCODE_CLIENT: "app",
   OPENCODE_STRICT_CONFIG_DEPS: "true",
 } satisfies Record<string, string>


### PR DESCRIPTION
## Summary
- let the local e2e launcher honor `OPENCODE_E2E_MODEL` so CI can override the default free model
- use `OPENCODE_API_KEY` to route internal CI e2e runs to `opencode/gpt-5`, while keeping `opencode/gpt-5-nano` as the no-secret fallback for fork PRs
- try to reduce CI flakes caused by rate limits on the public free OpenCode model path

## Verification
- bun typecheck