### PR TITLE
refactor(instruction): complete new service migration

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -1,16 +1,18 @@
-import path from "path"
 import os from "os"
-import { Global } from "../global"
-import { Filesystem } from "../util/filesystem"
-import { Config } from "../config/config"
-import { Instance } from "../project/instance"
-import { Flag } from "@/flag/flag"
-import { Log } from "../util/log"
-import { Glob } from "../util/glob"
-import type { MessageV2 } from "./message-v2"
+import path from "path"
 import { Effect, Layer, ServiceMap } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { Flag } from "@/flag/flag"
+import { AppFileSystem } from "@/filesystem"
+import { withTransientReadRetry } from "@/util/effect-http-client"
+import { Global } from "../global"
+import { Instance } from "../project/instance"
+import { Log } from "../util/log"
+import type { MessageV2 } from "./message-v2"
+import type { MessageID } from "./schema"
 
 const log = Log.create({ service: "instruction" })
 
@@ -32,19 +34,6 @@ function globals() {
   return files
 }
 
-function relative(instruction: string): Promise<string[]> {
-  if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-    return Filesystem.globUp(instruction, Instance.directory, Instance.worktree).catch(() => [])
-  }
-  if (!Flag.OPENCODE_CONFIG_DIR) {
-    log.warn(
-      `Skipping relative instruction "${instruction}" - no OPENCODE_CONFIG_DIR set while project config is disabled`,
-    )
-    return Promise.resolve([])
-  }
-  return Filesystem.globUp(instruction, Flag.OPENCODE_CONFIG_DIR, Flag.OPENCODE_CONFIG_DIR).catch(() => [])
-}
-
 function extract(messages: MessageV2.WithParts[]) {
   const paths = new Set<string>()
   for (const msg of messages) {
@@ -64,132 +53,156 @@ function extract(messages: MessageV2.WithParts[]) {
 
 export namespace Instruction {
   export interface Interface {
-    readonly clear: (messageID: string) => Effect.Effect<void>
-    readonly systemPaths: () => Effect.Effect<Set<string>>
-    readonly system: () => Effect.Effect<string[]>
-    readonly find: (dir: string) => Effect.Effect<string | undefined>
+    readonly clear: (messageID: MessageID) => Effect.Effect<void>
+    readonly systemPaths: () => Effect.Effect<Set<string>, AppFileSystem.Error>
+    readonly system: () => Effect.Effect<string[], AppFileSystem.Error>
+    readonly find: (dir: string) => Effect.Effect<string | undefined, AppFileSystem.Error>
     readonly resolve: (
       messages: MessageV2.WithParts[],
       filepath: string,
-      messageID: string,
-    ) => Effect.Effect<{ filepath: string; content: string }[]>
+      messageID: MessageID,
+    ) => Effect.Effect<{ filepath: string; content: string }[], AppFileSystem.Error>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Instruction") {}
 
-  export const layer = Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const cfg = yield* Config.Service
+  export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Config.Service | HttpClient.HttpClient> =
+    Layer.effect(
+      Service,
+      Effect.gen(function* () {
+        const cfg = yield* Config.Service
+        const fs = yield* AppFileSystem.Service
+        const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
 
-      const state = yield* InstanceState.make(
-        Effect.fn("Instruction.state")(() =>
-          Effect.succeed({
-            claims: new Map<string, Set<string>>(),
-          }),
-        ),
-      )
+        const state = yield* InstanceState.make(
+          Effect.fn("Instruction.state")(() =>
+            Effect.succeed({
+              // Track which instruction files have already been attached for a given assistant message.
+              claims: new Map<MessageID, Set<string>>(),
+            }),
+          ),
+        )
 
-      const clear = Effect.fn("Instruction.clear")(function* (messageID: string) {
-        const s = yield* InstanceState.get(state)
-        s.claims.delete(messageID)
-      })
-
-      const systemPaths = Effect.fnUntraced(function* () {
-        const config = yield* cfg.get()
-        const paths = new Set<string>()
-
-        if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-          for (const file of FILES) {
-            const matches = yield* Effect.promise(() =>
-              Filesystem.findUp(file, Instance.directory, Instance.worktree),
+        const relative = Effect.fnUntraced(function* (instruction: string) {
+          if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+            return yield* fs
+              .globUp(instruction, Instance.directory, Instance.worktree)
+              .pipe(Effect.catch(() => Effect.succeed([] as string[])))
+          }
+          if (!Flag.OPENCODE_CONFIG_DIR) {
+            log.warn(
+              `Skipping relative instruction "${instruction}" - no OPENCODE_CONFIG_DIR set while project config is disabled`,
             )
-            if (matches.length > 0) {
-              matches.forEach((p) => paths.add(path.resolve(p)))
+            return []
+          }
+          return yield* fs
+            .globUp(instruction, Flag.OPENCODE_CONFIG_DIR, Flag.OPENCODE_CONFIG_DIR)
+            .pipe(Effect.catch(() => Effect.succeed([] as string[])))
+        })
+
+        const read = Effect.fnUntraced(function* (filepath: string) {
+          return yield* fs.readFileString(filepath).pipe(Effect.catch(() => Effect.succeed("")))
+        })
+
+        const fetch = Effect.fnUntraced(function* (url: string) {
+          const res = yield* http.execute(HttpClientRequest.get(url)).pipe(Effect.catch(() => Effect.succeed(null)))
+          if (!res) return ""
+          const body = yield* res.arrayBuffer.pipe(Effect.catch(() => Effect.succeed(new ArrayBuffer(0))))
+          return new TextDecoder().decode(body)
+        })
+
+        const clear = Effect.fn("Instruction.clear")(function* (messageID: MessageID) {
+          const s = yield* InstanceState.get(state)
+          s.claims.delete(messageID)
+        })
+
+        const systemPaths = Effect.fn("Instruction.systemPaths")(function* () {
+          const config = yield* cfg.get()
+          const paths = new Set<string>()
+
+          // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
+          if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+            for (const file of FILES) {
+              const matches = yield* fs.findUp(file, Instance.directory, Instance.worktree)
+              if (matches.length > 0) {
+                matches.forEach((item) => paths.add(path.resolve(item)))
+                break
+              }
+            }
+          }
+
+          for (const file of globals()) {
+            if (yield* fs.existsSafe(file)) {
+              paths.add(path.resolve(file))
               break
             }
           }
-        }
 
-        for (const file of globals()) {
-          if (yield* Effect.promise(() => Filesystem.exists(file))) {
-            paths.add(path.resolve(file))
-            break
-          }
-        }
-
-        if (config.instructions) {
-          for (const raw of config.instructions) {
-            if (raw.startsWith("https://") || raw.startsWith("http://")) continue
-            const instruction = raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(2)) : raw
-            const matches = yield* Effect.promise(() =>
-              path.isAbsolute(instruction)
-                ? Glob.scan(path.basename(instruction), {
-                    cwd: path.dirname(instruction),
-                    absolute: true,
-                    include: "file",
-                  }).catch(() => [])
-                : relative(instruction),
-            )
-            matches.forEach((p) => paths.add(path.resolve(p)))
-          }
-        }
-
-        return paths
-      })
-
-      const system = Effect.fnUntraced(function* () {
-        const config = yield* cfg.get()
-        const paths = yield* systemPaths()
-
-        const files = Array.from(paths).map(async (p) => {
-          const content = await Filesystem.readText(p).catch(() => "")
-          return content ? "Instructions from: " + p + "\n" + content : ""
-        })
-
-        const urls: string[] = []
-        if (config.instructions) {
-          for (const instruction of config.instructions) {
-            if (instruction.startsWith("https://") || instruction.startsWith("http://")) {
-              urls.push(instruction)
+          if (config.instructions) {
+            for (const raw of config.instructions) {
+              if (raw.startsWith("https://") || raw.startsWith("http://")) continue
+              const instruction = raw.startsWith("~/") ? path.join(os.homedir(), raw.slice(2)) : raw
+              const matches = yield* (
+                path.isAbsolute(instruction)
+                  ? fs.glob(path.basename(instruction), {
+                      cwd: path.dirname(instruction),
+                      absolute: true,
+                      include: "file",
+                    })
+                  : relative(instruction)
+              ).pipe(Effect.catch(() => Effect.succeed([] as string[])))
+              matches.forEach((item) => paths.add(path.resolve(item)))
             }
           }
-        }
-        const fetches = urls.map((url) =>
-          fetch(url, { signal: AbortSignal.timeout(5000) })
-            .then((res) => (res.ok ? res.text() : ""))
-            .catch(() => "")
-            .then((x) => (x ? "Instructions from: " + url + "\n" + x : "")),
-        )
 
-        return yield* Effect.promise(() => Promise.all([...files, ...fetches]).then((r) => r.filter(Boolean)))
-      })
+          return paths
+        })
 
-      const find = Effect.fnUntraced(function* (dir: string) {
-        for (const file of FILES) {
-          const filepath = path.resolve(path.join(dir, file))
-          if (yield* Effect.promise(() => Filesystem.exists(filepath))) return filepath
-        }
-      })
+        const system = Effect.fn("Instruction.system")(function* () {
+          const config = yield* cfg.get()
+          const paths = yield* systemPaths()
+          const urls = (config.instructions ?? []).filter(
+            (item) => item.startsWith("https://") || item.startsWith("http://"),
+          )
 
-      const resolve = Effect.fnUntraced(function* (
-        messages: MessageV2.WithParts[],
-        filepath: string,
-        messageID: string,
-      ) {
-        const sys = yield* systemPaths()
-        const already = extract(messages)
-        const results: { filepath: string; content: string }[] = []
-        const s = yield* InstanceState.get(state)
+          const files = yield* Effect.forEach(Array.from(paths), read, { concurrency: 8 })
+          const remote = yield* Effect.forEach(urls, fetch, { concurrency: 4 })
 
-        const target = path.resolve(filepath)
-        let current = path.dirname(target)
-        const root = path.resolve(Instance.directory)
+          return [
+            ...Array.from(paths).flatMap((item, i) => (files[i] ? [`Instructions from: ${item}\n${files[i]}`] : [])),
+            ...urls.flatMap((item, i) => (remote[i] ? [`Instructions from: ${item}\n${remote[i]}`] : [])),
+          ]
+        })
 
-        while (current.startsWith(root) && current !== root) {
-          const found = yield* find(current)
+        const find = Effect.fn("Instruction.find")(function* (dir: string) {
+          for (const file of FILES) {
+            const filepath = path.resolve(path.join(dir, file))
+            if (yield* fs.existsSafe(filepath)) return filepath
+          }
+        })
 
-          if (found && found !== target && !sys.has(found) && !already.has(found)) {
+        const resolve = Effect.fn("Instruction.resolve")(function* (
+          messages: MessageV2.WithParts[],
+          filepath: string,
+          messageID: MessageID,
+        ) {
+          const sys = yield* systemPaths()
+          const already = extract(messages)
+          const results: { filepath: string; content: string }[] = []
+          const s = yield* InstanceState.get(state)
+
+          const target = path.resolve(filepath)
+          const root = path.resolve(Instance.directory)
+          let current = path.dirname(target)
+
+          // Walk upward from the file being read and attach nearby instruction files once per message.
+          while (current.startsWith(root) && current !== root) {
+            const found = yield* find(current)
+            if (!found || found === target || sys.has(found) || already.has(found)) {
+              current = path.dirname(current)
+              continue
+            }
+
             let set = s.claims.get(messageID)
             if (!set) {
               set = new Set()
@@ -199,27 +212,32 @@ export namespace Instruction {
               current = path.dirname(current)
               continue
             }
+
             set.add(found)
-            const content = yield* Effect.promise(() => Filesystem.readText(found).catch(() => undefined))
+            const content = yield* read(found)
             if (content) {
-              results.push({ filepath: found, content: "Instructions from: " + found + "\n" + content })
+              results.push({ filepath: found, content: `Instructions from: ${found}\n${content}` })
             }
+
+            current = path.dirname(current)
           }
-          current = path.dirname(current)
-        }
 
-        return results
-      })
+          return results
+        })
 
-      return Service.of({ clear, systemPaths, system, find, resolve })
-    }),
+        return Service.of({ clear, systemPaths, system, find, resolve })
+      }),
+    )
+
+  export const defaultLayer = layer.pipe(
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(AppFileSystem.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
   )
-
-  export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer))
 
   const { runPromise } = makeRuntime(Service, defaultLayer)
 
-  export function clear(messageID: string) {
+  export function clear(messageID: MessageID) {
     return runPromise((svc) => svc.clear(messageID))
   }
 
@@ -239,10 +257,7 @@ export namespace Instruction {
     return runPromise((svc) => svc.find(dir))
   }
 
-  export async function resolve(messages: MessageV2.WithParts[], filepath: string, messageID: string) {
+  export async function resolve(messages: MessageV2.WithParts[], filepath: string, messageID: MessageID) {
     return runPromise((svc) => svc.resolve(messages, filepath, messageID))
   }
 }
-
-/** @deprecated Use `Instruction` instead */
-export const InstructionPrompt = Instruction

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -15,7 +15,7 @@ import { Instance } from "../project/instance"
 import { Bus } from "../bus"
 import { ProviderTransform } from "../provider/transform"
 import { SystemPrompt } from "./system"
-import { InstructionPrompt } from "./instruction"
+import { Instruction } from "./instruction"
 import { Plugin } from "../plugin"
 import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
@@ -979,7 +979,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           variant,
         }
 
-        yield* Effect.addFinalizer(() => InstanceState.withALS(() => InstructionPrompt.clear(info.id)))
+        yield* Effect.addFinalizer(() => InstanceState.withALS(() => Instruction.clear(info.id)))
 
         type Draft<T> = T extends MessageV2.Part ? Omit<T, "id"> & { id?: string } : never
         const assign = (part: Draft<MessageV2.Part>): MessageV2.Part => ({
@@ -1490,7 +1490,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   Promise.all([
                     SystemPrompt.skills(agent),
                     SystemPrompt.environment(model),
-                    InstructionPrompt.system(),
+                    Instruction.system(),
                     MessageV2.toModelMessages(msgs, model),
                   ]),
                 )
@@ -1542,7 +1542,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }),
               Effect.fnUntraced(function* (exit) {
                 if (Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)) yield* handle.abort()
-                yield* InstanceState.withALS(() => InstructionPrompt.clear(handle.message.id))
+                yield* InstanceState.withALS(() => Instruction.clear(handle.message.id))
               }),
             )
             if (outcome === "break") break

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -9,7 +9,7 @@ import { FileTime } from "../file/time"
 import DESCRIPTION from "./read.txt"
 import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
-import { InstructionPrompt } from "../session/instruction"
+import { Instruction } from "../session/instruction"
 import { Filesystem } from "../util/filesystem"
 
 const DEFAULT_READ_LIMIT = 2000
@@ -118,7 +118,7 @@ export const ReadTool = Tool.define("read", {
       }
     }
 
-    const instructions = await InstructionPrompt.resolve(ctx.messages, filepath, ctx.messageID)
+    const instructions = await Instruction.resolve(ctx.messages, filepath, ctx.messageID)
 
     // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
     const mime = Filesystem.mimeType(filepath)

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1,11 +1,53 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import path from "path"
-import { InstructionPrompt } from "../../src/session/instruction"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Instruction } from "../../src/session/instruction"
+import type { MessageV2 } from "../../src/session/message-v2"
 import { Instance } from "../../src/project/instance"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { Global } from "../../src/global"
 import { tmpdir } from "../fixture/fixture"
 
-describe("InstructionPrompt.resolve", () => {
+function loaded(filepath: string): MessageV2.WithParts[] {
+  const sessionID = SessionID.make("session-loaded-1")
+  const messageID = MessageID.make("message-loaded-1")
+
+  return [
+    {
+      info: {
+        id: messageID,
+        sessionID,
+        role: "user",
+        time: { created: 0 },
+        agent: "build",
+        model: {
+          providerID: ProviderID.make("anthropic"),
+          modelID: ModelID.make("claude-sonnet-4-20250514"),
+        },
+      },
+      parts: [
+        {
+          id: PartID.make("part-loaded-1"),
+          messageID,
+          sessionID,
+          type: "tool",
+          callID: "call-loaded-1",
+          tool: "read",
+          state: {
+            status: "completed",
+            input: {},
+            output: "done",
+            title: "Read",
+            metadata: { loaded: [filepath] },
+            time: { start: 0, end: 1 },
+          },
+        },
+      ],
+    },
+  ]
+}
+
+describe("Instruction.resolve", () => {
   test("returns empty when AGENTS.md is at project root (already in systemPaths)", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -16,10 +58,14 @@ describe("InstructionPrompt.resolve", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const system = await InstructionPrompt.systemPaths()
+        const system = await Instruction.systemPaths()
         expect(system.has(path.join(tmp.path, "AGENTS.md"))).toBe(true)
 
-        const results = await InstructionPrompt.resolve([], path.join(tmp.path, "src", "file.ts"), "test-message-1")
+        const results = await Instruction.resolve(
+          [],
+          path.join(tmp.path, "src", "file.ts"),
+          MessageID.make("message-test-1"),
+        )
         expect(results).toEqual([])
       },
     })
@@ -35,13 +81,13 @@ describe("InstructionPrompt.resolve", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const system = await InstructionPrompt.systemPaths()
+        const system = await Instruction.systemPaths()
         expect(system.has(path.join(tmp.path, "subdir", "AGENTS.md"))).toBe(false)
 
-        const results = await InstructionPrompt.resolve(
+        const results = await Instruction.resolve(
           [],
           path.join(tmp.path, "subdir", "nested", "file.ts"),
-          "test-message-2",
+          MessageID.make("message-test-2"),
         )
         expect(results.length).toBe(1)
         expect(results[0].filepath).toBe(path.join(tmp.path, "subdir", "AGENTS.md"))
@@ -60,17 +106,87 @@ describe("InstructionPrompt.resolve", () => {
       directory: tmp.path,
       fn: async () => {
         const filepath = path.join(tmp.path, "subdir", "AGENTS.md")
-        const system = await InstructionPrompt.systemPaths()
+        const system = await Instruction.systemPaths()
         expect(system.has(filepath)).toBe(false)
 
-        const results = await InstructionPrompt.resolve([], filepath, "test-message-2")
+        const results = await Instruction.resolve([], filepath, MessageID.make("message-test-3"))
         expect(results).toEqual([])
       },
     })
   })
+
+  test("does not reattach the same nearby instructions twice for one message", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", "AGENTS.md"), "# Subdir Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const filepath = path.join(tmp.path, "subdir", "nested", "file.ts")
+        const id = MessageID.make("message-claim-1")
+
+        const first = await Instruction.resolve([], filepath, id)
+        const second = await Instruction.resolve([], filepath, id)
+
+        expect(first).toHaveLength(1)
+        expect(first[0].filepath).toBe(path.join(tmp.path, "subdir", "AGENTS.md"))
+        expect(second).toEqual([])
+      },
+    })
+  })
+
+  test("clear allows nearby instructions to be attached again for the same message", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", "AGENTS.md"), "# Subdir Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const filepath = path.join(tmp.path, "subdir", "nested", "file.ts")
+        const id = MessageID.make("message-claim-2")
+
+        const first = await Instruction.resolve([], filepath, id)
+        await Instruction.clear(id)
+        const second = await Instruction.resolve([], filepath, id)
+
+        expect(first).toHaveLength(1)
+        expect(second).toHaveLength(1)
+        expect(second[0].filepath).toBe(path.join(tmp.path, "subdir", "AGENTS.md"))
+      },
+    })
+  })
+
+  test("skips instructions already reported by prior read metadata", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", "AGENTS.md"), "# Subdir Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agents = path.join(tmp.path, "subdir", "AGENTS.md")
+        const filepath = path.join(tmp.path, "subdir", "nested", "file.ts")
+        const id = MessageID.make("message-claim-3")
+
+        const results = await Instruction.resolve(loaded(agents), filepath, id)
+
+        expect(results).toEqual([])
+      },
+    })
+  })
+
+  test.todo("fetches remote instructions from config URLs via HttpClient", () => {})
 })
 
-describe("InstructionPrompt.systemPaths OPENCODE_CONFIG_DIR", () => {
+describe("Instruction.systemPaths OPENCODE_CONFIG_DIR", () => {
   let originalConfigDir: string | undefined
 
   beforeEach(() => {
@@ -106,7 +222,7 @@ describe("InstructionPrompt.systemPaths OPENCODE_CONFIG_DIR", () => {
       await Instance.provide({
         directory: projectTmp.path,
         fn: async () => {
-          const paths = await InstructionPrompt.systemPaths()
+          const paths = await Instruction.systemPaths()
           expect(paths.has(path.join(profileTmp.path, "AGENTS.md"))).toBe(true)
           expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(false)
         },
@@ -133,7 +249,7 @@ describe("InstructionPrompt.systemPaths OPENCODE_CONFIG_DIR", () => {
       await Instance.provide({
         directory: projectTmp.path,
         fn: async () => {
-          const paths = await InstructionPrompt.systemPaths()
+          const paths = await Instruction.systemPaths()
           expect(paths.has(path.join(profileTmp.path, "AGENTS.md"))).toBe(false)
           expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(true)
         },
@@ -159,7 +275,7 @@ describe("InstructionPrompt.systemPaths OPENCODE_CONFIG_DIR", () => {
       await Instance.provide({
         directory: projectTmp.path,
         fn: async () => {
-          const paths = await InstructionPrompt.systemPaths()
+          const paths = await Instruction.systemPaths()
           expect(paths.has(path.join(globalTmp.path, "AGENTS.md"))).toBe(true)
         },
       })


### PR DESCRIPTION
## Summary
- switch the instruction service to `AppFileSystem` and Effect HTTP helpers so it matches the rest of the refactor
- update `prompt.ts` and `read.ts` to use the new `Instruction` API and remove the old `InstructionPrompt` path
- expand instruction tests to cover claim clearing and already-loaded instruction metadata

## Testing
- `bun typecheck`
- `bun run test test/session/instruction.test.ts`