### PR TITLE
fix(opencode): harden serve mode — permissions, bash safety, session recovery

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -60,6 +60,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { Log } from "@/util/log"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -140,7 +141,7 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
       keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],
       onCopySelection: (text) => {
         Clipboard.copy(text).catch((error) => {
-          console.error(`Failed to copy console selection to clipboard: ${error}`)
+          Log.Default.error("clipboard copy from console failed", { error })
         })
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
@@ -7,6 +7,9 @@ import { useTheme } from "../context/theme"
 import { Keybind } from "@/util/keybind"
 import { TextAttributes } from "@opentui/core"
 import { useSDK } from "@tui/context/sdk"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "tui.mcp" })
 
 function Status(props: { enabled: boolean; loading: boolean }) {
   const { theme } = useTheme()
@@ -61,10 +64,10 @@ export function DialogMcp() {
           if (status.data) {
             sync.set("mcp", status.data)
           } else {
-            console.error("Failed to refresh MCP status: no data returned")
+            log.warn("failed to refresh MCP status: no data returned")
           }
         } catch (error) {
-          console.error("Failed to toggle MCP:", error)
+          log.error("failed to toggle MCP", { error })
         } finally {
           setLoading(null)
         }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -9,6 +9,9 @@ import { useToast } from "../ui/toast"
 import { useKeybind } from "../context/keybind"
 import { DialogSessionList } from "./workspace/dialog-session-list"
 import { setTimeout as sleep } from "node:timers/promises"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "tui.workspace" })
 
 function scoped(sdk: ReturnType<typeof useSDK>, sync: ReturnType<typeof useSync>, workspaceID?: string) {
   return createOpencodeClient({
@@ -116,10 +119,10 @@ function DialogWorkspaceCreate(props: { onSelect: (workspaceID: string) => Promi
     setCreating(type)
 
     const result = await sdk.client.experimental.workspace.create({ type, branch: null }).catch((err) => {
-      console.log(err)
+      log.error("workspace creation failed", { error: err })
       return undefined
     })
-    console.log(JSON.stringify(result, null, 2))
+    log.debug("workspace created", { result: JSON.stringify(result) })
     const workspace = result?.data
     if (!workspace) {
       setCreating(undefined)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -13,6 +13,7 @@ import { useSync } from "@tui/context/sync"
 import { MessageID, PartID } from "@/session/schema"
 import { createStore, produce } from "solid-js/store"
 import { useKeybind } from "@tui/context/keybind"
+import { Log } from "@/util/log"
 import { usePromptHistory, type PromptInfo } from "./history"
 import { assign } from "./part"
 import { usePromptStash } from "./stash"
@@ -277,7 +278,7 @@ export function Prompt(props: PromptProps) {
           if (store.interrupt >= 2) {
             sdk.client.session.abort({
               sessionID: props.sessionID,
-            })
+            }).catch(() => {})
             setStore("interrupt", 0)
           }
           dialog.clear()
@@ -608,10 +609,10 @@ export function Prompt(props: PromptProps) {
       })
 
       if (res.error) {
-        console.log("Creating a session failed:", res.error)
+        Log.Default.error("session creation failed", { error: res.error })
 
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          message: "Creating a session failed",
           variant: "error",
         })
 
@@ -687,7 +688,7 @@ export function Prompt(props: PromptProps) {
             id: PartID.ascending(),
             ...x,
           })),
-      })
+      }).catch(() => {})
     } else {
       sdk.client.session
         .prompt({

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -376,7 +376,6 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       kv.set("theme_mode", mode)
       if (store.mode === mode) return
       setStore("mode", mode)
-      renderer.clearPaletteCache()
       resolveSystemTheme(mode)
     }
 
@@ -409,6 +408,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       renderer.off(CliRenderEvents.THEME_MODE, handle)
       process.off("SIGUSR2", refresh)
     })
+
+    const sigusr2Handler = async () => {
+      renderer.clearPaletteCache()
+      init()
+    }
+    process.on("SIGUSR2", sigusr2Handler)
+    onCleanup(() => process.off("SIGUSR2", sigusr2Handler))
 
     const values = createMemo(() => {
       const active = store.themes[store.active]

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -179,11 +179,6 @@ export const TuiThreadCommand = cmd({
       }
 
       const prompt = await input(args.prompt)
-      const config = await Instance.provide({
-        directory: cwd,
-        fn: () => TuiConfig.get(),
-      })
-
       const network = await resolveNetworkOptions(args)
       const external =
         process.argv.includes("--port") ||
@@ -193,46 +188,57 @@ export const TuiThreadCommand = cmd({
         network.port !== 0 ||
         network.hostname !== "127.0.0.1"
 
-      const transport = external
-        ? {
-            url: (await client.call("server", network)).url,
-            fetch: undefined,
-            events: undefined,
-          }
-        : {
-            url: "http://opencode.internal",
-            fetch: createWorkerFetch(client),
-            events: createEventSource(client),
-          }
+      await Instance.provide({
+        directory: cwd,
+        fn: async () => {
+          const config = await TuiConfig.get()
 
-      setTimeout(() => {
-        client.call("checkUpgrade", { directory: cwd }).catch(() => {})
-      }, 1000).unref?.()
+          const transport = external
+            ? {
+                url: (await client.call("server", network)).url,
+                fetch: undefined,
+                events: undefined,
+              }
+            : {
+                url: "http://opencode.internal",
+                fetch: createWorkerFetch(client),
+                events: createEventSource(client),
+              }
 
-      try {
-        await tui({
-          url: transport.url,
-          async onSnapshot() {
-            const tui = writeHeapSnapshot("tui.heapsnapshot")
-            const server = await client.call("snapshot", undefined)
-            return [tui, server]
-          },
-          config,
-          directory: cwd,
-          fetch: transport.fetch,
-          events: transport.events,
-          args: {
-            continue: args.continue,
-            sessionID: args.session,
-            agent: args.agent,
-            model: args.model,
-            prompt,
-            fork: args.fork,
-          },
-        })
-      } finally {
-        await stop()
-      }
+          setTimeout(() => {
+            client.call("checkUpgrade", { directory: cwd }).catch((err) => {
+              Log.Default.warn("tui.thread checkUpgrade failed", {
+                error: err instanceof Error ? err.message : String(err),
+              })
+            })
+          }, 1000).unref?.()
+
+          try {
+            await tui({
+              url: transport.url,
+              async onSnapshot() {
+                const tui = writeHeapSnapshot("tui.heapsnapshot")
+                const server = await client.call("snapshot", undefined)
+                return [tui, server]
+              },
+              config,
+              directory: cwd,
+              fetch: transport.fetch,
+              events: transport.events,
+              args: {
+                continue: args.continue,
+                sessionID: args.session,
+                agent: args.agent,
+                model: args.model,
+                prompt,
+                fork: args.fork,
+              },
+            })
+          } finally {
+            await stop()
+          }
+        },
+      })
     } finally {
       unguard?.()
     }

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -7,6 +7,9 @@ import fs from "fs/promises"
 import { Filesystem } from "../../../../util/filesystem"
 import { Process } from "../../../../util/process"
 import { which } from "../../../../util/which"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "tui.clipboard" })
 
 /**
  * Writes text to clipboard via OSC 52 escape sequence.
@@ -105,7 +108,7 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin" && which("osascript")) {
-      console.log("clipboard: using osascript")
+      log.info("clipboard: using osascript")
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
         await Process.run(["osascript", "-e", `set the clipboard to "${escaped}"`], { nothrow: true })
@@ -114,7 +117,7 @@ export namespace Clipboard {
 
     if (os === "linux") {
       if (process.env["WAYLAND_DISPLAY"] && which("wl-copy")) {
-        console.log("clipboard: using wl-copy")
+        log.info("clipboard: using wl-copy")
         return async (text: string) => {
           const proc = Process.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           if (!proc.stdin) return
@@ -124,7 +127,7 @@ export namespace Clipboard {
         }
       }
       if (which("xclip")) {
-        console.log("clipboard: using xclip")
+        log.info("clipboard: using xclip")
         return async (text: string) => {
           const proc = Process.spawn(["xclip", "-selection", "clipboard"], {
             stdin: "pipe",
@@ -138,7 +141,7 @@ export namespace Clipboard {
         }
       }
       if (which("xsel")) {
-        console.log("clipboard: using xsel")
+        log.info("clipboard: using xsel")
         return async (text: string) => {
           const proc = Process.spawn(["xsel", "--clipboard", "--input"], {
             stdin: "pipe",
@@ -154,7 +157,7 @@ export namespace Clipboard {
     }
 
     if (os === "win32") {
-      console.log("clipboard: using powershell")
+      log.info("clipboard: using powershell")
       return async (text: string) => {
         // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
         const proc = Process.spawn(
@@ -179,7 +182,7 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
+    log.info("clipboard: no native support")
     return async (text: string) => {
       await clipboardy.write(text).catch(() => {})
     }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -232,6 +232,10 @@ try {
   }
   process.exitCode = 1
 } finally {
+  // Dispose all instances (LSP, MCP, PTY child processes) to prevent zombies.
+  // Race with a 5-second timeout so we don't hang on unresponsive subprocesses.
+  const { Instance } = await import("./project/instance")
+  await Promise.race([Instance.disposeAll(), new Promise((r) => setTimeout(r, 5000))]).catch(() => {})
   // Some subprocesses don't react properly to SIGTERM and similar signals.
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -49,7 +49,9 @@ export namespace LSPClient {
       new StreamMessageWriter(input.server.process.stdin as any),
     )
 
+    const MAX_DIAGNOSTIC_FILES = 200
     const diagnostics = new Map<string, Diagnostic[]>()
+    const diagnosticOrder: string[] = [] // track insertion order for eviction
     connection.onNotification("textDocument/publishDiagnostics", (params) => {
       const filePath = Filesystem.normalizePath(fileURLToPath(params.uri))
       l.info("textDocument/publishDiagnostics", {
@@ -57,7 +59,29 @@ export namespace LSPClient {
         count: params.diagnostics.length,
       })
       const exists = diagnostics.has(filePath)
+
+      // If empty diagnostics, just remove the entry to free memory
+      if (params.diagnostics.length === 0) {
+        diagnostics.delete(filePath)
+        const idx = diagnosticOrder.indexOf(filePath)
+        if (idx !== -1) diagnosticOrder.splice(idx, 1)
+        if (exists) Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
+        return
+      }
+
       diagnostics.set(filePath, params.diagnostics)
+
+      // Update insertion order (move to end)
+      const idx = diagnosticOrder.indexOf(filePath)
+      if (idx !== -1) diagnosticOrder.splice(idx, 1)
+      diagnosticOrder.push(filePath)
+
+      // Evict oldest entries if we exceed the limit
+      while (diagnosticOrder.length > MAX_DIAGNOSTIC_FILES) {
+        const oldest = diagnosticOrder.shift()!
+        diagnostics.delete(oldest)
+      }
+
       if (!exists && input.serverID === "typescript") return
       Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
     })
@@ -133,6 +157,7 @@ export namespace LSPClient {
       })
     }
 
+    const MAX_OPEN_FILES = 1000
     const files: {
       [path: string]: number
     } = {}
@@ -201,6 +226,12 @@ export namespace LSPClient {
             },
           })
           files[input.path] = 0
+          // Evict oldest file if we exceed the limit
+          const keys = Object.keys(files)
+          if (keys.length > MAX_OPEN_FILES) {
+            const oldest = keys[0]
+            delete files[oldest]
+          }
           return
         },
       },
@@ -238,6 +269,9 @@ export namespace LSPClient {
       },
       async shutdown() {
         l.info("shutting down")
+        diagnostics.clear()
+        diagnosticOrder.length = 0
+        for (const key of Object.keys(files)) delete files[key]
         connection.end()
         connection.dispose()
         await Process.stop(input.server.process)

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -217,6 +217,9 @@ export namespace LSP {
           yield* Effect.addFinalizer(() =>
             Effect.promise(async () => {
               await Promise.all(s.clients.map((client) => client.shutdown()))
+              s.clients.length = 0
+              s.broken.clear()
+              s.spawning.clear()
             }),
           )
 
@@ -510,7 +513,7 @@ export namespace LSP {
 
   const { runPromise } = makeRuntime(Service, defaultLayer)
 
-  export const init = async () => runPromise((svc) => svc.init())
+  export const init: () => Promise<any> = async () => runPromise((svc) => svc.init())
 
   export const status = async () => runPromise((svc) => svc.status())
 

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -12,6 +12,20 @@ import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
 
+const cmd = Instance.state(
+  () => {
+    const pid = Instance.project.id
+    return Bus.subscribe(Command.Event.Executed, async (payload) => {
+      if (payload.properties.name === Command.Default.INIT) {
+        Project.setInitialized(pid)
+      }
+    })
+  },
+  async (fn) => {
+    fn()
+  },
+)
+
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await Plugin.init()
@@ -22,10 +36,5 @@ export async function InstanceBootstrap() {
   FileWatcher.init()
   Vcs.init()
   Snapshot.init()
-
-  Bus.subscribe(Command.Event.Executed, async (payload) => {
-    if (payload.properties.name === Command.Default.INIT) {
-      Project.setInitialized(Instance.project.id)
-    }
-  })
+  cmd()
 }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -12,9 +12,14 @@ export interface InstanceContext {
   worktree: string
   project: Project.Info
 }
-
 const context = Context.create<InstanceContext>("instance")
 const cache = new Map<string, Promise<InstanceContext>>()
+const activity = new Map<string, number>()
+const refs = new Map<string, number>()
+const disposing = new Set<string>()
+const IDLE_MS = 5 * 60 * 1000
+const SWEEP_MS = 60 * 1000
+let sweep: ReturnType<typeof setInterval> | undefined
 
 const disposal = {
   all: undefined as Promise<void> | undefined,
@@ -30,6 +35,63 @@ function emit(directory: string) {
       },
     },
   })
+}
+
+function touch(dir: string) {
+  activity.set(dir, Date.now())
+}
+
+function acquire(dir: string) {
+  refs.set(dir, (refs.get(dir) ?? 0) + 1)
+}
+
+function release(dir: string) {
+  const n = (refs.get(dir) ?? 1) - 1
+  if (n <= 0) refs.delete(dir)
+  else refs.set(dir, n)
+}
+
+async function wait(dir: string) {
+  while (disposing.has(dir)) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+async function reap() {
+  const now = Date.now()
+  for (const [dir, last] of activity) {
+    if (now - last < IDLE_MS) continue
+    if (refs.has(dir)) continue
+    if (disposing.has(dir)) continue
+    if (!cache.has(dir)) {
+      activity.delete(dir)
+      continue
+    }
+    const val = cache.get(dir)
+    if (!val) continue
+    disposing.add(dir)
+    cache.delete(dir)
+    try {
+      Log.Default.info("disposing idle instance", { directory: dir, idle_ms: now - last })
+      const ctx = await val.catch(() => undefined)
+      if (!ctx) continue
+      await context.provide(ctx, async () => {
+        await Promise.all([State.dispose(dir), disposeInstance(dir)])
+      })
+      emit(dir)
+    } catch (error) {
+      Log.Default.warn("idle instance dispose failed", { directory: dir, error })
+    } finally {
+      disposing.delete(dir)
+      activity.delete(dir)
+    }
+  }
+}
+
+function ensureSweep() {
+  if (sweep) return
+  sweep = setInterval(reap, SWEEP_MS)
+  sweep.unref?.()
 }
 
 function boot(input: { directory: string; init?: () => Promise<any>; project?: Project.Info; worktree?: string }) {
@@ -65,21 +127,33 @@ function track(directory: string, next: Promise<InstanceContext>) {
 export const Instance = {
   async provide<R>(input: { directory: string; init?: () => Promise<any>; fn: () => R }): Promise<R> {
     const directory = Filesystem.resolve(input.directory)
-    let existing = cache.get(directory)
-    if (!existing) {
-      Log.Default.info("creating instance", { directory })
-      existing = track(
-        directory,
-        boot({
+    while (true) {
+      await wait(directory)
+      let existing = cache.get(directory)
+      if (!existing) {
+        Log.Default.info("creating instance", { directory })
+        existing = track(
           directory,
-          init: input.init,
-        }),
-      )
+          boot({
+            directory,
+            init: input.init,
+          }),
+        )
+      }
+      touch(directory)
+      ensureSweep()
+      const ctx = await existing
+      if (disposing.has(directory)) continue
+      acquire(directory)
+      try {
+        return await context.provide(ctx, async () => {
+          return input.fn()
+        })
+      } finally {
+        release(directory)
+        touch(directory)
+      }
     }
-    const ctx = await existing
-    return context.provide(ctx, async () => {
-      return input.fn()
-    })
   },
   get current() {
     return context.use()

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -36,14 +36,15 @@ export namespace State {
 
     let disposalFinished = false
 
-    setTimeout(() => {
+    const warnTimeout = setTimeout(() => {
       if (!disposalFinished) {
         log.warn(
           "state disposal is taking an unusually long time - if it does not complete in a reasonable time, please report this as a bug",
           { key },
         )
       }
-    }, 10000).unref()
+    }, 10000)
+    warnTimeout.unref()
 
     const tasks: Promise<void>[] = []
     for (const [init, entry] of entries) {
@@ -64,6 +65,7 @@ export namespace State {
     entries.clear()
     recordsByKey.delete(key)
 
+    clearTimeout(warnTimeout)
     disposalFinished = true
     log.info("state disposal completed", { key })
   }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -150,10 +150,12 @@ export namespace ModelsDev {
 
 if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
   ModelsDev.refresh()
-  setInterval(
+  const modelsRefreshInterval = setInterval(
     async () => {
       await ModelsDev.refresh()
     },
     60 * 1000 * 60,
-  ).unref()
+  )
+  modelsRefreshInterval.unref()
+  process.on("exit", () => clearInterval(modelsRefreshInterval))
 }

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -102,6 +102,7 @@ export namespace Question {
     readonly reply: (input: { requestID: QuestionID; answers: Answer[] }) => Effect.Effect<void>
     readonly reject: (requestID: QuestionID) => Effect.Effect<void>
     readonly list: () => Effect.Effect<Request[]>
+    readonly clearSession: (sessionID: SessionID) => Effect.Effect<void>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Question") {}
@@ -194,7 +195,20 @@ export namespace Question {
         return Array.from(pending.values(), (x) => x.info)
       })
 
-      return Service.of({ ask, reply, reject, list })
+      const clearSession = Effect.fn("Question.clearSession")(function* (sessionID: SessionID) {
+        const pending = (yield* InstanceState.get(state)).pending
+        for (const [id, entry] of pending) {
+          if (entry.info.sessionID !== sessionID) continue
+          pending.delete(id)
+          Bus.publish(Event.Rejected, {
+            sessionID: entry.info.sessionID,
+            requestID: entry.info.id,
+          })
+          yield* Deferred.fail(entry.deferred, new RejectedError())
+        }
+      })
+
+      return Service.of({ ask, reply, reject, list, clearSession })
     }),
   )
 
@@ -218,6 +232,10 @@ export namespace Question {
     return runPromise((s) => s.reject(requestID))
   }
 
+
+  export async function clearSession(sessionID: SessionID) {
+    return runPromise((s) => s.clearSession(sessionID))
+  }
   export async function list() {
     return runPromise((s) => s.list())
   }

--- a/packages/opencode/src/server/error.ts
+++ b/packages/opencode/src/server/error.ts
@@ -29,6 +29,25 @@ export const ERRORS = {
       },
     },
   },
+  409: {
+    description: "Conflict",
+    content: {
+      "application/json": {
+        schema: resolver(
+          z
+            .object({
+              name: z.literal("DuplicateIDError"),
+              data: z.object({
+                id: z.string(),
+              }),
+            })
+            .meta({
+              ref: "DuplicateIDError",
+            }),
+        ),
+      },
+    },
+  },
 } as const
 
 export function errors(...codes: number[]) {

--- a/packages/opencode/src/server/middleware.ts
+++ b/packages/opencode/src/server/middleware.ts
@@ -18,6 +18,7 @@ export function errorHandler(log: Log.Logger): ErrorHandler {
       else if (err instanceof Provider.ModelNotFoundError) status = 400
       else if (err.name === "ProviderAuthValidationFailed") status = 400
       else if (err.name.startsWith("Worktree")) status = 400
+      else if (err.name === "DuplicateIDError") status = 409
       else status = 500
       return c.json(err.toObject(), { status })
     }

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -21,6 +21,7 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
 import { NamedError } from "@opencode-ai/util/error"
+import { Instance } from "@/project/instance"
 
 const log = Log.create({ service: "server" })
 
@@ -194,7 +195,7 @@ export const SessionRoutes = lazy(() =>
         description: "Create a new OpenCode session for interacting with AI assistants and managing conversations.",
         operationId: "session.create",
         responses: {
-          ...errors(400),
+          ...errors(400, 409),
           200: {
             description: "Successfully created session",
             content: {
@@ -381,7 +382,7 @@ export const SessionRoutes = lazy(() =>
         }),
       ),
       async (c) => {
-        await SessionPrompt.cancel(c.req.valid("param").sessionID)
+        await SessionPrompt.cancel(c.req.valid("param").sessionID).catch(() => {})
         return c.json(true)
       },
     )
@@ -843,19 +844,25 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
-        c.status(204)
-        c.header("Content-Type", "application/json")
-        return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const run = Instance.bind(() => {
           SessionPrompt.prompt({ ...body, sessionID }).catch((err) => {
-            log.error("prompt_async failed", { sessionID, error: err })
+            log.error("prompt_async failed", {
+              sessionID,
+              error: err,
+              stack: err instanceof Error ? err.stack : undefined,
+            })
+            const error = MessageV2.fromError(err, { providerID: "unknown" as any })
             Bus.publish(Session.Event.Error, {
               sessionID,
-              error: new NamedError.Unknown({ message: err instanceof Error ? err.message : String(err) }).toObject(),
+              error,
             })
           })
         })
+        run()
+        c.status(204)
+        return c.body(null)
       },
     )
     .post(

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1,4 +1,5 @@
 import { Slug } from "@opencode-ai/util/slug"
+import { NamedError } from "@opencode-ai/util/error"
 import path from "path"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
@@ -38,6 +39,13 @@ import { makeRuntime } from "@/effect/run-service"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
+
+  export const DuplicateIDError = NamedError.create(
+    "DuplicateIDError",
+    z.object({
+      id: z.string(),
+    }),
+  )
 
   const parentTitlePrefix = "New session - "
   const childTitlePrefix = "Child session - "
@@ -493,6 +501,7 @@ export namespace Session {
         }).pipe(Effect.withSpan("Session.updatePart"))
 
       const create = Effect.fn("Session.create")(function* (input?: {
+        id?: SessionID
         parentID?: SessionID
         title?: string
         permission?: Permission.Ruleset
@@ -500,6 +509,7 @@ export namespace Session {
       }) {
         const directory = yield* InstanceState.directory
         return yield* createNext({
+          id: input?.id,
           parentID: input?.parentID,
           directory,
           title: input?.title,
@@ -688,6 +698,7 @@ export namespace Session {
   export const create = fn(
     z
       .object({
+        id: SessionID.zod.optional(),
         parentID: SessionID.zod.optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -696,6 +696,10 @@ export namespace MessageV2 {
         ) {
           continue
         }
+        // Skip incomplete assistant messages (no finish, no error, and no meaningful parts)
+        if (!msg.info.finish && !msg.info.error && !msg.parts.some((part) => part.type !== "step-start")) {
+          continue
+        }
         const assistantMessage: UIMessage = {
           id: msg.info.id,
           role: "assistant",
@@ -972,7 +976,7 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
-      case APICallError.isInstance(e):
+      case APICallError.isInstance(e): {
         const parsed = ProviderError.parseAPICallError({
           providerID: ctx.providerID,
           error: e,
@@ -995,6 +999,33 @@ export namespace MessageV2 {
             responseHeaders: parsed.responseHeaders,
             responseBody: parsed.responseBody,
             metadata: parsed.metadata,
+          },
+          { cause: e },
+        ).toObject()
+      }
+      case e instanceof DOMException && e.name === "TimeoutError":
+        return new MessageV2.APIError(
+          {
+            message: "Request timed out",
+            isRetryable: true,
+          },
+          { cause: e },
+        ).toObject()
+      case e instanceof Error &&
+        "code" in e &&
+        typeof (e as SystemError).code === "string" &&
+        ["ECONNREFUSED", "ENOTFOUND", "ETIMEDOUT", "EPIPE", "ECONNABORTED", "EHOSTUNREACH"].includes(
+          (e as SystemError).code ?? "",
+        ):
+        return new MessageV2.APIError(
+          {
+            message: `Network error: ${(e as SystemError).message}`,
+            isRetryable: true,
+            metadata: {
+              code: (e as SystemError).code ?? "",
+              syscall: (e as SystemError).syscall ?? "",
+              message: (e as SystemError).message ?? "",
+            },
           },
           { cause: e },
         ).toObject()

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -414,7 +414,14 @@ export namespace SessionProcessor {
         })
 
         const halt = Effect.fn("SessionProcessor.halt")(function* (e: unknown) {
-          log.error("process", { error: e, stack: e instanceof Error ? e.stack : undefined })
+          log.error("process", {
+            error: e,
+            stack: e instanceof Error ? e.stack : undefined,
+            providerID: ctx.assistantMessage.providerID,
+            modelID: ctx.assistantMessage.modelID,
+            sessionID: ctx.sessionID,
+            agent: ctx.assistantMessage.agent,
+          })
           const error = parse(e)
           if (MessageV2.ContextOverflowError.isInstance(error)) {
             ctx.needsCompaction = true

--- a/packages/opencode/src/session/projectors.ts
+++ b/packages/opencode/src/session/projectors.ts
@@ -14,6 +14,12 @@ function foreign(err: unknown) {
   return "message" in err && typeof err.message === "string" && err.message.includes("FOREIGN KEY constraint failed")
 }
 
+function duplicate(err: unknown, table: string) {
+  if (typeof err !== "object" || err === null) return false
+  if (!("message" in err) || typeof err.message !== "string") return false
+  return err.message.includes(`UNIQUE constraint failed: ${table}.id`)
+}
+
 export type DeepPartial<T> = T extends object ? { [K in keyof T]?: DeepPartial<T[K]> | null } : T
 
 function grab<T extends object, K1 extends keyof T, X>(
@@ -63,7 +69,12 @@ export function toPartialRow(info: DeepPartial<Session.Info>) {
 
 export default [
   SyncEvent.project(Session.Event.Created, (db, data) => {
-    db.insert(SessionTable).values(Session.toRow(data.info)).run()
+    try {
+      db.insert(SessionTable).values(Session.toRow(data.info)).run()
+    } catch (err) {
+      if (duplicate(err, "session")) throw new Session.DuplicateIDError({ id: data.info.id })
+      throw err
+    }
   }),
 
   SyncEvent.project(Session.Event.Updated, (db, data) => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -946,7 +946,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
 
       const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-        const agentName = input.agent || (yield* agents.defaultAgent())
+        const agentName = input.agent ?? (yield* lastPrimaryAgent(input.sessionID))
         const ag = yield* agents.get(agentName)
         if (!ag) {
           const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
@@ -1308,6 +1308,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         function* (input: PromptInput) {
           const session = yield* sessions.get(input.sessionID)
           yield* Effect.promise(() => SessionRevert.cleanup(session))
+
+          const text = input.parts.find((part): part is MessageV2.TextPart => part.type === "text" && !part.synthetic)
+          const slash = text?.text.trim()
+          if (slash?.startsWith("/") && !slash.startsWith("//")) {
+            const body = slash.slice(1)
+            const at = body.search(/\s/)
+            const cmd = at === -1 ? body : body.slice(0, at)
+            const args = at === -1 ? "" : body.slice(at + 1).trim()
+            return yield* command({
+              sessionID: input.sessionID,
+              messageID: input.messageID,
+              agent: input.agent,
+              model: input.model ? `${input.model.providerID}/${input.model.modelID}` : undefined,
+              variant: input.variant,
+              command: cmd,
+              arguments: args,
+              parts: input.parts.filter((part) => part.type === "file"),
+            })
+          }
+
           const message = yield* createUserMessage(input)
           yield* sessions.touch(input.sessionID)
 
@@ -1372,12 +1392,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             // Keep the loop running so tool results can be sent back to the model.
             const hasToolCalls = lastAssistantMsg?.parts.some((part) => part.type === "tool") ?? false
 
-            if (
-              lastAssistant?.finish &&
-              !["tool-calls"].includes(lastAssistant.finish) &&
-              !hasToolCalls &&
-              lastUser.id < lastAssistant.id
-            ) {
+            if (shouldExitLoop(lastUser, lastAssistant, lastFinished, hasToolCalls)) {
               log.info("exiting loop", { sessionID })
               break
             }
@@ -1871,6 +1886,49 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
   export async function command(input: CommandInput) {
     return runPromise((svc) => svc.command(CommandInput.parse(input)))
+  }
+
+  const lastPrimaryAgent = Effect.fnUntraced(function* (sessionID: SessionID) {
+    const msgs = yield* Effect.promise(async () => {
+      const result: MessageV2.WithParts[] = []
+      for await (const item of MessageV2.stream(sessionID)) result.push(item)
+      return result
+    })
+    let name: string | undefined
+    for (const item of msgs) {
+      if (item.info.role !== "user") continue
+      if (!item.info.agent) continue
+      const agent = yield* Effect.promise(() => Agent.get(item.info.agent).catch(() => undefined))
+      if (!agent || agent.hidden || agent.mode === "subagent") continue
+      name = agent.name
+    }
+    if (name) return name
+    return yield* Effect.promise(() => Agent.defaultAgent())
+  })
+
+  export function shouldExitLoop(
+    lastUser: MessageV2.User | undefined,
+    lastAssistant: MessageV2.Assistant | undefined,
+    lastFinished?: MessageV2.Assistant,
+    hasToolCalls = false,
+  ): boolean {
+    if (!lastUser || hasToolCalls) return false
+    const done = lastFinished ?? lastAssistant
+    if (!done?.finish) return false
+    if (["tool-calls", "unknown"].includes(done.finish)) return false
+    if (!done.parentID) return true
+    return done.parentID === lastUser.id
+  }
+
+  export function shouldWrapSystemReminder(
+    msg: MessageV2.User | MessageV2.Assistant,
+    idx: number,
+    lastFinished: MessageV2.Assistant | undefined,
+    finishedIdx: number,
+  ): boolean {
+    if (msg.role !== "user") return false
+    if (!lastFinished) return false
+    return idx > finishedIdx
   }
 
   /** @internal Exported for testing */

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -9,10 +9,18 @@ import { setTimeout as sleep } from "node:timers/promises"
 const SIGKILL_TIMEOUT_MS = 200
 
 export namespace Shell {
+  function alive(pid: number): boolean {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch {
+      return false
+    }
+  }
+
   const BLACKLIST = new Set(["fish", "nu"])
   const LOGIN = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"])
   const POSIX = new Set(["bash", "dash", "ksh", "sh", "zsh"])
-
   export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
     const pid = proc.pid
     if (!pid || opts?.exited?.()) return
@@ -31,17 +39,24 @@ export namespace Shell {
 
     try {
       process.kill(-pid, "SIGTERM")
-      await sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        process.kill(-pid, "SIGKILL")
-      }
-    } catch (_e) {
-      proc.kill("SIGTERM")
-      await sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        proc.kill("SIGKILL")
-      }
+    } catch {
+      try {
+        proc.kill("SIGTERM")
+      } catch {}
     }
+
+    await sleep(SIGKILL_TIMEOUT_MS)
+
+    if (opts?.exited?.() || !alive(pid)) return
+    try {
+      process.kill(-pid, "SIGKILL")
+    } catch {
+      try {
+        proc.kill("SIGKILL")
+      } catch {}
+    }
+
+    await sleep(SIGKILL_TIMEOUT_MS)
   }
 
   function full(file: string) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -79,6 +79,39 @@ type Scan = {
 
 export const log = Log.create({ service: "bash-tool" })
 
+const active = new Map<
+  string,
+  {
+    pid: number
+    timeout: number
+    started: number
+    kill: () => void
+    done: () => void
+  }
+>()
+
+export function stale() {
+  const list: string[] = []
+  const now = Date.now()
+  for (const [id, item] of active) {
+    if (now - item.started > item.timeout + 5000) list.push(id)
+  }
+  return list
+}
+
+export function reap(id: string) {
+  const item = active.get(id)
+  if (!item) return
+  log.info("reaping stuck process", {
+    callID: id,
+    pid: item.pid,
+    age: Date.now() - item.started,
+  })
+  item.kill()
+  item.done()
+  active.delete(id)
+}
+
 const resolveWasm = (asset: string) => {
   if (asset.startsWith("file://")) return fileURLToPath(asset)
   if (asset.startsWith("/") || /^[a-z]:/i.test(asset)) return asset
@@ -345,6 +378,9 @@ async function run(
   let output = ""
   let expired = false
   let aborted = false
+  const cap = 10 * 1024 * 1024
+  const out: string[] = []
+  let size = 0
 
   ctx.metadata({
     metadata: {
@@ -353,13 +389,37 @@ async function run(
     },
   })
 
-  const exit = await CrossSpawnSpawner.runPromiseExit((spawner) =>
-    Effect.gen(function* () {
+  const exit: Exit.Exit<number | null, never> = await CrossSpawnSpawner.runPromiseExit((spawner) => {
+    const run = Effect.gen(function* () {
       const handle = yield* spawner.spawn(cmd(input.shell, input.name, input.command, input.cwd, input.env))
+      const callID = ctx.callID
+      let done = () => {}
+      const reaped = new Promise<void>((resolve) => {
+        done = resolve
+      })
+      if (callID) {
+        active.set(callID, {
+          pid: Number(handle.pid),
+          timeout: input.timeout,
+          started: Date.now(),
+          kill: () => {
+            void Effect.runPromise(handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie))
+          },
+          done,
+        })
+        yield* Effect.addFinalizer(() => Effect.sync(() => active.delete(callID)))
+      }
 
       yield* Effect.forkScoped(
         Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
           Effect.sync(() => {
+            out.push(chunk)
+            size += chunk.length
+            while (size > cap && out.length > 1) {
+              const item = out.shift()
+              if (!item) break
+              size -= item.length
+            }
             output += chunk
             ctx.metadata({
               metadata: {
@@ -384,6 +444,7 @@ async function run(
         handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
         abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
         timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+        Effect.promise(() => reaped).pipe(Effect.map(() => ({ kind: "reap" as const, code: null }))),
       ])
 
       if (exit.kind === "abort") {
@@ -394,15 +455,18 @@ async function run(
         expired = true
         yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
       }
+      if (exit.kind === "reap") {
+        yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
+      }
 
       return exit.kind === "exit" ? exit.code : null
-    }).pipe(Effect.scoped, Effect.orDie),
-  )
+    }).pipe(Effect.scoped, Effect.orDie)
+    return run as Effect.Effect<number | null, never, never>
+  })
 
   let code: number | null = null
-  if (Exit.isSuccess(exit)) {
-    code = exit.value
-  } else if (!Cause.hasInterruptsOnly(exit.cause)) {
+  if (Exit.isSuccess(exit)) code = exit.value
+  if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
     throw Cause.squash(exit.cause)
   }
 
@@ -411,6 +475,10 @@ async function run(
   if (aborted) meta.push("User aborted the command")
   if (meta.length > 0) {
     output += "\n\n<bash_metadata>\n" + meta.join("\n") + "\n</bash_metadata>"
+  }
+  if (size > cap) {
+    output = out.join("")
+    if (meta.length > 0) output += "\n\n<bash_metadata>\n" + meta.join("\n") + "\n</bash_metadata>"
   }
 
   return {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -143,6 +143,12 @@ export const TaskTool = Tool.define("task", async () => {
         "</task_result>",
       ].join("\n")
 
+      // Deallocate subagent session to free in-memory state (messages, parts, listeners)
+      // If the LLM later tries to resume via task_id, Session.get() will fail gracefully
+      if (!params.task_id) {
+        Session.remove(session.id).catch(() => {})
+      }
+
       return {
         title: params.description,
         metadata: {

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -59,6 +59,7 @@ export namespace Rpc {
         handlers.add(handler)
         return () => {
           handlers!.delete(handler)
+          if (handlers!.size === 0) listeners.delete(event)
         }
       },
     }

--- a/packages/opencode/test/project/bootstrap.test.ts
+++ b/packages/opencode/test/project/bootstrap.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import { Bus } from "../../src/bus"
+import { Command } from "../../src/command"
+import { File } from "../../src/file"
+import { FileWatcher } from "../../src/file/watcher"
+import { Format } from "../../src/format"
+import { LSP } from "../../src/lsp"
+import { Plugin } from "../../src/plugin"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { Instance } from "../../src/project/instance"
+import { Project } from "../../src/project/project"
+import { Vcs } from "../../src/project/vcs"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { ShareNext } from "../../src/share/share-next"
+import { Snapshot } from "../../src/snapshot"
+import { resetDatabase } from "../fixture/db"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await resetDatabase()
+})
+
+test("InstanceBootstrap captures project id for command handler and unsubscribes on reload", async () => {
+  await using tmp = await tmpdir()
+  const unsub = mock(() => {})
+  type Executed = {
+    type: typeof Command.Event.Executed.type
+    properties: {
+      name: string
+      sessionID: SessionID
+      arguments: string
+      messageID: MessageID
+    }
+  }
+  let cb: ((event: Executed) => unknown) | undefined
+  const sub = spyOn(Bus, "subscribe").mockImplementation((_def, fn) => {
+    cb = fn as (event: Executed) => unknown
+    return unsub
+  })
+  const set = spyOn(Project, "setInitialized").mockImplementation(() => undefined)
+  const share = spyOn(ShareNext, "init").mockResolvedValue(undefined)
+  const plugin = spyOn(Plugin, "init").mockResolvedValue(undefined)
+  const lsp = spyOn(LSP, "init").mockImplementation(async () => ({
+    broken: new Set<string>(),
+    servers: {},
+    clients: [],
+    spawning: new Map(),
+  }))
+  const format = spyOn(Format, "init").mockImplementation(async () => undefined)
+  const file = spyOn(File, "init").mockImplementation(async () => undefined)
+  const watcher = spyOn(FileWatcher, "init").mockImplementation(async () => undefined)
+  const vcs = spyOn(Vcs, "init").mockImplementation(async () => undefined)
+  const snapshot = spyOn(Snapshot, "init").mockImplementation(async () => undefined)
+
+  try {
+    const id = await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await InstanceBootstrap()
+        return Instance.project.id
+      },
+    })
+
+    expect(sub).toHaveBeenCalledTimes(1)
+    expect(unsub).toHaveBeenCalledTimes(0)
+    expect(cb).toBeDefined()
+
+    await Promise.resolve(
+      cb?.({
+        type: Command.Event.Executed.type,
+        properties: {
+          name: Command.Default.INIT,
+          sessionID: SessionID.make("ses_test"),
+          arguments: "",
+          messageID: MessageID.ascending(),
+        },
+      }),
+    )
+
+    expect(set).toHaveBeenCalledWith(id)
+
+    await Instance.reload({ directory: tmp.path })
+
+    expect(unsub).toHaveBeenCalledTimes(1)
+  } finally {
+    snapshot.mockRestore()
+    vcs.mockRestore()
+    watcher.mockRestore()
+    file.mockRestore()
+    format.mockRestore()
+    lsp.mockRestore()
+    plugin.mockRestore()
+    share.mockRestore()
+    set.mockRestore()
+    sub.mockRestore()
+  }
+})

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -145,6 +145,35 @@ describe("session messages endpoint", () => {
   })
 })
 
+describe("session create duplicate id", () => {
+  test("returns 409 when creating the same explicit session id twice", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const app = Server.Default()
+
+          const first = await app.request(`/session`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: "ses_duplicate_smoke", title: "duplicate one" }),
+          })
+          expect(first.status).toBe(200)
+
+          const second = await app.request(`/session`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: "ses_duplicate_smoke", title: "duplicate two" }),
+          })
+
+          expect(second.status).toBe(409)
+        },
+      }),
+    )
+  })
+})
+
 describe("session.prompt_async error handling", () => {
   test("prompt_async route has error handler for detached prompt call", async () => {
     const src = await Bun.file(new URL("../../src/server/routes/session.ts", import.meta.url)).text()
@@ -155,5 +184,7 @@ describe("session.prompt_async error handling", () => {
     const route = src.slice(start, end)
     expect(route).toContain(".catch(")
     expect(route).toContain("Bus.publish(Session.Event.Error")
+    expect(route).toContain("Instance.bind(")
+    expect(route).not.toContain("return stream(c")
   })
 })

--- a/packages/opencode/test/session/cancel.test.ts
+++ b/packages/opencode/test/session/cancel.test.ts
@@ -1,0 +1,154 @@
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionID } from "../../src/session/schema"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+function defer<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function hanging(ready: () => void) {
+  const encoder = new TextEncoder()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const first =
+    `data: ${JSON.stringify({
+      id: "chatcmpl-1",
+      object: "chat.completion.chunk",
+      choices: [{ delta: { role: "assistant" } }],
+    })}` + "\n\n"
+  const rest =
+    [
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: { content: "late" } }],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      })}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+
+  return new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      ctrl.enqueue(encoder.encode(first))
+      ready()
+      timer = setTimeout(() => {
+        ctrl.enqueue(encoder.encode(rest))
+        ctrl.close()
+      }, 10000)
+    },
+    cancel() {
+      if (timer) clearTimeout(timer)
+    },
+  })
+}
+
+describe("SessionPrompt.cancel", () => {
+  test("does not produce unhandled rejections", async () => {
+    const rejections: unknown[] = []
+    const handler = (e: unknown) => rejections.push(e)
+    process.on("unhandledRejection", handler)
+    const ready = defer<void>()
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url)
+        if (!url.pathname.endsWith("/chat/completions")) {
+          return new Response("not found", { status: 404 })
+        }
+        return new Response(
+          hanging(() => ready.resolve()),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        )
+      },
+    })
+
+    try {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              enabled_providers: ["alibaba"],
+              provider: {
+                alibaba: {
+                  options: {
+                    apiKey: "test-key",
+                    baseURL: `${server.url.origin}/v1`,
+                  },
+                },
+              },
+              agent: {
+                build: {
+                  model: "alibaba/qwen-plus",
+                },
+              },
+            }),
+          )
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({ title: "Prompt cancel regression" })
+          const run = SessionPrompt.prompt({
+            sessionID: session.id,
+            agent: "build",
+            parts: [{ type: "text", text: "Cancel me" }],
+          })
+
+          await ready.promise
+          await SessionPrompt.cancel(session.id)
+
+          const result = await Promise.race([
+            run,
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error("timed out waiting for cancel")), 1000),
+            ),
+          ])
+
+          expect(result.info.role).toBe("assistant")
+          if (result.info.role === "assistant") {
+            expect(result.info.error?.name).toBe("MessageAbortedError")
+          }
+
+          await new Promise((r) => setTimeout(r, 50))
+          expect(rejections).toEqual([])
+        },
+      })
+    } finally {
+      server.stop(true)
+      process.off("unhandledRejection", handler)
+    }
+  })
+
+  test("cancel on non-existent session does not throw", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await SessionPrompt.cancel(SessionID.make("ses_nonexistent"))
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/fixtures/skewed-messages.ts
+++ b/packages/opencode/test/session/fixtures/skewed-messages.ts
@@ -1,0 +1,84 @@
+import { Identifier } from "../../../src/id/id"
+import { MessageV2 } from "../../../src/session/message-v2"
+import { MessageID, SessionID } from "../../../src/session/schema"
+import { ModelID, ProviderID } from "../../../src/provider/schema"
+
+export function makeUser(
+  id: MessageID,
+  opts?: Partial<MessageV2.User>,
+): MessageV2.User {
+  return {
+    id,
+    sessionID: SessionID.make("test-session"),
+    role: "user",
+    time: { created: Date.now() },
+    agent: "default",
+    model: {
+      providerID: ProviderID.openai,
+      modelID: ModelID.make("gpt-4"),
+    },
+    ...opts,
+  }
+}
+
+export function makeAssistant(
+  id: MessageID,
+  parentID: MessageID,
+  opts?: Partial<MessageV2.Assistant>,
+): MessageV2.Assistant {
+  return {
+    id,
+    sessionID: SessionID.make("test-session"),
+    role: "assistant",
+    parentID,
+    time: { created: Date.now() },
+    modelID: ModelID.make("gpt-4"),
+    providerID: ProviderID.openai,
+    mode: "default",
+    agent: "default",
+    path: {
+      cwd: "/tmp",
+      root: "/tmp",
+    },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+    finish: "stop",
+    ...opts,
+  }
+}
+
+export function aheadPair(): {
+  user: MessageV2.User
+  assistant: MessageV2.Assistant
+} {
+  const now = Date.now()
+  const userID = MessageID.make(Identifier.create("message", false, now + 60_000))
+  const assistantID = MessageID.make(Identifier.create("message", false, now))
+
+  return {
+    user: makeUser(userID),
+    assistant: makeAssistant(assistantID, userID),
+  }
+}
+
+export function behindPair(): {
+  user: MessageV2.User
+  assistant: MessageV2.Assistant
+} {
+  const now = Date.now()
+  const userID = MessageID.make(Identifier.create("message", false, now - 60_000))
+  const assistantID = MessageID.make(Identifier.create("message", false, now))
+
+  return {
+    user: makeUser(userID),
+    assistant: makeAssistant(assistantID, userID),
+  }
+}

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -644,6 +644,54 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("toModelMessages skips assistant messages with no finish and no error", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "hello",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "step-start",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: userInfo("m-user-2"),
+        parts: [
+          {
+            ...basePart("m-user-2", "u2"),
+            type: "text",
+            text: "follow up",
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "follow up" }],
+      },
+    ])
+  })
+
   test("splits assistant messages on step-start boundaries", async () => {
     const assistantID = "m-assistant"
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -9,6 +9,8 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
+import { MessageID } from "../../src/session/schema"
+import { behindPair, makeUser, makeAssistant } from "./fixtures/skewed-messages"
 
 Log.init({ print: false })
 
@@ -447,6 +449,46 @@ describe("session.prompt agent variant", () => {
 })
 
 describe("session.agent-resolution", () => {
+  test("reuses the last primary agent when agent is omitted", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        default_agent: "sisyphus",
+        agent: {
+          hephaestus: {
+            model: "openai/gpt-5.2",
+          },
+          sisyphus: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const first = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "hephaestus",
+          noReply: true,
+          parts: [{ type: "text", text: "first" }],
+        })
+        if (first.info.role !== "user") throw new Error("expected user message")
+        expect(first.info.agent).toBe("hephaestus")
+
+        const second = await SessionPrompt.prompt({
+          sessionID: session.id,
+          noReply: true,
+          parts: [{ type: "text", text: "second" }],
+        })
+        if (second.info.role !== "user") throw new Error("expected user message")
+        expect(second.info.agent).toBe("hephaestus")
+      },
+    })
+  })
+
   test("unknown agent throws typed error", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({
@@ -501,10 +543,10 @@ describe("session.agent-resolution", () => {
       directory: tmp.path,
       fn: async () => {
         const session = await Session.create({})
-        const err = await SessionPrompt.command({
+        const err = await SessionPrompt.prompt({
           sessionID: session.id,
-          command: "nonexistent-command-xyz",
-          arguments: "",
+          noReply: true,
+          parts: [{ type: "text", text: "/nonexistent-command-xyz" }],
         }).then(
           () => undefined,
           (e) => e,
@@ -519,4 +561,59 @@ describe("session.agent-resolution", () => {
       },
     })
   }, 30000)
+})
+
+describe("shouldExitLoop", () => {
+  const user = { id: MessageID.make("msg-user-1") } as any
+  const assistant = (parentID: string | undefined, finish: string | undefined) =>
+    ({
+      role: "assistant",
+      finish,
+      parentID: parentID ? MessageID.make(parentID) : undefined,
+    }) as any
+
+  test("normal exit: parentID matches, finish=end_turn \u2192 true", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-user-1", "end_turn"))).toBe(true)
+  })
+
+  test("clock-skew exit: parentID matches, finish=stop \u2192 true", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-user-1", "stop"))).toBe(true)
+  })
+
+  test("tool-calls: finish=tool-calls \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-user-1", "tool-calls"))).toBe(false)
+  })
+
+  test("unknown: finish=unknown \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-user-1", "unknown"))).toBe(false)
+  })
+
+  test("no assistant: lastAssistant=undefined \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(user, undefined)).toBe(false)
+  })
+
+  test("no finish: finish=undefined \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-user-1", undefined))).toBe(false)
+  })
+
+  test("parentID mismatch: assistant.parentID !== user.id \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant("msg-other-user", "end_turn"))).toBe(false)
+  })
+
+  test("no user: lastUser=undefined \u2192 false", () => {
+    expect(SessionPrompt.shouldExitLoop(undefined, assistant("msg-user-1", "end_turn"))).toBe(false)
+  })
+
+  test("should return true when assistant has missing parentID (fail-safe)", () => {
+    expect(SessionPrompt.shouldExitLoop(user, assistant(undefined, "end_turn"))).toBe(true)
+  })
+})
+
+describe("system-reminder wrapping", () => {
+  test("wraps queued user messages based on position, not ID ordering", () => {
+    const { user, assistant } = behindPair()
+    expect(user.id < assistant.id).toBe(true)
+    expect(SessionPrompt.shouldWrapSystemReminder(user, 2, assistant, 1)).toBe(true)
+    expect(SessionPrompt.shouldWrapSystemReminder(user, 1, assistant, 1)).toBe(false)
+  })
 })

--- a/packages/opencode/test/util/process.test.ts
+++ b/packages/opencode/test/util/process.test.ts
@@ -126,3 +126,39 @@ describe("util.process", () => {
     })
   })
 })
+
+describe("util.process defensive patterns", () => {
+  test("Process.run completes normally", async () => {
+    const result = await Process.run(node('process.stdout.write("hello")'))
+    expect(result.code).toBe(0)
+    expect(result.stdout.toString()).toContain("hello")
+  })
+
+  test("Process.run handles failing command", async () => {
+    expect(Process.run(node("process.exit(1)"))).rejects.toThrow()
+  })
+
+  test("Process.run with nothrow returns non-zero code", async () => {
+    const result = await Process.run(node("process.exit(1)"), { nothrow: true })
+    expect(result.code).not.toBe(0)
+  })
+
+  test("Process.spawn returns valid exited promise", async () => {
+    const proc = Process.spawn(node('process.stdout.write("test")'), { stdout: "pipe" })
+    const code = await proc.exited
+    expect(code).toBe(0)
+  })
+
+  test("Process.spawn abort kills process", async () => {
+    const controller = new AbortController()
+    const proc = Process.spawn(node("setInterval(() => {}, 60000)"), { abort: controller.signal })
+    setTimeout(() => controller.abort(), 200)
+    const code = await proc.exited
+    expect(typeof code).toBe("number")
+  })
+
+  test("Process.run completes for fast commands", async () => {
+    const result = await Process.run(node("process.exit(0)"))
+    expect(result.code).toBe(0)
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1555,6 +1555,7 @@ export class Session2 extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
+      id?: string
       parentID?: string
       title?: string
       permission?: PermissionRuleset
@@ -1569,6 +1570,7 @@ export class Session2 extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "body", key: "id" },
             { in: "body", key: "parentID" },
             { in: "body", key: "title" },
             { in: "body", key: "permission" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1833,6 +1833,13 @@ export type McpResource = {
   client: string
 }
 
+export type DuplicateIdError = {
+  name: "DuplicateIDError"
+  data: {
+    id: string
+  }
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -3094,6 +3101,7 @@ export type SessionListResponse = SessionListResponses[keyof SessionListResponse
 
 export type SessionCreateData = {
   body?: {
+    id?: string
     parentID?: string
     title?: string
     permission?: PermissionRuleset
@@ -3112,6 +3120,10 @@ export type SessionCreateErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * Conflict
+   */
+  409: DuplicateIdError
 }
 
 export type SessionCreateError = SessionCreateErrors[keyof SessionCreateErrors]


### PR DESCRIPTION
### Issue for this PR

Fixes #14473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add next-generation permission system with granular tool/directory controls. Harden bash tool execution with improved timeout, signal handling, and output management. Fix session message ordering and prompt loop edge cases.

### How did you verify your code works?

- Ran `bun typecheck` from packages/opencode
- Ran targeted unit tests
- Tested with custom binary build

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR