### PR TITLE
fix: respect useCompletionUrls for custom @ai-sdk/azure providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1416,12 +1416,21 @@ export namespace Provider {
           const sdk = await resolveSDK(model, s)
 
           try {
+            const mergedOptions = { ...provider.options, ...model.options }
             const language = s.modelLoaders[model.providerID]
-              ? await s.modelLoaders[model.providerID](sdk, model.api.id, {
-                  ...provider.options,
-                  ...model.options,
-                })
-              : sdk.languageModel(model.api.id)
+              ? await s.modelLoaders[model.providerID](sdk, model.api.id, mergedOptions)
+              : (() => {
+                  // For custom providers using @ai-sdk/azure, apply azure-specific logic
+                  if (model.api.npm === "@ai-sdk/azure") {
+                    if (useLanguageModel(sdk)) return sdk.languageModel(model.api.id)
+                    if (mergedOptions["useCompletionUrls"]) {
+                      return sdk.chat(model.api.id)
+                    } else {
+                      return sdk.responses(model.api.id)
+                    }
+                  }
+                  return sdk.languageModel(model.api.id)
+                })()
             s.models.set(key, language)
             return language
           } catch (e) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2282,3 +2282,45 @@ test("cloudflare-ai-gateway forwards config metadata options", async () => {
     },
   })
 })
+
+test("custom provider using @ai-sdk/azure respects useCompletionUrls option", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            foundary: {
+              npm: "@ai-sdk/azure",
+              options: {
+                baseURL: "https://custom-domain/openai",
+                apiKey: "test-key",
+                apiVersion: "2025-04-01-preview",
+                useDeploymentBasedUrls: true,
+                useCompletionUrls: true,
+              },
+              models: {
+                "gpt-5.4": {
+                  name: "GPT-5.4",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers[ProviderID.make("foundary")]).toBeDefined()
+      expect(providers[ProviderID.make("foundary")].options.useCompletionUrls).toBe(true)
+      const model = await Provider.getModel(ProviderID.make("foundary"), ModelID.make("gpt-5.4"))
+      expect(model).toBeDefined()
+      // Verify the model has the correct npm package
+      expect(model.api.npm).toBe("@ai-sdk/azure")
+    },
+  })
+})


### PR DESCRIPTION
## Problem

When a custom provider uses npm: "@ai-sdk/azure" (e.g., a provider named "foundary" that wraps Azure), the useCompletionUrls option was being ignored. The getLanguage function was falling back to sdk.languageModel() which bypasses the Azure-specific logic that checks useCompletionUrls.

This caused the Azure provider to use the /responses endpoint instead of /chat/completions even when useCompletionUrls was set to true.

## Solution

Added a check in getLanguage to apply Azure-specific logic for any model using @ai-sdk/azure, ensuring useCompletionUrls is respected for both built-in and custom Azure providers.

## Testing

Added test case "custom provider using @ai-sdk/azure respects useCompletionUrls option" that verifies the option is properly stored and the model uses the correct npm package.

## Impact

- Fixes Azure completions API for custom providers using @ai-sdk/azure
- No breaking changes - only affects Azure provider behavior

Fixes #20287