### PR TITLE
fix(tui): keep tab inside shell mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -35,6 +35,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { shellAction } from "./shell"
 
 export type PromptProps = {
   sessionID?: string
@@ -939,8 +940,13 @@ export function Prompt(props: PromptProps) {
                   return
                 }
                 if (store.mode === "shell") {
-                  if ((e.name === "backspace" && input.visualCursor.offset === 0) || e.name === "escape") {
+                  const action = shellAction(e.name, input.visualCursor.offset)
+                  if (action === "normal") {
                     setStore("mode", "normal")
+                    e.preventDefault()
+                    return
+                  }
+                  if (action === "consume") {
                     e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/shell.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/shell.ts
@@ -1,0 +1,4 @@
+export function shellAction(name: string | undefined, offset: number) {
+  if ((name === "backspace" && offset === 0) || name === "escape") return "normal"
+  if (name === "tab") return "consume"
+}

--- a/packages/opencode/test/cli/cmd/tui/prompt-shell.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/prompt-shell.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { shellAction } from "../../../../src/cli/cmd/tui/component/prompt/shell"
+
+describe("prompt shell mode", () => {
+  test("consumes tab so it does not bubble to global agent cycle", () => {
+    expect(shellAction("tab", 3)).toBe("consume")
+  })
+
+  test("backspace at the start exits shell mode", () => {
+    expect(shellAction("backspace", 0)).toBe("normal")
+  })
+
+  test("escape exits shell mode", () => {
+    expect(shellAction("escape", 3)).toBe("normal")
+  })
+
+  test("backspace away from the start stays in shell mode", () => {
+    expect(shellAction("backspace", 2)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20328

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In shell mode, `Tab` was not handled by the prompt, so it could bubble to the global `agent_cycle` shortcut and switch agents unexpectedly.

This change consumes `Tab` while shell mode is active and adds a small regression test around the shell-mode key handling.

### How did you verify your code works?

- `bun test test/cli/cmd/tui/prompt-shell.test.ts`
- `bun typecheck`
- confirmed the new test fails without the `Tab` handling and passes with the fix

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR