### PR TITLE
fix(tui): suppress AI SDK warnings before provider imports

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -59,6 +59,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { Log } from "@/util/log"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -181,7 +182,16 @@ export function tui(input: {
     // the original console mode which re-enables ENABLE_PROCESSED_INPUT.
     win32DisableProcessedInput()
 
+    // Redirect console.warn/error to the log service so third-party SDK
+    // warnings (e.g. OpenRouter) don't bleed into the TUI as raw text.
+    const _warn = console.warn
+    const _error = console.error
+    console.warn = (...args: any[]) => Log.Default.warn("console", { message: args.map(String).join(" ") })
+    console.error = (...args: any[]) => Log.Default.error("console", { message: args.map(String).join(" ") })
+
     const onExit = async () => {
+      console.warn = _warn
+      console.error = _error
       unguard?.()
       resolve()
     }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,3 +1,6 @@
+// @ts-ignore Suppress AI SDK warnings from bleeding into TUI as raw text
+globalThis.AI_SDK_LOG_WARNINGS = false
+
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,6 +1,3 @@
-// @ts-ignore Suppress AI SDK warnings from bleeding into TUI as raw text
-globalThis.AI_SDK_LOG_WARNINGS = false
-
 import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"


### PR DESCRIPTION
### Issue for this PR
Closes #20047

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
AI SDK warnings from providers like OpenRouter appeared as raw text in the TUI because AI_SDK_LOG_WARNINGS was only set in server.ts and prompt.ts, which load after provider initialization. Moved the flag to the top of the CLI entry point so it takes effect before any provider module is imported.

The same pattern already exists in server.ts line 21.

### How did you verify your code works?
Tested with OpenRouter provider configured. Warnings no longer appear as raw text in the TUI.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR