### PR TITLE
refactor(summary): remove unnecessary Layer.unwrap

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -150,15 +150,11 @@ export namespace SessionSummary {
     }),
   )
 
-  export const defaultLayer = Layer.unwrap(
-    Effect.sync(() =>
-      layer.pipe(
-        Layer.provide(Session.defaultLayer),
-        Layer.provide(Snapshot.defaultLayer),
-        Layer.provide(Storage.defaultLayer),
-        Layer.provide(Bus.layer),
-      ),
-    ),
+  export const defaultLayer = layer.pipe(
+    Layer.provide(Session.defaultLayer),
+    Layer.provide(Snapshot.defaultLayer),
+    Layer.provide(Storage.defaultLayer),
+    Layer.provide(Bus.layer),
   )
 
   const { runPromise } = makeRuntime(Service, defaultLayer)


### PR DESCRIPTION
## Summary
- Remove `Layer.unwrap(Effect.sync(() => ...))` indirection from `SessionSummary.defaultLayer`
- No circular dependency between Session and SessionSummary, so direct `layer.pipe(Layer.provide(...))` works

## Test plan
- [x] Typecheck passes
- [x] Session tests pass (184/184)