### PR TITLE
feat(app): add plugin management to status popover

### DIFF
--- a/packages/app/e2e/status/status-popover.spec.ts
+++ b/packages/app/e2e/status/status-popover.spec.ts
@@ -70,6 +70,9 @@ test("status popover can switch to plugins tab", async ({ page, gotoSession }) =
 
   const pluginsContent = popoverBody.locator('[role="tabpanel"]:visible').first()
   await expect(pluginsContent).toBeVisible()
+
+  const manage = pluginsContent.getByRole("button", { name: /manage plugins/i })
+  await expect(manage).toBeVisible()
 })
 
 test("status popover closes on escape", async ({ page, gotoSession }) => {

--- a/packages/app/src/components/dialog-manage-plugins.tsx
+++ b/packages/app/src/components/dialog-manage-plugins.tsx
@@ -1,0 +1,184 @@
+import { Button } from "@opencode-ai/ui/button"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { showToast } from "@opencode-ai/ui/toast"
+import { createMemo } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useGlobalSync } from "@/context/global-sync"
+import { useLanguage } from "@/context/language"
+import type { Config } from "@opencode-ai/sdk/v2"
+
+type PluginItem = NonNullable<Config["plugin"]>[number]
+
+function spec(item: PluginItem) {
+  return typeof item === "string" ? item : item[0]
+}
+
+export function DialogManagePlugins() {
+  const globalSync = useGlobalSync()
+  const language = useLanguage()
+  const [state, setState] = createStore({
+    spec: "",
+    busy: false,
+    changed: false,
+  })
+
+  const list = createMemo(() => {
+    const plugins = globalSync.data.config.plugin ?? []
+    return plugins.map((item, index) => ({
+      index,
+      item,
+      spec: spec(item),
+    }))
+  })
+
+  const setPlugins = async (next: NonNullable<Config["plugin"]>, before: NonNullable<Config["plugin"]>) => {
+    globalSync.set("config", "plugin", next)
+    await globalSync.updateConfig({ plugin: next }).catch((err) => {
+      globalSync.set("config", "plugin", before)
+      throw err
+    })
+  }
+
+  const invalid = createMemo(() => {
+    const value = state.spec.trim()
+    if (!value) return false
+    if (value.includes(" ")) return true
+    return false
+  })
+
+  const add = async () => {
+    if (state.busy) return
+    const input = state.spec.trim()
+    if (!input) {
+      showToast({
+        variant: "error",
+        title: language.t("common.requestFailed"),
+        description: language.t("dialog.plugins.specRequired"),
+      })
+      return
+    }
+
+    if (invalid()) {
+      showToast({
+        variant: "error",
+        title: language.t("common.requestFailed"),
+        description: language.t("dialog.plugins.specInvalid"),
+      })
+      return
+    }
+
+    const before = globalSync.data.config.plugin ?? []
+    const has = before.some((item) => spec(item) === input)
+    if (has) {
+      showToast({
+        variant: "error",
+        title: language.t("dialog.plugins.exists"),
+      })
+      return
+    }
+
+    setState("busy", true)
+    const next = [...before, input]
+    await setPlugins(next, before)
+      .then(() => {
+        setState("spec", "")
+        setState("changed", true)
+        showToast({
+          variant: "success",
+          title: language.t("dialog.plugins.added"),
+        })
+      })
+      .catch((err) => {
+        showToast({
+          variant: "error",
+          title: language.t("common.requestFailed"),
+          description: err instanceof Error ? err.message : String(err),
+        })
+      })
+      .finally(() => {
+        setState("busy", false)
+      })
+  }
+
+  const remove = async (index: number) => {
+    if (state.busy) return
+    const before = globalSync.data.config.plugin ?? []
+    const next = before.filter((_, i) => i !== index)
+    if (next.length === before.length) return
+
+    setState("busy", true)
+    await setPlugins(next, before)
+      .then(() => {
+        setState("changed", true)
+        showToast({
+          variant: "success",
+          title: language.t("dialog.plugins.removed"),
+        })
+      })
+      .catch((err) => {
+        showToast({
+          variant: "error",
+          title: language.t("common.requestFailed"),
+          description: err instanceof Error ? err.message : String(err),
+        })
+      })
+      .finally(() => {
+        setState("busy", false)
+      })
+  }
+
+  return (
+    <Dialog title={language.t("dialog.plugins.manage.title")}>
+      <div class="flex flex-col gap-3 px-5 pb-5">
+        <div class="bg-surface-base rounded-md p-3 flex flex-col gap-3">
+          <TextField
+            type="text"
+            label={language.t("dialog.plugins.specLabel")}
+            placeholder={language.t("dialog.plugins.specPlaceholder")}
+            value={state.spec}
+            disabled={state.busy}
+            autofocus
+            validationState={invalid() ? "invalid" : "valid"}
+            error={invalid() ? language.t("dialog.plugins.specInvalid") : undefined}
+            onChange={(value) => setState("spec", value)}
+            onKeyDown={(evt: KeyboardEvent) => {
+              evt.stopPropagation()
+              if (evt.key !== "Enter" || evt.isComposing) return
+              evt.preventDefault()
+              void add()
+            }}
+          />
+          <div class="flex justify-end">
+            <Button size="large" variant="secondary" icon="plus-small" disabled={state.busy} onClick={() => void add()}>
+              {language.t("dialog.plugins.add")}
+            </Button>
+          </div>
+        </div>
+
+        {state.changed && (
+          <div class="rounded-md bg-surface-raised-base px-3 py-2 text-12-regular text-text-weak">
+            {language.t("dialog.plugins.restartHint")}
+          </div>
+        )}
+
+        <div class="bg-surface-base rounded-md p-2 max-h-72 overflow-y-auto">
+          <div class="text-12-regular text-text-weak px-2 pb-2">{language.t("dialog.plugins.listTitle")}</div>
+          <div class="flex flex-col">
+            {list().map((item) => (
+              <div class="flex items-center justify-between gap-3 py-1.5 px-2 border-b border-border-weak-base last:border-b-0">
+                <span class="text-13-regular text-text-base truncate">{item.spec}</span>
+                <Button size="small" variant="ghost" disabled={state.busy} onClick={() => void remove(item.index)}>
+                  {language.t("common.delete")}
+                </Button>
+              </div>
+            ))}
+            {list().length === 0 && (
+              <div class="text-13-regular text-text-weak px-2 py-3">{language.t("dialog.plugins.empty")}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/dialog-manage-plugins.tsx
+++ b/packages/app/src/components/dialog-manage-plugins.tsx
@@ -43,7 +43,7 @@ export function DialogManagePlugins() {
   const invalid = createMemo(() => {
     const value = state.spec.trim()
     if (!value) return false
-    if (value.includes(" ")) return true
+    if (/\s/.test(value)) return true
     return false
   })
 

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -436,6 +436,19 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                   )}
                 </For>
               </Show>
+              <Button
+                variant="secondary"
+                class="mt-3 self-start h-8 px-3 py-1.5"
+                onClick={() => {
+                  const run = ++dialogRun
+                  void import("./dialog-manage-plugins").then((x) => {
+                    if (dialogDead || dialogRun !== run) return
+                    dialog.show(() => <x.DialogManagePlugins />)
+                  })
+                }}
+              >
+                {language.t("status.popover.action.managePlugins")}
+              </Button>
             </div>
           </div>
         </Tabs.Content>

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -16,6 +16,7 @@ export const dict = {
   "command.category.permissions": "Permissions",
   "command.category.workspace": "Workspace",
   "command.category.settings": "Settings",
+  "command.category.window": "Window",
 
   "theme.scheme.system": "System",
   "theme.scheme.light": "Light",
@@ -602,6 +603,18 @@ export const dict = {
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
   "status.popover.action.manageServers": "Manage servers",
+  "status.popover.action.managePlugins": "Manage plugins",
+  "dialog.plugins.manage.title": "Manage plugins",
+  "dialog.plugins.specLabel": "Plugin spec",
+  "dialog.plugins.specPlaceholder": "@scope/plugin@version or file://...",
+  "dialog.plugins.add": "Add plugin",
+  "dialog.plugins.added": "Plugin added",
+  "dialog.plugins.removed": "Plugin removed",
+  "dialog.plugins.exists": "Plugin already exists",
+  "dialog.plugins.specRequired": "Plugin spec is required",
+  "dialog.plugins.specInvalid": "Plugin spec must not contain spaces",
+  "dialog.plugins.listTitle": "Configured plugins",
+  "dialog.plugins.restartHint": "Some plugin changes may require reconnect/restart to fully apply.",
 
   "session.share.popover.title": "Publish on web",
   "session.share.popover.description.shared":

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -612,7 +612,7 @@ export const dict = {
   "dialog.plugins.removed": "Plugin removed",
   "dialog.plugins.exists": "Plugin already exists",
   "dialog.plugins.specRequired": "Plugin spec is required",
-  "dialog.plugins.specInvalid": "Plugin spec must not contain spaces",
+  "dialog.plugins.specInvalid": "Plugin spec must not contain whitespace",
   "dialog.plugins.listTitle": "Configured plugins",
   "dialog.plugins.restartHint": "Some plugin changes may require reconnect/restart to fully apply.",
 


### PR DESCRIPTION
### Issue for this PR

Closes #19630

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a non-terminal plugin management flow in the Status popover Plugins tab.

- Adds a Manage plugins action in Status -> Plugins.
- Adds a Manage Plugins dialog to add/remove plugin specs in config.
- Adds inline validation and toast feedback for add/remove errors.
- Adds a restart/reconnect hint after plugin config changes.
- Updates status popover e2e assertion to verify manage action visibility.

### How did you verify your code works?

- un --cwd packages/app test:unit
- un --cwd packages/app typecheck
- un typecheck (repo root)

### Screenshots / recordings

Included screenshot of Status -> Plugins with the new Manage plugins entry and dialog flow.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR