### PR TITLE
fix(opencode): sanitize unknown MCP schema formats before jsonSchema()

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -20,6 +20,7 @@ import { AppFileSystem } from "@/filesystem"
 import { McpOAuthProvider } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
+import { stripUnknownFormats } from "./schema"
 import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
@@ -143,7 +144,7 @@ export namespace MCP {
 
     return dynamicTool({
       description: mcpTool.description ?? "",
-      inputSchema: jsonSchema(schema),
+      inputSchema: jsonSchema(stripUnknownFormats(schema) as JSONSchema7),
       execute: async (args: unknown) => {
         return client.callTool(
           {

--- a/packages/opencode/src/mcp/schema.ts
+++ b/packages/opencode/src/mcp/schema.ts
@@ -1,0 +1,74 @@
+const KNOWN_FORMATS = new Set([
+  "date-time",
+  "time",
+  "date",
+  "duration",
+  "email",
+  "hostname",
+  "ipv4",
+  "ipv6",
+  "uri",
+  "uri-reference",
+  "uri-template",
+  "uuid",
+  "json-pointer",
+  "relative-json-pointer",
+  "regex",
+])
+
+export function stripUnknownFormats(schema: unknown): unknown {
+  if (Array.isArray(schema)) return schema.map(stripUnknownFormats)
+  if (!schema || typeof schema !== "object") return schema
+
+  const input = schema as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(input)) {
+    if (key === "format" && typeof value === "string" && !KNOWN_FORMATS.has(value)) {
+      continue
+    }
+
+    if (
+      key === "properties" ||
+      key === "patternProperties" ||
+      key === "$defs" ||
+      key === "definitions" ||
+      key === "dependentSchemas"
+    ) {
+      out[key] =
+        value && typeof value === "object" && !Array.isArray(value)
+          ? Object.fromEntries(
+              Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, stripUnknownFormats(v)]),
+            )
+          : value
+      continue
+    }
+
+    if (
+      key === "items" ||
+      key === "additionalProperties" ||
+      key === "unevaluatedProperties" ||
+      key === "contains" ||
+      key === "propertyNames" ||
+      key === "if" ||
+      key === "then" ||
+      key === "else" ||
+      key === "not"
+    ) {
+      out[key] = stripUnknownFormats(value)
+      continue
+    }
+
+    if (
+      (key === "allOf" || key === "anyOf" || key === "oneOf" || key === "prefixItems") &&
+      Array.isArray(value)
+    ) {
+      out[key] = value.map(stripUnknownFormats)
+      continue
+    }
+
+    out[key] = stripUnknownFormats(value)
+  }
+
+  return out
+}

--- a/packages/opencode/test/mcp/schema.test.ts
+++ b/packages/opencode/test/mcp/schema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { stripUnknownFormats } from "../../src/mcp/schema"
+
+describe("mcp.schema", () => {
+  test("removes unknown formats and preserves standard ones", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        a: { type: "string", format: "uint64" },
+        b: { type: "string", format: "date-time" },
+        c: {
+          anyOf: [
+            { type: "string", format: "path" },
+            { type: "string", format: "email" },
+          ],
+        },
+      },
+    }
+
+    const out = stripUnknownFormats(schema) as Record<string, unknown>
+    const properties = out.properties as Record<string, unknown>
+    const a = properties.a as Record<string, unknown>
+    const b = properties.b as Record<string, unknown>
+    const c = properties.c as Record<string, unknown>
+    const anyOf = c.anyOf as Array<Record<string, unknown>>
+
+    expect(a.format).toBeUndefined()
+    expect(b.format).toBe("date-time")
+    expect(anyOf[0]?.format).toBeUndefined()
+    expect(anyOf[1]?.format).toBe("email")
+  })
+
+  test("preserves boolean schema positions and sanitizes nested $defs formats", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      $defs: {
+        nested: {
+          type: "object",
+          properties: {
+            createdAt: { type: "string", format: "google-datetime" },
+            id: { type: "string", format: "uuid" },
+          },
+        },
+      },
+    }
+
+    const out = stripUnknownFormats(schema) as Record<string, unknown>
+    const defs = out.$defs as Record<string, unknown>
+    const nested = defs.nested as Record<string, unknown>
+    const properties = nested.properties as Record<string, unknown>
+    const createdAt = properties.createdAt as Record<string, unknown>
+    const id = properties.id as Record<string, unknown>
+
+    expect(out.additionalProperties).toBe(false)
+    expect(createdAt.format).toBeUndefined()
+    expect(id.format).toBe("uuid")
+  })
+})


### PR DESCRIPTION
## Summary
Strip nonstandard JSON Schema format values from MCP tool input schemas before passing them to ai/jsonSchema().

## What changed
- add `stripUnknownFormats()` helper for MCP schemas
- sanitize unknown `format` values before `jsonSchema(...)`
- add regression tests for unknown and standard formats

## Why
Some MCP providers return nonstandard schema formats such as `uint64`, `google-datetime`, and `path`, which trigger AJV warnings. This keeps standard format validation while removing unsupported provider-specific format annotations.

## Testing
- `bun test test/mcp/schema.test.ts`
- `bun run typecheck`
- `bun run build`

Fixes #20749