### PR TITLE
feat: add optional messageID to ShellInput

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -756,7 +756,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         }
         const model = input.model ?? agent.model ?? (yield* lastModel(input.sessionID))
         const userMsg: MessageV2.User = {
-          id: MessageID.ascending(),
+          id: input.messageID ?? MessageID.ascending(),
           sessionID: input.sessionID,
           time: { created: Date.now() },
           role: "user",
@@ -1827,6 +1827,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
   export const ShellInput = z.object({
     sessionID: SessionID.zod,
+    messageID: MessageID.zod.optional(),
     agent: z.string(),
     model: z
       .object({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2231,6 +2231,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
+      messageID?: string
       agent?: string
       model?: {
         providerID: string
@@ -2248,6 +2249,7 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "body", key: "messageID" },
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
             { in: "body", key: "command" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3815,6 +3815,7 @@ export type SessionCommandResponse = SessionCommandResponses[keyof SessionComman
 
 export type SessionShellData = {
   body?: {
+    messageID?: string
     agent: string
     model?: {
       providerID: string


### PR DESCRIPTION
### Issue for this PR

Closes #20656

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows to specify a messageID for shell commands, matching PromptInput

### How did you verify your code works?

everything works + I can now determine messageID for shell commands

### Screenshots / recordings

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
