### PR TITLE
feat(app): add .agents directory as alternative path for agents

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -288,7 +288,14 @@ export namespace Config {
       })
       if (!md) continue
 
-      const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
+      const patterns = [
+        "/.opencode/agent/",
+        "/.opencode/agents/",
+        "/.agents/agent/",
+        "/.agents/agents/",
+        "/agent/",
+        "/agents/",
+      ]
       const file = rel(item, patterns) ?? path.basename(item)
       const agentName = trim(file)
 

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -25,7 +25,7 @@ export namespace ConfigPaths {
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? await Array.fromAsync(
             Filesystem.up({
-              targets: [".opencode"],
+              targets: [".opencode", ".agents"],
               start: directory,
               stop: worktree,
             }),
@@ -33,7 +33,7 @@ export namespace ConfigPaths {
         : []),
       ...(await Array.fromAsync(
         Filesystem.up({
-          targets: [".opencode"],
+          targets: [".opencode", ".agents"],
           start: Global.Path.home,
           stop: Global.Path.home,
         }),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -607,6 +607,55 @@ Nested agent prompt`,
   })
 })
 
+test("loads agents from .agents/agents (plural)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const agentsDir = path.join(dir, ".agents", "agents")
+      await fs.mkdir(path.join(agentsDir, "nested"), { recursive: true })
+
+      await Filesystem.write(
+        path.join(agentsDir, "custom-helper.md"),
+        `---
+model: test/model
+mode: subagent
+description: Custom helper from .agents
+---
+Custom helper agent prompt`,
+      )
+
+      await Filesystem.write(
+        path.join(agentsDir, "nested", "deep-agent.md"),
+        `---
+model: test/model
+mode: subagent
+---
+Nested custom agent prompt`,
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+
+      expect(config.agent?.["custom-helper"]).toMatchObject({
+        name: "custom-helper",
+        model: "test/model",
+        mode: "subagent",
+        prompt: "Custom helper agent prompt",
+      })
+
+      expect(config.agent?.["nested/deep-agent"]).toMatchObject({
+        name: "nested/deep-agent",
+        model: "test/model",
+        mode: "subagent",
+        prompt: "Nested custom agent prompt",
+      })
+    },
+  })
+})
+
 test("loads commands from .opencode/command (singular)", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #20510 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Support .agents/ alongside .opencode/ for agent files. This allows users to keep their custom agents in a separate directory. Newly agents in .agents folder are supported via /agents and @ trigger.

### How did you verify your code works?

Created .agents/agents/{agent_name}.md file in the project, run opencode . and checked via /agents and tagging @agent - resolved succesfully. Also included a test.

### Screenshots / recordings
<img width="600" height="258" alt="image" src="https://github.com/user-attachments/assets/52f53b88-720a-4e38-bb34-28cf59dd4bcf" />
<img width="596" height="303" alt="image" src="https://github.com/user-attachments/assets/b441066b-8dac-47cb-99c7-8b4c45c8a50d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
