### PR TITLE
feat(desktop): add opencode://append URL scheme to inject text into current session

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -772,16 +772,41 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     ),
   )
 
+  const resolveAppendPath = async (raw: string): Promise<{ pillPath: string; suffix: string } | null> => {
+    const match = raw.match(/^@?(.+?):(\d+)(?:-(\d+))?(?::(\d+))?$/)
+    if (!match) return null
+    const candidate = match[1]
+    const startLine = match[2]
+    const endLine = match[3]
+    const col = match[4]
+    const paths = await files.searchFilesAndDirectories(candidate)
+    const hit = paths.find((p) => p === candidate) ?? paths.find((p) => p.endsWith(candidate))
+    if (!hit) return null
+    const suffix = ":" + startLine + (endLine ? "-" + endLine : "") + (col ? ":" + col : "")
+    return { pillPath: hit, suffix }
+  }
+
   // Listen for external text append events (opencode://append?text=xxx)
   onMount(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ text: string; action: string }>).detail
       if (!detail?.text) return
-      const cursor = prompt.cursor() ?? promptLength(prompt.current())
-      addPart({ type: "text", content: detail.text, start: 0, end: 0 })
-      if (detail.action === "submit") {
-        requestAnimationFrame(() => handleSubmit(event as unknown as KeyboardEvent))
+
+      const tryInsert = async () => {
+        const resolved = await resolveAppendPath(detail.text)
+        if (resolved) {
+          addPart({ type: "file", path: resolved.pillPath, content: "@" + resolved.pillPath, start: 0, end: 0 })
+          if (resolved.suffix) {
+            addPart({ type: "text", content: resolved.suffix, start: 0, end: 0 })
+          }
+        } else {
+          addPart({ type: "text", content: detail.text, start: 0, end: 0 })
+        }
+        if (detail.action === "submit") {
+          requestAnimationFrame(() => handleSubmit(event as unknown as KeyboardEvent))
+        }
       }
+      void tryInsert()
     }
     makeEventListener(window, appendTextEvent, handler as EventListener)
   })

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1,6 +1,7 @@
 import { useFilteredList } from "@opencode-ai/ui/hooks"
 import { useSpring } from "@opencode-ai/ui/motion-spring"
-import { createEffect, on, Component, Show, onCleanup, createMemo, createSignal } from "solid-js"
+import { createEffect, on, onMount, Component, Show, onCleanup, createMemo, createSignal } from "solid-js"
+import { makeEventListener } from "@solid-primitives/event-listener"
 import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { selectionFromLines, type SelectedLineRange, useFile } from "@/context/file"
@@ -55,6 +56,7 @@ import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
+import { appendTextEvent } from "@/pages/layout/append-text"
 
 interface PromptInputProps {
   class?: string
@@ -769,6 +771,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       },
     ),
   )
+
+  // Listen for external text append events (opencode://append?text=xxx)
+  onMount(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ text: string; action: string }>).detail
+      if (!detail?.text) return
+      const cursor = prompt.cursor() ?? promptLength(prompt.current())
+      addPart({ type: "text", content: detail.text, start: 0, end: 0 })
+      if (detail.action === "submit") {
+        requestAnimationFrame(() => handleSubmit(event as unknown as KeyboardEvent))
+      }
+    }
+    makeEventListener(window, appendTextEvent, handler as EventListener)
+  })
 
   const parseFromDOM = (): Prompt => {
     const parts: Prompt = []

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -75,9 +75,11 @@ import {
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
+  collectAppendDeepLinks,
   deepLinkEvent,
   drainPendingDeepLinks,
 } from "./layout/deep-links"
+import { pushAppendText } from "./layout/append-text"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
   LocalWorkspace,
@@ -1376,6 +1378,10 @@ export default function Layout(props: ParentProps) {
       }
       const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
       navigateWithSidebarReset(href)
+    }
+
+    for (const link of collectAppendDeepLinks(urls)) {
+      pushAppendText(link)
     }
   }
 

--- a/packages/app/src/pages/layout/append-text.ts
+++ b/packages/app/src/pages/layout/append-text.ts
@@ -1,0 +1,27 @@
+import { makeEventListener } from "@solid-primitives/event-listener"
+
+export const appendTextEvent = "opencode:append-text"
+
+type AppendTextDetail = { text: string; action: string }
+
+const pendingAppends: AppendTextDetail[] = []
+
+export const pushAppendText = (detail: AppendTextDetail) => {
+  pendingAppends.push(detail)
+  window.dispatchEvent(new CustomEvent(appendTextEvent, { detail }))
+}
+
+export const drainPendingAppends = () => {
+  const items = [...pendingAppends]
+  pendingAppends.length = 0
+  return items
+}
+
+export const useAppendTextListener = (cb: (detail: AppendTextDetail) => void) => {
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<AppendTextDetail>).detail
+    if (detail) cb(detail)
+  }
+  makeEventListener(window, appendTextEvent, handler as EventListener)
+  return () => window.removeEventListener(appendTextEvent, handler)
+}

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -36,6 +36,18 @@ export const collectOpenProjectDeepLinks = (urls: string[]) =>
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
 
+export const parseAppendDeepLink = (input: string) => {
+  const url = parseUrl(input)
+  if (!url) return
+  if (url.hostname !== "append") return
+  const text = url.searchParams.get("text")
+  if (!text) return
+  return { text, action: url.searchParams.get("action") ?? "insert" }
+}
+
+export const collectAppendDeepLinks = (urls: string[]) =>
+  urls.map(parseAppendDeepLink).filter((link): link is { text: string; action: string } => !!link)
+
 type OpenCodeWindow = Window & {
   __OPENCODE__?: {
     deepLinks?: string[]

--- a/packages/desktop-electron/src/main/ipc.ts
+++ b/packages/desktop-electron/src/main/ipc.ts
@@ -193,3 +193,7 @@ export function sendMenuCommand(win: BrowserWindow, id: string) {
 export function sendDeepLinks(win: BrowserWindow, urls: string[]) {
   win.webContents.send("deep-link", urls)
 }
+
+export function sendAppendText(win: BrowserWindow, text: string, action: string) {
+  win.webContents.send("append-text", { text, action })
+}

--- a/packages/desktop-electron/src/preload/index.ts
+++ b/packages/desktop-electron/src/preload/index.ts
@@ -44,6 +44,11 @@ const api: ElectronAPI = {
     ipcRenderer.on("deep-link", handler)
     return () => ipcRenderer.removeListener("deep-link", handler)
   },
+  onAppendText: (cb) => {
+    const handler = (_: unknown, data: { text: string; action: string }) => cb(data)
+    ipcRenderer.on("append-text", handler)
+    return () => ipcRenderer.removeListener("append-text", handler)
+  },
 
   openDirectoryPicker: (opts) => ipcRenderer.invoke("open-directory-picker", opts),
   openFilePicker: (opts) => ipcRenderer.invoke("open-file-picker", opts),

--- a/packages/desktop-electron/src/preload/types.ts
+++ b/packages/desktop-electron/src/preload/types.ts
@@ -40,6 +40,7 @@ export type ElectronAPI = {
   onSqliteMigrationProgress: (cb: (progress: SqliteMigrationProgress) => void) => () => void
   onMenuCommand: (cb: (id: string) => void) => () => void
   onDeepLink: (cb: (urls: string[]) => void) => () => void
+  onAppendText: (cb: (data: { text: string; action: string }) => void) => () => void
 
   openDirectoryPicker: (opts?: {
     multiple?: boolean

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -33,6 +33,7 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
 void initI18n()
 
 const deepLinkEvent = "opencode:deep-link"
+const appendTextEvent = "opencode:append-text"
 
 const emitDeepLinks = (urls: string[]) => {
   if (urls.length === 0) return
@@ -42,10 +43,18 @@ const emitDeepLinks = (urls: string[]) => {
   window.dispatchEvent(new CustomEvent(deepLinkEvent, { detail: { urls } }))
 }
 
+const emitAppendText = (text: string, action: string) => {
+  window.dispatchEvent(new CustomEvent(appendTextEvent, { detail: { text, action } }))
+}
+
 const listenForDeepLinks = () => {
   const startUrls = window.__OPENCODE__?.deepLinks ?? []
   if (startUrls.length) emitDeepLinks(startUrls)
   return window.api.onDeepLink((urls) => emitDeepLinks(urls))
+}
+
+const listenForAppendText = () => {
+  return window.api.onAppendText(({ text, action }) => emitAppendText(text, action))
 }
 
 const createPlatform = (): Platform => {
@@ -246,6 +255,7 @@ window.api.onMenuCommand((id) => {
   menuTrigger?.(id)
 })
 listenForDeepLinks()
+listenForAppendText()
 
 render(() => {
   const platform = createPlatform()


### PR DESCRIPTION
## Summary

- Adds support for `opencode://append?text=...` URL scheme that appends text to the active prompt input in the current session, without requiring knowledge of the current project or session ID.
- Automatically resolves IDE-style file paths (e.g. `@/src/foo.ts:12-23`) into file mention pills when appended via deep link.
- Works on both Electron and Tauri desktop builds.
- Supports two actions: `insert` (default, fills input) and `submit` (fills input and auto-submits).

## How it works

1. A new `parseAppendDeepLink` parser recognizes `opencode://append` URLs alongside existing `open-project` and `new-session` handlers.
2. A lightweight global event bus (`append-text.ts`) dispatches `CustomEvent` from the layout layer to the `PromptInput` component.
3. On Electron, the IPC channel `append-text` is registered in preload and renderer to bridge the main process to the webview.
4. On Tauri, the existing deep link plugin already routes all `opencode://` URLs through the same frontend handler — no Rust changes needed.
5. When text is appended, `resolveAppendPath` checks if it matches a file path pattern and searches the project file tree. If found, a file mention pill is created instead of plain text.

## URL format

```
opencode://append?text=Hello%20World              # Insert into prompt input
opencode://append?text=Hello%20World&action=submit # Insert and auto-submit
opencode://append?text=%40/src/foo.ts%3A12-23     # Auto-resolve to file pill with line range
```

## Supported file path formats

When appended text matches one of these patterns, it is automatically converted to a `@file` mention pill:

| Format | Example | Result |
|--------|---------|--------|
| `path:line` | `/src/foo.ts:12` | File pill + `:12` |
| `path:start-end` | `/src/foo.ts:12-23` | File pill + `:12-23` |
| `path:line:col` | `/src/foo.ts:12:5` | File pill + `:12:5` |
| `@path:line` | `@/src/foo.ts:12` | File pill + `:12` |
| `@path:start-end` | `@/src/foo.ts:12-23` | File pill + `:12-23` |

If no matching file is found in the project, the text falls back to plain text insertion.

## Use cases

- External tools (browser extensions, scripts, Alfred/Raycast workflows) can inject prompts into the active OpenCode session.
- Copying a file path with line numbers from an IDE and appending it via deep link automatically creates a file reference — no manual `@` re-typing needed.
- No need to know the current project directory, session ID, or sidecar credentials.
- Enables integration with system-wide hotkeys and automation tools.

## Files changed

| File | Change |
|------|--------|
| `packages/app/src/pages/layout/append-text.ts` | **New** — global event bus for append-text events |
| `packages/app/src/pages/layout/deep-links.ts` | Add `parseAppendDeepLink` and `collectAppendDeepLinks` |
| `packages/app/src/pages/layout.tsx` | Process append links in `handleDeepLinks` |
| `packages/app/src/components/prompt-input.tsx` | Listen for `appendTextEvent`, inject text, and auto-resolve file paths to mention pills |
| `packages/desktop-electron/src/main/ipc.ts` | Add `sendAppendText` helper |
| `packages/desktop-electron/src/preload/types.ts` | Add `onAppendText` to `ElectronAPI` type |
| `packages/desktop-electron/src/preload/index.ts` | Register `onAppendText` IPC listener |
| `packages/desktop-electron/src/renderer/index.tsx` | Dispatch `append-text` CustomEvent from IPC |