### PR TITLE
feat(app): support prompt param in open-project deep link

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1364,8 +1364,20 @@ export default function Layout(props: ParentProps) {
   const handleDeepLinks = (urls: string[]) => {
     if (!server.isLocal()) return
 
-    for (const directory of collectOpenProjectDeepLinks(urls)) {
-      openProject(directory)
+    for (const result of collectOpenProjectDeepLinks(urls)) {
+      const directory = typeof result === "string" ? result : result.directory
+      const prompt = typeof result === "string" ? undefined : result.prompt
+      openProject(directory, !prompt)
+      if (prompt) {
+        const slug = base64Encode(directory)
+        const current = currentDir()
+        const sessionId = params.id
+        if (current && workspaceKey(current) === workspaceKey(directory) && sessionId) {
+          navigateWithSidebarReset(`/${slug}/session/${sessionId}?prompt=${encodeURIComponent(prompt)}`)
+        } else {
+          navigateWithSidebarReset(`/${slug}/session?prompt=${encodeURIComponent(prompt)}`)
+        }
+      }
     }
 
     for (const link of collectNewSessionDeepLinks(urls)) {

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -16,7 +16,9 @@ export const parseDeepLink = (input: string) => {
   if (url.hostname !== "open-project") return
   const directory = url.searchParams.get("directory")
   if (!directory) return
-  return directory
+  const prompt = url.searchParams.get("prompt") || undefined
+  if (!prompt) return directory
+  return { directory, prompt }
 }
 
 export const parseNewSessionDeepLink = (input: string) => {
@@ -31,7 +33,7 @@ export const parseNewSessionDeepLink = (input: string) => {
 }
 
 export const collectOpenProjectDeepLinks = (urls: string[]) =>
-  urls.map(parseDeepLink).filter((directory): directory is string => !!directory)
+  urls.map(parseDeepLink).filter((result): result is string | { directory: string; prompt: string } => !!result)
 
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -332,7 +332,6 @@ export default function Page() {
   createEffect(() => {
     if (!prompt.ready()) return
     untrack(() => {
-      if (params.id) return
       const text = searchParams.prompt
       if (!text) return
       prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -331,23 +331,21 @@ export default function Page() {
 
   createEffect(() => {
     if (!prompt.ready()) return
-    untrack(() => {
-      const text = searchParams.prompt
-      if (!text) return
-      const current = prompt.current()
-      const textPart = current.find((p): p is TextPart => p.type === "text")
-      if (textPart) {
-        const next = current.map((p) =>
-          p === textPart
-            ? { ...p, content: p.content + (p.content ? "\n" : "") + text, end: p.content.length + text.length }
-            : p,
-        )
-        prompt.set(next, textPart.start + textPart.content.length + text.length)
-      } else {
-        prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
-      }
-      setSearchParams({ ...searchParams, prompt: undefined })
-    })
+    const text = searchParams.prompt
+    if (!text) return
+    const current = prompt.current()
+    const textPart = current.find((p): p is TextPart => p.type === "text")
+    if (textPart) {
+      const next = current.map((p) =>
+        p === textPart
+          ? { ...p, content: p.content + (p.content ? "\n" : "") + text, end: p.content.length + text.length }
+          : p,
+      )
+      prompt.set(next, textPart.start + textPart.content.length + text.length)
+    } else {
+      prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
+    }
+    setSearchParams({ ...searchParams, prompt: undefined })
   })
 
   const [ui, setUi] = createStore({

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -35,7 +35,7 @@ import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
-import { usePrompt } from "@/context/prompt"
+import { usePrompt, type TextPart } from "@/context/prompt"
 import { useSDK } from "@/context/sdk"
 import { useSettings } from "@/context/settings"
 import { useSync } from "@/context/sync"
@@ -334,7 +334,18 @@ export default function Page() {
     untrack(() => {
       const text = searchParams.prompt
       if (!text) return
-      prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
+      const current = prompt.current()
+      const textPart = current.find((p): p is TextPart => p.type === "text")
+      if (textPart) {
+        const next = current.map((p) =>
+          p === textPart
+            ? { ...p, content: p.content + (p.content ? "\n" : "") + text, end: p.content.length + text.length }
+            : p,
+        )
+        prompt.set(next, textPart.start + textPart.content.length + text.length)
+      } else {
+        prompt.set([{ type: "text", content: text, start: 0, end: text.length }], text.length)
+      }
       setSearchParams({ ...searchParams, prompt: undefined })
     })
   })


### PR DESCRIPTION
## Summary

- Add support for a `prompt` query parameter in the `open-project` deep link scheme, allowing users to pre-fill a session prompt when opening a project via URL
- Update `parseDeepLink` to extract the optional `prompt` parameter and return either a string or `{ directory, prompt }` object
- Navigate to the appropriate session with the `prompt` query param set, handling both same-workspace and cross-workspace scenarios
- Remove the guard that blocked prompt insertion when a session ID already existed, so the prompt param works for existing sessions too

## Changes

- `packages/app/src/pages/layout/deep-links.ts` — Parse `prompt` param from `open-project` deep links, return structured result
- `packages/app/src/pages/layout.tsx` — Handle `prompt` from deep link: navigate with prompt query param after opening project
- `packages/app/src/pages/session.tsx` — Remove `if (params.id) return` guard so prompt URL param fills existing sessions

## Test plan

- [x] Open `opencode://open-project?directory=/path/to/project&prompt=hello%20world` and verify the session prompt is pre-filled
- [x] Open `opencode://open-project?directory=/path/to/project` (no prompt) and verify existing behavior unchanged
- [x] Test with a project that already has an active session — verify prompt fills into the existing session
- [x] Test with a project that has no active session — verify new session is created with the prompt