### PR TITLE
fix(sdk): use cross-spawn for opencode sdk process launch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -463,9 +463,13 @@
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
       "version": "1.3.13",
+      "dependencies": {
+        "cross-spawn": "7.0.6",
+      },
       "devDependencies": {
         "@hey-api/openapi-ts": "0.90.10",
         "@tsconfig/node22": "catalog:",
+        "@types/cross-spawn": "6.0.6",
         "@types/node": "catalog:",
         "@typescript/native-preview": "catalog:",
         "typescript": "catalog:",

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -23,9 +23,12 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "0.90.10",
     "@tsconfig/node22": "catalog:",
+    "@types/cross-spawn": "6.0.6",
     "@types/node": "catalog:",
-    "typescript": "catalog:",
-    "@typescript/native-preview": "catalog:"
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:"
   },
-  "dependencies": {}
+  "dependencies": {
+    "cross-spawn": "7.0.6"
+  }
 }

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process"
+import { Buffer } from "node:buffer"
+import spawn from "cross-spawn"
 import { type Config } from "./gen/types.gen.js"
 
 export type ServerOptions = {
@@ -44,7 +45,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
       reject(new Error(`Timeout waiting for server to start after ${options.timeout}ms`))
     }, options.timeout)
     let output = ""
-    proc.stdout?.on("data", (chunk) => {
+    proc.stdout?.on("data", (chunk: Buffer) => {
       output += chunk.toString()
       const lines = output.split("\n")
       for (const line of lines) {
@@ -59,10 +60,10 @@ export async function createOpencodeServer(options?: ServerOptions) {
         }
       }
     })
-    proc.stderr?.on("data", (chunk) => {
+    proc.stderr?.on("data", (chunk: Buffer) => {
       output += chunk.toString()
     })
-    proc.on("exit", (code) => {
+    proc.on("exit", (code: number | null) => {
       clearTimeout(id)
       let msg = `Server exited with code ${code}`
       if (output.trim()) {
@@ -70,7 +71,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
       }
       reject(new Error(msg))
     })
-    proc.on("error", (error) => {
+    proc.on("error", (error: Error) => {
       clearTimeout(id)
       reject(error)
     })

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process"
+import { Buffer } from "node:buffer"
+import spawn from "cross-spawn"
 import { type Config } from "./gen/types.gen.js"
 
 export type ServerOptions = {
@@ -44,7 +45,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
       reject(new Error(`Timeout waiting for server to start after ${options.timeout}ms`))
     }, options.timeout)
     let output = ""
-    proc.stdout?.on("data", (chunk) => {
+    proc.stdout?.on("data", (chunk: Buffer) => {
       output += chunk.toString()
       const lines = output.split("\n")
       for (const line of lines) {
@@ -59,10 +60,10 @@ export async function createOpencodeServer(options?: ServerOptions) {
         }
       }
     })
-    proc.stderr?.on("data", (chunk) => {
+    proc.stderr?.on("data", (chunk: Buffer) => {
       output += chunk.toString()
     })
-    proc.on("exit", (code) => {
+    proc.on("exit", (code: number | null) => {
       clearTimeout(id)
       let msg = `Server exited with code ${code}`
       if (output.trim()) {
@@ -70,7 +71,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
       }
       reject(new Error(msg))
     })
-    proc.on("error", (error) => {
+    proc.on("error", (error: Error) => {
       clearTimeout(id)
       reject(error)
     })


### PR DESCRIPTION
### Issue for this PR

Closes #20762

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Windows ENOENT error when spawning the `opencode` process in the SDK. Replaces `child_process.spawn` with `cross-spawn`, which handles `.cmd` extension resolution on Windows without needing `shell: true`. `cross-spawn` is already used in `packages/opencode` so this is consistent with the rest of the codebase.

Closes #2812, #8160. Alternative to #2813.

### How did you verify your code works?

Tested locally on Windows - the SDK now spawns correctly without ENOENT. Also verified existing behavior is unchanged on macOS/Linux.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR