### PR TITLE
refactor(provider): use Plugin Effect service instead of async facade

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -961,11 +961,12 @@ export namespace Provider {
     }
   }
 
-  const layer: Layer.Layer<Service, never, Config.Service | Auth.Service> = Layer.effect(
+  const layer: Layer.Layer<Service, never, Config.Service | Auth.Service | Plugin.Service> = Layer.effect(
     Service,
     Effect.gen(function* () {
       const config = yield* Config.Service
       const auth = yield* Auth.Service
+      const plugin = yield* Plugin.Service
 
       const cache = yield* InstanceState.make<State>(() =>
         Effect.gen(function* () {
@@ -1128,7 +1129,7 @@ export namespace Provider {
             }
           }
 
-          const plugins = yield* Effect.promise(() => Plugin.list())
+          const plugins = yield* plugin.list()
           for (const plugin of plugins) {
             if (!plugin.auth) continue
             const providerID = ProviderID.make(plugin.auth.provider)
@@ -1541,7 +1542,11 @@ export namespace Provider {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(Auth.defaultLayer))
+  export const defaultLayer = layer.pipe(
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Plugin.defaultLayer),
+  )
 
   const { runPromise } = makeRuntime(Service, defaultLayer)
 


### PR DESCRIPTION
## Summary

- Inject `Plugin.Service` into the Provider layer instead of calling the async `Plugin.list()` facade
- Replace `Effect.promise(() => Plugin.list())` with `yield* plugin.list()`
- Add `Plugin.defaultLayer` to Provider's `defaultLayer` dependencies

## Test plan

- [x] `bun run test -- test/provider` — 239/239 pass
- [x] `bun run test -- test/session/` — 181/181 pass (4 skipped)
- [x] Typecheck passes across all 13 packages