### PR TITLE
fix(tui): patch @opentui/core to prevent mouse garbling on exit and fragmented input

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -601,6 +601,7 @@
     "tree-sitter-bash",
   ],
   "patchedDependencies": {
+    "@opentui/core@0.1.95": "patches/@opentui%2Fcore@0.1.95.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@ai-sdk/provider-utils@4.0.21": "patches/@ai-sdk%2Fprovider-utils@4.0.21.patch",
-    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch"
+    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",
+    "@opentui/core@0.1.95": "patches/@opentui%2Fcore@0.1.95.patch"
   }
 }

--- a/packages/opencode/test/cli/tui/frag-pty.py
+++ b/packages/opencode/test/cli/tui/frag-pty.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+PTY wrapper that fragments mouse escape sequences before they reach opencode.
+Every mouse event is split byte-by-byte with 12ms delays between bytes.
+Keyboard input passes through instantly.
+
+Usage: python3 frag-pty.py opencode [args...]
+"""
+
+import os
+import pty
+import sys
+import select
+import time
+import struct
+import fcntl
+import termios
+import signal
+
+FRAGMENT_DELAY = 0.012  # 12ms — exceeds opentui's 10ms StdinParser timeout
+ESC = 0x1b
+
+def set_winsize(fd):
+    """Copy terminal size to PTY."""
+    try:
+        size = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, b'\x00' * 8)
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
+    except:
+        pass
+
+def contains_mouse_seq(data):
+    """Check if data contains SGR mouse sequence start: ESC [ <"""
+    for i in range(len(data) - 2):
+        if data[i] == ESC and data[i+1] == ord('[') and data[i+2] == ord('<'):
+            return True
+    return False
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 frag-pty.py opencode [args...]")
+        sys.exit(1)
+
+    # Create PTY
+    master_fd, slave_fd = pty.openpty()
+    set_winsize(master_fd)
+
+    pid = os.fork()
+    if pid == 0:
+        # Child: run opencode on the slave PTY
+        os.close(master_fd)
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+        os.dup2(slave_fd, 0)
+        os.dup2(slave_fd, 1)
+        os.dup2(slave_fd, 2)
+        if slave_fd > 2:
+            os.close(slave_fd)
+        os.execvp(sys.argv[1], sys.argv[1:])
+
+    # Parent: proxy between terminal and master PTY
+    os.close(slave_fd)
+
+    # Save and set raw mode
+    old_attrs = termios.tcgetattr(sys.stdin.fileno())
+    try:
+        raw = termios.tcgetattr(sys.stdin.fileno())
+        raw[0] = 0  # iflag
+        raw[1] = 0  # oflag
+        raw[2] = raw[2] & ~(termios.CSIZE | termios.PARENB) | termios.CS8  # cflag
+        raw[3] = 0  # lflag
+        raw[6][termios.VMIN] = 1
+        raw[6][termios.VTIME] = 0
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, raw)
+    except:
+        pass
+
+    # Handle SIGWINCH — resize PTY when terminal resizes
+    def on_resize(signum, frame):
+        set_winsize(master_fd)
+        os.kill(pid, signal.SIGWINCH)
+    signal.signal(signal.SIGWINCH, on_resize)
+
+    # Handle child exit
+    done = False
+    def on_child(signum, frame):
+        nonlocal done
+        done = True
+    signal.signal(signal.SIGCHLD, on_child)
+
+    stdin_fd = sys.stdin.fileno()
+    stdout_fd = sys.stdout.fileno()
+
+    try:
+        while not done:
+            try:
+                rlist, _, _ = select.select([stdin_fd, master_fd], [], [], 0.1)
+            except (select.error, InterruptedError):
+                continue
+
+            if master_fd in rlist:
+                # PTY output → terminal (pass through immediately)
+                try:
+                    data = os.read(master_fd, 65536)
+                    if not data:
+                        break
+                    os.write(stdout_fd, data)
+                except OSError:
+                    break
+
+            if stdin_fd in rlist:
+                # Terminal input → check for mouse, fragment if needed
+                try:
+                    data = os.read(stdin_fd, 65536)
+                    if not data:
+                        break
+
+                    if contains_mouse_seq(data):
+                        # Fragment byte-by-byte with delay
+                        for byte in data:
+                            os.write(master_fd, bytes([byte]))
+                            time.sleep(FRAGMENT_DELAY)
+                    else:
+                        # Pass through immediately
+                        os.write(master_fd, data)
+                except OSError:
+                    break
+    finally:
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_attrs)
+        try:
+            os.kill(pid, signal.SIGTERM)
+            os.waitpid(pid, 0)
+        except:
+            pass
+
+if __name__ == "__main__":
+    main()

--- a/packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs
+++ b/packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs
@@ -1,0 +1,116 @@
+/**
+ * Test: Verify that cleanupBeforeDestroy() disables mouse tracking before
+ * disabling raw mode. Without the fix, setRawMode(false) re-enables terminal
+ * ECHO while mouse tracking is still active, causing mouse events to appear
+ * as garbled text.
+ *
+ * This test verifies the fix by reading the patched source and checking that
+ * disableMouse() is called before setRawMode(false) in cleanupBeforeDestroy().
+ * A full integration test would require a PTY, but this structural test catches
+ * regressions in the patch ordering.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read the patched @opentui/core source
+const corePath = resolve(
+  __dirname,
+  "../../../../../node_modules/.bun/@opentui+core@0.1.95+8e67d58793ed4a15/node_modules/@opentui/core/index-wv534m5j.js",
+);
+const source = readFileSync(corePath, "utf-8");
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition) {
+  if (condition) {
+    console.log(` OK | ${name}`);
+    passed++;
+  } else {
+    console.log(`BUG | ${name}`);
+    failed++;
+  }
+}
+
+console.log("Testing @opentui/core destroy-path mouse cleanup ordering\n");
+
+// Test 1: cleanupBeforeDestroy calls disableMouse
+check(
+  "cleanupBeforeDestroy() contains disableMouse() call",
+  /cleanupBeforeDestroy\(\)\s*\{[\s\S]*?this\.disableMouse\(\)[\s\S]*?this\.stdin\.setRawMode\(false\)[\s\S]*?\n\s*\}/.test(
+    source,
+  ),
+);
+
+// Test 2: disableMouse comes BEFORE setRawMode(false) in cleanupBeforeDestroy
+{
+  // Extract cleanupBeforeDestroy method body
+  const methodMatch = source.match(
+    /cleanupBeforeDestroy\(\)\s*\{([\s\S]*?)(?=\n\s{2}\w|\n\s{2}(?:get |set |async ))/,
+  );
+  if (methodMatch) {
+    const body = methodMatch[1];
+    const disableMouseIdx = body.indexOf("this.disableMouse()");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "disableMouse() is called BEFORE setRawMode(false)",
+      disableMouseIdx !== -1 &&
+        setRawModeIdx !== -1 &&
+        disableMouseIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found cleanupBeforeDestroy method body", false);
+  }
+}
+
+// Test 3: stdin drain exists between disableMouse and setRawMode
+{
+  const methodMatch = source.match(
+    /cleanupBeforeDestroy\(\)\s*\{([\s\S]*?)(?=\n\s{2}\w|\n\s{2}(?:get |set |async ))/,
+  );
+  if (methodMatch) {
+    const body = methodMatch[1];
+    const drainIdx = body.indexOf("while (this.stdin.read() !== null)");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "stdin drain exists before setRawMode(false)",
+      drainIdx !== -1 && setRawModeIdx !== -1 && drainIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found cleanupBeforeDestroy method body for drain check", false);
+  }
+}
+
+// Test 4: suspend() also has correct ordering (regression guard)
+{
+  const suspendMatch = source.match(
+    /suspend\(\)\s*\{([\s\S]*?)(?=\n\s{2}resume\(\)|\n\s{2}\w)/,
+  );
+  if (suspendMatch) {
+    const body = suspendMatch[1];
+    const disableMouseIdx = body.indexOf("this.disableMouse()");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "suspend() still has correct ordering (disableMouse before setRawMode)",
+      disableMouseIdx !== -1 &&
+        setRawModeIdx !== -1 &&
+        disableMouseIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found suspend method body", false);
+  }
+}
+
+// Test 5: Verify DEFAULT_TIMEOUT_MS is bumped
+check(
+  "DEFAULT_TIMEOUT_MS is >= 25",
+  /var DEFAULT_TIMEOUT_MS = (\d+)/.test(source) &&
+    parseInt(source.match(/var DEFAULT_TIMEOUT_MS = (\d+)/)[1]) >= 25,
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/packages/opencode/test/cli/tui/test-stdin-parser.mjs
+++ b/packages/opencode/test/cli/tui/test-stdin-parser.mjs
@@ -1,0 +1,69 @@
+// Direct import from bun's cache — avoids loading native bindings, only the JS parser is needed.
+// This path is populated by `bun install` with the patch applied.
+import { StdinParser } from "../../../../../node_modules/.bun/@opentui+core@0.1.95+8e67d58793ed4a15/node_modules/@opentui/core/index-wv534m5j.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function test(name, chunks, delayMs) {
+  const events = [];
+  const parser = new StdinParser({
+    timeoutMs: 10,
+    armTimeouts: true,
+    onTimeoutFlush: () => {
+      parser.drain((e) => events.push(e));
+    },
+  });
+
+  for (let i = 0; i < chunks.length; i++) {
+    parser.push(Buffer.from(chunks[i]));
+    parser.drain((e) => events.push(e));
+    if (i < chunks.length - 1) await sleep(delayMs);
+  }
+  // Final drain after all timeouts settle
+  await sleep(delayMs + 5);
+  parser.drain((e) => events.push(e));
+
+  const summary = events.map((e) => {
+    if (e.type === "key") return `KEY:"${e.key?.name || e.raw}"`;
+    if (e.type === "mouse") return `MOUSE:${e.event?.type}`;
+    if (e.type === "response") return `RESP:${e.protocol}`;
+    if (e.type === "paste") return `PASTE`;
+    return `${e.type}`;
+  });
+
+  const hasKeyLeak = events.some((e) => e.type === "key" && !["escape"].includes(e.key?.name));
+  console.log(`${hasKeyLeak ? "BUG" : " OK"} | ${name}`);
+  console.log(`     events: [${summary.join(", ")}]`);
+  console.log();
+  parser.destroy();
+}
+
+console.log("Testing opentui StdinParser v0.1.95 SGR mouse fragmentation\n");
+console.log("If any line shows BUG — mouse bytes leaked as key events.\n");
+
+// Complete sequence — should always work
+await test("Complete sequence in one push", ["\x1b[<0;50;15M"], 0);
+
+// Split mid-coordinates — deferred state should handle
+await test("Split mid-coords, 15ms gap", ["\x1b[<0;50;1", "5M"], 15);
+
+// ESC alone then rest — timeout flushes ESC
+await test("ESC alone, rest after 15ms", ["\x1b", "[<0;50;15M"], 15);
+
+// Triple split — ESC, [, rest
+await test("ESC / [ / rest, 15ms gaps", ["\x1b", "[", "<0;50;15M"], 15);
+
+// Quadruple split — ESC, [, <, rest
+await test("ESC / [ / < / rest, 15ms gaps", ["\x1b", "[", "<", "0;50;15M"], 15);
+
+// Every byte separate with 15ms gaps
+const fullSeq = "\x1b[<0;50;15M";
+const byteByByte = [...fullSeq].map((c) => c);
+await test("Every byte separate, 15ms gaps", byteByByte, 15);
+
+// Scroll event
+await test("Scroll event complete", ["\x1b[<65;50;15M"], 0);
+await test("Scroll event split", ["\x1b[<65;5", "0;15M"], 15);
+await test("Scroll ESC alone", ["\x1b", "[<65;50;15M"], 15);
+
+console.log("Done.");

--- a/patches/@opentui%2Fcore@0.1.95.patch
+++ b/patches/@opentui%2Fcore@0.1.95.patch
@@ -1,0 +1,89 @@
+diff --git a/index-wv534m5j.js b/index-wv534m5j.js
+index 135575a0b101cd4e2bedda5e18a660d6924fcb1f..42e5223ebc164c2370362fb7e43c3aec57dd40cc 100644
+--- a/index-wv534m5j.js
++++ b/index-wv534m5j.js
+@@ -6843,7 +6843,7 @@
+
+ // src/lib/stdin-parser.ts
+ import { Buffer as Buffer3 } from "buffer";
+-var DEFAULT_TIMEOUT_MS = 20;
++var DEFAULT_TIMEOUT_MS = 25;
+ var DEFAULT_MAX_PENDING_BYTES = 64 * 1024;
+ var INITIAL_PENDING_CAPACITY = 256;
+ var ESC = 27;
+@@ -7155,6 +7155,7 @@
+   pendingSinceMs = null;
+   forceFlush = false;
+   justFlushedEsc = false;
++  justFlushedEscBracket = false;
+   state = { tag: "ground" };
+   cursor = 0;
+   unitStart = 0;
+@@ -7295,6 +7296,15 @@
+               continue;
+             }
+             this.justFlushedEsc = false;
++          }
++          if (this.justFlushedEscBracket) {
++            if (byte === 60) {
++              this.justFlushedEscBracket = false;
++              this.cursor += 1;
++              this.state = { tag: "esc_less_mouse" };
++              continue;
++            }
++            this.justFlushedEscBracket = false;
+           }
+           if (byte === ESC) {
+             this.cursor += 1;
+@@ -7422,7 +7432,8 @@
+               this.markPending();
+               return;
+             }
+-            this.emitKeyOrResponse("unknown", decodeUtf8(bytes.subarray(this.unitStart, this.cursor)));
++            this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
++            this.justFlushedEscBracket = true;
+             this.state = { tag: "ground" };
+             this.consumePrefix(this.cursor);
+             continue;
+@@ -7449,6 +7460,7 @@
+               return;
+             }
+             this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
++            this.justFlushedEscBracket = true;
+             this.state = { tag: "ground" };
+             this.consumePrefix(this.cursor);
+             continue;
+@@ -7924,10 +7936,9 @@
+               this.markPending();
+               return;
+             }
+-            this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
+-            this.state = { tag: "ground" };
+-            this.consumePrefix(this.cursor);
+-            continue;
++            this.pendingSinceMs = null;
++            this.forceFlush = false;
++            return;
+           }
+           if (byte >= 48 && byte <= 57 || byte === 59) {
+             this.cursor += 1;
+@@ -8128,6 +8139,7 @@
+     this.pendingSinceMs = null;
+     this.forceFlush = false;
+     this.justFlushedEsc = false;
++    this.justFlushedEscBracket = false;
+     this.state = { tag: "ground" };
+     this.cursor = 0;
+     this.unitStart = 0;
+@@ -18837,7 +18849,11 @@
+       explicitWidthCprActive: false
+     }, true);
+     this.setCapturedRenderable(undefined);
++    if (this._useMouse) {
++      this.disableMouse();
++    }
+     this.stdin.removeListener("data", this.stdinListener);
++    while (this.stdin.read() !== null) {}
+     if (this.stdin.setRawMode) {
+       this.stdin.setRawMode(false);
+     }


### PR DESCRIPTION
### Issue for this PR

Closes #20458

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Patches `@opentui/core@0.1.95` to fix two separate bugs that cause SGR mouse escape sequences to appear as garbled text in the terminal:

#### 1. Post-exit mouse garbling (new fix)

When the renderer is destroyed, `cleanupBeforeDestroy()` calls `stdin.setRawMode(false)` (re-enabling terminal ECHO) **before** mouse tracking is disabled. Any mouse events arriving during this window get echoed as raw escape sequence bytes like `35;89;19M35;84;20M35...`.

The correct ordering already exists in `suspend()`. This patch applies the same pattern to `cleanupBeforeDestroy()`:
1. `disableMouse()` — mouse off while raw mode is still on (no ECHO)
2. Drain buffered mouse events from stdin
3. `setRawMode(false)` — raw mode off last

**Upstream fix:** https://github.com/anomalyco/opentui/pull/905

#### 2. In-session mouse garbling (ported from #19520)

When SGR mouse escape sequences arrive fragmented across multiple stdin chunks (due to event loop pressure from LLM streaming + TUI rendering), the StdinParser's timeout fires mid-sequence and leaks individual bytes as KEY events. Three timeout paths are patched:

- `esc_recovery` timeout: changed to `emitOpaqueResponse` + recovery flag
- `csi` timeout: added recovery flag for subsequent `<` routing
- `esc_less_mouse` timeout: changed to deferred wait instead of flush

Also bumps `DEFAULT_TIMEOUT_MS` from 20 to 25ms for defense-in-depth.

### How did you verify your code works?

- `bun packages/opencode/test/cli/tui/test-stdin-parser.mjs` — StdinParser fragmentation tests (9/9 pass)
- `bun packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs` — structural tests verifying correct ordering in the patched code (5/5 pass)
- `packages/opencode/test/cli/tui/frag-pty.py` — PTY wrapper for manual end-to-end testing

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)