### PR TITLE
docs: use consistent Discord link across all README translations

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discord Community
-    url: https://discord.gg/opencode
+    url: https://opencode.ai/discord
     about: For quick questions or real-time discussion. Note that issues are searchable and help others with the same question.

--- a/README.ar.md
+++ b/README.ar.md
@@ -138,4 +138,4 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ---
 
-**انضم الى مجتمعنا** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**انضم الى مجتمعنا** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.bn.md
+++ b/README.bn.md
@@ -138,4 +138,4 @@ OpenCode এ দুটি বিল্ট-ইন এজেন্ট রয়ে
 
 ---
 
-**আমাদের কমিউনিটিতে যুক্ত হোন** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**আমাদের কমিউনিটিতে যুক্ত হোন** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.br.md
+++ b/README.br.md
@@ -138,4 +138,4 @@ Se você estiver trabalhando em um projeto relacionado ao OpenCode e estiver usa
 
 ---
 
-**Junte-se à nossa comunidade** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Junte-se à nossa comunidade** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.bs.md
+++ b/README.bs.md
@@ -138,4 +138,4 @@ Po mogućnostima je vrlo sličan Claude Code-u. Ključne razlike su:
 
 ---
 
-**Pridruži se našoj zajednici** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Pridruži se našoj zajednici** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.da.md
+++ b/README.da.md
@@ -138,4 +138,4 @@ Det minder meget om Claude Code i forhold til funktionalitet. Her er de vigtigst
 
 ---
 
-**Bliv en del af vores community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Bliv en del af vores community** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.de.md
+++ b/README.de.md
@@ -138,4 +138,4 @@ In Bezug auf die Fähigkeiten ist es Claude Code sehr ähnlich. Hier sind die wi
 
 ---
 
-**Tritt unserer Community bei** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Tritt unserer Community bei** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.es.md
+++ b/README.es.md
@@ -138,4 +138,4 @@ Es muy similar a Claude Code en cuanto a capacidades. Estas son las diferencias 
 
 ---
 
-**Únete a nuestra comunidad** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Únete a nuestra comunidad** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.fr.md
+++ b/README.fr.md
@@ -138,4 +138,4 @@ C'est très similaire à Claude Code en termes de capacités. Voici les principa
 
 ---
 
-**Rejoignez notre communauté** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Rejoignez notre communauté** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.gr.md
+++ b/README.gr.md
@@ -138,4 +138,4 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ---
 
-**Γίνε μέλος της κοινότητάς μας** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Γίνε μέλος της κοινότητάς μας** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.it.md
+++ b/README.it.md
@@ -138,4 +138,4 @@ Se stai lavorando a un progetto correlato a OpenCode e che utilizza â€œopencodeâ
 
 ---
 
-**Unisciti alla nostra community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Unisciti alla nostra community** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.ja.md
+++ b/README.ja.md
@@ -138,4 +138,4 @@ OpenCode に関連するプロジェクトで、名前に "opencode"（例: "ope
 
 ---
 
-**コミュニティに参加** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**コミュニティに参加** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.ko.md
+++ b/README.ko.md
@@ -138,4 +138,4 @@ OpenCode 와 관련된 프로젝트를 진행하면서 이름에 "opencode"(예:
 
 ---
 
-**커뮤니티에 참여하기** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**커뮤니티에 참여하기** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.md
+++ b/README.md
@@ -138,4 +138,4 @@ It's very similar to Claude Code in terms of capability. Here are the key differ
 
 ---
 
-**Join our community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Join our community** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.no.md
+++ b/README.no.md
@@ -138,4 +138,4 @@ Det er veldig likt Claude Code når det gjelder funksjonalitet. Her er de viktig
 
 ---
 
-**Bli med i fellesskapet** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Bli med i fellesskapet** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.pl.md
+++ b/README.pl.md
@@ -138,4 +138,4 @@ Jest bardzo podobne do Claude Code pod względem możliwości. Oto kluczowe ró�
 
 ---
 
-**Dołącz do naszej społeczności** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Dołącz do naszej społeczności** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.ru.md
+++ b/README.ru.md
@@ -138,4 +138,4 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ---
 
-**Присоединяйтесь к нашему сообществу** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Присоединяйтесь к нашему сообществу** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.th.md
+++ b/README.th.md
@@ -138,4 +138,4 @@ OpenCode รวมเอเจนต์ในตัวสองตัวที�
 
 ---
 
-**ร่วมชุมชนของเรา** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**ร่วมชุมชนของเรา** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.tr.md
+++ b/README.tr.md
@@ -138,4 +138,4 @@ Yetenekler açısından Claude Code'a çok benzer. İşte temel farklar:
 
 ---
 
-**Topluluğumuza katılın** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Topluluğumuza katılın** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.uk.md
+++ b/README.uk.md
@@ -139,4 +139,4 @@ OpenCode містить два вбудовані агенти, між яким�
 
 ---
 
-**Приєднуйтеся до нашої спільноти** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Приєднуйтеся до нашої спільноти** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)

--- a/README.vi.md
+++ b/README.vi.md
@@ -138,4 +138,4 @@ Về mặt tính năng, nó rất giống Claude Code. Dưới đây là những
 
 ---
 
-**Tham gia cộng đồng của chúng tôi** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+**Tham gia cộng đồng của chúng tôi** [Discord](https://opencode.ai/discord) | [X.com](https://x.com/opencode)


### PR DESCRIPTION
### Issue for this PR
N/A (docs consistency fix)

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
The Discord badge in README.md uses `opencode.ai/discord` but the community footer across all translated READMEs and the issue template config used `discord.gg/opencode`. This standardizes all occurrences to the canonical `opencode.ai/discord` URL for consistency.

### How did you verify your code works?
Verified both URLs resolve to the same Discord server.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR