### PR TITLE
feat: context window optimization — truncation, pruning, guidance budget

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1055,6 +1055,34 @@ export namespace Config {
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
         })
         .optional(),
+      truncation: z
+        .object({
+          max_lines: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum lines for tool output truncation (default: 2000)"),
+          max_bytes: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum bytes for tool output truncation (default: 51200)"),
+          max_line_bytes: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum bytes per line before mid-ellipsis pruning (default: 4096)"),
+          guidance_budget: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum bytes for AGENTS.md/instruction files loaded into system prompt (default: 32768)"),
+        })
+        .optional(),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -35,6 +35,21 @@ export namespace SessionCompaction {
   export const PRUNE_MINIMUM = 20_000
   export const PRUNE_PROTECT = 40_000
   const PRUNE_PROTECTED_TOOLS = ["skill"]
+  const ERROR_PURGE_TURNS = 4
+
+  function signature(part: MessageV2.ToolPart): string {
+    if (part.state.status === "pending" || part.state.status === "running") return ""
+    const input = part.state.input
+    if (!input || typeof input !== "object") return `${part.tool}::`
+    const sorted = Object.keys(input)
+      .sort()
+      .reduce<Record<string, unknown>>((o, k) => {
+        const v = input[k]
+        if (v !== undefined && v !== null) o[k] = v
+        return o
+      }, {})
+    return `${part.tool}::${JSON.stringify(sorted)}`
+  }
 
   export interface Interface {
     readonly isOverflow: (input: {
@@ -89,7 +104,9 @@ export namespace SessionCompaction {
       })
 
       // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
-      // calls, then erases output of older tool calls to free context space
+      // calls, then erases output of older tool calls to free context space.
+      // When the model's context window is known, protect 30% of it instead of
+      // the fixed default so large-context models keep more history.
       const prune = Effect.fn("SessionCompaction.prune")(function* (input: { sessionID: SessionID }) {
         const cfg = yield* config.get()
         if (cfg.compaction?.prune === false) return
@@ -99,6 +116,16 @@ export namespace SessionCompaction {
           .messages({ sessionID: input.sessionID })
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed(undefined)))
         if (!msgs) return
+
+        const lastUser = msgs.findLast((m) => m.info.role === "user")?.info as MessageV2.User | undefined
+        const context = yield* Effect.promise(() =>
+          lastUser?.model
+            ? Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+                .then((m) => m.limit.context)
+                .catch(() => 0)
+            : Promise.resolve(0),
+        )
+        const protect = context > 0 ? Math.max(PRUNE_PROTECT, Math.floor(context * 0.3)) : PRUNE_PROTECT
 
         let total = 0
         let pruned = 0
@@ -118,7 +145,7 @@ export namespace SessionCompaction {
                 if (part.state.time.compacted) break loop
                 const estimate = Token.estimate(part.state.output)
                 total += estimate
-                if (total > PRUNE_PROTECT) {
+                if (total > protect) {
                   pruned += estimate
                   toPrune.push(part)
                 }
@@ -126,7 +153,7 @@ export namespace SessionCompaction {
           }
         }
 
-        log.info("found", { pruned, total })
+        log.info("found", { pruned, total, protect })
         if (pruned > PRUNE_MINIMUM) {
           for (const part of toPrune) {
             if (part.state.status === "completed") {
@@ -135,6 +162,63 @@ export namespace SessionCompaction {
             }
           }
           log.info("pruned", { count: toPrune.length })
+        }
+
+        // Deduplicate: keep only the most recent tool call per (tool, params) signature.
+        // Earlier duplicates get compacted so the model sees "[Old tool result content cleared]".
+        const seen = new Map<string, MessageV2.ToolPart>()
+        const dupes: MessageV2.ToolPart[] = []
+        for (const msg of msgs) {
+          for (const part of msg.parts) {
+            if (part.type !== "tool") continue
+            if (part.state.status !== "completed") continue
+            if (part.state.time.compacted) continue
+            if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
+            const sig = signature(part)
+            if (!sig) continue
+            const prev = seen.get(sig)
+            if (prev) dupes.push(prev)
+            seen.set(sig, part)
+          }
+        }
+        if (dupes.length > 0) {
+          for (const part of dupes) {
+            if (part.state.status === "completed") {
+              part.state.time.compacted = Date.now()
+              yield* session.updatePart(part)
+            }
+          }
+          log.info("deduped", { count: dupes.length })
+        }
+
+        // Error age-gate: clear string inputs of errored tool calls older than N turns
+        // so they stop wasting context. The error message itself is preserved.
+        let age = 0
+        const errors: MessageV2.ToolPart[] = []
+        for (let i = msgs.length - 1; i >= 0; i--) {
+          const msg = msgs[i]
+          if (msg.info.role === "user") age++
+          if (msg.info.role === "assistant" && msg.info.summary) break
+          if (age < ERROR_PURGE_TURNS) continue
+          for (const part of msg.parts) {
+            if (part.type !== "tool") continue
+            if (part.state.status !== "error") continue
+            if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
+            const input = part.state.input
+            if (!input || typeof input !== "object") continue
+            let changed = false
+            for (const key of Object.keys(input)) {
+              if (typeof input[key] === "string" && input[key].length > 0) {
+                input[key] = ""
+                changed = true
+              }
+            }
+            if (changed) errors.push(part)
+          }
+        }
+        if (errors.length > 0) {
+          for (const part of errors) yield* session.updatePart(part)
+          log.info("purged errors", { count: errors.length })
         }
       })
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -114,8 +114,11 @@ export namespace InstructionPrompt {
     return paths
   }
 
+  const DEFAULT_GUIDANCE_BUDGET = 32 * 1024
+
   export async function system() {
     const config = await Config.get()
+    const budget = config.truncation?.guidance_budget ?? DEFAULT_GUIDANCE_BUDGET
     const paths = await systemPaths()
 
     const files = Array.from(paths).map(async (p) => {
@@ -138,7 +141,23 @@ export namespace InstructionPrompt {
         .then((x) => (x ? "Instructions from: " + url + "\n" + x : "")),
     )
 
-    return Promise.all([...files, ...fetches]).then((result) => result.filter(Boolean))
+    const all = await Promise.all([...files, ...fetches]).then((result) => result.filter(Boolean))
+    let total = 0
+    const result: string[] = []
+    for (const entry of all) {
+      const size = Buffer.byteLength(entry, "utf-8")
+      if (total + size > budget) {
+        const remaining = budget - total
+        if (remaining > 0) {
+          result.push(entry.substring(0, remaining) + "\n...(instructions truncated to fit budget)")
+          log.info("guidance budget reached", { budget, files: result.length })
+        }
+        break
+      }
+      total += size
+      result.push(entry)
+    }
+    return result
   }
 
   export function loaded(messages: MessageV2.WithParts[]) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -12,10 +12,10 @@ import { assertExternalDirectory } from "./external-directory"
 import { InstructionPrompt } from "../session/instruction"
 import { Filesystem } from "../util/filesystem"
 
-const DEFAULT_READ_LIMIT = 2000
+const DEFAULT_READ_LIMIT = 1000
 const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
-const MAX_BYTES = 50 * 1024
+const MAX_BYTES = 32 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
 
 export const ReadTool = Tool.define("read", {

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -2,7 +2,7 @@ Read a file or directory from the local filesystem. If the path does not exist, 
 
 Usage:
 - The filePath parameter should be an absolute path.
-- By default, this tool returns up to 2000 lines from the start of the file.
+- By default, this tool returns up to 1000 lines from the start of the file.
 - The offset parameter is the line number to start from (1-indexed).
 - To read later sections, call this tool again with a larger offset.
 - Use the grep tool to find specific content in large files or files with long lines.

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -9,6 +9,7 @@ import { Identifier } from "../id/id"
 import { Log } from "../util/log"
 import { ToolID } from "./schema"
 import { TRUNCATION_DIR } from "./truncation-dir"
+import { Config } from "@/config/config"
 
 export namespace Truncate {
   const log = Log.create({ service: "truncation" })
@@ -16,6 +17,7 @@ export namespace Truncate {
 
   export const MAX_LINES = 2000
   export const MAX_BYTES = 50 * 1024
+  export const MAX_LINE_BYTES = 4096
   export const DIR = TRUNCATION_DIR
   export const GLOB = path.join(TRUNCATION_DIR, "*")
 
@@ -24,7 +26,33 @@ export namespace Truncate {
   export interface Options {
     maxLines?: number
     maxBytes?: number
+    maxLineBytes?: number
     direction?: "head" | "tail"
+  }
+
+  function pruneLine(line: string, max: number): string {
+    if (Buffer.byteLength(line, "utf-8") <= max) return line
+    const half = Math.floor((max - 3) / 2)
+    let head = 0
+    let tail = line.length
+    let bytes = 0
+    while (head < line.length && bytes < half) {
+      const code = line.codePointAt(head)!
+      const size = code > 0xffff ? 4 : code > 0x7ff ? 3 : code > 0x7f ? 2 : 1
+      if (bytes + size > half) break
+      bytes += size
+      head += code > 0xffff ? 2 : 1
+    }
+    bytes = 0
+    while (tail > head && bytes < half) {
+      const prev = line.codePointAt(tail - 1)!
+      const code = prev >= 0xdc00 && prev <= 0xdfff && tail >= 2 ? line.codePointAt(tail - 2)! : prev
+      const size = code > 0xffff ? 4 : code > 0x7ff ? 3 : code > 0x7f ? 2 : 1
+      if (bytes + size > half) break
+      bytes += size
+      tail -= code > 0xffff ? 2 : 1
+    }
+    return line.substring(0, head) + "…" + line.substring(tail)
   }
 
   function hasTaskTool(agent?: Agent.Info) {
@@ -63,12 +91,20 @@ export namespace Truncate {
       const output = Effect.fn("Truncate.output")(function* (text: string, options: Options = {}, agent?: Agent.Info) {
         const maxLines = options.maxLines ?? MAX_LINES
         const maxBytes = options.maxBytes ?? MAX_BYTES
+        const maxLine = options.maxLineBytes ?? MAX_LINE_BYTES
         const direction = options.direction ?? "head"
         const lines = text.split("\n")
         const totalBytes = Buffer.byteLength(text, "utf-8")
 
         if (lines.length <= maxLines && totalBytes <= maxBytes) {
-          return { content: text, truncated: false } as const
+          let wide = false
+          for (const line of lines) {
+            if (Buffer.byteLength(line, "utf-8") > maxLine) {
+              wide = true
+              break
+            }
+          }
+          if (!wide) return { content: text, truncated: false } as const
         }
 
         const out: string[] = []
@@ -78,29 +114,36 @@ export namespace Truncate {
 
         if (direction === "head") {
           for (i = 0; i < lines.length && i < maxLines; i++) {
-            const size = Buffer.byteLength(lines[i], "utf-8") + (i > 0 ? 1 : 0)
+            const pruned = pruneLine(lines[i], maxLine)
+            const size = Buffer.byteLength(pruned, "utf-8") + (i > 0 ? 1 : 0)
             if (bytes + size > maxBytes) {
               hitBytes = true
               break
             }
-            out.push(lines[i])
+            out.push(pruned)
             bytes += size
           }
         } else {
           for (i = lines.length - 1; i >= 0 && out.length < maxLines; i--) {
-            const size = Buffer.byteLength(lines[i], "utf-8") + (out.length > 0 ? 1 : 0)
+            const pruned = pruneLine(lines[i], maxLine)
+            const size = Buffer.byteLength(pruned, "utf-8") + (out.length > 0 ? 1 : 0)
             if (bytes + size > maxBytes) {
               hitBytes = true
               break
             }
-            out.unshift(lines[i])
+            out.unshift(pruned)
             bytes += size
           }
         }
 
+        const preview = out.join("\n")
+        const allKept = !hitBytes && out.length === lines.length
+        if (allKept) {
+          return { content: preview, truncated: false } as const
+        }
+
         const removed = hitBytes ? totalBytes - bytes : lines.length - out.length
         const unit = hitBytes ? "bytes" : "lines"
-        const preview = out.join("\n")
         const file = path.join(TRUNCATION_DIR, ToolID.ascending())
 
         yield* fs.ensureDir(TRUNCATION_DIR).pipe(Effect.orDie)
@@ -139,6 +182,13 @@ export namespace Truncate {
   const { runPromise } = makeRuntime(Service, defaultLayer)
 
   export async function output(text: string, options: Options = {}, agent?: Agent.Info): Promise<Result> {
-    return runPromise((s) => s.output(text, options, agent))
+    const cfg = await Config.get().catch(() => undefined)
+    const merged: Options = {
+      maxLines: options.maxLines ?? cfg?.truncation?.max_lines,
+      maxBytes: options.maxBytes ?? cfg?.truncation?.max_bytes,
+      maxLineBytes: options.maxLineBytes ?? cfg?.truncation?.max_line_bytes,
+      direction: options.direction,
+    }
+    return runPromise((s) => s.output(text, merged, agent))
   }
 }

--- a/packages/opencode/src/util/token.ts
+++ b/packages/opencode/src/util/token.ts
@@ -1,5 +1,5 @@
 export namespace Token {
-  const CHARS_PER_TOKEN = 4
+  const CHARS_PER_TOKEN = 3.5
 
   export function estimate(input: string) {
     return Math.max(0, Math.round((input || "").length / CHARS_PER_TOKEN))


### PR DESCRIPTION
## Summary

Context window optimization inspired by AmpCode architectural patterns. Four improvements squashed into one clean commit:

### 1. Per-line truncation (4096B mid-ellipsis) + token estimation fix
- **`truncate.ts`**: Added `MAX_LINE_BYTES=4096` with `pruneLine()` — Unicode-safe mid-ellipsis that keeps head+tail, cuts middle with `…`. Handles surrogate pairs. When only wide lines are pruned (no line/byte truncation), returns `truncated:false` without writing to disk.
- **`token.ts`**: `CHARS_PER_TOKEN` from 4 → 3.5 for more accurate estimation with modern LLMs.

### 2. AGENTS.md guidance budget (32KB) + configurable truncation
- **`config.ts`**: Added `truncation` config section (`max_lines`, `max_bytes`, `max_line_bytes`, `guidance_budget`).
- **`instruction.ts`**: `DEFAULT_GUIDANCE_BUDGET = 32KB`. `system()` enforces budget, truncates with marker when exceeded.
- **`truncate.ts`**: Static `output()` reads Config to merge config-driven defaults so all callers pick up settings automatically.

### 3. Tighter read defaults + context-aware prune ratio
- **`read.ts`**: `DEFAULT_READ_LIMIT` 2000→1000, `MAX_BYTES` 50KB→32KB.
- **`read.txt`**: Updated description to match.
- **`compaction.ts`**: Prune uses `max(PRUNE_PROTECT, context_window * 0.3)` instead of fixed 40K, so large-context models keep more history.

### 4. Tool deduplication + error age-gate purging
- **`compaction.ts`**: `signature()` function deduplicates completed tool calls by `tool::sorted_JSON_params`, keeping only the most recent. `ERROR_PURGE_TURNS=4` clears string inputs of errored tool calls older than 4 turns (preserves error message, frees large prompt/code inputs). Both run at prune time.

## Files changed
- `packages/opencode/src/tool/truncate.ts`
- `packages/opencode/src/util/token.ts`
- `packages/opencode/src/config/config.ts`
- `packages/opencode/src/session/instruction.ts`
- `packages/opencode/src/session/compaction.ts`
- `packages/opencode/src/tool/read.ts`
- `packages/opencode/src/tool/read.txt`