### PR TITLE
fix(desktop-electron): use slice instead of splice for deepLinks copy

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -143,7 +143,7 @@ function injectGlobals(win: BrowserWindow, globals: Globals) {
     const deepLinks = globals.deepLinks ?? []
     const data = {
       updaterEnabled: globals.updaterEnabled,
-      deepLinks: Array.isArray(deepLinks) ? deepLinks.splice(0) : deepLinks,
+      deepLinks: Array.isArray(deepLinks) ? deepLinks.slice(0) : deepLinks,
     }
     void win.webContents.executeJavaScript(
       `window.__OPENCODE__ = Object.assign(window.__OPENCODE__ ?? {}, ${JSON.stringify(data)})`,


### PR DESCRIPTION
### Issue for this PR

Closes #20879

### Type of change

- [x] Bug fix

### What does this PR do?

`injectGlobals` was calling `deepLinks.splice(0)` to copy the array into the injected globals. `splice(0)` removes and returns all elements from the original array — it mutates `globals.deepLinks` in place. Because `injectGlobals` is called for both the loading overlay and the main window, the first call drains the shared array, so the second window always receives an empty deep links array.

Changed to `deepLinks.slice(0)` which returns a shallow copy without touching the source.

### How did you verify your code works?

Code inspection: `Array.prototype.splice(0)` is documented to remove all elements from the array and return them, while `Array.prototype.slice(0)` returns a copy. The two callers of `injectGlobals` in `index.ts` share the same `globals` object, confirming the mutation would affect the second window.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR