### PR TITLE
fix(tui): patch mouse garbling on SIGTSTP suspend and exit + PTY reproducers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -601,6 +601,7 @@
     "tree-sitter-bash",
   ],
   "patchedDependencies": {
+    "@opentui/core@0.1.95": "patches/@opentui%2Fcore@0.1.95.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
     "@ai-sdk/provider-utils@4.0.21": "patches/@ai-sdk%2Fprovider-utils@4.0.21.patch",
-    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch"
+    "@ai-sdk/anthropic@3.0.64": "patches/@ai-sdk%2Fanthropic@3.0.64.patch",
+    "@opentui/core@0.1.95": "patches/@opentui%2Fcore@0.1.95.patch"
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -192,6 +192,21 @@ export function tui(input: {
 
     const renderer = await createCliRenderer(rendererConfig(input.config))
 
+    // Handle external SIGTSTP (e.g., code-server terminal management, job control)
+    // to properly disable mouse tracking before suspension. Without this, the shell
+    // receives mouse events as garbled escape sequences.
+    const sigtstpHandler = () => {
+      renderer.suspend()
+      process.removeListener("SIGTSTP", sigtstpHandler)
+      process.kill(process.pid, "SIGTSTP")
+    }
+    const sigcontHandler = () => {
+      process.on("SIGTSTP", sigtstpHandler)
+      renderer.resume()
+    }
+    process.on("SIGTSTP", sigtstpHandler)
+    process.on("SIGCONT", sigcontHandler)
+
     await render(() => {
       return (
         <ErrorBoundary

--- a/packages/opencode/test/cli/tui/frag-pty.py
+++ b/packages/opencode/test/cli/tui/frag-pty.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+PTY wrapper that fragments mouse escape sequences before they reach opencode.
+Every mouse event is split byte-by-byte with 12ms delays between bytes.
+Keyboard input passes through instantly.
+
+Usage: python3 frag-pty.py opencode [args...]
+"""
+
+import os
+import pty
+import sys
+import select
+import time
+import struct
+import fcntl
+import termios
+import signal
+
+FRAGMENT_DELAY = 0.012  # 12ms — exceeds opentui's 10ms StdinParser timeout
+ESC = 0x1b
+
+def set_winsize(fd):
+    """Copy terminal size to PTY."""
+    try:
+        size = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, b'\x00' * 8)
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
+    except:
+        pass
+
+def contains_mouse_seq(data):
+    """Check if data contains SGR mouse sequence start: ESC [ <"""
+    for i in range(len(data) - 2):
+        if data[i] == ESC and data[i+1] == ord('[') and data[i+2] == ord('<'):
+            return True
+    return False
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 frag-pty.py opencode [args...]")
+        sys.exit(1)
+
+    # Create PTY
+    master_fd, slave_fd = pty.openpty()
+    set_winsize(master_fd)
+
+    pid = os.fork()
+    if pid == 0:
+        # Child: run opencode on the slave PTY
+        os.close(master_fd)
+        os.setsid()
+        fcntl.ioctl(slave_fd, termios.TIOCSCTTY, 0)
+        os.dup2(slave_fd, 0)
+        os.dup2(slave_fd, 1)
+        os.dup2(slave_fd, 2)
+        if slave_fd > 2:
+            os.close(slave_fd)
+        os.execvp(sys.argv[1], sys.argv[1:])
+
+    # Parent: proxy between terminal and master PTY
+    os.close(slave_fd)
+
+    # Save and set raw mode
+    old_attrs = termios.tcgetattr(sys.stdin.fileno())
+    try:
+        raw = termios.tcgetattr(sys.stdin.fileno())
+        raw[0] = 0  # iflag
+        raw[1] = 0  # oflag
+        raw[2] = raw[2] & ~(termios.CSIZE | termios.PARENB) | termios.CS8  # cflag
+        raw[3] = 0  # lflag
+        raw[6][termios.VMIN] = 1
+        raw[6][termios.VTIME] = 0
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, raw)
+    except:
+        pass
+
+    # Handle SIGWINCH — resize PTY when terminal resizes
+    def on_resize(signum, frame):
+        set_winsize(master_fd)
+        os.kill(pid, signal.SIGWINCH)
+    signal.signal(signal.SIGWINCH, on_resize)
+
+    # Handle child exit
+    done = False
+    def on_child(signum, frame):
+        nonlocal done
+        done = True
+    signal.signal(signal.SIGCHLD, on_child)
+
+    stdin_fd = sys.stdin.fileno()
+    stdout_fd = sys.stdout.fileno()
+
+    try:
+        while not done:
+            try:
+                rlist, _, _ = select.select([stdin_fd, master_fd], [], [], 0.1)
+            except (select.error, InterruptedError):
+                continue
+
+            if master_fd in rlist:
+                # PTY output → terminal (pass through immediately)
+                try:
+                    data = os.read(master_fd, 65536)
+                    if not data:
+                        break
+                    os.write(stdout_fd, data)
+                except OSError:
+                    break
+
+            if stdin_fd in rlist:
+                # Terminal input → check for mouse, fragment if needed
+                try:
+                    data = os.read(stdin_fd, 65536)
+                    if not data:
+                        break
+
+                    if contains_mouse_seq(data):
+                        # Fragment byte-by-byte with delay
+                        for byte in data:
+                            os.write(master_fd, bytes([byte]))
+                            time.sleep(FRAGMENT_DELAY)
+                    else:
+                        # Pass through immediately
+                        os.write(master_fd, data)
+                except OSError:
+                    break
+    finally:
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_attrs)
+        try:
+            os.kill(pid, signal.SIGTERM)
+            os.waitpid(pid, 0)
+        except:
+            pass
+
+if __name__ == "__main__":
+    main()

--- a/packages/opencode/test/cli/tui/post-exit-mouse-pty.py
+++ b/packages/opencode/test/cli/tui/post-exit-mouse-pty.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+post-exit-mouse-pty.py — Post-exit mouse cleanup reproducer (PR #20462 / issue #20458)
+
+Detects the destroy-path bug by checking the slave PTY's terminal state at the
+exact moment ?1003l (mouse disable) arrives at the master.
+
+With the fix (PR #20462): disableMouse() runs while the slave is still in RAW
+mode (ECHO off), because setRawMode(false) uses TCSADRAIN and can't complete
+until ?1003l has already drained to master. So when Python reads ?1003l, ECHO
+is OFF → PASS.
+
+Without the fix: setRawMode(false) runs first (invisible), switching slave to
+cooked mode (ECHO on). Then disableMouse() writes ?1003l. So when Python reads
+?1003l, ECHO is already ON → FAIL.
+
+Usage:
+    python3 post-exit-mouse-pty.py opencode [args...]
+    Quit opencode normally (Ctrl+Q / Esc), then watch for PASS/FAIL.
+"""
+
+import os
+import pty
+import select
+import signal
+import sys
+import termios
+import tty
+
+MOUSE_ENABLE  = b"\x1b[?1003h"
+MOUSE_DISABLE = b"\x1b[?1003l"
+
+
+def echo_is_on(fd):
+    """Returns True if the slave PTY has ECHO enabled (cooked mode)."""
+    try:
+        attrs = termios.tcgetattr(fd)
+        return bool(attrs[3] & termios.ECHO)
+    except Exception:
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: python3 {sys.argv[0]} <command> [args...]", file=sys.stderr)
+        sys.exit(1)
+
+    child_pid, master_fd = pty.fork()
+
+    if child_pid == 0:
+        os.execvp(sys.argv[1], sys.argv[1:])
+        os._exit(1)
+
+    stdin_fd = sys.stdin.fileno()
+    old_attrs = termios.tcgetattr(stdin_fd)
+    tty.setraw(stdin_fd)
+
+    def handle_sigwinch(signum, frame):
+        import fcntl
+        buf = fcntl.ioctl(stdin_fd, termios.TIOCGWINSZ, b"\x00" * 8)
+        fcntl.ioctl(master_fd, termios.TIOCSWINSZ, buf)
+
+    signal.signal(signal.SIGWINCH, handle_sigwinch)
+    handle_sigwinch(None, None)
+
+    buf = b""
+    mouse_enabled = False
+    echo_at_disable = None  # terminal state snapshot when ?1003l first arrived
+
+    try:
+        while True:
+            try:
+                rlist, _, _ = select.select([stdin_fd, master_fd], [], [], 0.05)
+            except (ValueError, OSError):
+                break
+
+            for fd in rlist:
+                if fd == stdin_fd:
+                    try:
+                        data = os.read(stdin_fd, 1024)
+                    except OSError:
+                        data = b""
+                    if data:
+                        try:
+                            os.write(master_fd, data)
+                        except OSError:
+                            pass
+
+                elif fd == master_fd:
+                    try:
+                        data = os.read(master_fd, 4096)
+                    except OSError:
+                        data = b""
+                    if data:
+                        os.write(sys.stdout.fileno(), data)
+                        buf += data
+
+                        if not mouse_enabled and MOUSE_ENABLE in buf:
+                            mouse_enabled = True
+
+                        # Snapshot terminal state the moment ?1003l arrives
+                        if mouse_enabled and echo_at_disable is None and MOUSE_DISABLE in buf:
+                            echo_at_disable = echo_is_on(master_fd)
+
+            try:
+                wpid, _ = os.waitpid(child_pid, os.WNOHANG)
+                if wpid == child_pid:
+                    break
+            except ChildProcessError:
+                break
+
+    finally:
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+    print()
+
+    if not mouse_enabled:
+        print("\033[33mSKIP: mouse tracking was never enabled.\033[0m")
+        sys.exit(0)
+
+    if echo_at_disable is None:
+        print("\033[33mSKIP: ?1003l was never observed.\033[0m")
+        sys.exit(0)
+
+    if echo_at_disable:
+        print("\033[31mFAIL: ECHO was ON when ?1003l arrived — setRawMode(false) ran before disableMouse().\033[0m")
+        print( "      Bug: mouse events can garble the shell between setRawMode and disableMouse.")
+        print( "      Fix: PR #20462 — reorder cleanupBeforeDestroy() in @opentui/core")
+        sys.exit(1)
+    else:
+        print("\033[32mPASS: ECHO was OFF when ?1003l arrived — disableMouse() ran before setRawMode(false).\033[0m")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/opencode/test/cli/tui/sigtstp-mouse-pty.py
+++ b/packages/opencode/test/cli/tui/sigtstp-mouse-pty.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+sigtstp-mouse-pty.py — SIGTSTP mouse garbling reproducer (PR #20507 / issue #20506)
+
+Runs a command inside a PTY, waits for TUI startup, then auto-sends SIGTSTP.
+Monitors whether the child sends the mouse-disable sequence (\x1b[?1003l) before
+suspending — if it does, the SIGTSTP handler is working; if not, the bug is present.
+
+Without the fix: opencode has no SIGTSTP handler, so mouse tracking stays active
+(\x1b[?1003l is never sent). Moving the mouse after suspension garbles the shell.
+
+With the fix (PR #20507): the SIGTSTP handler calls renderer.suspend() which sends
+\x1b[?1003l before the process suspends.
+
+Usage:
+    python3 sigtstp-mouse-pty.py opencode [args...]
+
+Smoke-test (no opencode needed — should FAIL since no cleanup handler):
+    python3 sigtstp-mouse-pty.py python3 -c \
+        "import sys; sys.stdout.write('\\x1b[?1003h\\x1b[?1006h'); input()"
+"""
+
+import os
+import pty
+import select
+import signal
+import sys
+import termios
+import time
+import tty
+
+# Mouse enable/disable sequences (SGR extended mouse + any-event tracking)
+MOUSE_ENABLE  = b"\x1b[?1003h"
+MOUSE_DISABLE = b"\x1b[?1003l"
+
+# After sending SIGTSTP, wait this long for cleanup sequences to arrive (seconds)
+CLEANUP_WAIT = 0.3
+
+# Max time to wait for TUI to enable mouse tracking before giving up (seconds)
+STARTUP_TIMEOUT = 30.0
+
+# After mouse tracking is detected, wait this long before sending SIGTSTP (seconds)
+SETTLE_WAIT = 1.5
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: python3 {sys.argv[0]} <command> [args...]", file=sys.stderr)
+        sys.exit(1)
+
+    child_pid, master_fd = pty.fork()
+
+    if child_pid == 0:
+        os.execvp(sys.argv[1], sys.argv[1:])
+        os._exit(1)
+
+    stdin_fd = sys.stdin.fileno()
+    old_attrs = termios.tcgetattr(stdin_fd)
+    tty.setraw(stdin_fd)
+
+    def handle_sigwinch(signum, frame):
+        import fcntl
+        buf = fcntl.ioctl(stdin_fd, termios.TIOCGWINSZ, b"\x00" * 8)
+        fcntl.ioctl(master_fd, termios.TIOCSWINSZ, buf)
+
+    signal.signal(signal.SIGWINCH, handle_sigwinch)
+    handle_sigwinch(None, None)
+
+    all_output = b""          # everything the child has written
+    post_signal_output = b""  # output after we sent SIGTSTP
+    phase = "startup"         # startup → settle → signaled → done
+    startup_timeout = time.monotonic() + STARTUP_TIMEOUT
+    settle_deadline = 0.0
+    cleanup_deadline = 0.0
+
+    try:
+        while True:
+            timeout = 0.05
+            if phase == "settle":
+                timeout = max(0.01, settle_deadline - time.monotonic())
+            elif phase == "signaled":
+                timeout = max(0.01, cleanup_deadline - time.monotonic())
+
+            try:
+                rlist, _, _ = select.select([stdin_fd, master_fd], [], [], timeout)
+            except (ValueError, OSError):
+                break
+
+            for fd in rlist:
+                if fd == stdin_fd:
+                    try:
+                        data = os.read(stdin_fd, 1024)
+                    except OSError:
+                        data = b""
+                    if data:
+                        try:
+                            os.write(master_fd, data)
+                        except OSError:
+                            pass
+
+                elif fd == master_fd:
+                    try:
+                        data = os.read(master_fd, 4096)
+                    except OSError:
+                        data = b""
+                    if data:
+                        os.write(sys.stdout.fileno(), data)
+                        all_output += data
+                        if phase == "signaled":
+                            post_signal_output += data
+
+            # Phase: wait until mouse tracking is enabled (TUI fully up)
+            if phase == "startup":
+                if MOUSE_ENABLE in all_output:
+                    phase = "settle"
+                    settle_deadline = time.monotonic() + SETTLE_WAIT
+                elif time.monotonic() >= startup_timeout:
+                    break  # timed out — TUI never started
+
+            # Phase: settle briefly, then send SIGTSTP to the whole process group
+            # (child_pid is the Node.js launcher; the real opencode binary is a
+            # grandchild in the same process group — killpg reaches all of them)
+            elif phase == "settle" and time.monotonic() >= settle_deadline:
+                phase = "signaled"
+                cleanup_deadline = time.monotonic() + CLEANUP_WAIT
+                os.killpg(os.getpgid(child_pid), signal.SIGTSTP)
+
+            # Phase: after cleanup window, resume and finish
+            elif phase == "signaled" and time.monotonic() >= cleanup_deadline:
+                os.killpg(os.getpgid(child_pid), signal.SIGCONT)
+                phase = "done"
+                break
+
+            # Check if child exited early
+            try:
+                wpid, _ = os.waitpid(child_pid, os.WNOHANG)
+                if wpid == child_pid:
+                    phase = "done"
+                    break
+            except ChildProcessError:
+                phase = "done"
+                break
+
+    finally:
+        termios.tcsetattr(stdin_fd, termios.TCSADRAIN, old_attrs)
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+    print()
+
+    if phase == "startup":
+        print("\033[33mSKIP: TUI never enabled mouse tracking within 30s — nothing to test.\033[0m")
+        sys.exit(0)
+
+    mouse_disabled = MOUSE_DISABLE in post_signal_output
+
+    if phase != "done" and phase != "signaled":
+        print("\033[33mSKIP: test did not reach the SIGTSTP phase.\033[0m")
+        sys.exit(0)
+
+    # Diagnostic: show captured bytes as hex for debugging
+    captured_repr = post_signal_output[:200].replace(b'\x1b', b'<ESC>').replace(b'\r', b'').replace(b'\n', b'|')
+    print(f"      Captured {len(post_signal_output)} bytes after SIGTSTP: {captured_repr[:120]}")
+
+    # Also check for other common mouse-disable sequences
+    mouse_disabled_any = any(seq in post_signal_output for seq in [
+        b"\x1b[?1003l", b"\x1b[?1002l", b"\x1b[?1000l", b"\x1b[?1006l"
+    ])
+
+    if mouse_disabled or mouse_disabled_any:
+        which = "\\x1b[?1003l" if mouse_disabled else "other mouse-disable sequence"
+        print(f"\033[32mPASS: mouse tracking was disabled before/during SIGTSTP suspension ({which}).\033[0m")
+        sys.exit(0)
+    else:
+        print("\033[31mFAIL: mouse tracking was NOT disabled before SIGTSTP suspension!\033[0m")
+        print( "      No mouse-disable sequence found in post-signal output.")
+        print( "      Fix: PR #20507 — add SIGTSTP/SIGCONT signal handlers in app.tsx")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs
+++ b/packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs
@@ -1,0 +1,116 @@
+/**
+ * Test: Verify that cleanupBeforeDestroy() disables mouse tracking before
+ * disabling raw mode. Without the fix, setRawMode(false) re-enables terminal
+ * ECHO while mouse tracking is still active, causing mouse events to appear
+ * as garbled text.
+ *
+ * This test verifies the fix by reading the patched source and checking that
+ * disableMouse() is called before setRawMode(false) in cleanupBeforeDestroy().
+ * A full integration test would require a PTY, but this structural test catches
+ * regressions in the patch ordering.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Read the patched @opentui/core source
+const corePath = resolve(
+  __dirname,
+  "../../../../../node_modules/.bun/@opentui+core@0.1.95+8e67d58793ed4a15/node_modules/@opentui/core/index-wv534m5j.js",
+);
+const source = readFileSync(corePath, "utf-8");
+
+let passed = 0;
+let failed = 0;
+
+function check(name, condition) {
+  if (condition) {
+    console.log(` OK | ${name}`);
+    passed++;
+  } else {
+    console.log(`BUG | ${name}`);
+    failed++;
+  }
+}
+
+console.log("Testing @opentui/core destroy-path mouse cleanup ordering\n");
+
+// Test 1: cleanupBeforeDestroy calls disableMouse
+check(
+  "cleanupBeforeDestroy() contains disableMouse() call",
+  /cleanupBeforeDestroy\(\)\s*\{[\s\S]*?this\.disableMouse\(\)[\s\S]*?this\.stdin\.setRawMode\(false\)[\s\S]*?\n\s*\}/.test(
+    source,
+  ),
+);
+
+// Test 2: disableMouse comes BEFORE setRawMode(false) in cleanupBeforeDestroy
+{
+  // Extract cleanupBeforeDestroy method body
+  const methodMatch = source.match(
+    /cleanupBeforeDestroy\(\)\s*\{([\s\S]*?)(?=\n\s{2}\w|\n\s{2}(?:get |set |async ))/,
+  );
+  if (methodMatch) {
+    const body = methodMatch[1];
+    const disableMouseIdx = body.indexOf("this.disableMouse()");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "disableMouse() is called BEFORE setRawMode(false)",
+      disableMouseIdx !== -1 &&
+        setRawModeIdx !== -1 &&
+        disableMouseIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found cleanupBeforeDestroy method body", false);
+  }
+}
+
+// Test 3: stdin drain exists between disableMouse and setRawMode
+{
+  const methodMatch = source.match(
+    /cleanupBeforeDestroy\(\)\s*\{([\s\S]*?)(?=\n\s{2}\w|\n\s{2}(?:get |set |async ))/,
+  );
+  if (methodMatch) {
+    const body = methodMatch[1];
+    const drainIdx = body.indexOf("while (this.stdin.read() !== null)");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "stdin drain exists before setRawMode(false)",
+      drainIdx !== -1 && setRawModeIdx !== -1 && drainIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found cleanupBeforeDestroy method body for drain check", false);
+  }
+}
+
+// Test 4: suspend() also has correct ordering (regression guard)
+{
+  const suspendMatch = source.match(
+    /suspend\(\)\s*\{([\s\S]*?)(?=\n\s{2}resume\(\)|\n\s{2}\w)/,
+  );
+  if (suspendMatch) {
+    const body = suspendMatch[1];
+    const disableMouseIdx = body.indexOf("this.disableMouse()");
+    const setRawModeIdx = body.indexOf("this.stdin.setRawMode(false)");
+    check(
+      "suspend() still has correct ordering (disableMouse before setRawMode)",
+      disableMouseIdx !== -1 &&
+        setRawModeIdx !== -1 &&
+        disableMouseIdx < setRawModeIdx,
+    );
+  } else {
+    check("Found suspend method body", false);
+  }
+}
+
+// Test 5: Verify DEFAULT_TIMEOUT_MS is bumped
+check(
+  "DEFAULT_TIMEOUT_MS is >= 25",
+  /var DEFAULT_TIMEOUT_MS = (\d+)/.test(source) &&
+    parseInt(source.match(/var DEFAULT_TIMEOUT_MS = (\d+)/)[1]) >= 25,
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/packages/opencode/test/cli/tui/test-sigtstp-mouse.sh
+++ b/packages/opencode/test/cli/tui/test-sigtstp-mouse.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Reproduction script for SIGTSTP mouse garbling.
+#
+# Usage:
+#   1. In Terminal 1: Run opencode normally
+#   2. In Terminal 2: Run this script with the opencode PID:
+#      ./test-sigtstp-mouse.sh <PID>
+#   3. In Terminal 1: Move the mouse after opencode is suspended
+#
+# Without the fix: garbled escape sequences appear (35;89;19M35;84;20M...)
+# With the fix: clean shell prompt, no garbled text
+#
+# You can also test without opencode by using any TUI that enables mouse:
+#   python3 -c "import sys; sys.stdout.write('\x1b[?1003h\x1b[?1006h'); input()"
+#   Then send SIGTSTP from another terminal.
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <PID>"
+  echo ""
+  echo "Sends SIGTSTP to the given PID to test mouse cleanup."
+  echo "Run opencode in another terminal first, then pass its PID."
+  echo ""
+  echo "Find the PID with: pgrep -f opencode"
+  exit 1
+fi
+
+PID="$1"
+
+echo "Sending SIGTSTP to PID $PID..."
+echo "Switch to the opencode terminal and move the mouse."
+echo "If you see garbled text like '35;89;19M35;84;20M...' the bug is present."
+echo ""
+
+kill -TSTP "$PID"
+
+echo "Done. Resume with: kill -CONT $PID  (or 'fg' in the opencode terminal)"

--- a/packages/opencode/test/cli/tui/test-stdin-parser.mjs
+++ b/packages/opencode/test/cli/tui/test-stdin-parser.mjs
@@ -1,0 +1,69 @@
+// Direct import from bun's cache — avoids loading native bindings, only the JS parser is needed.
+// This path is populated by `bun install` with the patch applied.
+import { StdinParser } from "../../../../../node_modules/.bun/@opentui+core@0.1.95+8e67d58793ed4a15/node_modules/@opentui/core/index-wv534m5j.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function test(name, chunks, delayMs) {
+  const events = [];
+  const parser = new StdinParser({
+    timeoutMs: 10,
+    armTimeouts: true,
+    onTimeoutFlush: () => {
+      parser.drain((e) => events.push(e));
+    },
+  });
+
+  for (let i = 0; i < chunks.length; i++) {
+    parser.push(Buffer.from(chunks[i]));
+    parser.drain((e) => events.push(e));
+    if (i < chunks.length - 1) await sleep(delayMs);
+  }
+  // Final drain after all timeouts settle
+  await sleep(delayMs + 5);
+  parser.drain((e) => events.push(e));
+
+  const summary = events.map((e) => {
+    if (e.type === "key") return `KEY:"${e.key?.name || e.raw}"`;
+    if (e.type === "mouse") return `MOUSE:${e.event?.type}`;
+    if (e.type === "response") return `RESP:${e.protocol}`;
+    if (e.type === "paste") return `PASTE`;
+    return `${e.type}`;
+  });
+
+  const hasKeyLeak = events.some((e) => e.type === "key" && !["escape"].includes(e.key?.name));
+  console.log(`${hasKeyLeak ? "BUG" : " OK"} | ${name}`);
+  console.log(`     events: [${summary.join(", ")}]`);
+  console.log();
+  parser.destroy();
+}
+
+console.log("Testing opentui StdinParser v0.1.95 SGR mouse fragmentation\n");
+console.log("If any line shows BUG — mouse bytes leaked as key events.\n");
+
+// Complete sequence — should always work
+await test("Complete sequence in one push", ["\x1b[<0;50;15M"], 0);
+
+// Split mid-coordinates — deferred state should handle
+await test("Split mid-coords, 15ms gap", ["\x1b[<0;50;1", "5M"], 15);
+
+// ESC alone then rest — timeout flushes ESC
+await test("ESC alone, rest after 15ms", ["\x1b", "[<0;50;15M"], 15);
+
+// Triple split — ESC, [, rest
+await test("ESC / [ / rest, 15ms gaps", ["\x1b", "[", "<0;50;15M"], 15);
+
+// Quadruple split — ESC, [, <, rest
+await test("ESC / [ / < / rest, 15ms gaps", ["\x1b", "[", "<", "0;50;15M"], 15);
+
+// Every byte separate with 15ms gaps
+const fullSeq = "\x1b[<0;50;15M";
+const byteByByte = [...fullSeq].map((c) => c);
+await test("Every byte separate, 15ms gaps", byteByByte, 15);
+
+// Scroll event
+await test("Scroll event complete", ["\x1b[<65;50;15M"], 0);
+await test("Scroll event split", ["\x1b[<65;5", "0;15M"], 15);
+await test("Scroll ESC alone", ["\x1b", "[<65;50;15M"], 15);
+
+console.log("Done.");

--- a/patches/@opentui%2Fcore@0.1.95.patch
+++ b/patches/@opentui%2Fcore@0.1.95.patch
@@ -1,0 +1,89 @@
+diff --git a/index-wv534m5j.js b/index-wv534m5j.js
+index 135575a0b101cd4e2bedda5e18a660d6924fcb1f..42e5223ebc164c2370362fb7e43c3aec57dd40cc 100644
+--- a/index-wv534m5j.js
++++ b/index-wv534m5j.js
+@@ -6843,7 +6843,7 @@
+
+ // src/lib/stdin-parser.ts
+ import { Buffer as Buffer3 } from "buffer";
+-var DEFAULT_TIMEOUT_MS = 20;
++var DEFAULT_TIMEOUT_MS = 25;
+ var DEFAULT_MAX_PENDING_BYTES = 64 * 1024;
+ var INITIAL_PENDING_CAPACITY = 256;
+ var ESC = 27;
+@@ -7155,6 +7155,7 @@
+   pendingSinceMs = null;
+   forceFlush = false;
+   justFlushedEsc = false;
++  justFlushedEscBracket = false;
+   state = { tag: "ground" };
+   cursor = 0;
+   unitStart = 0;
+@@ -7295,6 +7296,15 @@
+               continue;
+             }
+             this.justFlushedEsc = false;
++          }
++          if (this.justFlushedEscBracket) {
++            if (byte === 60) {
++              this.justFlushedEscBracket = false;
++              this.cursor += 1;
++              this.state = { tag: "esc_less_mouse" };
++              continue;
++            }
++            this.justFlushedEscBracket = false;
+           }
+           if (byte === ESC) {
+             this.cursor += 1;
+@@ -7422,7 +7432,8 @@
+               this.markPending();
+               return;
+             }
+-            this.emitKeyOrResponse("unknown", decodeUtf8(bytes.subarray(this.unitStart, this.cursor)));
++            this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
++            this.justFlushedEscBracket = true;
+             this.state = { tag: "ground" };
+             this.consumePrefix(this.cursor);
+             continue;
+@@ -7449,6 +7460,7 @@
+               return;
+             }
+             this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
++            this.justFlushedEscBracket = true;
+             this.state = { tag: "ground" };
+             this.consumePrefix(this.cursor);
+             continue;
+@@ -7924,10 +7936,9 @@
+               this.markPending();
+               return;
+             }
+-            this.emitOpaqueResponse("unknown", bytes.subarray(this.unitStart, this.cursor));
+-            this.state = { tag: "ground" };
+-            this.consumePrefix(this.cursor);
+-            continue;
++            this.pendingSinceMs = null;
++            this.forceFlush = false;
++            return;
+           }
+           if (byte >= 48 && byte <= 57 || byte === 59) {
+             this.cursor += 1;
+@@ -8128,6 +8139,7 @@
+     this.pendingSinceMs = null;
+     this.forceFlush = false;
+     this.justFlushedEsc = false;
++    this.justFlushedEscBracket = false;
+     this.state = { tag: "ground" };
+     this.cursor = 0;
+     this.unitStart = 0;
+@@ -18837,7 +18849,11 @@
+       explicitWidthCprActive: false
+     }, true);
+     this.setCapturedRenderable(undefined);
++    if (this._useMouse) {
++      this.disableMouse();
++    }
+     this.stdin.removeListener("data", this.stdinListener);
++    while (this.stdin.read() !== null) {}
+     if (this.stdin.setRawMode) {
+       this.stdin.setRawMode(false);
+     }


### PR DESCRIPTION
## Summary

Combines and verifies the three mouse garbling fixes:

- **PR #20462** — patch `@opentui/core@0.1.95`: reorder `cleanupBeforeDestroy()` to call `disableMouse()` before `setRawMode(false)`, preventing mouse events from garbling the shell on TUI exit. Also ports the StdinParser fragmentation fix.
- **PR #20507** — add SIGTSTP/SIGCONT signal handlers in `app.tsx` so external suspension (code-server, job control) properly disables mouse tracking before the process suspends.

## Test scripts added

- `sigtstp-mouse-pty.py` — PTY wrapper that auto-sends SIGTSTP after TUI startup and checks for `?1003l` in the output. Shows **FAIL → PASS** across the PR #20507 fix.
- `post-exit-mouse-pty.py` — PTY wrapper that snapshots the slave PTY ECHO state at the moment `?1003l` arrives. Structural verification is covered by `test-destroy-mouse-cleanup.mjs` (5/5 passing).

## Verification

```bash
# SIGTSTP: FAIL on unpatched, PASS on patched
python3 packages/opencode/test/cli/tui/sigtstp-mouse-pty.py opencode

# Post-exit structural test
bun run packages/opencode/test/cli/tui/test-destroy-mouse-cleanup.mjs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)