### PR TITLE
fix(opencode): replace zodToJsonSchema with z.toJSONSchema for Zod v4 compat

### DIFF
--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -8,7 +8,6 @@ import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
 import { MCP } from "../../mcp"
 import { Session } from "../../session"
-import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { WorkspaceRoutes } from "./workspace"
@@ -83,8 +82,11 @@ export const ExperimentalRoutes = lazy(() =>
           tools.map((t) => ({
             id: t.id,
             description: t.description,
-            // Handle both Zod schemas and plain JSON schemas
-            parameters: (t.parameters as any)?._def ? zodToJsonSchema(t.parameters as any) : t.parameters,
+            // Convert Zod schemas to JSON Schema via Zod v4 built-in.
+            // The previous zodToJsonSchema (zod-to-json-schema@3.x) is incompatible with Zod v4.
+            parameters: typeof (t.parameters as any)?.parse === "function"
+              ? z.toJSONSchema(t.parameters as any)
+              : t.parameters,
           })),
         )
       },


### PR DESCRIPTION
### Issue for this PR

Fixes #20807
Related: #4357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The experimental tools endpoint (`GET /experimental/tools`) uses `zodToJsonSchema()` from `zod-to-json-schema@3.24.5` to convert tool parameter schemas. This library is incompatible with Zod v4 — for an object schema with two described string properties, it returns `{"type":"string"}` instead of the correct object schema. All properties, descriptions, and required fields are lost.

The fix switches to `z.toJSONSchema()` (Zod v4 built-in), which is already used in `session/prompt.ts` for the same purpose and correctly preserves `.describe()` metadata. The Zod-vs-plain detection also changes from `_def` (Zod v3 internals) to `typeof parse === "function"` which works reliably with Zod v4.

I confirmed the original bug reported in #4357 (tool descriptions lost) is already fixed in the prompt path by the Zod v4 migration. This PR fixes the same issue in the experimental API path.

### How did you verify your code works?

- Tested both converters directly: `z.toJSONSchema()` produces correct output with descriptions, `zodToJsonSchema()` returns garbage `{"type":"string"}`
- 1808/1808 passing tests unchanged (6 pre-existing skill discovery failures on unmodified code)
- Full turbo typecheck passes across all 13 packages

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR