### PR TITLE
fix: reject empty apply_patch tool calls with clear error message

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -22,6 +22,14 @@ const PatchParams = z.object({
 export const ApplyPatchTool = Tool.define("apply_patch", {
   description: DESCRIPTION,
   parameters: PatchParams,
+  formatValidationError(error) {
+    // Check if patchText is missing or empty
+    const patchTextIssue = error.errors.find((e) => e.path.includes("patchText"))
+    if (patchTextIssue) {
+      return "apply_patch requires a non-empty patchText. You must provide the full patch text describing all changes to be made. Do not call apply_patch with an empty object or without patchText."
+    }
+    return `apply_patch validation failed: ${error.message}`
+  },
   async execute(params, ctx) {
     if (!params.patchText) {
       throw new Error("patchText is required")


### PR DESCRIPTION
Add formatValidationError to apply_patch tool to provide a clear error message when patchText is missing or empty. This prevents models like GPT-5.4 from entering a loop of empty tool calls.

## Problem

GPT-5.4 repeatedly sends empty apply_patch tool calls (), causing  errors and getting the session stuck in a loop.

## Solution

The formatValidationError function provides a clear, explicit error message that tells the model:
- patchText is required and must be non-empty
- Do not call apply_patch with an empty object
- The model should provide the full patch text describing all changes

## Test plan

- [ ] Verify empty apply_patch calls are rejected with clear error
- [ ] Verify models understand the error and don't retry with empty calls

🤖 Generated with [Claude Code](https://claude.ai/code)