### PR TITLE
fix(core): fix restoring earlier messages in a reverted chain

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -72,6 +72,7 @@ export namespace SessionRevert {
         if (!rev) return session
 
         rev.snapshot = session.revert?.snapshot ?? (yield* snap.track())
+        if (session.revert?.snapshot) yield* snap.restore(session.revert.snapshot)
         yield* snap.revert(patches)
         if (rev.snapshot) rev.diff = yield* snap.diff(rev.snapshot as string)
         const range = all.filter((msg) => msg.info.id >= rev!.messageID)

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Session } from "../../src/session"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionCompaction } from "../../src/session/compaction"
 import { MessageV2 } from "../../src/session/message-v2"
+import { Snapshot } from "../../src/snapshot"
 import { Log } from "../../src/util/log"
 import { Instance } from "../../src/project/instance"
 import { MessageID, PartID } from "../../src/session/schema"
@@ -68,6 +70,13 @@ function tool(sessionID: string, messageID: string) {
       time: { start: 0, end: 1 },
     },
   })
+}
+
+const tokens = {
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cache: { read: 0, write: 0 },
 }
 
 describe("revert + compact workflow", () => {
@@ -431,6 +440,81 @@ describe("revert + compact workflow", () => {
 
         const msgs = await Session.messages({ sessionID: sid })
         expect(msgs.length).toBe(1)
+      },
+    })
+  })
+
+  test("restore messages in sequential order", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await fs.writeFile(path.join(tmp.path, "a.txt"), "a0")
+        await fs.writeFile(path.join(tmp.path, "b.txt"), "b0")
+        await fs.writeFile(path.join(tmp.path, "c.txt"), "c0")
+
+        const session = await Session.create({})
+        const sid = session.id
+
+        const turn = async (file: string, next: string) => {
+          const u = await user(sid)
+          await text(sid, u.id, `${file}:${next}`)
+          const a = await assistant(sid, u.id, tmp.path)
+          const before = await Snapshot.track()
+          if (!before) throw new Error("expected snapshot")
+          await fs.writeFile(path.join(tmp.path, file), next)
+          const after = await Snapshot.track()
+          if (!after) throw new Error("expected snapshot")
+          const patch = await Snapshot.patch(before)
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-start",
+            snapshot: before,
+          })
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-finish",
+            reason: "stop",
+            snapshot: after,
+            cost: 0,
+            tokens,
+          })
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "patch",
+            hash: patch.hash,
+            files: patch.files,
+          })
+          return u.id
+        }
+
+        const first = await turn("a.txt", "a1")
+        await turn("b.txt", "b2")
+        const third = await turn("c.txt", "c3")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: first,
+        })
+
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a0")
+        expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b0")
+        expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c0")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: third,
+        })
+
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a1")
+        expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b2")
+        expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c0")
       },
     })
   })

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -495,15 +495,24 @@ describe("revert + compact workflow", () => {
         }
 
         const first = await turn("a.txt", "a1")
-        await turn("b.txt", "b2")
+        const second = await turn("b.txt", "b2")
         const third = await turn("c.txt", "c3")
 
         await SessionRevert.revert({
           sessionID: sid,
           messageID: first,
         })
-
+        expect((await Session.get(sid)).revert?.messageID).toBe(first)
         expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a0")
+        expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b0")
+        expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c0")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: second,
+        })
+        expect((await Session.get(sid)).revert?.messageID).toBe(second)
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a1")
         expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b0")
         expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c0")
 
@@ -511,10 +520,101 @@ describe("revert + compact workflow", () => {
           sessionID: sid,
           messageID: third,
         })
-
+        expect((await Session.get(sid)).revert?.messageID).toBe(third)
         expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a1")
         expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b2")
         expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c0")
+
+        await SessionRevert.unrevert({
+          sessionID: sid,
+        })
+        expect((await Session.get(sid)).revert).toBeUndefined()
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a1")
+        expect(await fs.readFile(path.join(tmp.path, "b.txt"), "utf-8")).toBe("b2")
+        expect(await fs.readFile(path.join(tmp.path, "c.txt"), "utf-8")).toBe("c3")
+      },
+    })
+  })
+
+  test("restore same file in sequential order", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await fs.writeFile(path.join(tmp.path, "a.txt"), "a0")
+
+        const session = await Session.create({})
+        const sid = session.id
+
+        const turn = async (next: string) => {
+          const u = await user(sid)
+          await text(sid, u.id, `a.txt:${next}`)
+          const a = await assistant(sid, u.id, tmp.path)
+          const before = await Snapshot.track()
+          if (!before) throw new Error("expected snapshot")
+          await fs.writeFile(path.join(tmp.path, "a.txt"), next)
+          const after = await Snapshot.track()
+          if (!after) throw new Error("expected snapshot")
+          const patch = await Snapshot.patch(before)
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-start",
+            snapshot: before,
+          })
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-finish",
+            reason: "stop",
+            snapshot: after,
+            cost: 0,
+            tokens,
+          })
+          await Session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "patch",
+            hash: patch.hash,
+            files: patch.files,
+          })
+          return u.id
+        }
+
+        const first = await turn("a1")
+        const second = await turn("a2")
+        const third = await turn("a3")
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a3")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: first,
+        })
+        expect((await Session.get(sid)).revert?.messageID).toBe(first)
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a0")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: second,
+        })
+        expect((await Session.get(sid)).revert?.messageID).toBe(second)
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a1")
+
+        await SessionRevert.revert({
+          sessionID: sid,
+          messageID: third,
+        })
+        expect((await Session.get(sid)).revert?.messageID).toBe(third)
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a2")
+
+        await SessionRevert.unrevert({
+          sessionID: sid,
+        })
+        expect((await Session.get(sid)).revert).toBeUndefined()
+        expect(await fs.readFile(path.join(tmp.path, "a.txt"), "utf-8")).toBe("a3")
       },
     })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #20781 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When users restored earlier messages while later messages in the same chain remained reverted, the server updated the revert point but did not rebuild the repo from the original pre revert snapshot first. That meant files from messages that were now restored could still stay reverted.

For example:

1. Start a session in a repo with three files, for example `a.txt`, `b.txt`, and `c.txt`.
2. Create three messages where each message changes a different file:
   - message `a` changes `a.txt`
   - message `b` changes `b.txt`
   - message `c` changes `c.txt`
3. Revert from message `a`, so all three messages are reverted.
4. Restore message `a`, then restore message `b`, while leaving message `c` reverted.
5. Check the files on disk.

Expected:
- `a.txt` and `b.txt` should be restored
- `c.txt` should still be reverted

Actual:
- file changes from the restored messages could still remain missing on disk
- the repo state could be out of sync with what the UI showed as restored vs. still reverted


This fix restores the saved pre revert snapshot before reapplying the messages that should still remain reverted. For example, if messages `a`, `b`, and `c` each changed different files, restoring `a` and `b` now correctly brings back those file changes while leaving only c reverted

### How did you verify your code works?

- Reproduced the bug manually with three messages that each changed a different file, then verified the restored file state after each restore step.
- Added targeted regression coverage in for:
  - restoring messages in sequential order across different files (which fails on the current code)
  - restoring messages in sequential order when all messages modify the same file
  - checking `revert.messageID` after each step
  - checking full `unrevert()` restores the final file state
- Ran `bun test test/session/revert-compact.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`

At the very least run the tests in this PR against the current code to see how the bug behaves
### Screenshots / recordings

Not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
