### PR TITLE
feat: publish tui.session.select event when switching sessions via dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -74,10 +74,7 @@ export function DialogSessionList() {
         setToDelete(undefined)
       }}
       onSelect={(option) => {
-        route.navigate({
-          type: "session",
-          sessionID: option.value,
-        })
+        sdk.client.tui.selectSession({ body: { sessionID: option.value } })
         dialog.clear()
       }}
       keybind={[


### PR DESCRIPTION
### Issue for this PR

Related to #5409

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#5409 identifies the root gap: internal session navigation doesn't fire a bus event, so plugins can't react to session focus changes. The full solution proposed there is a new `session.start` hook.

This PR is a smaller, self-contained step in that direction: when a user picks a session from the session list dialog, the dialog currently calls `route.navigate()` directly. The `tui.session.select` BusEvent already exists in `event.ts`, the server route already publishes it, and `app.tsx` already listens for it to call `route.navigate()`. The only missing piece is that internal navigation never goes through this path.

Changing `dialog-session-list.tsx` to call `sdk.client.tui.selectSession()` instead of `route.navigate()` directly means:
- Navigation behaviour is identical (the existing event handler in `app.tsx` calls `route.navigate()`)
- The bus event now fires, so plugins subscribed via `event` hooks can observe session switches from the dialog

This doesn't cover `opencode -s` / `opencode -c` startup navigation or the full `session.start` hook concept from #5409, but it's a no-risk incremental improvement for the dialog case specifically.

**Real-world use case:** I'm building [opencode-cache-guard](https://github.com/c0dn/opencode-cache-guard), a plugin that warns when switching to a session whose Anthropic prompt cache has expired. Currently it can only warn on send. With this change it could warn the moment you switch to a stale session.

### How did you verify your code works?

Tested manually with an opencode plugin listening for `tui.session.select`. Before: no event on session switch. After: event fires immediately, navigation still works correctly.

### Screenshots / recordings

N/A — no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR