### PR TITLE
feat(plugin): allow tool.execute.after hooks to inject AI-visible messages

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -385,6 +385,33 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         return input.messages
       })
 
+      const flush = Effect.fn("SessionPrompt.flush")(function* (
+        inject: Array<{ role: "user" | "system"; text: string }> | undefined,
+        sessionID: SessionID,
+        user: { agent: string; model: MessageV2.User["model"] },
+      ) {
+        if (!inject?.length) return
+        for (const entry of inject) {
+          const msg: MessageV2.User = {
+            id: MessageID.ascending(),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: user.agent,
+            model: user.model,
+          }
+          yield* sessions.updateMessage(msg)
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: msg.id,
+            sessionID,
+            type: "text",
+            text: entry.role === "system" ? `<system-reminder>\n${entry.text}\n</system-reminder>` : entry.text,
+            synthetic: true,
+          } satisfies MessageV2.TextPart)
+        }
+      })
+
       const resolveTools = Effect.fn("SessionPrompt.resolveTools")(function* (input: {
         agent: Agent.Info
         model: Provider.Model
@@ -466,6 +493,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
                     output,
                   )
+                  yield* flush(
+                    (output as Record<string, any>).inject,
+                    ctx.sessionID,
+                    { agent: input.agent.name, model: { providerID: input.model.providerID, modelID: ModelID.make(input.model.api.id) } },
+                  )
                   return output
                 }),
               )
@@ -497,6 +529,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   "tool.execute.after",
                   { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
                   result,
+                )
+                yield* flush(
+                  (result as Record<string, any>).inject,
+                  ctx.sessionID,
+                  { agent: input.agent.name, model: { providerID: input.model.providerID, modelID: ModelID.make(input.model.api.id) } },
                 )
 
                 const textParts: string[] = []
@@ -682,6 +719,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           "tool.execute.after",
           { tool: "task", sessionID, callID: part.id, args: taskArgs },
           result,
+        )
+        yield* flush(
+          (result as Record<string, any> | undefined)?.inject,
+          sessionID,
+          { agent: lastUser.agent, model: lastUser.model },
         )
 
         assistantMessage.finish = "tool-calls"

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -231,12 +231,32 @@ export interface Hooks {
     input: { cwd: string; sessionID?: string; callID?: string },
     output: { env: Record<string, string> },
   ) => Promise<void>
+  /**
+   * Called after a tool finishes execution. Plugins can modify the tool
+   * result (title, output, metadata) before the AI sees it.
+   *
+   * Set `inject` to append messages the AI will see on the **next** loop
+   * iteration. This enables behavioral enforcement — e.g. reminding the
+   * AI to update planning files after every edit.
+   *
+   * ```ts
+   * "tool.execute.after": async (input, output) => {
+   *   if (input.tool === "edit") {
+   *     output.inject = [
+   *       { role: "user", text: "Remember to update progress.md." },
+   *     ]
+   *   }
+   * }
+   * ```
+   */
   "tool.execute.after"?: (
     input: { tool: string; sessionID: string; callID: string; args: any },
     output: {
       title: string
       output: string
       metadata: any
+      /** Messages to inject into the conversation after this tool call. */
+      inject?: Array<{ role: "user" | "system"; text: string }>
     },
   ) => Promise<void>
   "experimental.chat.messages.transform"?: (


### PR DESCRIPTION
## Summary

- Adds an optional `inject` field to the `tool.execute.after` hook output type, enabling plugins to append synthetic user messages that the AI sees on the next loop iteration
- Implements a `flush` helper in `SessionPrompt` that persists injected entries as synthetic user messages (system-role messages wrapped in `<system-reminder>` tags), called at all three hook sites: registry tools, MCP tools, and subtask tools
- Enables behavioral enforcement skills (e.g. planning-with-files) that need to continuously remind the AI about workflow rules — previously impossible because instructions are forgotten after compaction

### Issue for this PR

Closes #17412

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds message injection support to `tool.execute.after` plugin hooks. When a plugin sets `output.inject`, the messages are persisted as synthetic user messages using the same `Session.updateMessage()` + `Session.updatePart()` pattern already used for subtask summary messages. This is fully backward compatible — `inject` is optional, existing plugins are unaffected.

**Usage:**

```ts
"tool.execute.after": async (input, output) => {
  if (input.tool === "edit") {
    output.inject = [
      { role: "user", text: "Remember to update progress.md." },
    ]
  }
}
```

**Files changed:**

- `packages/plugin/src/index.ts` — Added `inject` field to `tool.execute.after` output type with JSDoc and usage example
- `packages/opencode/src/session/prompt.ts` — Added `flush` Effect helper and integrated it at all three `tool.execute.after` call sites (registry tools, MCP tools, subtask tools)

### How did you verify your code works?

- Type checking passes across all 13 packages (`bun turbo typecheck`)
- All 1822 existing tests pass (4 pre-existing failures unrelated to this change)
- Implementation reuses the existing synthetic user message pattern from subtask summary injection

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
