### PR TITLE
fix(opencode): agent name shows full path prefix in Docker sandbox

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -188,15 +188,6 @@ export namespace Config {
     }
   }
 
-  function rel(item: string, patterns: string[]) {
-    const normalizedItem = item.replaceAll("\\", "/")
-    for (const pattern of patterns) {
-      const index = normalizedItem.indexOf(pattern)
-      if (index === -1) continue
-      return normalizedItem.slice(index + pattern.length)
-    }
-  }
-
   function trim(file: string) {
     const ext = path.extname(file)
     return ext.length ? file.slice(0, -ext.length) : file
@@ -221,8 +212,8 @@ export namespace Config {
       })
       if (!md) continue
 
-      const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
-      const file = rel(item, patterns) ?? path.basename(item)
+      const relative = path.relative(dir, item).replaceAll("\\", "/")
+      const file = relative.replace(/^commands?\//, "")
       const name = trim(file)
 
       const config = {
@@ -260,8 +251,8 @@ export namespace Config {
       })
       if (!md) continue
 
-      const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
-      const file = rel(item, patterns) ?? path.basename(item)
+      const relative = path.relative(dir, item).replaceAll("\\", "/")
+      const file = relative.replace(/^agents?\//, "")
       const agentName = trim(file)
 
       const config = {


### PR DESCRIPTION
### Issue for this PR
Closes #13898 (and a similar issue that could happen for command see #20829)

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
`loadAgent()` and `loadCommand()` extract agent/command names from absolute paths using `indexOf` with catch-all patterns like `/agent/` , `/agents/`, `/command/` and `/commands/`. In Docker sandbox shell the OS user is `agent` (home: `/home/agent`), so `/agent/` matches the home directory segment before reaching the config directory, producing names like `.config/opencode/agents/tutor` instead of `tutor`.

Both functions already receive `dir` as a parameter -- the same value used as `cwd` for the glob scan. The fix replaces the pattern matching with `path.relative(dir, item)`, which always gives the correct relative path regardless of what the home directory looks like. The now-unused `rel()` helper is removed.

This pr fixes both agent and the command case which could potentially happen if you had a user called command. However the most important one, for me, is the agent case and if you prefer I can remove the command case code.

### How did you verify your code works?
- `bun typecheck` passes from `packages/opencode`
- All 70 existing config tests pass (`bun test test/config/config.test.ts`), including project-local agents, nested agents (`sub/helper`), singular/plural directory variants, and command loading

### Screenshots / recordings
<img width="888" height="262" alt="image" src="https://github.com/user-attachments/assets/60008768-6855-47d6-bf76-cb1e25770648" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR