### PR TITLE
feat(tui): handle prompt.submit command in TUI event dispatcher

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -787,6 +787,10 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   ])
 
   sdk.event.on(TuiEvent.CommandExecute.type, (evt) => {
+    if (evt.properties.command === "prompt.submit") {
+      promptRef.current?.submit()
+      return
+    }
     command.trigger(evt.properties.command)
   })
 


### PR DESCRIPTION
## Summary

- Adds special handling for the `prompt.submit` command in the TUI `CommandExecute` event handler
- When the event command is `prompt.submit`, it directly calls `promptRef.current?.submit()` and returns early, bypassing the generic `command.trigger` path

## Changes

- `packages/opencode/src/cli/cmd/tui/app.tsx`: intercept `prompt.submit` in the event dispatcher to allow external events to submit the prompt