### PR TITLE
fix(tui): handle external SIGTSTP to prevent mouse garbling on suspend

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -192,6 +192,21 @@ export function tui(input: {
 
     const renderer = await createCliRenderer(rendererConfig(input.config))
 
+    // Handle external SIGTSTP (e.g., code-server terminal management, job control)
+    // to properly disable mouse tracking before suspension. Without this, the shell
+    // receives mouse events as garbled escape sequences.
+    const sigtstpHandler = () => {
+      renderer.suspend()
+      process.removeListener("SIGTSTP", sigtstpHandler)
+      process.kill(process.pid, "SIGTSTP")
+    }
+    const sigcontHandler = () => {
+      process.on("SIGTSTP", sigtstpHandler)
+      renderer.resume()
+    }
+    process.on("SIGTSTP", sigtstpHandler)
+    process.on("SIGCONT", sigcontHandler)
+
     await render(() => {
       return (
         <ErrorBoundary

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -195,14 +195,21 @@ export function tui(input: {
     // Handle external SIGTSTP (e.g., code-server terminal management, job control)
     // to properly disable mouse tracking before suspension. Without this, the shell
     // receives mouse events as garbled escape sequences.
+    // Guard resume() with a flag to prevent duplicate stdin listeners when SIGCONT
+    // arrives without a prior SIGTSTP through our handler (e.g., terminal refocus).
+    let suspendedBySigtstp = false
     const sigtstpHandler = () => {
+      suspendedBySigtstp = true
       renderer.suspend()
       process.removeListener("SIGTSTP", sigtstpHandler)
       process.kill(process.pid, "SIGTSTP")
     }
     const sigcontHandler = () => {
       process.on("SIGTSTP", sigtstpHandler)
-      renderer.resume()
+      if (suspendedBySigtstp) {
+        suspendedBySigtstp = false
+        renderer.resume()
+      }
     }
     process.on("SIGTSTP", sigtstpHandler)
     process.on("SIGCONT", sigcontHandler)

--- a/packages/opencode/test/cli/tui/test-sigtstp-mouse.sh
+++ b/packages/opencode/test/cli/tui/test-sigtstp-mouse.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Reproduction script for SIGTSTP mouse garbling.
+#
+# Usage:
+#   1. In Terminal 1: Run opencode normally
+#   2. In Terminal 2: Run this script with the opencode PID:
+#      ./test-sigtstp-mouse.sh <PID>
+#   3. In Terminal 1: Move the mouse after opencode is suspended
+#
+# Without the fix: garbled escape sequences appear (35;89;19M35;84;20M...)
+# With the fix: clean shell prompt, no garbled text
+#
+# You can also test without opencode by using any TUI that enables mouse:
+#   python3 -c "import sys; sys.stdout.write('\x1b[?1003h\x1b[?1006h'); input()"
+#   Then send SIGTSTP from another terminal.
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <PID>"
+  echo ""
+  echo "Sends SIGTSTP to the given PID to test mouse cleanup."
+  echo "Run opencode in another terminal first, then pass its PID."
+  echo ""
+  echo "Find the PID with: pgrep -f opencode"
+  exit 1
+fi
+
+PID="$1"
+
+echo "Sending SIGTSTP to PID $PID..."
+echo "Switch to the opencode terminal and move the mouse."
+echo "If you see garbled text like '35;89;19M35;84;20M...' the bug is present."
+echo ""
+
+kill -TSTP "$PID"
+
+echo "Done. Resume with: kill -CONT $PID  (or 'fg' in the opencode terminal)"


### PR DESCRIPTION
### Issue for this PR

Closes #20506

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode receives SIGTSTP from an external source (code-server terminal management during inactivity, job control, `kill -TSTP`), the process is suspended without terminal cleanup. Mouse tracking remains enabled, causing mouse events to echo as garbled escape sequences in the shell.

This PR registers SIGTSTP/SIGCONT handlers in `app.tsx` after renderer creation:
- **SIGTSTP handler**: calls `renderer.suspend()` (disables mouse, raw mode), removes itself, re-raises SIGTSTP
- **SIGCONT handler**: re-registers SIGTSTP handler, calls `renderer.resume()`

This is the same cleanup pattern the manual suspend keybind already uses.

**Upstream fix:** https://github.com/anomalyco/opentui/pull/907

### How did you verify your code works?

- The handlers delegate to `renderer.suspend()`/`resume()` which are proven correct (used by the existing suspend keybind)
- Includes `test-sigtstp-mouse.sh` reproduction script:
  ```bash
  # Terminal 1: run opencode
  # Terminal 2: ./test-sigtstp-mouse.sh $(pgrep -f opencode)
  # Terminal 1: move mouse → should be clean (no garbled text)
  ```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


🤖 Generated with [Claude Code](https://claude.com/claude-code)