### PR TITLE
fix(enterprise): session message list close on hover

### DIFF
--- a/packages/ui/src/components/message-nav.tsx
+++ b/packages/ui/src/components/message-nav.tsx
@@ -1,7 +1,7 @@
 import { UserMessage } from "@opencode-ai/sdk/v2"
+import { Tooltip } from "@kobalte/core/tooltip"
 import { ComponentProps, For, Match, Show, splitProps, Switch } from "solid-js"
 import { DiffChanges } from "./diff-changes"
-import { Tooltip } from "./tooltip"
 import { useI18n } from "../context/i18n"
 
 export function MessageNav(
@@ -70,20 +70,15 @@ export function MessageNav(
   return (
     <Switch>
       <Match when={local.size === "compact"}>
-        <Tooltip
-          openDelay={0}
-          placement="right-start"
-          gutter={-40}
-          shift={-10}
-          overlap
-          contentClass="message-nav-tooltip"
-          value={
-            <div data-slot="message-nav-tooltip-content">
-              <MessageNav {...props} size="normal" class="" />
-            </div>
-          }
-        >
-          {content()}
+        <Tooltip openDelay={0} closeDelay={0} placement="right" gutter={-40} shift={-10} overlap>
+          <Tooltip.Trigger as="div">{content()}</Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content class="message-nav-tooltip">
+              <div data-slot="message-nav-tooltip-content">
+                <MessageNav {...props} size="normal" class="" />
+              </div>
+            </Tooltip.Content>
+          </Tooltip.Portal>
         </Tooltip>
       </Match>
       <Match when={local.size === "normal"}>{content()}</Match>


### PR DESCRIPTION
### Issue for this PR

Closes #20916 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Re-implements Kobalte's native Tooltip component instead of its wrapped version to fix an issue where messages list for a session couldn't be navigated, as its popup would close immediately on mouse movement

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Started a local copy of the enterprise package and checked its functionality with an existing stored session

### Screenshots / recordings


https://github.com/user-attachments/assets/2ca2fa57-02b2-4533-a677-4d1ea43b5203

Displayed first: current behaviour
Displayed after stash pop: patched behaviour

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
