### PR TITLE
fix(opencode): use session cwd for command substitution

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1582,6 +1582,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
         log.info("command", input)
+        const session = yield* sessions.get(input.sessionID)
         const cmd = yield* commands.get(input.command)
         if (!cmd) {
           const available = (yield* commands.list()).map((c) => c.name)
@@ -1617,17 +1618,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           template = template + "\n\n" + input.arguments
         }
 
-        const shellMatches = ConfigMarkdown.shell(template)
-        if (shellMatches.length > 0) {
-          const sh = Shell.preferred()
-          const results = yield* Effect.promise(() =>
-            Promise.all(
-              shellMatches.map(async ([, cmd]) => (await Process.text([cmd], { shell: sh, nothrow: true })).text),
-            ),
-          )
-          let index = 0
-          template = template.replace(bashRegex, () => results[index++])
-        }
+        template = yield* replaceCommandShell(template, session.directory)
         template = template.trim()
 
         const taskModel = yield* Effect.gen(function* () {
@@ -1899,6 +1890,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     })
   }
+
+  export async function replaceCommandShell(template: string, cwd: string) {
+    const matches = ConfigMarkdown.shell(template)
+    if (matches.length === 0) return template
+    const sh = Shell.preferred()
+    const out = await Promise.all(matches.map(async ([, cmd]) => (await Process.text([cmd], { shell: sh, cwd, nothrow: true })).text))
+    let i = 0
+    return template.replace(bashRegex, () => out[i++])
+  }
+
   const bashRegex = /!`([^`]+)`/g
   // Match [Image N] as single token, quoted strings, or non-space sequences
   const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1618,7 +1618,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           template = template + "\n\n" + input.arguments
         }
 
-        template = yield* replaceCommandShell(template, session.directory)
+        template = yield* Effect.promise(() => replaceCommandShell(template, session.directory))
         template = template.trim()
 
         const taskModel = yield* Effect.gen(function* () {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -516,3 +516,16 @@ describe("session.agent-resolution", () => {
     })
   }, 30000)
 })
+
+describe("session.command shell substitution", () => {
+  test("runs command substitution in provided cwd", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const txt = await SessionPrompt.replaceCommandShell("cwd=!`pwd`", tmp.path)
+    expect(txt.trim()).toBe(`cwd=${tmp.path}`)
+  })
+
+  test("returns original template when no substitutions exist", async () => {
+    const txt = await SessionPrompt.replaceCommandShell("no shell here", process.cwd())
+    expect(txt).toBe("no shell here")
+  })
+})


### PR DESCRIPTION
## Summary
- resolve `!\`...\`` substitutions in slash-command templates using the session directory instead of process cwd
- keep command substitution logic in a reusable helper and call it from `SessionPrompt.command`
- add regression tests validating substitution output uses the provided cwd

Fixes #20735