### PR TITLE
test(app): emit junit artifacts for playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,15 +105,17 @@ jobs:
         run: bun --cwd packages/app test:e2e:local
         env:
           CI: true
+          PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-${{ matrix.settings.name }}.xml
         timeout-minutes: 30
 
       - name: Upload Playwright artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}
           if-no-files-found: ignore
           retention-days: 7
           path: |
+            packages/app/e2e/junit-*.xml
             packages/app/e2e/test-results
             packages/app/e2e/playwright-report

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -7,6 +7,11 @@ const serverPort = process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"
 const command = `bun run dev -- --host 0.0.0.0 --port ${port}`
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
+const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
+
+if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
+  reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
+}
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,7 +24,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers,
-  reporter: [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]],
+  reporter,
   webServer: {
     command,
     url: baseURL,


### PR DESCRIPTION
## Summary
- add optional Playwright JUnit output via `PLAYWRIGHT_JUNIT_OUTPUT`
- emit JUnit XML in the app e2e CI job
- upload the XML alongside the existing Playwright failure artifacts so CI debugging tools can parse failing tests directly