### PR TITLE
fix(app): guard keydown handlers against IME composition events

### DIFF
--- a/packages/app/src/components/session/session-sortable-terminal-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-terminal-tab.tsx
@@ -78,6 +78,7 @@ export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () =>
   }
 
   const keydown = (e: KeyboardEvent) => {
+    if (e.isComposing) return
     if (e.key === "Enter") {
       e.preventDefault()
       save()

--- a/packages/app/src/context/command.tsx
+++ b/packages/app/src/context/command.tsx
@@ -357,6 +357,7 @@ export const { use: useCommand, provider: CommandProvider } = createSimpleContex
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (suspended() || dialog.active) return
+      if (event.isComposing) return
 
       const sig = signatureFromEvent(event)
       const isPalette = palette().has(sig)

--- a/packages/app/src/pages/layout/inline-editor.tsx
+++ b/packages/app/src/pages/layout/inline-editor.tsx
@@ -28,6 +28,7 @@ export function createInlineEditorController() {
   }
 
   const editorKeyDown = (event: KeyboardEvent, callback: (next: string) => void) => {
+    if (event.isComposing) return
     if (event.key === "Enter") {
       event.preventDefault()
       saveEditor(callback)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -878,6 +878,7 @@ export default function Page() {
   }
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.isComposing) return
     const path = event.composedPath()
     const target = path.find((item): item is HTMLElement => item instanceof HTMLElement)
     const activeElement = deepActiveElement()

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -303,6 +303,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const nav = (event: KeyboardEvent) => {
     if (event.defaultPrevented) return
+    if (event.isComposing) return
 
     if (event.key === "Escape") {
       event.preventDefault()
@@ -543,6 +544,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                 rows={1}
                 disabled={sending()}
                 onKeyDown={(e) => {
+                  if (e.isComposing) return
                   if (e.key === "Escape") {
                     e.preventDefault()
                     setStore("editing", false)

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -697,6 +697,7 @@ export function MessageTimeline(props: {
                             onInput={(event) => setTitle("draft", event.currentTarget.value)}
                             onKeyDown={(event) => {
                               event.stopPropagation()
+                              if (event.isComposing) return
                               if (event.key === "Enter") {
                                 event.preventDefault()
                                 void saveTitleEditor()

--- a/packages/ui/src/pierre/file-find.ts
+++ b/packages/ui/src/pierre/file-find.ts
@@ -472,6 +472,7 @@ export function createFileFind(opts: CreateFileFindOptions) {
       target = host
     },
     onInputKeyDown: (event: KeyboardEvent) => {
+      if (event.isComposing) return
       if (event.key === "Escape") {
         event.preventDefault()
         close()


### PR DESCRIPTION
### Issue for this PR

Closes #20850

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When typing with an IME (Korean, Japanese, Chinese), keydown events fire with `isComposing: true` while the user is composing characters. Several keydown handlers in the codebase didn't check this property, causing two classes of bugs:

1. **Keybind leakage**: Pressing `cmd+'` during IME composition opened the model select dialog, and the last composed character leaked into the dialog's search input (because the composition was forcibly interrupted and the character committed into the newly auto-focused input).

2. **Premature Enter handling**: Pressing Enter to confirm an IME candidate (e.g. selecting a Korean syllable) was intercepted by keydown handlers and treated as a form submission — saving inline editors, submitting custom answers, or jumping to the next search result instead of committing the composed character.

The fix adds `if (event.isComposing) return` guards to 7 keydown handlers:

- `command.tsx` — global keybind dispatcher (fixes cmd+', cmd+k, cmd+p, etc.)
- `message-timeline.tsx` — session title inline editor (Enter to save)
- `inline-editor.tsx` — file tree / generic inline editor (Enter to save)
- `session-sortable-terminal-tab.tsx` — terminal tab rename input (Enter to save)
- `session-question-dock.tsx` — custom answer textarea (Enter to submit) + nav handler (Escape/Cmd+Enter)
- `session.tsx` — session page global handler (Escape to blur, auto-focus on keypress)
- `file-find.ts` — file search input (Enter to next match)

This is the same pattern already used in `list.tsx`, `use-filtered-list.tsx`, `line-comment.tsx`, and `prompt-input.tsx`.

### How did you verify your code works?

- Typed Korean text in the prompt input, pressed `cmd+'` — model select dialog opens with an empty search input (no leaked character)
- Typed Korean in session title inline editor, pressed Enter to confirm IME candidate — character committed normally, title not saved prematurely
- Typed Korean in file search input, pressed Enter to confirm IME — character committed, no jump to next match

### Screenshots / recordings

_N/A — behavioral fix for IME input, no visual change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR