### PR TITLE
fix(tui): enable OSC 8 hyperlink detection for tree-sitter markdown

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -27,6 +27,7 @@ import {
   type ScrollAcceleration,
   TextAttributes,
   RGBA,
+  detectLinks,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
@@ -1467,6 +1468,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
               fg={theme.text}
+              onChunks={detectLinks}
             />
           </Match>
         </Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #14966

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

URLs in tree-sitter markdown rendering don't emit OSC 8 hyperlink sequences, so Cmd/Ctrl+Click breaks when a URL wraps across terminal lines. The terminal's own URL auto-detection only sees the truncated portion on the clicked line.

This wires up the `detectLinks` hook from `@opentui/core` (added in [anomalyco/opentui#736](https://github.com/anomalyco/opentui/pull/736)) to the markdown `<code>` renderable. The hook post-processes tree-sitter highlights, detects URL-bearing scopes, and sets `chunk.link = { url }` so the renderer emits proper OSC 8 escape sequences.

2-line change:
1. Import `detectLinks` from `@opentui/core`
2. Pass `onChunks={detectLinks}` to the markdown `<code>` element in `TextPart`

### How did you verify your code works?

- Manually tested in iTerm2: Cmd+Click opens the full correct URL even when the link wraps across multiple terminal lines
- Verified existing tests still pass

### Screenshots / recordings

_See video in #14966 for the broken behavior. After this fix, wrapped URLs are fully clickable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR