### PR TITLE
fix(app): move sidebar session actions into a menu

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -2,7 +2,6 @@ import type { Message, Session, TextPart, UserMessage } from "@opencode-ai/sdk/v
 import { Avatar } from "@opencode-ai/ui/avatar"
 import { HoverCard } from "@opencode-ai/ui/hover-card"
 import { Icon } from "@opencode-ai/ui/icon"
-import { IconButton } from "@opencode-ai/ui/icon-button"
 import { MessageNav } from "@opencode-ai/ui/message-nav"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
@@ -18,6 +17,7 @@ import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
 import { hasProjectPermissions } from "./helpers"
+import { SessionMenu } from "./sidebar-session-menu"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -351,29 +351,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           </Show>
         </div>
 
-        <div
-          class="shrink-0 overflow-hidden transition-[width,opacity]"
-          classList={{
-            "w-6 opacity-100 pointer-events-auto": !!props.mobile,
-            "w-0 opacity-0 pointer-events-none": !props.mobile,
-            "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
-            "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
-          }}
-        >
-          <Tooltip value={language.t("common.archive")} placement="top">
-            <IconButton
-              icon="archive"
-              variant="ghost"
-              class="size-6 rounded-md"
-              aria-label={language.t("common.archive")}
-              onClick={(event) => {
-                event.preventDefault()
-                event.stopPropagation()
-                void props.archiveSession(props.session)
-              }}
-            />
-          </Tooltip>
-        </div>
+        <SessionMenu
+          mobile={props.mobile}
+          sidebarHovering={props.sidebarHovering}
+          session={props.session}
+          archive={props.archiveSession}
+        />
       </div>
     </div>
   )

--- a/packages/app/src/pages/layout/sidebar-session-menu.tsx
+++ b/packages/app/src/pages/layout/sidebar-session-menu.tsx
@@ -1,0 +1,46 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import type { Accessor, JSX } from "solid-js"
+import { useLanguage } from "@/context/language"
+
+export const SessionMenu = (props: {
+  mobile?: boolean
+  sidebarHovering: Accessor<boolean>
+  session: Session
+  archive: (session: Session) => Promise<void>
+}): JSX.Element => {
+  const language = useLanguage()
+
+  return (
+    <div
+      class="shrink-0 overflow-hidden transition-[width,opacity]"
+      classList={{
+        "w-6 opacity-100 pointer-events-auto": !!props.mobile,
+        "w-0 opacity-0 pointer-events-none": !props.mobile,
+        "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
+        "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
+      }}
+    >
+      <DropdownMenu modal={!props.sidebarHovering()} placement="bottom-end" gutter={4}>
+        <Tooltip value={language.t("common.moreOptions")} placement="top">
+          <DropdownMenu.Trigger
+            as={IconButton}
+            icon="dot-grid"
+            variant="ghost"
+            class="size-6 rounded-md"
+            aria-label={language.t("common.moreOptions")}
+          />
+        </Tooltip>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={() => void props.archive(props.session)}>
+              <DropdownMenu.ItemLabel>{language.t("common.archive")}</DropdownMenu.ItemLabel>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu>
+    </div>
+  )
+}


### PR DESCRIPTION
### Issue for this PR

Closes #20347

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This replaces the sidebar session row's standalone archive button with a compact options menu and extracts that UI into a dedicated `SessionMenu` component. It keeps the existing archive action available while matching the menu pattern already used elsewhere in the app, which makes the sidebar controls more consistent and easier to extend.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/app`

### Screenshots / recordings

_Not included yet._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR