### PR TITLE
fix(sdk): avoid implicit directory filtering on /session list

### DIFF
--- a/packages/opencode/test/server/session-list-sdk.test.ts
+++ b/packages/opencode/test/server/session-list-sdk.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir } from "fs/promises"
+import { createOpencodeClient as v1 } from "@opencode-ai/sdk"
+import { createOpencodeClient as v2 } from "@opencode-ai/sdk/v2"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("session.list with sdk directory", () => {
+  test("v2 does not implicitly filter by current directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = `${tmp.path}/.dmux/worktrees/a`
+    await mkdir(dir, { recursive: true })
+
+    const key = `worktree-v2-${Date.now()}`
+    const root = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Session.create({ title: `${key}-root` }),
+    })
+    const child = await Instance.provide({
+      directory: dir,
+      fn: async () => Session.create({ title: `${key}-child` }),
+    })
+
+    const app = Server.Default().app
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = new Request(input, init)
+      return app.request(req)
+    }) as typeof globalThis.fetch
+
+    const sdk = v2({
+      baseUrl: "http://opencode.internal",
+      directory: dir,
+      fetch: fetcher,
+    })
+    const res = await sdk.session.list({ search: key })
+    const ids = (res.data ?? []).map((item) => item.id)
+
+    expect(ids).toContain(root.id)
+    expect(ids).toContain(child.id)
+  })
+
+  test("v1 does not implicitly filter by current directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = `${tmp.path}/.dmux/worktrees/a`
+    await mkdir(dir, { recursive: true })
+
+    const key = `worktree-v1-${Date.now()}`
+    const root = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => Session.create({ title: `${key}-root` }),
+    })
+    const child = await Instance.provide({
+      directory: dir,
+      fn: async () => Session.create({ title: `${key}-child` }),
+    })
+
+    const app = Server.Default().app
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = new Request(input, init)
+      return app.request(req)
+    }) as typeof globalThis.fetch
+
+    const sdk = v1({
+      baseUrl: "http://opencode.internal",
+      directory: dir,
+      fetch: fetcher,
+    })
+    const res = await sdk.session.list()
+    const ids = (res.data ?? []).map((item) => item.id)
+
+    expect(ids).toContain(root.id)
+    expect(ids).toContain(child.id)
+  })
+})

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -16,11 +16,17 @@ function pick(value: string | null, fallback?: string) {
 function rewrite(request: Request, directory?: string) {
   if (request.method !== "GET" && request.method !== "HEAD") return request
 
+  const url = new URL(request.url)
+  const isSessionRequest = /\/session\/?$/.test(url.pathname)
+  const hasExplicitSearchParameter = url.searchParams.has("directory")
+
   const value = pick(request.headers.get("x-opencode-directory"), directory)
   if (!value) return request
 
-  const url = new URL(request.url)
-  if (!url.searchParams.has("directory")) {
+  // Keep implicit directory context in headers so /session is not accidentally directory-filtered.
+  if (isSessionRequest && !hasExplicitSearchParameter) return request
+
+  if (!hasExplicitSearchParameter) {
     url.searchParams.set("directory", value)
   }
 

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -17,15 +17,18 @@ function rewrite(request: Request, values: { directory?: string; workspace?: str
   if (request.method !== "GET" && request.method !== "HEAD") return request
 
   const url = new URL(request.url)
-  const session = /\/session\/?$/.test(url.pathname)
+  const isSessionRequest = /\/session\/?$/.test(url.pathname)
   let changed = false
 
   for (const [name, key] of [
     ["x-opencode-directory", "directory"],
     ["x-opencode-workspace", "workspace"],
   ] as const) {
-    const has = url.searchParams.has(key)
-    if (key === "directory" && session && !has) continue
+    const hasExplicitSearchParameter = url.searchParams.has(key)
+    if (isSessionRequest) {
+      // Keep implicit directory context in headers so /session is not accidentally directory-filtered.
+      if (key === "directory" && !hasExplicitSearchParameter) continue
+    }
 
     const value = pick(
       request.headers.get(name),
@@ -33,7 +36,7 @@ function rewrite(request: Request, values: { directory?: string; workspace?: str
       key === "directory" ? encodeURIComponent : undefined,
     )
     if (!value) continue
-    if (!has) {
+    if (!hasExplicitSearchParameter) {
       url.searchParams.set(key, value)
     }
     changed = true

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -17,19 +17,23 @@ function rewrite(request: Request, values: { directory?: string; workspace?: str
   if (request.method !== "GET" && request.method !== "HEAD") return request
 
   const url = new URL(request.url)
+  const session = /\/session\/?$/.test(url.pathname)
   let changed = false
 
   for (const [name, key] of [
     ["x-opencode-directory", "directory"],
     ["x-opencode-workspace", "workspace"],
   ] as const) {
+    const has = url.searchParams.has(key)
+    if (key === "directory" && session && !has) continue
+
     const value = pick(
       request.headers.get(name),
       key === "directory" ? values.directory : values.workspace,
       key === "directory" ? encodeURIComponent : undefined,
     )
     if (!value) continue
-    if (!url.searchParams.has(key)) {
+    if (!has) {
       url.searchParams.set(key, value)
     }
     changed = true


### PR DESCRIPTION
Keep `x-opencode-directory` as a header for `GET /session` unless callers explicitly set a directory query so worktree and subdirectory users still see project sessions.

A regression test that reproduces SDK session listing from a nested directory against the in-memory server was added, which is how I worked on the minimal fix.

### Issue for this PR

Closes #20238

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I've described more in-depth my investigation at the linked issue, so that is a good reference read. The TL:DR is that OpenCode 1.3.4 and onwards filters session list to be at the **exact** directory you are at, while not allowing sub-directory sessions. This was a helpful behavior in v1.3.3 and before that allowed Git worktree users to see all OpenCode sessions for their projects.

The behavior broke because TUI calls like `sdk.session.list()` (with no explicit directory filter) accidentally became `GET /session?directory=<cwd>`, which hid root/worktree siblings.

Fixed by making `GET /session` keep the `x-opencode-directory` header, but not rewrite to force the `?directory=...` filter. If the filter is explicitly provided, it will remain.

### How did you verify your code works?

I ran `OPENCODE_DB="$(opencode db path)" bun dev "/Users/<me>/projects/<sample-project>"` (needed to use my existing sessions; so used the true DB I have) and it now displays all my sessions.

I also checked via `bun test` that nothing else was broken.

### Screenshots / recordings

N/A -- bug fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
