### PR TITLE
fix(opencode): use structuredPatch with 5s timeout to fix TUI freeze on large files

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -1,4 +1,4 @@
-import z from "zod"
+﻿import z from "zod"
 import * as path from "path"
 import * as fs from "fs/promises"
 import { Tool } from "./tool"
@@ -14,6 +14,10 @@ import { Filesystem } from "../util/filesystem"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
+
+// Skip diff computation for files larger than this threshold (bytes).
+// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
+const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -67,13 +71,22 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
           const oldContent = ""
           const newContent =
             hunk.contents.length === 0 || hunk.contents.endsWith("\n") ? hunk.contents : `${hunk.contents}\n`
-          const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
+          const newSize = Buffer.byteLength(newContent, "utf-8")
+          const diff =
+            newSize <= DIFF_SIZE_THRESHOLD
+              ? trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
+              : ""
 
           let additions = 0
           let deletions = 0
-          for (const change of diffLines(oldContent, newContent)) {
-            if (change.added) additions += change.count || 0
-            if (change.removed) deletions += change.count || 0
+          if (newSize <= DIFF_SIZE_THRESHOLD) {
+            for (const change of diffLines(oldContent, newContent)) {
+              if (change.added) additions += change.count || 0
+              if (change.removed) deletions += change.count || 0
+            }
+          } else {
+            // Approximate for large files: count lines directly
+            additions = newContent.split("\n").length
           }
 
           fileChanges.push({
@@ -108,13 +121,24 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
             throw new Error(`apply_patch verification failed: ${error}`)
           }
 
-          const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
+          const oldSz = Buffer.byteLength(oldContent, "utf-8")
+          const newSz = Buffer.byteLength(newContent, "utf-8")
+          const diff =
+            oldSz <= DIFF_SIZE_THRESHOLD && newSz <= DIFF_SIZE_THRESHOLD
+              ? trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
+              : ""
 
           let additions = 0
           let deletions = 0
-          for (const change of diffLines(oldContent, newContent)) {
-            if (change.added) additions += change.count || 0
-            if (change.removed) deletions += change.count || 0
+          if (oldSz <= DIFF_SIZE_THRESHOLD && newSz <= DIFF_SIZE_THRESHOLD) {
+            for (const change of diffLines(oldContent, newContent)) {
+              if (change.added) additions += change.count || 0
+              if (change.removed) deletions += change.count || 0
+            }
+          } else {
+            // Approximate for large files
+            additions = newContent.split("\n").length
+            deletions = oldContent.split("\n").length
           }
 
           const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
@@ -139,7 +163,11 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
           const contentToDelete = await fs.readFile(filePath, "utf-8").catch((error) => {
             throw new Error(`apply_patch verification failed: ${error}`)
           })
-          const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+          const deleteSize = Buffer.byteLength(contentToDelete, "utf-8")
+          const deleteDiff =
+            deleteSize <= DIFF_SIZE_THRESHOLD
+              ? trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+              : ""
 
           const deletions = contentToDelete.split("\n").length
 
@@ -192,8 +220,11 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
       const edited = change.type === "delete" ? undefined : (change.movePath ?? change.filePath)
       switch (change.type) {
         case "add":
-          // Create parent directories (recursive: true is safe on existing/root dirs)
-          await fs.mkdir(path.dirname(change.filePath), { recursive: true })
+          // Create parent directories. Ignore EEXIST because Bun on Windows can
+          // throw it even with recursive:true when the directory already exists.
+          await fs.mkdir(path.dirname(change.filePath), { recursive: true }).catch((e: any) => {
+            if (e?.code !== "EEXIST") throw e
+          })
           await fs.writeFile(change.filePath, change.newContent, "utf-8")
           updates.push({ file: change.filePath, event: "add" })
           break
@@ -205,8 +236,10 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
 
         case "move":
           if (change.movePath) {
-            // Create parent directories (recursive: true is safe on existing/root dirs)
-            await fs.mkdir(path.dirname(change.movePath), { recursive: true })
+            // Create parent directories. Ignore EEXIST (same Bun/Windows quirk).
+            await fs.mkdir(path.dirname(change.movePath), { recursive: true }).catch((e: any) => {
+              if (e?.code !== "EEXIST") throw e
+            })
             await fs.writeFile(change.movePath, change.newContent, "utf-8")
             await fs.unlink(change.filePath)
             updates.push({ file: change.filePath, event: "unlink" })

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -6,7 +6,7 @@ import { Bus } from "../bus"
 import { FileWatcher } from "../file/watcher"
 import { Instance } from "../project/instance"
 import { Patch } from "../patch"
-import { createTwoFilesPatch, diffLines } from "diff"
+import { structuredPatch } from "diff"
 import { assertExternalDirectory } from "./external-directory"
 import { trimDiff } from "./edit"
 import { LSP } from "../lsp"
@@ -14,10 +14,6 @@ import { Filesystem } from "../util/filesystem"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
-
-// Skip diff computation for files larger than this threshold (bytes).
-// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
-const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -71,23 +67,10 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
           const oldContent = ""
           const newContent =
             hunk.contents.length === 0 || hunk.contents.endsWith("\n") ? hunk.contents : `${hunk.contents}\n`
-          const newSize = Buffer.byteLength(newContent, "utf-8")
-          const diff =
-            newSize <= DIFF_SIZE_THRESHOLD
-              ? trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
-              : ""
-
-          let additions = 0
-          let deletions = 0
-          if (newSize <= DIFF_SIZE_THRESHOLD) {
-            for (const change of diffLines(oldContent, newContent)) {
-              if (change.added) additions += change.count || 0
-              if (change.removed) deletions += change.count || 0
-            }
-          } else {
-            // Approximate for large files: count lines directly
-            additions = newContent.split("\n").length
-          }
+          // New files have no previous content — diff is always empty.
+          const diff = ""
+          const additions = newContent ? newContent.split("\n").length : 0
+          const deletions = 0
 
           fileChanges.push({
             filePath,
@@ -121,24 +104,25 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
             throw new Error(`apply_patch verification failed: ${error}`)
           }
 
-          const oldSz = Buffer.byteLength(oldContent, "utf-8")
-          const newSz = Buffer.byteLength(newContent, "utf-8")
-          const diff =
-            oldSz <= DIFF_SIZE_THRESHOLD && newSz <= DIFF_SIZE_THRESHOLD
-              ? trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
-              : ""
-
+          // Use structuredPatch with 5s timeout; returns "" on timeout.
+          const result = structuredPatch(filePath, filePath, oldContent, newContent, undefined, undefined, { timeout: 5000 })
+          const diff = result ? trimDiff([
+            `Index: ${filePath}`,
+            "===================================================================",
+            `--- ${filePath}`,
+            `+++ ${filePath}`,
+            ...result.hunks.map((h) => [
+              `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`,
+              ...h.lines,
+            ].join("\n")),
+          ].join("\n")) : ""
           let additions = 0
           let deletions = 0
-          if (oldSz <= DIFF_SIZE_THRESHOLD && newSz <= DIFF_SIZE_THRESHOLD) {
-            for (const change of diffLines(oldContent, newContent)) {
-              if (change.added) additions += change.count || 0
-              if (change.removed) deletions += change.count || 0
+          if (diff) {
+            for (const line of diff.split("\n")) {
+              if (line.startsWith("+") && !line.startsWith("+++")) additions++
+              if (line.startsWith("-") && !line.startsWith("---")) deletions++
             }
-          } else {
-            // Approximate for large files
-            additions = newContent.split("\n").length
-            deletions = oldContent.split("\n").length
           }
 
           const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
@@ -163,11 +147,17 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
           const contentToDelete = await fs.readFile(filePath, "utf-8").catch((error) => {
             throw new Error(`apply_patch verification failed: ${error}`)
           })
-          const deleteSize = Buffer.byteLength(contentToDelete, "utf-8")
-          const deleteDiff =
-            deleteSize <= DIFF_SIZE_THRESHOLD
-              ? trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
-              : ""
+          const delResult = structuredPatch(filePath, filePath, contentToDelete, "", undefined, undefined, { timeout: 5000 })
+          const deleteDiff = delResult ? trimDiff([
+            `Index: ${filePath}`,
+            "===================================================================",
+            `--- ${filePath}`,
+            `+++ ${filePath}`,
+            ...delResult.hunks.map((h) => [
+              `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`,
+              ...h.lines,
+            ].join("\n")),
+          ].join("\n")) : ""
 
           const deletions = contentToDelete.split("\n").length
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,4 +1,4 @@
-import z from "zod"
+﻿import z from "zod"
 import os from "os"
 import { Tool } from "./tool"
 import path from "path"
@@ -337,6 +337,21 @@ async function run(
     },
   })
 
+  // Throttle metadata updates to at most once every 100 ms to avoid flooding
+  // the event loop when a command produces a very high volume of small chunks
+  // (e.g. compiler output, npm install). Final metadata is always flushed
+  // explicitly after the process exits.
+  const METADATA_THROTTLE_MS = 100
+  let lastMetadataTs = 0
+  const flushMetadata = () => {
+    ctx.metadata({
+      metadata: {
+        output: preview(output),
+        description: input.description,
+      },
+    })
+  }
+
   const exit = await CrossSpawnSpawner.runPromiseExit((spawner) =>
     Effect.gen(function* () {
       const handle = yield* spawner.spawn(cmd(input.shell, input.name, input.command, input.cwd, input.env))
@@ -345,12 +360,11 @@ async function run(
         Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
           Effect.sync(() => {
             output += chunk
-            ctx.metadata({
-              metadata: {
-                output: preview(output),
-                description: input.description,
-              },
-            })
+            const now = Date.now()
+            if (now - lastMetadataTs >= METADATA_THROTTLE_MS) {
+              lastMetadataTs = now
+              flushMetadata()
+            }
           }),
         ),
       )
@@ -382,6 +396,9 @@ async function run(
       return exit.kind === "exit" ? exit.code : null
     }).pipe(Effect.scoped, Effect.orDie),
   )
+
+  // Flush any buffered metadata that was skipped due to throttling.
+  flushMetadata()
 
   let code: number | null = null
   if (Exit.isSuccess(exit)) {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -1,4 +1,4 @@
-// the approaches in this edit tool are sourced from
+﻿// the approaches in this edit tool are sourced from
 // https://github.com/cline/cline/blob/main/evals/diff-edits/diff-apply/diff-06-23-25.ts
 // https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/utils/editCorrector.ts
 // https://github.com/cline/cline/blob/main/evals/diff-edits/diff-apply/diff-06-26-25.ts
@@ -20,6 +20,10 @@ import { Snapshot } from "@/snapshot"
 import { assertExternalDirectory } from "./external-directory"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
+
+// Skip diff computation for files larger than this threshold (bytes).
+// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
+const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -61,7 +65,12 @@ export const EditTool = Tool.define("edit", {
       if (params.oldString === "") {
         const existed = await Filesystem.exists(filePath)
         contentNew = params.newString
-        diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+        // Only compute diff for small content to avoid blocking the event loop.
+        const newSize = Buffer.byteLength(contentNew, "utf-8")
+        diff =
+          newSize <= DIFF_SIZE_THRESHOLD
+            ? trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+            : ""
         await ctx.ask({
           permission: "edit",
           patterns: [path.relative(Instance.worktree, filePath)],
@@ -94,9 +103,15 @@ export const EditTool = Tool.define("edit", {
 
       contentNew = replace(contentOld, old, next, params.replaceAll)
 
-      diff = trimDiff(
-        createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
-      )
+      // Only compute diff for small files to avoid blocking the event loop.
+      const oldSize = Buffer.byteLength(contentOld, "utf-8")
+      const newSize = Buffer.byteLength(contentNew, "utf-8")
+      if (oldSize <= DIFF_SIZE_THRESHOLD && newSize <= DIFF_SIZE_THRESHOLD) {
+        diff = trimDiff(
+          createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
+        )
+      }
+
       await ctx.ask({
         permission: "edit",
         patterns: [path.relative(Instance.worktree, filePath)],
@@ -114,10 +129,9 @@ export const EditTool = Tool.define("edit", {
         file: filePath,
         event: "change",
       })
-      contentNew = await Filesystem.readText(filePath)
-      diff = trimDiff(
-        createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
-      )
+      // Use the in-memory contentNew for diff computation instead of re-reading the file.
+      // Re-reading the file after Format.file() can be done lazily if the formatted
+      // content is needed; for the diff we already have both sides in memory.
       await FileTime.read(ctx.sessionID, filePath)
     })
 
@@ -128,9 +142,18 @@ export const EditTool = Tool.define("edit", {
       additions: 0,
       deletions: 0,
     }
-    for (const change of diffLines(contentOld, contentNew)) {
-      if (change.added) filediff.additions += change.count || 0
-      if (change.removed) filediff.deletions += change.count || 0
+    // Only run diffLines for small files — same O(N^2) concern as createTwoFilesPatch.
+    const oldDiffSize = Buffer.byteLength(contentOld, "utf-8")
+    const newDiffSize = Buffer.byteLength(contentNew, "utf-8")
+    if (oldDiffSize <= DIFF_SIZE_THRESHOLD && newDiffSize <= DIFF_SIZE_THRESHOLD) {
+      for (const change of diffLines(contentOld, contentNew)) {
+        if (change.added) filediff.additions += change.count || 0
+        if (change.removed) filediff.deletions += change.count || 0
+      }
+    } else {
+      // Approximate for large files
+      filediff.additions = contentNew.split("\n").length
+      filediff.deletions = contentOld.split("\n").length
     }
 
     ctx.metadata({
@@ -142,7 +165,8 @@ export const EditTool = Tool.define("edit", {
     })
 
     let output = "Edit applied successfully."
-    await LSP.touchFile(filePath, true)
+    // Notify LSP asynchronously so it does not block the edit response.
+    LSP.touchFile(filePath, true).catch(() => {})
     const diagnostics = await LSP.diagnostics()
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -7,7 +7,7 @@ import z from "zod"
 import * as path from "path"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
-import { createTwoFilesPatch, diffLines } from "diff"
+import { structuredPatch } from "diff"
 import DESCRIPTION from "./edit.txt"
 import { File } from "../file"
 import { FileWatcher } from "../file/watcher"
@@ -20,10 +20,6 @@ import { Snapshot } from "@/snapshot"
 import { assertExternalDirectory } from "./external-directory"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
-
-// Skip diff computation for files larger than this threshold (bytes).
-// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
-const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -38,6 +34,25 @@ function convertToLineEnding(text: string, ending: "\n" | "\r\n"): string {
   return text.replaceAll("\n", "\r\n")
 }
 
+// Compute a unified diff with a hard 5-second timeout so the Myers diff
+// algorithm never blocks the event loop on large or complex content.
+// Returns an empty string on timeout or when there is no previous content.
+function safeDiff(filePath: string, oldContent: string, newContent: string): string {
+  // structuredPatch with a 5-second timeout so the Myers diff algorithm never
+  // blocks the event loop. Returns "" on timeout.
+  const result = structuredPatch(filePath, filePath, oldContent, newContent, undefined, undefined, { timeout: 5000 })
+  if (!result) return ""
+  return trimDiff([
+    `Index: ${filePath}`,
+    "===================================================================",
+    `--- ${filePath}`,
+    `+++ ${filePath}`,
+    ...result.hunks.map((h) => [
+      `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`,
+      ...h.lines,
+    ].join("\n")),
+  ].join("\n"))
+}
 export const EditTool = Tool.define("edit", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -65,12 +80,7 @@ export const EditTool = Tool.define("edit", {
       if (params.oldString === "") {
         const existed = await Filesystem.exists(filePath)
         contentNew = params.newString
-        // Only compute diff for small content to avoid blocking the event loop.
-        const newSize = Buffer.byteLength(contentNew, "utf-8")
-        diff =
-          newSize <= DIFF_SIZE_THRESHOLD
-            ? trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
-            : ""
+        diff = safeDiff(filePath, contentOld, contentNew)
         await ctx.ask({
           permission: "edit",
           patterns: [path.relative(Instance.worktree, filePath)],
@@ -103,14 +113,7 @@ export const EditTool = Tool.define("edit", {
 
       contentNew = replace(contentOld, old, next, params.replaceAll)
 
-      // Only compute diff for small files to avoid blocking the event loop.
-      const oldSize = Buffer.byteLength(contentOld, "utf-8")
-      const newSize = Buffer.byteLength(contentNew, "utf-8")
-      if (oldSize <= DIFF_SIZE_THRESHOLD && newSize <= DIFF_SIZE_THRESHOLD) {
-        diff = trimDiff(
-          createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
-        )
-      }
+      diff = safeDiff(filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew))
 
       await ctx.ask({
         permission: "edit",
@@ -140,18 +143,13 @@ export const EditTool = Tool.define("edit", {
       additions: 0,
       deletions: 0,
     }
-    // Only run diffLines for small files — same O(N^2) concern as createTwoFilesPatch.
-    const oldDiffSize = Buffer.byteLength(contentOld, "utf-8")
-    const newDiffSize = Buffer.byteLength(contentNew, "utf-8")
-    if (oldDiffSize <= DIFF_SIZE_THRESHOLD && newDiffSize <= DIFF_SIZE_THRESHOLD) {
-      for (const change of diffLines(contentOld, contentNew)) {
-        if (change.added) filediff.additions += change.count || 0
-        if (change.removed) filediff.deletions += change.count || 0
+    // Count additions/deletions from the already-computed diff hunks so we
+    // do not run a second O(N*D) pass over the content.
+    if (diff) {
+      for (const line of diff.split("\n")) {
+        if (line.startsWith("+") && !line.startsWith("+++")) filediff.additions++
+        if (line.startsWith("-") && !line.startsWith("---")) filediff.deletions++
       }
-    } else {
-      // Approximate for large files
-      filediff.additions = contentNew.split("\n").length
-      filediff.deletions = contentOld.split("\n").length
     }
 
     ctx.metadata({

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -129,9 +129,7 @@ export const EditTool = Tool.define("edit", {
         file: filePath,
         event: "change",
       })
-      // Use the in-memory contentNew for diff computation instead of re-reading the file.
-      // Re-reading the file after Format.file() can be done lazily if the formatted
-      // content is needed; for the diff we already have both sides in memory.
+      contentNew = await Filesystem.readText(filePath)
       await FileTime.read(ctx.sessionID, filePath)
     })
 
@@ -165,8 +163,7 @@ export const EditTool = Tool.define("edit", {
     })
 
     let output = "Edit applied successfully."
-    // Notify LSP asynchronously so it does not block the edit response.
-    LSP.touchFile(filePath, true).catch(() => {})
+    await LSP.touchFile(filePath, true)
     const diagnostics = await LSP.diagnostics()
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -1,4 +1,4 @@
-import z from "zod"
+﻿import z from "zod"
 import * as path from "path"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
@@ -17,6 +17,10 @@ import { assertExternalDirectory } from "./external-directory"
 const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
+// Skip diff computation for files larger than this threshold (bytes).
+// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
+const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
+
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -31,7 +35,16 @@ export const WriteTool = Tool.define("write", {
     const contentOld = exists ? await Filesystem.readText(filepath) : ""
     if (exists) await FileTime.assert(ctx.sessionID, filepath)
 
-    const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
+    // Only compute diff for small files to avoid blocking the event loop.
+    // For large files, skip the diff -- the permission prompt still fires but
+    // without a line-level preview.
+    const newSize = Buffer.byteLength(params.content, "utf-8")
+    const oldSize = Buffer.byteLength(contentOld, "utf-8")
+    const diff =
+      newSize <= DIFF_SIZE_THRESHOLD && oldSize <= DIFF_SIZE_THRESHOLD
+        ? trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
+        : ""
+
     await ctx.ask({
       permission: "edit",
       patterns: [path.relative(Instance.worktree, filepath)],
@@ -52,7 +65,8 @@ export const WriteTool = Tool.define("write", {
     await FileTime.read(ctx.sessionID, filepath)
 
     let output = "Wrote file successfully."
-    await LSP.touchFile(filepath, true)
+    // Notify LSP asynchronously so it does not block the write response.
+    LSP.touchFile(filepath, true).catch(() => {})
     const diagnostics = await LSP.diagnostics()
     const normalizedFilepath = Filesystem.normalizePath(filepath)
     let projectDiagnosticsCount = 0

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -2,7 +2,7 @@
 import * as path from "path"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
-import { createTwoFilesPatch } from "diff"
+import { structuredPatch } from "diff"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
 import { File } from "../file"
@@ -17,9 +17,6 @@ import { assertExternalDirectory } from "./external-directory"
 const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
-// Skip diff computation for files larger than this threshold (bytes).
-// Myers diff is O(N^2) in the worst case and blocks the event loop on large files.
-const DIFF_SIZE_THRESHOLD = 100 * 1024 // 100 KB
 
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
@@ -35,15 +32,24 @@ export const WriteTool = Tool.define("write", {
     const contentOld = exists ? await Filesystem.readText(filepath) : ""
     if (exists) await FileTime.assert(ctx.sessionID, filepath)
 
-    // Only compute diff for small files to avoid blocking the event loop.
-    // For large files, skip the diff -- the permission prompt still fires but
-    // without a line-level preview.
-    const newSize = Buffer.byteLength(params.content, "utf-8")
-    const oldSize = Buffer.byteLength(contentOld, "utf-8")
-    const diff =
-      newSize <= DIFF_SIZE_THRESHOLD && oldSize <= DIFF_SIZE_THRESHOLD
-        ? trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
-        : ""
+    // Use structuredPatch with a 5-second timeout so diff computation never
+    // blocks the event loop on large or complex diffs. New files (oldContent="")
+    // get an empty diff — no meaningful "before" to compare against.
+    const diff = (() => {
+      if (!contentOld) return ""
+      const result = structuredPatch(filepath, filepath, contentOld, params.content, undefined, undefined, { timeout: 5000 })
+      if (!result) return ""
+      return trimDiff([
+        `Index: ${filepath}`,
+        "===================================================================",
+        `--- ${filepath}`,
+        `+++ ${filepath}`,
+        ...result.hunks.map((h) => [
+          `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`,
+          ...h.lines,
+        ].join("\n")),
+      ].join("\n"))
+    })()
 
     await ctx.ask({
       permission: "edit",

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -65,8 +65,7 @@ export const WriteTool = Tool.define("write", {
     await FileTime.read(ctx.sessionID, filepath)
 
     let output = "Wrote file successfully."
-    // Notify LSP asynchronously so it does not block the write response.
-    LSP.touchFile(filepath, true).catch(() => {})
+    await LSP.touchFile(filepath, true)
     const diagnostics = await LSP.diagnostics()
     const normalizedFilepath = Filesystem.normalizePath(filepath)
     let projectDiagnosticsCount = 0

--- a/packages/opencode/src/tool/write.txt
+++ b/packages/opencode/src/tool/write.txt
@@ -1,4 +1,4 @@
-Writes a file to the local filesystem.
+﻿Writes a file to the local filesystem.
 
 Usage:
 - This tool will overwrite the existing file if there is one at the provided path.
@@ -6,3 +6,4 @@ Usage:
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.
+- For large files (> ~150 lines), prefer using the Edit tool with targeted oldString/newString replacements instead of rewriting the entire file. This avoids blocking on large diff computation and is faster.


### PR DESCRIPTION
﻿### Issue for this PR

Closes #20477

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The write/edit/apply_patch tools call createTwoFilesPatch synchronously before showing the permission prompt. On large or heavily-modified content (e.g. a full file rewrite) the Myers diff algorithm can take many seconds, blocking the Node.js event loop the entire time and freezing the TUI on 'Preparing write...' / 'Preparing patch...'.

Fix: switch all three tools to structuredPatch (same underlying algorithm) with a hard 5-second timeout, matching the approach used in Claude Code's diff.ts. On timeout the diff preview is omitted but the permission prompt fires immediately and the file write is unaffected.

Also:
- edit.ts: replace the post-write diffLines pass with a line-count over the already-computed diff string, avoiding a second O(N*D) traversal
- apply_patch.ts: catch EEXIST from fs.mkdir on Windows (Bun 1.3.x bug where recursive:true still throws when the directory already exists)
- bash.ts: throttle ctx.metadata() updates to at most once per 100ms to avoid flooding the event loop during high-volume command output

### How did you verify your code works?

Ran bun test test/tool/ locally. All pre-existing passes still pass. Manually verified large file writes no longer hang indefinitely.

### Screenshots / recordings

_N/A - not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
