### PR TITLE
fix(tui): stop clobbering theme mode with auto-detected value on every render event

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -314,8 +314,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     setStore(
       produce((draft) => {
         const lock = pick(kv.get("theme_mode_lock"))
-        const mode = pick(kv.get("theme_mode", props.mode))
-        draft.mode = lock ?? mode ?? props.mode
+        draft.mode = lock ?? props.mode
         draft.lock = lock
         const active = config.theme ?? kv.get("theme", "opencode")
         draft.active = typeof active === "string" ? active : "opencode"
@@ -373,7 +372,6 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
 
     function apply(mode: "dark" | "light") {
-      kv.set("theme_mode", mode)
       if (store.mode === mode) return
       setStore("mode", mode)
       renderer.clearPaletteCache()


### PR DESCRIPTION
### Issue for this PR

Closes #20926

### Type of change

- [x] Bug fix

### What does this PR do?

`apply()` was calling `kv.set("theme_mode", mode)` on every `THEME_MODE` renderer event, persisting the auto-detected value to KV. On the next launch, `kv.get("theme_mode")` returned this stale value and overrode `props.mode` (the freshly queried system background color), so the theme stayed stuck on whichever mode was last detected — even if the system had switched.

Two changes:

1. **Remove `kv.set("theme_mode", mode)` from `apply()`** — auto-detection should never be persisted; only an explicit user lock should be.
2. **Drop the `kv.get("theme_mode")` fallback in init** — on startup, if the user hasn't pinned a lock (`theme_mode_lock`), use `props.mode` directly (live system detection from `getTerminalBackgroundColor()`). This clears any stale KV value left over from the old behavior.

Explicit lock/unlock behavior is unaffected: `pin()` still writes `theme_mode_lock`, and `lock ?? props.mode` in the init correctly picks it up.

### How did you verify your code works?

- `bun run typecheck --filter=opencode` passes
- Traced the init path: without a lock, `draft.mode = props.mode` now comes directly from the terminal background color query — stale KV values can no longer interfere
- The `apply()` / renderer event path no longer touches KV at all, so repeated theme events during a session won't overwrite the next session's startup mode

### Screenshots / recordings

N/A — internal state fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR