### PR TITLE
fix(opencode): propagate worker errors to TUI prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -12,6 +12,7 @@ import { useSync } from "@tui/context/sync"
 import { MessageID, PartID } from "@/session/schema"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
+import { Log } from "@/util/log"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { assign } from "./part"
 import { usePromptStash } from "./stash"
@@ -102,6 +103,23 @@ export function Prompt(props: PromptProps) {
     if (sync.data.provider.length === 0) {
       dialog.replace(() => <DialogProviderConnect />)
     }
+  }
+
+  function failure(error: unknown) {
+    toast.show({
+      variant: "error",
+      message: error instanceof Error ? error.message : String(error),
+      duration: 5000,
+    })
+  }
+
+  function report(promise: Promise<unknown>) {
+    promise
+      .then((result) => {
+        if (!result || typeof result !== "object" || !("error" in result) || !result.error) return
+        failure(result.error)
+      })
+      .catch(failure)
   }
 
   const textareaKeybindings = useTextareaKeybindings()
@@ -595,10 +613,10 @@ export function Prompt(props: PromptProps) {
       })
 
       if (res.error) {
-        console.log("Creating a session failed:", res.error)
+        Log.Default.error("session creation failed", { error: res.error })
 
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          message: "Creating a session failed",
           variant: "error",
         })
 
@@ -635,15 +653,17 @@ export function Prompt(props: PromptProps) {
     const variant = local.model.variant.current()
 
     if (store.mode === "shell") {
-      sdk.client.session.shell({
-        sessionID,
-        agent: local.agent.current().name,
-        model: {
-          providerID: selectedModel.providerID,
-          modelID: selectedModel.modelID,
-        },
-        command: inputText,
-      })
+      report(
+        sdk.client.session.shell({
+          sessionID,
+          agent: local.agent.current().name,
+          model: {
+            providerID: selectedModel.providerID,
+            modelID: selectedModel.modelID,
+          },
+          command: inputText,
+        }),
+      )
       setStore("mode", "normal")
     } else if (
       inputText.startsWith("/") &&
@@ -660,24 +680,26 @@ export function Prompt(props: PromptProps) {
       const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
       const args = firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : "")
 
-      sdk.client.session.command({
-        sessionID,
-        command: command.slice(1),
-        arguments: args,
-        agent: local.agent.current().name,
-        model: `${selectedModel.providerID}/${selectedModel.modelID}`,
-        messageID,
-        variant,
-        parts: nonTextParts
-          .filter((x) => x.type === "file")
-          .map((x) => ({
-            id: PartID.ascending(),
-            ...x,
-          })),
-      })
+      report(
+        sdk.client.session.command({
+          sessionID,
+          command: command.slice(1),
+          arguments: args,
+          agent: local.agent.current().name,
+          model: `${selectedModel.providerID}/${selectedModel.modelID}`,
+          messageID,
+          variant,
+          parts: nonTextParts
+            .filter((x) => x.type === "file")
+            .map((x) => ({
+              id: PartID.ascending(),
+              ...x,
+            })),
+        }),
+      )
     } else {
-      sdk.client.session
-        .prompt({
+      report(
+        sdk.client.session.prompt({
           sessionID,
           ...selectedModel,
           messageID,
@@ -692,8 +714,8 @@ export function Prompt(props: PromptProps) {
             },
             ...nonTextParts.map(assign),
           ],
-        })
-        .catch(() => {})
+        }),
+      )
     }
     history.append({
       ...store.prompt,

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono"
-import { stream } from "hono/streaming"
 import { describeRoute, validator, resolver } from "hono-openapi"
 import { SessionID, MessageID, PartID } from "@/session/schema"
 import z from "zod"
@@ -20,7 +19,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
-import { NamedError } from "@opencode-ai/util/error"
+import { Instance } from "@/project/instance"
 
 const log = Log.create({ service: "server" })
 
@@ -811,14 +810,10 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(200)
-        c.header("Content-Type", "application/json")
-        return stream(c, async (stream) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
-        })
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const msg = await SessionPrompt.prompt({ ...body, sessionID })
+        return c.json(msg)
       },
     )
     .post(
@@ -843,19 +838,25 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const run = Instance.bind(() => {
           SessionPrompt.prompt({ ...body, sessionID }).catch((err) => {
-            log.error("prompt_async failed", { sessionID, error: err })
+            log.error("prompt_async failed", {
+              sessionID,
+              error: err,
+              stack: err instanceof Error ? err.stack : undefined,
+            })
+            const error = MessageV2.fromError(err, { providerID: "unknown" as any })
             Bus.publish(Session.Event.Error, {
               sessionID,
-              error: new NamedError.Unknown({ message: err instanceof Error ? err.message : String(err) }).toObject(),
+              error,
             })
           })
         })
+        run()
+        c.status(204)
+        return c.body(null)
       },
     )
     .post(

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -1,14 +1,49 @@
 export namespace Rpc {
+  type RpcError = {
+    name: string
+    message: string
+    stack?: string
+    cause?: string
+  }
+
   type Definition = {
     [method: string]: (input: any) => any
+  }
+
+  function serialize(error: unknown): RpcError {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+        cause: error.cause ? String(error.cause) : undefined,
+      }
+    }
+
+    return {
+      name: "Error",
+      message: String(error),
+    }
+  }
+
+  function hydrate(error: RpcError) {
+    const result = new Error(error.message)
+    result.name = error.name
+    result.stack = error.stack
+    if (error.cause) result.cause = error.cause
+    return result
   }
 
   export function listen(rpc: Definition) {
     onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.request") {
-        const result = await rpc[parsed.method](parsed.input)
-        postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        try {
+          const result = await rpc[parsed.method](parsed.input)
+          postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        } catch (error) {
+          postMessage(JSON.stringify({ type: "rpc.error", error: serialize(error), id: parsed.id }))
+        }
       }
     }
   }
@@ -21,15 +56,22 @@ export namespace Rpc {
     postMessage: (data: string) => void | null
     onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
   }) {
-    const pending = new Map<number, (result: any) => void>()
+    const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>()
     const listeners = new Map<string, Set<(data: any) => void>>()
     let id = 0
     target.onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.result") {
-        const resolve = pending.get(parsed.id)
-        if (resolve) {
-          resolve(parsed.result)
+        const entry = pending.get(parsed.id)
+        if (entry) {
+          entry.resolve(parsed.result)
+          pending.delete(parsed.id)
+        }
+      }
+      if (parsed.type === "rpc.error") {
+        const entry = pending.get(parsed.id)
+        if (entry) {
+          entry.reject(hydrate(parsed.error))
           pending.delete(parsed.id)
         }
       }
@@ -45,8 +87,8 @@ export namespace Rpc {
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
         const requestId = id++
-        return new Promise((resolve) => {
-          pending.set(requestId, resolve)
+        return new Promise((resolve, reject) => {
+          pending.set(requestId, { resolve, reject })
           target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
         })
       },


### PR DESCRIPTION
### Issue for this PR

Fixes #12834

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Propagate worker errors to the TUI prompt component so users see failures instead of a frozen UI. Fix RPC stream error handling to surface underlying causes.

### How did you verify your code works?

- Ran `bun typecheck` from packages/opencode
- Ran targeted unit tests
- Tested with custom binary build

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR