### PR TITLE
fix(session): compaction agent responds in same language as conversation

### DIFF
--- a/packages/opencode/src/agent/prompt/compaction.txt
+++ b/packages/opencode/src/agent/prompt/compaction.txt
@@ -12,3 +12,4 @@ Focus on information that would be helpful for continuing the conversation, incl
 Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
 
 Do not respond to any questions in the conversation, only output the summary.
+Respond in the same language the user used in the conversation.

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -190,6 +190,7 @@ export namespace SessionCompaction {
 Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
 The summary that you construct will be used so that another agent can read it and continue the work.
 Do not call any tools. Respond only with the summary text.
+Respond in the same language as the user's messages in the conversation.
 
 When constructing the summary, try to stick to this template:
 ---


### PR DESCRIPTION
### Issue for this PR
Closes #20156

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
The compaction agent always generated summaries in English regardless of the language used in the conversation. Added a language matching instruction to both the compaction system prompt and the inline compaction prompt so the agent writes the summary in the same language the user was using.

### How did you verify your code works?
Started a conversation in Chinese, triggered compaction, verified the summary was generated in Chinese instead of English.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR