### PR TITLE
fix(build): replace require() with dynamic import() in cross-spawn-spawner

### DIFF
--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -491,12 +491,13 @@ export const defaultLayer = layer.pipe(Layer.provide(NodeFileSystem.layer), Laye
 
 import { lazy } from "@/util/lazy"
 
-const rt = lazy(() => {
+const rt = lazy(async () => {
   // Dynamic import to avoid circular dep: cross-spawn-spawner → run-service → Instance → project → cross-spawn-spawner
-  const { makeRuntime } = require("@/effect/run-service") as typeof import("@/effect/run-service")
+  const { makeRuntime } = await import("@/effect/run-service")
   return makeRuntime(ChildProcessSpawner, defaultLayer)
 })
 
-export const runPromiseExit: ReturnType<typeof rt>["runPromiseExit"] = (...args) =>
-  rt().runPromiseExit(...(args as [any]))
-export const runPromise: ReturnType<typeof rt>["runPromise"] = (...args) => rt().runPromise(...(args as [any]))
+type RT = Awaited<ReturnType<typeof rt>>
+export const runPromiseExit: RT["runPromiseExit"] = async (...args) =>
+  (await rt()).runPromiseExit(...(args as [any]))
+export const runPromise: RT["runPromise"] = async (...args) => (await rt()).runPromise(...(args as [any]))


### PR DESCRIPTION
## Summary
- The build fails because `cross-spawn-spawner.ts` uses `require("@/effect/run-service")` but the transitive dependency chain reaches `global/index.ts` which has a top-level `await` — Bun's bundler disallows `require()` in that case
- Replace the sync `require()` with `await import()` and make the `lazy()` callback async
- The `runPromiseExit` / `runPromise` exports now await the lazy promise before calling through

## Test plan
- [x] `bun run ./script/build.ts --single` passes (smoke test included)