### PR TITLE
feat(desktop): add 'Open in TUI' context menu for sessions

### DIFF
--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -87,6 +87,9 @@ export type Platform = {
 
   /** Read image from clipboard (desktop only) */
   readClipboardImage?(): Promise<File | null>
+
+  /** Open a session in the TUI terminal (desktop only) */
+  openInTui?(session: string, url: string, password: string): Promise<void>
 }
 
 export type DisplayBackend = "auto" | "wayland"

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -1,5 +1,6 @@
 import type { Message, Session, TextPart, UserMessage } from "@opencode-ai/sdk/v2/client"
 import { Avatar } from "@opencode-ai/ui/avatar"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { HoverCard } from "@opencode-ai/ui/hover-card"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
@@ -15,6 +16,8 @@ import { useLanguage } from "@/context/language"
 import { getAvatarColors, type LocalProject, useLayout } from "@/context/layout"
 import { useNotification } from "@/context/notification"
 import { usePermission } from "@/context/permission"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
 import { hasProjectPermissions } from "./helpers"
@@ -205,6 +208,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const notification = useNotification()
   const permission = usePermission()
   const globalSync = useGlobalSync()
+  const server = useServer()
+  const platform = usePlatform()
   const unseenCount = createMemo(() => notification.session.unseenCount(props.session.id))
   const hasError = createMemo(() => notification.session.unseenHasError(props.session.id))
   const [sessionStore] = globalSync.child(props.session.directory)
@@ -307,75 +312,101 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   )
 
   return (
-    <div
-      data-session-id={props.session.id}
-      class="group/session relative w-full min-w-0 rounded-md cursor-default pl-2 pr-3 transition-colors
-             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
-    >
-      <div class="flex min-w-0 items-center gap-1">
-        <div class="min-w-0 flex-1">
-          <Show
-            when={hoverEnabled()}
-            fallback={
-              <Tooltip
-                placement={props.mobile ? "bottom" : "right"}
-                value={props.session.title}
-                gutter={10}
-                class="min-w-0 w-full"
-              >
-                {item}
-              </Tooltip>
-            }
+    <ContextMenu>
+      <ContextMenu.Trigger
+        as="div"
+        data-session-id={props.session.id}
+        class="group/session relative w-full min-w-0 rounded-md cursor-default pl-2 pr-3 transition-colors
+               hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
+      >
+        <div class="flex min-w-0 items-center gap-1">
+          <div class="min-w-0 flex-1">
+            <Show
+              when={hoverEnabled()}
+              fallback={
+                <Tooltip
+                  placement={props.mobile ? "bottom" : "right"}
+                  value={props.session.title}
+                  gutter={10}
+                  class="min-w-0 w-full"
+                >
+                  {item}
+                </Tooltip>
+              }
+            >
+              <SessionHoverPreview
+                mobile={props.mobile}
+                nav={props.nav}
+                hoverSession={props.hoverSession}
+                session={props.session}
+                sidebarHovering={props.sidebarHovering}
+                hoverReady={hoverReady}
+                hoverMessages={hoverMessages}
+                language={language}
+                isActive={isActive}
+                slug={props.slug}
+                setHoverSession={props.setHoverSession}
+                messageLabel={messageLabel}
+                onMessageSelect={(message) => {
+                  if (!isActive())
+                    layout.pendingMessage.set(`${base64Encode(props.session.directory)}/${props.session.id}`, message.id)
+
+                  navigate(`${props.slug}/session/${props.session.id}#message-${message.id}`)
+                }}
+                trigger={item}
+              />
+            </Show>
+          </div>
+
+          <div
+            class="shrink-0 overflow-hidden transition-[width,opacity]"
+            classList={{
+              "w-6 opacity-100 pointer-events-auto": !!props.mobile,
+              "w-0 opacity-0 pointer-events-none": !props.mobile,
+              "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
+              "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
+            }}
           >
-            <SessionHoverPreview
-              mobile={props.mobile}
-              nav={props.nav}
-              hoverSession={props.hoverSession}
-              session={props.session}
-              sidebarHovering={props.sidebarHovering}
-              hoverReady={hoverReady}
-              hoverMessages={hoverMessages}
-              language={language}
-              isActive={isActive}
-              slug={props.slug}
-              setHoverSession={props.setHoverSession}
-              messageLabel={messageLabel}
-              onMessageSelect={(message) => {
-                if (!isActive())
-                  layout.pendingMessage.set(`${base64Encode(props.session.directory)}/${props.session.id}`, message.id)
-
-                navigate(`${props.slug}/session/${props.session.id}#message-${message.id}`)
-              }}
-              trigger={item}
-            />
-          </Show>
+            <Tooltip value={language.t("common.archive")} placement="top">
+              <IconButton
+                icon="archive"
+                variant="ghost"
+                class="size-6 rounded-md"
+                aria-label={language.t("common.archive")}
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  void props.archiveSession(props.session)
+                }}
+              />
+            </Tooltip>
+          </div>
         </div>
-
-        <div
-          class="shrink-0 overflow-hidden transition-[width,opacity]"
-          classList={{
-            "w-6 opacity-100 pointer-events-auto": !!props.mobile,
-            "w-0 opacity-0 pointer-events-none": !props.mobile,
-            "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
-            "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
-          }}
-        >
-          <Tooltip value={language.t("common.archive")} placement="top">
-            <IconButton
-              icon="archive"
-              variant="ghost"
-              class="size-6 rounded-md"
-              aria-label={language.t("common.archive")}
-              onClick={(event) => {
-                event.preventDefault()
-                event.stopPropagation()
-                void props.archiveSession(props.session)
-              }}
-            />
-          </Tooltip>
-        </div>
-      </div>
-    </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content>
+          <ContextMenu.Item
+            onSelect={() => {
+              const conn = server.current
+              if (!conn) return
+              const url = conn.http.url
+              const pwd = conn.http.password ?? ""
+              void platform.openInTui?.(props.session.id, url, pwd)
+            }}
+          >
+            <ContextMenu.ItemLabel>Open in TUI</ContextMenu.ItemLabel>
+          </ContextMenu.Item>
+          <ContextMenu.Separator />
+          <ContextMenu.Item
+            onSelect={() => {
+              void props.archiveSession(props.session)
+            }}
+          >
+            <ContextMenu.ItemLabel>{language.t("common.archive")}</ContextMenu.ItemLabel>
+          </ContextMenu.Item>
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
   )
 }
 

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -1,5 +1,6 @@
-import { execFile } from "node:child_process"
+import { execFile, spawn } from "node:child_process"
 import { BrowserWindow, Notification, app, clipboard, dialog, ipcMain, shell } from "electron"
+import { getSidecarPath } from "./cli"
 import type { IpcMainEvent, IpcMainInvokeEvent } from "electron"
 
 import type { InitStep, ServerReadyData, SqliteMigrationProgress, TitlebarTheme, WslConfig } from "../preload/types"
@@ -60,6 +61,44 @@ export function registerIpcHandlers(deps: Deps) {
   ipcMain.handle("check-update", () => deps.checkUpdate())
   ipcMain.handle("install-update", () => deps.installUpdate())
   ipcMain.handle("set-background-color", (_event: IpcMainInvokeEvent, color: string) => deps.setBackgroundColor(color))
+
+  ipcMain.handle("open-in-tui", (_event: IpcMainInvokeEvent, session: string, url: string, password: string) => {
+    const bin = getSidecarPath()
+    const args = ["attach", url, "--session", session, "--password", password]
+
+    switch (process.platform) {
+      case "win32":
+        spawn("cmd", ["/c", "start", "cmd", "/k", bin, ...args], {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: false,
+        }).unref()
+        break
+      case "darwin": {
+        const escaped = [bin, ...args].map((a) => `'${a.replace(/'/g, `'"'"'`)}'`).join(" ")
+        spawn("osascript", ["-e", `tell app "Terminal" to do script "${escaped.replace(/"/g, '\\"')}"`], {
+          detached: true,
+          stdio: "ignore",
+        }).unref()
+        break
+      }
+      default:
+        // Linux: try common terminal emulators
+        for (const term of ["x-terminal-emulator", "gnome-terminal", "konsole", "xterm"]) {
+          try {
+            const child = spawn(term, ["-e", bin, ...args], {
+              detached: true,
+              stdio: "ignore",
+            })
+            child.unref()
+            break
+          } catch {
+            continue
+          }
+        }
+    }
+  })
+
   ipcMain.handle("store-get", (_event: IpcMainInvokeEvent, name: string, key: string) => {
     const store = getStore(name)
     const value = store.get(key)

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -64,6 +64,7 @@ const api: ElectronAPI = {
   checkUpdate: () => ipcRenderer.invoke("check-update"),
   installUpdate: () => ipcRenderer.invoke("install-update"),
   setBackgroundColor: (color: string) => ipcRenderer.invoke("set-background-color", color),
+  openInTui: (session, url, password) => ipcRenderer.invoke("open-in-tui", session, url, password),
 }
 
 contextBridge.exposeInMainWorld("api", api)

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -70,4 +70,5 @@ export type ElectronAPI = {
   checkUpdate: () => Promise<{ updateAvailable: boolean; version?: string }>
   installUpdate: () => Promise<void>
   setBackgroundColor: (color: string) => Promise<void>
+  openInTui: (session: string, url: string, password: string) => Promise<void>
 }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -238,6 +238,8 @@ const createPlatform = (): Platform => {
         type: "image/png",
       })
     },
+
+    openInTui: (session, url, password) => window.api.openInTui(session, url, password),
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

N/A — new feature request. No existing issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a right-click context menu on session items in the desktop sidebar. The menu has two actions:

1. **Open in TUI** — spawns a system terminal running `opencode attach <url> --session <id> --password <pwd>`, connecting to the same running sidecar and session so users can continue working in TUI mode.
2. **Archive** — archives the session (existing functionality, now accessible via context menu).

The terminal spawning is cross-platform:
- **Windows**: `cmd /c start cmd /k ...` opens a new cmd window
- **macOS**: `osascript` tells Terminal.app to run the command
- **Linux**: tries `x-terminal-emulator`, `gnome-terminal`, `konsole`, `xterm` in order

The implementation follows the existing IPC chain pattern: ElectronAPI type → preload bridge → IPC handler → Platform abstraction → UI. The `packages/app` layer stays platform-agnostic by using an optional `openInTui` method on the `Platform` interface.

### How did you verify your code works?

- Launched the desktop app with `npx electron-vite dev`
- Confirmed the sidecar starts and the app reaches `done` state
- Reviewed all 6 changed files for type correctness against existing patterns
- Verified no new type errors introduced (all typecheck failures are pre-existing in `packages/opencode/src/provider/sdk/copilot/`)

### Screenshots / recordings

<img width="277" height="253" alt="image" src="https://github.com/user-attachments/assets/02b4f3a6-e863-4fc4-a9a1-0f8875b47e6c" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR