### PR TITLE
chore(tui): clean up scroll config follow-up

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -19,15 +19,7 @@ import { useSync } from "@tui/context/sync"
 import { SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { selectedForeground, useTheme } from "@tui/context/theme"
-import {
-  BoxRenderable,
-  ScrollBoxRenderable,
-  addDefaultParsers,
-  MacOSScrollAccel,
-  type ScrollAcceleration,
-  TextAttributes,
-  RGBA,
-} from "@opentui/core"
+import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
@@ -80,9 +72,9 @@ import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
+import { getScrollAcceleration } from "../../util/scroll"
 
 addDefaultParsers(parsers.parsers)
-import { getScrollAcceleration } from "../../util/scroll"
 
 const context = createContext<{
   width: number

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -10,7 +10,6 @@ import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
 import { Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
-import { useSync } from "@tui/context/sync"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../context/tui-config"
 
@@ -53,7 +52,6 @@ export type DialogSelectRef<T> = {
 export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const dialog = useDialog()
   const { theme } = useTheme()
-  const sync = useSync()
   const tuiConfig = useTuiConfig()
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
 

--- a/packages/opencode/src/cli/cmd/tui/util/scroll.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/scroll.ts
@@ -1,5 +1,5 @@
 import { MacOSScrollAccel, type ScrollAcceleration } from "@opentui/core"
-import { TuiConfig } from "@/config/tui"
+import type { TuiConfig } from "@/config/tui"
 
 export class CustomSpeedScroll implements ScrollAcceleration {
   constructor(private speed: number) {}
@@ -15,7 +15,7 @@ export function getScrollAcceleration(tuiConfig?: TuiConfig.Info): ScrollAcceler
   if (tuiConfig?.scroll_acceleration?.enabled) {
     return new MacOSScrollAccel()
   }
-  if (tuiConfig?.scroll_speed) {
+  if (tuiConfig?.scroll_speed !== undefined) {
     return new CustomSpeedScroll(tuiConfig.scroll_speed)
   }
 


### PR DESCRIPTION
## Summary
- remove the dead TUI import and local left behind after the scroll-config merge
- move the shared scroll helper import back into the main import block in the session route
- make the shared scroll speed check explicit and keep `TuiConfig` type-only in the helper

## Testing
- bun typecheck