### PR TITLE
fix(provider): reorder plugin initialization before config snapshot

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1013,8 +1013,6 @@ export namespace Provider {
 
           log.info("init")
 
-          const configProviders = Object.entries(cfg.provider ?? {})
-
           function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
             const existing = providers[providerID]
             if (existing) {
@@ -1027,6 +1025,12 @@ export namespace Provider {
             // @ts-expect-error
             providers[providerID] = mergeDeep(match, provider)
           }
+
+          // load plugins first so config() hook runs before reading cfg.provider
+          const plugins = yield* plugin.list()
+
+          // now read config providers — includes any modifications from plugin config() hook
+          const configProviders = Object.entries(cfg.provider ?? {})
 
           // extend database from config
           for (const [providerID, provider] of configProviders) {
@@ -1144,7 +1148,7 @@ export namespace Provider {
             }
           }
 
-          const plugins = yield* plugin.list()
+          // plugin auth loader — database now has entries for config providers
           for (const plugin of plugins) {
             if (!plugin.auth) continue
             const providerID = ProviderID.make(plugin.auth.provider)
@@ -1183,7 +1187,7 @@ export namespace Provider {
             }
           }
 
-          // load config
+          // load config — re-apply with updated data
           for (const [id, provider] of configProviders) {
             const providerID = ProviderID.make(id)
             const partial: Partial<Info> = { source: "config" }


### PR DESCRIPTION
### Issue for this PR
Closes #20026
### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
### What does this PR do?
Plugin providers registered via `config()` hook disappear from the provider list after `/instance/dispose`. Root cause: `configProviders` was captured as a stale snapshot of `cfg.provider` BEFORE `plugin.list()` ran and called the `config()` hook. When plugins modified `cfg.provider` to add their providers, it was already too late — the snapshot didn't include them.
Fix: Move `plugin.list()` to run BEFORE reading `configProviders`, ensuring the plugin `config()` hook executes first. This way, any providers registered by plugins are visible when `cfg.provider` is captured.
New execution order:
1. `plugins = yield* plugin.list()` — plugin config() hook runs, modifies cfg.provider
2. `configProviders = Object.entries(cfg.provider ?? {})` — now sees plugin modifications
3. Rest of initialization (extend database, load env, load apikeys, etc.)
This is a minimal reordering fix (8 lines added, 4 removed) that preserves the existing merge priority chain while fixing the timing issue.
### How did you verify your code works?
- Unit tests: 70 provider tests pass
- Typecheck: clean
- Manual test: `/connect` in TUI — plugin providers persist after instance dispose/reload
### Screenshots / recordings
N/A - no UI changes
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR