### PR TITLE
fix(session): subagents not being clickable

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -403,7 +403,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             Effect.runPromise(
               Effect.gen(function* () {
                 const match = input.processor.partFromToolCall(options.toolCallId)
-                if (!match || match.state.status !== "running") return
+                if (!match || !["running", "pending"].includes(match.state.status)) return
                 yield* sessions.updatePart({
                   ...match,
                   state: {


### PR DESCRIPTION
Fixes an issue where tool calls with "pending" status were not being matched, only "running" status was checked.

## Changes
- Updated the status check in  to include both "running" and "pending" statuses when matching tool calls