### PR TITLE
fix(ui): add clipboard fallback for non-secure HTTP contexts

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -24,6 +24,7 @@ import { messageAgentColor } from "@/utils/agent"
 import { decode64 } from "@/utils/base64"
 import { Persist, persisted } from "@/utils/persist"
 import { StatusPopover } from "../status-popover"
+import { copyToClipboard } from "@opencode-ai/ui/clipboard"
 
 const OPEN_APPS = [
   "vscode",
@@ -246,20 +247,18 @@ export function SessionHeader() {
       })
   }
 
-  const copyPath = () => {
+  const copyPath = async () => {
     const directory = projectDirectory()
     if (!directory) return
-    navigator.clipboard
-      .writeText(directory)
-      .then(() => {
-        showToast({
-          variant: "success",
-          icon: "circle-check",
-          title: language.t("session.share.copy.copied"),
-          description: directory,
-        })
+    const ok = await copyToClipboard(directory)
+    if (ok) {
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: language.t("session.share.copy.copied"),
+        description: directory,
       })
-      .catch((err: unknown) => showRequestError(language, err))
+    }
   }
 
   const centerMount = createMemo(() => document.getElementById("opencode-titlebar-center"))

--- a/packages/ui/src/components/clipboard.tsx
+++ b/packages/ui/src/components/clipboard.tsx
@@ -1,0 +1,26 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  const isSecure =
+    typeof window !== "undefined" &&
+    (window.isSecureContext ?? (location.protocol === "https:" || location.hostname === "localhost"))
+  if (isSecure && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return true
+  }
+  const textarea = document.createElement("textarea")
+  textarea.value = text
+  textarea.style.position = "fixed"
+  textarea.style.left = "-9999px"
+  textarea.style.top = "-9999px"
+  textarea.style.opacity = "0"
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  try {
+    const ok = document.execCommand("copy")
+    document.body.removeChild(textarea)
+    return ok
+  } catch {
+    document.body.removeChild(textarea)
+    return false
+  }
+}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -6,6 +6,7 @@ import { checksum } from "@opencode-ai/util/encode"
 import { ComponentProps, createEffect, createResource, createSignal, onCleanup, splitProps } from "solid-js"
 import { isServer } from "solid-js/web"
 import { stream } from "./markdown-stream"
+import { copyToClipboard } from "./clipboard"
 
 type Entry = {
   hash: string
@@ -199,9 +200,8 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
     const code = button.closest('[data-component="markdown-code"]')?.querySelector("code")
     const content = code?.textContent ?? ""
     if (!content) return
-    const clipboard = navigator?.clipboard
-    if (!clipboard) return
-    await clipboard.writeText(content)
+    const ok = await copyToClipboard(content)
+    if (!ok) return
     const labels = getLabels()
     setCopyState(button, labels, true)
     const existing = timeouts.get(button)

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -55,6 +55,7 @@ import { ToolStatusTitle } from "./tool-status-title"
 import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
+import { copyToClipboard } from "./clipboard"
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -984,7 +985,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
+    await copyToClipboard(content)
     setState("copied", true)
     setTimeout(() => setState("copied", false), 2000)
   }
@@ -1404,7 +1405,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const handleCopy = async () => {
     const content = text()
     if (!content) return
-    await navigator.clipboard.writeText(content)
+    await copyToClipboard(content)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
@@ -1743,27 +1744,9 @@ ToolRegistry.register({
     const handleCopy = async () => {
       const content = text()
       if (!content) return
-
-      try {
-        // Prefer modern clipboard API first
-        if (navigator.clipboard) {
-          await navigator.clipboard.writeText(content)
-        } else {
-          // Fallback to execCommand for non-secure contexts (HTTP environments)
-          const textArea = document.createElement('textarea')
-          textArea.value = content
-          textArea.style.position = 'fixed'
-          textArea.style.opacity = '0'
-          document.body.appendChild(textArea)
-          textArea.select()
-          document.execCommand('copy')
-          document.body.removeChild(textArea)
-        }
-        setCopied(true)
-        setTimeout(() => setCopied(false), 2000)
-      } catch (err) {
-        console.error("Copy failed:", err)
-      }
+      await copyToClipboard(content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
     }
 
     return (

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1743,9 +1743,27 @@ ToolRegistry.register({
     const handleCopy = async () => {
       const content = text()
       if (!content) return
-      await navigator.clipboard.writeText(content)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+
+      try {
+        // Prefer modern clipboard API first
+        if (navigator.clipboard) {
+          await navigator.clipboard.writeText(content)
+        } else {
+          // Fallback to execCommand for non-secure contexts (HTTP environments)
+          const textArea = document.createElement('textarea')
+          textArea.value = content
+          textArea.style.position = 'fixed'
+          textArea.style.opacity = '0'
+          document.body.appendChild(textArea)
+          textArea.select()
+          document.execCommand('copy')
+          document.body.removeChild(textArea)
+        }
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      } catch (err) {
+        console.error("Copy failed:", err)
+      }
     }
 
     return (

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "solid-js"
 import { useI18n } from "../context/i18n"
 import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
+import { copyToClipboard } from "./clipboard"
 
 export interface TextFieldProps
   extends ComponentProps<typeof Kobalte.Input>,
@@ -69,7 +70,7 @@ export function TextField(props: TextFieldProps) {
 
   async function handleCopy() {
     const value = local.value ?? local.defaultValue ?? ""
-    await navigator.clipboard.writeText(value)
+    await copyToClipboard(value)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -6,6 +6,7 @@ import { Icon } from "./icon"
 import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
 import { useI18n } from "../context/i18n"
+import { copyToClipboard } from "./clipboard"
 
 export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "children" | "variant"> {
   tool: string
@@ -69,7 +70,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
   const copy = async () => {
     const text = cleaned()
     if (!text) return
-    await navigator.clipboard.writeText(text)
+    await copyToClipboard(text)
     setState("copied", true)
     setTimeout(() => setState("copied", false), 2000)
   }


### PR DESCRIPTION
### Issue for this PR

Closes #14803

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`navigator.clipboard` is only available in secure contexts (HTTPS or localhost). When accessing the web UI over HTTP on a LAN, the clipboard API is `undefined`, causing copy buttons to throw `TypeError: Cannot read properties of undefined (reading 'writeText')`.
This PR adds a shared `copyToClipboard` utility in `packages/ui/src/components/clipboard.tsx` that:
1. Tries `navigator.clipboard.writeText` in secure contexts
2. Falls back to `document.execCommand("copy")` for non-secure HTTP contexts
Replaced all direct `navigator.clipboard.writeText` calls in `message-part.tsx`, `text-field.tsx`, `tool-error-card.tsx`, `markdown.tsx`, and `session-header.tsx` to use this utility.

### How did you verify your code works?

Built the app with `bun run --cwd packages/app build`, started the server with `bun run --cwd packages/opencode src/index.ts web --hostname 0.0.0.0`, and verified copy buttons work over HTTP on a LAN. Also verified the modern clipboard API still works correctly on localhost/HTTPS.

### Screenshots / recordings
N/A — behavioral fix, no visual changes.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR