### PR TITLE
fix(copilot): correct Claude thinking variants and context windows

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -916,7 +916,27 @@ export namespace Provider {
           : undefined,
       },
       limit: {
-        context: model.limit.context,
+        context: iife(() => {
+          // Override stale context window data from models.dev for GitHub Copilot Claude models.
+          // Anthropic official context windows: https://docs.anthropic.com/en/docs/about-claude/models
+          if (m.api.npm === "@ai-sdk/github-copilot") {
+            const contextOverrides: Record<string, number> = {
+              "claude-opus-4.6": 1_000_000,
+              "claude-opus-4-6": 1_000_000,
+              "claude-sonnet-4.6": 1_000_000,
+              "claude-sonnet-4-6": 1_000_000,
+              "claude-opus-4.5": 200_000,
+              "claude-opus-4-5": 200_000,
+              "claude-sonnet-4.5": 200_000,
+              "claude-sonnet-4-5": 200_000,
+              "claude-haiku-4.5": 200_000,
+              "claude-haiku-4-5": 200_000,
+            }
+            const override = Object.entries(contextOverrides).find(([k]) => model.id.includes(k))
+            if (override) return override[1]
+          }
+          return model.limit.context
+        }),
         input: model.limit.input,
         output: model.limit.output,
       },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -465,7 +465,10 @@ export namespace ProviderTransform {
         }
         if (model.id.includes("claude")) {
           return {
-            thinking: { thinking_budget: 4000 },
+            low: { thinking_budget: 1_000 },
+            medium: { thinking_budget: 4_000 },
+            high: { thinking_budget: 10_000 },
+            max: { thinking_budget: 16_000 },
           }
         }
         const copilotEfforts = iife(() => {


### PR DESCRIPTION
## Summary

Two bugs fixed for Claude models served via GitHub Copilot:

### 1. Multi-level thinking budget variants (`transform.ts`)

**Before:** Only a single binary `thinking` variant with a hardcoded 4,000-token budget.

**After:** Four granular budget levels matching standard tiers:

| Variant | `thinking_budget` |
|---------|------------------|
| `low`   | 1,000 tokens     |
| `medium`| 4,000 tokens     |
| `high`  | 10,000 tokens    |
| `max`   | 16,000 tokens    |

Uses the Copilot SDK flat snake_case format (`thinking_budget: number`) as defined in `openai-compatible-chat-options.ts` — not the `@ai-sdk/anthropic` format.

### 2. Correct context windows (`provider.ts`)

**Before:** Context windows sourced from `models.dev` which contains stale/incorrect values (e.g. `claude-opus-4.6` shown as ~128K).

**After:** Override table applied when `m.api.npm === "@ai-sdk/github-copilot"`, based on [official Anthropic documentation](https://docs.anthropic.com/en/docs/about-claude/models):

| Model | Correct context |
|-------|----------------|
| `claude-opus-4.6`, `claude-sonnet-4.6` | 1,000,000 tokens |
| `claude-opus-4.5`, `claude-sonnet-4.5`, `claude-haiku-4.5` | 200,000 tokens |

Both dot-notation (`4.6`) and dash-notation (`4-6`) IDs are handled to cover API naming variations.

## Files changed

- `packages/opencode/src/provider/transform.ts`
- `packages/opencode/src/provider/provider.ts`