### PR TITLE
fix(tui): Don't overwrite the agent that was specified on the command line

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -37,6 +37,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { useArgs } from "@tui/context/args"
 
 export type PromptProps = {
   sessionID?: string
@@ -81,6 +82,7 @@ export function Prompt(props: PromptProps) {
 
   const keybind = useKeybind()
   const local = useLocal()
+  const args = useArgs()
   const sdk = useSDK()
   const route = useRoute()
   const sync = useSync()
@@ -202,7 +204,8 @@ export function Prompt(props: PromptProps) {
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
       if (msg.agent && isPrimaryAgent) {
-        local.agent.set(msg.agent)
+        // Keep command line --agent if specified.
+        if (!args.agent) local.agent.set(msg.agent)
         if (msg.model) {
           local.model.set(msg.model)
           local.model.variant.set(msg.model.variant)


### PR DESCRIPTION
If both -s and --agent are given, we should pick the agent from the latter.

### Issue for this PR

Closes #20536

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

At this point the command line arguments are already known; so we can simply check
for the existence of `args.agent` (with `const args = useArgs()`) to know if an --agent
command line parameter exists. If it does then the agent found in the last user message
of the given session ID -- that previously was unconditionally used to overwrite whatever
was in `local.agent` -- is no longer used. We simply keep the agent value that was
specified on the command line.

### How did you verify your code works?

I repeated the 'Steps to reproduce' steps of #20536.
I can now specify -s and --agent at the same time and pick any agent I want.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
