### PR TITLE
fix(opencode): truncate first user message as session title when no title model configured

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,4 +1,4 @@
-import path from "path"
+﻿import path from "path"
 import os from "os"
 import z from "zod"
 import { SessionID, MessageID, PartID } from "./schema"
@@ -209,12 +209,30 @@ export namespace SessionPrompt {
         const subtasks = firstUser.parts.filter((p): p is MessageV2.SubtaskPart => p.type === "subtask")
         const onlySubtasks = subtasks.length > 0 && firstUser.parts.every((p) => p.type === "subtask")
 
+        // Truncate the first line of the user's message directly as the title.
+        // This is instant and costs no tokens. Falls through to LLM-based
+        // naming only when a dedicated title agent model is explicitly configured.
         const ag = yield* agents.get("title")
-        if (!ag) return
-        const mdl = ag.model
-          ? yield* provider.getModel(ag.model.providerID, ag.model.modelID)
-          : ((yield* provider.getSmallModel(input.providerID)) ??
-            (yield* provider.getModel(input.providerID, input.modelID)))
+        if (!ag?.model) {
+          const text = firstUser.parts
+            .filter((p): p is MessageV2.TextPart => p.type === "text" && !p.synthetic)
+            .map((p) => p.text)
+            .join(" ")
+            .trim()
+          if (!text) return
+          const firstLine = text.split("\n")[0].trim()
+          const t = firstLine.length > 100 ? firstLine.substring(0, 97) + "..." : firstLine
+          if (!t) return
+          yield* sessions
+            .setTitle({ sessionID: input.session.id, title: t })
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.sync(() => log.error("failed to set title from prompt", { error: Cause.squash(cause) })),
+              ),
+            )
+          return
+        }
+        const mdl = yield* provider.getModel(ag.model.providerID, ag.model.modelID)
         const msgs = onlySubtasks
           ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\n") }]
           : yield* MessageV2.toModelMessagesEffect(context, mdl)

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -1239,3 +1239,111 @@ unix(
     ),
   30_000,
 )
+
+// Title auto-generation semantics
+
+it.live("loop sets session title from first user message when no title model is configured", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+
+      const chat = yield* sessions.create({
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "How do I fix the memory leak in my Unity game?" }],
+      })
+      yield* llm.text("here is my answer")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const updated = yield* sessions.get(chat.id)
+      expect(updated.title).toBe("How do I fix the memory leak in my Unity game?")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop truncates long first message to 100 chars with ellipsis as title", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+
+      const longText = "A".repeat(120)
+      const chat = yield* sessions.create({
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: longText }],
+      })
+      yield* llm.text("ok")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const updated = yield* sessions.get(chat.id)
+      expect(updated.title).toBe("A".repeat(97) + "...")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop uses only first line of multiline user message as title", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+
+      const chat = yield* sessions.create({
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "First line of message\nSecond line should be ignored\nThird line too" }],
+      })
+      yield* llm.text("ok")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const updated = yield* sessions.get(chat.id)
+      expect(updated.title).toBe("First line of message")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop does not overwrite manually set session title", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+
+      const chat = yield* sessions.create({
+        title: "My Custom Title",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        noReply: true,
+        parts: [{ type: "text", text: "This should not override the title" }],
+      })
+      yield* llm.text("ok")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const updated = yield* sessions.get(chat.id)
+      expect(updated.title).toBe("My Custom Title")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)


### PR DESCRIPTION
﻿### Issue for this PR

Closes #20501

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Without a dedicated title model configured, sessions were named with raw ISO timestamps (e.g. "New Session 2026-01-01T12:00:00.000Z"), making the session list completely unusable. When small_model was configured, the LLM would generate a title but the result was often too abstract and didn't reflect what the session was actually about.

This PR derives the session title directly from the first line of the user's first message when no explicit agent.title.model is configured. This is instant, costs no tokens, and always produces an accurate and recognizable title.

LLM-based title generation is preserved for users who explicitly configure a model under agent.title.model.

### How did you verify your code works?

Manually tested: sent a first message in a new session, confirmed the session title immediately updated to the truncated first line of the message without any LLM call.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
