### PR TITLE
feat: enable prompt caching and cache token tracking for google-vertex-anthropic

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -280,6 +280,7 @@ export namespace ProviderTransform {
     msgs = normalizeMessages(msgs, model, options)
     if (
       (model.providerID === "anthropic" ||
+        model.providerID === "google-vertex-anthropic" ||
         model.api.id.includes("anthropic") ||
         model.api.id.includes("claude") ||
         model.id.includes("anthropic") ||

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -257,6 +257,9 @@ export namespace Session {
     const cacheReadInputTokens = safe(input.usage.cachedInputTokens ?? 0)
     const cacheWriteInputTokens = safe(
       (input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
+        // google-vertex-anthropic returns metadata under "vertex" key
+        // (AnthropicMessagesLanguageModel custom provider key from 'vertex.anthropic.messages')
+        input.metadata?.["vertex"]?.["cacheCreationInputTokens"] ??
         // @ts-expect-error
         input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
         // @ts-expect-error

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1763,6 +1763,58 @@ describe("ProviderTransform.message - cache control on gateway", () => {
       },
     })
   })
+
+  test("google-vertex-anthropic applies cache control", () => {
+    const model = createModel({
+      providerID: "google-vertex-anthropic",
+      api: {
+        id: "google-vertex-anthropic",
+        url: "https://us-central1-aiplatform.googleapis.com",
+        npm: "@ai-sdk/google-vertex/anthropic",
+      },
+      id: "claude-sonnet-4@20250514",
+    })
+    const msgs = [
+      {
+        role: "system",
+        content: "You are a helpful assistant",
+      },
+      {
+        role: "user",
+        content: "Hello",
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, {}) as any[]
+
+    expect(result[0].providerOptions).toEqual({
+      anthropic: {
+        cacheControl: {
+          type: "ephemeral",
+        },
+      },
+      openrouter: {
+        cacheControl: {
+          type: "ephemeral",
+        },
+      },
+      bedrock: {
+        cachePoint: {
+          type: "default",
+        },
+      },
+      openaiCompatible: {
+        cache_control: {
+          type: "ephemeral",
+        },
+      },
+      copilot: {
+        copilot_cache_control: {
+          type: "ephemeral",
+        },
+      },
+    })
+  })
 })
 
 describe("ProviderTransform.variants", () => {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1199,4 +1199,26 @@ describe("session.getUsage", () => {
       expect(result.tokens.total).toBe(1500)
     },
   )
+
+  test("extracts cache write tokens from vertex metadata key", () => {
+    const model = createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/google-vertex/anthropic" })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        cachedInputTokens: 200,
+      },
+      metadata: {
+        vertex: {
+          cacheCreationInputTokens: 300,
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(500)
+    expect(result.tokens.cache.read).toBe(200)
+    expect(result.tokens.cache.write).toBe(300)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #20265

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds explicit prompt caching and cache token tracking support for the `google-vertex-anthropic` provider.

**Commit 1 - prompt caching:** Adds `model.providerID === "google-vertex-anthropic"` to the `applyCaching()` gate condition in `transform.ts`. The gate already catches this implicitly via `model.api.id.includes("anthropic")`, but an explicit `providerID` check is more stable and readable. Includes a test verifying cache control options are applied.

**Commit 2 - cache token tracking:** Adds `input.metadata?.["vertex"]?.["cacheCreationInputTokens"]` to the cache write extraction chain in `session/index.ts`. The Anthropic SDK on Vertex uses provider string `vertex.anthropic.messages`, which derives a custom metadata key of `"vertex"`. Response metadata is stored under both `"anthropic"` (canonical) and `"vertex"` (custom). The existing `"anthropic"` check handles the common case; the `"vertex"` fallback is defensive. Includes a test verifying extraction from the `"vertex"` metadata key.

**Why no native google-vertex (Gemini) changes?** Gemini uses implicit server-side caching, not Anthropic-style per-message cache breakpoints. Adding Gemini to `applyCaching()` would send cache control options the SDK ignores. Gemini's implicit caching already works without client-side changes (verified with test script: 97.8% cache hit on second request).

### How did you verify your code works?

- 120 tests pass in `test/provider/transform.test.ts` (including new google-vertex-anthropic cache control test)
- 37 tests pass in `test/session/compaction.test.ts` (including new vertex metadata key extraction test)
- `bun typecheck` passes clean
- Tested with `bun run dev` against live Vertex API:
  - **Vertex Anthropic** (claude-opus-4-6): cache write tokens tracked correctly (46,946 tokens)
  - **Vertex Gemini** (gemini-3.1-pro-preview): responses work, provider identified as `google-vertex`
  - **Gemini implicit caching**: standalone test showed `cachedContentTokenCount: 28645` out of 29,293 input tokens (97.8% cache hit)

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR