### PR TITLE
fix(test): use effect helper in snapshot race test

### DIFF
--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -212,7 +212,7 @@ it.live("tool execution produces non-empty session diff (snapshot race)", () =>
       expect(fileExists).toBe(true)
 
       // Verify the tool call completed (in the first assistant message)
-      const allMsgs = yield* Effect.promise(() => MessageV2.filterCompacted(MessageV2.stream(session.id)))
+      const allMsgs = yield* MessageV2.filterCompactedEffect(session.id)
       const tool = allMsgs
         .flatMap((m) => m.parts)
         .find((p): p is MessageV2.ToolPart => p.type === "tool" && p.tool === "bash")


### PR DESCRIPTION
## Summary
- replace a synchronous `MessageV2.filterCompacted(...)` call wrapped in `Effect.promise(...)`
- use `MessageV2.filterCompactedEffect(...)` instead so the test matches the actual return type
- restore green typecheck and test runs on current `dev`

## Why
Latest `dev` was broken by this test. `Effect.promise` expects a promise-returning callback, but `MessageV2.filterCompacted(...)` returns a plain array. That broke typecheck and caused the snapshot race test to fail at runtime.

## Testing
- `bun typecheck`
- `bun run test ./test/session/snapshot-tool-race.test.ts`
- `bun run test`