### PR TITLE
fix: clarify Claude Code credential auth error

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -27,6 +27,8 @@ export namespace ProviderError {
     /too large for model with \d+ maximum context length/i, // Mistral
     /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
   ]
+  const CLAUDE_CODE_CREDENTIAL_PATTERN =
+    /This credential is only authorized for use with Claude Code and cannot be used for other API requests\./i
 
   function isOpenAiErrorRetryable(e: APICallError) {
     const status = e.statusCode
@@ -44,6 +46,13 @@ export namespace ProviderError {
     // - Cerebras: often returns "400 (no body)" / "413 (no body)"
     // - Mistral: often returns "400 (no body)" / "413 (no body)"
     return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
+  }
+
+  function isClaudeCodeCredential(providerID: ProviderID, message: string, responseBody?: string) {
+    if (providerID !== "anthropic") return false
+    if (CLAUDE_CODE_CREDENTIAL_PATTERN.test(message)) return true
+    if (!responseBody) return false
+    return CLAUDE_CODE_CREDENTIAL_PATTERN.test(responseBody)
   }
 
   function message(providerID: ProviderID, e: APICallError) {
@@ -67,9 +76,22 @@ export namespace ProviderError {
         // try to extract common error message fields
         const errMsg = body.message || body.error || body.error?.message
         if (errMsg && typeof errMsg === "string") {
+          if (isClaudeCodeCredential(providerID, errMsg, e.responseBody)) {
+            return [
+              "This Anthropic credential is restricted to Claude Code and cannot be used with OpenCode.",
+              "Use a standard Anthropic API key instead, then run `opencode auth login anthropic` to update your credentials.",
+            ].join(" ")
+          }
           return `${msg}: ${errMsg}`
         }
       } catch {}
+
+      if (isClaudeCodeCredential(providerID, msg, e.responseBody)) {
+        return [
+          "This Anthropic credential is restricted to Claude Code and cannot be used with OpenCode.",
+          "Use a standard Anthropic API key instead, then run `opencode auth login anthropic` to update your credentials.",
+        ].join(" ")
+      }
 
       // If responseBody is HTML (e.g. from a gateway or proxy error page),
       // provide a human-readable message instead of dumping raw markup

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { APICallError } from "ai"
+import { ProviderError } from "../../src/provider/error"
+import { ProviderID } from "../../src/provider/schema"
+
+describe("provider.error", () => {
+  test("clarifies Claude Code-only Anthropic credentials", () => {
+    const result = ProviderError.parseAPICallError({
+      providerID: ProviderID.make("anthropic"),
+      error: new APICallError({
+        message: "Unauthorized",
+        url: "https://api.anthropic.com/v1/messages",
+        requestBodyValues: {},
+        statusCode: 401,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: JSON.stringify({
+          type: "error",
+          error: {
+            type: "authentication_error",
+            message: "This credential is only authorized for use with Claude Code and cannot be used for other API requests.",
+          },
+        }),
+        isRetryable: false,
+      }),
+    })
+
+    expect(result.type).toBe("api_error")
+    if (result.type !== "api_error") return
+    expect(result.message).toContain("restricted to Claude Code")
+    expect(result.message).toContain("standard Anthropic API key")
+    expect(result.message).toContain("opencode auth login anthropic")
+  })
+
+  test("keeps generic Anthropic auth errors unchanged", () => {
+    const result = ProviderError.parseAPICallError({
+      providerID: ProviderID.make("anthropic"),
+      error: new APICallError({
+        message: "Unauthorized",
+        url: "https://api.anthropic.com/v1/messages",
+        requestBodyValues: {},
+        statusCode: 401,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: JSON.stringify({
+          type: "error",
+          error: {
+            type: "authentication_error",
+            message: "Invalid API key",
+          },
+        }),
+        isRetryable: false,
+      }),
+    })
+
+    expect(result.type).toBe("api_error")
+    if (result.type !== "api_error") return
+    expect(result.message).not.toContain("restricted to Claude Code")
+    expect(result.message).not.toContain("standard Anthropic API key")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #7456

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenCode receives Anthropic auth errors for Claude Code-only credentials, the existing error text does not clearly tell the user what to do next.

This change detects that specific credential error and replaces it with clearer guidance that says the credential is restricted to Claude Code, cannot be used with OpenCode, and that the user should use a standard Anthropic API key and run `opencode auth login anthropic`.

The change is intentionally narrow and only affects provider error messaging for this specific Anthropic auth case.

### How did you verify your code works?

- added a focused provider error test for the Claude Code-only credential case
- ran `bun test test/provider/error.test.ts`
- ran `bun typecheck`
- verified generic Anthropic auth errors are not rewritten into the Claude Code-specific guidance

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR