### PR TITLE
feat: add Buf protobuf LSP support

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -2019,7 +2019,7 @@ export namespace LSPServer {
         }
 
         if (platform !== "win32") {
-          await $`chmod +x ${bin}`.quiet().nothrow()
+          await fs.chmod(bin, 0o755).catch(() => {})
         }
 
         log.info("installed buf", { bin })

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1982,8 +1982,9 @@ export namespace LSPServer {
         const platform = process.platform
         const arch = process.arch
 
-        const bufArch =
-          platform === "linux" ? (arch === "arm64" ? "aarch64" : "x86_64") : arch === "arm64" ? "arm64" : "x86_64"
+        let bufArch = "x86_64"
+        if (arch === "arm64") bufArch = platform === "linux" ? "aarch64" : "arm64"
+        else if (arch === "x64") bufArch = "x86_64"
 
         const platforms: Record<string, string> = { darwin: "Darwin", linux: "Linux", win32: "Windows" }
         const bufPlatform = platforms[platform]

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1955,4 +1955,80 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const Buf: Info = {
+    id: "buf",
+    extensions: [".proto"],
+    root: NearestRoot(["buf.yaml", "buf.gen.yaml"]),
+    async spawn(root) {
+      let bin = Bun.which("buf", {
+        PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
+      })
+
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("downloading buf from GitHub releases")
+
+        const releaseResponse = await fetch("https://api.github.com/repos/bufbuild/buf/releases/latest")
+        if (!releaseResponse.ok) {
+          log.error("Failed to fetch buf release info")
+          return
+        }
+
+        const release = (await releaseResponse.json()) as {
+          assets?: { name?: string; browser_download_url?: string }[]
+        }
+
+        const platform = process.platform
+        const arch = process.arch
+
+        const bufArch =
+          platform === "linux" ? (arch === "arm64" ? "aarch64" : "x86_64") : arch === "arm64" ? "arm64" : "x86_64"
+
+        const platforms: Record<string, string> = { darwin: "Darwin", linux: "Linux", win32: "Windows" }
+        const bufPlatform = platforms[platform]
+        if (!bufPlatform) {
+          log.error(`Platform ${platform} is not supported by buf`)
+          return
+        }
+
+        // buf provides plain binaries (no archive needed)
+        const ext = platform === "win32" ? ".exe" : ""
+        const assetName = `buf-${bufPlatform}-${bufArch}${ext}`
+
+        const assets = release.assets ?? []
+        const asset = assets.find((a) => a.name === assetName)
+        if (!asset?.browser_download_url) {
+          log.error(`Could not find asset ${assetName} in buf release`)
+          return
+        }
+
+        const downloadResponse = await fetch(asset.browser_download_url)
+        if (!downloadResponse.ok) {
+          log.error("Failed to download buf")
+          return
+        }
+
+        bin = path.join(Global.Path.bin, "buf" + ext)
+        await Bun.file(bin).write(downloadResponse)
+
+        if (!(await Bun.file(bin).exists())) {
+          log.error("Failed to download buf binary")
+          return
+        }
+
+        if (platform !== "win32") {
+          await $`chmod +x ${bin}`.quiet().nothrow()
+        }
+
+        log.info("installed buf", { bin })
+      }
+
+      return {
+        process: spawn(bin, ["lsp", "serve"], {
+          cwd: root,
+        }),
+      }
+    },
+  }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #10073

Reopened from #10075 (auto-closed by stale bot).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add support for Buf's Protobuf LSP https://buf.build/blog/protobuf-lsp. Opencode didn't have support for a Protobuf LSP. This adds auto-download from GitHub releases and language server configuration for `.proto` files.

### How did you verify your code works?

Read and edit Protobuf files, language server emits warnings.

### Screenshots / recordings

<img width="1261" height="999" alt="image" src="https://github.com/user-attachments/assets/dd65f0db-e19b-4477-9399-4c37bcae2784" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR