### PR TITLE
fix(enterprise): pass label to message entry to avoid fallback

### DIFF
--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -190,6 +190,14 @@ export default function () {
                             )
                           : [],
                       )
+                      const messageLabel = (message: UserMessage) => {
+                        const parts = data().part[message.id] ?? []
+                        const text = parts.find(
+                          (part): part is Extract<Part, { type: "text" }> =>
+                            part.type === "text" && !part.synthetic && !part.ignored,
+                        )
+                        return text?.text
+                      }
                       const firstUserMessage = createMemo(() => messages().at(0))
                       const activeMessage = createMemo(
                         () => messages().find((m) => m.id === store.messageId) ?? firstUserMessage(),
@@ -307,6 +315,7 @@ export default function () {
                                       class="sticky top-0 shrink-0 py-2 pl-4"
                                       messages={messages()}
                                       current={activeMessage()}
+                                      getLabel={messageLabel}
                                       size="compact"
                                       onMessageSelect={setActiveMessage}
                                     />


### PR DESCRIPTION
### Issue for this PR

Closes #20915

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Commit 45fa5e719 removed a piece of funcionality that auto-generated a summary of each message, which was then used by enterprise's session share view for message navigation

This gap was never bridged, so after that, all entries on the navigation list displayed the fallback "New Message"

This patch bridges that gap, instead using the actual message as a label whenever possible, and falling back to "New Message" in cases where it's not possible (example: compaction messages)

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I opened an existing session with a local copy of enterprise with this patch applied to it

### Screenshots / recordings

Existing behaviour:
<img width="260" height="327" alt="image" src="https://github.com/user-attachments/assets/2131c76e-dc00-4395-8d43-3f55ba0ed51f" />

Patched behaviour:
<img width="253" height="858" alt="image" src="https://github.com/user-attachments/assets/07451810-4860-4c54-a7b9-e26a423581e2" />

> [!NOTE]
> These are 2 separate sessions, as the one on my local copy was created before the title generation behaviour was removed

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
