### PR TITLE
fix(app): skip key handlers during IME composition in question dock

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -303,6 +303,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const nav = (event: KeyboardEvent) => {
     if (event.defaultPrevented) return
+    if (event.isComposing || event.keyCode === 229) return
 
     if (event.key === "Escape") {
       event.preventDefault()
@@ -543,6 +544,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                 rows={1}
                 disabled={sending()}
                 onKeyDown={(e) => {
+                  if (e.isComposing || e.keyCode === 229) return
                   if (e.key === "Escape") {
                     e.preventDefault()
                     setStore("editing", false)


### PR DESCRIPTION
### Issue for this PR

Closes #20850

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The custom answer textarea in `SessionQuestionDock` does not check `event.isComposing` before handling Enter, so pressing Enter to confirm a CJK IME candidate submits the answer instead of committing the composed character. This is the same class of bug fixed for `LineCommentEditor` in #16361.

Added the `isComposing || keyCode === 229` early return to both the textarea `onKeyDown` and the parent `nav` handler.

### How did you verify your code works?

Tested with Japanese IME on macOS (Chrome and Safari). Enter now confirms the IME candidate without submitting the custom answer.

### Screenshots / recordings

_Same visual behavior as #16360 — IME composition Enter no longer triggers submit._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR