### PR TITLE
fix: fix system prompt formatting issues

### DIFF
--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -69,7 +69,6 @@ I've found some existing telemetry code. Let me mark the first todo as in_progre
 
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
-- 
 - Use the TodoWrite tool to plan the task if required
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.

--- a/packages/opencode/src/session/prompt/beast.txt
+++ b/packages/opencode/src/session/prompt/beast.txt
@@ -10,12 +10,12 @@ Only terminate your turn when you are sure that the problem is solved and all it
 
 THE PROBLEM CAN NOT BE SOLVED WITHOUT EXTENSIVE INTERNET RESEARCH.
 
-You must use the webfetch tool to recursively gather all information from URL's provided to  you by the user, as well as any links you find in the content of those pages.
+You must use the webfetch tool to recursively gather all information from URLs provided to you by the user, as well as any links you find in the content of those pages.
 
 Your knowledge on everything is out of date because your training date is in the past. 
 
 You CANNOT successfully complete this task without using Google to verify your
-understanding of third party packages and dependencies is up to date. You must use the webfetch tool to search google for how to properly use libraries, packages, frameworks, dependencies, etc. every single time you install or implement one. It is not enough to just search, you must also read the  content of the pages you find and recursively gather all relevant information by fetching additional links until you have all the information you need.
+understanding of third party packages and dependencies is up to date. You must use the webfetch tool to search google for how to properly use libraries, packages, frameworks, dependencies, etc. every single time you install or implement one. It is not enough to just search, you must also read the content of the pages you find and recursively gather all relevant information by fetching additional links until you have all the information you need.
 
 Always tell the user what you are going to do before making a tool call with a single concise sentence. This will help them understand what you are doing and why.
 
@@ -135,7 +135,7 @@ If the user asks you to remember something or add something to your memory, you 
 - This will save time, reduce unnecessary operations, and make your workflow more efficient.
 
 # Writing Prompts
-If you are asked to write a prompt,  you should always generate the prompt in markdown format.
+If you are asked to write a prompt, you should always generate the prompt in markdown format.
 
 If you are not writing the prompt in a file, you should always wrap the prompt in triple backticks so that it is formatted correctly and can be easily copied from the chat.
 

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -109,6 +109,7 @@ Refactoring complete. Running verification...
 [tool_call: bash for 'ruff check src/auth.py && pytest']
 (After verification passes)
 All checks passed. This is a stable checkpoint.
+</example>
 
 <example>
 user: Delete the temp directory.


### PR DESCRIPTION
## Summary
- Add missing `</example>` closing tag in gemini.txt — the example boundary was malformed which could confuse few-shot parsing
- Remove empty bullet point in anthropic.txt
- Fix double spaces and `URL's` → `URLs` in beast.txt

## Test plan
- [ ] Verify Gemini prompt has matching example tags
- [ ] Verify prompt rendering is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)