### PR TITLE
fix(opencode): scope TUI prompt history by session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -10,6 +10,7 @@ import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
 export type PromptInfo = {
   input: string
   mode?: "normal" | "shell"
+  scope?: string
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
@@ -26,6 +27,10 @@ export type PromptInfo = {
 }
 
 const MAX_HISTORY_ENTRIES = 50
+
+function scope(value?: string) {
+  return value ?? "global"
+}
 
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
@@ -57,32 +62,44 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
 
     const [store, setStore] = createStore({
       index: 0,
+      scope: "global",
       history: [] as PromptInfo[],
     })
 
     return {
-      move(direction: 1 | -1, input: string) {
-        if (!store.history.length) return undefined
-        const current = store.history.at(store.index)
+      move(direction: 1 | -1, input: string, currentScope?: string) {
+        const nextScope = scope(currentScope)
+        const changed = store.scope !== nextScope
+        const index = changed ? 0 : store.index
+        if (changed) {
+          setStore("scope", nextScope)
+          setStore("index", 0)
+        }
+
+        const list = store.history.filter((item) => scope(item.scope) === nextScope)
+        if (!list.length) return undefined
+        const current = list.at(index)
         if (!current) return undefined
         if (current.input !== input && input.length) return
-        setStore(
-          produce((draft) => {
-            const next = store.index + direction
-            if (Math.abs(next) > store.history.length) return
-            if (next > 0) return
-            draft.index = next
-          }),
-        )
-        if (store.index === 0)
+        const next = index + direction
+        if (Math.abs(next) > list.length) return undefined
+        if (next > 0) return undefined
+
+        setStore("scope", nextScope)
+        setStore("index", next)
+
+        if (next === 0)
           return {
             input: "",
             parts: [],
           }
-        return store.history.at(store.index)
+        return list.at(next)
       },
-      append(item: PromptInfo) {
-        const entry = structuredClone(unwrap(item))
+      append(item: PromptInfo, currentScope?: string) {
+        const entry = {
+          ...structuredClone(unwrap(item)),
+          scope: scope(currentScope),
+        } satisfies PromptInfo
         let trimmed = false
         setStore(
           produce((draft) => {
@@ -91,6 +108,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
               draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
               trimmed = true
             }
+            draft.scope = entry.scope
             draft.index = 0
           }),
         )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -92,6 +92,7 @@ export function Prompt(props: PromptProps) {
   const kv = useKV()
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
+  const scope = (id?: string) => id ?? props.workspaceID ?? "global"
 
   function promptModelWarning() {
     toast.show({
@@ -695,10 +696,13 @@ export function Prompt(props: PromptProps) {
         })
         .catch(() => {})
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
+    history.append(
+      {
+        ...store.prompt,
+        mode: currentMode,
+      },
+      scope(sessionID),
+    )
     input.extmarks.clear()
     setStore("prompt", {
       input: "",
@@ -952,7 +956,7 @@ export function Prompt(props: PromptProps) {
                     (keybind.match("history_next", e) && input.cursorOffset === input.plainText.length)
                   ) {
                     const direction = keybind.match("history_previous", e) ? -1 : 1
-                    const item = history.move(direction, input.plainText)
+                    const item = history.move(direction, input.plainText, scope(props.sessionID))
 
                     if (item) {
                       input.setText(item.input)


### PR DESCRIPTION
### Issue for this PR

Closes #15187

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This scopes TUI prompt history to the active session. Each saved prompt now carries a scope, and ArrowUp/ArrowDown only read entries from the current session instead of the shared global history. The first prompt in a newly created session is also stored under that new session, so recall works immediately after session creation.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Pre-push hook also ran `bun turbo typecheck`
- Manual repro:
  - sent a prompt in Session A
  - switched to Session B
  - verified `ArrowUp` only showed Session B history
  - switched back to Session A
  - verified `ArrowUp` showed Session A history again

### Screenshots / recordings

Not included. This is a TUI behavior fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR