### PR TITLE
test(ci): publish unit reports in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   unit:
@@ -45,13 +46,38 @@ jobs:
           git config --global user.email "bot@opencode.ai"
           git config --global user.name "opencode"
 
+      - name: Cache Turbo
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.cache/turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-
+            turbo-${{ runner.os }}-
+
       - name: Run unit tests
-        run: bun turbo test
+        run: bun turbo test:ci
         env:
-          # Bun 1.3.11 intermittently crashes on Windows during test teardown
-          # inside the native @parcel/watcher binding. Unit CI does not rely on
-          # the live watcher backend there, so disable it for that platform.
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
+
+      - name: Publish unit reports
+        if: always()
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: packages/*/.artifacts/unit/junit.xml
+          check_name: "unit results (${{ matrix.settings.name }})"
+          detailed_summary: true
+          include_time_in_summary: true
+          fail_on_failure: false
+
+      - name: Upload unit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-${{ matrix.settings.name }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: packages/*/.artifacts/unit/junit.xml
 
   e2e:
     name: e2e (${{ matrix.settings.name }})

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "test": "bun run test:unit",
+    "test:ci": "bun test --preload ./happydom.ts ./src --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "test:unit": "bun test --preload ./happydom.ts ./src",
     "test:unit:watch": "bun test --watch --preload ./happydom.ts ./src",
     "test:e2e": "playwright test",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -9,6 +9,7 @@
     "prepare": "effect-language-service patch || true",
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000",
+    "test:ci": "bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "build": "bun run script/build.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -13,9 +13,19 @@
       "outputs": [],
       "passThroughEnv": ["*"]
     },
+    "opencode#test:ci": {
+      "dependsOn": ["^build"],
+      "outputs": [".artifacts/unit/junit.xml"],
+      "passThroughEnv": ["*"]
+    },
     "@opencode-ai/app#test": {
       "dependsOn": ["^build"],
       "outputs": []
+    },
+    "@opencode-ai/app#test:ci": {
+      "dependsOn": ["^build"],
+      "outputs": [".artifacts/unit/junit.xml"],
+      "passThroughEnv": ["*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add JUnit reporting to unit tests via `test:ci` scripts with `--reporter=junit`
- Publish test results as GitHub check annotations via `mikepenz/action-junit-report`
- Upload JUnit XML as artifacts for debugging
- Add Turbo cache via `actions/cache`
- No structural changes to the test matrix — same `unit (linux)` / `unit (windows)` jobs as before

## Test plan
- [ ] `unit (linux)` passes with JUnit output
- [ ] `unit (windows)` passes with JUnit output
- [ ] JUnit annotations appear on PR checks
- [ ] Branch protection checks satisfied (same job names as before)