### PR TITLE
fix(tui): restore exit shortcuts on plugin routes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app-exit.ts
+++ b/packages/opencode/src/cli/cmd/tui/app-exit.ts
@@ -1,0 +1,5 @@
+import type { Route } from "./context/route"
+
+export function shouldExit(route: Route["type"]) {
+  return route === "plugin"
+}

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -59,6 +59,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { shouldExit } from "./app-exit"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -324,6 +325,15 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
 
     renderer.clearSelection()
+  })
+
+  useKeyboard((evt) => {
+    if (evt.defaultPrevented) return
+    if (!shouldExit(route.data.type)) return
+    if (!keybind.match("app_exit", evt)) return
+    exit()
+    evt.preventDefault()
+    evt.stopPropagation()
   })
 
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback

--- a/packages/opencode/test/cli/tui/app-exit.test.ts
+++ b/packages/opencode/test/cli/tui/app-exit.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test"
+import { shouldExit } from "../../../src/cli/cmd/tui/app-exit"
+
+describe("shouldExit", () => {
+  test("allows app exit on plugin routes", () => {
+    expect(shouldExit("plugin")).toBe(true)
+  })
+
+  test("does not claim session routes", () => {
+    expect(shouldExit("session")).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20069

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin routes did not have a fallback `app_exit` handler, so `Ctrl+C`, `Ctrl+D`, and `leader+q` could stop working after navigating into a plugin route.

This adds a small app-level plugin-route fallback for `app_exit` and a regression test covering that route behavior.

### How did you verify your code works?

- `bun test test/cli/tui/app-exit.test.ts`
- `bun typecheck`
- confirmed the regression test fails before the fix and passes after restoring plugin-route exit handling

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR