### PR TITLE
feat: support context_tiers for arbitrary tiered pricing

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -47,6 +47,9 @@ export namespace ModelsDev {
         output: z.number(),
         cache_read: z.number().optional(),
         cache_write: z.number().optional(),
+        /**
+         * @deprecated Use `context_tiers` instead.
+         */
         context_over_200k: z
           .object({
             input: z.number(),
@@ -54,6 +57,21 @@ export namespace ModelsDev {
             cache_read: z.number().optional(),
             cache_write: z.number().optional(),
           })
+          .optional(),
+        /**
+         * Ordered array of pricing tiers that apply when total input tokens
+         * (input + cache_read) meet or exceed the tier's min_context threshold.
+         */
+        context_tiers: z
+          .array(
+            z.object({
+              min_context: z.number(),
+              input: z.number(),
+              output: z.number(),
+              cache_read: z.number().optional(),
+              cache_write: z.number().optional(),
+            }),
+          )
           .optional(),
       })
       .optional(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -832,6 +832,10 @@ export namespace Provider {
           read: z.number(),
           write: z.number(),
         }),
+        /**
+         * @deprecated Use `contextTiers` instead.
+         * Kept for backward compatibility with older models.dev snapshots.
+         */
         experimentalOver200K: z
           .object({
             input: z.number(),
@@ -841,6 +845,25 @@ export namespace Provider {
               write: z.number(),
             }),
           })
+          .optional(),
+        /**
+         * Ordered pricing tiers that apply when total input tokens
+         * (input + cache_read) meet or exceed the tier's min_context threshold.
+         * Consumers should select the highest tier whose min_context is <=
+         * the current total input tokens.
+         */
+        contextTiers: z
+          .array(
+            z.object({
+              min_context: z.number(),
+              input: z.number(),
+              output: z.number(),
+              cache: z.object({
+                read: z.number(),
+                write: z.number(),
+              }),
+            }),
+          )
           .optional(),
       }),
       limit: z.object({
@@ -927,6 +950,17 @@ export namespace Provider {
               input: model.cost.context_over_200k.input,
               output: model.cost.context_over_200k.output,
             }
+          : undefined,
+        contextTiers: model.cost?.context_tiers
+          ? model.cost.context_tiers.map((tier) => ({
+              min_context: tier.min_context,
+              input: tier.input,
+              output: tier.output,
+              cache: {
+                read: tier.cache_read ?? 0,
+                write: tier.cache_write ?? 0,
+              },
+            }))
           : undefined,
       },
       limit: {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -286,10 +286,28 @@ export namespace Session {
       },
     }
 
-    const costInfo =
-      input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
-        ? input.model.cost.experimentalOver200K
-        : input.model.cost
+    const costInfo = (() => {
+      const totalInputTokens = tokens.input + tokens.cache.read;
+
+      // Prefer new context_tiers with arbitrary thresholds
+      if (input.model.cost?.contextTiers && input.model.cost.contextTiers.length > 0) {
+        // Find the highest tier whose min_context <= totalInputTokens
+        let selected = input.model.cost; // base cost (no tier)
+        for (const tier of input.model.cost.contextTiers) {
+          if (totalInputTokens >= tier.min_context) {
+            selected = tier;
+          }
+        }
+        return selected;
+      }
+
+      // Fall back to legacy experimentalOver200K (hardcoded 200K threshold)
+      if (input.model.cost?.experimentalOver200K && totalInputTokens > 200_000) {
+        return input.model.cost.experimentalOver200K;
+      }
+
+      return input.model.cost;
+    })();
     return {
       cost: safe(
         new Decimal(0)


### PR DESCRIPTION
## Problem

OpenCode currently uses a hardcoded `200_000` token threshold to switch between base and long-context pricing (`experimentalOver200K`). This doesn't match how providers like OpenRouter handle tiered pricing, which supports **arbitrary context length thresholds**.

## Solution

This PR adds support for the new `context_tiers` schema from [models.dev#1324](https://github.com/anomalyco/models.dev/pull/1324), replacing the hardcoded threshold with dynamic tier selection.

### Changes

| File | Change |
|---|---|
| `src/provider/models.ts` | Add `context_tiers` array to ModelsDev cost schema |
| `src/provider/provider.ts` | Add `contextTiers` to internal Model cost type; parse tiers from models.dev |
| `src/session/index.ts` | Replace hardcoded `200_000` check with dynamic tier selection — picks the highest tier where `input + cache_read >= min_context` |

### How It Works

```typescript
const costInfo = (() => {
  const totalInputTokens = tokens.input + tokens.cache.read;

  // Prefer new context_tiers with arbitrary thresholds
  if (input.model.cost?.contextTiers?.length > 0) {
    let selected = input.model.cost; // base cost
    for (const tier of input.model.cost.contextTiers) {
      if (totalInputTokens >= tier.min_context) {
        selected = tier;  // highest matching tier wins
      }
    }
    return selected;
  }

  // Fall back to legacy experimentalOver200K (hardcoded 200K)
  if (input.model.cost?.experimentalOver200K && totalInputTokens > 200_000) {
    return input.model.cost.experimentalOver200K;
  }

  return input.model.cost;
})();
```

### Backward Compatibility

- Falls back to `experimentalOver200K` for models using the legacy `context_over_200k` field
- Falls back to base cost if neither is defined
- No breaking changes to existing models or cost calculations

### Companion PR

- [models.dev#1324](https://github.com/anomalyco/models.dev/pull/1324) — adds `context_tiers` schema and example usage