### PR TITLE
fix(opencode): scope TUI prompt history by session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -26,7 +26,7 @@ export type PromptInfo = {
   )[]
 }
 
-const MAX_HISTORY_ENTRIES = 50
+const MAX_HISTORY_ENTRIES = 1000
 
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -28,10 +28,6 @@ export type PromptInfo = {
 
 const MAX_HISTORY_ENTRIES = 50
 
-function scope(value?: string) {
-  return value ?? "global"
-}
-
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
   init: () => {
@@ -60,23 +56,26 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       }
     })
 
-    const [store, setStore] = createStore({
+    const [store, setStore] = createStore<{
+      index: number
+      scope?: string
+      history: PromptInfo[]
+    }>({
       index: 0,
-      scope: "global",
-      history: [] as PromptInfo[],
+      scope: undefined,
+      history: [],
     })
 
     return {
-      move(direction: 1 | -1, input: string, currentScope?: string) {
-        const nextScope = scope(currentScope)
-        const changed = store.scope !== nextScope
+      move(direction: 1 | -1, input: string, scope?: string) {
+        const changed = store.scope !== scope
         const index = changed ? 0 : store.index
         if (changed) {
-          setStore("scope", nextScope)
+          setStore("scope", scope)
           setStore("index", 0)
         }
 
-        const list = store.history.filter((item) => scope(item.scope) === nextScope)
+        const list = scope === undefined ? store.history : store.history.filter((item) => item.scope === scope)
         if (!list.length) return undefined
         const current = list.at(index)
         if (!current) return undefined
@@ -85,7 +84,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
         if (Math.abs(next) > list.length) return undefined
         if (next > 0) return undefined
 
-        setStore("scope", nextScope)
+        setStore("scope", scope)
         setStore("index", next)
 
         if (next === 0)
@@ -95,11 +94,8 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
           }
         return list.at(next)
       },
-      append(item: PromptInfo, currentScope?: string) {
-        const entry = {
-          ...structuredClone(unwrap(item)),
-          scope: scope(currentScope),
-        } satisfies PromptInfo
+      append(item: PromptInfo, scope?: string) {
+        const entry = { ...structuredClone(unwrap(item)), scope } satisfies PromptInfo
         let trimmed = false
         setStore(
           produce((draft) => {
@@ -108,7 +104,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
               draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
               trimmed = true
             }
-            draft.scope = entry.scope
+            draft.scope = scope
             draft.index = 0
           }),
         )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -10,6 +10,7 @@ import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
 export type PromptInfo = {
   input: string
   mode?: "normal" | "shell"
+  scope?: string
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
@@ -26,6 +27,10 @@ export type PromptInfo = {
 }
 
 const MAX_HISTORY_ENTRIES = 50
+
+function scope(value?: string) {
+  return value ?? "global"
+}
 
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
@@ -57,32 +62,44 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
 
     const [store, setStore] = createStore({
       index: 0,
+      scope: "global",
       history: [] as PromptInfo[],
     })
 
     return {
-      move(direction: 1 | -1, input: string) {
-        if (!store.history.length) return undefined
-        const current = store.history.at(store.index)
+      move(direction: 1 | -1, input: string, currentScope?: string) {
+        const nextScope = scope(currentScope)
+        const changed = store.scope !== nextScope
+        const index = changed ? 0 : store.index
+        if (changed) {
+          setStore("scope", nextScope)
+          setStore("index", 0)
+        }
+
+        const list = store.history.filter((item) => scope(item.scope) === nextScope)
+        if (!list.length) return undefined
+        const current = list.at(index)
         if (!current) return undefined
         if (current.input !== input && input.length) return
-        setStore(
-          produce((draft) => {
-            const next = store.index + direction
-            if (Math.abs(next) > store.history.length) return
-            if (next > 0) return
-            draft.index = next
-          }),
-        )
-        if (store.index === 0)
+        const next = index + direction
+        if (Math.abs(next) > list.length) return undefined
+        if (next > 0) return undefined
+
+        setStore("scope", nextScope)
+        setStore("index", next)
+
+        if (next === 0)
           return {
             input: "",
             parts: [],
           }
-        return store.history.at(store.index)
+        return list.at(next)
       },
-      append(item: PromptInfo) {
-        const entry = structuredClone(unwrap(item))
+      append(item: PromptInfo, currentScope?: string) {
+        const entry = {
+          ...structuredClone(unwrap(item)),
+          scope: scope(currentScope),
+        } satisfies PromptInfo
         let trimmed = false
         setStore(
           produce((draft) => {
@@ -91,6 +108,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
               draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
               trimmed = true
             }
+            draft.scope = entry.scope
             draft.index = 0
           }),
         )

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -92,7 +92,6 @@ export function Prompt(props: PromptProps) {
   const kv = useKV()
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
-  const scope = (id?: string) => id ?? props.workspaceID ?? "global"
 
   function promptModelWarning() {
     toast.show({
@@ -701,7 +700,7 @@ export function Prompt(props: PromptProps) {
         ...store.prompt,
         mode: currentMode,
       },
-      scope(sessionID),
+      sessionID,
     )
     input.extmarks.clear()
     setStore("prompt", {
@@ -956,7 +955,7 @@ export function Prompt(props: PromptProps) {
                     (keybind.match("history_next", e) && input.cursorOffset === input.plainText.length)
                   ) {
                     const direction = keybind.match("history_previous", e) ? -1 : 1
-                    const item = history.move(direction, input.plainText, scope(props.sessionID))
+                    const item = history.move(direction, input.plainText, props.sessionID)
 
                     if (item) {
                       input.setText(item.input)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -92,6 +92,7 @@ export function Prompt(props: PromptProps) {
   const kv = useKV()
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
+  const scope = (id?: string) => id ?? props.workspaceID ?? "global"
 
   function promptModelWarning() {
     toast.show({
@@ -695,10 +696,13 @@ export function Prompt(props: PromptProps) {
         })
         .catch(() => {})
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
+    history.append(
+      {
+        ...store.prompt,
+        mode: currentMode,
+      },
+      scope(sessionID),
+    )
     input.extmarks.clear()
     setStore("prompt", {
       input: "",
@@ -952,7 +956,7 @@ export function Prompt(props: PromptProps) {
                     (keybind.match("history_next", e) && input.cursorOffset === input.plainText.length)
                   ) {
                     const direction = keybind.match("history_previous", e) ? -1 : 1
-                    const item = history.move(direction, input.plainText)
+                    const item = history.move(direction, input.plainText, scope(props.sessionID))
 
                     if (item) {
                       input.setText(item.input)


### PR DESCRIPTION
### Issue for this PR

Closes #15187

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This updates TUI prompt history so session prompts only recall prompts from the active session, while prompts without a `sessionID` read the full history. History entries are still written with the resolved session ID, so the first prompt in a newly created session stays attached to that session. It also raises the retained TUI prompt history size to 1000 entries so recent prompts do not age out as quickly from the shared history file.

Design decision: `sessionID` means session-local history; no `sessionID` means unscoped history. Limitation: non-session prompts, including the home/new chat prompt, can still recall prompts from other sessions by design. Old prompts without a session scope also do not appear inside session-scoped history by design.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Pre-push hook also ran `bun turbo typecheck`
- Manual repro:
  - sent a prompt in Session A
  - switched to Session B
  - verified `ArrowUp` only showed Session B history
  - switched back to Session A
  - verified `ArrowUp` showed Session A history again

### Screenshots / recordings

[Screencast from 2026-04-02 11-09-15.webm](https://github.com/user-attachments/assets/b6c0a623-5cfb-40e1-82f1-c3f99b0b9e10)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR