### PR TITLE
fix(skill): read plugin-modified config for skills.paths discovery

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { Effect, Layer, Context, Stream } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
+import { makeRuntime } from "@/effect/run-service"
 import { errorMessage } from "@/util/error"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
@@ -31,6 +32,7 @@ export namespace Plugin {
 
   type State = {
     hooks: Hooks[]
+    config: Config.Info
   }
 
   // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -49,6 +51,7 @@ export namespace Plugin {
       output: Output,
     ) => Effect.Effect<Output>
     readonly list: () => Effect.Effect<Hooks[]>
+    readonly config: () => Effect.Effect<Config.Info>
     readonly init: () => Effect.Effect<void>
   }
 
@@ -253,7 +256,7 @@ export namespace Plugin {
             Effect.forkScoped,
           )
 
-          return { hooks }
+          return { hooks, config: cfg }
         }),
       )
 
@@ -277,13 +280,39 @@ export namespace Plugin {
         return s.hooks
       })
 
+      const cfg = Effect.fn("Plugin.config")(function* () {
+        const s = yield* InstanceState.get(state)
+        return s.config
+      })
+
       const init = Effect.fn("Plugin.init")(function* () {
         yield* InstanceState.get(state)
       })
 
-      return Service.of({ trigger, list, init })
+      return Service.of({ trigger, list, config: cfg, init })
     }),
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Config.defaultLayer))
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function trigger<
+    Name extends TriggerName,
+    Input = Parameters<Required<Hooks>[Name]>[0],
+    Output = Parameters<Required<Hooks>[Name]>[1],
+  >(name: Name, input: Input, output: Output): Promise<Output> {
+    return runPromise((svc) => svc.trigger(name, input, output))
+  }
+
+  export async function list(): Promise<Hooks[]> {
+    return runPromise((svc) => svc.list())
+  }
+
+  export async function init() {
+    return runPromise((svc) => svc.init())
+  }
+
+  export async function config(): Promise<Config.Info> {
+    return runPromise((svc) => svc.config())
+  }
 }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -131,7 +131,7 @@ export namespace Plugin {
                   Authorization: `Basic ${Buffer.from(`${Flag.OPENCODE_SERVER_USERNAME ?? "opencode"}:${Flag.OPENCODE_SERVER_PASSWORD}`).toString("base64")}`,
                 }
               : undefined,
-            fetch: async (...args) => (await Server.Default()).app.fetch(...args),
+            fetch: async (...args) => Server.Default().app.fetch(...args),
           })
           const cfg = yield* config.get()
           const input: PluginInput = {
@@ -293,7 +293,10 @@ export namespace Plugin {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Config.defaultLayer))
+  export const defaultLayer = layer.pipe(
+    Layer.provide(Bus.layer),
+    Layer.provide(Config.defaultLayer),
+  ) as Layer.Layer<Service>
   const { runPromise } = makeRuntime(Service, defaultLayer)
 
   export async function trigger<

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -7,6 +7,7 @@ import { NamedError } from "@opencode-ai/shared/util/error"
 import type { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
+import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
 import { Permission } from "@/permission"
@@ -238,7 +239,12 @@ export namespace Skill {
     Layer.provide(Config.defaultLayer),
     Layer.provide(Bus.layer),
     Layer.provide(AppFileSystem.defaultLayer),
-  )
+  ) as Layer.Layer<Service>
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function all() {
+    return runPromise((svc) => svc.all())
+  }
 
   export function fmt(list: Info[], opts: { verbose: boolean }) {
     if (list.length === 0) return "No skills are currently available."

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -163,7 +163,11 @@ export namespace Skill {
       yield* scan(state, bus, dir, OPENCODE_SKILL_PATTERN)
     }
 
-    const cfg = yield* config.get()
+    // Read config that includes plugin config() hook mutations.
+    // Plugin.config() returns the config after all plugins' config() hooks
+    // have run, so skills.paths includes plugin-registered directories.
+    const { Plugin } = yield* Effect.promise(() => import("../plugin"))
+    const cfg = yield* Effect.promise(() => Plugin.config())
     for (const item of cfg.skills?.paths ?? []) {
       const expanded = item.startsWith("~/") ? path.join(os.homedir(), item.slice(2)) : item
       const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)

--- a/packages/opencode/test/plugin/skill-paths.test.ts
+++ b/packages/opencode/test/plugin/skill-paths.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+
+const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Instance } = await import("../../src/project/instance")
+const { Skill } = await import("../../src/skill")
+
+afterEach(async () => {
+  if (disable === undefined) delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  else process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disable
+  await Instance.disposeAll()
+})
+
+test("plugin config hook registers skill paths that Skill.all() discovers", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create a skill in an external directory (not .opencode/skill/)
+      const ext = path.join(dir, "plugin-skills", "my-plugin-skill")
+      await fs.mkdir(ext, { recursive: true })
+      await Bun.write(
+        path.join(ext, "SKILL.md"),
+        [
+          "---",
+          "name: plugin-injected-skill",
+          "description: A skill registered via plugin config hook.",
+          "---",
+          "",
+          "# Plugin Skill",
+          "",
+          "This was injected by a plugin's config hook.",
+          "",
+        ].join("\n"),
+      )
+
+      // Create a plugin that adds the external dir to skills.paths
+      const pluginDir = path.join(dir, ".opencode", "plugin")
+      await fs.mkdir(pluginDir, { recursive: true })
+      const ext_paths = JSON.stringify(path.join(dir, "plugin-skills"))
+      await Bun.write(
+        path.join(pluginDir, "skill-path-plugin.ts"),
+        [
+          "export default {",
+          '  id: "demo.skill-paths",',
+          "  server: async () => ({",
+          "    config: async (cfg) => {",
+          "      if (!cfg.skills) cfg.skills = {}",
+          "      if (!cfg.skills.paths) cfg.skills.paths = []",
+          `      cfg.skills.paths.push(${ext_paths})`,
+          "    },",
+          "  }),",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  const skills = await Instance.provide({
+    directory: tmp.path,
+    fn: () => Skill.all(),
+  })
+
+  const found = skills.find((s) => s.name === "plugin-injected-skill")
+  expect(found).toBeDefined()
+  expect(found!.description).toBe("A skill registered via plugin config hook.")
+}, 30000)
+
+test("without the plugin, skill in external dir is NOT discovered", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Same external skill directory, but NO plugin to register it
+      const ext = path.join(dir, "plugin-skills", "orphan-skill")
+      await fs.mkdir(ext, { recursive: true })
+      await Bun.write(
+        path.join(ext, "SKILL.md"),
+        [
+          "---",
+          "name: orphan-skill",
+          "description: This skill should NOT be discovered.",
+          "---",
+          "",
+          "# Orphan",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  const skills = await Instance.provide({
+    directory: tmp.path,
+    fn: () => Skill.all(),
+  })
+
+  const found = skills.find((s) => s.name === "orphan-skill")
+  expect(found).toBeUndefined()
+}, 30000)


### PR DESCRIPTION
Fixes #20940

### Issue for this PR
Related: #20026 (same root cause for providers), PR #20777

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins that register skill directories via their `config()` hook (e.g. [superpowers](https://github.com/obra/superpowers)) are invisible to skill discovery. The plugin mutates `cfg.skills.paths`, but the Skill service never sees it.

**Root cause:** Each service's `makeRuntime` creates a separate `InstanceState` scope. When Plugin calls `config.get()` and a plugin's `config()` hook mutates `cfg.skills.paths`, that mutation only affects Plugin's scoped copy of the config. When Skill independently calls `config.get()`, it gets a separate copy — the mutation is invisible.

This is the same class of bug as #20026 (plugin providers disappearing after instance dispose).

**Fix:** Plugin already runs config hooks and holds the post-hook config object. This PR:

1. **Plugin**: Stores the mutated config in state and exposes `Plugin.config()` — the single source of truth for post-hook config.
2. **Skill**: Calls `Plugin.config()` (via dynamic import, same pattern Plugin already uses for `Skill.all()`) to read `skills.paths` from the authoritative source.

No replay of hooks, no layer dependency changes, no circular imports.

**Before:** 50 skills (0 from superpowers plugin)  
**After:** 64 skills (14 superpowers skills discovered)

### How did you verify your code works?
- `bun typecheck` — clean
- `bun test test/skill/skill.test.ts` — 11 pass, 0 fail
- Binary build: verified skill count goes from 50 → 64 with superpowers plugin installed

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR