### PR TITLE
feat: Send x-session-affinity and x-parent-session-id headers

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -25,6 +25,7 @@ export namespace LLM {
   export type StreamInput = {
     user: MessageV2.User
     sessionID: string
+    parentSessionID?: string
     model: Provider.Model
     agent: Agent.Info
     permission?: Permission.Ruleset
@@ -301,6 +302,8 @@ export namespace LLM {
               "x-opencode-client": Flag.OPENCODE_CLIENT,
             }
           : {
+              "x-session-affinity": input.sessionID,
+              ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
               "User-Agent": `opencode/${Installation.VERSION}`,
             }),
         ...input.model.headers,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1512,6 +1512,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   agent,
                   permission: session.permission,
                   sessionID,
+                  parentSessionID: session.parentID,
                   system,
                   messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
                   tools,


### PR DESCRIPTION
### Issue for this PR

Closes #12930 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This change adds a header that allows all providers to correlate requests across sessions (`x-session-affinity`). It also adds a header for requests related to sub-agent sessions that indicate the parent session id (`x-parent-session-id`). 

### How did you verify your code works?

- Ran `bun test` locally.
- Ran with `bun run` and confirmed the provider received the header.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
