### PR TITLE
chore: always put `offset` before `limit`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -104,11 +104,14 @@ function grep(info: ToolProps<typeof GrepTool>) {
 
 function read(info: ToolProps<typeof ReadTool>) {
   const file = normalizePath(info.input.filePath)
-  const pairs = Object.entries(info.input).filter(([key, value]) => {
-    if (key === "filePath") return false
-    return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
-  })
-  const description = pairs.length ? `[${pairs.map(([key, value]) => `${key}=${value}`).join(", ")}]` : undefined
+  const parts: string[] = []
+  if (info.input.offset !== undefined) {
+    parts.push(`offset=${info.input.offset}`)
+  }
+  if (info.input.limit !== undefined) {
+    parts.push(`limit=${info.input.limit}`)
+  }
+  const description = parts.length ? `[${parts.join(", ")}]` : undefined
   inline({
     icon: "→",
     title: `Read ${file}`,


### PR DESCRIPTION
### Issue for this PR

Closes #20520


### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation


### What does this PR do?

Make so that in `Read` tool call output that user sees, `offset` is always before `limit` because that makes more sense


### How did you verify your code works?

By running locally


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
