### PR TITLE
instrument

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -366,6 +366,7 @@
         "hono-openapi": "catalog:",
         "ignore": "7.0.5",
         "jsonc-parser": "3.3.1",
+        "langfuse": "3.38.6",
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
         "open": "10.1.2",
@@ -3406,6 +3407,10 @@
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lang-map": ["lang-map@0.4.0", "", { "dependencies": { "language-map": "^1.1.0" } }, "sha512-oiSqZIEUnWdFeDNsp4HId4tAxdFbx5iMBOwA3666Fn2L8Khj8NiD9xRvMsGmKXopPVkaDFtSv3CJOmXFUB0Hcg=="],
+
+    "langfuse": ["langfuse@3.38.6", "", { "dependencies": { "langfuse-core": "^3.38.6" } }, "sha512-mtwfsNGIYvObRh+NYNGlJQJDiBN+Wr3Hnr++wN25mxuOpSTdXX+JQqVCyAqGL5GD2TAXRZ7COsN42Vmp9krYmg=="],
+
+    "langfuse-core": ["langfuse-core@3.38.6", "", { "dependencies": { "mustache": "^4.2.0" } }, "sha512-EcZXa+DK9FJdi1I30+u19eKjuBJ04du6j2Nybk19KKCuraLczg/ppkTQcGvc4QOk//OAi3qUHrajUuV74RXsBQ=="],
 
     "language-map": ["language-map@1.5.0", "", {}, "sha512-n7gFZpe+DwEAX9cXVTw43i3wiudWDDtSn28RmdnS/HCPr284dQI/SztsamWanRr75oSlKSaGbV2nmWCTzGCoVg=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -130,6 +130,7 @@
     "hono-openapi": "catalog:",
     "ignore": "7.0.5",
     "jsonc-parser": "3.3.1",
+    "langfuse": "3.38.6",
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
     "open": "10.1.2",

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -329,7 +329,7 @@ export namespace ProviderTransform {
     if (id.includes("glm-4.7")) return 1.0
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
-      // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
+      // kimi-k2-thinking, kimi-k2.5, kimi-k2p5, kimi-k2-5
       if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
         return 1.0
       }
@@ -373,9 +373,7 @@ export namespace ProviderTransform {
       id.includes("minimax") ||
       id.includes("glm") ||
       id.includes("mistral") ||
-      id.includes("kimi") ||
-      // TODO: Remove this after models.dev data is fixed to use "kimi-k2.5" instead of "k2p5"
-      id.includes("k2p5")
+      id.includes("kimi")
     )
       return {}
 

--- a/packages/opencode/src/session/langfuse.ts
+++ b/packages/opencode/src/session/langfuse.ts
@@ -1,0 +1,42 @@
+import Langfuse from "langfuse"
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "langfuse" })
+
+let client: Langfuse | undefined
+let initFailed = false
+
+export function getLangfuse(): Langfuse | undefined {
+  if (client) return client
+  if (initFailed) return undefined
+
+  const secretKey = process.env.LANGFUSE_SECRET_KEY
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY
+  const baseUrl = process.env.LANGFUSE_BASE_URL
+
+  if (!secretKey || !publicKey) {
+    log.info("langfuse disabled: missing LANGFUSE_SECRET_KEY or LANGFUSE_PUBLIC_KEY")
+    initFailed = true
+    return undefined
+  }
+
+  try {
+    client = new Langfuse({
+      secretKey,
+      publicKey,
+      baseUrl: baseUrl ?? "https://cloud.langfuse.com",
+    })
+    log.info("langfuse initialized", { baseUrl })
+    return client
+  } catch (e) {
+    log.error("langfuse init failed", { error: e })
+    initFailed = true
+    return undefined
+  }
+}
+
+export async function flushLangfuse() {
+  if (client) {
+    await client.flushAsync()
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -749,35 +749,106 @@ export namespace SessionPrompt {
       })
 
       // Langfuse: record the LLM generation and tool calls from this iteration
+      // The parts array for an assistant message flows in order:
+      //   step-start → reasoning → text → tool (calls+results) → step-finish
+      //   → step-start (next internal step) → reasoning → text → ... → step-finish
+      // We reconstruct each LLM call as a generation with its full context.
       if (iterationSpan) {
         const parts = await MessageV2.parts(processor.message.id)
 
-        // Record each LLM step as a generation
+        let stepIndex = 0
+        // Accumulate parts for the current LLM step
+        let currentReasoning: string[] = []
+        let currentText: string[] = []
+        let currentToolCalls: { tool: string; input: any; output?: string; error?: string }[] = []
+        // Track tool results from the PREVIOUS step (they become input to the next LLM call)
+        let prevToolResults: { tool: string; input: any; output?: string; error?: string }[] = []
+
+        const flushStep = (stepPart: MessageV2.StepFinishPart) => {
+          const reasoning = currentReasoning.join("")
+          const text = currentText.join("")
+          const toolCalls = currentToolCalls.map((tc) => ({
+            tool: tc.tool,
+            input: tc.input,
+            ...(tc.output ? { output: tc.output.slice(0, 500) } : {}),
+            ...(tc.error ? { error: tc.error } : {}),
+          }))
+
+          // Input: first step gets the user message; subsequent steps get tool results
+          const input = stepIndex === 0
+            ? msgs
+                .filter((m) => m.info.role === "user")
+                .slice(-1)
+                .map((m) =>
+                  m.parts
+                    .filter((p): p is MessageV2.TextPart => p.type === "text")
+                    .map((p) => p.text)
+                    .join("\n"),
+                )
+                .join("\n")
+            : prevToolResults
+
+          // Output: structured to show reasoning + text + tool calls (mirrors the TUI)
+          const outputParts: Record<string, unknown> = {}
+          if (reasoning) outputParts.thinking = reasoning
+          if (text) outputParts.text = text
+          if (toolCalls.length > 0) outputParts.toolCalls = toolCalls
+          const output = Object.keys(outputParts).length > 0 ? outputParts : undefined
+
+          iterationSpan.generation({
+            name: `llm-call-${stepIndex}`,
+            model: `${model.providerID}/${model.id}`,
+            modelParameters: {
+              ...(agent.temperature != null ? { temperature: String(agent.temperature) } : {}),
+            },
+            input,
+            output,
+            usage: {
+              input: stepPart.tokens.input,
+              output: stepPart.tokens.output,
+              total: stepPart.tokens.total ?? stepPart.tokens.input + stepPart.tokens.output,
+            },
+            metadata: {
+              finishReason: stepPart.reason,
+              cost: stepPart.cost,
+              reasoning_tokens: stepPart.tokens.reasoning,
+              cache_read: stepPart.tokens.cache.read,
+              cache_write: stepPart.tokens.cache.write,
+            },
+          })
+
+          // Carry tool calls forward as input context for the next step
+          prevToolResults = currentToolCalls.map((tc) => ({
+            tool: tc.tool,
+            input: tc.input,
+            ...(tc.output ? { output: tc.output.slice(0, 500) } : {}),
+            ...(tc.error ? { error: tc.error } : {}),
+          }))
+
+          stepIndex++
+          currentReasoning = []
+          currentText = []
+          currentToolCalls = []
+        }
+
         for (const part of parts) {
-          if (part.type === "step-finish") {
-            iterationSpan.generation({
-              name: "llm",
-              model: `${model.providerID}/${model.id}`,
-              modelParameters: {
-                ...(agent.temperature != null ? { temperature: agent.temperature } : {}),
-              },
-              usage: {
-                input: part.tokens.input,
-                output: part.tokens.output,
-                total: part.tokens.total ?? part.tokens.input + part.tokens.output,
-              },
-              metadata: {
-                finishReason: part.reason,
-                cost: part.cost,
-                reasoning_tokens: part.tokens.reasoning,
-                cache_read: part.tokens.cache.read,
-                cache_write: part.tokens.cache.write,
-              },
-            })
+          // Accumulate reasoning (thinking) for the current step
+          if (part.type === "reasoning") {
+            currentReasoning.push(part.text)
           }
 
-          // Record each tool call as a span
+          // Accumulate text output for the current step
+          if (part.type === "text") {
+            currentText.push(part.text)
+          }
+
+          // Record each tool call as a span and accumulate for generation context
           if (part.type === "tool" && part.state.status === "completed") {
+            currentToolCalls.push({
+              tool: part.tool,
+              input: part.state.input,
+              output: part.state.output,
+            })
             iterationSpan.span({
               name: `tool.${part.tool}`,
               input: part.state.input,
@@ -791,6 +862,11 @@ export namespace SessionPrompt {
             })
           }
           if (part.type === "tool" && part.state.status === "error") {
+            currentToolCalls.push({
+              tool: part.tool,
+              input: part.state.input,
+              error: part.state.error,
+            })
             iterationSpan.span({
               name: `tool.${part.tool}`,
               input: part.state.input,
@@ -799,6 +875,11 @@ export namespace SessionPrompt {
               endTime: new Date(part.state.time.end),
               level: "ERROR",
             })
+          }
+
+          // Flush accumulated content when a step finishes
+          if (part.type === "step-finish") {
+            flushStep(part)
           }
         }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -49,6 +49,7 @@ import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import { getLangfuse, flushLangfuse } from "./langfuse"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -293,6 +294,14 @@ export namespace SessionPrompt {
     // on the user message and will be retrieved from lastUser below
     let structuredOutput: unknown | undefined
 
+    // Langfuse tracing: one trace per loop invocation (coding session turn)
+    const langfuse = getLangfuse()
+    const trace = langfuse?.trace({
+      name: "opencode.loop",
+      sessionId: sessionID,
+      metadata: { resume_existing },
+    })
+
     let step = 0
     const session = await Session.get(sessionID)
     while (true) {
@@ -335,13 +344,29 @@ export namespace SessionPrompt {
       }
 
       step++
-      if (step === 1)
+      if (step === 1) {
+        // Langfuse: capture user input on first step
+        if (trace) {
+          const userMsg = msgs.findLast((m) => m.info.role === "user")
+          const userText = userMsg?.parts
+            .filter((p): p is MessageV2.TextPart => p.type === "text")
+            .map((p) => p.text)
+            .join("\n")
+          trace.update({
+            input: userText,
+            metadata: {
+              agent: lastUser.agent,
+              model: `${lastUser.model.providerID}/${lastUser.model.modelID}`,
+            },
+          })
+        }
         ensureTitle({
           session,
           modelID: lastUser.model.modelID,
           providerID: lastUser.model.providerID,
           history: msgs,
         })
+      }
 
       const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID).catch((e) => {
         if (Provider.ModelNotFoundError.isInstance(e)) {
@@ -690,6 +715,16 @@ export namespace SessionPrompt {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
       }
 
+      // Langfuse: create a span for this loop iteration
+      const iterationSpan = trace?.span({
+        name: `loop.step-${step}`,
+        input: {
+          agent: agent.name,
+          model: `${model.providerID}/${model.id}`,
+          toolCount: Object.keys(tools).length,
+        },
+      })
+
       const result = await processor.process({
         user: lastUser,
         agent,
@@ -712,6 +747,70 @@ export namespace SessionPrompt {
         model,
         toolChoice: format.type === "json_schema" ? "required" : undefined,
       })
+
+      // Langfuse: record the LLM generation and tool calls from this iteration
+      if (iterationSpan) {
+        const parts = await MessageV2.parts(processor.message.id)
+
+        // Record each LLM step as a generation
+        for (const part of parts) {
+          if (part.type === "step-finish") {
+            iterationSpan.generation({
+              name: "llm",
+              model: `${model.providerID}/${model.id}`,
+              modelParameters: {
+                ...(agent.temperature != null ? { temperature: agent.temperature } : {}),
+              },
+              usage: {
+                input: part.tokens.input,
+                output: part.tokens.output,
+                total: part.tokens.total ?? part.tokens.input + part.tokens.output,
+              },
+              metadata: {
+                finishReason: part.reason,
+                cost: part.cost,
+                reasoning_tokens: part.tokens.reasoning,
+                cache_read: part.tokens.cache.read,
+                cache_write: part.tokens.cache.write,
+              },
+            })
+          }
+
+          // Record each tool call as a span
+          if (part.type === "tool" && part.state.status === "completed") {
+            iterationSpan.span({
+              name: `tool.${part.tool}`,
+              input: part.state.input,
+              output: part.state.output,
+              startTime: new Date(part.state.time.start),
+              endTime: new Date(part.state.time.end),
+              metadata: {
+                title: part.state.title,
+                ...part.state.metadata,
+              },
+            })
+          }
+          if (part.type === "tool" && part.state.status === "error") {
+            iterationSpan.span({
+              name: `tool.${part.tool}`,
+              input: part.state.input,
+              output: part.state.error,
+              startTime: new Date(part.state.time.start),
+              endTime: new Date(part.state.time.end),
+              level: "ERROR",
+            })
+          }
+        }
+
+        iterationSpan.end({
+          output: {
+            finish: processor.message.finish,
+            result,
+            tokens: processor.message.tokens,
+            cost: processor.message.cost,
+          },
+        })
+      }
 
       // If structured output was captured, save it and exit immediately
       // This takes priority because the StructuredOutput tool was called successfully
@@ -749,6 +848,14 @@ export namespace SessionPrompt {
       }
       continue
     }
+    // Langfuse: finalize trace
+    if (trace) {
+      trace.update({
+        output: { steps: step },
+      })
+      flushLangfuse().catch(() => {})
+    }
+
     SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -159,8 +159,6 @@ export namespace SyncEvent {
     })
   }
 
-  // TODO:
-  //
   // * Support applying multiple events at one time. One transaction,
   //   and it validets all the sequence ids
   // * when loading events from db, apply zod validation to ensure shape


### PR DESCRIPTION
Exactly — here's the description:

---

## Langfuse Tracing for the OpenCode Agentic Loop

### Why this exists

OpenCode's core loop is not a simple request/response — it's a **multi-step agent** that thinks, calls tools, gets results, thinks again, and repeats until it decides it's done. When you type a message in the TUI, a lot happens that's invisible: multiple LLM calls, chains of tool executions, reasoning traces, token accumulation. This instrumentation makes all of that visible in Langfuse as a structured trace, so you can read a session the same way you'd read source code.

---

### The core loop, explained

The entry point is `prompt()` in `packages/opencode/src/session/prompt.ts`, which creates your user message and calls `loop()`. The loop is a `while(true)` that keeps running until the model decides it's done:

```
loop():
  while (true):
    1. Load all messages for the session
    2. Check exit: did the model finish with a non-tool reason? → break
    3. Handle special cases: pending subtasks, context compaction
    4. NORMAL PATH:
       a. Resolve agent + available tools
       b. Create a SessionProcessor
       c. processor.process() → calls LLM.stream() → AI SDK's streamText()
       d. The stream emits events processed in order:
            start-step
              reasoning-start/delta/end   ← "thinking" blocks
              text-start/delta/end        ← response text
              tool-input-start/delta/end  ← tool args streaming in
              tool-call                   ← tool execution begins
              tool-result                 ← tool execution completes
            finish-step                   ← token usage captured here
            (repeat if finish reason = "tool-calls")
       e. result = "continue" | "stop" | "compact"
    5. If finish reason is "tool-calls" → loop again
       Otherwise → break
```

The key insight: **one `while` iteration ≠ one LLM call**. The AI SDK's `streamText()` handles an internal sub-loop: if the model calls tools, it sends results back and calls the model again — all within one `processor.process()` call. So one loop step can contain multiple LLM calls chained together.

---

### Why we instrumented where we did

**Trace = one `loop()` invocation.** This is the natural unit of a "coding session turn" — one user message through to final response.

**`loop.step-N` span = one `while` iteration.** Each iteration is one attempt to make progress: resolve the agent, call the LLM (possibly multiple times with tool use), and land on a result. Seeing steps lets you understand how many times the agent had to "go back" — e.g. compaction, subtasks, or continuing after tools.

**`llm-call-N` generation = one internal LLM call within a step.** This is where the actual model activity is. Each generation captures:
- **Input**: what the model received — user message on call 0, tool results on subsequent calls
- **Output**: `{ thinking, text, toolCalls }` — exactly what you see in the TUI, now queryable
- **Usage**: input/output/reasoning tokens, cache hits, cost per call

This is the most granular and important level. It lets you answer: *how much of the token budget is going to reasoning vs. output? Which tool results are being fed back in? Is the model thinking before or after tool calls?*

**`tool.*` spans = individual tool executions.** These are children of the iteration span, not the generation, because they happen *between* LLM calls — the model requests them, they execute, and their results become the input to the next LLM call. Seeing them as spans with timing lets you identify which tools are slow or returning large outputs.

---

### The data flow as a trace

```
trace: opencode.loop  (input = user message)
  loop.step-1
    llm-call-0   input: "fix a simple TODO"
                 output: { thinking: "Let me find TODOs...", toolCalls: [read, read] }
                 usage: 1056 in → 170 out
    tool.read    input: { path: "config.ts" }  output: "file contents..."
    tool.read    input: { path: "bun/index.ts" } output: "..."
    llm-call-1   input: [tool results]
                 output: { thinking: "These reference a Bun issue, let me check...", toolCalls: [webfetch] }
                 usage: 581 in → 253 out
    tool.webfetch ...
    llm-call-2   input: [tool results]
                 output: { thinking: "Issue is resolved, safe to remove", text: "Here's the fix..." }
                 usage: 680 in → 76 out
```

The rising input token counts across `llm-call-N` within one step show context accumulation — the model is carrying more and more tool results forward. The reasoning tokens tell you how much of the output budget went to thinking vs. actual response.