### PR TITLE
fix(opencode): forward configured headers in startAuth and mcp debug

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -692,6 +692,7 @@ export const McpDebugCommand = cmd({
             headers: {
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
+              ...serverConfig.headers,
             },
             body: JSON.stringify({
               jsonrpc: "2.0",
@@ -743,6 +744,7 @@ export const McpDebugCommand = cmd({
             // Try creating transport with auth provider to trigger discovery
             const transport = new StreamableHTTPClientTransport(new URL(serverConfig.url), {
               authProvider,
+              requestInit: serverConfig.headers ? { headers: serverConfig.headers } : undefined,
             })
 
             try {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -751,7 +751,10 @@ export const layer = Layer.effect(
         auth,
       )
 
-      const transport = new StreamableHTTPClientTransport(new URL(mcpConfig.url), { authProvider })
+      const transport = new StreamableHTTPClientTransport(new URL(mcpConfig.url), {
+        authProvider,
+        requestInit: mcpConfig.headers ? { headers: mcpConfig.headers } : undefined,
+      })
 
       return yield* Effect.tryPromise({
         try: () => {

--- a/packages/opencode/test/mcp/headers-start-auth.test.ts
+++ b/packages/opencode/test/mcp/headers-start-auth.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, mock, beforeEach } from "bun:test"
+import { Effect } from "effect"
+import type { MCP as MCPNS } from "../../src/mcp/index"
+
+// Mock UnauthorizedError so instanceof checks in startAuth work
+class MockUnauthorizedError extends Error {
+  constructor() {
+    super("Unauthorized")
+    this.name = "UnauthorizedError"
+  }
+}
+
+// Track constructor arguments for all StreamableHTTPClientTransport instances
+const transportCalls: Array<{
+  url: string
+  options: { authProvider?: unknown; requestInit?: RequestInit }
+}> = []
+
+// The mock transport simulates a 401 that captures the auth URL via
+// authProvider.redirectToAuthorization(), then throws UnauthorizedError —
+// exactly what the real SDK transport does on a 401 response.
+mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: class MockStreamableHTTP {
+    authProvider: { redirectToAuthorization?: (url: URL) => Promise<void> } | undefined
+    constructor(url: URL, options?: { authProvider?: unknown; requestInit?: RequestInit }) {
+      this.authProvider = options?.authProvider as typeof this.authProvider
+      transportCalls.push({ url: url.toString(), options: options ?? {} })
+    }
+    async start() {
+      if (this.authProvider?.redirectToAuthorization) {
+        await this.authProvider.redirectToAuthorization(new URL("https://auth.example.com/authorize?client_id=test"))
+      }
+      throw new MockUnauthorizedError()
+    }
+    async finishAuth(_code: string) {}
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: class MockSSE {
+    constructor(url: URL, options?: { authProvider?: unknown; requestInit?: RequestInit }) {
+      transportCalls.push({ url: url.toString(), options: options ?? {} })
+    }
+    async start() {
+      throw new Error("Mock SSE transport cannot connect")
+    }
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class MockClient {
+    async connect(transport: { start: () => Promise<void> }) {
+      await transport.start()
+    }
+  },
+}))
+
+mock.module("@modelcontextprotocol/sdk/client/auth.js", () => ({
+  UnauthorizedError: MockUnauthorizedError,
+}))
+
+beforeEach(() => {
+  transportCalls.length = 0
+})
+
+// Import modules after mocking
+const { MCP } = await import("../../src/mcp/index")
+const { AppRuntime } = await import("../../src/effect/app-runtime")
+const { Instance } = await import("../../src/project/instance")
+const { tmpdir } = await import("../fixture/fixture")
+const service = MCP.Service as unknown as Effect.Effect<MCPNS.Interface, never, never>
+
+test("startAuth passes headers to StreamableHTTPClientTransport", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          mcp: {
+            "test-server": {
+              type: "remote",
+              url: "https://example.com/mcp",
+              headers: { "X-Custom-Header": "realm-value" },
+              oauth: {},
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      // startAuth throws (no real callback server) but we only care that the
+      // transport was constructed with the correct requestInit before that.
+      await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const mcp = yield* service
+          yield* mcp.startAuth("test-server").pipe(Effect.ignore)
+        }),
+      )
+
+      const startAuthCall = transportCalls.find((c) => c.url === "https://example.com/mcp")
+      expect(startAuthCall).toBeDefined()
+      expect(startAuthCall!.options.requestInit).toBeDefined()
+      expect(startAuthCall!.options.requestInit?.headers).toEqual({
+        "X-Custom-Header": "realm-value",
+      })
+    },
+  })
+})
+
+test("startAuth does not set requestInit when no headers are configured", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        `${dir}/opencode.json`,
+        JSON.stringify({
+          mcp: {
+            "test-server-no-headers": {
+              type: "remote",
+              url: "https://example.com/mcp",
+              oauth: {},
+            },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const mcp = yield* service
+          yield* mcp.startAuth("test-server-no-headers").pipe(Effect.ignore)
+        }),
+      )
+
+      const startAuthCall = transportCalls.find((c) => c.url === "https://example.com/mcp")
+      expect(startAuthCall).toBeDefined()
+      expect(startAuthCall!.options.requestInit).toBeUndefined()
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20286

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a remote MCP server requires custom headers on all requests, `mcp auth` and `mcp debug` fail because the headers from config are not forwarded during the OAuth flow. The `connectRemote` path already passes them correctly but we still miss headers when we run initial authentication (oauth). 

### How did you verify your code works?
Tested against a real MCP server that requires a custom header on every request. Before the fix `mcp auth` returned 404 and failed. After the fix auth completes successfully. Added two unit tests to `test/mcp/headers-start-auth.test.ts` that verify `startAuth` passes `requestInit` with the configured headers to the transport constructor.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
