### PR TITLE
fix(opencode): inherit thinking level (variant) in task tool subtasks

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -135,6 +135,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
+        variant: msg.info.variant,
         tools: {
           ...(hasTodoWritePermission ? {} : { todowrite: false }),
           ...(hasTaskPermission ? {} : { task: false }),


### PR DESCRIPTION
### Issue for this PR

Fixes #20810

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The task tool spawns subtasks via `SessionPrompt.prompt()` but doesn't pass the parent session's thinking level (`variant`). The variant is already on the assistant message (`msg.info.variant`) and `PromptInput` already accepts it — this just wires them together.

The internal subtask path in `prompt.ts` (line 572) already does this correctly (`variant: lastUser.variant`). This PR makes the external task tool path consistent.

### How did you verify your code works?

- Traced the variant field through the full chain: `MessageV2.Assistant` (line 445) → `msg.info.variant` (task.ts line 105) → `SessionPrompt.prompt()` → `PromptInput.variant` (prompt.ts line 1753)
- Confirmed `PromptInput` already accepts and uses `variant` (prompt.ts line 968)
- Task tool tests pass (1/1)
- Full turbo typecheck passes (13/13 packages)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR