### PR TITLE
fix(tui): reconstruct pasted prompt text after wide characters

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -72,6 +72,22 @@ function randomIndex(count: number) {
   return Math.floor(Math.random() * count)
 }
 
+function locate(text: string, width: number) {
+  if (width <= 0) return 0
+
+  let seen = 0
+  let idx = 0
+  for (const char of text) {
+    const span = Bun.stringWidth(char)
+    const next = seen + span
+    if (next >= width) return next === width ? idx + char.length : idx
+    seen = next
+    idx += char.length
+  }
+
+  return idx
+}
+
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
@@ -642,8 +658,10 @@ export function Prompt(props: PromptProps) {
       if (partIndex !== undefined) {
         const part = store.prompt.parts[partIndex]
         if (part?.type === "text" && part.text) {
-          const before = inputText.slice(0, extmark.start)
-          const after = inputText.slice(extmark.end)
+          const start = locate(inputText, extmark.start)
+          const end = locate(inputText, extmark.end)
+          const before = inputText.slice(0, start)
+          const after = inputText.slice(end)
           inputText = before + part.text + after
         }
       }


### PR DESCRIPTION
### Issue for this PR

Closes #20986

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a prompt reconstruction bug in the TUI when multiline pasted text is summarized and the prompt contains wide characters before the pasted token.
Before this change, the submit path used terminal-width offsets as JavaScript string indices when expanding `[Pasted ~N lines]` back into the original text. That caused the submitted prompt to be corrupted for Korean characters.
This change converts width-based extmark offsets to string indices before reconstructing the final prompt text, so the pasted content and trailing input are restored in the correct position.

### How did you verify your code works?

- Reproduced the bug locally in the TUI with Korean text before a multiline paste summary
- Confirmed the submitted prompt was previously corrupted
- Confirmed the submitted prompt now matches the original pasted text plus trailing input

### Screenshots / recordings


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
