### PR TITLE
feat(tui): add built-in system notifications for session completion

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -822,10 +822,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const focused = await Notification.terminalIsFocused().catch(() => false)
     if (focused) return
 
-    const sessionID = evt.properties.info?.id
-    const session = sessionID ? sync.data.session?.[sessionID] : undefined
-    const title = session?.title ?? sessionID ?? "Session"
-    Notification.show("opencode", `${title} completed`).catch(() => {})
+    const sessionID = evt.properties.sessionID
+    Notification.show("opencode", `${sessionID} completed`).catch(() => {})
   })
 
   sdk.event.on("session.error", (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -825,7 +825,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const sessionID = evt.properties.info?.id
     const session = sessionID ? sync.data.session?.[sessionID] : undefined
     const title = session?.title ?? sessionID ?? "Session"
-    Notification.show("opencode", `${title} completed`)
+    Notification.show("opencode", `${title} completed`).catch(() => {})
   })
 
   sdk.event.on("session.error", (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -59,6 +59,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { Notification } from "@/notification"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -816,6 +817,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
   })
 
+  sdk.event.on("session.idle", async (evt) => {
+    if (tuiConfig.notifications === false) return
+    const focused = await Notification.terminalIsFocused().catch(() => false)
+    if (focused) return
+
+    const sessionID = evt.properties.info?.id
+    const session = sessionID ? sync.data.session?.[sessionID] : undefined
+    const title = session?.title ?? sessionID ?? "Session"
+    Notification.show("opencode", `${title} completed`)
+  })
+
   sdk.event.on("session.error", (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
@@ -825,6 +837,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       variant: "error",
       message,
       duration: 5000,
+    })
+
+    void Notification.terminalIsFocused().then((focused) => {
+      if (focused) return
+      if (tuiConfig.notifications === false) return
+      Notification.show("opencode", `Error: ${message}`)
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -1,18 +1,34 @@
-import { createContext, useContext, type ParentProps, Show } from "solid-js"
+import { createContext, useContext, type ParentProps, Show, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "@tui/context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
-import { SplitBorder } from "../component/border"
 import { TextAttributes } from "@opentui/core"
 import z from "zod"
 import { TuiEvent } from "../event"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
 
+const VARIANT_ICONS: Record<string, string> = {
+  error: "✗",
+  success: "✓",
+  info: "ℹ",
+  warning: "⚠",
+}
+
 export function Toast() {
   const toast = useToast()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
+
+  const icon = createMemo(() => {
+    if (!toast.currentToast) return ""
+    return VARIANT_ICONS[toast.currentToast.variant] ?? "●"
+  })
+
+  const iconColor = createMemo(() => {
+    if (!toast.currentToast) return theme.text
+    return theme[toast.currentToast.variant] ?? theme.text
+  })
 
   return (
     <Show when={toast.currentToast}>
@@ -30,14 +46,18 @@ export function Toast() {
           paddingBottom={1}
           backgroundColor={theme.backgroundPanel}
           borderColor={theme[current().variant]}
-          border={["left", "right"]}
-          customBorderChars={SplitBorder.customBorderChars}
+          border={["top", "bottom", "left", "right"]}
         >
-          <Show when={current().title}>
-            <text attributes={TextAttributes.BOLD} marginBottom={1} fg={theme.text}>
-              {current().title}
+          <box flexDirection="row" gap={1} marginBottom={1}>
+            <text fg={iconColor()} attributes={TextAttributes.BOLD}>
+              {icon()}
             </text>
-          </Show>
+            <Show when={current().title}>
+              <text attributes={TextAttributes.BOLD} fg={theme.text}>
+                {current().title}
+              </text>
+            </Show>
+          </box>
           <text fg={theme.text} wrapMode="word" width="100%">
             {current().message}
           </text>
@@ -64,7 +84,7 @@ function init() {
         setStore("currentToast", null)
       }, duration).unref()
     },
-    error: (err: any) => {
+    error: (err: unknown) => {
       if (err instanceof Error)
         return toast.show({
           variant: "error",

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -22,6 +22,11 @@ export const TuiOptions = z.object({
     .enum(["auto", "stacked"])
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+  notifications: z
+    .boolean()
+    .default(true)
+    .optional()
+    .describe("Show system notifications when sessions complete or error. Requires terminal focus-loss detection."),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -16,7 +16,13 @@ const TERMINAL_APPS = [
   "wave",
   "tmux",
   "zellij",
+  "vscode",
+  "code",
 ]
+
+function escapeForOsascript(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
 
 export namespace Notification {
   export async function terminalIsFocused(): Promise<boolean> {
@@ -38,8 +44,8 @@ export namespace Notification {
     const os = platform()
 
     if (os === "darwin") {
-      const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
-      const titleEscaped = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      const escaped = escapeForOsascript(message)
+      const titleEscaped = escapeForOsascript(title)
       await Process.run(
         [
           "osascript",

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -1,0 +1,89 @@
+import { platform } from "os"
+import { Process } from "@/util/process"
+import { which } from "@/util/which"
+
+const TERMINAL_APPS = [
+  "terminal",
+  "iterm",
+  "iterm2",
+  "warp",
+  "alacritty",
+  "kitty",
+  "ghostty",
+  "wezterm",
+  "hyper",
+  "tabby",
+  "wave",
+  "tmux",
+  "zellij",
+]
+
+export namespace Notification {
+  export async function terminalIsFocused(): Promise<boolean> {
+    if (platform() !== "darwin") return false
+
+    const result = await Process.text(
+      [
+        "osascript",
+        "-e",
+        'tell application "System Events" to get name of first application process whose frontmost is true',
+      ],
+      { nothrow: true },
+    )
+    const frontmost = result.text.trim().toLowerCase()
+    return TERMINAL_APPS.some((app) => frontmost.includes(app))
+  }
+
+  export async function show(title: string, message: string): Promise<void> {
+    const os = platform()
+
+    if (os === "darwin") {
+      const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      const titleEscaped = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      await Process.run(
+        [
+          "osascript",
+          "-e",
+          `tell application "Terminal" to display notification "${escaped}" with title "${titleEscaped}"`,
+        ],
+        { nothrow: true },
+      )
+      return
+    }
+
+    if (os === "linux") {
+      if (which("notify-send")) {
+        await Process.run(["notify-send", "--app-name=opencode", title, message], { nothrow: true })
+        return
+      }
+      if (which("notify")) {
+        await Process.run(["notify", title, message], { nothrow: true })
+        return
+      }
+      return
+    }
+
+    if (os === "win32") {
+      const script = [
+        "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null",
+        "[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null",
+        `$template = "<toast><visual><binding template='ToastText02'><text id='1'>${escapeXml(title)}</text><text id='2'>${escapeXml(message)}</text></binding></visual></toast>"`,
+        "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument",
+        "$xml.LoadXml($template)",
+        "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)",
+        '[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("opencode").Show($toast)',
+      ].join("; ")
+      await Process.run(["powershell.exe", "-NonInteractive", "-NoProfile", "-Command", script], { nothrow: true })
+      return
+    }
+  }
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}

--- a/packages/web/src/content/docs/ar/plugins.mdx
+++ b/packages/web/src/content/docs/ar/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/bs/plugins.mdx
+++ b/packages/web/src/content/docs/bs/plugins.mdx
@@ -216,7 +216,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/da/plugins.mdx
+++ b/packages/web/src/content/docs/da/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/de/plugins.mdx
+++ b/packages/web/src/content/docs/de/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/es/plugins.mdx
+++ b/packages/web/src/content/docs/es/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/fr/plugins.mdx
+++ b/packages/web/src/content/docs/fr/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/it/plugins.mdx
+++ b/packages/web/src/content/docs/it/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ja/plugins.mdx
+++ b/packages/web/src/content/docs/ja/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ko/plugins.mdx
+++ b/packages/web/src/content/docs/ko/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/nb/plugins.mdx
+++ b/packages/web/src/content/docs/nb/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/pl/plugins.mdx
+++ b/packages/web/src/content/docs/pl/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/pt-br/plugins.mdx
+++ b/packages/web/src/content/docs/pt-br/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ru/plugins.mdx
+++ b/packages/web/src/content/docs/ru/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/th/plugins.mdx
+++ b/packages/web/src/content/docs/th/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/tr/plugins.mdx
+++ b/packages/web/src/content/docs/tr/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/zh-cn/plugins.mdx
+++ b/packages/web/src/content/docs/zh-cn/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/zh-tw/plugins.mdx
+++ b/packages/web/src/content/docs/zh-tw/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }


### PR DESCRIPTION
## Summary
- Add built-in system notifications for TUI (zero dependencies)
- Fix macOS notification attribution (click opens Terminal, not Script Editor)
- Add terminal focus detection (only notify when terminal is backgrounded)
- Add `notifications` config option to tui.json
- Beautify TUI toast with full borders and variant icons

## Changes

### New: Notification Service (`src/notification/index.ts`)
- Cross-platform notification API using system tools only
- macOS: `osascript` attributed to Terminal.app
- Linux: `notify-send` 
- Windows: PowerShell BurntToast
- Added `terminalIsFocused()` for focus detection

### Config (`tui-schema.ts`)
- Added `notifications: boolean` option (default: true)

### TUI Integration (`app.tsx`)
- Listen to `session.idle` → show system notification
- Listen to `session.error` → show system notification (complementing toast)

### Documentation Fix (`plugins.mdx`)
- Fixed osascript example: now uses `tell application "Terminal"` to attribute notifications correctly

### UI Improvement (`toast.tsx`)
- Full borders on all sides (was only left/right)
- Added variant icons: ✓ success, ✗ error, ℹ info, ⚠ warning
- Color-coded icons based on variant

## Testing
Tested manually on macOS. Linux/Windows use existing system notification APIs.

## Related Issues
- #7242 - Notification when plan/build is done
- #13334 - Sub-Agents Constantly Trigger OS Notifications
- #18366 - Add config option to disable macOS system notifications