### PR TITLE
fix(opencode): load .gitignore patterns in experimental file watcher

### DIFF
--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -123,9 +123,30 @@ export namespace FileWatcher {
             const cfgIgnores = cfg.watcher?.ignore ?? []
 
             if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
+              // Load .gitignore and .ignore so the watcher skips ignored
+              // subtrees instead of traversing them (critical for large repos
+              // with heavy gitignored directories like build artifacts).
+              const gitignorePatterns = yield* Effect.promise(async () => {
+                const patterns: string[] = []
+                for (const name of [".gitignore", ".ignore"]) {
+                  try {
+                    const content = await Bun.file(path.join(Instance.directory, name)).text()
+                    for (const line of content.split("\n")) {
+                      const trimmed = line.trim()
+                      if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("!")) continue
+                      patterns.push(trimmed.startsWith("/") ? trimmed.slice(1) : trimmed)
+                    }
+                  } catch {
+                    // file doesn't exist
+                  }
+                }
+                return patterns
+              })
+
               yield* subscribe(Instance.directory, [
                 ...FileIgnore.PATTERNS,
                 ...cfgIgnores,
+                ...gitignorePatterns,
                 ...protecteds(Instance.directory),
               ])
             }


### PR DESCRIPTION
### Issue for this PR

Closes #20977

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The experimental file watcher passes only hardcoded ignore patterns (node_modules, dist, .git, etc.) to `@parcel/watcher`. It never reads `.gitignore` or `.ignore`. So on projects with large gitignored directories (Rust `target/`, data dirs, build artifacts), Parcel watcher traverses and sets up inotify watches on every single ignored file. This pegs the sidecar at 100% CPU indefinitely on startup.

The fix reads `.gitignore` and `.ignore` from the project root before calling `w.subscribe()` and passes the parsed patterns alongside the existing hardcoded and config-based ignores. This lets Parcel watcher skip ignored subtrees entirely during its initial traversal.

I skipped negation patterns (`!`) since Parcel watcher's ignore option doesn't support them — they'd need filtering at the callback level instead, which is a separate concern.

### How did you verify your code works?

Reproduced the issue on a project with ~11GB of gitignored content (.swarm/, engine/, target/). Without the fix, sidecar stays at 98%+ CPU for 45+ seconds and never settles. With the fix (verified via `watcher.ignore` config which exercises the same code path), sidecar drops to ~13% on startup and settles to idle within seconds.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR