### PR TITLE
docs(effect): refresh migration status

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -214,17 +214,17 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 - [x] `SessionProcessor` — `session/processor.ts`
 - [x] `SessionPrompt` — `session/prompt.ts`
 - [x] `SessionCompaction` — `session/compaction.ts`
+- [x] `SessionSummary` — `session/summary.ts`
+- [x] `SessionRevert` — `session/revert.ts`
+- [x] `Instruction` — `session/instruction.ts`
 - [x] `Provider` — `provider/provider.ts`
+- [x] `Storage` — `storage/storage.ts`
 
 Still open:
 
-- [ ] `SessionSummary` — `session/summary.ts`
 - [ ] `SessionTodo` — `session/todo.ts`
-- [ ] `SessionRevert` — `session/revert.ts`
-- [ ] `Instruction` — `session/instruction.ts`
 - [ ] `ShareNext` — `share/share-next.ts`
 - [ ] `SyncEvent` — `sync/index.ts`
-- [ ] `Storage` — `storage/storage.ts`
 - [ ] `Workspace` — `control-plane/workspace.ts`
 
 ## Tool interface → Effect
@@ -238,6 +238,7 @@ Once individual tools are effectified, change `Tool.Info` (`tool/tool.ts`) so `i
 Individual tools, ordered by value:
 
 - [ ] `apply_patch.ts` — HIGH: multi-step orchestration, error accumulation, Bus events
+- [ ] `bash.ts` — HIGH: shell orchestration, quoting, timeout handling, output capture
 - [ ] `read.ts` — HIGH: streaming I/O, readline, binary detection → FileSystem + Stream
 - [ ] `edit.ts` — HIGH: multi-step diff/format/publish pipeline, FileWatcher lock
 - [ ] `grep.ts` — MEDIUM: spawns ripgrep → ChildProcessSpawner, timeout handling
@@ -247,40 +248,42 @@ Individual tools, ordered by value:
 - [ ] `websearch.ts` — MEDIUM: MCP over HTTP → HttpClient
 - [ ] `batch.ts` — MEDIUM: parallel execution, per-call error recovery → Effect.all
 - [ ] `task.ts` — MEDIUM: task state management
+- [ ] `ls.ts` — MEDIUM: bounded directory listing over ripgrep-backed traversal
+- [ ] `multiedit.ts` — MEDIUM: sequential edit orchestration over `edit.ts`
 - [ ] `glob.ts` — LOW: simple async generator
 - [ ] `lsp.ts` — LOW: dispatch switch over LSP operations
+- [ ] `question.ts` — LOW: prompt wrapper
 - [ ] `skill.ts` — LOW: skill tool adapter
+- [ ] `todo.ts` — LOW: todo persistence wrapper
+- [ ] `invalid.ts` — LOW: invalid-tool fallback
 - [ ] `plan.ts` — LOW: plan file operations
 
 ## Effect service adoption in already-migrated code
 
-Some services are effectified but still use raw `Filesystem.*` or `Process.spawn` instead of the Effect equivalents. These are low-hanging fruit — the layers already exist, they just need the dependency swap.
+Some already-effectified areas still use raw `Filesystem.*` or `Process.spawn` in their implementation or helper modules. These are low-hanging fruit — the layers already exist, they just need the dependency swap.
 
 ### `Filesystem.*` → `AppFileSystem.Service` (yield in layer)
 
-- [ ] `file/index.ts` — 11 calls (the File service itself)
-- [ ] `config/config.ts` — 7 calls
-- [ ] `auth/index.ts` — 3 calls
-- [ ] `skill/index.ts` — 3 calls
-- [ ] `file/time.ts` — 1 call
+- [ ] `file/index.ts` — 1 remaining `Filesystem.readText()` call in untracked diff handling
+- [ ] `config/config.ts` — 5 remaining `Filesystem.*` calls in `installDependencies()`
+- [ ] `provider/provider.ts` — 1 remaining `Filesystem.readJson()` call for recent model state
 
 ### `Process.spawn` → `ChildProcessSpawner` (yield in layer)
 
-- [ ] `format/index.ts` — 1 call
+- [ ] `format/formatter.ts` — 2 remaining `Process.spawn()` checks (`air`, `uv`)
+- [ ] `lsp/server.ts` — multiple `Process.spawn()` installs/download helpers
 
 ## Filesystem consolidation
 
-`util/filesystem.ts` (raw fs wrapper) is used by **64 files**. The effectified `AppFileSystem` service (`filesystem/index.ts`) exists but only has **8 consumers**. As services and tools are effectified, they should switch from `Filesystem.*` to yielding `AppFileSystem.Service` — this happens naturally during each migration, not as a separate effort.
+`util/filesystem.ts` (raw fs wrapper) is currently imported by **34 files**. The effectified `AppFileSystem` service (`filesystem/index.ts`) is currently imported by **15 files**. As services and tools are effectified, they should switch from `Filesystem.*` to yielding `AppFileSystem.Service` — this happens naturally during each migration, not as a separate effort.
 
-Similarly, **28 files** still import raw `fs` or `fs/promises` directly. These should migrate to `AppFileSystem` or `Filesystem.*` as they're touched.
+Similarly, **21 files** still import raw `fs` or `fs/promises` directly. These should migrate to `AppFileSystem` or `Filesystem.*` as they're touched.
 
 Current raw fs users that will convert during tool migration:
 
 - `tool/read.ts` — fs.createReadStream, readline
 - `tool/apply_patch.ts` — fs/promises
-- `tool/bash.ts` — fs/promises
 - `file/ripgrep.ts` — fs/promises
-- `storage/storage.ts` — fs/promises
 - `patch/index.ts` — fs, fs/promises
 
 ## Primitives & utilities


### PR DESCRIPTION
## Summary
- refresh `packages/opencode/specs/effect-migration.md` to match the current migration state
- move several services from the open list to the migrated list
- update stale tool, filesystem, and process-spawn notes with current counts and remaining hotspots

## Verification
- documentation-only change