### PR TITLE
fix(opencode): use session cwd for command substitution

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1590,7 +1590,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           template = template + "\n\n" + input.arguments
         }
 
-        template = yield* replaceCommandShell(template, session.directory)
+        template = yield* Effect.promise(() => replaceCommandShell(template, session.directory))
         template = template.trim()
 
         const taskModel = yield* Effect.gen(function* () {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1554,6 +1554,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
         yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
+        const session = yield* sessions.get(input.sessionID)
         const cmd = yield* commands.get(input.command)
         if (!cmd) {
           const available = (yield* commands.list()).map((c) => c.name)
@@ -1589,17 +1590,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           template = template + "\n\n" + input.arguments
         }
 
-        const shellMatches = ConfigMarkdown.shell(template)
-        if (shellMatches.length > 0) {
-          const sh = Shell.preferred()
-          const results = yield* Effect.promise(() =>
-            Promise.all(
-              shellMatches.map(async ([, cmd]) => (await Process.text([cmd], { shell: sh, nothrow: true })).text),
-            ),
-          )
-          let index = 0
-          template = template.replace(bashRegex, () => results[index++])
-        }
+        template = yield* replaceCommandShell(template, session.directory)
         template = template.trim()
 
         const taskModel = yield* Effect.gen(function* () {
@@ -1846,6 +1837,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     })
   }
+
+  export async function replaceCommandShell(template: string, cwd: string) {
+    const matches = ConfigMarkdown.shell(template)
+    if (matches.length === 0) return template
+    const sh = Shell.preferred()
+    const out = await Promise.all(matches.map(async ([, cmd]) => (await Process.text([cmd], { shell: sh, cwd, nothrow: true })).text))
+    let i = 0
+    return template.replace(bashRegex, () => out[i++])
+  }
+
   const bashRegex = /!`([^`]+)`/g
   // Match [Image N] as single token, quoted strings, or non-space sequences
   const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -587,3 +587,16 @@ describe("session.agent-resolution", () => {
     })
   }, 30000)
 })
+
+describe("session.command shell substitution", () => {
+  test("runs command substitution in provided cwd", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const txt = await SessionPrompt.replaceCommandShell("cwd=!`pwd`", tmp.path)
+    expect(txt.trim()).toBe(`cwd=${tmp.path}`)
+  })
+
+  test("returns original template when no substitutions exist", async () => {
+    const txt = await SessionPrompt.replaceCommandShell("no shell here", process.cwd())
+    expect(txt).toBe("no shell here")
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -592,7 +592,8 @@ describe("session.command shell substitution", () => {
   test("runs command substitution in provided cwd", async () => {
     await using tmp = await tmpdir({ git: true })
     const txt = await SessionPrompt.replaceCommandShell("cwd=!`pwd`", tmp.path)
-    expect(txt.trim()).toBe(`cwd=${tmp.path}`)
+    expect(txt).toContain("cwd=")
+    expect(txt).toContain(tmp.path)
   })
 
   test("returns original template when no substitutions exist", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #20735

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes slash-command shell substitutions (for `!` backtick expressions) to run in the active session directory instead of the server process working directory. It adds a reusable substitution helper and keeps behavior unchanged when no substitutions exist.

It also adds regression tests and makes the assertion shell-agnostic so the test is valid across Windows PowerShell and Unix-like shells.

### How did you verify your code works?

- Ran `bun test test/session/prompt.test.ts` in `packages/opencode`
- Pre-push hook runs `bun turbo typecheck` successfully

### Screenshots / recordings

N/A (non-UI backend fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR