### PR TITLE
fix: strip variant from title generation to prevent effort parameter leakage

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -215,7 +215,7 @@ export namespace SessionPrompt {
             : await MessageV2.toModelMessages(context, mdl)
           const result = await LLM.stream({
             agent: ag,
-            user: firstInfo,
+            user: { ...firstInfo, variant: undefined },
             system: [],
             small: true,
             tools: {},

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -516,3 +516,80 @@ describe("session.agent-resolution", () => {
     })
   }, 30000)
 })
+
+describe("session.title generation", () => {
+  test("strips variant from title generation to avoid effort parameter leakage", async () => {
+    let titleRequestCaptured = false
+    let titleRequestHasEffort = false
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) {
+          return new Response("not found", { status: 404 })
+        }
+        const body = JSON.parse(await req.text())
+        const isTitleRequest = body.messages?.some((m: any) => m.content?.includes("Generate a title"))
+        if (isTitleRequest) {
+          titleRequestCaptured = true
+          titleRequestHasEffort = !!body.output_config?.effort || !!body.reasoning_effort
+        }
+        return new Response(chat("Test session title"), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                  variant: "max",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          const result = await SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            variant: "max",
+            parts: [{ type: "text", text: "Hello, help me with something" }],
+          })
+
+          expect(result.info.role).toBe("assistant")
+          await new Promise((r) => setTimeout(r, 500))
+          expect(titleRequestCaptured).toBe(true)
+          expect(titleRequestHasEffort).toBe(false)
+          const updated = await Session.get(session.id)
+          expect(updated.title).toBe("Test session title")
+        },
+      })
+    } finally {
+      server.stop(true)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Session title generation was silently failing since v1.3.3 when users had a model variant that includes an effort parameter (e.g., anthropic/claude-opus-4-6 with variant max). The variant was leaking into the LLM.stream call for the title agent, which uses a small model (e.g., claude-haiku-4-5) that does not support the effort parameter, causing a 400 error from the Anthropic API.

## Solution

Strip the variant from the user info when calling LLM.stream for title generation in packages/opencode/src/session/prompt.ts. This ensures the small model receives only compatible parameters.

## Testing

Added a new test case session.title generation that:
1. Sets up a mock server that captures title generation requests
2. Verifies that the effort parameter is NOT present in title generation requests
3. Confirms the session title is properly generated

## Impact

- Fixes 0% title generation success rate for users with effort-bearing variants
- No breaking changes - only affects internal title generation flow

Fixes #20269