### PR TITLE
refactor(effect): move read tool onto defineEffect

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -240,7 +240,7 @@ Once individual tools are effectified, change `Tool.Info` (`tool/tool.ts`) so `i
 Until the tool interface itself returns `Effect`, use this transitional pattern for migrated tools:
 
 - `Tool.defineEffect(...)` should `yield*` the services the tool depends on and close over them in the returned tool definition.
-- Keep the bridge at the Promise boundary only. In the temporary `async execute(...)` implementation, call service methods with `await Effect.runPromise(...)` instead of falling back to static async facades.
+- Keep the bridge at the Promise boundary only. Prefer a single `Effect.runPromise(...)` in the temporary `async execute(...)` implementation, and move the inner logic into `Effect.fn(...)` helpers instead of scattering `runPromise` islands through the tool body.
 - If a tool starts requiring new services, wire them into `ToolRegistry.defaultLayer` so production callers resolve the same dependencies as tests.
 
 Tool tests should use the existing Effect helpers in `packages/opencode/test/lib/effect.ts`:

--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -235,6 +235,22 @@ Once individual tools are effectified, change `Tool.Info` (`tool/tool.ts`) so `i
 2. Update `Tool.define()` factory to work with Effects
 3. Update `SessionPrompt` to `yield*` tool results instead of `await`ing
 
+### Tool migration details
+
+Until the tool interface itself returns `Effect`, use this transitional pattern for migrated tools:
+
+- `Tool.defineEffect(...)` should `yield*` the services the tool depends on and close over them in the returned tool definition.
+- Keep the bridge at the Promise boundary only. In the temporary `async execute(...)` implementation, call service methods with `await Effect.runPromise(...)` instead of falling back to static async facades.
+- If a tool starts requiring new services, wire them into `ToolRegistry.defaultLayer` so production callers resolve the same dependencies as tests.
+
+Tool tests should use the existing Effect helpers in `packages/opencode/test/lib/effect.ts`:
+
+- Use `testEffect(...)` / `it.live(...)` instead of creating fake local wrappers around effectful tools.
+- Yield the real tool export, then initialize it: `const info = yield* ReadTool`, `const tool = yield* Effect.promise(() => info.init())`.
+- Run tests inside a real instance with `provideTmpdirInstance(...)` or `provideInstance(tmpdirScoped(...))` so instance-scoped services resolve exactly as they do in production.
+
+This keeps migrated tool tests aligned with the production service graph today, and makes the eventual `Tool.Info` → `Effect` cleanup mostly mechanical later.
+
 Individual tools, ordered by value:
 
 - [ ] `apply_patch.ts` — HIGH: multi-step orchestration, error accumulation, Bus events

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -1,10 +1,11 @@
 import z from "zod"
 import { Effect } from "effect"
 import { createReadStream } from "fs"
-import * as fs from "fs/promises"
+import { open } from "fs/promises"
 import * as path from "path"
 import { createInterface } from "readline"
 import { Tool } from "./tool"
+import { AppFileSystem } from "../filesystem"
 import { LSP } from "../lsp"
 import { FileTime } from "../file/time"
 import DESCRIPTION from "./read.txt"
@@ -27,217 +28,228 @@ const parameters = z.object({
 
 export const ReadTool = Tool.defineEffect(
   "read",
-  Effect.succeed({
-    description: DESCRIPTION,
-    parameters,
-    async execute(params: z.infer<typeof parameters>, ctx) {
-      if (params.offset !== undefined && params.offset < 1) {
-        throw new Error("offset must be greater than or equal to 1")
-      }
-      let filepath = params.filePath
-      if (!path.isAbsolute(filepath)) {
-        filepath = path.resolve(Instance.directory, filepath)
-      }
-      if (process.platform === "win32") {
-        filepath = Filesystem.normalizePath(filepath)
-      }
-      const title = path.relative(Instance.worktree, filepath)
+  Effect.gen(function* () {
+    const fs = yield* AppFileSystem.Service
+    const instruction = yield* Instruction.Service
+    const lsp = yield* LSP.Service
+    const time = yield* FileTime.Service
 
-      const stat = Filesystem.stat(filepath)
+    return {
+      description: DESCRIPTION,
+      parameters,
+      async execute(params: z.infer<typeof parameters>, ctx) {
+        if (params.offset !== undefined && params.offset < 1) {
+          throw new Error("offset must be greater than or equal to 1")
+        }
+        let filepath = params.filePath
+        if (!path.isAbsolute(filepath)) {
+          filepath = path.resolve(Instance.directory, filepath)
+        }
+        if (process.platform === "win32") {
+          filepath = Filesystem.normalizePath(filepath)
+        }
+        const title = path.relative(Instance.worktree, filepath)
 
-      await assertExternalDirectory(ctx, filepath, {
-        bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
-        kind: stat?.isDirectory() ? "directory" : "file",
-      })
+        const stat = await Effect.runPromise(fs.stat(filepath).pipe(Effect.catch(() => Effect.succeed(undefined))))
 
-      await ctx.ask({
-        permission: "read",
-        patterns: [filepath],
-        always: ["*"],
-        metadata: {},
-      })
+        await assertExternalDirectory(ctx, filepath, {
+          bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
+          kind: stat?.type === "Directory" ? "directory" : "file",
+        })
 
-      if (!stat) {
-        const dir = path.dirname(filepath)
-        const base = path.basename(filepath)
+        await ctx.ask({
+          permission: "read",
+          patterns: [filepath],
+          always: ["*"],
+          metadata: {},
+        })
 
-        const suggestions = await fs
-          .readdir(dir)
-          .then((entries) =>
-            entries
-              .filter(
-                (entry) =>
-                  entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
-              )
-              .map((entry) => path.join(dir, entry))
-              .slice(0, 3),
+        if (!stat) {
+          const dir = path.dirname(filepath)
+          const base = path.basename(filepath)
+
+          const suggestions = await Effect.runPromise(
+            fs.readDirectory(dir).pipe(
+              Effect.map((entries) =>
+                entries
+                  .filter(
+                    (entry) =>
+                      entry.toLowerCase().includes(base.toLowerCase()) ||
+                      base.toLowerCase().includes(entry.toLowerCase()),
+                  )
+                  .map((entry) => path.join(dir, entry))
+                  .slice(0, 3),
+              ),
+              Effect.catch(() => Effect.succeed([] as string[])),
+            ),
           )
-          .catch(() => [])
 
-        if (suggestions.length > 0) {
-          throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+          if (suggestions.length > 0) {
+            throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+          }
+
+          throw new Error(`File not found: ${filepath}`)
         }
 
-        throw new Error(`File not found: ${filepath}`)
-      }
+        if (stat.type === "Directory") {
+          const dirents = await Effect.runPromise(fs.readDirectoryEntries(filepath))
+          const entries = await Promise.all(
+            dirents.map(async (dirent) => {
+              if (dirent.type === "directory") return dirent.name + "/"
+              if (dirent.type === "symlink") {
+                const target = await Effect.runPromise(
+                  fs.stat(path.join(filepath, dirent.name)).pipe(Effect.catch(() => Effect.succeed(undefined))),
+                )
+                if (target?.type === "Directory") return dirent.name + "/"
+              }
+              return dirent.name
+            }),
+          )
+          entries.sort((a, b) => a.localeCompare(b))
 
-      if (stat.isDirectory()) {
-        const dirents = await fs.readdir(filepath, { withFileTypes: true })
-        const entries = await Promise.all(
-          dirents.map(async (dirent) => {
-            if (dirent.isDirectory()) return dirent.name + "/"
-            if (dirent.isSymbolicLink()) {
-              const target = await fs.stat(path.join(filepath, dirent.name)).catch(() => undefined)
-              if (target?.isDirectory()) return dirent.name + "/"
-            }
-            return dirent.name
-          }),
-        )
-        entries.sort((a, b) => a.localeCompare(b))
+          const limit = params.limit ?? DEFAULT_READ_LIMIT
+          const offset = params.offset ?? 1
+          const start = offset - 1
+          const sliced = entries.slice(start, start + limit)
+          const truncated = start + sliced.length < entries.length
+
+          const output = [
+            `<path>${filepath}</path>`,
+            `<type>directory</type>`,
+            `<entries>`,
+            sliced.join("\n"),
+            truncated
+              ? `\n(Showing ${sliced.length} of ${entries.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
+              : `\n(${entries.length} entries)`,
+            `</entries>`,
+          ].join("\n")
+
+          return {
+            title,
+            output,
+            metadata: {
+              preview: sliced.slice(0, 20).join("\n"),
+              truncated,
+              loaded: [] as string[],
+            },
+          }
+        }
+
+        const instructions = await Effect.runPromise(instruction.resolve(ctx.messages, filepath, ctx.messageID))
+
+        // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
+        const mime = Filesystem.mimeType(filepath)
+        const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
+        const isPdf = mime === "application/pdf"
+        if (isImage || isPdf) {
+          const msg = `${isImage ? "Image" : "PDF"} read successfully`
+          return {
+            title,
+            output: msg,
+            metadata: {
+              preview: msg,
+              truncated: false,
+              loaded: instructions.map((i) => i.filepath),
+            },
+            attachments: [
+              {
+                type: "file",
+                mime,
+                url: `data:${mime};base64,${Buffer.from(await Effect.runPromise(fs.readFile(filepath))).toString("base64")}`,
+              },
+            ],
+          }
+        }
+
+        const isBinary = await isBinaryFile(filepath, Number(stat.size))
+        if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
+
+        const stream = createReadStream(filepath, { encoding: "utf8" })
+        const rl = createInterface({
+          input: stream,
+          // Note: we use the crlfDelay option to recognize all instances of CR LF
+          // ('\r\n') in file as a single line break.
+          crlfDelay: Infinity,
+        })
 
         const limit = params.limit ?? DEFAULT_READ_LIMIT
         const offset = params.offset ?? 1
         const start = offset - 1
-        const sliced = entries.slice(start, start + limit)
-        const truncated = start + sliced.length < entries.length
+        const raw: string[] = []
+        let bytes = 0
+        let lines = 0
+        let truncatedByBytes = false
+        let hasMoreLines = false
+        try {
+          for await (const text of rl) {
+            lines += 1
+            if (lines <= start) continue
 
-        const output = [
-          `<path>${filepath}</path>`,
-          `<type>directory</type>`,
-          `<entries>`,
-          sliced.join("\n"),
-          truncated
-            ? `\n(Showing ${sliced.length} of ${entries.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
-            : `\n(${entries.length} entries)`,
-          `</entries>`,
-        ].join("\n")
+            if (raw.length >= limit) {
+              hasMoreLines = true
+              continue
+            }
+
+            const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+            const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+            if (bytes + size > MAX_BYTES) {
+              truncatedByBytes = true
+              hasMoreLines = true
+              break
+            }
+
+            raw.push(line)
+            bytes += size
+          }
+        } finally {
+          rl.close()
+          stream.destroy()
+        }
+
+        if (lines < offset && !(lines === 0 && offset === 1)) {
+          throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
+        }
+
+        const content = raw.map((line, index) => {
+          return `${index + offset}: ${line}`
+        })
+        const preview = raw.slice(0, 20).join("\n")
+
+        let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
+        output += content.join("\n")
+
+        const totalLines = lines
+        const lastReadLine = offset + raw.length - 1
+        const nextOffset = lastReadLine + 1
+        const truncated = hasMoreLines || truncatedByBytes
+
+        if (truncatedByBytes) {
+          output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
+        } else if (hasMoreLines) {
+          output += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
+        } else {
+          output += `\n\n(End of file - total ${totalLines} lines)`
+        }
+        output += "\n</content>"
+
+        await Effect.runPromise(lsp.touchFile(filepath, false))
+        await Effect.runPromise(time.read(ctx.sessionID, filepath))
+
+        if (instructions.length > 0) {
+          output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
+        }
 
         return {
           title,
           output,
           metadata: {
-            preview: sliced.slice(0, 20).join("\n"),
+            preview,
             truncated,
-            loaded: [] as string[],
-          },
-        }
-      }
-
-      const instructions = await Instruction.resolve(ctx.messages, filepath, ctx.messageID)
-
-      // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
-      const mime = Filesystem.mimeType(filepath)
-      const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
-      const isPdf = mime === "application/pdf"
-      if (isImage || isPdf) {
-        const msg = `${isImage ? "Image" : "PDF"} read successfully`
-        return {
-          title,
-          output: msg,
-          metadata: {
-            preview: msg,
-            truncated: false,
             loaded: instructions.map((i) => i.filepath),
           },
-          attachments: [
-            {
-              type: "file",
-              mime,
-              url: `data:${mime};base64,${Buffer.from(await Filesystem.readBytes(filepath)).toString("base64")}`,
-            },
-          ],
         }
-      }
-
-      const isBinary = await isBinaryFile(filepath, Number(stat.size))
-      if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
-
-      const stream = createReadStream(filepath, { encoding: "utf8" })
-      const rl = createInterface({
-        input: stream,
-        // Note: we use the crlfDelay option to recognize all instances of CR LF
-        // ('\r\n') in file as a single line break.
-        crlfDelay: Infinity,
-      })
-
-      const limit = params.limit ?? DEFAULT_READ_LIMIT
-      const offset = params.offset ?? 1
-      const start = offset - 1
-      const raw: string[] = []
-      let bytes = 0
-      let lines = 0
-      let truncatedByBytes = false
-      let hasMoreLines = false
-      try {
-        for await (const text of rl) {
-          lines += 1
-          if (lines <= start) continue
-
-          if (raw.length >= limit) {
-            hasMoreLines = true
-            continue
-          }
-
-          const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
-          const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
-          if (bytes + size > MAX_BYTES) {
-            truncatedByBytes = true
-            hasMoreLines = true
-            break
-          }
-
-          raw.push(line)
-          bytes += size
-        }
-      } finally {
-        rl.close()
-        stream.destroy()
-      }
-
-      if (lines < offset && !(lines === 0 && offset === 1)) {
-        throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
-      }
-
-      const content = raw.map((line, index) => {
-        return `${index + offset}: ${line}`
-      })
-      const preview = raw.slice(0, 20).join("\n")
-
-      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
-      output += content.join("\n")
-
-      const totalLines = lines
-      const lastReadLine = offset + raw.length - 1
-      const nextOffset = lastReadLine + 1
-      const truncated = hasMoreLines || truncatedByBytes
-
-      if (truncatedByBytes) {
-        output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
-      } else if (hasMoreLines) {
-        output += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
-      } else {
-        output += `\n\n(End of file - total ${totalLines} lines)`
-      }
-      output += "\n</content>"
-
-      // just warms the lsp client
-      await LSP.touchFile(filepath, false)
-      await FileTime.read(ctx.sessionID, filepath)
-
-      if (instructions.length > 0) {
-        output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
-      }
-
-      return {
-        title,
-        output,
-        metadata: {
-          preview,
-          truncated,
-          loaded: instructions.map((i) => i.filepath),
-        },
-      }
-    },
+      },
+    }
   }),
 )
 
@@ -280,7 +292,7 @@ async function isBinaryFile(filepath: string, fileSize: number): Promise<boolean
 
   if (fileSize === 0) return false
 
-  const fh = await fs.open(filepath, "r")
+  const fh = await open(filepath, "r")
   try {
     const sampleSize = Math.min(4096, fileSize)
     const bytes = Buffer.alloc(sampleSize)

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -34,224 +34,247 @@ export const ReadTool = Tool.defineEffect(
     const lsp = yield* LSP.Service
     const time = yield* FileTime.Service
 
-    return {
-      description: DESCRIPTION,
-      parameters,
-      async execute(params: z.infer<typeof parameters>, ctx) {
-        if (params.offset !== undefined && params.offset < 1) {
-          throw new Error("offset must be greater than or equal to 1")
-        }
-        let filepath = params.filePath
-        if (!path.isAbsolute(filepath)) {
-          filepath = path.resolve(Instance.directory, filepath)
-        }
-        if (process.platform === "win32") {
-          filepath = Filesystem.normalizePath(filepath)
-        }
-        const title = path.relative(Instance.worktree, filepath)
+    const miss = Effect.fn("ReadTool.miss")(function* (filepath: string) {
+      const dir = path.dirname(filepath)
+      const base = path.basename(filepath)
+      const items = yield* fs.readDirectory(dir).pipe(
+        Effect.map((items) =>
+          items
+            .filter(
+              (item) =>
+                item.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(item.toLowerCase()),
+            )
+            .map((item) => path.join(dir, item))
+            .slice(0, 3),
+        ),
+        Effect.catch(() => Effect.succeed([] as string[])),
+      )
 
-        const stat = await Effect.runPromise(fs.stat(filepath).pipe(Effect.catch(() => Effect.succeed(undefined))))
+      if (items.length > 0) {
+        return yield* Effect.fail(
+          new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${items.join("\n")}`),
+        )
+      }
 
-        await assertExternalDirectory(ctx, filepath, {
+      return yield* Effect.fail(new Error(`File not found: ${filepath}`))
+    })
+
+    const list = Effect.fn("ReadTool.list")(function* (filepath: string) {
+      const items = yield* fs.readDirectoryEntries(filepath)
+      return yield* Effect.forEach(
+        items,
+        Effect.fnUntraced(function* (item) {
+          if (item.type === "directory") return item.name + "/"
+          if (item.type !== "symlink") return item.name
+
+          const target = yield* fs
+            .stat(path.join(filepath, item.name))
+            .pipe(Effect.catch(() => Effect.succeed(undefined)))
+          if (target?.type === "Directory") return item.name + "/"
+          return item.name
+        }),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.map((items: string[]) => items.sort((a, b) => a.localeCompare(b))))
+    })
+
+    const warm = Effect.fn("ReadTool.warm")(function* (filepath: string, sessionID: Tool.Context["sessionID"]) {
+      yield* lsp.touchFile(filepath, false)
+      yield* time.read(sessionID, filepath)
+    })
+
+    const run = Effect.fn("ReadTool.execute")(function* (params: z.infer<typeof parameters>, ctx: Tool.Context) {
+      if (params.offset !== undefined && params.offset < 1) {
+        return yield* Effect.fail(new Error("offset must be greater than or equal to 1"))
+      }
+
+      let filepath = params.filePath
+      if (!path.isAbsolute(filepath)) {
+        filepath = path.resolve(Instance.directory, filepath)
+      }
+      if (process.platform === "win32") {
+        filepath = Filesystem.normalizePath(filepath)
+      }
+      const title = path.relative(Instance.worktree, filepath)
+
+      const stat = yield* fs.stat(filepath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+
+      yield* Effect.promise(() =>
+        assertExternalDirectory(ctx, filepath, {
           bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
           kind: stat?.type === "Directory" ? "directory" : "file",
-        })
+        }),
+      )
 
-        await ctx.ask({
+      yield* Effect.promise(() =>
+        ctx.ask({
           permission: "read",
           patterns: [filepath],
           always: ["*"],
           metadata: {},
-        })
+        }),
+      )
 
-        if (!stat) {
-          const dir = path.dirname(filepath)
-          const base = path.basename(filepath)
+      if (!stat) return yield* miss(filepath)
 
-          const suggestions = await Effect.runPromise(
-            fs.readDirectory(dir).pipe(
-              Effect.map((entries) =>
-                entries
-                  .filter(
-                    (entry) =>
-                      entry.toLowerCase().includes(base.toLowerCase()) ||
-                      base.toLowerCase().includes(entry.toLowerCase()),
-                  )
-                  .map((entry) => path.join(dir, entry))
-                  .slice(0, 3),
-              ),
-              Effect.catch(() => Effect.succeed([] as string[])),
-            ),
-          )
+      if (stat.type === "Directory") {
+        const items = yield* list(filepath)
+        const limit = params.limit ?? DEFAULT_READ_LIMIT
+        const offset = params.offset ?? 1
+        const start = offset - 1
+        const sliced = items.slice(start, start + limit)
+        const truncated = start + sliced.length < items.length
 
-          if (suggestions.length > 0) {
-            throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
-          }
-
-          throw new Error(`File not found: ${filepath}`)
-        }
-
-        if (stat.type === "Directory") {
-          const dirents = await Effect.runPromise(fs.readDirectoryEntries(filepath))
-          const entries = await Promise.all(
-            dirents.map(async (dirent) => {
-              if (dirent.type === "directory") return dirent.name + "/"
-              if (dirent.type === "symlink") {
-                const target = await Effect.runPromise(
-                  fs.stat(path.join(filepath, dirent.name)).pipe(Effect.catch(() => Effect.succeed(undefined))),
-                )
-                if (target?.type === "Directory") return dirent.name + "/"
-              }
-              return dirent.name
-            }),
-          )
-          entries.sort((a, b) => a.localeCompare(b))
-
-          const limit = params.limit ?? DEFAULT_READ_LIMIT
-          const offset = params.offset ?? 1
-          const start = offset - 1
-          const sliced = entries.slice(start, start + limit)
-          const truncated = start + sliced.length < entries.length
-
-          const output = [
+        return {
+          title,
+          output: [
             `<path>${filepath}</path>`,
             `<type>directory</type>`,
             `<entries>`,
             sliced.join("\n"),
             truncated
-              ? `\n(Showing ${sliced.length} of ${entries.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
-              : `\n(${entries.length} entries)`,
+              ? `\n(Showing ${sliced.length} of ${items.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
+              : `\n(${items.length} entries)`,
             `</entries>`,
-          ].join("\n")
-
-          return {
-            title,
-            output,
-            metadata: {
-              preview: sliced.slice(0, 20).join("\n"),
-              truncated,
-              loaded: [] as string[],
-            },
-          }
-        }
-
-        const instructions = await Effect.runPromise(instruction.resolve(ctx.messages, filepath, ctx.messageID))
-
-        // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
-        const mime = Filesystem.mimeType(filepath)
-        const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
-        const isPdf = mime === "application/pdf"
-        if (isImage || isPdf) {
-          const msg = `${isImage ? "Image" : "PDF"} read successfully`
-          return {
-            title,
-            output: msg,
-            metadata: {
-              preview: msg,
-              truncated: false,
-              loaded: instructions.map((i) => i.filepath),
-            },
-            attachments: [
-              {
-                type: "file",
-                mime,
-                url: `data:${mime};base64,${Buffer.from(await Effect.runPromise(fs.readFile(filepath))).toString("base64")}`,
-              },
-            ],
-          }
-        }
-
-        const isBinary = await isBinaryFile(filepath, Number(stat.size))
-        if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
-
-        const stream = createReadStream(filepath, { encoding: "utf8" })
-        const rl = createInterface({
-          input: stream,
-          // Note: we use the crlfDelay option to recognize all instances of CR LF
-          // ('\r\n') in file as a single line break.
-          crlfDelay: Infinity,
-        })
-
-        const limit = params.limit ?? DEFAULT_READ_LIMIT
-        const offset = params.offset ?? 1
-        const start = offset - 1
-        const raw: string[] = []
-        let bytes = 0
-        let lines = 0
-        let truncatedByBytes = false
-        let hasMoreLines = false
-        try {
-          for await (const text of rl) {
-            lines += 1
-            if (lines <= start) continue
-
-            if (raw.length >= limit) {
-              hasMoreLines = true
-              continue
-            }
-
-            const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
-            const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
-            if (bytes + size > MAX_BYTES) {
-              truncatedByBytes = true
-              hasMoreLines = true
-              break
-            }
-
-            raw.push(line)
-            bytes += size
-          }
-        } finally {
-          rl.close()
-          stream.destroy()
-        }
-
-        if (lines < offset && !(lines === 0 && offset === 1)) {
-          throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
-        }
-
-        const content = raw.map((line, index) => {
-          return `${index + offset}: ${line}`
-        })
-        const preview = raw.slice(0, 20).join("\n")
-
-        let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
-        output += content.join("\n")
-
-        const totalLines = lines
-        const lastReadLine = offset + raw.length - 1
-        const nextOffset = lastReadLine + 1
-        const truncated = hasMoreLines || truncatedByBytes
-
-        if (truncatedByBytes) {
-          output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
-        } else if (hasMoreLines) {
-          output += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
-        } else {
-          output += `\n\n(End of file - total ${totalLines} lines)`
-        }
-        output += "\n</content>"
-
-        await Effect.runPromise(lsp.touchFile(filepath, false))
-        await Effect.runPromise(time.read(ctx.sessionID, filepath))
-
-        if (instructions.length > 0) {
-          output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
-        }
-
-        return {
-          title,
-          output,
+          ].join("\n"),
           metadata: {
-            preview,
+            preview: sliced.slice(0, 20).join("\n"),
             truncated,
-            loaded: instructions.map((i) => i.filepath),
+            loaded: [] as string[],
           },
         }
+      }
+
+      const loaded = yield* instruction.resolve(ctx.messages, filepath, ctx.messageID)
+
+      const mime = Filesystem.mimeType(filepath)
+      const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
+      const isPdf = mime === "application/pdf"
+      if (isImage || isPdf) {
+        const msg = `${isImage ? "Image" : "PDF"} read successfully`
+        return {
+          title,
+          output: msg,
+          metadata: {
+            preview: msg,
+            truncated: false,
+            loaded: loaded.map((item) => item.filepath),
+          },
+          attachments: [
+            {
+              type: "file" as const,
+              mime,
+              url: `data:${mime};base64,${Buffer.from(yield* fs.readFile(filepath)).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      if (yield* Effect.promise(() => isBinaryFile(filepath, Number(stat.size)))) {
+        return yield* Effect.fail(new Error(`Cannot read binary file: ${filepath}`))
+      }
+
+      const file = yield* Effect.promise(() =>
+        lines(filepath, { limit: params.limit ?? DEFAULT_READ_LIMIT, offset: params.offset ?? 1 }),
+      )
+      if (file.count < file.offset && !(file.count === 0 && file.offset === 1)) {
+        return yield* Effect.fail(
+          new Error(`Offset ${file.offset} is out of range for this file (${file.count} lines)`),
+        )
+      }
+
+      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
+      output += file.raw.map((line, i) => `${i + file.offset}: ${line}`).join("\n")
+
+      const last = file.offset + file.raw.length - 1
+      const next = last + 1
+      const truncated = file.more || file.cut
+      if (file.cut) {
+        output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${file.offset}-${last}. Use offset=${next} to continue.)`
+      } else if (file.more) {
+        output += `\n\n(Showing lines ${file.offset}-${last} of ${file.count}. Use offset=${next} to continue.)`
+      } else {
+        output += `\n\n(End of file - total ${file.count} lines)`
+      }
+      output += "\n</content>"
+
+      yield* warm(filepath, ctx.sessionID)
+
+      if (loaded.length > 0) {
+        output += `\n\n<system-reminder>\n${loaded.map((item) => item.content).join("\n\n")}\n</system-reminder>`
+      }
+
+      return {
+        title,
+        output,
+        metadata: {
+          preview: file.raw.slice(0, 20).join("\n"),
+          truncated,
+          loaded: loaded.map((item) => item.filepath),
+        },
+      }
+    })
+
+    return {
+      description: DESCRIPTION,
+      parameters,
+      async execute(params: z.infer<typeof parameters>, ctx) {
+        return Effect.runPromise(
+          run(params, ctx).pipe(
+            Effect.catch((err) =>
+              Effect.sync(() => {
+                throw err
+              }),
+            ),
+          ),
+        )
       },
     }
   }),
 )
+
+async function lines(filepath: string, opts: { limit: number; offset: number }) {
+  const stream = createReadStream(filepath, { encoding: "utf8" })
+  const rl = createInterface({
+    input: stream,
+    // Note: we use the crlfDelay option to recognize all instances of CR LF
+    // ('\r\n') in file as a single line break.
+    crlfDelay: Infinity,
+  })
+
+  const start = opts.offset - 1
+  const raw: string[] = []
+  let bytes = 0
+  let count = 0
+  let cut = false
+  let more = false
+  try {
+    for await (const text of rl) {
+      count += 1
+      if (count <= start) continue
+
+      if (raw.length >= opts.limit) {
+        more = true
+        continue
+      }
+
+      const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+      const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+      if (bytes + size > MAX_BYTES) {
+        cut = true
+        more = true
+        break
+      }
+
+      raw.push(line)
+      bytes += size
+    }
+  } finally {
+    rl.close()
+    stream.destroy()
+  }
+
+  return { raw, count, cut, more, offset: opts.offset }
+}
 
 async function isBinaryFile(filepath: string, fileSize: number): Promise<boolean> {
   const ext = path.extname(filepath).toLowerCase()

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { Effect } from "effect"
 import { createReadStream } from "fs"
 import * as fs from "fs/promises"
 import * as path from "path"
@@ -18,222 +19,227 @@ const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
 const MAX_BYTES = 50 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
 
-export const ReadTool = Tool.define("read", {
-  description: DESCRIPTION,
-  parameters: z.object({
-    filePath: z.string().describe("The absolute path to the file or directory to read"),
-    offset: z.coerce.number().describe("The line number to start reading from (1-indexed)").optional(),
-    limit: z.coerce.number().describe("The maximum number of lines to read (defaults to 2000)").optional(),
-  }),
-  async execute(params, ctx) {
-    if (params.offset !== undefined && params.offset < 1) {
-      throw new Error("offset must be greater than or equal to 1")
-    }
-    let filepath = params.filePath
-    if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
-    }
-    if (process.platform === "win32") {
-      filepath = Filesystem.normalizePath(filepath)
-    }
-    const title = path.relative(Instance.worktree, filepath)
+const parameters = z.object({
+  filePath: z.string().describe("The absolute path to the file or directory to read"),
+  offset: z.coerce.number().describe("The line number to start reading from (1-indexed)").optional(),
+  limit: z.coerce.number().describe("The maximum number of lines to read (defaults to 2000)").optional(),
+})
 
-    const stat = Filesystem.stat(filepath)
+export const ReadTool = Tool.defineEffect(
+  "read",
+  Effect.succeed({
+    description: DESCRIPTION,
+    parameters,
+    async execute(params: z.infer<typeof parameters>, ctx) {
+      if (params.offset !== undefined && params.offset < 1) {
+        throw new Error("offset must be greater than or equal to 1")
+      }
+      let filepath = params.filePath
+      if (!path.isAbsolute(filepath)) {
+        filepath = path.resolve(Instance.directory, filepath)
+      }
+      if (process.platform === "win32") {
+        filepath = Filesystem.normalizePath(filepath)
+      }
+      const title = path.relative(Instance.worktree, filepath)
 
-    await assertExternalDirectory(ctx, filepath, {
-      bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
-      kind: stat?.isDirectory() ? "directory" : "file",
-    })
+      const stat = Filesystem.stat(filepath)
 
-    await ctx.ask({
-      permission: "read",
-      patterns: [filepath],
-      always: ["*"],
-      metadata: {},
-    })
+      await assertExternalDirectory(ctx, filepath, {
+        bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
+        kind: stat?.isDirectory() ? "directory" : "file",
+      })
 
-    if (!stat) {
-      const dir = path.dirname(filepath)
-      const base = path.basename(filepath)
+      await ctx.ask({
+        permission: "read",
+        patterns: [filepath],
+        always: ["*"],
+        metadata: {},
+      })
 
-      const suggestions = await fs
-        .readdir(dir)
-        .then((entries) =>
-          entries
-            .filter(
-              (entry) =>
-                entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
-            )
-            .map((entry) => path.join(dir, entry))
-            .slice(0, 3),
-        )
-        .catch(() => [])
+      if (!stat) {
+        const dir = path.dirname(filepath)
+        const base = path.basename(filepath)
 
-      if (suggestions.length > 0) {
-        throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+        const suggestions = await fs
+          .readdir(dir)
+          .then((entries) =>
+            entries
+              .filter(
+                (entry) =>
+                  entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
+              )
+              .map((entry) => path.join(dir, entry))
+              .slice(0, 3),
+          )
+          .catch(() => [])
+
+        if (suggestions.length > 0) {
+          throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+        }
+
+        throw new Error(`File not found: ${filepath}`)
       }
 
-      throw new Error(`File not found: ${filepath}`)
-    }
+      if (stat.isDirectory()) {
+        const dirents = await fs.readdir(filepath, { withFileTypes: true })
+        const entries = await Promise.all(
+          dirents.map(async (dirent) => {
+            if (dirent.isDirectory()) return dirent.name + "/"
+            if (dirent.isSymbolicLink()) {
+              const target = await fs.stat(path.join(filepath, dirent.name)).catch(() => undefined)
+              if (target?.isDirectory()) return dirent.name + "/"
+            }
+            return dirent.name
+          }),
+        )
+        entries.sort((a, b) => a.localeCompare(b))
 
-    if (stat.isDirectory()) {
-      const dirents = await fs.readdir(filepath, { withFileTypes: true })
-      const entries = await Promise.all(
-        dirents.map(async (dirent) => {
-          if (dirent.isDirectory()) return dirent.name + "/"
-          if (dirent.isSymbolicLink()) {
-            const target = await fs.stat(path.join(filepath, dirent.name)).catch(() => undefined)
-            if (target?.isDirectory()) return dirent.name + "/"
-          }
-          return dirent.name
-        }),
-      )
-      entries.sort((a, b) => a.localeCompare(b))
+        const limit = params.limit ?? DEFAULT_READ_LIMIT
+        const offset = params.offset ?? 1
+        const start = offset - 1
+        const sliced = entries.slice(start, start + limit)
+        const truncated = start + sliced.length < entries.length
+
+        const output = [
+          `<path>${filepath}</path>`,
+          `<type>directory</type>`,
+          `<entries>`,
+          sliced.join("\n"),
+          truncated
+            ? `\n(Showing ${sliced.length} of ${entries.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
+            : `\n(${entries.length} entries)`,
+          `</entries>`,
+        ].join("\n")
+
+        return {
+          title,
+          output,
+          metadata: {
+            preview: sliced.slice(0, 20).join("\n"),
+            truncated,
+            loaded: [] as string[],
+          },
+        }
+      }
+
+      const instructions = await Instruction.resolve(ctx.messages, filepath, ctx.messageID)
+
+      // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
+      const mime = Filesystem.mimeType(filepath)
+      const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
+      const isPdf = mime === "application/pdf"
+      if (isImage || isPdf) {
+        const msg = `${isImage ? "Image" : "PDF"} read successfully`
+        return {
+          title,
+          output: msg,
+          metadata: {
+            preview: msg,
+            truncated: false,
+            loaded: instructions.map((i) => i.filepath),
+          },
+          attachments: [
+            {
+              type: "file",
+              mime,
+              url: `data:${mime};base64,${Buffer.from(await Filesystem.readBytes(filepath)).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      const isBinary = await isBinaryFile(filepath, Number(stat.size))
+      if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
+
+      const stream = createReadStream(filepath, { encoding: "utf8" })
+      const rl = createInterface({
+        input: stream,
+        // Note: we use the crlfDelay option to recognize all instances of CR LF
+        // ('\r\n') in file as a single line break.
+        crlfDelay: Infinity,
+      })
 
       const limit = params.limit ?? DEFAULT_READ_LIMIT
       const offset = params.offset ?? 1
       const start = offset - 1
-      const sliced = entries.slice(start, start + limit)
-      const truncated = start + sliced.length < entries.length
+      const raw: string[] = []
+      let bytes = 0
+      let lines = 0
+      let truncatedByBytes = false
+      let hasMoreLines = false
+      try {
+        for await (const text of rl) {
+          lines += 1
+          if (lines <= start) continue
 
-      const output = [
-        `<path>${filepath}</path>`,
-        `<type>directory</type>`,
-        `<entries>`,
-        sliced.join("\n"),
-        truncated
-          ? `\n(Showing ${sliced.length} of ${entries.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
-          : `\n(${entries.length} entries)`,
-        `</entries>`,
-      ].join("\n")
+          if (raw.length >= limit) {
+            hasMoreLines = true
+            continue
+          }
+
+          const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+          const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+          if (bytes + size > MAX_BYTES) {
+            truncatedByBytes = true
+            hasMoreLines = true
+            break
+          }
+
+          raw.push(line)
+          bytes += size
+        }
+      } finally {
+        rl.close()
+        stream.destroy()
+      }
+
+      if (lines < offset && !(lines === 0 && offset === 1)) {
+        throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
+      }
+
+      const content = raw.map((line, index) => {
+        return `${index + offset}: ${line}`
+      })
+      const preview = raw.slice(0, 20).join("\n")
+
+      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
+      output += content.join("\n")
+
+      const totalLines = lines
+      const lastReadLine = offset + raw.length - 1
+      const nextOffset = lastReadLine + 1
+      const truncated = hasMoreLines || truncatedByBytes
+
+      if (truncatedByBytes) {
+        output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
+      } else if (hasMoreLines) {
+        output += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
+      } else {
+        output += `\n\n(End of file - total ${totalLines} lines)`
+      }
+      output += "\n</content>"
+
+      // just warms the lsp client
+      await LSP.touchFile(filepath, false)
+      await FileTime.read(ctx.sessionID, filepath)
+
+      if (instructions.length > 0) {
+        output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
+      }
 
       return {
         title,
         output,
         metadata: {
-          preview: sliced.slice(0, 20).join("\n"),
+          preview,
           truncated,
-          loaded: [] as string[],
-        },
-      }
-    }
-
-    const instructions = await Instruction.resolve(ctx.messages, filepath, ctx.messageID)
-
-    // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
-    const mime = Filesystem.mimeType(filepath)
-    const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
-    const isPdf = mime === "application/pdf"
-    if (isImage || isPdf) {
-      const msg = `${isImage ? "Image" : "PDF"} read successfully`
-      return {
-        title,
-        output: msg,
-        metadata: {
-          preview: msg,
-          truncated: false,
           loaded: instructions.map((i) => i.filepath),
         },
-        attachments: [
-          {
-            type: "file",
-            mime,
-            url: `data:${mime};base64,${Buffer.from(await Filesystem.readBytes(filepath)).toString("base64")}`,
-          },
-        ],
       }
-    }
-
-    const isBinary = await isBinaryFile(filepath, Number(stat.size))
-    if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
-
-    const stream = createReadStream(filepath, { encoding: "utf8" })
-    const rl = createInterface({
-      input: stream,
-      // Note: we use the crlfDelay option to recognize all instances of CR LF
-      // ('\r\n') in file as a single line break.
-      crlfDelay: Infinity,
-    })
-
-    const limit = params.limit ?? DEFAULT_READ_LIMIT
-    const offset = params.offset ?? 1
-    const start = offset - 1
-    const raw: string[] = []
-    let bytes = 0
-    let lines = 0
-    let truncatedByBytes = false
-    let hasMoreLines = false
-    try {
-      for await (const text of rl) {
-        lines += 1
-        if (lines <= start) continue
-
-        if (raw.length >= limit) {
-          hasMoreLines = true
-          continue
-        }
-
-        const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
-        const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
-        if (bytes + size > MAX_BYTES) {
-          truncatedByBytes = true
-          hasMoreLines = true
-          break
-        }
-
-        raw.push(line)
-        bytes += size
-      }
-    } finally {
-      rl.close()
-      stream.destroy()
-    }
-
-    if (lines < offset && !(lines === 0 && offset === 1)) {
-      throw new Error(`Offset ${offset} is out of range for this file (${lines} lines)`)
-    }
-
-    const content = raw.map((line, index) => {
-      return `${index + offset}: ${line}`
-    })
-    const preview = raw.slice(0, 20).join("\n")
-
-    let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
-    output += content.join("\n")
-
-    const totalLines = lines
-    const lastReadLine = offset + raw.length - 1
-    const nextOffset = lastReadLine + 1
-    const truncated = hasMoreLines || truncatedByBytes
-
-    if (truncatedByBytes) {
-      output += `\n\n(Output capped at ${MAX_BYTES_LABEL}. Showing lines ${offset}-${lastReadLine}. Use offset=${nextOffset} to continue.)`
-    } else if (hasMoreLines) {
-      output += `\n\n(Showing lines ${offset}-${lastReadLine} of ${totalLines}. Use offset=${nextOffset} to continue.)`
-    } else {
-      output += `\n\n(End of file - total ${totalLines} lines)`
-    }
-    output += "\n</content>"
-
-    // just warms the lsp client
-    LSP.touchFile(filepath, false)
-    await FileTime.read(ctx.sessionID, filepath)
-
-    if (instructions.length > 0) {
-      output += `\n\n<system-reminder>\n${instructions.map((i) => i.content).join("\n\n")}\n</system-reminder>`
-    }
-
-    return {
-      title,
-      output,
-      metadata: {
-        preview,
-        truncated,
-        loaded: instructions.map((i) => i.filepath),
-      },
-    }
-  },
-})
+    },
+  }),
+)
 
 async function isBinaryFile(filepath: string, fileSize: number): Promise<boolean> {
   const ext = path.extname(filepath).toLowerCase()

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -12,7 +12,6 @@ import DESCRIPTION from "./read.txt"
 import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
 import { Instruction } from "../session/instruction"
-import { Filesystem } from "../util/filesystem"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -78,7 +77,9 @@ export const ReadTool = Tool.defineEffect(
     })
 
     const warm = Effect.fn("ReadTool.warm")(function* (filepath: string, sessionID: Tool.Context["sessionID"]) {
-      yield* lsp.touchFile(filepath, false)
+      yield* Effect.sync(() => {
+        void Effect.runFork(lsp.touchFile(filepath, false))
+      })
       yield* time.read(sessionID, filepath)
     })
 
@@ -92,7 +93,7 @@ export const ReadTool = Tool.defineEffect(
         filepath = path.resolve(Instance.directory, filepath)
       }
       if (process.platform === "win32") {
-        filepath = Filesystem.normalizePath(filepath)
+        filepath = AppFileSystem.normalizePath(filepath)
       }
       const title = path.relative(Instance.worktree, filepath)
 
@@ -146,7 +147,7 @@ export const ReadTool = Tool.defineEffect(
 
       const loaded = yield* instruction.resolve(ctx.messages, filepath, ctx.messageID)
 
-      const mime = Filesystem.mimeType(filepath)
+      const mime = AppFileSystem.mimeType(filepath)
       const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
       const isPdf = mime === "application/pdf"
       if (isImage || isPdf) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -36,6 +36,10 @@ import { Env } from "../env"
 import { Agent as AgentSvc } from "../agent/agent"
 import { Question } from "../question"
 import { Todo } from "../session/todo"
+import { LSP } from "../lsp"
+import { FileTime } from "../file/time"
+import { Instruction } from "../session/instruction"
+import { AppFileSystem } from "../filesystem"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -61,7 +65,15 @@ export namespace ToolRegistry {
   export const layer: Layer.Layer<
     Service,
     never,
-    Config.Service | Plugin.Service | Question.Service | Todo.Service | AgentSvc.Service
+    | Config.Service
+    | Plugin.Service
+    | Question.Service
+    | Todo.Service
+    | AgentSvc.Service
+    | LSP.Service
+    | FileTime.Service
+    | Instruction.Service
+    | AppFileSystem.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -230,6 +242,10 @@ export namespace ToolRegistry {
         Layer.provide(AgentSvc.defaultLayer),
         Layer.provide(Question.defaultLayer),
         Layer.provide(Todo.defaultLayer),
+        Layer.provide(LSP.defaultLayer),
+        Layer.provide(FileTime.defaultLayer),
+        Layer.provide(Instruction.defaultLayer),
+        Layer.provide(AppFileSystem.defaultLayer),
       ),
     ),
   )

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -49,17 +49,20 @@ const init = Effect.fn("ReadToolTest.init")(function* () {
   return yield* Effect.promise(() => info.init())
 })
 
+const run = Effect.fn("ReadToolTest.run")(function* (
+  args: Tool.InferParameters<typeof ReadTool>,
+  next: Tool.Context = ctx,
+) {
+  const tool = yield* init()
+  return yield* Effect.promise(() => tool.execute(args, next))
+})
+
 const exec = Effect.fn("ReadToolTest.exec")(function* (
   dir: string,
   args: Tool.InferParameters<typeof ReadTool>,
   next: Tool.Context = ctx,
 ) {
-  return yield* provideInstance(dir)(
-    Effect.gen(function* () {
-      const tool = yield* init()
-      return yield* Effect.promise(() => tool.execute(args, next))
-    }),
-  )
+  return yield* provideInstance(dir)(run(args, next))
 })
 
 const fail = Effect.fn("ReadToolTest.fail")(function* (
@@ -86,6 +89,18 @@ const load = Effect.fn("ReadToolTest.load")(function* (p: string) {
   const fs = yield* AppFileSystem.Service
   return yield* fs.readFileString(p)
 })
+const asks = () => {
+  const items: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+  return {
+    items,
+    next: {
+      ...ctx,
+      ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+        items.push(req)
+      },
+    },
+  }
+}
 
 describe("tool.read external_directory permission", () => {
   it.live("allows reading absolute path inside project directory", () =>
@@ -114,16 +129,10 @@ describe("tool.read external_directory permission", () => {
       const dir = yield* tmpdirScoped({ git: true })
       yield* put(path.join(outer, "secret.txt"), "secret data")
 
-      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-      const next = {
-        ...ctx,
-        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-          requests.push(req)
-        },
-      }
+      const { items, next } = asks()
 
       yield* exec(dir, { filePath: path.join(outer, "secret.txt") }, next)
-      const ext = requests.find((item) => item.permission === "external_directory")
+      const ext = items.find((item) => item.permission === "external_directory")
       expect(ext).toBeDefined()
       expect(ext!.patterns).toContain(glob(path.join(outer, "*")))
     }),
@@ -135,13 +144,7 @@ describe("tool.read external_directory permission", () => {
         const dir = yield* tmpdirScoped({ git: true })
         yield* put(path.join(dir, "test.txt"), "hello world")
 
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const next = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
+        const { items, next } = asks()
         const target = path.join(dir, "test.txt")
         const alt = target
           .replace(/^[A-Za-z]:/, "")
@@ -149,7 +152,7 @@ describe("tool.read external_directory permission", () => {
           .toLowerCase()
 
         yield* exec(dir, { filePath: alt }, next)
-        const read = requests.find((item) => item.permission === "read")
+        const read = items.find((item) => item.permission === "read")
         expect(read).toBeDefined()
         expect(read!.patterns).toEqual([full(target)])
       }),
@@ -162,16 +165,10 @@ describe("tool.read external_directory permission", () => {
       const dir = yield* tmpdirScoped({ git: true })
       yield* put(path.join(outer, "external", "a.txt"), "a")
 
-      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-      const next = {
-        ...ctx,
-        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-          requests.push(req)
-        },
-      }
+      const { items, next } = asks()
 
       yield* exec(dir, { filePath: path.join(outer, "external") }, next)
-      const ext = requests.find((item) => item.permission === "external_directory")
+      const ext = items.find((item) => item.permission === "external_directory")
       expect(ext).toBeDefined()
       expect(ext!.patterns).toContain(glob(path.join(outer, "external", "*")))
     }),
@@ -181,16 +178,10 @@ describe("tool.read external_directory permission", () => {
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })
 
-      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-      const next = {
-        ...ctx,
-        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-          requests.push(req)
-        },
-      }
+      const { items, next } = asks()
 
       yield* fail(dir, { filePath: "../outside.txt" }, next)
-      const ext = requests.find((item) => item.permission === "external_directory")
+      const ext = items.find((item) => item.permission === "external_directory")
       expect(ext).toBeDefined()
     }),
   )
@@ -200,16 +191,10 @@ describe("tool.read external_directory permission", () => {
       const dir = yield* tmpdirScoped({ git: true })
       yield* put(path.join(dir, "internal.txt"), "internal content")
 
-      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-      const next = {
-        ...ctx,
-        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-          requests.push(req)
-        },
-      }
+      const { items, next } = asks()
 
       yield* exec(dir, { filePath: path.join(dir, "internal.txt") }, next)
-      const ext = requests.find((item) => item.permission === "external_directory")
+      const ext = items.find((item) => item.permission === "external_directory")
       expect(ext).toBeUndefined()
     }),
   )
@@ -234,29 +219,31 @@ describe("tool.read env file permissions", () => {
             const dir = yield* tmpdirScoped()
             yield* put(path.join(dir, filename), "content")
 
-            const info = yield* provideInstance(dir)(
+            const asked = yield* provideInstance(dir)(
               Effect.gen(function* () {
                 const agent = yield* Agent.Service
-                return yield* agent.get(agentName)
+                const info = yield* agent.get(agentName)
+                let asked = false
+                const next = {
+                  ...ctx,
+                  ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+                    for (const pattern of req.patterns) {
+                      const rule = Permission.evaluate(req.permission, pattern, info.permission)
+                      if (rule.action === "ask" && req.permission === "read") {
+                        asked = true
+                      }
+                      if (rule.action === "deny") {
+                        throw new Permission.DeniedError({ ruleset: info.permission })
+                      }
+                    }
+                  },
+                }
+
+                yield* run({ filePath: path.join(dir, filename) }, next)
+                return asked
               }),
             )
-            let asked = false
-            const next = {
-              ...ctx,
-              ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-                for (const pattern of req.patterns) {
-                  const rule = Permission.evaluate(req.permission, pattern, info.permission)
-                  if (rule.action === "ask" && req.permission === "read") {
-                    asked = true
-                  }
-                  if (rule.action === "deny") {
-                    throw new Permission.DeniedError({ ruleset: info.permission })
-                  }
-                }
-              },
-            }
 
-            yield* exec(dir, { filePath: path.join(dir, filename) }, next)
             expect(asked).toBe(shouldAsk)
           }),
         )

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,14 +1,20 @@
-import { afterEach, describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { afterEach, describe, expect } from "bun:test"
+import { Cause, Effect, Exit, Layer } from "effect"
 import path from "path"
+import { Agent } from "../../src/agent/agent"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { AppFileSystem } from "../../src/filesystem"
+import { FileTime } from "../../src/file/time"
+import { LSP } from "../../src/lsp"
+import { Permission } from "../../src/permission"
 import { Instance } from "../../src/project/instance"
-import { ReadTool as ReadToolFx } from "../../src/tool/read"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { Instruction } from "../../src/session/instruction"
+import { ReadTool } from "../../src/tool/read"
 import { Tool } from "../../src/tool/tool"
 import { Filesystem } from "../../src/util/filesystem"
-import { tmpdir } from "../fixture/fixture"
-import { Permission } from "../../src/permission"
-import { Agent } from "../../src/agent/agent"
-import { SessionID, MessageID } from "../../src/session/schema"
+import { provideInstance, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 const FIXTURES_DIR = path.join(import.meta.dir, "fixtures")
 
@@ -27,185 +33,186 @@ const ctx = {
   ask: async () => {},
 }
 
-const ReadTool = {
-  init: async () => ({
-    execute: (args: Tool.InferParameters<typeof ReadToolFx>, ctx: Tool.Context) =>
-      Effect.runPromise(
-        ReadToolFx.pipe(
-          Effect.flatMap((tool) => Effect.promise(() => tool.init())),
-          Effect.flatMap((tool) => Effect.promise(() => tool.execute(args, ctx))),
-        ),
-      ),
-  }),
-}
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    AppFileSystem.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    FileTime.defaultLayer,
+    Instruction.defaultLayer,
+    LSP.defaultLayer,
+  ),
+)
+
+const init = Effect.fn("ReadToolTest.init")(function* () {
+  const info = yield* ReadTool
+  return yield* Effect.promise(() => info.init())
+})
+
+const exec = Effect.fn("ReadToolTest.exec")(function* (
+  dir: string,
+  args: Tool.InferParameters<typeof ReadTool>,
+  next: Tool.Context = ctx,
+) {
+  return yield* provideInstance(dir)(
+    Effect.gen(function* () {
+      const tool = yield* init()
+      return yield* Effect.promise(() => tool.execute(args, next))
+    }),
+  )
+})
+
+const fail = Effect.fn("ReadToolTest.fail")(function* (
+  dir: string,
+  args: Tool.InferParameters<typeof ReadTool>,
+  next: Tool.Context = ctx,
+) {
+  const exit = yield* exec(dir, args, next).pipe(Effect.exit)
+  if (Exit.isFailure(exit)) {
+    const err = Cause.squash(exit.cause)
+    return err instanceof Error ? err : new Error(String(err))
+  }
+  throw new Error("expected read to fail")
+})
 
 const full = (p: string) => (process.platform === "win32" ? Filesystem.normalizePath(p) : p)
 const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
+const put = Effect.fn("ReadToolTest.put")(function* (p: string, content: string | Buffer | Uint8Array) {
+  const fs = yield* AppFileSystem.Service
+  yield* fs.writeWithDirs(p, content)
+})
+const load = Effect.fn("ReadToolTest.load")(function* (p: string) {
+  const fs = yield* AppFileSystem.Service
+  return yield* fs.readFileString(p)
+})
 
 describe("tool.read external_directory permission", () => {
-  test("allows reading absolute path inside project directory", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "test.txt"), "hello world")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "test.txt") }, ctx)
-        expect(result.output).toContain("hello world")
-      },
-    })
-  })
+  it.live("allows reading absolute path inside project directory", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "test.txt"), "hello world")
 
-  test("allows reading file in subdirectory inside project directory", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "subdir", "test.txt"), "nested content")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "subdir", "test.txt") }, ctx)
-        expect(result.output).toContain("nested content")
-      },
-    })
-  })
+      const result = yield* exec(dir, { filePath: path.join(dir, "test.txt") })
+      expect(result.output).toContain("hello world")
+    }),
+  )
 
-  test("asks for external_directory permission when reading absolute path outside project", async () => {
-    await using outerTmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "secret.txt"), "secret data")
-      },
-    })
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await read.execute({ filePath: path.join(outerTmp.path, "secret.txt") }, testCtx)
-        const extDirReq = requests.find((r) => r.permission === "external_directory")
-        expect(extDirReq).toBeDefined()
-        expect(extDirReq!.patterns).toContain(glob(path.join(outerTmp.path, "*")))
-      },
-    })
-  })
+  it.live("allows reading file in subdirectory inside project directory", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "subdir", "test.txt"), "nested content")
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "subdir", "test.txt") })
+      expect(result.output).toContain("nested content")
+    }),
+  )
+
+  it.live("asks for external_directory permission when reading absolute path outside project", () =>
+    Effect.gen(function* () {
+      const outer = yield* tmpdirScoped()
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(outer, "secret.txt"), "secret data")
+
+      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+      const next = {
+        ...ctx,
+        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+          requests.push(req)
+        },
+      }
+
+      yield* exec(dir, { filePath: path.join(outer, "secret.txt") }, next)
+      const ext = requests.find((item) => item.permission === "external_directory")
+      expect(ext).toBeDefined()
+      expect(ext!.patterns).toContain(glob(path.join(outer, "*")))
+    }),
+  )
 
   if (process.platform === "win32") {
-    test("normalizes read permission paths on Windows", async () => {
-      await using tmp = await tmpdir({
-        git: true,
-        init: async (dir) => {
-          await Bun.write(path.join(dir, "test.txt"), "hello world")
-        },
-      })
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const read = await ReadTool.init()
-          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-          const testCtx = {
-            ...ctx,
-            ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-              requests.push(req)
-            },
-          }
-          const target = path.join(tmp.path, "test.txt")
-          const alt = target
-            .replace(/^[A-Za-z]:/, "")
-            .replaceAll("\\", "/")
-            .toLowerCase()
-          await read.execute({ filePath: alt }, testCtx)
-          const readReq = requests.find((r) => r.permission === "read")
-          expect(readReq).toBeDefined()
-          expect(readReq!.patterns).toEqual([full(target)])
-        },
-      })
-    })
+    it.live("normalizes read permission paths on Windows", () =>
+      Effect.gen(function* () {
+        const dir = yield* tmpdirScoped({ git: true })
+        yield* put(path.join(dir, "test.txt"), "hello world")
+
+        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+        const next = {
+          ...ctx,
+          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        const target = path.join(dir, "test.txt")
+        const alt = target
+          .replace(/^[A-Za-z]:/, "")
+          .replaceAll("\\", "/")
+          .toLowerCase()
+
+        yield* exec(dir, { filePath: alt }, next)
+        const read = requests.find((item) => item.permission === "read")
+        expect(read).toBeDefined()
+        expect(read!.patterns).toEqual([full(target)])
+      }),
+    )
   }
 
-  test("asks for directory-scoped external_directory permission when reading external directory", async () => {
-    await using outerTmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "external", "a.txt"), "a")
-      },
-    })
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await read.execute({ filePath: path.join(outerTmp.path, "external") }, testCtx)
-        const extDirReq = requests.find((r) => r.permission === "external_directory")
-        expect(extDirReq).toBeDefined()
-        expect(extDirReq!.patterns).toContain(glob(path.join(outerTmp.path, "external", "*")))
-      },
-    })
-  })
+  it.live("asks for directory-scoped external_directory permission when reading external directory", () =>
+    Effect.gen(function* () {
+      const outer = yield* tmpdirScoped()
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(outer, "external", "a.txt"), "a")
 
-  test("asks for external_directory permission when reading relative path outside project", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        // This will fail because file doesn't exist, but we can check if permission was asked
-        await read.execute({ filePath: "../outside.txt" }, testCtx).catch(() => {})
-        const extDirReq = requests.find((r) => r.permission === "external_directory")
-        expect(extDirReq).toBeDefined()
-      },
-    })
-  })
+      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+      const next = {
+        ...ctx,
+        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+          requests.push(req)
+        },
+      }
 
-  test("does not ask for external_directory permission when reading inside project", async () => {
-    await using tmp = await tmpdir({
-      git: true,
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "internal.txt"), "internal content")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
-        const testCtx = {
-          ...ctx,
-          ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-            requests.push(req)
-          },
-        }
-        await read.execute({ filePath: path.join(tmp.path, "internal.txt") }, testCtx)
-        const extDirReq = requests.find((r) => r.permission === "external_directory")
-        expect(extDirReq).toBeUndefined()
-      },
-    })
-  })
+      yield* exec(dir, { filePath: path.join(outer, "external") }, next)
+      const ext = requests.find((item) => item.permission === "external_directory")
+      expect(ext).toBeDefined()
+      expect(ext!.patterns).toContain(glob(path.join(outer, "external", "*")))
+    }),
+  )
+
+  it.live("asks for external_directory permission when reading relative path outside project", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+
+      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+      const next = {
+        ...ctx,
+        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+          requests.push(req)
+        },
+      }
+
+      yield* fail(dir, { filePath: "../outside.txt" }, next)
+      const ext = requests.find((item) => item.permission === "external_directory")
+      expect(ext).toBeDefined()
+    }),
+  )
+
+  it.live("does not ask for external_directory permission when reading inside project", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "internal.txt"), "internal content")
+
+      const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+      const next = {
+        ...ctx,
+        ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+          requests.push(req)
+        },
+      }
+
+      yield* exec(dir, { filePath: path.join(dir, "internal.txt") }, next)
+      const ext = requests.find((item) => item.permission === "external_directory")
+      expect(ext).toBeUndefined()
+    }),
+  )
 })
 
 describe("tool.read env file permissions", () => {
@@ -219,261 +226,202 @@ describe("tool.read env file permissions", () => {
     ["environment.ts", false],
   ]
 
-  describe.each(["build", "plan"])("agent=%s", (agentName) => {
-    test.each(cases)("%s asks=%s", async (filename, shouldAsk) => {
-      await using tmp = await tmpdir({
-        init: (dir) => Bun.write(path.join(dir, filename), "content"),
-      })
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const agent = await Agent.get(agentName)
-          let askedForEnv = false
-          const ctxWithPermissions = {
-            ...ctx,
-            ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
-              for (const pattern of req.patterns) {
-                const rule = Permission.evaluate(req.permission, pattern, agent.permission)
-                if (rule.action === "ask" && req.permission === "read") {
-                  askedForEnv = true
+  for (const agentName of ["build", "plan"] as const) {
+    describe(`agent=${agentName}`, () => {
+      for (const [filename, shouldAsk] of cases) {
+        it.live(`${filename} asks=${shouldAsk}`, () =>
+          Effect.gen(function* () {
+            const dir = yield* tmpdirScoped()
+            yield* put(path.join(dir, filename), "content")
+
+            const info = yield* provideInstance(dir)(
+              Effect.gen(function* () {
+                const agent = yield* Agent.Service
+                return yield* agent.get(agentName)
+              }),
+            )
+            let asked = false
+            const next = {
+              ...ctx,
+              ask: async (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) => {
+                for (const pattern of req.patterns) {
+                  const rule = Permission.evaluate(req.permission, pattern, info.permission)
+                  if (rule.action === "ask" && req.permission === "read") {
+                    asked = true
+                  }
+                  if (rule.action === "deny") {
+                    throw new Permission.DeniedError({ ruleset: info.permission })
+                  }
                 }
-                if (rule.action === "deny") {
-                  throw new Permission.DeniedError({ ruleset: agent.permission })
-                }
-              }
-            },
-          }
-          const read = await ReadTool.init()
-          await read.execute({ filePath: path.join(tmp.path, filename) }, ctxWithPermissions)
-          expect(askedForEnv).toBe(shouldAsk)
-        },
-      })
+              },
+            }
+
+            yield* exec(dir, { filePath: path.join(dir, filename) }, next)
+            expect(asked).toBe(shouldAsk)
+          }),
+        )
+      }
     })
-  })
+  }
 })
 
 describe("tool.read truncation", () => {
-  test("truncates large file by bytes and sets truncated metadata", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const base = await Filesystem.readText(path.join(FIXTURES_DIR, "models-api.json"))
-        const target = 60 * 1024
-        const content = base.length >= target ? base : base.repeat(Math.ceil(target / base.length))
-        await Filesystem.write(path.join(dir, "large.json"), content)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "large.json") }, ctx)
-        expect(result.metadata.truncated).toBe(true)
-        expect(result.output).toContain("Output capped at")
-        expect(result.output).toContain("Use offset=")
-      },
-    })
-  })
+  it.live("truncates large file by bytes and sets truncated metadata", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const base = yield* load(path.join(FIXTURES_DIR, "models-api.json"))
+      const target = 60 * 1024
+      const content = base.length >= target ? base : base.repeat(Math.ceil(target / base.length))
+      yield* put(path.join(dir, "large.json"), content)
 
-  test("truncates by line count when limit is specified", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const lines = Array.from({ length: 100 }, (_, i) => `line${i}`).join("\n")
-        await Bun.write(path.join(dir, "many-lines.txt"), lines)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "many-lines.txt"), limit: 10 }, ctx)
-        expect(result.metadata.truncated).toBe(true)
-        expect(result.output).toContain("Showing lines 1-10 of 100")
-        expect(result.output).toContain("Use offset=11")
-        expect(result.output).toContain("line0")
-        expect(result.output).toContain("line9")
-        expect(result.output).not.toContain("line10")
-      },
-    })
-  })
+      const result = yield* exec(dir, { filePath: path.join(dir, "large.json") })
+      expect(result.metadata.truncated).toBe(true)
+      expect(result.output).toContain("Output capped at")
+      expect(result.output).toContain("Use offset=")
+    }),
+  )
 
-  test("does not truncate small file", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "small.txt"), "hello world")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "small.txt") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.output).toContain("End of file")
-      },
-    })
-  })
+  it.live("truncates by line count when limit is specified", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const lines = Array.from({ length: 100 }, (_, i) => `line${i}`).join("\n")
+      yield* put(path.join(dir, "many-lines.txt"), lines)
 
-  test("respects offset parameter", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`).join("\n")
-        await Bun.write(path.join(dir, "offset.txt"), lines)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "offset.txt"), offset: 10, limit: 5 }, ctx)
-        expect(result.output).toContain("10: line10")
-        expect(result.output).toContain("14: line14")
-        expect(result.output).not.toContain("9: line10")
-        expect(result.output).not.toContain("15: line15")
-        expect(result.output).toContain("line10")
-        expect(result.output).toContain("line14")
-        expect(result.output).not.toContain("line0")
-        expect(result.output).not.toContain("line15")
-      },
-    })
-  })
+      const result = yield* exec(dir, { filePath: path.join(dir, "many-lines.txt"), limit: 10 })
+      expect(result.metadata.truncated).toBe(true)
+      expect(result.output).toContain("Showing lines 1-10 of 100")
+      expect(result.output).toContain("Use offset=11")
+      expect(result.output).toContain("line0")
+      expect(result.output).toContain("line9")
+      expect(result.output).not.toContain("line10")
+    }),
+  )
 
-  test("throws when offset is beyond end of file", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const lines = Array.from({ length: 3 }, (_, i) => `line${i + 1}`).join("\n")
-        await Bun.write(path.join(dir, "short.txt"), lines)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        await expect(
-          read.execute({ filePath: path.join(tmp.path, "short.txt"), offset: 4, limit: 5 }, ctx),
-        ).rejects.toThrow("Offset 4 is out of range for this file (3 lines)")
-      },
-    })
-  })
+  it.live("does not truncate small file", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "small.txt"), "hello world")
 
-  test("allows reading empty file at default offset", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "empty.txt"), "")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "empty.txt") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.output).toContain("End of file - total 0 lines")
-      },
-    })
-  })
+      const result = yield* exec(dir, { filePath: path.join(dir, "small.txt") })
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.output).toContain("End of file")
+    }),
+  )
 
-  test("throws when offset > 1 for empty file", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "empty.txt"), "")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        await expect(read.execute({ filePath: path.join(tmp.path, "empty.txt"), offset: 2 }, ctx)).rejects.toThrow(
-          "Offset 2 is out of range for this file (0 lines)",
-        )
-      },
-    })
-  })
+  it.live("respects offset parameter", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`).join("\n")
+      yield* put(path.join(dir, "offset.txt"), lines)
 
-  test("does not mark final directory page as truncated", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Promise.all(
-          Array.from({ length: 10 }, (_, i) => Bun.write(path.join(dir, "dir", `file-${i + 1}.txt`), `line${i}`)),
-        )
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "dir"), offset: 6, limit: 5 }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.output).not.toContain("Showing 5 of 10 entries")
-      },
-    })
-  })
+      const result = yield* exec(dir, { filePath: path.join(dir, "offset.txt"), offset: 10, limit: 5 })
+      expect(result.output).toContain("10: line10")
+      expect(result.output).toContain("14: line14")
+      expect(result.output).not.toContain("9: line10")
+      expect(result.output).not.toContain("15: line15")
+      expect(result.output).toContain("line10")
+      expect(result.output).toContain("line14")
+      expect(result.output).not.toContain("line0")
+      expect(result.output).not.toContain("line15")
+    }),
+  )
 
-  test("truncates long lines", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const longLine = "x".repeat(3000)
-        await Bun.write(path.join(dir, "long-line.txt"), longLine)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "long-line.txt") }, ctx)
-        expect(result.output).toContain("(line truncated to 2000 chars)")
-        expect(result.output.length).toBeLessThan(3000)
-      },
-    })
-  })
+  it.live("throws when offset is beyond end of file", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const lines = Array.from({ length: 3 }, (_, i) => `line${i + 1}`).join("\n")
+      yield* put(path.join(dir, "short.txt"), lines)
 
-  test("image files set truncated to false", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        // 1x1 red PNG
-        const png = Buffer.from(
-          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
-          "base64",
-        )
-        await Bun.write(path.join(dir, "image.png"), png)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "image.png") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.attachments).toBeDefined()
-        expect(result.attachments?.length).toBe(1)
-        expect(result.attachments?.[0]).not.toHaveProperty("id")
-        expect(result.attachments?.[0]).not.toHaveProperty("sessionID")
-        expect(result.attachments?.[0]).not.toHaveProperty("messageID")
-      },
-    })
-  })
+      const err = yield* fail(dir, { filePath: path.join(dir, "short.txt"), offset: 4, limit: 5 })
+      expect(err.message).toContain("Offset 4 is out of range for this file (3 lines)")
+    }),
+  )
 
-  test("large image files are properly attached without error", async () => {
-    await Instance.provide({
-      directory: FIXTURES_DIR,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(FIXTURES_DIR, "large-image.png") }, ctx)
-        expect(result.metadata.truncated).toBe(false)
-        expect(result.attachments).toBeDefined()
-        expect(result.attachments?.length).toBe(1)
-        expect(result.attachments?.[0].type).toBe("file")
-        expect(result.attachments?.[0]).not.toHaveProperty("id")
-        expect(result.attachments?.[0]).not.toHaveProperty("sessionID")
-        expect(result.attachments?.[0]).not.toHaveProperty("messageID")
-      },
-    })
-  })
+  it.live("allows reading empty file at default offset", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "empty.txt"), "")
 
-  test(".fbs files (FlatBuffers schema) are read as text, not images", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        // FlatBuffers schema content
-        const fbsContent = `namespace MyGame;
+      const result = yield* exec(dir, { filePath: path.join(dir, "empty.txt") })
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.output).toContain("End of file - total 0 lines")
+    }),
+  )
+
+  it.live("throws when offset > 1 for empty file", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "empty.txt"), "")
+
+      const err = yield* fail(dir, { filePath: path.join(dir, "empty.txt"), offset: 2 })
+      expect(err.message).toContain("Offset 2 is out of range for this file (0 lines)")
+    }),
+  )
+
+  it.live("does not mark final directory page as truncated", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.forEach(
+        Array.from({ length: 10 }, (_, i) => i),
+        (i) => put(path.join(dir, "dir", `file-${i + 1}.txt`), `line${i}`),
+        {
+          concurrency: "unbounded",
+        },
+      )
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "dir"), offset: 6, limit: 5 })
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.output).not.toContain("Showing 5 of 10 entries")
+    }),
+  )
+
+  it.live("truncates long lines", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "long-line.txt"), "x".repeat(3000))
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "long-line.txt") })
+      expect(result.output).toContain("(line truncated to 2000 chars)")
+      expect(result.output.length).toBeLessThan(3000)
+    }),
+  )
+
+  it.live("image files set truncated to false", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+        "base64",
+      )
+      yield* put(path.join(dir, "image.png"), png)
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "image.png") })
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.attachments).toBeDefined()
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0]).not.toHaveProperty("id")
+      expect(result.attachments?.[0]).not.toHaveProperty("sessionID")
+      expect(result.attachments?.[0]).not.toHaveProperty("messageID")
+    }),
+  )
+
+  it.live("large image files are properly attached without error", () =>
+    Effect.gen(function* () {
+      const result = yield* exec(FIXTURES_DIR, { filePath: path.join(FIXTURES_DIR, "large-image.png") })
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.attachments).toBeDefined()
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].type).toBe("file")
+      expect(result.attachments?.[0]).not.toHaveProperty("id")
+      expect(result.attachments?.[0]).not.toHaveProperty("sessionID")
+      expect(result.attachments?.[0]).not.toHaveProperty("messageID")
+    }),
+  )
+
+  it.live(".fbs files (FlatBuffers schema) are read as text, not images", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const fbs = `namespace MyGame;
 
 table Monster {
   pos:Vec3;
@@ -482,79 +430,52 @@ table Monster {
 }
 
 root_type Monster;`
-        await Bun.write(path.join(dir, "schema.fbs"), fbsContent)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "schema.fbs") }, ctx)
-        // Should be read as text, not as image
-        expect(result.attachments).toBeUndefined()
-        expect(result.output).toContain("namespace MyGame")
-        expect(result.output).toContain("table Monster")
-      },
-    })
-  })
+      yield* put(path.join(dir, "schema.fbs"), fbs)
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "schema.fbs") })
+      expect(result.attachments).toBeUndefined()
+      expect(result.output).toContain("namespace MyGame")
+      expect(result.output).toContain("table Monster")
+    }),
+  )
 })
 
 describe("tool.read loaded instructions", () => {
-  test("loads AGENTS.md from parent directory and includes in metadata", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "subdir", "AGENTS.md"), "# Test Instructions\nDo something special.")
-        await Bun.write(path.join(dir, "subdir", "nested", "test.txt"), "test content")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "subdir", "nested", "test.txt") }, ctx)
-        expect(result.output).toContain("test content")
-        expect(result.output).toContain("system-reminder")
-        expect(result.output).toContain("Test Instructions")
-        expect(result.metadata.loaded).toBeDefined()
-        expect(result.metadata.loaded).toContain(path.join(tmp.path, "subdir", "AGENTS.md"))
-      },
-    })
-  })
+  it.live("loads AGENTS.md from parent directory and includes in metadata", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "subdir", "AGENTS.md"), "# Test Instructions\nDo something special.")
+      yield* put(path.join(dir, "subdir", "nested", "test.txt"), "test content")
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "subdir", "nested", "test.txt") })
+      expect(result.output).toContain("test content")
+      expect(result.output).toContain("system-reminder")
+      expect(result.output).toContain("Test Instructions")
+      expect(result.metadata.loaded).toBeDefined()
+      expect(result.metadata.loaded).toContain(path.join(dir, "subdir", "AGENTS.md"))
+    }),
+  )
 })
 
 describe("tool.read binary detection", () => {
-  test("rejects text extension files with null bytes", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const bytes = Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x77, 0x6f, 0x72, 0x6c, 0x64])
-        await Bun.write(path.join(dir, "null-byte.txt"), bytes)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        await expect(read.execute({ filePath: path.join(tmp.path, "null-byte.txt") }, ctx)).rejects.toThrow(
-          "Cannot read binary file",
-        )
-      },
-    })
-  })
+  it.live("rejects text extension files with null bytes", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const bytes = Buffer.from([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x00, 0x77, 0x6f, 0x72, 0x6c, 0x64])
+      yield* put(path.join(dir, "null-byte.txt"), bytes)
 
-  test("rejects known binary extensions", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "module.wasm"), "not really wasm")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        await expect(read.execute({ filePath: path.join(tmp.path, "module.wasm") }, ctx)).rejects.toThrow(
-          "Cannot read binary file",
-        )
-      },
-    })
-  })
+      const err = yield* fail(dir, { filePath: path.join(dir, "null-byte.txt") })
+      expect(err.message).toContain("Cannot read binary file")
+    }),
+  )
+
+  it.live("rejects known binary extensions", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* put(path.join(dir, "module.wasm"), "not really wasm")
+
+      const err = yield* fail(dir, { filePath: path.join(dir, "module.wasm") })
+      expect(err.message).toContain("Cannot read binary file")
+    }),
+  )
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import path from "path"
-import { ReadTool } from "../../src/tool/read"
 import { Instance } from "../../src/project/instance"
+import { ReadTool as ReadToolFx } from "../../src/tool/read"
+import { Tool } from "../../src/tool/tool"
 import { Filesystem } from "../../src/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
 import { Permission } from "../../src/permission"
@@ -23,6 +25,18 @@ const ctx = {
   messages: [],
   metadata: () => {},
   ask: async () => {},
+}
+
+const ReadTool = {
+  init: async () => ({
+    execute: (args: Tool.InferParameters<typeof ReadToolFx>, ctx: Tool.Context) =>
+      Effect.runPromise(
+        ReadToolFx.pipe(
+          Effect.flatMap((tool) => Effect.promise(() => tool.init())),
+          Effect.flatMap((tool) => Effect.promise(() => tool.execute(args, ctx))),
+        ),
+      ),
+  }),
 }
 
 const full = (p: string) => (process.platform === "win32" ? Filesystem.normalizePath(p) : p)


### PR DESCRIPTION
## Summary
- move `ReadTool` onto `Tool.defineEffect(...)` so it follows the new tool-constructor shape
- keep the runtime behavior the same while letting the registry resolve the read tool the same way as other built tools
- adapt `read.test.ts` with a tiny local helper so the existing read test body can keep calling `ReadTool.init()`-style semantics

## Validation
- `bun typecheck`
- `bun run test test/tool/read.test.ts test/tool/task.test.ts test/tool/question.test.ts`
- `bun run test test/session/prompt-effect.test.ts --test-name-pattern "cancel finalizes subtask tool state"`

<!-- stack:links:start -->
## Stack
Base: `dev`

Merged
1. #20911 `refactor/effectify-task-tool`

Current / Remaining
2. **#20793 `refactor/effectify-read-tool`** - current
<!-- stack:links:end -->