### PR TITLE
fix(opencode): add path store fallback to prevent type errors

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -421,7 +421,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             }),
             sdk.client.provider.auth().then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get().then((x) => setStore("vcs", reconcile(x.data))),
-            sdk.client.path.get().then((x) => setStore("path", reconcile(x.data!))),
+            sdk.client.path
+              .get()
+              .then((x) =>
+                setStore("path", reconcile(x.data ?? { state: "", config: "", worktree: "", directory: "" })),
+              ),
             syncWorkspaces(),
           ]).then(() => {
             setStore("status", "complete")

--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -47,7 +47,7 @@ export function pluginSource(spec: string): PluginSource {
 function resolveExportPath(raw: string, dir: string) {
   if (raw.startsWith("./") || raw.startsWith("../")) return path.resolve(dir, raw)
   if (raw.startsWith("file://")) return fileURLToPath(raw)
-  return raw
+  return path.resolve(dir, raw)
 }
 
 function extractExportValue(value: unknown): string | undefined {


### PR DESCRIPTION
### Issue for this PR

Fixes #16323

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add typed fallback for `path` store data to prevent runtime type errors when SDK returns null/undefined. Fix plugin entry path resolution for paths without leading `./`.

### How did you verify your code works?

- Ran `bun typecheck` from packages/opencode
- Ran targeted unit tests
- Tested with custom binary build

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR