### PR TITLE
fix persistent desktop sidebar layout

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -2,7 +2,6 @@ import { createEffect, createMemo, onCleanup, Show, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { IconButton } from "@opencode-ai/ui/icon-button"
-import { Icon } from "@opencode-ai/ui/icon"
 import { Button } from "@opencode-ai/ui/button"
 import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { useTheme } from "@opencode-ai/ui/theme/context"
@@ -200,23 +199,9 @@ export function Titlebar() {
           </div>
         </Show>
         <div class="flex items-center gap-1 shrink-0">
-          <TooltipKeybind
-            class={web() ? "hidden xl:flex shrink-0 ml-14" : "hidden xl:flex shrink-0 ml-2"}
-            placement="bottom"
-            title={language.t("command.sidebar.toggle")}
-            keybind={command.keybind("sidebar.toggle")}
+          <div
+            class={web() ? "hidden xl:flex items-center shrink-0 ml-14" : "hidden xl:flex items-center shrink-0 ml-2"}
           >
-            <Button
-              variant="ghost"
-              class="group/sidebar-toggle titlebar-icon w-8 h-6 p-0 box-border"
-              onClick={layout.sidebar.toggle}
-              aria-label={language.t("command.sidebar.toggle")}
-              aria-expanded={layout.sidebar.opened()}
-            >
-              <Icon size="small" name={layout.sidebar.opened() ? "sidebar-active" : "sidebar"} />
-            </Button>
-          </TooltipKeybind>
-          <div class="hidden xl:flex items-center shrink-0">
             <Show when={params.dir}>
               <div
                 class="flex items-center shrink-0 w-8 mr-1"

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -599,14 +599,16 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
       },
       sidebar: {
-        opened: createMemo(() => store.sidebar.opened),
+        opened: createMemo(() => platform.platform === "desktop" || store.sidebar.opened),
         open() {
           setStore("sidebar", "opened", true)
         },
         close() {
+          if (platform.platform === "desktop") return
           setStore("sidebar", "opened", false)
         },
         toggle() {
+          if (platform.platform === "desktop") return
           setStore("sidebar", "opened", (x) => !x)
         },
         width: createMemo(() => store.sidebar.width),

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -314,6 +314,8 @@ function createSessionHistoryWindow(input: SessionHistoryWindowInput) {
 }
 
 export default function Page() {
+  const chatMin = 450
+  const reviewMin = 360
   const globalSync = useGlobalSync()
   const layout = useLayout()
   const local = useLocal()
@@ -348,6 +350,7 @@ export default function Page() {
       overflow: false,
       bottom: true,
     },
+    width: 0,
   })
 
   const composer = createSessionComposerState()
@@ -396,12 +399,59 @@ export default function Page() {
   const desktopReviewOpen = createMemo(() => isDesktop() && view().reviewPanel.opened())
   const desktopFileTreeOpen = createMemo(() => isDesktop() && layout.fileTree.opened())
   const desktopSidePanelOpen = createMemo(() => desktopReviewOpen() || desktopFileTreeOpen())
+  const treePane = createMemo(() => {
+    if (!desktopFileTreeOpen()) return 0
+    const width = ui.width
+    if (!width) return layout.fileTree.width()
+    const spare = width - chatMin - (desktopReviewOpen() ? reviewMin : 0)
+    if (spare <= 0) return 0
+    return Math.min(layout.fileTree.width(), spare)
+  })
+  const chatPane = createMemo(() => {
+    if (!desktopSidePanelOpen()) return
+    const width = ui.width
+    if (!width) {
+      if (desktopReviewOpen()) return layout.session.width()
+      return
+    }
+    if (!desktopReviewOpen()) return Math.max(0, width - treePane())
+    const full = Math.max(0, width - treePane())
+    const min = Math.min(chatMin, full)
+    const reserve = full <= chatMin ? 0 : Math.min(reviewMin, full - chatMin)
+    const max = Math.max(min, full - reserve)
+    const base = Math.min(layout.session.width(), max)
+    return Math.max(min, base)
+  })
+  const sidePane = createMemo(() => {
+    if (!desktopSidePanelOpen()) return
+    const width = ui.width
+    if (!width) {
+      if (desktopReviewOpen()) return
+      return treePane()
+    }
+    return Math.max(0, width - (chatPane() ?? 0))
+  })
+  const treeMax = createMemo(() => {
+    const width = ui.width
+    if (!width) return 480
+    return Math.max(200, Math.min(480, width - chatMin - (desktopReviewOpen() ? reviewMin : 0)))
+  })
+  const chatMax = createMemo(() => {
+    const width = ui.width
+    if (!width) return typeof window === "undefined" ? 1000 : window.innerWidth * 0.45
+    const full = Math.max(0, width - treePane())
+    const min = Math.min(chatMin, full)
+    const reserve = full <= chatMin ? 0 : Math.min(reviewMin, full - chatMin)
+    return Math.max(min, full - reserve)
+  })
   const sessionPanelWidth = createMemo(() => {
     if (!desktopSidePanelOpen()) return "100%"
+    const width = chatPane()
+    if (width !== undefined) return `${width}px`
     if (desktopReviewOpen()) return `${layout.session.width()}px`
     return `calc(100% - ${layout.fileTree.width()}px)`
   })
-  const centered = createMemo(() => isDesktop() && !desktopReviewOpen())
+  const centered = createMemo(() => isDesktop() && !desktopSidePanelOpen())
 
   function normalizeTab(tab: string) {
     if (!tab.startsWith("file://")) return tab
@@ -684,6 +734,7 @@ export default function Page() {
   let inputRef!: HTMLDivElement
   let promptDock: HTMLDivElement | undefined
   let dockHeight = 0
+  let body: HTMLDivElement | undefined
   let scroller: HTMLDivElement | undefined
   let content: HTMLDivElement | undefined
   let scrollMark = 0
@@ -1636,6 +1687,15 @@ export default function Page() {
   })
 
   createResizeObserver(
+    () => body,
+    ({ width }) => {
+      const next = Math.ceil(width)
+      if (next === ui.width) return
+      setUi("width", next)
+    },
+  )
+
+  createResizeObserver(
     () => promptDock,
     ({ height }) => {
       const next = Math.ceil(height)
@@ -1706,7 +1766,7 @@ export default function Page() {
   return (
     <div class="relative bg-background-base size-full overflow-hidden flex flex-col">
       <SessionHeader />
-      <div class="flex-1 min-h-0 flex flex-col md:flex-row">
+      <div ref={body} class="flex-1 min-h-0 flex flex-col md:flex-row">
         <Show when={!isDesktop() && !!params.id}>
           <Tabs value={store.mobileTab} class="h-auto">
             <Tabs.List>
@@ -1849,9 +1909,9 @@ export default function Page() {
             <div onPointerDown={() => size.start()}>
               <ResizeHandle
                 direction="horizontal"
-                size={layout.session.width()}
+                size={chatPane() ?? layout.session.width()}
                 min={450}
-                max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}
+                max={chatMax()}
                 onResize={(width) => {
                   size.touch()
                   layout.session.resize(width)
@@ -1867,6 +1927,9 @@ export default function Page() {
           focusReviewDiff={focusReviewDiff}
           reviewSnap={ui.reviewSnap}
           size={size}
+          panelWidth={sidePane}
+          treeWidth={treePane}
+          treeMax={treeMax}
         />
       </div>
 

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -31,6 +31,9 @@ export function SessionSidePanel(props: {
   focusReviewDiff: (path: string) => void
   reviewSnap: boolean
   size: Sizing
+  panelWidth?: () => number | undefined
+  treeWidth?: () => number
+  treeMax?: () => number
 }) {
   const layout = useLayout()
   const sync = useSync()
@@ -48,10 +51,15 @@ export function SessionSidePanel(props: {
   const reviewTab = createMemo(() => isDesktop())
   const panelWidth = createMemo(() => {
     if (!open()) return "0px"
+    const width = props.panelWidth?.()
+    if (width !== undefined) return `${width}px`
     if (reviewOpen()) return `calc(100% - ${layout.session.width()}px)`
     return `${layout.fileTree.width()}px`
   })
-  const treeWidth = createMemo(() => (fileOpen() ? `${layout.fileTree.width()}px` : "0px"))
+  const treeWidth = createMemo(() => {
+    if (!fileOpen()) return "0px"
+    return `${props.treeWidth?.() ?? layout.fileTree.width()}px`
+  })
 
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const diffs = createMemo(() => (params.id ? (sync.data.session_diff[params.id] ?? []) : []))
@@ -436,9 +444,9 @@ export function SessionSidePanel(props: {
                 <ResizeHandle
                   direction="horizontal"
                   edge="start"
-                  size={layout.fileTree.width()}
+                  size={props.treeWidth?.() ?? layout.fileTree.width()}
                   min={200}
-                  max={480}
+                  max={props.treeMax?.() ?? 480}
                   onResize={(width) => {
                     props.size.touch()
                     layout.fileTree.resize(width)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -40,32 +40,6 @@ export namespace Server {
     const app = new Hono()
     return app
       .onError(errorHandler(log))
-      .use((c, next) => {
-        // Allow CORS preflight requests to succeed without auth.
-        // Browser clients sending Authorization headers will preflight with OPTIONS.
-        if (c.req.method === "OPTIONS") return next()
-        const password = Flag.OPENCODE_SERVER_PASSWORD
-        if (!password) return next()
-        const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
-        return basicAuth({ username, password })(c, next)
-      })
-      .use(async (c, next) => {
-        const skip = c.req.path === "/log"
-        if (!skip) {
-          log.info("request", {
-            method: c.req.method,
-            path: c.req.path,
-          })
-        }
-        const timer = log.time("request", {
-          method: c.req.method,
-          path: c.req.path,
-        })
-        await next()
-        if (!skip) {
-          timer.stop()
-        }
-      })
       .use(
         cors({
           maxAge: 86_400,
@@ -93,6 +67,32 @@ export namespace Server {
           },
         }),
       )
+      .use((c, next) => {
+        // Allow CORS preflight requests to succeed without auth.
+        // Browser clients sending Authorization headers will preflight with OPTIONS.
+        if (c.req.method === "OPTIONS") return next()
+        const password = Flag.OPENCODE_SERVER_PASSWORD
+        if (!password) return next()
+        const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+        return basicAuth({ username, password })(c, next)
+      })
+      .use(async (c, next) => {
+        const skip = c.req.path === "/log"
+        if (!skip) {
+          log.info("request", {
+            method: c.req.method,
+            path: c.req.path,
+          })
+        }
+        const timer = log.time("request", {
+          method: c.req.method,
+          path: c.req.path,
+        })
+        await next()
+        if (!skip) {
+          timer.stop()
+        }
+      })
       .use((c, next) => {
         if (skipCompress(c.req.path, c.req.method)) return next()
         return zipped(c, next)


### PR DESCRIPTION
## Summary
- keep the desktop project sidebar pinned open, remove the dead desktop toggle affordance, and rebalance the session/review/file tree layout so the chat pane stays usable on narrower desktop widths
- move server CORS middleware ahead of auth so allowed browser origins still receive CORS headers when auth rejects a request, which unblocks local browser verification from surfacing as opaque CORS failures
- verified with `bun typecheck` in `packages/app` and `packages/opencode`, plus `bun run build` in `packages/app`