### PR TITLE
fix(node): set OPENCODE_CHANNEL during build

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { Script } from "@opencode-ai/script"
 import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
@@ -48,6 +49,7 @@ await Bun.build({
   external: ["jsonc-parser"],
   define: {
     OPENCODE_MIGRATIONS: JSON.stringify(migrations),
+    OPENCODE_CHANNEL: `'${Script.channel}'`,
   },
 })
 


### PR DESCRIPTION
Without this, beta builds use `opencode-.db` as the database instead of the correct db