### PR TITLE
feat: pluggable compaction providers with Morph as default

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1057,7 +1057,34 @@ export function Session() {
             >
               <box height={1} />
               <For each={messages()}>
-                {(message, index) => (
+                {(message, index) => {
+                  const msgParts = sync.data.part[message.id] ?? []
+                  const isCompactionTrigger =
+                    message.role === "user" && msgParts.some((p: Part) => p.type === "compaction")
+                  const isSummary = message.role === "assistant" && (message as AssistantMessage).summary === true
+
+                  // Find last compaction boundary
+                  const lastCompIdx = messages().findLastIndex((m) => {
+                    const mp = sync.data.part[m.id] ?? []
+                    return m.role === "user" && mp.some((p: Part) => p.type === "compaction")
+                  })
+
+                  // Hide everything before last compaction
+                  if (lastCompIdx >= 0 && index() < lastCompIdx) return <></>
+
+                  // At the compaction trigger: show a single line
+                  if (isCompactionTrigger) {
+                    return (
+                      <box marginTop={1} paddingLeft={2}>
+                        <text fg={theme.textMuted}>▣ Compaction · morph</text>
+                      </box>
+                    )
+                  }
+
+                  // Hide summary messages (compaction output, LLM context only)
+                  if (isSummary) return <></>
+
+                  return (
                   <Switch>
                     <Match when={message.id === revert()?.messageID}>
                       {(function () {
@@ -1149,7 +1176,8 @@ export function Session() {
                       />
                     </Match>
                   </Switch>
-                )}
+                  )
+                }}
               </For>
             </scrollbox>
             <box flexShrink={0}>
@@ -1235,8 +1263,6 @@ function UserMessage(props: {
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
-  const compaction = createMemo(() => props.parts.find((x) => x.type === "compaction"))
-
   return (
     <>
       <Show when={text()}>
@@ -1299,15 +1325,6 @@ function UserMessage(props: {
             </Show>
           </box>
         </box>
-      </Show>
-      <Show when={compaction()}>
-        <box
-          marginTop={1}
-          border={["top"]}
-          title=" Compaction "
-          titleAlignment="center"
-          borderColor={theme.borderActive}
-        />
       </Show>
     </>
   )

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -962,6 +962,16 @@ export namespace Config {
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
+          provider: z
+            .enum(["builtin", "morph"])
+            .optional()
+            .describe('Compaction provider to use (default: "morph"). "builtin" uses an LLM to summarize.'),
+          compressionRatio: z
+            .number()
+            .min(0)
+            .max(1)
+            .optional()
+            .describe("Compression ratio for external compaction providers like Morph (default: 0.3)"),
           reserved: z
             .number()
             .int()

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -19,6 +19,7 @@ import { Effect, Layer, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import { InstanceState } from "@/effect/instance-state"
 import { isOverflow as overflow } from "./overflow"
+import { createMorphProvider, type CompactionMessage } from "./compaction/index"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -138,6 +139,260 @@ export namespace SessionCompaction {
         }
       })
 
+      // --- Morph compaction provider ---
+      const processMorph = Effect.fn("SessionCompaction.processMorph")(function* (params: {
+        cfg: Config.Info
+        modelMessages: import("ai").ModelMessage[]
+        originalMessages: MessageV2.WithParts[]
+        userMessage: MessageV2.User
+        input: {
+          parentID: MessageID
+          sessionID: SessionID
+          auto: boolean
+          overflow?: boolean
+        }
+        ctx: { directory: string; worktree: string }
+        model: Provider.Model
+      }) {
+        // WARNING: Always defaults to Morph. Assumes MORPH_API_KEY is set.
+        // Not production-ready — no graceful fallback if key is missing.
+        const morphApiKey = globalThis.process.env.MORPH_API_KEY
+        if (!morphApiKey) {
+          throw new Error(
+            "MORPH_API_KEY environment variable is required when compaction provider is 'morph'. " +
+              "Set MORPH_API_KEY or change compaction.provider to 'builtin' in your config.",
+          )
+        }
+
+        const morph = createMorphProvider(morphApiKey)
+        const compressionRatio = params.cfg.compaction?.compressionRatio ?? 0.3
+
+        // Convert ModelMessage[] to simple {role, content} for the Morph API.
+        const simpleMessages: CompactionMessage[] = []
+        for (const m of params.modelMessages) {
+          const text = (() => {
+            if (typeof m.content === "string") return m.content
+            if (Array.isArray(m.content))
+              return m.content
+                .map((p: any) => {
+                  if (typeof p === "string") return p
+                  if (p.type === "text") return p.text
+                  if (p.type === "tool-call") return JSON.stringify({ tool: p.toolName, input: p.args })
+                  if (p.type === "tool-result") return typeof p.result === "string" ? p.result : JSON.stringify(p.result)
+                  return ""
+                })
+                .filter(Boolean)
+                .join("\n")
+            return ""
+          })()
+          if (text) simpleMessages.push({ role: m.role, content: text })
+        }
+
+        log.info("morph compaction input", {
+          count: simpleMessages.length,
+          ratio: compressionRatio,
+          messages: JSON.stringify(simpleMessages),
+        })
+
+        const result = yield* Effect.promise(() => morph.compact({ messages: simpleMessages, compressionRatio }))
+
+        log.info("morph compaction output", {
+          count: result.messages.length,
+          messages: JSON.stringify(result.messages),
+        })
+
+        // Delete all old messages, then insert the compacted ones.
+        log.info("morph compaction deleting old messages", {
+          count: params.originalMessages.length,
+          ids: params.originalMessages.map((m) => m.info.id),
+        })
+        for (const msg of params.originalMessages) {
+          yield* session.removeMessage({
+            sessionID: params.input.sessionID,
+            messageID: msg.info.id,
+          })
+        }
+
+        // Insert compacted messages.
+        const insertedIds: string[] = []
+        for (const compactedMsg of result.messages) {
+          const role = compactedMsg.role
+          if (role === "assistant" || role === "system") {
+            const assistantMsg: MessageV2.Assistant = {
+              id: MessageID.ascending(),
+              role: "assistant",
+              parentID: params.input.parentID,
+              sessionID: params.input.sessionID,
+              mode: "compaction",
+              agent: "compaction",
+              variant: params.userMessage.variant,
+              summary: true,
+              path: { cwd: params.ctx.directory, root: params.ctx.worktree },
+              cost: 0,
+              tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              modelID: "morph" as any,
+              providerID: "morph" as any,
+              time: { created: Date.now(), completed: Date.now() },
+              finish: "stop",
+            }
+            yield* session.updateMessage(assistantMsg)
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: assistantMsg.id,
+              sessionID: params.input.sessionID,
+              type: "text",
+              text: compactedMsg.content,
+              time: { start: Date.now(), end: Date.now() },
+            })
+            insertedIds.push(assistantMsg.id)
+          } else {
+            const userMsg = yield* session.updateMessage({
+              id: MessageID.ascending(),
+              role: "user" as const,
+              sessionID: params.input.sessionID,
+              time: { created: Date.now() },
+              agent: params.userMessage.agent,
+              model: params.userMessage.model,
+            })
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: userMsg.id,
+              sessionID: params.input.sessionID,
+              type: "text",
+              text: compactedMsg.content,
+              time: { start: Date.now(), end: Date.now() },
+            })
+            insertedIds.push(userMsg.id)
+          }
+        }
+
+        // Log final state
+        const finalMsgs = yield* session
+          .messages({ sessionID: params.input.sessionID })
+          .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([] as MessageV2.WithParts[])))
+        log.info("morph compaction complete", {
+          original: params.originalMessages.length,
+          compacted: result.messages.length,
+          inserted: insertedIds,
+          finalMessageCount: finalMsgs.length,
+          finalMessages: finalMsgs.map((m) => ({
+            id: m.info.id,
+            role: m.info.role,
+            mode: m.info.role === "assistant" ? m.info.mode : undefined,
+            summary: m.info.role === "assistant" ? m.info.summary : undefined,
+            partTypes: m.parts.map((p) => p.type),
+          })),
+        })
+
+        return "continue" as const
+      })
+
+      // --- Builtin compaction provider (existing LLM-based summarization) ---
+      const processBuiltin = Effect.fn("SessionCompaction.processBuiltin")(function* (params: {
+        modelMessages: import("ai").ModelMessage[]
+        userMessage: MessageV2.User
+        input: {
+          parentID: MessageID
+          sessionID: SessionID
+          auto: boolean
+          overflow?: boolean
+        }
+        ctx: { directory: string; worktree: string }
+        model: Provider.Model
+        agent: Agent.Info
+        replay?: { info: MessageV2.User; parts: MessageV2.Part[] }
+      }) {
+        // Allow plugins to inject context or replace compaction prompt.
+        const compacting = yield* plugin.trigger(
+          "experimental.session.compacting",
+          { sessionID: params.input.sessionID },
+          { context: [], prompt: undefined },
+        )
+        const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
+Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
+The summary that you construct will be used so that another agent can read it and continue the work.
+Do not call any tools. Respond only with the summary text.
+
+When constructing the summary, try to stick to this template:
+---
+## Goal
+
+[What goal(s) is the user trying to accomplish?]
+
+## Instructions
+
+- [What important instructions did the user give you that are relevant]
+- [If there is a plan or spec, include information about it so next agent can continue using it]
+
+## Discoveries
+
+[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
+
+## Accomplished
+
+[What work has been completed, what work is still in progress, and what work is left?]
+
+## Relevant files / directories
+
+[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
+---`
+
+        const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
+        const msg: MessageV2.Assistant = {
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: params.input.parentID,
+          sessionID: params.input.sessionID,
+          mode: "compaction",
+          agent: "compaction",
+          variant: params.userMessage.variant,
+          summary: true,
+          path: { cwd: params.ctx.directory, root: params.ctx.worktree },
+          cost: 0,
+          tokens: { output: 0, input: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID: params.model.id,
+          providerID: params.model.providerID,
+          time: { created: Date.now() },
+        }
+        yield* session.updateMessage(msg)
+        const processor = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: params.input.sessionID,
+          model: params.model,
+        })
+        const result = yield* processor
+          .process({
+            user: params.userMessage,
+            agent: params.agent,
+            sessionID: params.input.sessionID,
+            tools: {},
+            system: [],
+            messages: [
+              ...params.modelMessages,
+              {
+                role: "user",
+                content: [{ type: "text", text: prompt }],
+              },
+            ],
+            model: params.model,
+          })
+          .pipe(Effect.onInterrupt(() => processor.abort()))
+
+        if (result === "compact") {
+          processor.message.error = new MessageV2.ContextOverflowError({
+            message: params.replay
+              ? "Conversation history too large to compact - exceeds model context limit"
+              : "Session too large to compact - context exceeds model limit even after stripping media",
+          }).toObject()
+          processor.message.finish = "error"
+          yield* session.updateMessage(processor.message)
+          return "stop" as const
+        }
+
+        if (processor.message.error) return "stop" as const
+        return "continue" as const
+      })
+
       const processCompaction = Effect.fn("SessionCompaction.process")(function* (input: {
         parentID: MessageID
         messages: MessageV2.WithParts[]
@@ -176,112 +431,48 @@ export namespace SessionCompaction {
           }
         }
 
+        const cfg = yield* config.get()
+        const compactionProvider = cfg.compaction?.provider ?? "morph"
+
         const agent = yield* agents.get("compaction")
         const model = agent.model
           ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)
           : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
-        // Allow plugins to inject context or replace compaction prompt.
-        const compacting = yield* plugin.trigger(
-          "experimental.session.compacting",
-          { sessionID: input.sessionID },
-          { context: [], prompt: undefined },
-        )
-        const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
-Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
-The summary that you construct will be used so that another agent can read it and continue the work.
-Do not call any tools. Respond only with the summary text.
+        const ctx = yield* InstanceState.context
 
-When constructing the summary, try to stick to this template:
----
-## Goal
-
-[What goal(s) is the user trying to accomplish?]
-
-## Instructions
-
-- [What important instructions did the user give you that are relevant]
-- [If there is a plan or spec, include information about it so next agent can continue using it]
-
-## Discoveries
-
-[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
-
-## Accomplished
-
-[What work has been completed, what work is still in progress, and what work is left?]
-
-## Relevant files / directories
-
-[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
----`
-
-        const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
         const msgs = structuredClone(messages)
         yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
         const modelMessages = yield* Effect.promise(() => MessageV2.toModelMessages(msgs, model, { stripMedia: true }))
-        const ctx = yield* InstanceState.context
-        const msg: MessageV2.Assistant = {
-          id: MessageID.ascending(),
-          role: "assistant",
-          parentID: input.parentID,
-          sessionID: input.sessionID,
-          mode: "compaction",
-          agent: "compaction",
-          variant: userMessage.variant,
-          summary: true,
-          path: {
-            cwd: ctx.directory,
-            root: ctx.worktree,
-          },
-          cost: 0,
-          tokens: {
-            output: 0,
-            input: 0,
-            reasoning: 0,
-            cache: { read: 0, write: 0 },
-          },
-          modelID: model.id,
-          providerID: model.providerID,
-          time: {
-            created: Date.now(),
-          },
-        }
-        yield* session.updateMessage(msg)
-        const processor = yield* processors.create({
-          assistantMessage: msg,
-          sessionID: input.sessionID,
-          model,
-        })
-        const result = yield* processor
-          .process({
-            user: userMessage,
-            agent,
-            sessionID: input.sessionID,
-            tools: {},
-            system: [],
-            messages: [
-              ...modelMessages,
-              {
-                role: "user",
-                content: [{ type: "text", text: prompt }],
-              },
-            ],
+
+        let compactionResult: "continue" | "stop"
+
+        if (compactionProvider === "morph") {
+          compactionResult = yield* processMorph({
+            cfg,
+            modelMessages,
+            originalMessages: msgs,
+            userMessage,
+            input,
+            ctx,
             model,
           })
-          .pipe(Effect.onInterrupt(() => processor.abort()))
-
-        if (result === "compact") {
-          processor.message.error = new MessageV2.ContextOverflowError({
-            message: replay
-              ? "Conversation history too large to compact - exceeds model context limit"
-              : "Session too large to compact - context exceeds model limit even after stripping media",
-          }).toObject()
-          processor.message.finish = "error"
-          yield* session.updateMessage(processor.message)
-          return "stop"
+        } else {
+          // --- Builtin provider path (existing LLM-based compaction) ---
+          compactionResult = yield* processBuiltin({
+            modelMessages,
+            userMessage,
+            input,
+            ctx,
+            model,
+            agent,
+            replay,
+          })
         }
 
-        if (result === "continue" && input.auto) {
+        if (compactionResult === "stop") return "stop"
+
+        // --- Shared post-compaction: replay and continue ---
+        if (input.auto) {
           if (replay) {
             const original = replay.info
             const replayMsg = yield* session.updateMessage({
@@ -340,9 +531,8 @@ When constructing the summary, try to stick to this template:
           }
         }
 
-        if (processor.message.error) return "stop"
-        if (result === "continue") yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
-        return result
+        yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
+        return "continue" as const
       })
 
       const create = Effect.fn("SessionCompaction.create")(function* (input: {

--- a/packages/opencode/src/session/compaction/index.ts
+++ b/packages/opencode/src/session/compaction/index.ts
@@ -1,0 +1,2 @@
+export type { CompactionProvider, CompactionInput, CompactionResult, CompactionMessage } from "./provider"
+export { createMorphProvider } from "./morph"

--- a/packages/opencode/src/session/compaction/morph.ts
+++ b/packages/opencode/src/session/compaction/morph.ts
@@ -1,0 +1,44 @@
+import { Log } from "@/util/log"
+import type { CompactionInput, CompactionProvider, CompactionResult } from "./provider"
+
+const MORPH_API_URL = "https://api.morphllm.com/v1/compact"
+const TIMEOUT_MS = 120_000
+
+const log = Log.create({ service: "compaction.morph" })
+
+export function createMorphProvider(apiKey: string): CompactionProvider {
+  return {
+    name: "morph",
+    async compact(input: CompactionInput): Promise<CompactionResult> {
+      log.info("sending", { messages: input.messages.length, ratio: input.compressionRatio })
+
+      const response = await fetch(MORPH_API_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: input.messages,
+          compression_ratio: input.compressionRatio,
+        }),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      })
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "")
+        throw new Error(`Morph compaction failed (${response.status}): ${body}`)
+      }
+
+      const data = (await response.json()) as { messages: Array<{ role: string; content: string }> }
+
+      if (!data.messages || !Array.isArray(data.messages)) {
+        throw new Error("Morph compaction returned invalid response: missing messages array")
+      }
+
+      log.info("received", { messages: data.messages.length })
+
+      return { messages: data.messages }
+    },
+  }
+}

--- a/packages/opencode/src/session/compaction/provider.ts
+++ b/packages/opencode/src/session/compaction/provider.ts
@@ -1,0 +1,18 @@
+export interface CompactionProvider {
+  readonly name: string
+  compact(input: CompactionInput): Promise<CompactionResult>
+}
+
+export interface CompactionMessage {
+  role: string
+  content: string
+}
+
+export interface CompactionInput {
+  messages: CompactionMessage[]
+  compressionRatio: number
+}
+
+export interface CompactionResult {
+  messages: CompactionMessage[]
+}

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -669,10 +669,7 @@ export namespace MessageV2 {
           }
 
           if (part.type === "compaction") {
-            userMessage.parts.push({
-              type: "text",
-              text: "What did we do so far?",
-            })
+            // no-op: compaction parts don't inject user-visible text
           }
           if (part.type === "subtask") {
             userMessage.parts.push({

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -5,6 +5,14 @@ import type { MessageV2 } from "./message-v2"
 
 const COMPACTION_BUFFER = 20_000
 
+function getThresholdFromEnv(): number | undefined {
+  const raw = globalThis.process.env.OPENCODE_COMPACTION_THRESHOLD
+  if (!raw) return undefined
+  const value = parseFloat(raw)
+  if (isNaN(value) || value < 0.3 || value > 0.95) return undefined
+  return value
+}
+
 export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
   if (input.cfg.compaction?.auto === false) return false
   const context = input.model.limit.context
@@ -12,6 +20,11 @@ export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistan
 
   const count =
     input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
+
+  const threshold = getThresholdFromEnv()
+  if (threshold !== undefined) {
+    return count >= context * threshold
+  }
 
   const reserved =
     input.cfg.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))


### PR DESCRIPTION
## Summary

- Adds a `CompactionProvider` interface (`messages in → messages out`) for pluggable compaction
- Ships Morph as the default compaction provider (POST `/v1/compact`, auth via `MORPH_API_KEY`)
- Existing LLM-based compaction preserved as `"builtin"` provider
- After compaction, old messages are deleted and replaced with compacted output
- TUI hides pre-compaction history, shows `▣ Compaction · morph` marker

## Config

```jsonc
{
  "compaction": {
    "provider": "morph",          // or "builtin"
    "compressionRatio": 0.3,      // 0-1, for Morph
  }
}
```

`OPENCODE_COMPACTION_THRESHOLD` env var (0.3–0.95) overrides the overflow detection threshold.

## Files changed

- `src/session/compaction/provider.ts` — CompactionProvider interface
- `src/session/compaction/morph.ts` — Morph API client
- `src/session/compaction.ts` — Branching logic (morph vs builtin)
- `src/config/config.ts` — New config fields
- `src/session/overflow.ts` — Env var threshold support
- `src/session/message-v2.ts` — Remove synthetic compaction text
- `src/cli/cmd/tui/routes/session/index.tsx` — Post-compaction display

## Test plan

- [ ] Set `MORPH_API_KEY`, trigger `/compact` — calls Morph, replaces history
- [ ] Unset `MORPH_API_KEY` — clear error message
- [ ] Set `provider: "builtin"` — existing LLM compaction works
- [ ] `OPENCODE_COMPACTION_THRESHOLD=0.5` — auto-compact at 50%
- [ ] TUI shows single `▣ Compaction · morph` after compaction, no message spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)