### PR TITLE
fix(tui): add numpad key support for prompt input and dialogs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -11,6 +11,7 @@ import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util/locale"
+import { isEnterKey } from "@/util/keybind"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
 
@@ -564,7 +565,7 @@ export function Autocomplete(props: {
             e.preventDefault()
             return
           }
-          if (name === "return") {
+          if (isEnterKey(e)) {
             select()
             e.preventDefault()
             return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -898,9 +898,25 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
-                // Check clipboard for images before terminal-handled paste runs.
-                // This helps terminals that forward Ctrl+V to the app; Windows
-                // Terminal 1.25+ usually handles Ctrl+V before this path.
+                if (/^kp[0-9]$/.test(e.name) && !e.ctrl && !e.meta && !e.shift && !e.super) {
+                  const digit = e.name.charAt(2)
+                  input.insertText(digit)
+                  e.preventDefault()
+                  return
+                }
+                const numpadOperatorMap: Record<string, string> = {
+                  kpdivide: "/",
+                  kpmultiply: "*",
+                  kpminus: "-",
+                  kpplus: "+",
+                  kpdecimal: ".",
+                  kpequal: "=",
+                }
+                if (numpadOperatorMap[e.name] && !e.ctrl && !e.meta && !e.shift && !e.super) {
+                  input.insertText(numpadOperatorMap[e.name])
+                  e.preventDefault()
+                  return
+                }
                 if (keybind.match("input_paste", e)) {
                   const content = await Clipboard.read()
                   if (content?.mime.startsWith("image/")) {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -16,6 +16,7 @@ import { Locale } from "@/util/locale"
 import { Global } from "@/global"
 import { useDialog } from "../../ui/dialog"
 import { useTuiConfig } from "../../context/tui-config"
+import { isEnterKey } from "@/util/keybind"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -482,7 +483,7 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
       props.onCancel()
       return
     }
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       evt.preventDefault()
       props.onConfirm(input.plainText)
     }
@@ -575,7 +576,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       setStore("selected", next)
     }
 
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       evt.preventDefault()
       props.onSelect(store.selected)
     }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -9,6 +9,7 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
 import { useTextareaKeybindings } from "../../component/textarea-keybindings"
 import { useDialog } from "../../ui/dialog"
+import { isEnterKey } from "@/util/keybind"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
@@ -143,7 +144,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         textarea?.setText("")
         return
       }
-      if (evt.name === "return") {
+      if (isEnterKey(evt)) {
         evt.preventDefault()
         const text = textarea?.plainText?.trim() ?? ""
         const prev = store.custom[store.tab]
@@ -206,7 +207,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     }
 
     if (confirm()) {
-      if (evt.name === "return") {
+      if (isEnterKey(evt)) {
         evt.preventDefault()
         submit()
       }
@@ -238,7 +239,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         moveTo((store.selected + 1) % total)
       }
 
-      if (evt.name === "return") {
+      if (isEnterKey(evt)) {
         evt.preventDefault()
         selectOption()
       }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,6 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { isEnterKey } from "@/util/keybind"
 
 export type DialogAlertProps = {
   title: string
@@ -14,7 +15,7 @@ export function DialogAlert(props: DialogAlertProps) {
   const { theme } = useTheme()
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       props.onConfirm?.()
       dialog.clear()
     }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -5,6 +5,7 @@ import { createStore } from "solid-js/store"
 import { For } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import { Locale } from "@/util/locale"
+import { isEnterKey } from "@/util/keybind"
 
 export type DialogConfirmProps = {
   title: string
@@ -24,7 +25,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
   })
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       if (store.active === "confirm") props.onConfirm?.()
       if (store.active === "cancel") props.onCancel?.()
       dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-export-options.tsx
@@ -4,6 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
 import { onMount, Show, type JSX } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
+import { isEnterKey } from "@/util/keybind"
 
 export type DialogExportOptionsProps = {
   defaultFilename: string
@@ -34,7 +35,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
   })
 
   useKeyboard((evt) => {
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       props.onConfirm?.({
         filename: textarea.plainText,
         thinking: store.thinking,

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "@tui/context/theme"
 import { useDialog } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
 import { useKeybind } from "@tui/context/keybind"
+import { isEnterKey } from "@/util/keybind"
 
 export function DialogHelp() {
   const dialog = useDialog()
@@ -10,7 +11,7 @@ export function DialogHelp() {
   const keybind = useKeybind()
 
   useKeyboard((evt) => {
-    if (evt.name === "return" || evt.name === "escape") {
+    if (isEnterKey(evt) || evt.name === "escape") {
       dialog.clear()
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -4,6 +4,7 @@ import { useDialog, type DialogContext } from "./dialog"
 import { Show, createEffect, onMount, type JSX } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import { Spinner } from "../component/spinner"
+import { isEnterKey } from "@/util/keybind"
 
 export type DialogPromptProps = {
   title: string
@@ -28,7 +29,7 @@ export function DialogPrompt(props: DialogPromptProps) {
       evt.stopPropagation()
       return
     }
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       props.onConfirm?.(textarea.plainText)
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -8,7 +8,7 @@ import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
-import { Keybind } from "@/util/keybind"
+import { Keybind, isEnterKey } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 
 export interface DialogSelectProps<T> {
@@ -194,7 +194,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     if (evt.name === "home") moveTo(0)
     if (evt.name === "end") moveTo(flat().length - 1)
 
-    if (evt.name === "return") {
+    if (isEnterKey(evt)) {
       const option = selected()
       if (option) {
         evt.preventDefault()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -710,20 +710,20 @@ export namespace Config {
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
-      input_submit: z.string().optional().default("return").describe("Submit input"),
+      input_submit: z.string().optional().default("return,kpenter").describe("Submit input"),
       input_newline: z
         .string()
         .optional()
-        .default("shift+return,ctrl+return,alt+return,ctrl+j")
+        .default("shift+return,ctrl+return,alt+return,ctrl+j,shift+kpenter")
         .describe("Insert newline in input"),
-      input_move_left: z.string().optional().default("left,ctrl+b").describe("Move cursor left in input"),
-      input_move_right: z.string().optional().default("right,ctrl+f").describe("Move cursor right in input"),
-      input_move_up: z.string().optional().default("up").describe("Move cursor up in input"),
-      input_move_down: z.string().optional().default("down").describe("Move cursor down in input"),
-      input_select_left: z.string().optional().default("shift+left").describe("Select left in input"),
-      input_select_right: z.string().optional().default("shift+right").describe("Select right in input"),
-      input_select_up: z.string().optional().default("shift+up").describe("Select up in input"),
-      input_select_down: z.string().optional().default("shift+down").describe("Select down in input"),
+      input_move_left: z.string().optional().default("left,ctrl+b,kp4").describe("Move cursor left in input"),
+      input_move_right: z.string().optional().default("right,ctrl+f,kp6").describe("Move cursor right in input"),
+      input_move_up: z.string().optional().default("up,kp8").describe("Move cursor up in input"),
+      input_move_down: z.string().optional().default("down,kp2").describe("Move cursor down in input"),
+      input_select_left: z.string().optional().default("shift+left,shift+kp4").describe("Select left in input"),
+      input_select_right: z.string().optional().default("shift+right,shift+kp6").describe("Select right in input"),
+      input_select_up: z.string().optional().default("shift+up,shift+kp8").describe("Select up in input"),
+      input_select_down: z.string().optional().default("shift+down,shift+kp2").describe("Select down in input"),
       input_line_home: z.string().optional().default("ctrl+a").describe("Move to start of line in input"),
       input_line_end: z.string().optional().default("ctrl+e").describe("Move to end of line in input"),
       input_select_line_home: z
@@ -744,19 +744,31 @@ export namespace Config {
         .optional()
         .default("alt+shift+e")
         .describe("Select to end of visual line in input"),
-      input_buffer_home: z.string().optional().default("home").describe("Move to start of buffer in input"),
-      input_buffer_end: z.string().optional().default("end").describe("Move to end of buffer in input"),
+      input_buffer_home: z.string().optional().default("home,kp7,kphome").describe("Move to start of buffer in input"),
+      input_buffer_end: z.string().optional().default("end,kp9,kpend").describe("Move to end of buffer in input"),
       input_select_buffer_home: z
         .string()
         .optional()
-        .default("shift+home")
+        .default("shift+home,shift+kp7,shift+kphome")
         .describe("Select to start of buffer in input"),
-      input_select_buffer_end: z.string().optional().default("shift+end").describe("Select to end of buffer in input"),
+      input_select_buffer_end: z
+        .string()
+        .optional()
+        .default("shift+end,shift+kp9,shift+kpend")
+        .describe("Select to end of buffer in input"),
       input_delete_line: z.string().optional().default("ctrl+shift+d").describe("Delete line in input"),
       input_delete_to_line_end: z.string().optional().default("ctrl+k").describe("Delete to end of line in input"),
       input_delete_to_line_start: z.string().optional().default("ctrl+u").describe("Delete to start of line in input"),
-      input_backspace: z.string().optional().default("backspace,shift+backspace").describe("Backspace in input"),
-      input_delete: z.string().optional().default("ctrl+d,delete,shift+delete").describe("Delete character in input"),
+      input_backspace: z
+        .string()
+        .optional()
+        .default("backspace,shift+backspace,kpbackspace")
+        .describe("Backspace in input"),
+      input_delete: z
+        .string()
+        .optional()
+        .default("ctrl+d,delete,shift+delete,kpdelete")
+        .describe("Delete character in input"),
       input_undo: z.string().optional().default("ctrl+-,super+z").describe("Undo in input"),
       input_redo: z.string().optional().default("ctrl+.,super+shift+z").describe("Redo in input"),
       input_word_forward: z

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -1,6 +1,48 @@
 import { isDeepEqual } from "remeda"
 import type { ParsedKey } from "@opentui/core"
 
+/**
+ * Numpad key name mapping from OpenTUI ParsedKey names
+ * Handles kitty protocol names (kp0-kp9, kpenter, etc.)
+ */
+const NUMPAD_KEY_NAMES = new Set([
+  "kp0",
+  "kp1",
+  "kp2",
+  "kp3",
+  "kp4",
+  "kp5",
+  "kp6",
+  "kp7",
+  "kp8",
+  "kp9",
+  "kpdecimal",
+  "kpdivide",
+  "kpmultiply",
+  "kpplus",
+  "kpminus",
+  "kpenter",
+  "kpequal",
+  "kphome",
+  "kpend",
+  "kppgup",
+  "kppgdn",
+  "kpup",
+  "kpdown",
+  "kpleft",
+  "kpright",
+  "kpdelete",
+  "kpbackspace",
+])
+
+/**
+ * Check if a key event should be treated as Enter/Return.
+ * Includes main keyboard Enter and numpad Enter variants.
+ */
+export function isEnterKey(key: { name: string }): boolean {
+  return key.name === "return" || key.name === "kpenter"
+}
+
 export namespace Keybind {
   /**
    * Keybind info derived from OpenTUI's ParsedKey with our custom `leader` field.
@@ -22,14 +64,80 @@ export namespace Keybind {
    * This helper ensures all required fields are present and avoids manual object creation.
    */
   export function fromParsedKey(key: ParsedKey, leader = false): Info {
+    // Detect numpad keys from kitty protocol or legacy sequences
+    const detectedNumpad = detectNumpadKeyName(key)
+
     return {
-      name: key.name === " " ? "space" : key.name,
+      name: detectedNumpad ?? (key.name === " " ? "space" : key.name),
       ctrl: key.ctrl,
       meta: key.meta,
       shift: key.shift,
       super: key.super ?? false,
       leader,
     }
+  }
+
+  /**
+   * Detect numpad key name from ParsedKey
+   *
+   * Handles:
+   * - Kitty protocol: name already contains "kp*" names
+   * - Legacy SS3 sequences: \x1bO0-\x1bO9 mapped to kp0-kp9
+   * - Terminal limitation: raw digits (NumLock ON in VSCode) treated as numpad
+   */
+  function detectNumpadKeyName(key: ParsedKey): string | null {
+    // Already detected by OpenTUI (kitty protocol)
+    if (key.name && NUMPAD_KEY_NAMES.has(key.name)) {
+      return key.name
+    }
+
+    // Legacy SS3 sequences (DEC Aided Key mode)
+    const sequence = (key as { sequence?: string }).sequence
+    if (sequence) {
+      // Match SS3 numpad: \x1bO followed by digit
+      const ss3Match = sequence.match(/^\x1bO([0-9])$/)
+      if (ss3Match) {
+        return "kp" + ss3Match[1]
+      }
+
+      // Match SS3 numpad operators
+      const ss3OpMap: Record<string, string> = {
+        "\x1bO*": "kpmultiply",
+        "\x1bO+": "kpplus",
+        "\x1bO-": "kpminus",
+        "\x1bO/": "kpdivide",
+        "\x1bO.": "kpdecimal",
+        "\x1b[3~": "kpdelete",
+        "\x1b[1~": "kphome",
+        "\x1b[4~": "kpend",
+        "\x1b[5~": "kppgup",
+        "\x1b[6~": "kppgdn",
+        "\x1bOA": "kpup",
+        "\x1bOB": "kpdown",
+        "\x1bOC": "kpright",
+        "\x1bOD": "kpleft",
+      }
+      if (ss3OpMap[sequence]) {
+        return ss3OpMap[sequence]
+      }
+    }
+
+    // modifyOtherKeys numpad codes (48-57 = kp0-kp9)
+    if (sequence) {
+      const csiuMatch = sequence.match(/^\x1b\[\d+;?[0-9]*u$/)
+      if (csiuMatch) {
+        const codeMatch = sequence.match(/\x1b\[(\d+);?(\d*)u/)
+        if (codeMatch) {
+          const code = parseInt(codeMatch[1])
+          if (code >= 48 && code <= 57) {
+            const digit = code - 48
+            return "kp" + digit
+          }
+        }
+      }
+    }
+
+    return null
   }
 
   export function toString(info: Info | undefined): string {


### PR DESCRIPTION
### Issue for this PR

Closes #20461

### Type of change

- [x] Bug fix

### What does this PR do?

Numpad keys (Enter, digits, operators, navigation) are not recognized in the TUI because OpenTUI's kitty keyboard protocol sends them as distinct key names (kpenter, kp0-kp9, etc.) and legacy terminals send SS3 escape sequences. This PR maps those key names and escape sequences to their standard equivalents so numpad keys work in the prompt input, all dialogs, permission/question prompts, and autocomplete.

Changes:
- Added isEnterKey() helper and NUMPAD_KEY_NAMES set in keybind.ts`n- Added detectNumpadKeyName() to handle SS3 escape sequences from legacy terminals
- Updated default keybindings in config.ts with numpad equivalents
- Added numpad digit/operator insertion handlers in the prompt component
- Applied isEnterKey() across all dialog and prompt confirmation points

### How did you verify your code works?

Tested manually in Windows Terminal and VS Code integrated terminal — numpad Enter, digits, arithmetic operators, and navigation keys all function correctly in the prompt input, dialogs, permission prompts, question prompts, and autocomplete.

### Screenshots / recordings

_N/A — no visible UI change, only input handling._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR