### PR TITLE
fix: default cache prices to input/output to avoid underestimating costs

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -915,14 +915,15 @@ export namespace Provider {
         input: model.cost?.input ?? 0,
         output: model.cost?.output ?? 0,
         cache: {
-          read: model.cost?.cache_read ?? 0,
-          write: model.cost?.cache_write ?? 0,
+          // Default cache prices to input/output prices to overestimate rather than undercharge
+          read: model.cost?.cache_read ?? model.cost?.input ?? 0,
+          write: model.cost?.cache_write ?? model.cost?.output ?? 0,
         },
         experimentalOver200K: model.cost?.context_over_200k
           ? {
               cache: {
-                read: model.cost.context_over_200k.cache_read ?? 0,
-                write: model.cost.context_over_200k.cache_write ?? 0,
+                read: model.cost.context_over_200k.cache_read ?? model.cost.context_over_200k.input ?? 0,
+                write: model.cost.context_over_200k.cache_write ?? model.cost.context_over_200k.output ?? 0,
               },
               input: model.cost.context_over_200k.input,
               output: model.cost.context_over_200k.output,
@@ -1093,8 +1094,19 @@ export namespace Provider {
                   input: model?.cost?.input ?? existingModel?.cost?.input ?? 0,
                   output: model?.cost?.output ?? existingModel?.cost?.output ?? 0,
                   cache: {
-                    read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
-                    write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
+                    // Default cache prices to input/output prices to overestimate rather than undercharge
+                    read:
+                      model?.cost?.cache_read ??
+                      existingModel?.cost?.cache.read ??
+                      model?.cost?.input ??
+                      existingModel?.cost?.input ??
+                      0,
+                    write:
+                      model?.cost?.cache_write ??
+                      existingModel?.cost?.cache.write ??
+                      model?.cost?.output ??
+                      existingModel?.cost?.output ??
+                      0,
                   },
                 },
                 options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -295,8 +295,17 @@ export namespace Session {
         new Decimal(0)
           .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
           .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-          .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
-          .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
+          // Default cache prices to input/output to overestimate rather than undercharge
+          .add(
+            new Decimal(tokens.cache.read)
+              .mul(costInfo?.cache?.read ?? costInfo?.input ?? 0)
+              .div(1_000_000),
+          )
+          .add(
+            new Decimal(tokens.cache.write)
+              .mul(costInfo?.cache?.write ?? costInfo?.output ?? 0)
+              .div(1_000_000),
+          )
           // TODO: update models.dev to have better pricing model, for now:
           // charge reasoning tokens at the same rate as output tokens
           .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))


### PR DESCRIPTION
### Issue for this PR Closes #5951

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When models.dev omits cache_read or cache_write pricing for a model, the cost calculation falls back to $0. This leads to systematic underestimation of session costs since cached context tokens are counted as free.

The fix changes the fallback in three locations so that when cache pricing is missing, it defaults to the input/output price instead of zero. This ensures we overestimate rather than underestimate cost. The worst case is charging the same rate as regular tokens, which is more honest than charging $0.

Files changed:
- src/provider/provider.ts: in fromModelsDevModel, cache.read falls back to model.cost?.input, cache.write falls back to model.cost?.output. Same for the context_over_200k block. Also updated mergeModel with the same fallback chain.
- src/session/index.ts: in getUsage, the Decimal calculation for cache.read falls back to costInfo?.input, and cache.write falls back to costInfo?.output.

### How did you verify your code works?
Ran a local build of opencode against my real database and used opencode stats --models to confirm it reads session data correctly. Then independently verified with a Python script that recalculates costs from raw token data in the database: for openrouter/xiaomi/mimo-v2-pro with 89 messages and 3.46M cache_read tokens, the old calculation gives $0.36 while the fixed calculation gives $3.81 — a 968% increase that accounts for the previously-free cache tokens.

### Screenshots / recordings
_N/A — no UI changes._

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR