### PR TITLE
docs(ecosystem): add opencode-effect-enforcer plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -50,6 +50,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [opencode-effect-enforcer](https://github.com/mpsuesser/opencode-effect-enforcer)                  | Real-time Effect v4 pattern violation enforcement with 44 rules, skill gating, and guidance injection |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [opencode-effect-enforcer](https://github.com/mpsuesser/opencode-effect-enforcer) to the ecosystem plugins table

Real-time Effect v4 pattern violation enforcement with 44 rules (regex + AST), a skill gate requiring 7 of 39 bundled Effect skills before writing Effect code, and session guidance injection.