### PR TITLE
fix: treat "other" as a continue stop reason

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1359,7 +1359,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
 
   const final = createMemo(() => {
-    return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
+    return props.message.finish && !["tool-calls", "other"].includes(props.message.finish)
   })
 
   const duration = createMemo(() => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1439,7 +1439,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (
             lastAssistant?.finish &&
-            !["tool-calls"].includes(lastAssistant.finish) &&
+            !["tool-calls", "other"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
             lastUser.id < lastAssistant.id
           ) {
@@ -1594,7 +1594,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return "break" as const
             }
 
-            const finished = handle.message.finish && !["tool-calls", "unknown"].includes(handle.message.finish)
+            const finished = handle.message.finish && !["tool-calls", "other"].includes(handle.message.finish)
             if (finished && !handle.message.error) {
               if (format.type === "json_schema") {
                 handle.message.error = new MessageV2.StructuredOutputError({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1439,7 +1439,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
           if (
             lastAssistant?.finish &&
-            !["tool-calls", "other"].includes(lastAssistant.finish) &&
+            !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
             lastUser.id < lastAssistant.id
           ) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -347,6 +347,23 @@ it.live("loop exits immediately when last assistant has stop finish", () =>
   ),
 )
 
+it.live("loop exits immediately when last assistant has other finish without tool calls", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      yield* seed(chat.id, { finish: "other" })
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      if (result.info.role === "assistant") expect(result.info.finish).toBe("other")
+      expect(yield* llm.calls).toBe(0)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("loop calls LLM and returns assistant message", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
### Issue for this PR

Closes #20465

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes blank assistant text in TUI when MCP servers are enabled, a regression introduced in v1.3.4 by the AI SDK 5 -> 6 upgrade.

**Root cause:** The v6 finish-reason adapter changed the default unmapped reason from `unknown` to `other`. The prompt loop continue sets in `prompt.ts` had `unknown` removed but `other` was never added as a replacement. This causes the loop to exit after MCP tool calls before the model produces final text. MCP amplifies this because tool-enabled requests hit this code path far more often.

**Additional fix:** The TUI `AssistantMessage` component rendered empty space for intermediate assistant messages whose parts were all hidden (completed tools with details off, empty text). Added a reactive `visible` memo that hides the entire message when no parts would render.

### How did you verify your code works?

- Tested locally with MCP enabled: assistant text renders correctly, symptom gone
- Tested with MCP disabled: no behavior change
- `bun typecheck` — no new errors (only pre-existing ripgrep.ts errors on dev)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR