### PR TITLE
fix: add timeouts to LSP server spawn to prevent indefinite blocking

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -14,9 +14,13 @@ import { spawn as lspspawn } from "./launch"
 import { Effect, Layer, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { withTimeout } from "../util/timeout"
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
+
+  // Safety net timeout for LSP server spawn (must exceed worst-case individual timeouts)
+  const LSP_SPAWN_TIMEOUT_MS = 300_000
 
   export const Event = {
     Updated: BusEvent.define("lsp.updated", z.object({})),
@@ -285,7 +289,11 @@ export namespace LSP {
 
             const inflight = s.spawning.get(root + server.id)
             if (inflight) {
-              const client = await inflight
+              const client = await withTimeout(inflight, LSP_SPAWN_TIMEOUT_MS).catch(() => {
+                s.broken.add(root + server.id)
+                log.warn("LSP server spawn timed out (inflight)", { serverID: server.id, root })
+                return undefined
+              })
               if (!client) continue
               result.push(client)
               continue
@@ -300,7 +308,11 @@ export namespace LSP {
               }
             })
 
-            const client = await task
+            const client = await withTimeout(task, LSP_SPAWN_TIMEOUT_MS).catch(() => {
+              s.broken.add(root + server.id)
+              log.warn("LSP server spawn timed out", { serverID: server.id, root })
+              return undefined
+            })
             if (!client) continue
 
             result.push(client)

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -163,7 +163,9 @@ export namespace LSPServer {
       if (!(await Filesystem.exists(serverPath))) {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading and building VS Code ESLint server")
-        const response = await fetch("https://github.com/microsoft/vscode-eslint/archive/refs/heads/main.zip")
+        const response = await fetch("https://github.com/microsoft/vscode-eslint/archive/refs/heads/main.zip", {
+          signal: AbortSignal.timeout(30_000),
+        })
         if (!response.ok) return
 
         const zipPath = path.join(Global.Path.bin, "vscode-eslint.zip")
@@ -189,8 +191,8 @@ export namespace LSPServer {
         await fs.rename(extractedPath, finalPath)
 
         const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm"
-        await Process.run([npmCmd, "install"], { cwd: finalPath })
-        await Process.run([npmCmd, "run", "compile"], { cwd: finalPath })
+        await Process.run([npmCmd, "install"], { cwd: finalPath, timeout: 60_000 })
+        await Process.run([npmCmd, "run", "compile"], { cwd: finalPath, timeout: 120_000 })
 
         log.info("installed VS Code ESLint server", { serverPath })
       }
@@ -358,14 +360,11 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
 
         log.info("installing gopls")
-        const proc = Process.spawn(["go", "install", "golang.org/x/tools/gopls@latest"], {
+        const result = await run(["go", "install", "golang.org/x/tools/gopls@latest"], {
           env: { ...process.env, GOBIN: Global.Path.bin },
-          stdout: "pipe",
-          stderr: "pipe",
-          stdin: "pipe",
+          timeout: 60_000,
         })
-        const exit = await proc.exited
-        if (exit !== 0) {
+        if (result.code !== 0) {
           log.error("Failed to install gopls")
           return
         }
@@ -397,13 +396,10 @@ export namespace LSPServer {
         }
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("installing rubocop")
-        const proc = Process.spawn(["gem", "install", "rubocop", "--bindir", Global.Path.bin], {
-          stdout: "pipe",
-          stderr: "pipe",
-          stdin: "pipe",
+        const result = await run(["gem", "install", "rubocop", "--bindir", Global.Path.bin], {
+          timeout: 60_000,
         })
-        const exit = await proc.exited
-        if (exit !== 0) {
+        if (result.code !== 0) {
           log.error("Failed to install rubocop")
           return
         }
@@ -553,7 +549,9 @@ export namespace LSPServer {
           if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
           log.info("downloading elixir-ls from GitHub releases")
 
-          const response = await fetch("https://github.com/elixir-lsp/elixir-ls/archive/refs/heads/master.zip")
+          const response = await fetch("https://github.com/elixir-lsp/elixir-ls/archive/refs/heads/master.zip", {
+            signal: AbortSignal.timeout(30_000),
+          })
           if (!response.ok) return
           const zipPath = path.join(Global.Path.bin, "elixir-ls.zip")
           if (response.body) await Filesystem.writeStream(zipPath, response.body)
@@ -573,9 +571,9 @@ export namespace LSPServer {
 
           const cwd = path.join(Global.Path.bin, "elixir-ls-master")
           const env = { MIX_ENV: "prod", ...process.env }
-          await Process.run(["mix", "deps.get"], { cwd, env })
-          await Process.run(["mix", "compile"], { cwd, env })
-          await Process.run(["mix", "elixir_ls.release2", "-o", "release"], { cwd, env })
+          await Process.run(["mix", "deps.get"], { cwd, env, timeout: 60_000 })
+          await Process.run(["mix", "compile"], { cwd, env, timeout: 120_000 })
+          await Process.run(["mix", "elixir_ls.release2", "-o", "release"], { cwd, env, timeout: 120_000 })
 
           log.info(`installed elixir-ls`, {
             path: elixirLsPath,
@@ -608,7 +606,9 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading zls from GitHub releases")
 
-        const releaseResponse = await fetch("https://api.github.com/repos/zigtools/zls/releases/latest")
+        const releaseResponse = await fetch("https://api.github.com/repos/zigtools/zls/releases/latest", {
+          signal: AbortSignal.timeout(30_000),
+        })
         if (!releaseResponse.ok) {
           log.error("Failed to fetch zls release info")
           return
@@ -656,7 +656,7 @@ export namespace LSPServer {
         }
 
         const downloadUrl = asset.browser_download_url
-        const downloadResponse = await fetch(downloadUrl)
+        const downloadResponse = await fetch(downloadUrl, { signal: AbortSignal.timeout(30_000) })
         if (!downloadResponse.ok) {
           log.error("Failed to download zls")
           return
@@ -715,13 +715,10 @@ export namespace LSPServer {
 
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("installing csharp-ls via dotnet tool")
-        const proc = Process.spawn(["dotnet", "tool", "install", "csharp-ls", "--tool-path", Global.Path.bin], {
-          stdout: "pipe",
-          stderr: "pipe",
-          stdin: "pipe",
+        const result = await run(["dotnet", "tool", "install", "csharp-ls", "--tool-path", Global.Path.bin], {
+          timeout: 60_000,
         })
-        const exit = await proc.exited
-        if (exit !== 0) {
+        if (result.code !== 0) {
           log.error("Failed to install csharp-ls")
           return
         }
@@ -752,13 +749,10 @@ export namespace LSPServer {
 
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("installing fsautocomplete via dotnet tool")
-        const proc = Process.spawn(["dotnet", "tool", "install", "fsautocomplete", "--tool-path", Global.Path.bin], {
-          stdout: "pipe",
-          stderr: "pipe",
-          stdin: "pipe",
+        const result = await run(["dotnet", "tool", "install", "fsautocomplete", "--tool-path", Global.Path.bin], {
+          timeout: 60_000,
         })
-        const exit = await proc.exited
-        if (exit !== 0) {
+        if (result.code !== 0) {
           log.error("Failed to install fsautocomplete")
           return
         }
@@ -897,7 +891,7 @@ export namespace LSPServer {
       if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
       log.info("downloading clangd from GitHub releases")
 
-      const releaseResponse = await fetch("https://api.github.com/repos/clangd/clangd/releases/latest")
+      const releaseResponse = await fetch("https://api.github.com/repos/clangd/clangd/releases/latest", { signal: AbortSignal.timeout(30_000) })
       if (!releaseResponse.ok) {
         log.error("Failed to fetch clangd release info")
         return
@@ -943,7 +937,7 @@ export namespace LSPServer {
       }
 
       const name = asset.name
-      const downloadResponse = await fetch(asset.browser_download_url)
+      const downloadResponse = await fetch(asset.browser_download_url, { signal: AbortSignal.timeout(30_000) })
       if (!downloadResponse.ok) {
         log.error("Failed to download clangd")
         return
@@ -1119,7 +1113,7 @@ export namespace LSPServer {
         const archiveName = "release.tar.gz"
 
         log.info("Downloading JDTLS archive", { url: releaseURL, dest: distPath })
-        const download = await fetch(releaseURL)
+        const download = await fetch(releaseURL, { signal: AbortSignal.timeout(30_000) })
         if (!download.ok || !download.body) {
           log.error("Failed to download JDTLS", { status: download.status, statusText: download.statusText })
           return
@@ -1212,7 +1206,7 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("Downloading Kotlin Language Server from GitHub.")
 
-        const releaseResponse = await fetch("https://api.github.com/repos/Kotlin/kotlin-lsp/releases/latest")
+        const releaseResponse = await fetch("https://api.github.com/repos/Kotlin/kotlin-lsp/releases/latest", { signal: AbortSignal.timeout(30_000) })
         if (!releaseResponse.ok) {
           log.error("Failed to fetch kotlin-lsp release info")
           return
@@ -1252,7 +1246,7 @@ export namespace LSPServer {
 
         await fs.mkdir(distPath, { recursive: true })
         const archivePath = path.join(distPath, "kotlin-ls.zip")
-        const download = await fetch(releaseURL)
+        const download = await fetch(releaseURL, { signal: AbortSignal.timeout(30_000) })
         if (!download.ok || !download.body) {
           log.error("Failed to download Kotlin Language Server", {
             status: download.status,
@@ -1331,7 +1325,7 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading lua-language-server from GitHub releases")
 
-        const releaseResponse = await fetch("https://api.github.com/repos/LuaLS/lua-language-server/releases/latest")
+        const releaseResponse = await fetch("https://api.github.com/repos/LuaLS/lua-language-server/releases/latest", { signal: AbortSignal.timeout(30_000) })
         if (!releaseResponse.ok) {
           log.error("Failed to fetch lua-language-server release info")
           return
@@ -1379,7 +1373,7 @@ export namespace LSPServer {
         }
 
         const downloadUrl = asset.browser_download_url
-        const downloadResponse = await fetch(downloadUrl)
+        const downloadResponse = await fetch(downloadUrl, { signal: AbortSignal.timeout(30_000) })
         if (!downloadResponse.ok) {
           log.error("Failed to download lua-language-server")
           return
@@ -1574,7 +1568,7 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading terraform-ls from HashiCorp releases")
 
-        const releaseResponse = await fetch("https://api.releases.hashicorp.com/v1/releases/terraform-ls/latest")
+        const releaseResponse = await fetch("https://api.releases.hashicorp.com/v1/releases/terraform-ls/latest", { signal: AbortSignal.timeout(30_000) })
         if (!releaseResponse.ok) {
           log.error("Failed to fetch terraform-ls release info")
           return
@@ -1598,7 +1592,7 @@ export namespace LSPServer {
           return
         }
 
-        const downloadResponse = await fetch(build.url)
+        const downloadResponse = await fetch(build.url, { signal: AbortSignal.timeout(30_000) })
         if (!downloadResponse.ok) {
           log.error("Failed to download terraform-ls")
           return
@@ -1655,7 +1649,7 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading texlab from GitHub releases")
 
-        const response = await fetch("https://api.github.com/repos/latex-lsp/texlab/releases/latest")
+        const response = await fetch("https://api.github.com/repos/latex-lsp/texlab/releases/latest", { signal: AbortSignal.timeout(30_000) })
         if (!response.ok) {
           log.error("Failed to fetch texlab release info")
           return
@@ -1686,7 +1680,7 @@ export namespace LSPServer {
           return
         }
 
-        const downloadResponse = await fetch(asset.browser_download_url)
+        const downloadResponse = await fetch(asset.browser_download_url, { signal: AbortSignal.timeout(30_000) })
         if (!downloadResponse.ok) {
           log.error("Failed to download texlab")
           return
@@ -1839,7 +1833,7 @@ export namespace LSPServer {
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
         log.info("downloading tinymist from GitHub releases")
 
-        const response = await fetch("https://api.github.com/repos/Myriad-Dreamin/tinymist/releases/latest")
+        const response = await fetch("https://api.github.com/repos/Myriad-Dreamin/tinymist/releases/latest", { signal: AbortSignal.timeout(30_000) })
         if (!response.ok) {
           log.error("Failed to fetch tinymist release info")
           return
@@ -1877,7 +1871,7 @@ export namespace LSPServer {
           return
         }
 
-        const downloadResponse = await fetch(asset.browser_download_url)
+        const downloadResponse = await fetch(asset.browser_download_url, { signal: AbortSignal.timeout(30_000) })
         if (!downloadResponse.ok) {
           log.error("Failed to download tinymist")
           return


### PR DESCRIPTION
## Summary

Fixes #20824

LSP server `spawn()` functions that download or build external resources (ESLint, ElixirLS, Zls, etc.) have no timeout on `fetch()` or `Process.run()` calls. When the network is blocked or the build hangs, the spawn promise stays pending forever, stored in the `spawning` Map. This causes every subsequent `getClients()` call to block indefinitely, which makes all file-modifying tools (Write, Edit) hang permanently after writing the file.

## Changes

**Layer 1 — Individual operation timeouts (`lsp/server.ts`):**
- Add `AbortSignal.timeout(30_000)` to all `fetch()` calls across 14 LSP servers
- Add `timeout: 60_000` to package install operations (`npm install`, `go install`, `gem install`, `dotnet tool install`)
- Add `timeout: 120_000` to build/compile operations (`npm run compile`, `mix compile`)
- Convert `Process.spawn()` + `await proc.exited` patterns (Gopls, Rubocop, CSharp, FSharp) to `run()` which supports the `timeout` option

**Layer 2 — Safety net timeout (`lsp/index.ts`):**
- Wrap both `schedule()` and inflight `await` in `getClients()` with `withTimeout(promise, 300_000)`
- On timeout, mark the server as `broken` to prevent retry and log a warning
- This catches any spawn that hangs for reasons not covered by Layer 1

## Test Plan

- [ ] Verify LSP servers still initialize correctly in normal network conditions
- [ ] Verify that a blocked `fetch()` times out and marks the server as broken
- [ ] Verify Write/Edit tools complete successfully even when an LSP server spawn fails
- [ ] Verify timed-out servers are not retried (present in `broken` set)