### PR TITLE
chore: drop OPENCODE_API_KEY and REQUIRE_PAID from e2e workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,9 +100,6 @@ jobs:
         run: bun --cwd packages/app test:e2e:local
         env:
           CI: true
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          OPENCODE_E2E_MODEL: opencode/claude-haiku-4-5
-          OPENCODE_E2E_REQUIRE_PAID: "true"
         timeout-minutes: 30
 
       - name: Upload Playwright artifacts

--- a/packages/app/e2e/session/session-child-navigation.spec.ts
+++ b/packages/app/e2e/session/session-child-navigation.spec.ts
@@ -1,8 +1,14 @@
 import { seedSessionTask, withSession } from "../actions"
 import { test, expect } from "../fixtures"
+import { openaiModel, withMockOpenAI } from "../prompt/mock"
 import { promptSelector } from "../selectors"
 
-test("task tool child-session link does not trigger stale show errors", async ({ page, withBackendProject }) => {
+test("task tool child-session link does not trigger stale show errors", async ({
+  page,
+  llm,
+  backend,
+  withBackendProject,
+}) => {
   test.setTimeout(120_000)
 
   const errs: string[] = []
@@ -12,28 +18,43 @@ test("task tool child-session link does not trigger stale show errors", async ({
   page.on("pageerror", onError)
 
   try {
-    await withBackendProject(async ({ gotoSession, trackSession, sdk }) => {
-      await withSession(sdk, `e2e child nav ${Date.now()}`, async (session) => {
-        const child = await seedSessionTask(sdk, {
-          sessionID: session.id,
-          description: "Open child session",
-          prompt: "Search the repository for AssistantParts and then reply with exactly CHILD_OK.",
-        })
-        trackSession(child.sessionID)
+    await withMockOpenAI({
+      serverUrl: backend.url,
+      llmUrl: llm.url,
+      fn: async () => {
+        await withBackendProject(
+          async ({ gotoSession, trackSession, sdk }) => {
+            await withSession(sdk, `e2e child nav ${Date.now()}`, async (session) => {
+              const taskInput = {
+                description: "Open child session",
+                prompt: "Search the repository for AssistantParts and then reply with exactly CHILD_OK.",
+                subagent_type: "general",
+              }
+              await llm.tool("task", taskInput)
+              const child = await seedSessionTask(sdk, {
+                sessionID: session.id,
+                description: taskInput.description,
+                prompt: taskInput.prompt,
+              })
+              trackSession(child.sessionID)
 
-        await gotoSession(session.id)
+              await gotoSession(session.id)
 
-        const link = page
-          .locator("a.subagent-link")
-          .filter({ hasText: /open child session/i })
-          .first()
-        await expect(link).toBeVisible({ timeout: 30_000 })
-        await link.click()
+              const link = page
+                .locator("a.subagent-link")
+                .filter({ hasText: /open child session/i })
+                .first()
+              await expect(link).toBeVisible({ timeout: 30_000 })
+              await link.click()
 
-        await expect(page).toHaveURL(new RegExp(`/session/${child.sessionID}(?:[/?#]|$)`), { timeout: 30_000 })
-        await expect(page.locator(promptSelector)).toBeVisible({ timeout: 30_000 })
-        await expect.poll(() => errs, { timeout: 5_000 }).toEqual([])
-      })
+              await expect(page).toHaveURL(new RegExp(`/session/${child.sessionID}(?:[/?#]|$)`), { timeout: 30_000 })
+              await expect(page.locator(promptSelector)).toBeVisible({ timeout: 30_000 })
+              await expect.poll(() => errs, { timeout: 5_000 }).toEqual([])
+            })
+          },
+          { model: openaiModel },
+        )
+      },
     })
   } finally {
     page.off("pageerror", onError)

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -14,6 +14,7 @@ import {
   sessionTodoToggleButtonSelector,
 } from "../selectors"
 import { modKey } from "../utils"
+import { openaiModel, withMockOpenAI } from "../prompt/mock"
 
 type Sdk = Parameters<typeof clearSessionDockSeed>[0]
 type PermissionRule = { permission: string; pattern: string; action: "allow" | "deny" | "ask" }
@@ -291,121 +292,154 @@ test("auto-accept toggle works before first submit", async ({ page, withBackendP
   })
 })
 
-test("blocked question flow unblocks after submit", async ({ page, withBackendProject }) => {
-  await withBackendProject(async (project) => {
-    await withDockSession(
-      project.sdk,
-      "e2e composer dock question",
-      async (session) => {
-        await withDockSeed(project.sdk, session.id, async () => {
-          await project.gotoSession(session.id)
+test("blocked question flow unblocks after submit", async ({ page, llm, backend, withBackendProject }) => {
+  const questions = [
+    {
+      header: "Need input",
+      question: "Pick one option",
+      options: [
+        { label: "Continue", description: "Continue now" },
+        { label: "Stop", description: "Stop here" },
+      ],
+    },
+  ]
+  await withMockOpenAI({
+    serverUrl: backend.url,
+    llmUrl: llm.url,
+    fn: async () => {
+      await withBackendProject(
+        async (project) => {
+          await withDockSession(
+            project.sdk,
+            "e2e composer dock question",
+            async (session) => {
+              await withDockSeed(project.sdk, session.id, async () => {
+                await project.gotoSession(session.id)
 
-          await seedSessionQuestion(project.sdk, {
-            sessionID: session.id,
-            questions: [
-              {
-                header: "Need input",
-                question: "Pick one option",
-                options: [
-                  { label: "Continue", description: "Continue now" },
-                  { label: "Stop", description: "Stop here" },
-                ],
-              },
-            ],
-          })
+                await llm.tool("question", { questions })
+                await seedSessionQuestion(project.sdk, {
+                  sessionID: session.id,
+                  questions,
+                })
 
-          const dock = page.locator(questionDockSelector)
-          await expectQuestionBlocked(page)
+                const dock = page.locator(questionDockSelector)
+                await expectQuestionBlocked(page)
 
-          await dock.locator('[data-slot="question-option"]').first().click()
-          await dock.getByRole("button", { name: /submit/i }).click()
+                await dock.locator('[data-slot="question-option"]').first().click()
+                await dock.getByRole("button", { name: /submit/i }).click()
 
-          await expectQuestionOpen(page)
-        })
-      },
-      { trackSession: project.trackSession },
-    )
+                await expectQuestionOpen(page)
+              })
+            },
+            { trackSession: project.trackSession },
+          )
+        },
+        { model: openaiModel },
+      )
+    },
   })
 })
 
-test("blocked question flow supports keyboard shortcuts", async ({ page, withBackendProject }) => {
-  await withBackendProject(async (project) => {
-    await withDockSession(
-      project.sdk,
-      "e2e composer dock question keyboard",
-      async (session) => {
-        await withDockSeed(project.sdk, session.id, async () => {
-          await project.gotoSession(session.id)
+test("blocked question flow supports keyboard shortcuts", async ({ page, llm, backend, withBackendProject }) => {
+  const questions = [
+    {
+      header: "Need input",
+      question: "Pick one option",
+      options: [
+        { label: "Continue", description: "Continue now" },
+        { label: "Stop", description: "Stop here" },
+      ],
+    },
+  ]
+  await withMockOpenAI({
+    serverUrl: backend.url,
+    llmUrl: llm.url,
+    fn: async () => {
+      await withBackendProject(
+        async (project) => {
+          await withDockSession(
+            project.sdk,
+            "e2e composer dock question keyboard",
+            async (session) => {
+              await withDockSeed(project.sdk, session.id, async () => {
+                await project.gotoSession(session.id)
 
-          await seedSessionQuestion(project.sdk, {
-            sessionID: session.id,
-            questions: [
-              {
-                header: "Need input",
-                question: "Pick one option",
-                options: [
-                  { label: "Continue", description: "Continue now" },
-                  { label: "Stop", description: "Stop here" },
-                ],
-              },
-            ],
-          })
+                await llm.tool("question", { questions })
+                await seedSessionQuestion(project.sdk, {
+                  sessionID: session.id,
+                  questions,
+                })
 
-          const dock = page.locator(questionDockSelector)
-          const first = dock.locator('[data-slot="question-option"]').first()
-          const second = dock.locator('[data-slot="question-option"]').nth(1)
+                const dock = page.locator(questionDockSelector)
+                const first = dock.locator('[data-slot="question-option"]').first()
+                const second = dock.locator('[data-slot="question-option"]').nth(1)
 
-          await expectQuestionBlocked(page)
-          await expect(first).toBeFocused()
+                await expectQuestionBlocked(page)
+                await expect(first).toBeFocused()
 
-          await page.keyboard.press("ArrowDown")
-          await expect(second).toBeFocused()
+                await page.keyboard.press("ArrowDown")
+                await expect(second).toBeFocused()
 
-          await page.keyboard.press("Space")
-          await page.keyboard.press(`${modKey}+Enter`)
-          await expectQuestionOpen(page)
-        })
-      },
-      { trackSession: project.trackSession },
-    )
+                await page.keyboard.press("Space")
+                await page.keyboard.press(`${modKey}+Enter`)
+                await expectQuestionOpen(page)
+              })
+            },
+            { trackSession: project.trackSession },
+          )
+        },
+        { model: openaiModel },
+      )
+    },
   })
 })
 
-test("blocked question flow supports escape dismiss", async ({ page, withBackendProject }) => {
-  await withBackendProject(async (project) => {
-    await withDockSession(
-      project.sdk,
-      "e2e composer dock question escape",
-      async (session) => {
-        await withDockSeed(project.sdk, session.id, async () => {
-          await project.gotoSession(session.id)
+test("blocked question flow supports escape dismiss", async ({ page, llm, backend, withBackendProject }) => {
+  const questions = [
+    {
+      header: "Need input",
+      question: "Pick one option",
+      options: [
+        { label: "Continue", description: "Continue now" },
+        { label: "Stop", description: "Stop here" },
+      ],
+    },
+  ]
+  await withMockOpenAI({
+    serverUrl: backend.url,
+    llmUrl: llm.url,
+    fn: async () => {
+      await withBackendProject(
+        async (project) => {
+          await withDockSession(
+            project.sdk,
+            "e2e composer dock question escape",
+            async (session) => {
+              await withDockSeed(project.sdk, session.id, async () => {
+                await project.gotoSession(session.id)
 
-          await seedSessionQuestion(project.sdk, {
-            sessionID: session.id,
-            questions: [
-              {
-                header: "Need input",
-                question: "Pick one option",
-                options: [
-                  { label: "Continue", description: "Continue now" },
-                  { label: "Stop", description: "Stop here" },
-                ],
-              },
-            ],
-          })
+                await llm.tool("question", { questions })
+                await seedSessionQuestion(project.sdk, {
+                  sessionID: session.id,
+                  questions,
+                })
 
-          const dock = page.locator(questionDockSelector)
-          const first = dock.locator('[data-slot="question-option"]').first()
+                const dock = page.locator(questionDockSelector)
+                const first = dock.locator('[data-slot="question-option"]').first()
 
-          await expectQuestionBlocked(page)
-          await expect(first).toBeFocused()
+                await expectQuestionBlocked(page)
+                await expect(first).toBeFocused()
 
-          await page.keyboard.press("Escape")
-          await expectQuestionOpen(page)
-        })
-      },
-      { trackSession: project.trackSession },
-    )
+                await page.keyboard.press("Escape")
+                await expectQuestionOpen(page)
+              })
+            },
+            { trackSession: project.trackSession },
+          )
+        },
+        { model: openaiModel },
+      )
+    },
   })
 })
 
@@ -512,54 +546,67 @@ test("blocked permission flow supports allow always", async ({ page, withBackend
 
 test("child session question request blocks parent dock and unblocks after submit", async ({
   page,
+  llm,
+  backend,
   withBackendProject,
 }) => {
-  await withBackendProject(async (project) => {
-    await withDockSession(
-      project.sdk,
-      "e2e composer dock child question parent",
-      async (session) => {
-        await project.gotoSession(session.id)
+  const questions = [
+    {
+      header: "Child input",
+      question: "Pick one child option",
+      options: [
+        { label: "Continue", description: "Continue child" },
+        { label: "Stop", description: "Stop child" },
+      ],
+    },
+  ]
+  await withMockOpenAI({
+    serverUrl: backend.url,
+    llmUrl: llm.url,
+    fn: async () => {
+      await withBackendProject(
+        async (project) => {
+          await withDockSession(
+            project.sdk,
+            "e2e composer dock child question parent",
+            async (session) => {
+              await project.gotoSession(session.id)
 
-        const child = await project.sdk.session
-          .create({
-            title: "e2e composer dock child question",
-            parentID: session.id,
-          })
-          .then((r) => r.data)
-        if (!child?.id) throw new Error("Child session create did not return an id")
-        project.trackSession(child.id)
+              const child = await project.sdk.session
+                .create({
+                  title: "e2e composer dock child question",
+                  parentID: session.id,
+                })
+                .then((r) => r.data)
+              if (!child?.id) throw new Error("Child session create did not return an id")
+              project.trackSession(child.id)
 
-        try {
-          await withDockSeed(project.sdk, child.id, async () => {
-            await seedSessionQuestion(project.sdk, {
-              sessionID: child.id,
-              questions: [
-                {
-                  header: "Child input",
-                  question: "Pick one child option",
-                  options: [
-                    { label: "Continue", description: "Continue child" },
-                    { label: "Stop", description: "Stop child" },
-                  ],
-                },
-              ],
-            })
+              try {
+                await withDockSeed(project.sdk, child.id, async () => {
+                  await llm.tool("question", { questions })
+                  await seedSessionQuestion(project.sdk, {
+                    sessionID: child.id,
+                    questions,
+                  })
 
-            const dock = page.locator(questionDockSelector)
-            await expectQuestionBlocked(page)
+                  const dock = page.locator(questionDockSelector)
+                  await expectQuestionBlocked(page)
 
-            await dock.locator('[data-slot="question-option"]').first().click()
-            await dock.getByRole("button", { name: /submit/i }).click()
+                  await dock.locator('[data-slot="question-option"]').first().click()
+                  await dock.getByRole("button", { name: /submit/i }).click()
 
-            await expectQuestionOpen(page)
-          })
-        } finally {
-          await cleanupSession({ sdk: project.sdk, sessionID: child.id })
-        }
-      },
-      { trackSession: project.trackSession },
-    )
+                  await expectQuestionOpen(page)
+                })
+              } finally {
+                await cleanupSession({ sdk: project.sdk, sessionID: child.id })
+              }
+            },
+            { trackSession: project.trackSession },
+          )
+        },
+        { model: openaiModel },
+      )
+    },
   })
 })
 
@@ -652,34 +699,45 @@ test("todo dock transitions and collapse behavior", async ({ page, withBackendPr
   })
 })
 
-test("keyboard focus stays off prompt while blocked", async ({ page, withBackendProject }) => {
-  await withBackendProject(async (project) => {
-    await withDockSession(
-      project.sdk,
-      "e2e composer dock keyboard",
-      async (session) => {
-        await withDockSeed(project.sdk, session.id, async () => {
-          await project.gotoSession(session.id)
+test("keyboard focus stays off prompt while blocked", async ({ page, llm, backend, withBackendProject }) => {
+  const questions = [
+    {
+      header: "Need input",
+      question: "Pick one option",
+      options: [{ label: "Continue", description: "Continue now" }],
+    },
+  ]
+  await withMockOpenAI({
+    serverUrl: backend.url,
+    llmUrl: llm.url,
+    fn: async () => {
+      await withBackendProject(
+        async (project) => {
+          await withDockSession(
+            project.sdk,
+            "e2e composer dock keyboard",
+            async (session) => {
+              await withDockSeed(project.sdk, session.id, async () => {
+                await project.gotoSession(session.id)
 
-          await seedSessionQuestion(project.sdk, {
-            sessionID: session.id,
-            questions: [
-              {
-                header: "Need input",
-                question: "Pick one option",
-                options: [{ label: "Continue", description: "Continue now" }],
-              },
-            ],
-          })
+                await llm.tool("question", { questions })
+                await seedSessionQuestion(project.sdk, {
+                  sessionID: session.id,
+                  questions,
+                })
 
-          await expectQuestionBlocked(page)
+                await expectQuestionBlocked(page)
 
-          await page.locator("main").click({ position: { x: 5, y: 5 } })
-          await page.keyboard.type("abc")
-          await expect(page.locator(promptSelector)).toHaveCount(0)
-        })
-      },
-      { trackSession: project.trackSession },
-    )
+                await page.locator("main").click({ position: { x: 5, y: 5 } })
+                await page.keyboard.type("abc")
+                await expect(page.locator(promptSelector)).toHaveCount(0)
+              })
+            },
+            { trackSession: project.trackSession },
+          )
+        },
+        { model: openaiModel },
+      )
+    },
   })
 })

--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -2,7 +2,6 @@ const dir = process.env.OPENCODE_E2E_PROJECT_DIR ?? process.cwd()
 const title = process.env.OPENCODE_E2E_SESSION_TITLE ?? "E2E Session"
 const text = process.env.OPENCODE_E2E_MESSAGE ?? "Seeded for UI e2e"
 const model = process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano"
-const requirePaid = process.env.OPENCODE_E2E_REQUIRE_PAID === "true"
 const parts = model.split("/")
 const providerID = parts[0] ?? "opencode"
 const modelID = parts[1] ?? "gpt-5-nano"
@@ -12,7 +11,6 @@ const seed = async () => {
   const { Instance } = await import("../src/project/instance")
   const { InstanceBootstrap } = await import("../src/project/bootstrap")
   const { Config } = await import("../src/config/config")
-  const { Provider } = await import("../src/provider/provider")
   const { Session } = await import("../src/session")
   const { MessageID, PartID } = await import("../src/session/schema")
   const { Project } = await import("../src/project/project")
@@ -26,19 +24,6 @@ const seed = async () => {
       fn: async () => {
         await Config.waitForDependencies()
         await ToolRegistry.ids()
-
-        if (requirePaid && providerID === "opencode" && !process.env.OPENCODE_API_KEY) {
-          throw new Error("OPENCODE_API_KEY is required when OPENCODE_E2E_REQUIRE_PAID=true")
-        }
-
-        const info = await Provider.getModel(ProviderID.make(providerID), ModelID.make(modelID))
-        if (requirePaid) {
-          const paid =
-            info.cost.input > 0 || info.cost.output > 0 || info.cost.cache.read > 0 || info.cost.cache.write > 0
-          if (!paid) {
-            throw new Error(`OPENCODE_E2E_MODEL must resolve to a paid model: ${providerID}/${modelID}`)
-          }
-        }
 
         const session = await Session.create({ title })
         const messageID = MessageID.ascending()


### PR DESCRIPTION
## Summary
- Remove `OPENCODE_API_KEY`, `OPENCODE_E2E_MODEL`, and `OPENCODE_E2E_REQUIRE_PAID` from the CI workflow
- Remove the paid-model guard and Provider import from `seed-e2e.ts`
- Fixes the Windows CI failure where `OPENCODE_API_KEY` was unavailable

## Context
All e2e tests now use the mock LLM server (via `withBackendProject` + `withMockOpenAI`) or `noReply` seeding. No test makes real provider calls, so the API key and paid-model enforcement are dead config.

Stacked on #20528.

## Test plan
- [x] `bun run typecheck` — no new errors
- [x] Seed script still creates session metadata with default `opencode/gpt-5-nano` model