### PR TITLE
fix(server): include live routes in /doc

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,5 +1,5 @@
 import { Log } from "../util/log"
-import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
+import { describeRoute, generateSpecs, validator, resolver } from "hono-openapi"
 import { Hono } from "hono"
 import { compress } from "hono/compress"
 import { cors } from "hono/cors"
@@ -160,19 +160,9 @@ export namespace Server {
           return c.json(true)
         },
       )
-      .get(
-        "/doc",
-        openAPIRouteHandler(app, {
-          documentation: {
-            info: {
-              title: "opencode",
-              version: "0.0.3",
-              description: "opencode api",
-            },
-            openapi: "3.1.1",
-          },
-        }),
-      )
+      .get("/doc", async (c) => {
+        return c.json(await openapi())
+      })
       .use(
         validator(
           "query",

--- a/packages/opencode/test/server/doc-openapi.test.ts
+++ b/packages/opencode/test/server/doc-openapi.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+import { resetDatabase } from "../fixture/db"
+
+afterEach(async () => {
+  await resetDatabase()
+})
+
+describe("/doc", () => {
+  test("includes live instance routes in the generated spec", async () => {
+    const app = Server.Default()
+
+    const doc = await app.request("/doc")
+    expect(doc.status).toBe(200)
+
+    const body = await doc.json()
+    expect(Object.keys(body.paths)).toContain("/project/current")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20295

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The live `/doc` endpoint only exposed control-plane routes, while the generated OpenAPI spec already included the full set of instance routes.

This switches `/doc` to return `Server.openapi()` so the live endpoint matches the full API surface, and adds a regression test that checks `/project/current` is present in the generated paths.

### How did you verify your code works?

- `bun test test/server/doc-openapi.test.ts`
- `bun typecheck`
- confirmed the regression test fails before the fix and passes once `/doc` uses `Server.openapi()`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR