### PR TITLE
fix: call models.dev once instead of twice on start

### DIFF
--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -28,7 +28,7 @@ export const ModelsCommand = cmd({
   },
   handler: async (args) => {
     if (args.refresh) {
-      await ModelsDev.refresh()
+      await ModelsDev.refresh(true)
       UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
     }
 

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -303,7 +303,7 @@ export const ProvidersLoginCommand = cmd({
           prompts.outro("Done")
           return
         }
-        await ModelsDev.refresh().catch(() => {})
+        await ModelsDev.refresh(true).catch(() => {})
 
         const config = await Config.get()
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -7,6 +7,7 @@ import { Flag } from "../flag/flag"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
 import { Flock } from "@/util/flock"
+import { Hash } from "@/util/hash"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -14,7 +15,11 @@ import { Flock } from "@/util/flock"
 
 export namespace ModelsDev {
   const log = Log.create({ service: "models.dev" })
-  const filepath = path.join(Global.Path.cache, "models.json")
+  const source = url()
+  const filepath = path.join(
+    Global.Path.cache,
+    source === "https://models.dev" ? "models.json" : `models-${Hash.fast(source)}.json`,
+  )
   const ttl = 5 * 60 * 1000
 
   export const Model = z.object({
@@ -92,7 +97,7 @@ export namespace ModelsDev {
   }
 
   function skip(force: boolean) {
-    return !force && !Flag.OPENCODE_MODELS_URL && fresh()
+    return !force && fresh()
   }
 
   let fetching: Promise<{ ok: boolean; text: string }> | undefined
@@ -113,7 +118,13 @@ export namespace ModelsDev {
       .catch(() => undefined)
     if (snapshot) return snapshot
     if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-    return JSON.parse((await fetchApi()).text)
+    return Flock.withLock(`models-dev:${filepath}`, async () => {
+      const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+      if (result) return result
+      const result2 = await fetchApi()
+      if (result2.ok) await Filesystem.write(filepath, result2.text)
+      return JSON.parse(result2.text)
+    })
   })
 
   export async function get() {
@@ -123,7 +134,7 @@ export namespace ModelsDev {
 
   export async function refresh(force = false) {
     if (skip(force)) return ModelsDev.Data.reset()
-    const result = await Flock.withLock(`models-dev:${url()}:${filepath}`, async () => {
+    const result = await Flock.withLock(`models-dev:${filepath}`, async () => {
       if (skip(force)) return ModelsDev.Data.reset()
       return fetchApi()
     }).catch((e) => {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -100,14 +100,13 @@ export namespace ModelsDev {
     return !force && fresh()
   }
 
-  let fetching: Promise<{ ok: boolean; text: string }> | undefined
-  const fetchApi = () =>
-    (fetching ??= fetch(`${url()}/api.json`, {
+  const fetchApi = async () => {
+    const result = await fetch(`${url()}/api.json`, {
       headers: { "User-Agent": Installation.USER_AGENT },
       signal: AbortSignal.timeout(10000),
     })
-      .then(async (x) => ({ ok: x.ok, text: await x.text() }))
-      .finally(() => (fetching = undefined)))
+    return { ok: result.ok, text: await result.text() }
+  }
 
   export const Data = lazy(async () => {
     const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -6,6 +6,7 @@ import { Installation } from "../installation"
 import { Flag } from "../flag/flag"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "../util/filesystem"
+import { Flock } from "@/util/flock"
 
 // Try to import bundled snapshot (generated at build time)
 // Falls back to undefined in dev mode when snapshot doesn't exist
@@ -14,6 +15,7 @@ import { Filesystem } from "../util/filesystem"
 export namespace ModelsDev {
   const log = Log.create({ service: "models.dev" })
   const filepath = path.join(Global.Path.cache, "models.json")
+  const ttl = 5 * 60 * 1000
 
   export const Model = z.object({
     id: z.string(),
@@ -85,6 +87,19 @@ export namespace ModelsDev {
     return Flag.OPENCODE_MODELS_URL || "https://models.dev"
   }
 
+  function fresh() {
+    return Date.now() - Number(Filesystem.stat(filepath)?.mtimeMs ?? 0) < ttl
+  }
+
+  let fetching: Promise<{ ok: boolean; text: string }> | undefined
+  const fetchApi = () =>
+    (fetching ??= fetch(`${url()}/api.json`, {
+      headers: { "User-Agent": Installation.USER_AGENT },
+      signal: AbortSignal.timeout(10000),
+    })
+      .then(async (x) => ({ ok: x.ok, text: await x.text() }))
+      .finally(() => (fetching = undefined)))
+
   export const Data = lazy(async () => {
     const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
     if (result) return result
@@ -94,8 +109,7 @@ export namespace ModelsDev {
       .catch(() => undefined)
     if (snapshot) return snapshot
     if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
-    const json = await fetch(`${url()}/api.json`).then((x) => x.text())
-    return JSON.parse(json)
+    return JSON.parse((await fetchApi()).text)
   })
 
   export async function get() {
@@ -104,18 +118,17 @@ export namespace ModelsDev {
   }
 
   export async function refresh() {
-    const result = await fetch(`${url()}/api.json`, {
-      headers: {
-        "User-Agent": Installation.USER_AGENT,
-      },
-      signal: AbortSignal.timeout(10 * 1000),
+    if (fresh()) return
+    const result = await Flock.withLock(`models-dev:${filepath}`, async () => {
+      if (fresh()) return
+      return fetchApi()
     }).catch((e) => {
       log.error("Failed to fetch models.dev", {
         error: e,
       })
     })
     if (result && result.ok) {
-      await Filesystem.write(filepath, await result.text())
+      await Filesystem.write(filepath, result.text)
       ModelsDev.Data.reset()
     }
   }

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -134,18 +134,17 @@ export namespace ModelsDev {
 
   export async function refresh(force = false) {
     if (skip(force)) return ModelsDev.Data.reset()
-    const result = await Flock.withLock(`models-dev:${filepath}`, async () => {
+    await Flock.withLock(`models-dev:${filepath}`, async () => {
       if (skip(force)) return ModelsDev.Data.reset()
-      return fetchApi()
+      const result = await fetchApi()
+      if (!result.ok) return
+      await Filesystem.write(filepath, result.text)
+      ModelsDev.Data.reset()
     }).catch((e) => {
       log.error("Failed to fetch models.dev", {
         error: e,
       })
     })
-    if (result && result.ok) {
-      await Filesystem.write(filepath, result.text)
-      ModelsDev.Data.reset()
-    }
   }
 }
 

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -91,6 +91,10 @@ export namespace ModelsDev {
     return Date.now() - Number(Filesystem.stat(filepath)?.mtimeMs ?? 0) < ttl
   }
 
+  function skip(force: boolean) {
+    return !force && !Flag.OPENCODE_MODELS_URL && fresh()
+  }
+
   let fetching: Promise<{ ok: boolean; text: string }> | undefined
   const fetchApi = () =>
     (fetching ??= fetch(`${url()}/api.json`, {
@@ -118,9 +122,9 @@ export namespace ModelsDev {
   }
 
   export async function refresh(force = false) {
-    if (!force && fresh()) return ModelsDev.Data.reset()
-    const result = await Flock.withLock(`models-dev:${filepath}`, async () => {
-      if (!force && fresh()) return ModelsDev.Data.reset()
+    if (skip(force)) return ModelsDev.Data.reset()
+    const result = await Flock.withLock(`models-dev:${url()}:${filepath}`, async () => {
+      if (skip(force)) return ModelsDev.Data.reset()
       return fetchApi()
     }).catch((e) => {
       log.error("Failed to fetch models.dev", {

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -122,7 +122,11 @@ export namespace ModelsDev {
       const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
       if (result) return result
       const result2 = await fetchApi()
-      if (result2.ok) await Filesystem.write(filepath, result2.text)
+      if (result2.ok) {
+        await Filesystem.write(filepath, result2.text).catch((e) => {
+          log.error("Failed to write models cache", { error: e })
+        })
+      }
       return JSON.parse(result2.text)
     })
   })

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -117,10 +117,10 @@ export namespace ModelsDev {
     return result as Record<string, Provider>
   }
 
-  export async function refresh() {
-    if (fresh()) return
+  export async function refresh(force = false) {
+    if (!force && fresh()) return ModelsDev.Data.reset()
     const result = await Flock.withLock(`models-dev:${filepath}`, async () => {
-      if (fresh()) return
+      if (!force && fresh()) return ModelsDev.Data.reset()
       return fetchApi()
     }).catch((e) => {
       log.error("Failed to fetch models.dev", {


### PR DESCRIPTION
## Summary
- add a short freshness check before refreshing `models.dev`
- guard `ModelsDev.refresh()` with `Flock` so the CLI process and TUI worker share one startup refresh
- keep eager refresh behavior while preventing duplicate startup fetches on plain `opencode`

## Verification
- `bun run typecheck` in `packages/opencode`
- rebuilt the Windows binary and verified isolated no-args startup only hit `/api.json` once