### PR TITLE
feat(opencode): support github ref plugins and config model limit overrides

### DIFF
--- a/.sisyphus/notepads/rebase-v146/decisions.md
+++ b/.sisyphus/notepads/rebase-v146/decisions.md
@@ -1,0 +1,4 @@
+## Branch 11: feat/github-ref-plugins
+
+- Kept dev's workspace-aware plugin API/types (`experimental_workspace`, adaptor registration, workspace metadata) and layered the branch's skill discovery additions on top.
+- Kept the plugin skill integration test in `skill.test.ts`, but ran it through `ToolRegistry.defaultLayer` with a longer per-test timeout because plugin/tool initialization exceeds Bun's default 5s timeout in this workspace.

--- a/.sisyphus/notepads/rebase-v146/learnings.md
+++ b/.sisyphus/notepads/rebase-v146/learnings.md
@@ -1,0 +1,5 @@
+## Branch 11: feat/github-ref-plugins
+
+- `PluginInput.skills` now has to bridge through `Skill.Service.use(...)` inside `packages/opencode/src/plugin/index.ts`; direct `Skill.all/get/dirs` calls are not valid on the rebased Effect service shape.
+- `packages/opencode/test/skill/skill.test.ts` must keep the `it.live(...)`/`testEffect(...)` harness. Raw `test(...)` blocks from the branch need conversion to Effect tests to typecheck against the rebased helpers.
+- The workspace needed `bun install` before verification; without local dependencies, `bun typecheck` could not find `tsgo` and Bun test preloads failed to resolve.

--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -1,0 +1,157 @@
+import z from "zod"
+import { Global } from "../global"
+import { Log } from "../util/log"
+import path from "path"
+import { Filesystem } from "../util/filesystem"
+import { NamedError } from "@opencode-ai/shared/util/error"
+import { Lock } from "../util/lock"
+import { Npm } from "../npm"
+import { online, proxied } from "@/util/network"
+import { Process } from "../util/process"
+
+export namespace BunProc {
+  const log = Log.create({ service: "bun" })
+
+  export async function run(cmd: string[], options?: Process.RunOptions) {
+    const full = [which(), ...cmd]
+    log.info("running", {
+      cmd: full,
+      ...options,
+    })
+    const result = await Process.run(full, {
+      cwd: options?.cwd,
+      abort: options?.abort,
+      kill: options?.kill,
+      timeout: options?.timeout,
+      nothrow: options?.nothrow,
+      env: {
+        ...process.env,
+        ...options?.env,
+        BUN_BE_BUN: "1",
+      },
+    })
+    log.info("done", {
+      code: result.code,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+    })
+    return result
+  }
+
+  export function which() {
+    return process.execPath
+  }
+
+  export const InstallFailedError = NamedError.create(
+    "BunInstallFailedError",
+    z.object({
+      pkg: z.string(),
+      version: z.string(),
+    }),
+  )
+
+  // For github: dependencies, bun installs under the package's actual name
+  // (from its package.json "name" field), not under the github: specifier.
+  // Resolve the real module path by reading the installed package name from
+  // the cache lockfile.
+  async function resolveModulePath(pkg: string): Promise<string> {
+    const nodeModules = path.join(Global.Path.cache, "node_modules")
+    if (!pkg.startsWith("github:")) return path.join(nodeModules, pkg)
+    const lockPath = path.join(Global.Path.cache, "bun.lock")
+    const lock = await Filesystem.readText(lockPath).catch(() => "")
+    // lockfile maps "actual-name": "github:owner/repo#ref"
+    for (const line of lock.split("\n")) {
+      if (line.includes(pkg)) {
+        const match = line.match(/^\s*"([^"]+)":\s*"/)
+        if (match && match[1] !== pkg) return path.join(nodeModules, match[1])
+      }
+    }
+    // Fallback: strip github: prefix and use repo name
+    const repoName = pkg
+      .replace(/^github:/, "")
+      .split("#")[0]
+      .split("/")
+      .pop()
+    if (repoName) return path.join(nodeModules, repoName)
+    return path.join(nodeModules, pkg)
+  }
+
+  export async function install(pkg: string, version = "latest") {
+    // Use lock to ensure only one install at a time
+    using _ = await Lock.write("bun-install")
+
+    const mod = await resolveModulePath(pkg)
+    const pkgjsonPath = path.join(Global.Path.cache, "package.json")
+    const parsed = await Filesystem.readJson<{ dependencies: Record<string, string> }>(pkgjsonPath).catch(async () => {
+      const result = { dependencies: {} as Record<string, string> }
+      await Filesystem.writeJson(pkgjsonPath, result)
+      return result
+    })
+    if (!parsed.dependencies) parsed.dependencies = {} as Record<string, string>
+    const dependencies = parsed.dependencies
+    const modExists = await Filesystem.exists(mod)
+    const cachedVersion = dependencies[pkg]
+
+    if (!modExists || !cachedVersion) {
+      // continue to install
+    } else if (version === "latest") {
+      if (!online()) return mod
+      const stale = await Npm.outdated(pkg, cachedVersion)
+      if (!stale) return mod
+      log.info("Cached version is outdated, proceeding with install", { pkg, cachedVersion })
+    } else if (cachedVersion === version) {
+      return mod
+    }
+
+    // Build command arguments
+    const args = [
+      "add",
+      "--force",
+      "--exact",
+      // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
+      ...(proxied() || process.env.CI ? ["--no-cache"] : []),
+      "--cwd",
+      Global.Path.cache,
+      pkg.includes("#") ? pkg : pkg + "@" + version,
+    ]
+
+    // Let Bun handle registry resolution:
+    // - If .npmrc files exist, Bun will use them automatically
+    // - If no .npmrc files exist, Bun will default to https://registry.npmjs.org
+    // - No need to pass --registry flag
+    log.info("installing package using Bun's default registry resolution", {
+      pkg,
+      version,
+    })
+
+    await BunProc.run(args, {
+      cwd: Global.Path.cache,
+    }).catch((e) => {
+      throw new InstallFailedError(
+        { pkg, version },
+        {
+          cause: e,
+        },
+      )
+    })
+
+    // Re-resolve after install in case lockfile changed
+    const installedMod = await resolveModulePath(pkg)
+
+    // Resolve actual version from installed package when using "latest"
+    // This ensures subsequent starts use the cached version until explicitly updated
+    let resolvedVersion = version
+    if (version === "latest") {
+      const installedPkg = await Filesystem.readJson<{ version?: string }>(
+        path.join(installedMod, "package.json"),
+      ).catch(() => null)
+      if (installedPkg?.version) {
+        resolvedVersion = installedPkg.version
+      }
+    }
+
+    parsed.dependencies[pkg] = resolvedVersion
+    await Filesystem.writeJson(pkgjsonPath, parsed)
+    return installedMod
+  }
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -25,6 +25,7 @@ import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
 import { registerAdaptor } from "@/control-plane/adaptors"
 import type { WorkspaceAdaptor } from "@/control-plane/types"
+import { Skill } from "../skill"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -53,6 +54,28 @@ export namespace Plugin {
   }
 
   export class Service extends Context.Service<Service, Interface>()("@opencode/Plugin") {}
+
+  // Extract package name from a plugin specifier for dedup.
+  // "github:owner/repo#branch" → "repo"
+  // "@scope/pkg@version" → "@scope/pkg"
+  // "pkg@version" → "pkg"
+  export function pluginRepo(plugin: Config.PluginOrigin | Config.PluginSpec): string {
+    const spec = Config.pluginSpecifier(typeof plugin === "string" || Array.isArray(plugin) ? plugin : plugin.spec)
+    if (spec.startsWith("github:")) {
+      const repo = spec.replace(/^github:/, "").split("#")[0]
+      return repo.split("/").pop()!
+    }
+    const last = spec.lastIndexOf("@")
+    if (last > 0) return spec.substring(0, last)
+    return spec
+  }
+
+  // Merge BUILTIN and user plugins, dropping any BUILTIN whose
+  // package name is already provided by a user plugin.
+  export function dedup(builtin: Config.PluginOrigin[], user: Config.PluginOrigin[]): Config.PluginOrigin[] {
+    const names = new Set(user.map(pluginRepo))
+    return [...builtin.filter((b) => !names.has(pluginRepo(b))), ...user]
+  }
 
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [
@@ -146,6 +169,11 @@ export namespace Plugin {
             },
             // @ts-expect-error
             $: typeof Bun === "undefined" ? undefined : Bun.$,
+            skills: {
+              all: () => bridge.promise(Skill.Service.use((svc) => svc.all()).pipe(Effect.orDie)),
+              get: (name: string) => bridge.promise(Skill.Service.use((svc) => svc.get(name)).pipe(Effect.orDie)),
+              dirs: () => bridge.promise(Skill.Service.use((svc) => svc.dirs()).pipe(Effect.orDie)),
+            },
           }
 
           for (const plugin of INTERNAL_PLUGINS) {
@@ -159,7 +187,7 @@ export namespace Plugin {
             if (init._tag === "Some") hooks.push(init.value)
           }
 
-          const plugins = Flag.OPENCODE_PURE ? [] : (cfg.plugin_origins ?? [])
+          const plugins: Config.PluginOrigin[] = Flag.OPENCODE_PURE ? [] : dedup([], cfg.plugin_origins ?? [])
           if (Flag.OPENCODE_PURE && cfg.plugin_origins?.length) {
             log.info("skipping external plugins in pure mode", { count: cfg.plugin_origins.length })
           }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1341,6 +1341,13 @@ export namespace Provider {
                   (v) => omit(v, ["disabled"]),
                 )
               }
+
+              const configLimit = configProvider?.models?.[modelID]?.limit
+              if (configLimit) {
+                if (configLimit.context) model.limit.context = configLimit.context
+                if (configLimit.input) model.limit.input = configLimit.input
+                if (configLimit.output) model.limit.output = configLimit.output
+              }
             }
 
             if (Object.keys(provider.models).length === 0) {

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -130,6 +130,11 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
     },
     serverUrl: new URL("https://example.com"),
     $: {} as never,
+    skills: {
+      all: async () => [],
+      get: async () => undefined,
+      dirs: async () => [],
+    },
   })
 
   const models = await hooks.provider!.models!(

--- a/packages/opencode/test/plugin/native-skills.test.ts
+++ b/packages/opencode/test/plugin/native-skills.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+
+const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+const cfg = process.env.OPENCODE_CONFIG_DIR
+const content = process.env.OPENCODE_CONFIG_CONTENT
+const home = process.env.OPENCODE_TEST_HOME
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Effect } = await import("effect")
+const { Instance } = await import("../../src/project/instance")
+const { ToolRegistry } = await import("../../src/tool/registry")
+
+afterEach(async () => {
+  if (disable === undefined) delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  else process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disable
+  if (cfg === undefined) delete process.env.OPENCODE_CONFIG_DIR
+  else process.env.OPENCODE_CONFIG_DIR = cfg
+  if (content === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+  else process.env.OPENCODE_CONFIG_CONTENT = content
+  if (home === undefined) delete process.env.OPENCODE_TEST_HOME
+  else process.env.OPENCODE_TEST_HOME = home
+  await Instance.disposeAll()
+})
+
+// Validates the OMO+superpowers coexistence pattern:
+// A plugin captures ctx.skills during server(), then calls ctx.skills.all()
+// LAZILY (via a tool execute) after plugin loading completes.
+// Native skills must be visible in the lazy call.
+test("plugin tool can lazily call ctx.skills.all() and see native skills", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create a native skill in the standard location
+      const skill = path.join(dir, ".opencode", "skill", "test-native")
+      await fs.mkdir(skill, { recursive: true })
+      await Bun.write(
+        path.join(skill, "SKILL.md"),
+        ["---", "name: test-native", "description: A test native skill", "---", "", "# Test Native Skill", ""].join("\n"),
+      )
+
+      // Create a plugin that captures ctx.skills and exposes a tool
+      // whose execute calls ctx.skills.all() lazily
+      const plugin = path.join(dir, ".opencode", "plugin")
+      await fs.mkdir(plugin, { recursive: true })
+      const out = JSON.stringify(path.join(dir, "skills-result.json"))
+      await Bun.write(
+        path.join(plugin, "skill-reader.ts"),
+        [
+          'import { writeFileSync } from "fs"',
+          "",
+          "export default {",
+          '  id: \"test.skill-reader\",',
+          "  server: async (ctx) => {",
+          "    // Capture ctx.skills — do NOT call all() during server()",
+          "    const skills = ctx.skills",
+          "    return {",
+          "      tool: {",
+          "        check_native_skills: {",
+          '          description: \"Returns native skills found via ctx.skills.all()\",',
+          "          args: {},",
+          "          execute: async () => {",
+          "            // LAZY call — runs after server() has returned",
+          "            const all = await skills.all()",
+          `            writeFileSync(${out}, JSON.stringify(all.map(s => s.name)))`,
+          '            return all.map(s => s.name).join(\", \")',
+          "          }",
+          "        }",
+          "      }",
+          "    }",
+          "  },",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.OPENCODE_CONFIG_DIR = path.join(tmp.path, ".config")
+  delete process.env.OPENCODE_CONFIG_CONTENT
+  await fs.mkdir(process.env.OPENCODE_CONFIG_DIR, { recursive: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const svc = yield* ToolRegistry.Service
+          const tools = yield* svc.all()
+          const tool = tools.find((t) => t.id === "check_native_skills")
+          if (!tool) throw new Error("Plugin tool not found")
+          yield* tool.execute({}, {
+            sessionID: "ses_test" as any,
+            messageID: "msg_test" as any,
+            agent: "test",
+            abort: new AbortController().signal,
+            extra: {},
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          })
+        }).pipe(Effect.provide(ToolRegistry.defaultLayer)),
+      )
+    },
+  })
+
+  const names = (await Bun.file(path.join(tmp.path, "skills-result.json")).json()) as string[]
+  expect(names).toContain("test-native")
+}, 30000)

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -2,6 +2,10 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Skill } from "../../src/skill"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { ToolRegistry } from "../../src/tool/registry"
+import type { Tool } from "../../src/tool/tool"
 import { provideInstance, provideTmpdirInstance, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
@@ -10,6 +14,18 @@ import fs from "fs/promises"
 const node = CrossSpawnSpawner.defaultLayer
 
 const it = testEffect(Layer.mergeAll(Skill.defaultLayer, node))
+const kit = testEffect(Layer.mergeAll(ToolRegistry.defaultLayer, node))
+
+const toolCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test-plugin-skill"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
 
 async function createGlobalSkill(homeDir: string) {
   const skillDir = path.join(homeDir, ".claude", "skills", "global-test-skill")
@@ -387,5 +403,247 @@ description: A skill in the .opencode/skills directory.
         }),
       { git: true },
     ),
+  )
+  it.live("discovers skills from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "config-skill", "SKILL.md"),
+              `---
+name: config-skill
+description: A skill registered via config.skills.paths.
+---
+
+# Config Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = (yield* skill.all()).find((x) => x.name === "config-skill")
+          expect(item).toBeDefined()
+          expect(item!.description).toBe("A skill registered via config.skills.paths.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns skill from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "get-test-skill", "SKILL.md"),
+              `---
+name: get-test-skill
+description: Skill for get() test.
+---
+
+# Get Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = yield* skill.get("get-test-skill")
+          expect(item).toBeDefined()
+          expect(item!.name).toBe("get-test-skill")
+          expect(item!.description).toBe("Skill for get() test.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("includes config.skills.paths directories in dirs", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          const item = path.join(root, "dirs-test-skill")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(item, "SKILL.md"),
+              `---
+name: dirs-test-skill
+description: Skill for dirs() test.
+---
+
+# Dirs Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          expect(yield* skill.dirs()).toContain(item)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns undefined for missing skills", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          expect(yield* skill.get("nonexistent-skill")).toBeUndefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("keeps opencode and claude skill loading with config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skill", "opencode-skill", "SKILL.md"),
+                `---
+name: opencode-skill
+description: Skill in .opencode/skill directory.
+---
+
+# OpenCode Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+                `---
+name: claude-skill
+description: Skill in .claude/skills directory.
+---
+
+# Claude Skill
+`,
+              ),
+              Bun.write(
+                path.join(root, "config-skill", "SKILL.md"),
+                `---
+name: config-skill
+description: Skill in config.skills.paths.
+---
+
+# Config Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, "opencode.json"),
+                JSON.stringify({
+                  $schema: "https://opencode.ai/config.json",
+                  skills: { paths: [root] },
+                }),
+              ),
+            ]),
+          )
+          const skill = yield* Skill.Service
+          const list = yield* skill.all()
+          expect(list.length).toBe(3)
+          expect(list.find((x) => x.name === "opencode-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "claude-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "config-skill")).toBeDefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  kit.live(
+    "PluginInput.skills works in plugin tool execute after config hooks populate skills.paths",
+    () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const plugin = path.join(dir, ".opencode", "plugin")
+            yield* Effect.promise(() => fs.mkdir(plugin, { recursive: true }))
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(dir, "plugin-config-skills", "plugin-config-skill", "SKILL.md"),
+                `---
+name: plugin-config-skill
+description: A skill registered by a plugin config hook.
+---
+
+# Plugin Config Skill
+`,
+              ),
+            )
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(plugin, "plugin-skill-check.ts"),
+                [
+                  'import { tool } from "@opencode-ai/plugin"',
+                  "",
+                  "export default async (input) => ({",
+                  "  config: async (config) => {",
+                  "    config.skills ??= {}",
+                  "    config.skills.paths ??= []",
+                  '    config.skills.paths.push("./plugin-config-skills")',
+                  "  },",
+                  "  tool: {",
+                  '    "plugin-skill-check": tool({',
+                  '      description: "Checks PluginInput.skills access",',
+                  "      args: {},",
+                  "      execute: async () => {",
+                  '        const skill = await input.skills.get("plugin-config-skill")',
+                  "        const dirs = await input.skills.dirs()",
+                  "        const all = await input.skills.all()",
+                  '        return [skill?.name ?? "", skill?.description ?? "", String(all.length), ...dirs].join("\\n")',
+                  "      },",
+                  "    }),",
+                  "  },",
+                  "})",
+                  "",
+                ].join("\n"),
+              ),
+            )
+            const list = yield* ToolRegistry.Service.use((svc) =>
+              svc.tools({
+                providerID: ProviderID.opencode,
+                modelID: ModelID.make("gpt-5"),
+                agent: { name: "build", mode: "primary", permission: [], options: {} },
+              }),
+            )
+            const tool = list.find((item) => item.id === "plugin-skill-check")
+            expect(tool).toBeDefined()
+            const out = yield* tool!.execute({}, toolCtx)
+            const lines = out.output.split("\n")
+            expect(lines[0]).toBe("plugin-config-skill")
+            expect(lines[1]).toBe("A skill registered by a plugin config hook.")
+            expect(Number(lines[2])).toBeGreaterThanOrEqual(1)
+            expect(lines).toContain(path.join(dir, "plugin-config-skills", "plugin-config-skill"))
+          }),
+        { git: true },
+      ),
+    30000,
   )
 })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -54,6 +54,13 @@ export type WorkspaceAdaptor = {
   target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
 }
 
+export type SkillInfo = {
+  name: string
+  description: string
+  location: string
+  content: string
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -64,6 +71,11 @@ export type PluginInput = {
   }
   serverUrl: URL
   $: BunShell
+  skills: {
+    all(): Promise<SkillInfo[]>
+    get(name: string): Promise<SkillInfo | undefined>
+    dirs(): Promise<string[]>
+  }
 }
 
 export type PluginOptions = Record<string, unknown>


### PR DESCRIPTION
### Issue for this PR

Fixes #12143

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Support `github:owner/repo#ref` plugin specifiers in bun install. Resolves plugin install path for github-based dependencies and adds config-level model token limit overrides.

### How did you verify your code works?

- Ran `bun typecheck` from packages/opencode
- Ran targeted unit tests
- Tested with custom binary build

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR