### PR TITLE
fix(opencode): accept agent and agent_type as task tool parameter aliases

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -15,7 +15,18 @@ import { Permission } from "@/permission"
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
   prompt: z.string().describe("The task for the agent to perform"),
-  subagent_type: z.string().describe("The type of specialized agent to use for this task"),
+  subagent_type: z
+    .string()
+    .describe("The type of specialized agent to use for this task")
+    .optional(),
+  agent: z
+    .string()
+    .describe("Alias for subagent_type — the agent to use for this task")
+    .optional(),
+  agent_type: z
+    .string()
+    .describe("Alias for subagent_type — the agent to use for this task")
+    .optional(),
   task_id: z
     .string()
     .describe(
@@ -24,6 +35,19 @@ const parameters = z.object({
     .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
 })
+
+/**
+ * Resolve the agent type from params, accepting "agent" and "agent_type" as
+ * aliases for "subagent_type". Non-Claude models frequently use the shorter
+ * parameter names when calling the task tool.
+ */
+export function resolveAgentType(params: z.infer<typeof parameters>): string {
+  const resolved = params.subagent_type || params.agent || params.agent_type
+  if (!resolved) {
+    throw new Error("One of subagent_type, agent, or agent_type is required")
+  }
+  return resolved
+}
 
 export const TaskTool = Tool.define("task", async (ctx) => {
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
@@ -45,23 +69,25 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     description,
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
+      const agentType = resolveAgentType(params)
+
       const config = await Config.get()
 
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
         await ctx.ask({
           permission: "task",
-          patterns: [params.subagent_type],
+          patterns: [agentType],
           always: ["*"],
           metadata: {
             description: params.description,
-            subagent_type: params.subagent_type,
+            subagent_type: agentType,
           },
         })
       }
 
-      const agent = await Agent.get(params.subagent_type)
-      if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+      const agent = await Agent.get(agentType)
+      if (!agent) throw new Error(`Unknown agent type: ${agentType} is not a valid agent type`)
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
       const hasTodoWritePermission = agent.permission.some((rule) => rule.permission === "todowrite")

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -628,7 +628,9 @@ it.live(
             parameters: z.object({
               description: z.string(),
               prompt: z.string(),
-              subagent_type: z.string(),
+              subagent_type: z.string().optional(),
+              agent: z.string().optional(),
+              agent_type: z.string().optional(),
               task_id: z.string().optional(),
               command: z.string().optional(),
             }),

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Agent } from "../../src/agent/agent"
 import { Instance } from "../../src/project/instance"
-import { TaskTool } from "../../src/tool/task"
+import { TaskTool, resolveAgentType } from "../../src/tool/task"
 import { tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
@@ -45,5 +45,64 @@ describe("tool.task", () => {
         expect(zebra).toBeGreaterThan(general)
       },
     })
+  })
+})
+
+describe("resolveAgentType", () => {
+  test("returns subagent_type when provided", () => {
+    const result = resolveAgentType({
+      description: "test",
+      prompt: "test",
+      subagent_type: "Engineer",
+    })
+    expect(result).toBe("Engineer")
+  })
+
+  test("falls back to agent when subagent_type is missing", () => {
+    const result = resolveAgentType({
+      description: "test",
+      prompt: "test",
+      agent: "Engineer",
+    })
+    expect(result).toBe("Engineer")
+  })
+
+  test("falls back to agent_type when subagent_type and agent are missing", () => {
+    const result = resolveAgentType({
+      description: "test",
+      prompt: "test",
+      agent_type: "Engineer",
+    })
+    expect(result).toBe("Engineer")
+  })
+
+  test("prefers subagent_type over agent and agent_type", () => {
+    const result = resolveAgentType({
+      description: "test",
+      prompt: "test",
+      subagent_type: "Architect",
+      agent: "Engineer",
+      agent_type: "Designer",
+    })
+    expect(result).toBe("Architect")
+  })
+
+  test("prefers agent over agent_type when subagent_type is missing", () => {
+    const result = resolveAgentType({
+      description: "test",
+      prompt: "test",
+      agent: "Engineer",
+      agent_type: "Designer",
+    })
+    expect(result).toBe("Engineer")
+  })
+
+  test("throws when no agent parameter is provided", () => {
+    expect(() =>
+      resolveAgentType({
+        description: "test",
+        prompt: "test",
+      }),
+    ).toThrow("One of subagent_type, agent, or agent_type is required")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #20804

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Non-Claude models (MiniMax, Gemini, Qwen) send `agent` or `agent_type` instead of `subagent_type` when calling the task tool. Zod rejects these because `subagent_type` is the only accepted parameter name and it's required. Models retry in a loop (20+ times in my testing) without ever guessing the right name.

The fix makes `subagent_type` optional and adds `agent` and `agent_type` as optional aliases. A new exported `resolveAgentType()` function normalizes these to a single value at the top of `execute()` with clear precedence: `subagent_type` > `agent` > `agent_type`. If none are provided, it throws the same error as before.

This is the minimal change — one source file and one test mock updated. The resolver is a pure function with no side effects.

### How did you verify your code works?

- 170/170 existing tool tests pass (`bun test test/tool/`)
- 6 new unit tests for `resolveAgentType` covering all alias paths and the error case
- Runtime tested with MiniMax M2.5 Free: agent resolved correctly on first call (was failing 20+ times before)
- Runtime tested with Gemini 2.5 Flash: same fix confirmed
- Full turbo typecheck passes across all 13 packages

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR