### PR TITLE
fix(opencode): tolerate wrapped workflow tool arguments

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -245,7 +245,7 @@ export namespace LLM {
               return { result: "", error: `Unknown tool: ${toolName}` }
             }
             try {
-              const result = await t.execute!(JSON.parse(argsJson), {
+              const result = await t.execute!(parseWorkflowToolArgs(argsJson), {
                 toolCallId: _requestID,
                 messages: input.messages,
                 abortSignal: input.abort,
@@ -422,14 +422,14 @@ export namespace LLM {
 
   export const layer = live.pipe(Layer.provide(Permission.defaultLayer))
 
-  export const defaultLayer = Layer.suspend(() =>
-    layer.pipe(
-      Layer.provide(Auth.defaultLayer),
-      Layer.provide(Config.defaultLayer),
-      Layer.provide(Provider.defaultLayer),
-      Layer.provide(Plugin.defaultLayer),
-    ),
-  )
+export const defaultLayer = Layer.suspend(() =>
+  layer.pipe(
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Provider.defaultLayer),
+    Layer.provide(Plugin.defaultLayer),
+  ),
+)
 
   function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
     const disabled = Permission.disabled(
@@ -449,5 +449,49 @@ export namespace LLM {
       }
     }
     return false
+  }
+
+  function parseCandidate(text: string) {
+    const parsed = JSON.parse(text)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Tool arguments must be a JSON object")
+    }
+    return parsed as Record<string, unknown>
+  }
+
+  export function parseWorkflowToolArgs(input: string) {
+    const text = input.trim()
+    const rawErr = (() => {
+      try {
+        return parseCandidate(text)
+      } catch (err) {
+        return err
+      }
+    })()
+    if (!(rawErr instanceof Error)) return rawErr
+
+    const fence = /```(?:json)?\s*([\s\S]*?)\s*```/gi
+    for (const match of text.matchAll(fence)) {
+      const body = match[1]?.trim()
+      if (!body) continue
+      try {
+        return parseCandidate(body)
+      } catch {
+        continue
+      }
+    }
+
+    const first = text.indexOf("{")
+    const last = text.lastIndexOf("}")
+    if (first >= 0 && last > first) {
+      const body = text.slice(first, last + 1).trim()
+      try {
+        return parseCandidate(body)
+      } catch {
+        // no-op, throw below
+      }
+    }
+
+    throw rawErr
   }
 }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -119,6 +119,25 @@ describe("session.llm.hasToolCalls", () => {
   })
 })
 
+describe("session.llm.parseWorkflowToolArgs", () => {
+  test("parses strict json object", () => {
+    expect(LLM.parseWorkflowToolArgs('{"path":"a.txt"}')).toEqual({ path: "a.txt" })
+  })
+
+  test("parses fenced json object", () => {
+    expect(LLM.parseWorkflowToolArgs('```json\n{"path":"a.txt"}\n```')).toEqual({ path: "a.txt" })
+  })
+
+  test("parses json object wrapped in prose", () => {
+    const input = 'Use this args payload:\n```json\n{"path":"a.txt","old":"x","new":"y"}\n```\nThanks.'
+    expect(LLM.parseWorkflowToolArgs(input)).toEqual({ path: "a.txt", old: "x", new: "y" })
+  })
+
+  test("rejects non-object json", () => {
+    expect(() => LLM.parseWorkflowToolArgs('[1,2,3]')).toThrow("Tool arguments must be a JSON object")
+  })
+})
+
 type Capture = {
   url: URL
   headers: Headers


### PR DESCRIPTION
### Issue for this PR

Closes #20757

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes workflow tool-call argument parsing for GitLab workflow models when tool arguments are wrapped in fenced JSON or surrounding prose. Instead of directly calling `JSON.parse(argsJson)`, it now uses a tolerant parser that accepts strict JSON objects, fenced JSON blocks, and prose-wrapped object payloads while still rejecting malformed or non-object inputs.

### How did you verify your code works?

- Ran `bun test test/session/llm.test.ts` in `packages/opencode`
- Added regression tests for strict JSON, fenced JSON, prose-wrapped JSON, and non-object rejection

### Screenshots / recordings

N/A (non-UI backend fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR