### PR TITLE
feat(tui): show console-managed providers

### DIFF
--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -52,6 +52,11 @@ export type AccountOrgs = {
   orgs: readonly Org[]
 }
 
+export type ActiveOrg = {
+  account: Info
+  org: Org
+}
+
 class RemoteConfig extends Schema.Class<RemoteConfig>("RemoteConfig")({
   config: Schema.Record(Schema.String, Schema.Json),
 }) {}
@@ -137,6 +142,7 @@ const mapAccountServiceError =
 export namespace Account {
   export interface Interface {
     readonly active: () => Effect.Effect<Option.Option<Info>, AccountError>
+    readonly activeOrg: () => Effect.Effect<Option.Option<ActiveOrg>, AccountError>
     readonly list: () => Effect.Effect<Info[], AccountError>
     readonly orgsByAccount: () => Effect.Effect<readonly AccountOrgs[], AccountError>
     readonly remove: (accountID: AccountID) => Effect.Effect<void, AccountError>
@@ -279,6 +285,20 @@ export namespace Account {
         resolveAccess(accountID).pipe(Effect.map(Option.map((r) => r.accessToken))),
       )
 
+      const activeOrg = Effect.fn("Account.activeOrg")(function* () {
+        const activeAccount = yield* repo.active()
+        if (Option.isNone(activeAccount)) return Option.none<ActiveOrg>()
+
+        const account = activeAccount.value
+        if (!account.active_org_id) return Option.none<ActiveOrg>()
+
+        const accountOrgs = yield* orgs(account.id)
+        const org = accountOrgs.find((item) => item.id === account.active_org_id)
+        if (!org) return Option.none<ActiveOrg>()
+
+        return Option.some({ account, org })
+      })
+
       const orgsByAccount = Effect.fn("Account.orgsByAccount")(function* () {
         const accounts = yield* repo.list()
         const [errors, results] = yield* Effect.partition(
@@ -396,6 +416,7 @@ export namespace Account {
 
       return Service.of({
         active: repo.active,
+        activeOrg,
         list: repo.list,
         orgsByAccount,
         remove: repo.remove,
@@ -415,6 +436,10 @@ export namespace Account {
 
   export async function active(): Promise<Info | undefined> {
     return Option.getOrUndefined(await runPromise((service) => service.active()))
+  }
+
+  export async function activeOrg(): Promise<ActiveOrg | undefined> {
+    return Option.getOrUndefined(await runPromise((service) => service.activeOrg()))
   }
 
   export async function token(accountID: AccountID): Promise<AccessToken | undefined> {

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -301,17 +301,15 @@ export namespace Account {
 
       const orgsByAccount = Effect.fn("Account.orgsByAccount")(function* () {
         const accounts = yield* repo.list()
-        const [errors, results] = yield* Effect.partition(
+        return yield* Effect.forEach(
           accounts,
-          (account) => orgs(account.id).pipe(Effect.map((orgs) => ({ account, orgs }))),
+          (account) =>
+            orgs(account.id).pipe(
+              Effect.catch(() => Effect.succeed([] as readonly Org[])),
+              Effect.map((orgs) => ({ account, orgs })),
+            ),
           { concurrency: 3 },
         )
-        for (const error of errors) {
-          yield* Effect.logWarning("failed to fetch orgs for account").pipe(
-            Effect.annotateLogs({ error: String(error) }),
-          )
-        }
-        return results
       })
 
       const orgs = Effect.fn("Account.orgs")(function* (accountID: AccountID) {

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -438,12 +438,20 @@ export namespace Account {
     return Option.getOrUndefined(await runPromise((service) => service.active()))
   }
 
+  export async function list(): Promise<Info[]> {
+    return runPromise((service) => service.list())
+  }
+
   export async function activeOrg(): Promise<ActiveOrg | undefined> {
     return Option.getOrUndefined(await runPromise((service) => service.activeOrg()))
   }
 
   export async function orgsByAccount(): Promise<readonly AccountOrgs[]> {
     return runPromise((service) => service.orgsByAccount())
+  }
+
+  export async function orgs(accountID: AccountID): Promise<readonly Org[]> {
+    return runPromise((service) => service.orgs(accountID))
   }
 
   export async function switchOrg(accountID: AccountID, orgID: OrgID) {

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -442,6 +442,14 @@ export namespace Account {
     return Option.getOrUndefined(await runPromise((service) => service.activeOrg()))
   }
 
+  export async function orgsByAccount(): Promise<readonly AccountOrgs[]> {
+    return runPromise((service) => service.orgsByAccount())
+  }
+
+  export async function switchOrg(accountID: AccountID, orgID: OrgID) {
+    return runPromise((service) => service.use(accountID, Option.some(orgID)))
+  }
+
   export async function token(accountID: AccountID): Promise<AccessToken | undefined> {
     const t = await runPromise((service) => service.token(accountID))
     return Option.getOrUndefined(t)

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -36,6 +36,7 @@ import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { DialogWorkspaceList } from "@tui/component/dialog-workspace-list"
+import { DialogConsoleOrg } from "@tui/component/dialog-console-org"
 import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
@@ -626,6 +627,19 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       onSelect: () => {
         dialog.replace(() => <DialogProviderList />)
+      },
+      category: "Provider",
+    },
+    {
+      title: "Switch org",
+      value: "console.org.switch",
+      suggested: Boolean(sync.data.console_state.activeOrgName),
+      slash: {
+        name: "org",
+        aliases: ["orgs", "switch-org"],
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogConsoleOrg />)
       },
       category: "Provider",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
@@ -13,6 +13,17 @@ type OrgOption = {
   active: boolean
 }
 
+const accountHost = (url: string) => {
+  try {
+    return new URL(url).host
+  } catch {
+    return url
+  }
+}
+
+const accountLabel = (item: Pick<OrgOption, "accountEmail" | "accountUrl">) =>
+  `${item.accountEmail}  ${accountHost(item.accountUrl)}`
+
 export function DialogConsoleOrg() {
   const sdk = useSDK()
   const dialog = useDialog()
@@ -49,19 +60,19 @@ export function DialogConsoleOrg() {
 
     return listed
       .toSorted((a, b) => {
-        if (a.active !== b.active) return a.active ? -1 : 1
+        const activeAccountA = a.active ? 0 : 1
+        const activeAccountB = b.active ? 0 : 1
+        if (activeAccountA !== activeAccountB) return activeAccountA - activeAccountB
+
+        const accountCompare = accountLabel(a).localeCompare(accountLabel(b))
+        if (accountCompare !== 0) return accountCompare
+
         return a.orgName.localeCompare(b.orgName)
       })
       .map((item) => ({
         title: item.orgName,
         value: item,
-        description: `${item.accountEmail} · ${(() => {
-          try {
-            return new URL(item.accountUrl).host
-          } catch {
-            return item.accountUrl
-          }
-        })()}`,
+        category: accountLabel(item),
         onSelect: async () => {
           if (item.active) {
             dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
@@ -3,6 +3,7 @@ import { DialogSelect } from "@tui/ui/dialog-select"
 import { useSDK } from "@tui/context/sdk"
 import { useDialog } from "@tui/ui/dialog"
 import { useToast } from "@tui/ui/toast"
+import { useTheme } from "@tui/context/theme"
 
 type OrgOption = {
   accountID: string
@@ -28,6 +29,7 @@ export function DialogConsoleOrg() {
   const sdk = useSDK()
   const dialog = useDialog()
   const toast = useToast()
+  const { theme } = useTheme()
 
   const [orgs] = createResource(async () => {
     const result = await sdk.client.experimental.console.listOrgs({}, { throwOnError: true })
@@ -73,6 +75,12 @@ export function DialogConsoleOrg() {
         title: item.orgName,
         value: item,
         category: accountLabel(item),
+        categoryView: (
+          <box flexDirection="row" gap={2}>
+            <text fg={theme.accent}>{item.accountEmail}</text>
+            <text fg={theme.textMuted}>{accountHost(item.accountUrl)}</text>
+          </box>
+        ),
         onSelect: async () => {
           if (item.active) {
             dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
@@ -1,0 +1,90 @@
+import { createResource, createMemo } from "solid-js"
+import { DialogSelect } from "@tui/ui/dialog-select"
+import { useSDK } from "@tui/context/sdk"
+import { useDialog } from "@tui/ui/dialog"
+import { useToast } from "@tui/ui/toast"
+
+type OrgOption = {
+  accountID: string
+  accountEmail: string
+  accountUrl: string
+  orgID: string
+  orgName: string
+  active: boolean
+}
+
+export function DialogConsoleOrg() {
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const toast = useToast()
+
+  const [orgs] = createResource(async () => {
+    const result = await sdk.client.experimental.console.listOrgs({}, { throwOnError: true })
+    return result.data?.orgs ?? []
+  })
+
+  const current = createMemo(() => orgs()?.find((item) => item.active))
+
+  const options = createMemo(() => {
+    const listed = orgs()
+    if (listed === undefined) {
+      return [
+        {
+          title: "Loading orgs...",
+          value: "loading",
+          onSelect: () => {},
+        },
+      ]
+    }
+
+    if (listed.length === 0) {
+      return [
+        {
+          title: "No orgs found",
+          value: "empty",
+          onSelect: () => {},
+        },
+      ]
+    }
+
+    return listed
+      .toSorted((a, b) => {
+        if (a.active !== b.active) return a.active ? -1 : 1
+        return a.orgName.localeCompare(b.orgName)
+      })
+      .map((item) => ({
+        title: item.orgName,
+        value: item,
+        description: `${item.accountEmail} · ${(() => {
+          try {
+            return new URL(item.accountUrl).host
+          } catch {
+            return item.accountUrl
+          }
+        })()}`,
+        onSelect: async () => {
+          if (item.active) {
+            dialog.clear()
+            return
+          }
+
+          await sdk.client.experimental.console.switchOrg(
+            {
+              accountID: item.accountID,
+              orgID: item.orgID,
+            },
+            { throwOnError: true },
+          )
+
+          await sdk.client.instance.dispose()
+          toast.show({
+            message: `Switched to ${item.orgName}`,
+            variant: "info",
+          })
+          dialog.clear()
+        },
+      }))
+  })
+
+  return <DialogSelect<string | OrgOption> title="Switch org" options={options()} current={current()} />
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-console-org.tsx
@@ -4,15 +4,9 @@ import { useSDK } from "@tui/context/sdk"
 import { useDialog } from "@tui/ui/dialog"
 import { useToast } from "@tui/ui/toast"
 import { useTheme } from "@tui/context/theme"
+import type { ExperimentalConsoleListOrgsResponse } from "@opencode-ai/sdk/v2"
 
-type OrgOption = {
-  accountID: string
-  accountEmail: string
-  accountUrl: string
-  orgID: string
-  orgName: string
-  active: boolean
-}
+type OrgOption = ExperimentalConsoleListOrgsResponse["orgs"][number]
 
 const accountHost = (url: string) => {
   try {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -8,6 +8,7 @@ import { createDialogProviderOptions, DialogProvider } from "./dialog-provider"
 import { DialogVariant } from "./dialog-variant"
 import { useKeybind } from "../context/keybind"
 import * as fuzzysort from "fuzzysort"
+import { consoleManagedProviderLabel } from "@tui/util/provider-origin"
 
 export function useConnected() {
   const sync = useSync()
@@ -33,6 +34,7 @@ export function DialogModel(props: { providerID?: string }) {
     const showSections = showExtra() && needle.length === 0
     const favorites = connected() ? local.model.favorite() : []
     const recents = local.model.recent()
+    const consoleManagedProviders = new Set(sync.data.console_state.consoleManagedProviders)
 
     function toOptions(items: typeof favorites, category: string) {
       if (!showSections) return []
@@ -46,7 +48,7 @@ export function DialogModel(props: { providerID?: string }) {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
             title: model.name ?? item.modelID,
-            description: provider.name,
+            description: consoleManagedProviderLabel(consoleManagedProviders, provider.id, provider.name),
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -84,7 +86,9 @@ export function DialogModel(props: { providerID?: string }) {
             description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
               ? "(Favorite)"
               : undefined,
-            category: connected() ? provider.name : undefined,
+            category: connected()
+              ? consoleManagedProviderLabel(consoleManagedProviders, provider.id, provider.name)
+              : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
             onSelect() {
@@ -132,7 +136,11 @@ export function DialogModel(props: { providerID?: string }) {
     props.providerID ? sync.data.provider.find((x) => x.id === props.providerID) : null,
   )
 
-  const title = createMemo(() => provider()?.name ?? "Select model")
+  const title = createMemo(() => {
+    const value = provider()
+    if (!value) return "Select model"
+    return consoleManagedProviderLabel(sync.data.console_state.consoleManagedProviders, value.id, value.name)
+  })
 
   function onSelect(providerID: string, modelID: string) {
     local.model.set({ providerID, modelID }, { recent: true })

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -34,7 +34,6 @@ export function DialogModel(props: { providerID?: string }) {
     const showSections = showExtra() && needle.length === 0
     const favorites = connected() ? local.model.favorite() : []
     const recents = local.model.recent()
-    const consoleManagedProviders = new Set(sync.data.console_state.consoleManagedProviders)
 
     function toOptions(items: typeof favorites, category: string) {
       if (!showSections) return []
@@ -48,7 +47,11 @@ export function DialogModel(props: { providerID?: string }) {
             key: item,
             value: { providerID: provider.id, modelID: model.id },
             title: model.name ?? item.modelID,
-            description: consoleManagedProviderLabel(consoleManagedProviders, provider.id, provider.name),
+            description: consoleManagedProviderLabel(
+              sync.data.console_state.consoleManagedProviders,
+              provider.id,
+              provider.name,
+            ),
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
             footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
@@ -87,7 +90,7 @@ export function DialogModel(props: { providerID?: string }) {
               ? "(Favorite)"
               : undefined,
             category: connected()
-              ? consoleManagedProviderLabel(consoleManagedProviders, provider.id, provider.name)
+              ? consoleManagedProviderLabel(sync.data.console_state.consoleManagedProviders, provider.id, provider.name)
               : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
             footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -13,6 +13,7 @@ import { DialogModel } from "./dialog-model"
 import { useKeyboard } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
+import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   opencode: 0,
@@ -28,87 +29,113 @@ export function createDialogProviderOptions() {
   const dialog = useDialog()
   const sdk = useSDK()
   const toast = useToast()
+  const { theme } = useTheme()
   const options = createMemo(() => {
+    const consoleManagedProviders = new Set(sync.data.console_state.consoleManagedProviders)
+
     return pipe(
       sync.data.provider_next.all,
       sortBy((x) => PROVIDER_PRIORITY[x.id] ?? 99),
-      map((provider) => ({
-        title: provider.name,
-        value: provider.id,
-        description: {
-          opencode: "(Recommended)",
-          anthropic: "(API key)",
-          openai: "(ChatGPT Plus/Pro or API key)",
-          "opencode-go": "Low cost subscription for everyone",
-        }[provider.id],
-        category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Other",
-        async onSelect() {
-          const methods = sync.data.provider_auth[provider.id] ?? [
-            {
-              type: "api",
-              label: "API key",
-            },
-          ]
-          let index: number | null = 0
-          if (methods.length > 1) {
-            index = await new Promise<number | null>((resolve) => {
-              dialog.replace(
-                () => (
-                  <DialogSelect
-                    title="Select auth method"
-                    options={methods.map((x, index) => ({
-                      title: x.label,
-                      value: index,
-                    }))}
-                    onSelect={(option) => resolve(option.value)}
-                  />
-                ),
-                () => resolve(null),
-              )
-            })
-          }
-          if (index == null) return
-          const method = methods[index]
-          if (method.type === "oauth") {
-            let inputs: Record<string, string> | undefined
-            if (method.prompts?.length) {
-              const value = await PromptsMethod({
-                dialog,
-                prompts: method.prompts,
-              })
-              if (!value) return
-              inputs = value
-            }
+      map((provider) => {
+        const consoleManaged = isConsoleManagedProvider(consoleManagedProviders, provider.id)
+        const connected = sync.data.provider_next.connected.includes(provider.id)
 
-            const result = await sdk.client.provider.oauth.authorize({
-              providerID: provider.id,
-              method: index,
-              inputs,
-            })
-            if (result.error) {
-              toast.show({
-                variant: "error",
-                message: JSON.stringify(result.error),
+        return {
+          title: provider.name,
+          value: provider.id,
+          description: {
+            opencode: "(Recommended)",
+            anthropic: "(API key)",
+            openai: "(ChatGPT Plus/Pro or API key)",
+            "opencode-go": "Low cost subscription for everyone",
+          }[provider.id],
+          footer: consoleManaged ? sync.data.console_state.activeOrgName : undefined,
+          category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Other",
+          gutter: consoleManaged ? (
+            <text fg={theme.textMuted}>{CONSOLE_MANAGED_ICON}</text>
+          ) : connected ? (
+            <text fg={theme.success}>✓</text>
+          ) : undefined,
+          async onSelect() {
+            if (consoleManaged) return
+
+            const methods = sync.data.provider_auth[provider.id] ?? [
+              {
+                type: "api",
+                label: "API key",
+              },
+            ]
+            let index: number | null = 0
+            if (methods.length > 1) {
+              index = await new Promise<number | null>((resolve) => {
+                dialog.replace(
+                  () => (
+                    <DialogSelect
+                      title="Select auth method"
+                      options={methods.map((x, index) => ({
+                        title: x.label,
+                        value: index,
+                      }))}
+                      onSelect={(option) => resolve(option.value)}
+                    />
+                  ),
+                  () => resolve(null),
+                )
               })
-              dialog.clear()
-              return
             }
-            if (result.data?.method === "code") {
-              dialog.replace(() => (
-                <CodeMethod providerID={provider.id} title={method.label} index={index} authorization={result.data!} />
-              ))
+            if (index == null) return
+            const method = methods[index]
+            if (method.type === "oauth") {
+              let inputs: Record<string, string> | undefined
+              if (method.prompts?.length) {
+                const value = await PromptsMethod({
+                  dialog,
+                  prompts: method.prompts,
+                })
+                if (!value) return
+                inputs = value
+              }
+
+              const result = await sdk.client.provider.oauth.authorize({
+                providerID: provider.id,
+                method: index,
+                inputs,
+              })
+              if (result.error) {
+                toast.show({
+                  variant: "error",
+                  message: JSON.stringify(result.error),
+                })
+                dialog.clear()
+                return
+              }
+              if (result.data?.method === "code") {
+                dialog.replace(() => (
+                  <CodeMethod
+                    providerID={provider.id}
+                    title={method.label}
+                    index={index}
+                    authorization={result.data!}
+                  />
+                ))
+              }
+              if (result.data?.method === "auto") {
+                dialog.replace(() => (
+                  <AutoMethod
+                    providerID={provider.id}
+                    title={method.label}
+                    index={index}
+                    authorization={result.data!}
+                  />
+                ))
+              }
             }
-            if (result.data?.method === "auto") {
-              dialog.replace(() => (
-                <AutoMethod providerID={provider.id} title={method.label} index={index} authorization={result.data!} />
-              ))
+            if (method.type === "api") {
+              return dialog.replace(() => <ApiMethod providerID={provider.id} title={method.label} />)
             }
-          }
-          if (method.type === "api") {
-            return dialog.replace(() => <ApiMethod providerID={provider.id} title={method.label} />)
-          }
-        },
-      })),
+          },
+        }
+      }),
     )
   })
   return options

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -31,13 +31,11 @@ export function createDialogProviderOptions() {
   const toast = useToast()
   const { theme } = useTheme()
   const options = createMemo(() => {
-    const consoleManagedProviders = new Set(sync.data.console_state.consoleManagedProviders)
-
     return pipe(
       sync.data.provider_next.all,
       sortBy((x) => PROVIDER_PRIORITY[x.id] ?? 99),
       map((provider) => {
-        const consoleManaged = isConsoleManagedProvider(consoleManagedProviders, provider.id)
+        const consoleManaged = isConsoleManagedProvider(sync.data.console_state.consoleManagedProviders, provider.id)
         const connected = sync.data.provider_next.connected.includes(provider.id)
 
         return {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -35,6 +35,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
 
 export type PromptProps = {
   sessionID?: string
@@ -94,6 +95,14 @@ export function Prompt(props: PromptProps) {
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
   const [auto, setAuto] = createSignal<AutocompleteRef>()
+  const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
+  const currentProviderLabel = createMemo(() => {
+    const current = local.model.current()
+    const provider = local.model.parsed().provider
+    if (!current) return provider
+    return consoleManagedProviderLabel(sync.data.console_state.consoleManagedProviders, current.providerID, provider)
+  })
+  const hasRightContent = createMemo(() => Boolean(props.right || activeOrgName()))
 
   function promptModelWarning() {
     toast.show({
@@ -1095,7 +1104,7 @@ export function Prompt(props: PromptProps) {
                     <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
                       {local.model.parsed().model}
                     </text>
-                    <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
+                    <text fg={theme.textMuted}>{currentProviderLabel()}</text>
                     <Show when={showVariant()}>
                       <text fg={theme.textMuted}>·</text>
                       <text>
@@ -1105,7 +1114,14 @@ export function Prompt(props: PromptProps) {
                   </box>
                 </Show>
               </box>
-              {props.right}
+              <Show when={hasRightContent()}>
+                <box flexDirection="row" gap={1} alignItems="center">
+                  {props.right}
+                  <Show when={activeOrgName()}>
+                    <text fg={theme.textMuted}>{`${CONSOLE_MANAGED_ICON} ${activeOrgName()}`}</text>
+                  </Show>
+                </box>
+              </Show>
             </box>
           </box>
         </box>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1118,7 +1118,9 @@ export function Prompt(props: PromptProps) {
                 <box flexDirection="row" gap={1} alignItems="center">
                   {props.right}
                   <Show when={activeOrgName()}>
-                    <text fg={theme.textMuted}>{`${CONSOLE_MANAGED_ICON} ${activeOrgName()}`}</text>
+                    <text fg={theme.textMuted} onMouseUp={() => command.trigger("console.org.switch")}>
+                      {`${CONSOLE_MANAGED_ICON} ${activeOrgName()}`}
+                    </text>
                   </Show>
                 </box>
               </Show>

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -29,6 +29,7 @@ import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
 import type { Workspace } from "@opencode-ai/sdk/v2"
+import { ConsoleState, emptyConsoleState, type ConsoleState as ConsoleStateType } from "@/config/console-state"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -38,6 +39,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       provider: Provider[]
       provider_default: Record<string, string>
       provider_next: ProviderListResponse
+      console_state: ConsoleStateType
       provider_auth: Record<string, ProviderAuthMethod[]>
       agent: Agent[]
       command: Command[]
@@ -81,6 +83,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         default: {},
         connected: [],
       },
+      console_state: emptyConsoleState,
       provider_auth: {},
       config: {},
       status: "loading",
@@ -365,11 +368,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       // blocking - include session.list when continuing a session
       const providersPromise = sdk.client.config.providers({}, { throwOnError: true })
       const providerListPromise = sdk.client.provider.list({}, { throwOnError: true })
+      const consoleStatePromise = sdk.client.experimental.console
+        .get({}, { throwOnError: true })
+        .then((x) => ConsoleState.parse(x.data))
+        .catch(() => emptyConsoleState)
       const agentsPromise = sdk.client.app.agents({}, { throwOnError: true })
       const configPromise = sdk.client.config.get({}, { throwOnError: true })
       const blockingRequests: Promise<unknown>[] = [
         providersPromise,
         providerListPromise,
+        consoleStatePromise,
         agentsPromise,
         configPromise,
         ...(args.continue ? [sessionListPromise] : []),
@@ -379,6 +387,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         .then(() => {
           const providersResponse = providersPromise.then((x) => x.data!)
           const providerListResponse = providerListPromise.then((x) => x.data!)
+          const consoleStateResponse = consoleStatePromise
           const agentsResponse = agentsPromise.then((x) => x.data ?? [])
           const configResponse = configPromise.then((x) => x.data!)
           const sessionListResponse = args.continue ? sessionListPromise : undefined
@@ -386,20 +395,23 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           return Promise.all([
             providersResponse,
             providerListResponse,
+            consoleStateResponse,
             agentsResponse,
             configResponse,
             ...(sessionListResponse ? [sessionListResponse] : []),
           ]).then((responses) => {
             const providers = responses[0]
             const providerList = responses[1]
-            const agents = responses[2]
-            const config = responses[3]
-            const sessions = responses[4]
+            const consoleState = responses[2]
+            const agents = responses[3]
+            const config = responses[4]
+            const sessions = responses[5]
 
             batch(() => {
               setStore("provider", reconcile(providers.providers))
               setStore("provider_default", reconcile(providers.default))
               setStore("provider_next", reconcile(providerList))
+              setStore("console_state", reconcile(consoleState))
               setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
               if (sessions !== undefined) setStore("session", reconcile(sessions))

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -377,7 +377,6 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       const blockingRequests: Promise<unknown>[] = [
         providersPromise,
         providerListPromise,
-        consoleStatePromise,
         agentsPromise,
         configPromise,
         ...(args.continue ? [sessionListPromise] : []),
@@ -423,6 +422,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           // non-blocking
           Promise.all([
             ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
+            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -38,6 +38,7 @@ export interface DialogSelectOption<T = any> {
   description?: string
   footer?: JSX.Element | string
   category?: string
+  categoryView?: JSX.Element
   disabled?: boolean
   bg?: RGBA
   gutter?: JSX.Element
@@ -291,9 +292,16 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
               <>
                 <Show when={category}>
                   <box paddingTop={index() > 0 ? 1 : 0} paddingLeft={3}>
-                    <text fg={theme.accent} attributes={TextAttributes.BOLD}>
-                      {category}
-                    </text>
+                    <Show
+                      when={options[0]?.categoryView}
+                      fallback={
+                        <text fg={theme.accent} attributes={TextAttributes.BOLD}>
+                          {category}
+                        </text>
+                      }
+                    >
+                      {options[0]?.categoryView}
+                    </Show>
                   </box>
                 </Show>
                 <For each={options}>

--- a/packages/opencode/src/cli/cmd/tui/util/provider-origin.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/provider-origin.ts
@@ -1,0 +1,20 @@
+export const CONSOLE_MANAGED_ICON = "⌂"
+
+const contains = (consoleManagedProviders: string[] | ReadonlySet<string>, providerID: string) =>
+  Array.isArray(consoleManagedProviders)
+    ? consoleManagedProviders.includes(providerID)
+    : consoleManagedProviders.has(providerID)
+
+export const isConsoleManagedProvider = (consoleManagedProviders: string[] | ReadonlySet<string>, providerID: string) =>
+  contains(consoleManagedProviders, providerID)
+
+export const consoleManagedProviderSuffix = (
+  consoleManagedProviders: string[] | ReadonlySet<string>,
+  providerID: string,
+) => (contains(consoleManagedProviders, providerID) ? ` ${CONSOLE_MANAGED_ICON}` : "")
+
+export const consoleManagedProviderLabel = (
+  consoleManagedProviders: string[] | ReadonlySet<string>,
+  providerID: string,
+  providerName: string,
+) => `${providerName}${consoleManagedProviderSuffix(consoleManagedProviders, providerID)}`

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -33,6 +33,7 @@ import { Account } from "@/account"
 import { isRecord } from "@/util/record"
 import { ConfigPaths } from "./paths"
 import { Filesystem } from "@/util/filesystem"
+import type { ConsoleState } from "./console-state"
 import { AppFileSystem } from "@/filesystem"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
@@ -1050,11 +1051,14 @@ export namespace Config {
     config: Info
     directories: string[]
     deps: Promise<void>[]
+    consoleManagedProviders: string[]
+    activeOrgName?: string
   }
 
   export interface Interface {
     readonly get: () => Effect.Effect<Info>
     readonly getGlobal: () => Effect.Effect<Info>
+    readonly getConsoleState: () => Effect.Effect<ConsoleState>
     readonly update: (config: Info) => Effect.Effect<void>
     readonly updateGlobal: (config: Info) => Effect.Effect<Info>
     readonly invalidate: (wait?: boolean) => Effect.Effect<void>
@@ -1260,6 +1264,8 @@ export namespace Config {
           const auth = yield* authSvc.all().pipe(Effect.orDie)
 
           let result: Info = {}
+          const consoleManagedProviders = new Set<string>()
+          let activeOrgName: string | undefined
 
           const scope = (source: string): PluginScope => {
             if (source.startsWith("http://") || source.startsWith("https://")) return "global"
@@ -1371,26 +1377,31 @@ export namespace Config {
             log.debug("loaded custom config from OPENCODE_CONFIG_CONTENT")
           }
 
-          const active = Option.getOrUndefined(yield* accountSvc.active().pipe(Effect.orDie))
-          if (active?.active_org_id) {
+          const activeOrg = Option.getOrUndefined(
+            yield* accountSvc.activeOrg().pipe(Effect.catch(() => Effect.succeed(Option.none()))),
+          )
+          if (activeOrg) {
             yield* Effect.gen(function* () {
               const [configOpt, tokenOpt] = yield* Effect.all(
-                [accountSvc.config(active.id, active.active_org_id!), accountSvc.token(active.id)],
+                [accountSvc.config(activeOrg.account.id, activeOrg.org.id), accountSvc.token(activeOrg.account.id)],
                 { concurrency: 2 },
               )
-              const token = Option.getOrUndefined(tokenOpt)
-              if (token) {
-                process.env["OPENCODE_CONSOLE_TOKEN"] = token
-                Env.set("OPENCODE_CONSOLE_TOKEN", token)
+              if (Option.isSome(tokenOpt)) {
+                process.env["OPENCODE_CONSOLE_TOKEN"] = tokenOpt.value
+                Env.set("OPENCODE_CONSOLE_TOKEN", tokenOpt.value)
               }
 
-              const config = Option.getOrUndefined(configOpt)
-              if (config) {
-                const source = `${active.url}/api/config`
-                const next = yield* loadConfig(JSON.stringify(config), {
+              activeOrgName = activeOrg.org.name
+
+              if (Option.isSome(configOpt)) {
+                const source = `${activeOrg.account.url}/api/config`
+                const next = yield* loadConfig(JSON.stringify(configOpt.value), {
                   dir: path.dirname(source),
                   source,
                 })
+                for (const providerID of Object.keys(next.provider ?? {})) {
+                  consoleManagedProviders.add(providerID)
+                }
                 merge(source, next, "global")
               }
             }).pipe(
@@ -1456,6 +1467,8 @@ export namespace Config {
             config: result,
             directories,
             deps,
+            consoleManagedProviders: Array.from(consoleManagedProviders),
+            activeOrgName,
           }
         })
 
@@ -1471,6 +1484,13 @@ export namespace Config {
 
         const directories = Effect.fn("Config.directories")(function* () {
           return yield* InstanceState.use(state, (s) => s.directories)
+        })
+
+        const getConsoleState = Effect.fn("Config.getConsoleState")(function* () {
+          return yield* InstanceState.use(state, (s) => ({
+            consoleManagedProviders: s.consoleManagedProviders,
+            activeOrgName: s.activeOrgName,
+          }))
         })
 
         const waitForDependencies = Effect.fn("Config.waitForDependencies")(function* () {
@@ -1528,6 +1548,7 @@ export namespace Config {
         return Service.of({
           get,
           getGlobal,
+          getConsoleState,
           update,
           updateGlobal,
           invalidate,
@@ -1551,6 +1572,10 @@ export namespace Config {
 
   export async function getGlobal() {
     return runPromise((svc) => svc.getGlobal())
+  }
+
+  export async function getConsoleState() {
+    return runPromise((svc) => svc.getConsoleState())
   }
 
   export async function update(config: Info) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1051,8 +1051,7 @@ export namespace Config {
     config: Info
     directories: string[]
     deps: Promise<void>[]
-    consoleManagedProviders: string[]
-    activeOrgName?: string
+    consoleState: ConsoleState
   }
 
   export interface Interface {
@@ -1467,8 +1466,10 @@ export namespace Config {
             config: result,
             directories,
             deps,
-            consoleManagedProviders: Array.from(consoleManagedProviders),
-            activeOrgName,
+            consoleState: {
+              consoleManagedProviders: Array.from(consoleManagedProviders),
+              activeOrgName,
+            },
           }
         })
 
@@ -1487,10 +1488,7 @@ export namespace Config {
         })
 
         const getConsoleState = Effect.fn("Config.getConsoleState")(function* () {
-          return yield* InstanceState.use(state, (s) => ({
-            consoleManagedProviders: s.consoleManagedProviders,
-            activeOrgName: s.activeOrgName,
-          }))
+          return yield* InstanceState.use(state, (s) => s.consoleState)
         })
 
         const waitForDependencies = Effect.fn("Config.waitForDependencies")(function* () {

--- a/packages/opencode/src/config/console-state.ts
+++ b/packages/opencode/src/config/console-state.ts
@@ -1,0 +1,13 @@
+import z from "zod"
+
+export const ConsoleState = z.object({
+  consoleManagedProviders: z.array(z.string()),
+  activeOrgName: z.string().optional(),
+})
+
+export type ConsoleState = z.infer<typeof ConsoleState>
+
+export const emptyConsoleState: ConsoleState = {
+  consoleManagedProviders: [],
+  activeOrgName: undefined,
+}

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -8,6 +8,8 @@ import { Instance } from "../../project/instance"
 import { Project } from "../../project/project"
 import { MCP } from "../../mcp"
 import { Session } from "../../session"
+import { Config } from "../../config/config"
+import { ConsoleState } from "../../config/console-state"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
@@ -15,6 +17,27 @@ import { WorkspaceRoutes } from "./workspace"
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
+    .get(
+      "/console",
+      describeRoute({
+        summary: "Get active Console provider metadata",
+        description: "Get the active Console org name and the set of provider IDs managed by that Console org.",
+        operationId: "experimental.console.get",
+        responses: {
+          200: {
+            description: "Active Console provider metadata",
+            content: {
+              "application/json": {
+                schema: resolver(ConsoleState),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await Config.getConsoleState())
+      },
+    )
     .get(
       "/tool/ids",
       describeRoute({

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -75,17 +75,7 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [accounts, active] = await Promise.all([Account.list(), Account.active()])
-        const groups = await Promise.all(
-          accounts.map(async (account) => {
-            try {
-              const orgs = await Account.orgs(account.id)
-              return { account, orgs }
-            } catch {
-              return { account, orgs: [] }
-            }
-          }),
-        )
+        const [groups, active] = await Promise.all([Account.orgsByAccount(), Account.active()])
 
         const orgs = groups.flatMap((group) =>
           group.orgs.map((org) => ({

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -10,10 +10,29 @@ import { MCP } from "../../mcp"
 import { Session } from "../../session"
 import { Config } from "../../config/config"
 import { ConsoleState } from "../../config/console-state"
+import { Account, AccountID, OrgID } from "../../account"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { WorkspaceRoutes } from "./workspace"
+
+const ConsoleOrgOption = z.object({
+  accountID: z.string(),
+  accountEmail: z.string(),
+  accountUrl: z.string(),
+  orgID: z.string(),
+  orgName: z.string(),
+  active: z.boolean(),
+})
+
+const ConsoleOrgList = z.object({
+  orgs: z.array(ConsoleOrgOption),
+})
+
+const ConsoleSwitchBody = z.object({
+  accountID: z.string(),
+  orgID: z.string(),
+})
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
@@ -36,6 +55,62 @@ export const ExperimentalRoutes = lazy(() =>
       }),
       async (c) => {
         return c.json(await Config.getConsoleState())
+      },
+    )
+    .get(
+      "/console/orgs",
+      describeRoute({
+        summary: "List switchable Console orgs",
+        description: "Get the available Console orgs across logged-in accounts, including the current active org.",
+        operationId: "experimental.console.listOrgs",
+        responses: {
+          200: {
+            description: "Switchable Console orgs",
+            content: {
+              "application/json": {
+                schema: resolver(ConsoleOrgList),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const [groups, active] = await Promise.all([Account.orgsByAccount(), Account.active()])
+        const orgs = groups.flatMap((group) =>
+          group.orgs.map((org) => ({
+            accountID: group.account.id,
+            accountEmail: group.account.email,
+            accountUrl: group.account.url,
+            orgID: org.id,
+            orgName: org.name,
+            active: !!active && active.id === group.account.id && active.active_org_id === org.id,
+          })),
+        )
+        return c.json({ orgs })
+      },
+    )
+    .post(
+      "/console/switch",
+      describeRoute({
+        summary: "Switch active Console org",
+        description: "Persist a new active Console account/org selection for the current local OpenCode state.",
+        operationId: "experimental.console.switchOrg",
+        responses: {
+          200: {
+            description: "Switch success",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", ConsoleSwitchBody),
+      async (c) => {
+        const body = c.req.valid("json")
+        await Account.switchOrg(AccountID.make(body.accountID), OrgID.make(body.orgID))
+        return c.json(true)
       },
     )
     .get(

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -75,7 +75,18 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [groups, active] = await Promise.all([Account.orgsByAccount(), Account.active()])
+        const [accounts, active] = await Promise.all([Account.list(), Account.active()])
+        const groups = await Promise.all(
+          accounts.map(async (account) => {
+            try {
+              const orgs = await Account.orgs(account.id)
+              return { account, orgs }
+            } catch {
+              return { account, orgs: [] }
+            }
+          }),
+        )
+
         const orgs = groups.flatMap((group) =>
           group.orgs.map((org) => ({
             accountID: group.account.id,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -25,6 +25,7 @@ import { Npm } from "../../src/npm"
 
 const emptyAccount = Layer.mock(Account.Service)({
   active: () => Effect.succeed(Option.none()),
+  activeOrg: () => Effect.succeed(Option.none()),
 })
 
 const emptyAuth = Layer.mock(Auth.Service)({
@@ -280,6 +281,21 @@ test("resolves env templates in account config with account token", async () => 
           email: "user@example.com",
           url: "https://control.example.com",
           active_org_id: OrgID.make("org-1"),
+        }),
+      ),
+    activeOrg: () =>
+      Effect.succeed(
+        Option.some({
+          account: {
+            id: AccountID.make("account-1"),
+            email: "user@example.com",
+            url: "https://control.example.com",
+            active_org_id: OrgID.make("org-1"),
+          },
+          org: {
+            id: OrgID.make("org-1"),
+            name: "Example Org",
+          },
         }),
       ),
     config: () =>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -24,6 +24,7 @@ import type {
   EventTuiPromptAppend,
   EventTuiSessionSelect,
   EventTuiToastShow,
+  ExperimentalConsoleGetResponses,
   ExperimentalResourceListResponses,
   ExperimentalSessionListResponses,
   ExperimentalWorkspaceCreateErrors,
@@ -981,13 +982,13 @@ export class Config2 extends HeyApiClient {
   }
 }
 
-export class Tool extends HeyApiClient {
+export class Console extends HeyApiClient {
   /**
-   * List tool IDs
+   * Get active Console provider metadata
    *
-   * Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.
+   * Get the active Console org name and the set of provider IDs managed by that Console org.
    */
-  public ids<ThrowOnError extends boolean = false>(
+  public get<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       workspace?: string
@@ -1005,42 +1006,8 @@ export class Tool extends HeyApiClient {
         },
       ],
     )
-    return (options?.client ?? this.client).get<ToolIdsResponses, ToolIdsErrors, ThrowOnError>({
-      url: "/experimental/tool/ids",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * List tools
-   *
-   * Get a list of available tools with their JSON schema parameters for a specific provider and model combination.
-   */
-  public list<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      provider: string
-      model: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "provider" },
-            { in: "query", key: "model" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<ToolListResponses, ToolListErrors, ThrowOnError>({
-      url: "/experimental/tool",
+    return (options?.client ?? this.client).get<ExperimentalConsoleGetResponses, unknown, ThrowOnError>({
+      url: "/experimental/console",
       ...options,
       ...params,
     })
@@ -1239,6 +1206,11 @@ export class Resource extends HeyApiClient {
 }
 
 export class Experimental extends HeyApiClient {
+  private _console?: Console
+  get console(): Console {
+    return (this._console ??= new Console({ client: this.client }))
+  }
+
   private _workspace?: Workspace
   get workspace(): Workspace {
     return (this._workspace ??= new Workspace({ client: this.client }))
@@ -1252,6 +1224,72 @@ export class Experimental extends HeyApiClient {
   private _resource?: Resource
   get resource(): Resource {
     return (this._resource ??= new Resource({ client: this.client }))
+  }
+}
+
+export class Tool extends HeyApiClient {
+  /**
+   * List tool IDs
+   *
+   * Get a list of all available tool IDs, including both built-in tools and dynamically registered tools.
+   */
+  public ids<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ToolIdsResponses, ToolIdsErrors, ThrowOnError>({
+      url: "/experimental/tool/ids",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * List tools
+   *
+   * Get a list of available tools with their JSON schema parameters for a specific provider and model combination.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      provider: string
+      model: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "provider" },
+            { in: "query", key: "model" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ToolListResponses, ToolListErrors, ThrowOnError>({
+      url: "/experimental/tool",
+      ...options,
+      ...params,
+    })
   }
 }
 
@@ -4017,14 +4055,14 @@ export class OpencodeClient extends HeyApiClient {
     return (this._config ??= new Config2({ client: this.client }))
   }
 
-  private _tool?: Tool
-  get tool(): Tool {
-    return (this._tool ??= new Tool({ client: this.client }))
-  }
-
   private _experimental?: Experimental
   get experimental(): Experimental {
     return (this._experimental ??= new Experimental({ client: this.client }))
+  }
+
+  private _tool?: Tool
+  get tool(): Tool {
+    return (this._tool ??= new Tool({ client: this.client }))
   }
 
   private _worktree?: Worktree

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -25,6 +25,8 @@ import type {
   EventTuiSessionSelect,
   EventTuiToastShow,
   ExperimentalConsoleGetResponses,
+  ExperimentalConsoleListOrgsResponses,
+  ExperimentalConsoleSwitchOrgResponses,
   ExperimentalResourceListResponses,
   ExperimentalSessionListResponses,
   ExperimentalWorkspaceCreateErrors,
@@ -1010,6 +1012,75 @@ export class Console extends HeyApiClient {
       url: "/experimental/console",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * List switchable Console orgs
+   *
+   * Get the available Console orgs across logged-in accounts, including the current active org.
+   */
+  public listOrgs<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ExperimentalConsoleListOrgsResponses, unknown, ThrowOnError>({
+      url: "/experimental/console/orgs",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Switch active Console org
+   *
+   * Persist a new active Console account/org selection for the current local OpenCode state.
+   */
+  public switchOrg<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      accountID?: string
+      orgID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "accountID" },
+            { in: "body", key: "orgID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ExperimentalConsoleSwitchOrgResponses, unknown, ThrowOnError>({
+      url: "/experimental/console/switch",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2653,6 +2653,28 @@ export type ConfigProvidersResponses = {
 
 export type ConfigProvidersResponse = ConfigProvidersResponses[keyof ConfigProvidersResponses]
 
+export type ExperimentalConsoleGetData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/console"
+}
+
+export type ExperimentalConsoleGetResponses = {
+  /**
+   * Active Console provider metadata
+   */
+  200: {
+    consoleManagedProviders: Array<string>
+    activeOrgName?: string
+  }
+}
+
+export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[keyof ExperimentalConsoleGetResponses]
+
 export type ToolIdsData = {
   body?: never
   path?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2675,6 +2675,58 @@ export type ExperimentalConsoleGetResponses = {
 
 export type ExperimentalConsoleGetResponse = ExperimentalConsoleGetResponses[keyof ExperimentalConsoleGetResponses]
 
+export type ExperimentalConsoleListOrgsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/console/orgs"
+}
+
+export type ExperimentalConsoleListOrgsResponses = {
+  /**
+   * Switchable Console orgs
+   */
+  200: {
+    orgs: Array<{
+      accountID: string
+      accountEmail: string
+      accountUrl: string
+      orgID: string
+      orgName: string
+      active: boolean
+    }>
+  }
+}
+
+export type ExperimentalConsoleListOrgsResponse =
+  ExperimentalConsoleListOrgsResponses[keyof ExperimentalConsoleListOrgsResponses]
+
+export type ExperimentalConsoleSwitchOrgData = {
+  body?: {
+    accountID: string
+    orgID: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/experimental/console/switch"
+}
+
+export type ExperimentalConsoleSwitchOrgResponses = {
+  /**
+   * Switch success
+   */
+  200: boolean
+}
+
+export type ExperimentalConsoleSwitchOrgResponse =
+  ExperimentalConsoleSwitchOrgResponses[keyof ExperimentalConsoleSwitchOrgResponses]
+
 export type ToolIdsData = {
   body?: never
   path?: never


### PR DESCRIPTION
## Summary
- track active Console org metadata and expose it through a typed experimental route
- show Console-managed providers across the TUI with org-aware indicators in provider, model, and prompt surfaces
- keep the stable provider API unchanged by fusing the metadata in the TUI through the experimental SDK path

## Verification
- bun run --cwd packages/opencode typecheck
- bun --cwd packages/sdk/js script/build.ts