### PR TITLE
fix(session): prevent model options from overriding small model defaults

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -134,12 +134,18 @@ export namespace LLM {
           sessionID: input.sessionID,
           providerOptions: provider.options,
         })
-    const options: Record<string, any> = pipe(
-      base,
-      mergeDeep(input.model.options),
-      mergeDeep(input.agent.options),
-      mergeDeep(variant),
-    )
+    const options: Record<string, any> = input.small
+      ? pipe(
+          input.model.options ?? {},
+          mergeDeep(input.agent.options),
+          mergeDeep(base),
+        )
+      : pipe(
+          base,
+          mergeDeep(input.model.options),
+          mergeDeep(input.agent.options),
+          mergeDeep(variant),
+        )
     if (isOpenaiOauth) {
       options.instructions = system.join("\n")
     }


### PR DESCRIPTION
### Issue for this PR
Closes #20269

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When generating session titles using a small model, ProviderTransform.smallOptions() sets safe defaults like reasoningEffort: "low". However, these were immediately overridden by model.options and agent.options merged on top, causing the small model call to receive unsupported parameters and fail silently.

Reversed the merge order for small model calls so smallOptions takes precedence over model/agent options. The non-small path is completely unchanged.

### How did you verify your code works?
Configured a model with reasoningEffort: "high", started a session, verified title generation succeeds with the small model using "low" effort instead of inheriting "high".

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR