### PR TITLE
feat(ui): render and improve code blocks in user messages

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -26,8 +26,8 @@
     font-size: var(--font-size-base);
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
-    margin-top: 2rem;
-    margin-bottom: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 0.375rem;
     line-height: var(--line-height-large);
   }
 
@@ -40,7 +40,8 @@
 
   /* Paragraphs */
   p {
-    margin-bottom: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
   /* Links */
@@ -117,7 +118,7 @@
   hr {
     border: none;
     height: 0;
-    margin: 2.5rem 0;
+    margin: 1rem 0;
   }
 
   .shiki {
@@ -129,6 +130,11 @@
 
   [data-component="markdown-code"] {
     position: relative;
+
+    pre {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
   }
 
   [data-slot="markdown-copy-button"] {
@@ -201,8 +207,8 @@
   }
 
   pre {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
     overflow: auto;
 
     scrollbar-width: none;
@@ -229,7 +235,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    margin: 1.5rem 0;
+    margin: 0.75rem 0;
     font-size: var(--font-size-base);
     display: block;
     overflow-x: auto;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -154,7 +154,7 @@
 
     [data-slot="user-message-code-block"] {
       display: block;
-      margin: 4px 0;
+      margin: 4px 0 8px;
       border: 1px solid var(--border-weak-base);
       border-radius: 6px;
       overflow: hidden;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -159,18 +159,29 @@
       border-radius: 6px;
       overflow: hidden;
       white-space: normal;
+      line-height: var(--line-height-x-large);
 
       pre {
         margin: 0;
-        padding: 8px 10px;
+        padding: 8px 12px;
         overflow-x: auto;
         font-family: var(--font-mono);
-        font-size: 0.85em;
-        line-height: 1.5;
+        font-size: 13px;
         background: var(--surface-stronger);
 
         code {
           white-space: pre;
+        }
+      }
+
+      [data-slot="user-message-code-highlighted"] {
+        .shiki {
+          margin: 0;
+          padding: 8px 12px;
+          overflow-x: auto;
+          font-size: 13px;
+          border-radius: 0;
+          border: none;
         }
       }
 

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -143,6 +143,65 @@
       color: var(--syntax-type);
     }
 
+    [data-slot="user-message-code-inline"] {
+      font-family: var(--font-mono);
+      font-size: 0.9em;
+      background: var(--surface-stronger);
+      border: 1px solid var(--border-weak-base);
+      border-radius: 3px;
+      padding: 0 4px;
+    }
+
+    [data-slot="user-message-code-block"] {
+      display: block;
+      margin: 4px 0;
+      border: 1px solid var(--border-weak-base);
+      border-radius: 6px;
+      overflow: hidden;
+      white-space: normal;
+
+      pre {
+        margin: 0;
+        padding: 8px 10px;
+        overflow-x: auto;
+        font-family: var(--font-mono);
+        font-size: 0.85em;
+        line-height: 1.5;
+        background: var(--surface-stronger);
+
+        code {
+          white-space: pre;
+        }
+      }
+
+      [data-slot="user-message-code-lang"] {
+        display: block;
+        padding: 3px 10px;
+        font-size: 0.75em;
+        color: var(--text-weak);
+        background: var(--surface-stronger);
+        border-bottom: 1px solid var(--border-weak-base);
+      }
+
+      [data-slot="user-message-code-toggle"] {
+        display: block;
+        width: 100%;
+        padding: 3px 10px;
+        font-size: 0.75em;
+        color: var(--text-weak);
+        background: var(--surface-stronger);
+        border: none;
+        border-top: 1px solid var(--border-weak-base);
+        cursor: pointer;
+        text-align: left;
+        font-family: inherit;
+
+        &:hover {
+          color: var(--text-base);
+        }
+      }
+    }
+
     max-width: 100%;
   }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1135,6 +1135,7 @@ function CodeBlock(props: { text: string; lang?: string }) {
   const [open, setOpen] = createSignal(false)
   const preview = createMemo(() => lines().slice(0, COLLAPSE_LINES).join("\n"))
   const extra = createMemo(() => lines().length - COLLAPSE_LINES)
+  const i18n = useI18n()
 
   return (
     <div data-slot="user-message-code-block">
@@ -1150,7 +1151,9 @@ function CodeBlock(props: { text: string; lang?: string }) {
           data-slot="user-message-code-toggle"
           onClick={() => setOpen((v) => !v)}
         >
-          {open() ? "Show less" : `Show ${extra()} more lines`}
+          {open()
+            ? i18n.t("ui.message.codeBlock.showLess")
+            : i18n.t("ui.message.codeBlock.showMore", { count: String(extra()) })}
         </button>
       </Show>
     </div>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1115,6 +1115,8 @@ type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" 
 const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
+  // if fenced code blocks are unbalanced (unclosed), render as plain text
+  if ((text.match(/```/g) ?? []).length % 2 !== 0) return [{ text }]
   const result: HighlightSegment[] = []
   const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1115,18 +1115,18 @@ type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" 
 const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
-  // if fenced code blocks are unbalanced (unclosed), render as plain text
-  if ((text.match(/```/g) ?? []).length % 2 !== 0) return [{ text }]
+  const count = (text.match(/```/g) ?? []).length
+  // if fenced code blocks are unbalanced, auto-close the last fence
+  const src = count % 2 !== 0 ? text + "\n```" : text
   const result: HighlightSegment[] = []
   const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0
   let match: RegExpExecArray | null
-  while ((match = re.exec(text)) !== null) {
+  while ((match = re.exec(src)) !== null) {
     if (match.index > last) {
-      // trim leading newlines from text that follows a code block
       const chunk = result.some((s) => s.type === "code-block")
-        ? text.slice(last, match.index).replace(/^\n+/, "")
-        : text.slice(last, match.index)
+        ? src.slice(last, match.index).replace(/^\n+/, "")
+        : src.slice(last, match.index)
       if (chunk) result.push({ text: chunk })
     }
     if (match[2] !== undefined) {
@@ -1136,10 +1136,10 @@ function parseCode(text: string): HighlightSegment[] {
     }
     last = match.index + match[0].length
   }
-  if (last < text.length) {
+  if (last < src.length) {
     const chunk = result.some((s) => s.type === "code-block")
-      ? text.slice(last).replace(/^\n+/, "")
-      : text.slice(last)
+      ? src.slice(last).replace(/^\n+/, "")
+      : src.slice(last)
     if (chunk) result.push({ text: chunk })
   }
   return result

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1106,7 +1106,25 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   )
 }
 
-type HighlightSegment = { text: string; type?: "file" | "agent" }
+type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block" }
+
+function parseCode(text: string): HighlightSegment[] {
+  const result: HighlightSegment[] = []
+  const re = /```([\w-]*)\n?([\s\S]*?)```|`([^`\n]+)`/g
+  let last = 0
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) result.push({ text: text.slice(last, match.index) })
+    if (match[2] !== undefined) {
+      result.push({ text: match[0], type: "code-block" })
+    } else {
+      result.push({ text: match[3], type: "code-inline" })
+    }
+    last = match.index + match[0].length
+  }
+  if (last < text.length) result.push({ text: text.slice(last) })
+  return result
+}
 
 function HighlightedText(props: { text: string; references: FilePart[]; agents: AgentPart[] }) {
   const segments = createMemo(() => {
@@ -1121,28 +1139,35 @@ function HighlightedText(props: { text: string; references: FilePart[]; agents: 
         .map((a) => ({ start: a.source!.start, end: a.source!.end, type: "agent" as const })),
     ].sort((a, b) => a.start - b.start)
 
-    const result: HighlightSegment[] = []
+    const raw: HighlightSegment[] = []
     let lastIndex = 0
 
     for (const ref of allRefs) {
       if (ref.start < lastIndex) continue
-
-      if (ref.start > lastIndex) {
-        result.push({ text: text.slice(lastIndex, ref.start) })
-      }
-
-      result.push({ text: text.slice(ref.start, ref.end), type: ref.type })
+      if (ref.start > lastIndex) raw.push({ text: text.slice(lastIndex, ref.start) })
+      raw.push({ text: text.slice(ref.start, ref.end), type: ref.type })
       lastIndex = ref.end
     }
 
-    if (lastIndex < text.length) {
-      result.push({ text: text.slice(lastIndex) })
-    }
+    if (lastIndex < text.length) raw.push({ text: text.slice(lastIndex) })
 
-    return result
+    return raw.flatMap((seg) => (seg.type ? [seg] : parseCode(seg.text)))
   })
 
-  return <For each={segments()}>{(segment) => <span data-highlight={segment.type}>{segment.text}</span>}</For>
+  return (
+    <For each={segments()}>
+      {(seg) => (
+        <Switch fallback={<span data-highlight={seg.type}>{seg.text}</span>}>
+          <Match when={seg.type === "code-block"}>
+            <Markdown text={seg.text} data-slot="user-message-code-block" />
+          </Match>
+          <Match when={seg.type === "code-inline"}>
+            <code data-slot="user-message-code-inline">{seg.text}</code>
+          </Match>
+        </Switch>
+      )}
+    </For>
+  )
 }
 
 export function Part(props: MessagePartProps) {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2,6 +2,7 @@ import {
   Component,
   createEffect,
   createMemo,
+  createResource,
   createSignal,
   For,
   Match,
@@ -48,6 +49,9 @@ import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
 import { Tooltip } from "./tooltip"
+import { getSharedHighlighter } from "@pierre/diffs"
+import { bundledLanguages, type BundledLanguage } from "shiki"
+import { isServer } from "solid-js/web"
 import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
 import { AnimatedCountList } from "./tool-count-summary"
@@ -1139,6 +1143,21 @@ function parseCode(text: string): HighlightSegment[] {
   return result
 }
 
+async function highlight(code: string, lang: string | undefined) {
+  if (isServer) return null
+  const highlighter = await getSharedHighlighter({
+    themes: ["OpenCode"],
+    langs: [],
+    preferredHighlighter: "shiki-wasm",
+  })
+  let language = lang || "text"
+  if (!(language in bundledLanguages)) language = "text"
+  if (!highlighter.getLoadedLanguages().includes(language)) {
+    await highlighter.loadLanguage(language as BundledLanguage)
+  }
+  return highlighter.codeToHtml(code, { lang: language, theme: "OpenCode", tabindex: false })
+}
+
 function CodeBlock(props: { text: string; lang?: string }) {
   const lines = createMemo(() => props.text.trimEnd().split("\n"))
   const collapsible = createMemo(() => lines().length > COLLAPSE_LINES)
@@ -1147,14 +1166,24 @@ function CodeBlock(props: { text: string; lang?: string }) {
   const extra = createMemo(() => lines().length - COLLAPSE_LINES)
   const i18n = useI18n()
 
+  const src = createMemo(() => ({
+    code: collapsible() && !open() ? preview() : props.text.trimEnd(),
+    lang: props.lang,
+  }))
+
+  const [html] = createResource(src, (s) => highlight(s.code, s.lang))
+
   return (
     <div data-slot="user-message-code-block">
       <Show when={props.lang}>
         <span data-slot="user-message-code-lang">{props.lang}</span>
       </Show>
-      <pre>
-        <code>{collapsible() && !open() ? preview() : props.text.trimEnd()}</code>
-      </pre>
+      <Show
+        when={html()}
+        fallback={<pre><code>{src().code}</code></pre>}
+      >
+        {(h) => <div data-slot="user-message-code-highlighted" innerHTML={h()} />}
+      </Show>
       <Show when={collapsible()}>
         <button
           type="button"

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1106,17 +1106,20 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   )
 }
 
-type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block" }
+type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block"; lang?: string }
+
+const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
   const result: HighlightSegment[] = []
-  const re = /```([\w-]*)\n?([\s\S]*?)```|`([^`\n]+)`/g
+  // match fenced code blocks first, then inline code
+  const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0
   let match: RegExpExecArray | null
   while ((match = re.exec(text)) !== null) {
     if (match.index > last) result.push({ text: text.slice(last, match.index) })
     if (match[2] !== undefined) {
-      result.push({ text: match[0], type: "code-block" })
+      result.push({ text: match[2], type: "code-block", lang: match[1] || undefined })
     } else {
       result.push({ text: match[3], type: "code-inline" })
     }
@@ -1124,6 +1127,34 @@ function parseCode(text: string): HighlightSegment[] {
   }
   if (last < text.length) result.push({ text: text.slice(last) })
   return result
+}
+
+function CodeBlock(props: { text: string; lang?: string }) {
+  const lines = createMemo(() => props.text.trimEnd().split("\n"))
+  const collapsible = createMemo(() => lines().length > COLLAPSE_LINES)
+  const [open, setOpen] = createSignal(false)
+  const preview = createMemo(() => lines().slice(0, COLLAPSE_LINES).join("\n"))
+  const extra = createMemo(() => lines().length - COLLAPSE_LINES)
+
+  return (
+    <div data-slot="user-message-code-block">
+      <Show when={props.lang}>
+        <span data-slot="user-message-code-lang">{props.lang}</span>
+      </Show>
+      <pre>
+        <code>{collapsible() && !open() ? preview() : props.text.trimEnd()}</code>
+      </pre>
+      <Show when={collapsible()}>
+        <button
+          type="button"
+          data-slot="user-message-code-toggle"
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open() ? "Show less" : `Show ${extra()} more lines`}
+        </button>
+      </Show>
+    </div>
+  )
 }
 
 function HighlightedText(props: { text: string; references: FilePart[]; agents: AgentPart[] }) {
@@ -1159,7 +1190,7 @@ function HighlightedText(props: { text: string; references: FilePart[]; agents: 
       {(seg) => (
         <Switch fallback={<span data-highlight={seg.type}>{seg.text}</span>}>
           <Match when={seg.type === "code-block"}>
-            <Markdown text={seg.text} data-slot="user-message-code-block" />
+            <CodeBlock text={seg.text} lang={seg.lang} />
           </Match>
           <Match when={seg.type === "code-inline"}>
             <code data-slot="user-message-code-inline">{seg.text}</code>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1112,12 +1112,17 @@ const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
   const result: HighlightSegment[] = []
-  // match fenced code blocks first, then inline code
   const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0
   let match: RegExpExecArray | null
   while ((match = re.exec(text)) !== null) {
-    if (match.index > last) result.push({ text: text.slice(last, match.index) })
+    if (match.index > last) {
+      // trim leading newlines from text that follows a code block
+      const chunk = result.some((s) => s.type === "code-block")
+        ? text.slice(last, match.index).replace(/^\n+/, "")
+        : text.slice(last, match.index)
+      if (chunk) result.push({ text: chunk })
+    }
     if (match[2] !== undefined) {
       result.push({ text: match[2], type: "code-block", lang: match[1] || undefined })
     } else {
@@ -1125,7 +1130,12 @@ function parseCode(text: string): HighlightSegment[] {
     }
     last = match.index + match[0].length
   }
-  if (last < text.length) result.push({ text: text.slice(last) })
+  if (last < text.length) {
+    const chunk = result.some((s) => s.type === "code-block")
+      ? text.slice(last).replace(/^\n+/, "")
+      : text.slice(last)
+    if (chunk) result.push({ text: chunk })
+  }
   return result
 }
 

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "نسخ الخطأ",
   "ui.message.duration.seconds": "{{count}}ث",
   "ui.message.duration.minutesSeconds": "{{minutes}}د {{seconds}}ث",
+
+  "ui.message.codeBlock.showMore": "عرض {{count}} سطر إضافي",
+  "ui.message.codeBlock.showLess": "عرض أقل",
 }

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copiar erro",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Mostrar mais {{count}} linhas",
+  "ui.message.codeBlock.showLess": "Mostrar menos",
 }

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopiraj grešku",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Prikaži još {{count}} redova",
+  "ui.message.codeBlock.showLess": "Prikaži manje",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopier fejl",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Vis {{count}} flere linjer",
+  "ui.message.codeBlock.showLess": "Vis mindre",
 }

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -162,4 +162,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Fehler kopieren",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "{{count}} weitere Zeilen anzeigen",
+  "ui.message.codeBlock.showLess": "Weniger anzeigen",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -165,4 +165,7 @@ export const dict: Record<string, string> = {
   "ui.question.multiHint": "Select all answers that apply",
   "ui.question.singleHint": "Select one answer",
   "ui.question.custom.placeholder": "Type your answer...",
+
+  "ui.message.codeBlock.showMore": "Show {{count}} more lines",
+  "ui.message.codeBlock.showLess": "Show less",
 }

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copiar error",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Mostrar {{count}} líneas más",
+  "ui.message.codeBlock.showLess": "Mostrar menos",
 }

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copier l'erreur",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Afficher {{count}} lignes de plus",
+  "ui.message.codeBlock.showLess": "Afficher moins",
 }

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "エラーをコピー",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "さらに{{count}}行を表示",
+  "ui.message.codeBlock.showLess": "折りたたむ",
 }

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "오류 복사",
   "ui.message.duration.seconds": "{{count}}초",
   "ui.message.duration.minutesSeconds": "{{minutes}}분 {{seconds}}초",
+
+  "ui.message.codeBlock.showMore": "{{count}}줄 더 보기",
+  "ui.message.codeBlock.showLess": "접기",
 }

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -160,4 +160,7 @@ export const dict: Record<Keys, string> = {
   "ui.toolErrorCard.copyError": "Kopier feil",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Vis {{count}} flere linjer",
+  "ui.message.codeBlock.showLess": "Vis mindre",
 }

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopiuj błąd",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Pokaż {{count}} więcej linii",
+  "ui.message.codeBlock.showLess": "Pokaż mniej",
 }

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Скопировать ошибку",
   "ui.message.duration.seconds": "{{count}}с",
   "ui.message.duration.minutesSeconds": "{{minutes}}м {{seconds}}с",
+
+  "ui.message.codeBlock.showMore": "Показать ещё {{count}} строк",
+  "ui.message.codeBlock.showLess": "Свернуть",
 }

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -158,4 +158,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "คัดลอกข้อผิดพลาด",
   "ui.message.duration.seconds": "{{count}}วิ",
   "ui.message.duration.minutesSeconds": "{{minutes}}นาที {{seconds}}วิ",
+
+  "ui.message.codeBlock.showMore": "แสดงอีก {{count}} บรรทัด",
+  "ui.message.codeBlock.showLess": "แสดงน้อยลง",
 }

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -163,4 +163,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Hatayı kopyala",
   "ui.message.duration.seconds": "{{count}}sn",
   "ui.message.duration.minutesSeconds": "{{minutes}}dk {{seconds}}sn",
+
+  "ui.message.codeBlock.showMore": "{{count}} satır daha göster",
+  "ui.message.codeBlock.showLess": "Daha az göster",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "复制错误",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "显示更多 {{count}} 行",
+  "ui.message.codeBlock.showLess": "收起",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "複製錯誤",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "顯示更多 {{count}} 行",
+  "ui.message.codeBlock.showLess": "收起",
 } satisfies Partial<Record<Keys, string>>


### PR DESCRIPTION
### Issue for this PR

Closes #12791

### Type of change

- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

User messages display backtick syntax as raw text. This PR addresses that
with the following changes:

1. Parse and render inline code (single backtick) and fenced code blocks
   (triple backtick) in user message text
2. Auto-collapse code blocks exceeding 8 lines with a show/hide toggle
3. Add i18n keys for the toggle in en.ts and all 16 locale files
4. Trim orphan leading newlines that appear after extracted code blocks
5. Reduce excessive prose spacing in markdown.css (headings, hr, pre, table)
   — this is opinionated, happy to revert if preferred
6. Add syntax highlighting using the shared Shiki highlighter (same as
   `AI response` code blocks), with async loading and plain text fallback
7. Fallback to plain text when fenced code blocks are unbalanced (odd
   number of triple backticks) — prevents malformed renders when users
   paste content containing triple backticks, e.g. terminal output or
   incident reports

### How did you verify your code works?

Tested manually with inline code, short blocks, long blocks (700+ lines
with collapse), and multiple languages (Python, TypeScript, Bash, SQL, Rust).

### Screenshots / recordings

**1. Inline code rendering**
<img width="800" height="680" alt="image" src="https://github.com/user-attachments/assets/5fe65e26-d377-4774-b5d5-3fa4333a66a5" />

**2. Short code block rendered (no collapse)**
<img width="810" height="726" alt="image" src="https://github.com/user-attachments/assets/26d13527-6c31-47bd-9eb1-55cdd3436154" />

**3. Long code block — collapsed**
<img width="827" height="687" alt="image" src="https://github.com/user-attachments/assets/c5a4bef0-5353-46ad-b4ea-b7911073ca4b" />

**4. Long code block — expanded**
<img width="862" height="680" alt="image" src="https://github.com/user-attachments/assets/b83d797a-3360-4e10-8d81-21948153490b" />

**5. Syntax highlighting across multiple languages**
<img width="377" height="302" alt="image" src="https://github.com/user-attachments/assets/28d79da5-aec8-40bb-9223-c028713f90ca" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR