### PR TITLE
fix: cap long-lived queue and shell buffers

### DIFF
--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -32,7 +32,7 @@ export const EventRoutes = () =>
       c.header("X-Accel-Buffering", "no")
       c.header("X-Content-Type-Options", "nosniff")
       return streamSSE(c, async (stream) => {
-        const q = new AsyncQueue<string | null>()
+        const q = new AsyncQueue<string | null>({ capacity: 512, sentinel: null })
         let done = false
 
         q.push(
@@ -57,15 +57,27 @@ export const EventRoutes = () =>
           done = true
           clearInterval(heartbeat)
           unsub()
-          q.push(null)
+          q.close({ clear: true })
           log.info("event disconnected")
         }
 
+        const finish = (data: string) => {
+          if (done) return
+          done = true
+          clearInterval(heartbeat)
+          unsub()
+          q.push(data)
+          q.close()
+          log.info("event finished")
+        }
+
         const unsub = Bus.subscribeAll((event) => {
-          q.push(JSON.stringify(event))
+          const data = JSON.stringify(event)
           if (event.type === Bus.InstanceDisposed.type) {
-            stop()
+            finish(data)
+            return
           }
+          q.push(data)
         })
 
         stream.onAbort(stop)

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -19,7 +19,7 @@ export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({
 
 async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>) => () => void) {
   return streamSSE(c, async (stream) => {
-    const q = new AsyncQueue<string | null>()
+    const q = new AsyncQueue<string | null>({ capacity: 512, sentinel: null })
     let done = false
 
     q.push(
@@ -48,7 +48,7 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
       done = true
       clearInterval(heartbeat)
       unsub()
-      q.push(null)
+      q.close({ clear: true })
       log.info("global event disconnected")
     }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -49,6 +49,8 @@ import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
 
@@ -857,6 +859,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         )
 
         let output = ""
+        let outputTruncated = false
         const write = () => {
           if (part.state.status !== "running") return
           part.state.metadata = { output, description: "" }
@@ -864,11 +867,21 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         }
 
         proc.stdout?.on("data", (chunk) => {
+          if (outputTruncated) return
           output += chunk.toString()
+          if (output.length > MAX_OUTPUT_BYTES) {
+            output = output.slice(0, MAX_OUTPUT_BYTES) + `\n\n... output truncated at ${MAX_OUTPUT_BYTES} bytes`
+            outputTruncated = true
+          }
           write()
         })
         proc.stderr?.on("data", (chunk) => {
+          if (outputTruncated) return
           output += chunk.toString()
+          if (output.length > MAX_OUTPUT_BYTES) {
+            output = output.slice(0, MAX_OUTPUT_BYTES) + `\n\n... output truncated at ${MAX_OUTPUT_BYTES} bytes`
+            outputTruncated = true
+          }
           write()
         })
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import os from "os"
 import { spawn } from "child_process"
+import { appendFile, mkdir, writeFile } from "fs/promises"
 import { Tool } from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
@@ -17,9 +18,11 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncate"
+import { ToolID } from "./schema"
 import { Plugin } from "@/plugin"
 
 const MAX_METADATA_LENGTH = 30_000
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 const PS = new Set(["powershell", "pwsh"])
 const CWD = new Set(["cd", "push-location", "set-location"])
@@ -256,6 +259,10 @@ function preview(text: string) {
   return text.slice(0, MAX_METADATA_LENGTH) + "\n\n..."
 }
 
+function hint(file: string) {
+  return `The tool call succeeded but the output was truncated. Full output saved to: ${file}\nUse Grep to search the full content or Read with offset/limit to view specific sections.`
+}
+
 async function parse(command: string, ps: boolean) {
   const tree = await parser().then((p) => (ps ? p.ps : p.bash).parse(command))
   if (!tree) throw new Error("Failed to parse command")
@@ -328,6 +335,18 @@ async function run(
 ) {
   const proc = launch(input.shell, input.name, input.command, input.cwd, input.env)
   let output = ""
+  let size = 0
+  let file = ""
+  let writes = Promise.resolve()
+
+  const flush = (chunk: string, next: string) => {
+    file = next
+    writes = writes.then(async () => {
+      await mkdir(Truncate.DIR, { recursive: true })
+      await writeFile(file, output + chunk)
+    })
+    output += `\n\n... output truncated at ${MAX_OUTPUT_BYTES} bytes`
+  }
 
   ctx.metadata({
     metadata: {
@@ -337,7 +356,15 @@ async function run(
   })
 
   const append = (chunk: Buffer) => {
-    output += chunk.toString()
+    const text = chunk.toString()
+    if (file) {
+      writes = writes.then(() => appendFile(file, text))
+    } else if (size + chunk.length > MAX_OUTPUT_BYTES) {
+      flush(text, path.join(Truncate.DIR, ToolID.ascending()))
+    } else {
+      output += text
+      size += chunk.length
+    }
     ctx.metadata({
       metadata: {
         output: preview(output),
@@ -394,21 +421,30 @@ async function run(
     })
   })
 
+  await writes
+
   const metadata: string[] = []
   if (expired) metadata.push(`bash tool terminated command after exceeding timeout ${input.timeout} ms`)
   if (aborted) metadata.push("User aborted the command")
   if (metadata.length > 0) {
     output += "\n\n<bash_metadata>\n" + metadata.join("\n") + "\n</bash_metadata>"
+    if (file)
+      writes = writes.then(() => appendFile(file, "\n\n<bash_metadata>\n" + metadata.join("\n") + "\n</bash_metadata>"))
   }
+
+  await writes
+
+  const final = file ? `${output}\n\n${hint(file)}` : output
 
   return {
     title: input.description,
     metadata: {
-      output: preview(output),
+      output: preview(final),
       exit: proc.exitCode,
       description: input.description,
+      ...(file && { truncated: true, outputPath: file }),
     },
-    output,
+    output: final,
   }
 }
 

--- a/packages/opencode/src/util/queue.ts
+++ b/packages/opencode/src/util/queue.ts
@@ -1,15 +1,45 @@
 export class AsyncQueue<T> implements AsyncIterable<T> {
   private queue: T[] = []
   private resolvers: ((value: T) => void)[] = []
+  private closed = false
+  private sentinel: T
+  readonly capacity: number | undefined
+
+  constructor(opts?: { capacity?: number; sentinel?: T }) {
+    this.capacity = opts?.capacity
+    this.sentinel = opts?.sentinel as T
+  }
 
   push(item: T) {
+    if (this.closed) return
     const resolve = this.resolvers.shift()
     if (resolve) resolve(item)
-    else this.queue.push(item)
+    else {
+      if (this.capacity !== undefined && this.queue.length >= this.capacity) this.queue.shift()
+      this.queue.push(item)
+    }
+  }
+
+  clear() {
+    this.queue.length = 0
+  }
+
+  close(opts?: { clear?: boolean }) {
+    if (this.closed) return
+    this.closed = true
+    if (opts?.clear) this.clear()
+    if (this.sentinel === undefined) return
+    if (this.resolvers.length > 0) {
+      const list = this.resolvers.splice(0)
+      for (const resolve of list) resolve(this.sentinel)
+      return
+    }
+    this.queue.push(this.sentinel)
   }
 
   async next(): Promise<T> {
     if (this.queue.length > 0) return this.queue.shift()!
+    if (this.closed) return this.sentinel
     return new Promise((resolve) => this.resolvers.push(resolve))
   }
 

--- a/packages/opencode/src/util/queue.ts
+++ b/packages/opencode/src/util/queue.ts
@@ -26,9 +26,9 @@ export class AsyncQueue<T> implements AsyncIterable<T> {
 
   close(opts?: { clear?: boolean }) {
     if (this.closed) return
+    if (this.sentinel === undefined) throw new Error("AsyncQueue.close requires a sentinel")
     this.closed = true
     if (opts?.clear) this.clear()
-    if (this.sentinel === undefined) return
     if (this.resolvers.length > 0) {
       const list = this.resolvers.splice(0)
       for (const resolve of list) resolve(this.sentinel)

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -982,3 +982,66 @@ describe("tool.bash truncation", () => {
     })
   })
 })
+
+describe("tool.bash large-output spill-to-file", () => {
+  // bash.ts has its own MAX_OUTPUT_BYTES = 2 MiB streaming buffer.
+  // Once exceeded, full output is written to a file under Truncate.DIR.
+  const OVER_2MIB = 2_100_000 // 2.1 MB — safely above the 2 MiB threshold
+
+  test("sets truncated and outputPath when output exceeds 2 MiB", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          { command: fill("bytes", OVER_2MIB), description: "Generate bytes exceeding 2 MiB" },
+          ctx,
+        )
+
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.metadata.outputPath).toMatch(/\//)
+      },
+    })
+  })
+
+  test("returned output includes truncation hint with file path", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          { command: fill("bytes", OVER_2MIB), description: "Generate bytes for hint check" },
+          ctx,
+        )
+        const file = result.metadata.outputPath
+        if (!file) throw new Error("missing outputPath")
+
+        expect(result.output).toContain("output was truncated")
+        expect(result.output).toContain("Full output saved to:")
+        expect(result.output).toContain(file)
+      },
+    })
+  })
+
+  test("saved file contains full output beyond the preview cap", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          { command: fill("bytes", OVER_2MIB), description: "Generate bytes for full-file check" },
+          ctx,
+        )
+        mustTruncate(result)
+        const file = result.metadata.outputPath
+        if (!file) throw new Error("missing outputPath")
+
+        const saved = await Filesystem.readText(file)
+        // The saved file must contain the full generated output (may include stderr)
+        expect(saved.length).toBeGreaterThanOrEqual(OVER_2MIB)
+        // The returned output (preview + hint) must be significantly shorter
+        expect(result.output.length).toBeLessThan(OVER_2MIB)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/util/queue.test.ts
+++ b/packages/opencode/test/util/queue.test.ts
@@ -135,6 +135,11 @@ describe("AsyncQueue", () => {
       q.close({ clear: false }) // no-op
       expect(await q.next()).toBe(null)
     })
+
+    test("throws when closed without a sentinel", () => {
+      const q = new AsyncQueue<number>()
+      expect(() => q.close()).toThrow("sentinel")
+    })
   })
 
   // --- async iteration ---

--- a/packages/opencode/test/util/queue.test.ts
+++ b/packages/opencode/test/util/queue.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import { AsyncQueue } from "../../src/util/queue"
+
+describe("AsyncQueue", () => {
+  // --- bounded mode ---
+
+  describe("bounded mode (capacity)", () => {
+    test("drops oldest item when full", async () => {
+      const q = new AsyncQueue<number>({ capacity: 3 })
+      q.push(1)
+      q.push(2)
+      q.push(3)
+      // at capacity — next push evicts oldest
+      q.push(4)
+      expect(await q.next()).toBe(2)
+      expect(await q.next()).toBe(3)
+      expect(await q.next()).toBe(4)
+    })
+
+    test("resolves pending waiters directly, bypassing capacity", async () => {
+      const q = new AsyncQueue<number>({ capacity: 2 })
+      // queue is empty, next() creates a waiter
+      const p = q.next()
+      q.push(1) // resolves waiter with 1, queue stays empty
+      expect(await p).toBe(1)
+      // push more to fill beyond capacity
+      q.push(2)
+      q.push(3)
+      // only 2 and 3 in queue (capacity 2), nothing evicted because 1 went to waiter
+      expect(await q.next()).toBe(2)
+      expect(await q.next()).toBe(3)
+    })
+
+    test("no capacity constraint when capacity is undefined", async () => {
+      const q = new AsyncQueue<number>()
+      for (let i = 0; i < 1000; i++) q.push(i)
+      for (let i = 0; i < 1000; i++) expect(await q.next()).toBe(i)
+    })
+  })
+
+  // --- close({ clear: true }) ---
+
+  describe("close({ clear: true }) clears backlog and finishes with sentinel", () => {
+    test("emits sentinel after clearing queued items", async () => {
+      const q = new AsyncQueue<string | null>({ capacity: 10, sentinel: null })
+      q.push("a")
+      q.push("b")
+      q.close({ clear: true })
+      // backlog cleared, next item should be the sentinel
+      expect(await q.next()).toBe(null)
+      // stays closed
+      expect(await q.next()).toBe(null)
+    })
+
+    test("resolves pending waiters with sentinel", async () => {
+      const q = new AsyncQueue<string | null>({ capacity: 10, sentinel: null })
+      const p1 = q.next()
+      const p2 = q.next()
+      q.close({ clear: true })
+      expect(await p1).toBe(null)
+      expect(await p2).toBe(null)
+    })
+
+    test("ignores push after close", async () => {
+      const q = new AsyncQueue<number>({ capacity: 10, sentinel: -1 })
+      q.push(1)
+      q.close({ clear: true })
+      q.push(999) // ignored
+      expect(await q.next()).toBe(-1) // sentinel
+    })
+  })
+
+  // --- close() preserves queued items ---
+
+  describe("close() preserves queued items before sentinel", () => {
+    test("drains remaining items then yields sentinel", async () => {
+      const q = new AsyncQueue<string | null>({ capacity: 10, sentinel: null })
+      q.push("x")
+      q.push("y")
+      q.close() // no clear
+      expect(await q.next()).toBe("x")
+      expect(await q.next()).toBe("y")
+      expect(await q.next()).toBe(null)
+    })
+
+    test("resolves pending waiters with queued items, then sentinel", async () => {
+      const q = new AsyncQueue<string | null>({ capacity: 10, sentinel: null })
+      q.push("first")
+      const p = q.next() // resolves with "first"
+      const sentinelP = q.next() // no items left, will wait → resolved by sentinel on close
+      q.close()
+      expect(await p).toBe("first")
+      expect(await sentinelP).toBe(null)
+    })
+
+    test("InstanceDisposed pattern: push final event then close preserves both", async () => {
+      // This mirrors the real route pattern:
+      //   q.push(data)   // InstanceDisposed event
+      //   q.close()      // no clear → sentinel queued after
+      const q = new AsyncQueue<string | null>({ capacity: 512, sentinel: null })
+      q.push("event-a")
+      q.push("event-b")
+
+      // simulate Bus.InstanceDisposed
+      q.push('{"type":"Bus.InstanceDisposed","properties":{}}')
+      q.close()
+
+      expect(await q.next()).toBe("event-a")
+      expect(await q.next()).toBe("event-b")
+      expect(await q.next()).toBe('{"type":"Bus.InstanceDisposed","properties":{}}')
+      expect(await q.next()).toBe(null) // sentinel
+    })
+  })
+
+  // --- clear() ---
+
+  describe("clear()", () => {
+    test("removes all queued items", async () => {
+      const q = new AsyncQueue<number>({ capacity: 10, sentinel: -1 })
+      q.push(1)
+      q.push(2)
+      q.clear()
+      q.close()
+      expect(await q.next()).toBe(-1)
+    })
+  })
+
+  // --- idempotent close ---
+
+  describe("close idempotency", () => {
+    test("second close is a no-op", async () => {
+      const q = new AsyncQueue<string | null>({ sentinel: null })
+      q.push("a")
+      q.close({ clear: true })
+      q.close({ clear: false }) // no-op
+      expect(await q.next()).toBe(null)
+    })
+  })
+
+  // --- async iteration ---
+
+  describe("async iteration", () => {
+    test("yields items then sentinel and stops", async () => {
+      const q = new AsyncQueue<number>({ sentinel: -1 })
+      q.push(10)
+      q.push(20)
+      q.close()
+      const items: number[] = []
+      for await (const item of q) {
+        items.push(item)
+        if (item === -1) break
+      }
+      expect(items).toEqual([10, 20, -1])
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20626

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two long-running memory growth paths that can make a single OpenCode window consume very large amounts of memory over time.

First, it bounds the SSE queues used by the event routes and adds explicit close behavior so stalled or disconnected consumers do not keep accumulating buffered events in memory. It also preserves the final `InstanceDisposed` event before shutdown instead of dropping it.

Second, it stops bash and prompt subprocess output from growing unbounded in memory. Large bash output is now spilled to a truncation file while keeping the existing `truncated` / `outputPath` behavior, and prompt subprocess output is capped in memory as well. I also added a small follow-up guard so `AsyncQueue.close()` fails fast if called without a sentinel instead of leaving the queue in a half-closed state.

### How did you verify your code works?

I tested the queue and bash-output regressions locally:

- `bun test test/util/queue.test.ts`
- `bun test test/tool/bash.test.ts --filter "large-output spill-to-file|truncation"`
- `bun typecheck 2>&1 | grep -E "test/util/queue.test.ts|test/tool/bash.test.ts|src/util/queue.ts|src/server/routes/event.ts|src/server/routes/global.ts|src/tool/bash.ts|src/session/prompt.ts"`

During push, the repo hook also ran successfully:

- `bun turbo typecheck`

I did not mark the full package test suite here because it is currently blocked by an existing `@ai-sdk/provider-utils` import error unrelated to this patch.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR