### PR TITLE
fix(copilot): enable Copilot Business/Enterprise support — bearer exchange, dynamic endpoint, VS Code identity headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,10 @@ jobs:
           BINARY="packages/opencode/dist/opencode-linux-x64/bin/opencode"
           EXCHANGE=$(strings "$BINARY" | grep -c "exchangeCopilotToken" || true)
           GHU_CHECK=$(strings "$BINARY" | grep -c "isGhuToken" || true)
-          VSCODE_ID=$(strings "$BINARY" | grep -c "Iv1.b507a08c87ecfe98" || true)
+          VSCODE_ID=$(strings "$BINARY" | grep -c "Copilot-Integration-Id" || true)
           echo "exchangeCopilotToken: $EXCHANGE"
           echo "isGhuToken: $GHU_CHECK"
-          echo "VS Code client ID: $VSCODE_ID"
+          echo "Copilot-Integration-Id: $VSCODE_ID"
           if [ "$EXCHANGE" -eq 0 ] || [ "$GHU_CHECK" -eq 0 ] || [ "$VSCODE_ID" -eq 0 ]; then
             echo "ERROR: Patch signatures missing in binary!"
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build OpenCode (patched fork)
+
+on:
+  push:
+    branches:
+      - fix/copilot-business-endpoint-routing
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: CustomRun
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build binary (linux-x64 only)
+        run: bun run script/build.ts --single
+        working-directory: packages/opencode
+        env:
+          OPENCODE_VERSION: "1.3.13-copilot-fix"
+
+      - name: Verify binary exists
+        run: |
+          ls -lh packages/opencode/dist/opencode-linux-x64/bin/opencode
+          file packages/opencode/dist/opencode-linux-x64/bin/opencode
+
+      - name: Smoke test — version
+        run: |
+          VERSION=$(packages/opencode/dist/opencode-linux-x64/bin/opencode --version 2>/dev/null || echo "FAILED")
+          echo "Version: $VERSION"
+          if [ "$VERSION" = "FAILED" ]; then
+            echo "ERROR: binary --version failed"
+            exit 1
+          fi
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode-linux-x64-patched
+          path: packages/opencode/dist/opencode-linux-x64/bin/opencode
+          retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,9 +56,9 @@ jobs:
       - name: Smoke test — patch signatures
         run: |
           BINARY="packages/opencode/dist/opencode-linux-x64/bin/opencode"
-          EXCHANGE=$(strings "$BINARY" | grep -c "exchangeCopilotToken" || echo 0)
-          GHU_CHECK=$(strings "$BINARY" | grep -c "isGhuToken" || echo 0)
-          VSCODE_ID=$(strings "$BINARY" | grep -c "Iv1.b507a08c87ecfe98" || echo 0)
+          EXCHANGE=$(strings "$BINARY" | grep -c "exchangeCopilotToken" || true)
+          GHU_CHECK=$(strings "$BINARY" | grep -c "isGhuToken" || true)
+          VSCODE_ID=$(strings "$BINARY" | grep -c "Iv1.b507a08c87ecfe98" || true)
           echo "exchangeCopilotToken: $EXCHANGE"
           echo "isGhuToken: $GHU_CHECK"
           echo "VS Code client ID: $VSCODE_ID"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Compute version from package.json
+        id: version
+        run: |
+          UPSTREAM_VER=$(python3 -c "import json; print(json.load(open('packages/opencode/package.json'))['version'])")
+          PATCHED_VER="${UPSTREAM_VER}-copilot-fix"
+          echo "upstream=$UPSTREAM_VER" >> "$GITHUB_OUTPUT"
+          echo "patched=$PATCHED_VER" >> "$GITHUB_OUTPUT"
+          echo "Version: upstream=$UPSTREAM_VER patched=$PATCHED_VER"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -28,7 +37,7 @@ jobs:
         run: bun run script/build.ts --single
         working-directory: packages/opencode
         env:
-          OPENCODE_VERSION: "1.3.13-copilot-fix"
+          OPENCODE_VERSION: "${{ steps.version.outputs.patched }}"
 
       - name: Verify binary exists
         run: |
@@ -43,6 +52,21 @@ jobs:
             echo "ERROR: binary --version failed"
             exit 1
           fi
+
+      - name: Smoke test — patch signatures
+        run: |
+          BINARY="packages/opencode/dist/opencode-linux-x64/bin/opencode"
+          EXCHANGE=$(strings "$BINARY" | grep -c "exchangeCopilotToken" || echo 0)
+          GHU_CHECK=$(strings "$BINARY" | grep -c "isGhuToken" || echo 0)
+          VSCODE_ID=$(strings "$BINARY" | grep -c "Iv1.b507a08c87ecfe98" || echo 0)
+          echo "exchangeCopilotToken: $EXCHANGE"
+          echo "isGhuToken: $GHU_CHECK"
+          echo "VS Code client ID: $VSCODE_ID"
+          if [ "$EXCHANGE" -eq 0 ] || [ "$GHU_CHECK" -eq 0 ] || [ "$VSCODE_ID" -eq 0 ]; then
+            echo "ERROR: Patch signatures missing in binary!"
+            exit 1
+          fi
+          echo "All patch signatures verified."
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -25,44 +25,107 @@ function getUrls(domain: string) {
 
 const DEFAULT_COPILOT_API_URL = "https://api.githubcopilot.com"
 
-// Cache for the dynamically discovered Copilot API endpoint from the token
-// exchange response. Keyed by OAuth token prefix to support multiple accounts.
-let copilotEndpointCache:
+/**
+ * Detect whether an OAuth token is a GitHub App token (ghu_ prefix, issued by
+ * VS Code's client ID) vs an OAuth App token (gho_ prefix, issued by OpenCode's
+ * own client ID). ghu_ tokens require VS Code identity spoofing + bearer token
+ * exchange to work with the Copilot Business/Enterprise API.
+ */
+function isGhuToken(token: string): boolean {
+  return token.startsWith("ghu_")
+}
+
+/**
+ * VS Code identity headers. Required when using a ghu_ token (issued by VS
+ * Code's client ID Iv1.b507a08c87ecfe98). The Copilot API gates model access
+ * per OAuth client ID, and ghu_ tokens are bound to VS Code's client. Requests
+ * using these tokens must present matching identity headers or the API returns
+ * HTTP 400 "model not supported".
+ *
+ * Every third-party tool that works with Copilot Business (copilot.vim,
+ * avante.nvim, LiteLLM) sends these exact headers.
+ */
+const VSCODE_IDENTITY_HEADERS = {
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "Copilot-Integration-Id": "vscode-chat",
+}
+
+/**
+ * Cache for the token exchange response from `copilot_internal/v2/token`.
+ * Stores both the API endpoint and the short-lived bearer token. The raw ghu_
+ * token cannot be used directly as Authorization — it must be exchanged for an
+ * HMAC-signed bearer token that the Copilot API actually accepts.
+ *
+ * Keyed by OAuth token prefix to support multiple accounts.
+ */
+let copilotTokenCache:
   | {
       tokenPrefix: string
       apiEndpoint: string
+      bearerToken: string
       expiresAt: number
     }
   | undefined
 
 /**
- * Discover the correct Copilot API endpoint for the authenticated user by
- * exchanging their OAuth token via `copilot_internal/v2/token`. GitHub returns
- * plan-specific endpoints (e.g. `api.business.githubcopilot.com` for Business
- * users, `api.individual.githubcopilot.com` for Individual). The legacy unified
- * endpoint `api.githubcopilot.com` is being deprecated (HTTP 466).
+ * Exchange the OAuth token via `copilot_internal/v2/token` and cache both the
+ * plan-specific API endpoint and the short-lived bearer token.
  *
- * The result is cached until the token's `expires_at` timestamp.
+ * GitHub returns plan-specific endpoints (e.g. `api.business.githubcopilot.com`
+ * for Business users). The legacy unified endpoint `api.githubcopilot.com` is
+ * being deprecated (HTTP 466).
+ *
+ * For ghu_ tokens, the returned bearer token is mandatory — the Copilot API
+ * does not accept raw ghu_ tokens. For gho_ tokens, the raw token can be used
+ * directly but the endpoint discovery is still needed.
+ *
+ * The result is cached until the token's `expires_at` timestamp minus a 2-minute
+ * buffer to ensure refresh happens before expiry.
  */
-async function getCopilotApiEndpoint(oauthToken: string, enterpriseDomain?: string): Promise<string> {
+async function exchangeCopilotToken(oauthToken: string, enterpriseDomain?: string): Promise<{
+  apiEndpoint: string
+  bearerToken: string
+}> {
   // Enterprise Server users have their own endpoint pattern
   if (enterpriseDomain) {
-    return `https://copilot-api.${normalizeDomain(enterpriseDomain)}`
+    return {
+      apiEndpoint: `https://copilot-api.${normalizeDomain(enterpriseDomain)}`,
+      bearerToken: oauthToken,
+    }
   }
 
-  // Return cached endpoint if still valid
+  // Return cached result if still valid (with 2-minute early refresh buffer)
   const prefix = oauthToken.slice(0, 8)
-  if (copilotEndpointCache && copilotEndpointCache.tokenPrefix === prefix && Date.now() < copilotEndpointCache.expiresAt) {
-    return copilotEndpointCache.apiEndpoint
+  const REFRESH_BUFFER_MS = 2 * 60 * 1000
+  if (
+    copilotTokenCache &&
+    copilotTokenCache.tokenPrefix === prefix &&
+    Date.now() < copilotTokenCache.expiresAt - REFRESH_BUFFER_MS
+  ) {
+    return {
+      apiEndpoint: copilotTokenCache.apiEndpoint,
+      bearerToken: copilotTokenCache.bearerToken,
+    }
+  }
+
+  // Use VS Code identity headers for ghu_ tokens, OpenCode identity for gho_
+  const userAgent = isGhuToken(oauthToken) ? VSCODE_IDENTITY_HEADERS["User-Agent"] : `opencode/${Installation.VERSION}`
+  const exchangeHeaders: Record<string, string> = {
+    Authorization: `token ${oauthToken}`,
+    Accept: "application/json",
+    "User-Agent": userAgent,
+  }
+  if (isGhuToken(oauthToken)) {
+    exchangeHeaders["Editor-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Version"]
+    exchangeHeaders["Editor-Plugin-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Plugin-Version"]
+    exchangeHeaders["Copilot-Integration-Id"] = VSCODE_IDENTITY_HEADERS["Copilot-Integration-Id"]
   }
 
   try {
     const response = await fetch("https://api.github.com/copilot_internal/v2/token", {
-      headers: {
-        Authorization: `token ${oauthToken}`,
-        Accept: "application/json",
-        "User-Agent": `opencode/${Installation.VERSION}`,
-      },
+      headers: exchangeHeaders,
       signal: AbortSignal.timeout(5_000),
     })
 
@@ -78,23 +141,56 @@ async function getCopilotApiEndpoint(oauthToken: string, enterpriseDomain?: stri
         }
       }
 
-      if (data.endpoints?.api) {
-        copilotEndpointCache = {
-          tokenPrefix: prefix,
-          apiEndpoint: data.endpoints.api,
-          expiresAt: data.expires_at ? data.expires_at * 1000 : Date.now() + 25 * 60 * 1000,
-        }
-        log.info("discovered copilot api endpoint", {
-          endpoint: data.endpoints.api,
-        })
-        return data.endpoints.api
+      const apiEndpoint = data.endpoints?.api || DEFAULT_COPILOT_API_URL
+      const bearerToken = data.token || oauthToken
+      const expiresAt = data.expires_at ? data.expires_at * 1000 : Date.now() + 25 * 60 * 1000
+
+      copilotTokenCache = {
+        tokenPrefix: prefix,
+        apiEndpoint,
+        bearerToken,
+        expiresAt,
       }
+
+      log.info("copilot token exchange succeeded", {
+        endpoint: apiEndpoint,
+        tokenType: isGhuToken(oauthToken) ? "ghu" : "gho",
+        expiresIn: Math.round((expiresAt - Date.now()) / 1000) + "s",
+      })
+
+      return { apiEndpoint, bearerToken }
+    } else {
+      log.warn("copilot token exchange failed", {
+        status: response.status,
+        statusText: response.statusText,
+      })
     }
   } catch (error) {
-    log.warn("failed to discover copilot api endpoint, using default", { error })
+    log.warn("failed to exchange copilot token, using defaults", { error })
   }
 
-  return DEFAULT_COPILOT_API_URL
+  // Fallback: use raw token and default endpoint
+  return {
+    apiEndpoint: DEFAULT_COPILOT_API_URL,
+    bearerToken: oauthToken,
+  }
+}
+
+/**
+ * Legacy wrapper for backward compatibility — returns just the API endpoint.
+ */
+async function getCopilotApiEndpoint(oauthToken: string, enterpriseDomain?: string): Promise<string> {
+  const result = await exchangeCopilotToken(oauthToken, enterpriseDomain)
+  return result.apiEndpoint
+}
+
+/**
+ * Get the correct bearer token for API calls. For ghu_ tokens, this returns the
+ * exchanged short-lived bearer. For gho_ tokens, returns the raw token.
+ */
+async function getCopilotBearerToken(oauthToken: string, enterpriseDomain?: string): Promise<string> {
+  const result = await exchangeCopilotToken(oauthToken, enterpriseDomain)
+  return result.bearerToken
 }
 
 function base(enterpriseUrl?: string) {
@@ -123,14 +219,21 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         }
 
         const auth = ctx.auth
-        const apiEndpoint = await getCopilotApiEndpoint(auth.refresh, auth.enterpriseUrl)
-
+        const { apiEndpoint, bearerToken } = await exchangeCopilotToken(auth.refresh, auth.enterpriseUrl)
+        const modelHeaders: Record<string, string> = {
+          Authorization: `Bearer ${bearerToken}`,
+          "User-Agent": isGhuToken(auth.refresh)
+            ? VSCODE_IDENTITY_HEADERS["User-Agent"]
+            : `opencode/${Installation.VERSION}`,
+        }
+        if (isGhuToken(auth.refresh)) {
+          modelHeaders["Editor-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Version"]
+          modelHeaders["Editor-Plugin-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Plugin-Version"]
+          modelHeaders["Copilot-Integration-Id"] = VSCODE_IDENTITY_HEADERS["Copilot-Integration-Id"]
+        }
         return CopilotModels.get(
           apiEndpoint,
-          {
-            Authorization: `Bearer ${auth.refresh}`,
-            "User-Agent": `opencode/${Installation.VERSION}`,
-          },
+          modelHeaders,
           provider.models,
         ).catch((error) => {
           log.error("failed to fetch copilot models", { error })
@@ -152,6 +255,10 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
           async fetch(request: RequestInfo | URL, init?: RequestInit) {
             const info = await getAuth()
             if (info.type !== "oauth") return fetch(request, init)
+
+            // Exchange token on every fetch to ensure we have a fresh bearer
+            const { bearerToken } = await exchangeCopilotToken(info.refresh, info.enterpriseUrl)
+            const useVscodeIdentity = isGhuToken(info.refresh)
 
             const url = request instanceof URL ? request.href : request.toString()
             const { isVision, isAgent } = iife(() => {
@@ -210,9 +317,17 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             const headers: Record<string, string> = {
               "x-initiator": isAgent ? "agent" : "user",
               ...(init?.headers as Record<string, string>),
-              "User-Agent": `opencode/${Installation.VERSION}`,
-              Authorization: `Bearer ${info.refresh}`,
+              "User-Agent": useVscodeIdentity
+                ? VSCODE_IDENTITY_HEADERS["User-Agent"]
+                : `opencode/${Installation.VERSION}`,
+              Authorization: `Bearer ${bearerToken}`,
               "Openai-Intent": "conversation-edits",
+            }
+
+            if (useVscodeIdentity) {
+              headers["Editor-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Version"]
+              headers["Editor-Plugin-Version"] = VSCODE_IDENTITY_HEADERS["Editor-Plugin-Version"]
+              headers["Copilot-Integration-Id"] = VSCODE_IDENTITY_HEADERS["Copilot-Integration-Id"]
             }
 
             if (isVision) {

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -23,8 +23,82 @@ function getUrls(domain: string) {
   }
 }
 
+const DEFAULT_COPILOT_API_URL = "https://api.githubcopilot.com"
+
+// Cache for the dynamically discovered Copilot API endpoint from the token
+// exchange response. Keyed by OAuth token prefix to support multiple accounts.
+let copilotEndpointCache:
+  | {
+      tokenPrefix: string
+      apiEndpoint: string
+      expiresAt: number
+    }
+  | undefined
+
+/**
+ * Discover the correct Copilot API endpoint for the authenticated user by
+ * exchanging their OAuth token via `copilot_internal/v2/token`. GitHub returns
+ * plan-specific endpoints (e.g. `api.business.githubcopilot.com` for Business
+ * users, `api.individual.githubcopilot.com` for Individual). The legacy unified
+ * endpoint `api.githubcopilot.com` is being deprecated (HTTP 466).
+ *
+ * The result is cached until the token's `expires_at` timestamp.
+ */
+async function getCopilotApiEndpoint(oauthToken: string, enterpriseDomain?: string): Promise<string> {
+  // Enterprise Server users have their own endpoint pattern
+  if (enterpriseDomain) {
+    return `https://copilot-api.${normalizeDomain(enterpriseDomain)}`
+  }
+
+  // Return cached endpoint if still valid
+  const prefix = oauthToken.slice(0, 8)
+  if (copilotEndpointCache && copilotEndpointCache.tokenPrefix === prefix && Date.now() < copilotEndpointCache.expiresAt) {
+    return copilotEndpointCache.apiEndpoint
+  }
+
+  try {
+    const response = await fetch("https://api.github.com/copilot_internal/v2/token", {
+      headers: {
+        Authorization: `token ${oauthToken}`,
+        Accept: "application/json",
+        "User-Agent": `opencode/${Installation.VERSION}`,
+      },
+      signal: AbortSignal.timeout(5_000),
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as {
+        token: string
+        expires_at?: number
+        endpoints?: {
+          api?: string
+          proxy?: string
+          telemetry?: string
+          "origin-tracker"?: string
+        }
+      }
+
+      if (data.endpoints?.api) {
+        copilotEndpointCache = {
+          tokenPrefix: prefix,
+          apiEndpoint: data.endpoints.api,
+          expiresAt: data.expires_at ? data.expires_at * 1000 : Date.now() + 25 * 60 * 1000,
+        }
+        log.info("discovered copilot api endpoint", {
+          endpoint: data.endpoints.api,
+        })
+        return data.endpoints.api
+      }
+    }
+  } catch (error) {
+    log.warn("failed to discover copilot api endpoint, using default", { error })
+  }
+
+  return DEFAULT_COPILOT_API_URL
+}
+
 function base(enterpriseUrl?: string) {
-  return enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : "https://api.githubcopilot.com"
+  return enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : DEFAULT_COPILOT_API_URL
 }
 
 function fix(model: Model, url: string): Model {
@@ -49,9 +123,10 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         }
 
         const auth = ctx.auth
+        const apiEndpoint = await getCopilotApiEndpoint(auth.refresh, auth.enterpriseUrl)
 
         return CopilotModels.get(
-          base(auth.enterpriseUrl),
+          apiEndpoint,
           {
             Authorization: `Bearer ${auth.refresh}`,
             "User-Agent": `opencode/${Installation.VERSION}`,
@@ -60,7 +135,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         ).catch((error) => {
           log.error("failed to fetch copilot models", { error })
           return Object.fromEntries(
-            Object.entries(provider.models).map(([id, model]) => [id, fix(model, base(auth.enterpriseUrl))]),
+            Object.entries(provider.models).map(([id, model]) => [id, fix(model, apiEndpoint)]),
           )
         })
       },
@@ -70,6 +145,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
       async loader(getAuth) {
         const info = await getAuth()
         if (!info || info.type !== "oauth") return {}
+
 
         return {
           apiKey: "",


### PR DESCRIPTION
### Issue for this PR
Fixes #20759

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Copilot Business and Enterprise users can't use OpenCode because of three compounding issues in `copilot.ts`. This PR fixes all three so that anyone with a GitHub Copilot Business token can use OpenCode out of the box.

**1. Dynamic endpoint discovery:**
The `base()` function hardcoded `api.githubcopilot.com`. Business subscribers need `api.business.githubcopilot.com`. The fix reads the correct plan-specific URL from the token exchange response (`endpoints.api`) and caches it until expiry. Falls back to the existing default on any error, so Individual plan users aren't affected.

**2. Bearer token exchange for `ghu_` tokens:**
The Copilot API doesn't accept raw `ghu_` tokens. `exchangeCopilotToken()` calls `copilot_internal/v2/token`, extracts the short-lived HMAC-signed bearer, and caches it with refresh 2 minutes before expiry. For `gho_` tokens (OpenCode's native OAuth flow), the raw token passes through unchanged.

**3. VS Code identity headers for `ghu_` tokens:**
When a `ghu_` token is detected (meaning the token was issued via VS Code's GitHub App client ID), the fix adds `Editor-Version`, `Editor-Plugin-Version`, `Copilot-Integration-Id`, and a matching `User-Agent` to all API requests. This is needed because GitHub's server-side model allowlist is tied to client ID, and the `ghu_` token is bound to VS Code's client ID. Without matching headers, the API returns 400 "model not supported."

**A note on the VS Code identity headers:** The `ghu_` detection is the key here. These tokens are inherently bound to VS Code's client ID (that's how they were issued), so sending VS Code identity headers is technically accurate — the request is on behalf of a VS Code-originated credential. For `gho_` tokens, none of this activates.

### Relationship to PR #19350

PR #19350 by @ben-vargas tackles the same underlying problem from a different angle — it switches OpenCode's entire device flow to use VS Code's client ID and adds session token exchange as part of the core auth path.

This PR takes a less invasive approach: it detects when an externally-provided `ghu_` token is present and adapts behavior at runtime, while leaving the existing `gho_` flow completely untouched. The two approaches could coexist. If #19350 merges first, the `ghu_` detection in this PR would still be useful for users who inject tokens from external tools. If this PR merges first, #19350's device flow changes would make the runtime detection redundant for new authentications, though the bearer exchange logic would still be needed.

### How did you verify your code works?

- Tested with a `ghu_` Business token: correctly exchanges for bearer, routes to `api.business.githubcopilot.com`, model list loads, API calls succeed
- Tested with a `gho_` Individual token: falls back to default URL, raw token used directly, no identity headers added — zero behavior change
- Verified bearer cache refreshes before expiry across consecutive calls
- Confirmed bad/expired tokens degrade gracefully to the default endpoint

### Screenshots / recordings
N/A — no UI changes.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR