### PR TITLE
fix: use exit event instead of close to resolve bash tool hang with background processes

### DIFF
--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -272,12 +272,10 @@ export const make = Effect.gen(function* () {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
       proc.on("exit", (...args) => {
-        exit = args
-      })
-      proc.on("close", (...args) => {
         if (end) return
         end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        exit = args
+        Deferred.doneUnsafe(signal, Exit.succeed(exit))
       })
       proc.on("spawn", () => {
         resume(Effect.succeed([proc, signal]))


### PR DESCRIPTION
### Issue for this PR

Closes #20902

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The bash tool hangs when a command spawns a background child process (e.g., `npm run build &`, `bash -c "sleep 10 &"`). The spawner in `cross-spawn-spawner.ts` waits for the `close` event to mark a process complete, but Node.js fires `close` only after all stdio streams are closed. Background children inherit stdout/stderr pipe descriptors, so the streams stay open even after the shell exits.

Changed the spawn callback to use `exit` instead of `close`. The `exit` event fires as soon as the spawned process terminates, regardless of inherited pipes.

### How did you verify your code works?

Ran a test script that measures when `exit` vs `close` fires for three scenarios:

| Command | `exit` | `close` |
|---------|--------|---------|
| `echo hello` | 1ms | 1ms |
| `bash -c "sleep 10 &"` | 1ms | 10004ms |
| `bash -c "nohup sleep 10 >/dev/null 2>&1 &"` | 2ms | 7ms |

The `sleep 10 &` case shows the hang — shell exits at 1ms but `close` waits 10 seconds for the background process. With this fix, completion is detected at 1ms.

Existing tests in `test/effect/cross-spawn-spawner.test.ts` should still pass since `exit` fires before `close` in all cases.

### Screenshots / recordings

Not a UI change.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR