### PR TITLE
fix(compaction): prune context before overflow compaction to prevent unrecoverable 413 errors

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -177,38 +177,19 @@ export namespace SessionCompaction {
         }
 
         // When compaction is triggered by a context overflow (413), aggressively
-        // strip tool outputs from messages *before* sending them to the compaction
-        // model. Without this the compaction call itself would exceed the context
-        // limit and fail, leaving the user stuck with no way to recover — not even
-        // /compact would work because it also needs an API call.
+        // prune messages *before* sending them to the compaction model.  Without
+        // this the compaction call itself would exceed the context limit and fail,
+        // leaving the user stuck with no way to recover — not even /compact would
+        // work because it also needs an API call.
+        //
+        // We shallow-copy every message, part, and part.state so we never mutate
+        // the objects owned by the caller (which may still reference DB/cache data).
         if (input.overflow) {
-          log.info("overflow compaction: pruning tool outputs before compaction call")
-          const OVERFLOW_OUTPUT_BUDGET = 500 // chars to keep per tool output as a hint
-          const OVERFLOW_TEXT_BUDGET = 2000 // chars to keep per synthetic text part
-          for (const m of messages) {
-            for (const part of m.parts) {
-              if (part.type === "tool" && part.state.status === "completed") {
-                const output = part.state.output
-                if (typeof output === "string" && output.length > OVERFLOW_OUTPUT_BUDGET) {
-                  part.state.output =
-                    output.slice(0, OVERFLOW_OUTPUT_BUDGET) +
-                    `\n\n[... truncated ${output.length - OVERFLOW_OUTPUT_BUDGET} chars for compaction]`
-                }
-              }
-              // Also truncate large synthetic text parts (e.g. file contents injected
-              // via @ references) which can be massive and blow up the context.
-              if (part.type === "text" && "synthetic" in part && part.synthetic) {
-                if (part.text.length > OVERFLOW_TEXT_BUDGET) {
-                  part.text =
-                    part.text.slice(0, OVERFLOW_TEXT_BUDGET) +
-                    `\n\n[... truncated ${part.text.length - OVERFLOW_TEXT_BUDGET} chars for compaction]`
-                }
-              }
-            }
-          }
-          // If the conversation is very long, also drop older messages keeping
-          // only the most recent turns. The compaction model only needs enough
-          // context to produce a useful summary — it doesn't need every message.
+          log.info("overflow compaction: pruning messages before compaction call")
+
+          // 40 messages is more than enough for the compaction model to produce a
+          // useful summary.  Keeping fewer means less to truncate and a smaller
+          // request overall.  Adjust if compaction summaries lose important context.
           const OVERFLOW_MAX_MESSAGES = 40
           if (messages.length > OVERFLOW_MAX_MESSAGES) {
             log.info("overflow compaction: trimming old messages", {
@@ -217,6 +198,41 @@ export namespace SessionCompaction {
             })
             messages = messages.slice(-OVERFLOW_MAX_MESSAGES)
           }
+
+          const OVERFLOW_OUTPUT_BUDGET = 500 // chars to keep per tool output as a hint
+          const OVERFLOW_TEXT_BUDGET = 2000 // chars to keep per synthetic text part
+          messages = messages.map((m) => ({
+            ...m,
+            parts: m.parts.map((part) => {
+              if (part.type === "tool" && part.state.status === "completed") {
+                const output = part.state.output
+                if (typeof output === "string" && output.length > OVERFLOW_OUTPUT_BUDGET) {
+                  return {
+                    ...part,
+                    state: {
+                      ...part.state,
+                      output:
+                        output.slice(0, OVERFLOW_OUTPUT_BUDGET) +
+                        `\n\n[... truncated ${output.length - OVERFLOW_OUTPUT_BUDGET} chars for compaction]`,
+                    },
+                  }
+                }
+              }
+              // Also truncate large synthetic text parts (e.g. file contents injected
+              // via @ references) which can be massive and blow up the context.
+              if (part.type === "text" && "synthetic" in part && part.synthetic) {
+                if (part.text.length > OVERFLOW_TEXT_BUDGET) {
+                  return {
+                    ...part,
+                    text:
+                      part.text.slice(0, OVERFLOW_TEXT_BUDGET) +
+                      `\n\n[... truncated ${part.text.length - OVERFLOW_TEXT_BUDGET} chars for compaction]`,
+                  }
+                }
+              }
+              return part
+            }),
+          }))
         }
 
         const agent = yield* agents.get("compaction")

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -176,6 +176,49 @@ export namespace SessionCompaction {
           }
         }
 
+        // When compaction is triggered by a context overflow (413), aggressively
+        // strip tool outputs from messages *before* sending them to the compaction
+        // model. Without this the compaction call itself would exceed the context
+        // limit and fail, leaving the user stuck with no way to recover — not even
+        // /compact would work because it also needs an API call.
+        if (input.overflow) {
+          log.info("overflow compaction: pruning tool outputs before compaction call")
+          const OVERFLOW_OUTPUT_BUDGET = 500 // chars to keep per tool output as a hint
+          const OVERFLOW_TEXT_BUDGET = 2000 // chars to keep per synthetic text part
+          for (const m of messages) {
+            for (const part of m.parts) {
+              if (part.type === "tool" && part.state.status === "completed") {
+                const output = part.state.output
+                if (typeof output === "string" && output.length > OVERFLOW_OUTPUT_BUDGET) {
+                  part.state.output =
+                    output.slice(0, OVERFLOW_OUTPUT_BUDGET) +
+                    `\n\n[... truncated ${output.length - OVERFLOW_OUTPUT_BUDGET} chars for compaction]`
+                }
+              }
+              // Also truncate large synthetic text parts (e.g. file contents injected
+              // via @ references) which can be massive and blow up the context.
+              if (part.type === "text" && "synthetic" in part && part.synthetic) {
+                if (part.text.length > OVERFLOW_TEXT_BUDGET) {
+                  part.text =
+                    part.text.slice(0, OVERFLOW_TEXT_BUDGET) +
+                    `\n\n[... truncated ${part.text.length - OVERFLOW_TEXT_BUDGET} chars for compaction]`
+                }
+              }
+            }
+          }
+          // If the conversation is very long, also drop older messages keeping
+          // only the most recent turns. The compaction model only needs enough
+          // context to produce a useful summary — it doesn't need every message.
+          const OVERFLOW_MAX_MESSAGES = 40
+          if (messages.length > OVERFLOW_MAX_MESSAGES) {
+            log.info("overflow compaction: trimming old messages", {
+              before: messages.length,
+              after: OVERFLOW_MAX_MESSAGES,
+            })
+            messages = messages.slice(-OVERFLOW_MAX_MESSAGES)
+          }
+        }
+
         const agent = yield* agents.get("compaction")
         const model = agent.model
           ? yield* provider.getModel(agent.model.providerID, agent.model.modelID)

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1175,11 +1175,15 @@ describe("session.compaction.overflow-pruning", () => {
           expect(captured.length).toBeGreaterThanOrEqual(1)
           const modelMsgs = captured[0].messages
           const allText = JSON.stringify(modelMsgs)
-          // Should NOT contain the very first messages (trimmed away)
-          expect(allText).not.toContain("msg-000")
-          expect(allText).not.toContain("msg-001")
-          expect(allText).not.toContain("msg-008")
-          // Should still contain recent messages that survived the trim
+          // With 50 messages before the compaction parent and OVERFLOW_MAX_MESSAGES = 40,
+          // the overflow replay logic pulls msg-049 out as the replay turn, leaving
+          // 49 messages (indices 0–48).  slice(-40) then drops the first 9 (indices 0–8).
+          for (let i = 0; i <= 8; i++) {
+            expect(allText).not.toContain(`msg-${String(i).padStart(3, "0")}`)
+          }
+          // msg-009 should be the first surviving message
+          expect(allText).toContain("msg-009")
+          // Recent messages should survive the trim
           expect(allText).toContain("msg-048")
         } finally {
           await rt.dispose()

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -990,6 +990,244 @@ describe("session.compaction.process", () => {
   })
 })
 
+describe("session.compaction.overflow-pruning", () => {
+  // Helper: create a processor layer that captures the messages sent to the
+  // compaction model, so we can assert they were pruned correctly.
+  function capturingLayer() {
+    const captured: { messages: import("ai").ModelMessage[] }[] = []
+    const processorLayer = Layer.succeed(
+      SessionProcessorModule.SessionProcessor.Service,
+      SessionProcessorModule.SessionProcessor.Service.of({
+        create: Effect.fn("CapturingProcessor.create")((input) => {
+          const msg = input.assistantMessage
+          return Effect.succeed({
+            get message() {
+              return msg
+            },
+            abort: Effect.fn("CapturingProcessor.abort")(() => Effect.void),
+            partFromToolCall() {
+              return {
+                id: PartID.ascending(),
+                messageID: msg.id,
+                sessionID: msg.sessionID,
+                type: "tool",
+                callID: "fake",
+                tool: "fake",
+                state: { status: "pending", input: {}, raw: "" },
+              }
+            },
+            process: Effect.fn("CapturingProcessor.process")((streamInput: import("../../src/session/llm").LLM.StreamInput) => {
+              captured.push({ messages: streamInput.messages })
+              return Effect.succeed("continue" as const)
+            }),
+          } satisfies SessionProcessorModule.SessionProcessor.Handle)
+        }),
+      }),
+    )
+    return { captured, processorLayer }
+  }
+
+  function capturingRuntime(processorLayer: Layer.Layer<SessionProcessorModule.SessionProcessor.Service>, provider = ProviderTest.fake()) {
+    const bus = Bus.layer
+    return ManagedRuntime.make(
+      Layer.mergeAll(SessionCompaction.layer, bus).pipe(
+        Layer.provide(provider.layer),
+        Layer.provide(Session.defaultLayer),
+        Layer.provide(processorLayer),
+        Layer.provide(Agent.defaultLayer),
+        Layer.provide(Plugin.defaultLayer),
+        Layer.provide(bus),
+        Layer.provide(Config.defaultLayer),
+      ),
+    )
+  }
+
+  test("overflow compaction truncates large tool outputs before sending to model", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        // Build a conversation with a very large tool output
+        const u1 = await user(session.id, "first message")
+        const a1 = await assistant(session.id, u1.id, tmp.path)
+        const hugeOutput = "x".repeat(50_000)
+        await tool(session.id, a1.id, "bash", hugeOutput)
+        const u2 = await user(session.id, "second message")
+        // The compaction parent — this triggers overflow compaction
+        const compactionParent = await user(session.id, "compact me")
+
+        const { captured, processorLayer } = capturingLayer()
+        const rt = capturingRuntime(processorLayer, wide())
+        try {
+          const msgs = await Session.messages({ sessionID: session.id })
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: compactionParent.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+                overflow: true,
+              }),
+            ),
+          )
+
+          // The captured messages should NOT contain the full 50k output
+          expect(captured.length).toBeGreaterThanOrEqual(1)
+          const allText = JSON.stringify(captured[0].messages)
+          expect(allText).not.toContain("x".repeat(1000))
+          expect(allText).toContain("truncated")
+
+          // Verify original DB messages are NOT modified
+          const dbMsgs = await Session.messages({ sessionID: session.id })
+          const dbToolPart = dbMsgs.flatMap((m) => m.parts).find((p) => p.type === "tool" && p.state.status === "completed")
+          expect(dbToolPart?.type).toBe("tool")
+          if (dbToolPart?.type === "tool" && dbToolPart.state.status === "completed") {
+            expect(dbToolPart.state.output).toBe(hugeOutput)
+          }
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("overflow compaction truncates large synthetic text parts", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const u1 = await user(session.id, "first message")
+        // Add a large synthetic text part (like a file read via @)
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: u1.id,
+          sessionID: session.id,
+          type: "text",
+          synthetic: true,
+          text: "y".repeat(10_000),
+        })
+        const compactionParent = await user(session.id, "compact me")
+
+        const { captured, processorLayer } = capturingLayer()
+        const rt = capturingRuntime(processorLayer, wide())
+        try {
+          const msgs = await Session.messages({ sessionID: session.id })
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: compactionParent.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+                overflow: true,
+              }),
+            ),
+          )
+
+          expect(captured.length).toBeGreaterThanOrEqual(1)
+          const allText = JSON.stringify(captured[0].messages)
+          // Should not contain the full 10k of y's
+          expect(allText).not.toContain("y".repeat(3000))
+          expect(allText).toContain("truncated")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("overflow compaction trims old messages when conversation is very long", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        // Create 50 user messages — more than the OVERFLOW_MAX_MESSAGES limit of 40
+        for (let i = 0; i < 50; i++) {
+          await user(session.id, `msg-${String(i).padStart(3, "0")}`)
+        }
+        const compactionParent = await user(session.id, "compact me")
+
+        const { captured, processorLayer } = capturingLayer()
+        const rt = capturingRuntime(processorLayer, wide())
+        try {
+          const msgs = await Session.messages({ sessionID: session.id })
+          expect(msgs.length).toBeGreaterThan(40)
+
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: compactionParent.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: true,
+                overflow: true,
+              }),
+            ),
+          )
+
+          // The model should receive fewer messages than the full conversation.
+          // The overflow replay logic slices off the last user turn first, then
+          // our trimming drops old messages from the beginning.
+          expect(captured.length).toBeGreaterThanOrEqual(1)
+          const modelMsgs = captured[0].messages
+          const allText = JSON.stringify(modelMsgs)
+          // Should NOT contain the very first messages (trimmed away)
+          expect(allText).not.toContain("msg-000")
+          expect(allText).not.toContain("msg-001")
+          expect(allText).not.toContain("msg-008")
+          // Should still contain recent messages that survived the trim
+          expect(allText).toContain("msg-048")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("non-overflow compaction does NOT prune tool outputs", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const u1 = await user(session.id, "first message")
+        const a1 = await assistant(session.id, u1.id, tmp.path)
+        const largeOutput = "z".repeat(5_000)
+        await tool(session.id, a1.id, "bash", largeOutput)
+        const compactionParent = await user(session.id, "compact me")
+
+        const { captured, processorLayer } = capturingLayer()
+        const rt = capturingRuntime(processorLayer, wide())
+        try {
+          const msgs = await Session.messages({ sessionID: session.id })
+          await rt.runPromise(
+            SessionCompaction.Service.use((svc) =>
+              svc.process({
+                parentID: compactionParent.id,
+                messages: msgs,
+                sessionID: session.id,
+                auto: false,
+                // overflow is NOT set — normal compaction
+              }),
+            ),
+          )
+
+          expect(captured.length).toBeGreaterThanOrEqual(1)
+          const allText = JSON.stringify(captured[0].messages)
+          // Normal compaction should preserve the full output
+          expect(allText).not.toContain("truncated")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+})
+
 describe("util.token.estimate", () => {
   test("estimates tokens from text (4 chars per token)", () => {
     const text = "x".repeat(4000)


### PR DESCRIPTION
### Issue for this PR

Fixes #15849
Fixes #17340
Related: #14562

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a conversation hits "Request Entity Too Large" (HTTP 413) or a context overflow error, OpenCode triggers auto-compaction. But the compaction call sends the full oversized context to the LLM for summarization — so it also fails with the same error. The user is stuck: the session is broken and even `/compact` cannot recover it.

This PR adds pre-flight pruning of messages **before** the overflow compaction API call. When `input.overflow` is `true` in `processCompaction()`, we now:

1. **Drop older messages** if there are more than 40 — the compaction model only needs enough recent context to produce a useful summary (sliced first, so truncation only runs on surviving messages)
2. **Truncate completed tool outputs** to 500 chars — enough for the compaction model to understand what happened, but removes the bulk (e.g. large file reads, command outputs)
3. **Truncate large synthetic text parts** to 2,000 chars — these are injected file contents from `@` references that can be massive

All modifications are made on shallow copies (`map` + spread) of the messages, parts, and part state — the caller's objects and database records are never mutated.

This works because the existing overflow path already slices off the most recent user turn for replay (lines 161-177). Our pruning runs right after that, further reducing what gets sent to the compaction model.

### How did you verify your code works?

- **4 new tests** covering all pruning paths:
  - Large tool outputs (50k chars) are truncated before sending to the compaction model
  - Large synthetic text parts (10k chars) are truncated
  - 50+ messages are trimmed to the most recent 40 (with systematic assertions on which messages are dropped vs. retained)
  - Non-overflow compaction does NOT prune (normal path unaffected)
- **Test 1 also verifies no DB mutation** — re-reads messages from the database after compaction and asserts the original 50k tool output is intact
- All **41 tests pass** (37 existing + 4 new): `bun test test/session/compaction.test.ts`
- Full **typecheck passes** across all 13 packages: `bun turbo typecheck`
- **All 8 CI checks pass**: unit tests (linux + windows), e2e tests (linux + windows), typecheck, nix-eval, check-compliance, check-standards

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR