### PR TITLE
feat(ui): add copy button to user message code blocks

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -26,8 +26,8 @@
     font-size: var(--font-size-base);
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
-    margin-top: 2rem;
-    margin-bottom: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 0.375rem;
     line-height: var(--line-height-large);
   }
 
@@ -40,7 +40,8 @@
 
   /* Paragraphs */
   p {
-    margin-bottom: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 
   /* Links */
@@ -117,7 +118,7 @@
   hr {
     border: none;
     height: 0;
-    margin: 2.5rem 0;
+    margin: 1rem 0;
   }
 
   .shiki {
@@ -129,6 +130,11 @@
 
   [data-component="markdown-code"] {
     position: relative;
+
+    pre {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
   }
 
   [data-slot="markdown-copy-button"] {
@@ -201,8 +207,8 @@
   }
 
   pre {
-    margin-top: 2rem;
-    margin-bottom: 2rem;
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
     overflow: auto;
 
     scrollbar-width: none;
@@ -229,7 +235,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    margin: 1.5rem 0;
+    margin: 0.75rem 0;
     font-size: var(--font-size-base);
     display: block;
     overflow-x: auto;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -160,6 +160,30 @@
       overflow: hidden;
       white-space: normal;
 
+      [data-slot="user-message-code-header"] {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 3px 6px 3px 10px;
+        background: var(--surface-stronger);
+        border-bottom: 1px solid var(--border-weak-base);
+        min-height: 24px;
+      }
+
+      [data-slot="user-message-code-lang"] {
+        font-size: 0.75em;
+        color: var(--text-weak);
+      }
+
+      [data-slot="user-message-code-copy"] {
+        opacity: 0;
+        transition: opacity 0.15s ease;
+
+        &[data-copied] {
+          opacity: 1;
+        }
+      }
+
       pre {
         margin: 0;
         padding: 8px 10px;
@@ -174,13 +198,8 @@
         }
       }
 
-      [data-slot="user-message-code-lang"] {
-        display: block;
-        padding: 3px 10px;
-        font-size: 0.75em;
-        color: var(--text-weak);
-        background: var(--surface-stronger);
-        border-bottom: 1px solid var(--border-weak-base);
+      &:hover [data-slot="user-message-code-copy"] {
+        opacity: 1;
       }
 
       [data-slot="user-message-code-toggle"] {

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -154,7 +154,7 @@
 
     [data-slot="user-message-code-block"] {
       display: block;
-      margin: 4px 0;
+      margin: 4px 0 8px;
       border: 1px solid var(--border-weak-base);
       border-radius: 6px;
       overflow: hidden;

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -143,6 +143,65 @@
       color: var(--syntax-type);
     }
 
+    [data-slot="user-message-code-inline"] {
+      font-family: var(--font-mono);
+      font-size: 0.9em;
+      background: var(--surface-stronger);
+      border: 1px solid var(--border-weak-base);
+      border-radius: 3px;
+      padding: 0 4px;
+    }
+
+    [data-slot="user-message-code-block"] {
+      display: block;
+      margin: 4px 0;
+      border: 1px solid var(--border-weak-base);
+      border-radius: 6px;
+      overflow: hidden;
+      white-space: normal;
+
+      pre {
+        margin: 0;
+        padding: 8px 10px;
+        overflow-x: auto;
+        font-family: var(--font-mono);
+        font-size: 0.85em;
+        line-height: 1.5;
+        background: var(--surface-stronger);
+
+        code {
+          white-space: pre;
+        }
+      }
+
+      [data-slot="user-message-code-lang"] {
+        display: block;
+        padding: 3px 10px;
+        font-size: 0.75em;
+        color: var(--text-weak);
+        background: var(--surface-stronger);
+        border-bottom: 1px solid var(--border-weak-base);
+      }
+
+      [data-slot="user-message-code-toggle"] {
+        display: block;
+        width: 100%;
+        padding: 3px 10px;
+        font-size: 0.75em;
+        color: var(--text-weak);
+        background: var(--surface-stronger);
+        border: none;
+        border-top: 1px solid var(--border-weak-base);
+        cursor: pointer;
+        text-align: left;
+        font-family: inherit;
+
+        &:hover {
+          color: var(--text-base);
+        }
+      }
+    }
+
     max-width: 100%;
   }
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1143,15 +1143,31 @@ function CodeBlock(props: { text: string; lang?: string }) {
   const lines = createMemo(() => props.text.trimEnd().split("\n"))
   const collapsible = createMemo(() => lines().length > COLLAPSE_LINES)
   const [open, setOpen] = createSignal(false)
+  const [copied, setCopied] = createSignal(false)
   const preview = createMemo(() => lines().slice(0, COLLAPSE_LINES).join("\n"))
   const extra = createMemo(() => lines().length - COLLAPSE_LINES)
   const i18n = useI18n()
 
+  const copy = async () => {
+    await navigator.clipboard.writeText(props.text.trimEnd())
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
     <div data-slot="user-message-code-block">
-      <Show when={props.lang}>
-        <span data-slot="user-message-code-lang">{props.lang}</span>
-      </Show>
+      <div data-slot="user-message-code-header">
+        <span data-slot="user-message-code-lang">{props.lang ?? ""}</span>
+        <IconButton
+          icon={copied() ? "check" : "copy"}
+          size="small"
+          variant="ghost"
+          aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+          data-slot="user-message-code-copy"
+          data-copied={copied() || undefined}
+          onClick={copy}
+        />
+      </div>
       <pre>
         <code>{collapsible() && !open() ? preview() : props.text.trimEnd()}</code>
       </pre>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1135,6 +1135,7 @@ function CodeBlock(props: { text: string; lang?: string }) {
   const [open, setOpen] = createSignal(false)
   const preview = createMemo(() => lines().slice(0, COLLAPSE_LINES).join("\n"))
   const extra = createMemo(() => lines().length - COLLAPSE_LINES)
+  const i18n = useI18n()
 
   return (
     <div data-slot="user-message-code-block">
@@ -1150,7 +1151,9 @@ function CodeBlock(props: { text: string; lang?: string }) {
           data-slot="user-message-code-toggle"
           onClick={() => setOpen((v) => !v)}
         >
-          {open() ? "Show less" : `Show ${extra()} more lines`}
+          {open()
+            ? i18n.t("ui.message.codeBlock.showLess")
+            : i18n.t("ui.message.codeBlock.showMore", { count: String(extra()) })}
         </button>
       </Show>
     </div>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1106,7 +1106,25 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   )
 }
 
-type HighlightSegment = { text: string; type?: "file" | "agent" }
+type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block" }
+
+function parseCode(text: string): HighlightSegment[] {
+  const result: HighlightSegment[] = []
+  const re = /```([\w-]*)\n?([\s\S]*?)```|`([^`\n]+)`/g
+  let last = 0
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > last) result.push({ text: text.slice(last, match.index) })
+    if (match[2] !== undefined) {
+      result.push({ text: match[0], type: "code-block" })
+    } else {
+      result.push({ text: match[3], type: "code-inline" })
+    }
+    last = match.index + match[0].length
+  }
+  if (last < text.length) result.push({ text: text.slice(last) })
+  return result
+}
 
 function HighlightedText(props: { text: string; references: FilePart[]; agents: AgentPart[] }) {
   const segments = createMemo(() => {
@@ -1121,28 +1139,35 @@ function HighlightedText(props: { text: string; references: FilePart[]; agents: 
         .map((a) => ({ start: a.source!.start, end: a.source!.end, type: "agent" as const })),
     ].sort((a, b) => a.start - b.start)
 
-    const result: HighlightSegment[] = []
+    const raw: HighlightSegment[] = []
     let lastIndex = 0
 
     for (const ref of allRefs) {
       if (ref.start < lastIndex) continue
-
-      if (ref.start > lastIndex) {
-        result.push({ text: text.slice(lastIndex, ref.start) })
-      }
-
-      result.push({ text: text.slice(ref.start, ref.end), type: ref.type })
+      if (ref.start > lastIndex) raw.push({ text: text.slice(lastIndex, ref.start) })
+      raw.push({ text: text.slice(ref.start, ref.end), type: ref.type })
       lastIndex = ref.end
     }
 
-    if (lastIndex < text.length) {
-      result.push({ text: text.slice(lastIndex) })
-    }
+    if (lastIndex < text.length) raw.push({ text: text.slice(lastIndex) })
 
-    return result
+    return raw.flatMap((seg) => (seg.type ? [seg] : parseCode(seg.text)))
   })
 
-  return <For each={segments()}>{(segment) => <span data-highlight={segment.type}>{segment.text}</span>}</For>
+  return (
+    <For each={segments()}>
+      {(seg) => (
+        <Switch fallback={<span data-highlight={seg.type}>{seg.text}</span>}>
+          <Match when={seg.type === "code-block"}>
+            <Markdown text={seg.text} data-slot="user-message-code-block" />
+          </Match>
+          <Match when={seg.type === "code-inline"}>
+            <code data-slot="user-message-code-inline">{seg.text}</code>
+          </Match>
+        </Switch>
+      )}
+    </For>
+  )
 }
 
 export function Part(props: MessagePartProps) {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1106,17 +1106,20 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   )
 }
 
-type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block" }
+type HighlightSegment = { text: string; type?: "file" | "agent" | "code-inline" | "code-block"; lang?: string }
+
+const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
   const result: HighlightSegment[] = []
-  const re = /```([\w-]*)\n?([\s\S]*?)```|`([^`\n]+)`/g
+  // match fenced code blocks first, then inline code
+  const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0
   let match: RegExpExecArray | null
   while ((match = re.exec(text)) !== null) {
     if (match.index > last) result.push({ text: text.slice(last, match.index) })
     if (match[2] !== undefined) {
-      result.push({ text: match[0], type: "code-block" })
+      result.push({ text: match[2], type: "code-block", lang: match[1] || undefined })
     } else {
       result.push({ text: match[3], type: "code-inline" })
     }
@@ -1124,6 +1127,34 @@ function parseCode(text: string): HighlightSegment[] {
   }
   if (last < text.length) result.push({ text: text.slice(last) })
   return result
+}
+
+function CodeBlock(props: { text: string; lang?: string }) {
+  const lines = createMemo(() => props.text.trimEnd().split("\n"))
+  const collapsible = createMemo(() => lines().length > COLLAPSE_LINES)
+  const [open, setOpen] = createSignal(false)
+  const preview = createMemo(() => lines().slice(0, COLLAPSE_LINES).join("\n"))
+  const extra = createMemo(() => lines().length - COLLAPSE_LINES)
+
+  return (
+    <div data-slot="user-message-code-block">
+      <Show when={props.lang}>
+        <span data-slot="user-message-code-lang">{props.lang}</span>
+      </Show>
+      <pre>
+        <code>{collapsible() && !open() ? preview() : props.text.trimEnd()}</code>
+      </pre>
+      <Show when={collapsible()}>
+        <button
+          type="button"
+          data-slot="user-message-code-toggle"
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open() ? "Show less" : `Show ${extra()} more lines`}
+        </button>
+      </Show>
+    </div>
+  )
 }
 
 function HighlightedText(props: { text: string; references: FilePart[]; agents: AgentPart[] }) {
@@ -1159,7 +1190,7 @@ function HighlightedText(props: { text: string; references: FilePart[]; agents: 
       {(seg) => (
         <Switch fallback={<span data-highlight={seg.type}>{seg.text}</span>}>
           <Match when={seg.type === "code-block"}>
-            <Markdown text={seg.text} data-slot="user-message-code-block" />
+            <CodeBlock text={seg.text} lang={seg.lang} />
           </Match>
           <Match when={seg.type === "code-inline"}>
             <code data-slot="user-message-code-inline">{seg.text}</code>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1112,12 +1112,17 @@ const COLLAPSE_LINES = 8
 
 function parseCode(text: string): HighlightSegment[] {
   const result: HighlightSegment[] = []
-  // match fenced code blocks first, then inline code
   const re = /```([\w.-]*)[^\S\r\n]*\r?\n?([\s\S]*?)```|`([^`\n]+)`/g
   let last = 0
   let match: RegExpExecArray | null
   while ((match = re.exec(text)) !== null) {
-    if (match.index > last) result.push({ text: text.slice(last, match.index) })
+    if (match.index > last) {
+      // trim leading newlines from text that follows a code block
+      const chunk = result.some((s) => s.type === "code-block")
+        ? text.slice(last, match.index).replace(/^\n+/, "")
+        : text.slice(last, match.index)
+      if (chunk) result.push({ text: chunk })
+    }
     if (match[2] !== undefined) {
       result.push({ text: match[2], type: "code-block", lang: match[1] || undefined })
     } else {
@@ -1125,7 +1130,12 @@ function parseCode(text: string): HighlightSegment[] {
     }
     last = match.index + match[0].length
   }
-  if (last < text.length) result.push({ text: text.slice(last) })
+  if (last < text.length) {
+    const chunk = result.some((s) => s.type === "code-block")
+      ? text.slice(last).replace(/^\n+/, "")
+      : text.slice(last)
+    if (chunk) result.push({ text: chunk })
+  }
   return result
 }
 

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "نسخ الخطأ",
   "ui.message.duration.seconds": "{{count}}ث",
   "ui.message.duration.minutesSeconds": "{{minutes}}د {{seconds}}ث",
+
+  "ui.message.codeBlock.showMore": "عرض {{count}} سطر إضافي",
+  "ui.message.codeBlock.showLess": "عرض أقل",
 }

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copiar erro",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Mostrar mais {{count}} linhas",
+  "ui.message.codeBlock.showLess": "Mostrar menos",
 }

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopiraj grešku",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Prikaži još {{count}} redova",
+  "ui.message.codeBlock.showLess": "Prikaži manje",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopier fejl",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Vis {{count}} flere linjer",
+  "ui.message.codeBlock.showLess": "Vis mindre",
 }

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -162,4 +162,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Fehler kopieren",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "{{count}} weitere Zeilen anzeigen",
+  "ui.message.codeBlock.showLess": "Weniger anzeigen",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -165,4 +165,7 @@ export const dict: Record<string, string> = {
   "ui.question.multiHint": "Select all answers that apply",
   "ui.question.singleHint": "Select one answer",
   "ui.question.custom.placeholder": "Type your answer...",
+
+  "ui.message.codeBlock.showMore": "Show {{count}} more lines",
+  "ui.message.codeBlock.showLess": "Show less",
 }

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copiar error",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Mostrar {{count}} líneas más",
+  "ui.message.codeBlock.showLess": "Mostrar menos",
 }

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Copier l'erreur",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Afficher {{count}} lignes de plus",
+  "ui.message.codeBlock.showLess": "Afficher moins",
 }

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "エラーをコピー",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "さらに{{count}}行を表示",
+  "ui.message.codeBlock.showLess": "折りたたむ",
 }

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -157,4 +157,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "오류 복사",
   "ui.message.duration.seconds": "{{count}}초",
   "ui.message.duration.minutesSeconds": "{{minutes}}분 {{seconds}}초",
+
+  "ui.message.codeBlock.showMore": "{{count}}줄 더 보기",
+  "ui.message.codeBlock.showLess": "접기",
 }

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -160,4 +160,7 @@ export const dict: Record<Keys, string> = {
   "ui.toolErrorCard.copyError": "Kopier feil",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Vis {{count}} flere linjer",
+  "ui.message.codeBlock.showLess": "Vis mindre",
 }

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Kopiuj błąd",
   "ui.message.duration.seconds": "{{count}}s",
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
+
+  "ui.message.codeBlock.showMore": "Pokaż {{count}} więcej linii",
+  "ui.message.codeBlock.showLess": "Pokaż mniej",
 }

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -156,4 +156,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Скопировать ошибку",
   "ui.message.duration.seconds": "{{count}}с",
   "ui.message.duration.minutesSeconds": "{{minutes}}м {{seconds}}с",
+
+  "ui.message.codeBlock.showMore": "Показать ещё {{count}} строк",
+  "ui.message.codeBlock.showLess": "Свернуть",
 }

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -158,4 +158,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "คัดลอกข้อผิดพลาด",
   "ui.message.duration.seconds": "{{count}}วิ",
   "ui.message.duration.minutesSeconds": "{{minutes}}นาที {{seconds}}วิ",
+
+  "ui.message.codeBlock.showMore": "แสดงอีก {{count}} บรรทัด",
+  "ui.message.codeBlock.showLess": "แสดงน้อยลง",
 }

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -163,4 +163,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "Hatayı kopyala",
   "ui.message.duration.seconds": "{{count}}sn",
   "ui.message.duration.minutesSeconds": "{{minutes}}dk {{seconds}}sn",
+
+  "ui.message.codeBlock.showMore": "{{count}} satır daha göster",
+  "ui.message.codeBlock.showLess": "Daha az göster",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "复制错误",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "显示更多 {{count}} 行",
+  "ui.message.codeBlock.showLess": "收起",
 } satisfies Partial<Record<Keys, string>>

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -161,4 +161,7 @@ export const dict = {
   "ui.toolErrorCard.copyError": "複製錯誤",
   "ui.message.duration.seconds": "{{count}}秒",
   "ui.message.duration.minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+
+  "ui.message.codeBlock.showMore": "顯示更多 {{count}} 行",
+  "ui.message.codeBlock.showLess": "收起",
 } satisfies Partial<Record<Keys, string>>


### PR DESCRIPTION
### Issue for this PR

Closes #20943

### Type of change

- [x] New feature

### What does this PR do?

While working on #20942, I noticed code blocks in user messages had no
copy button — unlike code blocks in `AI responses`. This adds one to the
top-right of the language label bar, using IconButton for consistency
with the rest of the UI.

This PR depends on #20942 and is submitted as draft until that one merges.

### How did you verify your code works?

Tested manually — button appears on hover, copies to clipboard, shows
check icon briefly then resets.

### Screenshots / recordings

**1. Copy button visible (hover state)**
<img width="128" alt="image" src="https://github.com/user-attachments/assets/63a7c433-d722-4de9-a2cd-45e0af3d7f62" />

**2. Copied state**
<img width="128" alt="image" src="https://github.com/user-attachments/assets/4311749c-3bb5-4f75-ba00-9d3427986e24" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR