### PR TITLE
fix(tui): lazy load bun ffi on windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -16,7 +16,7 @@ import {
   on,
   onCleanup,
 } from "solid-js"
-import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { win32DisableProcessedInput, win32Init, win32InstallCtrlCGuard } from "./win32"
 import { Flag } from "@/flag/flag"
 import semver from "semver"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -172,6 +172,7 @@ export function tui(input: {
 }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
+    await win32Init()
     const unguard = win32InstallCtrlCGuard()
     win32DisableProcessedInput()
 

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -2,8 +2,19 @@ const STD_INPUT_HANDLE = -10
 const ENABLE_PROCESSED_INPUT = 0x0001
 
 let mod: typeof import("bun:ffi") | undefined
-let k32: ReturnType<typeof mod.dlopen> | undefined
+type K32 = {
+  symbols: {
+    GetStdHandle: (n: number) => bigint | number
+    GetConsoleMode: (h: bigint | number, mode: unknown) => number
+    SetConsoleMode: (h: bigint | number, mode: number) => number
+    FlushConsoleInputBuffer: (h: bigint | number) => number
+  }
+}
+
+let k32: K32 | undefined
 let ready: boolean | undefined
+
+type Ptr = typeof import("bun:ffi").ptr
 
 export async function win32Init() {
   if (process.platform !== "win32") return false
@@ -15,7 +26,7 @@ export async function win32Init() {
       GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
       SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
       FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
-    })
+    }) as K32
     ready = true
     return true
   } catch {
@@ -31,14 +42,15 @@ export function win32DisableProcessedInput() {
   if (process.platform !== "win32") return
   if (!process.stdin.isTTY) return
   if (!k32 || !mod) return
+  const ptr = mod.ptr as Ptr
 
-  const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
+  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
-  if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
+  if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
 
   const mode = buf[0]!
   if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
-  k32!.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
+  k32.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
 }
 
 /**
@@ -49,8 +61,8 @@ export function win32FlushInputBuffer() {
   if (!process.stdin.isTTY) return
   if (!k32) return
 
-  const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
-  k32!.symbols.FlushConsoleInputBuffer(handle)
+  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
+  k32.symbols.FlushConsoleInputBuffer(handle)
 }
 
 let unhook: (() => void) | undefined
@@ -71,21 +83,22 @@ export function win32InstallCtrlCGuard() {
   if (!process.stdin.isTTY) return
   if (!k32 || !mod) return
   if (unhook) return unhook
+  const ptr = mod.ptr as Ptr
 
   const stdin = process.stdin as any
   const original = stdin.setRawMode
 
-  const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
+  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
 
-  if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
+  if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
   const initial = buf[0]!
 
   const enforce = () => {
-    if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
+    if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
     const mode = buf[0]!
     if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
-    k32!.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
+    k32.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
   }
 
   // Some runtimes can re-apply console modes on the next tick; enforce twice.
@@ -122,7 +135,7 @@ export function win32InstallCtrlCGuard() {
       stdin.setRawMode = original
     }
 
-    k32!.symbols.SetConsoleMode(handle, initial)
+    k32.symbols.SetConsoleMode(handle, initial)
     unhook = undefined
   }
 

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -1,24 +1,25 @@
-import { dlopen, ptr } from "bun:ffi"
-
 const STD_INPUT_HANDLE = -10
 const ENABLE_PROCESSED_INPUT = 0x0001
 
-const kernel = () =>
-  dlopen("kernel32.dll", {
-    GetStdHandle: { args: ["i32"], returns: "ptr" },
-    GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
-    SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
-    FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
-  })
+let mod: typeof import("bun:ffi") | undefined
+let k32: ReturnType<typeof mod.dlopen> | undefined
+let ready: boolean | undefined
 
-let k32: ReturnType<typeof kernel> | undefined
-
-function load() {
+export async function win32Init() {
   if (process.platform !== "win32") return false
+  if (ready !== undefined) return ready
   try {
-    k32 ??= kernel()
+    mod = await import("bun:ffi")
+    k32 = mod.dlopen("kernel32.dll", {
+      GetStdHandle: { args: ["i32"], returns: "ptr" },
+      GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
+      SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
+      FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
+    })
+    ready = true
     return true
   } catch {
+    ready = false
     return false
   }
 }
@@ -29,11 +30,11 @@ function load() {
 export function win32DisableProcessedInput() {
   if (process.platform !== "win32") return
   if (!process.stdin.isTTY) return
-  if (!load()) return
+  if (!k32 || !mod) return
 
   const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
-  if (k32!.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+  if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
 
   const mode = buf[0]!
   if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
@@ -46,7 +47,7 @@ export function win32DisableProcessedInput() {
 export function win32FlushInputBuffer() {
   if (process.platform !== "win32") return
   if (!process.stdin.isTTY) return
-  if (!load()) return
+  if (!k32) return
 
   const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
   k32!.symbols.FlushConsoleInputBuffer(handle)
@@ -68,7 +69,7 @@ let unhook: (() => void) | undefined
 export function win32InstallCtrlCGuard() {
   if (process.platform !== "win32") return
   if (!process.stdin.isTTY) return
-  if (!load()) return
+  if (!k32 || !mod) return
   if (unhook) return unhook
 
   const stdin = process.stdin as any
@@ -77,11 +78,11 @@ export function win32InstallCtrlCGuard() {
   const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
 
-  if (k32!.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+  if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
   const initial = buf[0]!
 
   const enforce = () => {
-    if (k32!.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+    if (k32!.symbols.GetConsoleMode(handle, mod.ptr(buf)) === 0) return
     const mode = buf[0]!
     if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
     k32!.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -24,7 +24,7 @@ export async function win32Init() {
       GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
       SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
       FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
-    }).symbols as unknown as K32
+    }).symbols as unknown as K32)
     ready = true
     return true
   } catch {

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -3,12 +3,10 @@ const ENABLE_PROCESSED_INPUT = 0x0001
 
 let mod: typeof import("bun:ffi") | undefined
 type K32 = {
-  symbols: {
-    GetStdHandle: (n: number) => bigint | number
-    GetConsoleMode: (h: bigint | number, mode: unknown) => number
-    SetConsoleMode: (h: bigint | number, mode: number) => number
-    FlushConsoleInputBuffer: (h: bigint | number) => number
-  }
+  GetStdHandle: (n: number) => bigint | number
+  GetConsoleMode: (h: bigint | number, mode: unknown) => number
+  SetConsoleMode: (h: bigint | number, mode: number) => number
+  FlushConsoleInputBuffer: (h: bigint | number) => number
 }
 
 let k32: K32 | undefined
@@ -21,12 +19,12 @@ export async function win32Init() {
   if (ready !== undefined) return ready
   try {
     mod = await import("bun:ffi")
-    k32 = mod.dlopen("kernel32.dll", {
+    k32 = (mod.dlopen("kernel32.dll", {
       GetStdHandle: { args: ["i32"], returns: "ptr" },
       GetConsoleMode: { args: ["ptr", "ptr"], returns: "i32" },
       SetConsoleMode: { args: ["ptr", "u32"], returns: "i32" },
       FlushConsoleInputBuffer: { args: ["ptr"], returns: "i32" },
-    }) as K32
+    }).symbols as unknown as K32
     ready = true
     return true
   } catch {
@@ -44,13 +42,14 @@ export function win32DisableProcessedInput() {
   if (!k32 || !mod) return
   const ptr = mod.ptr as Ptr
 
-  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
+  const lib = k32
+  const handle = lib.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
-  if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+  if (lib.GetConsoleMode(handle, ptr(buf)) === 0) return
 
   const mode = buf[0]!
   if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
-  k32.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
+  lib.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
 }
 
 /**
@@ -61,8 +60,9 @@ export function win32FlushInputBuffer() {
   if (!process.stdin.isTTY) return
   if (!k32) return
 
-  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
-  k32.symbols.FlushConsoleInputBuffer(handle)
+  const lib = k32
+  const handle = lib.GetStdHandle(STD_INPUT_HANDLE)
+  lib.FlushConsoleInputBuffer(handle)
 }
 
 let unhook: (() => void) | undefined
@@ -84,21 +84,22 @@ export function win32InstallCtrlCGuard() {
   if (!k32 || !mod) return
   if (unhook) return unhook
   const ptr = mod.ptr as Ptr
+  const lib = k32
 
   const stdin = process.stdin as any
   const original = stdin.setRawMode
 
-  const handle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE)
+  const handle = lib.GetStdHandle(STD_INPUT_HANDLE)
   const buf = new Uint32Array(1)
 
-  if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+  if (lib.GetConsoleMode(handle, ptr(buf)) === 0) return
   const initial = buf[0]!
 
   const enforce = () => {
-    if (k32.symbols.GetConsoleMode(handle, ptr(buf)) === 0) return
+    if (lib.GetConsoleMode(handle, ptr(buf)) === 0) return
     const mode = buf[0]!
     if ((mode & ENABLE_PROCESSED_INPUT) === 0) return
-    k32.symbols.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
+    lib.SetConsoleMode(handle, mode & ~ENABLE_PROCESSED_INPUT)
   }
 
   // Some runtimes can re-apply console modes on the next tick; enforce twice.
@@ -135,7 +136,7 @@ export function win32InstallCtrlCGuard() {
       stdin.setRawMode = original
     }
 
-    k32.symbols.SetConsoleMode(handle, initial)
+    lib.SetConsoleMode(handle, initial)
     unhook = undefined
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #20767

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a Windows TUI startup failure on Bun builds where `bun:ffi` is unavailable.

The Windows console helper imported `bun:ffi` at module load time. On some Windows ARM64 Bun builds that fails early with `dlopen() is not available in this build (TinyCC is disabled)`, so the TUI exits before startup finishes.

This change lazy-loads `bun:ffi` through an async `win32Init()` step and makes the Win32 console helpers no-op if that init is unavailable. Supported Windows builds keep the existing behavior, while unsupported builds now continue without crashing.

### How did you verify your code works?

I traced the TUI startup path and limited the change to the Win32 console helper plus the canonical TUI initialization point.

The fix moves the failure from an eager module import into a handled runtime branch, which is the specific problem reported for Windows ARM64.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR