### PR TITLE
Fix: Config Get returns stale data after Patch

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1422,11 +1422,12 @@ export namespace Config {
 
         const update = Effect.fn("Config.update")(function* (config: Info) {
           const dir = yield* InstanceState.directory
-          const file = path.join(dir, "config.json")
+          const file = path.join(dir, "opencode.json")
           const existing = yield* loadFile(file)
           yield* fs
             .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))
             .pipe(Effect.orDie)
+          yield* invalidate()
           yield* Effect.promise(() => Instance.dispose())
         })
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -710,8 +710,21 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await Config.update(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "opencode.json"))
       expect(writtenConfig.model).toBe("updated/model")
+    },
+  })
+})
+
+test("patch then get returns updated config", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Config.update({ agent: { testAgent: { model: "test/model" } } } as any)
+
+      const config = await Config.get()
+      expect(config.agent?.testAgent?.model).toBe("test/model")
     },
   })
 })


### PR DESCRIPTION
- Change config file path from config.json to opencode.json to match the auto-loader which reads from .opencode/opencode.json
- Add invalidate() call to clear config cache after writing, ensuring subsequent Config.get() calls return updated data

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### Description
After calling the `patch /config` endpoint to add a custom agent configuration, immediately reading from the `/config`returned stale data without the newly patched agent configuration.

### What does this PR do?

This PR fixes a configuration caching issue where Config.get() returns stale data after calling Config.update(). The fix ensures that:
1. Updates are written to the correct file (opencode.json not config.json) that the auto-loader reads
2. The config cache is cleared after writing, so subsequent reads reflect the updated configuration

### How did you verify your code works?
I added a failing test case

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

