### PR TITLE
feat(tui): add toggle to follow bash output in collapsed view

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -94,6 +94,7 @@ const context = createContext<{
   showTimestamps: () => boolean
   showDetails: () => boolean
   showGenericToolOutput: () => boolean
+  bashFollowCollapsed: () => boolean
   diffWrapMode: () => "word" | "none"
   providers: () => ReadonlyMap<string, Provider>
   sync: ReturnType<typeof useSync>
@@ -153,6 +154,7 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [bashFollowCollapsed, setBashFollowCollapsed] = kv.signal("bash_follow_collapsed", false)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -638,6 +640,16 @@ export function Session() {
       },
     },
     {
+      title: "Toggle collapsed bash follow",
+      value: "session.toggle.bash_follow_collapsed",
+      keybind: "bash_follow_collapsed",
+      category: "Session",
+      onSelect: (dialog) => {
+        setBashFollowCollapsed((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
       title: "Page up",
       value: "session.page.up",
       keybind: "messages_page_up",
@@ -1025,6 +1037,7 @@ export function Session() {
         showTimestamps,
         showDetails,
         showGenericToolOutput,
+        bashFollowCollapsed,
         diffWrapMode,
         providers,
         sync,
@@ -1759,6 +1772,7 @@ function BlockTool(props: {
 
 function Bash(props: ToolProps<typeof BashTool>) {
   const { theme } = useTheme()
+  const ctx = use()
   const sync = useSync()
   const isRunning = createMemo(() => props.part.state.status === "running")
   const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))
@@ -1767,6 +1781,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
   const overflow = createMemo(() => lines().length > 10)
   const limited = createMemo(() => {
     if (expanded() || !overflow()) return output()
+    if (ctx.bashFollowCollapsed()) return ["…", ...lines().slice(-10)].join("\n")
     return [...lines().slice(0, 10), "…"].join("\n")
   })
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -658,6 +658,11 @@ export namespace Config {
         .default("<leader>h")
         .describe("Toggle code block concealment in messages"),
       tool_details: z.string().optional().default("none").describe("Toggle tool details visibility"),
+      bash_follow_collapsed: z
+        .string()
+        .optional()
+        .default("none")
+        .describe("Toggle bash output following in collapsed view"),
       model_list: z.string().optional().default("<leader>m").describe("List available models"),
       model_cycle_recent: z.string().optional().default("f2").describe("Next recently used model"),
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco/opencode#14247

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Added a new toggle in the TUI that allows to toggle the Bash *collapsed* output view between showing the head of the output (default today) and showing the tail -f view of the output.

### How did you verify your code works?

Ran some long commands that output and used the toggle to check it works.

Eg `find /`

### Screenshots / recordings

https://github.com/user-attachments/assets/ae2cfcb1-283e-446b-b565-1aa8d0fafaa5



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR