### PR TITLE
fix: handle 'latest' version string in plugin semver check

### DIFF
--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -49,6 +49,10 @@ export namespace Npm {
       return false
     }
 
+    if (cachedVersion === "latest") {
+      return false
+    }
+
     const range = /[\s^~*xX<>|=]/.test(cachedVersion)
     if (range) return !semver.satisfies(latestVersion, cachedVersion)
 


### PR DESCRIPTION
## Problem

When a plugin is specified without a version (e.g., `my-plugin` instead of `my-plugin@1.0.0`), opencode defaults the version to the string `"latest"`. The `Npm.outdated()` function then calls `semver.lt("latest", ...)`, which throws because `"latest"` is not a valid SemVer string.

This matches issue #12143.

## Fix

Added an early return in `Npm.outdated()` that skips the version check when `cachedVersion === "latest"`.

## Testing

- Verified that plugins without a version no longer cause crashes
- Verified that plugins with explicit versions still update correctly

Fixes #12143