### PR TITLE
feat(tui): add Ctrl+Q hotkey to quote selected text into prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -302,6 +302,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const sel = renderer.getSelection()
     if (!sel) return
 
+    if (keybind.match("input_quote_selection", evt)) {
+      if (route.data.type !== "session") return
+      if (!Selection.text(renderer)) return
+      evt.preventDefault()
+      evt.stopPropagation()
+      promptRef.current?.focus()
+      command.trigger("prompt.quote_selection")
+      return
+    }
+
     // Windows Terminal-like behavior:
     // - Ctrl+C copies and dismisses selection
     // - Esc dismisses selection

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -22,6 +22,7 @@ import { useKeyboard, useRenderer, type JSX } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
+import { Selection } from "../../util/selection"
 import type { AssistantMessage, FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
@@ -244,6 +245,19 @@ export function Prompt(props: PromptProps) {
               content: content.data,
             })
           }
+        },
+      },
+      {
+        title: "Quote selection",
+        value: "prompt.quote_selection",
+        keybind: "input_quote_selection",
+        category: "Prompt",
+        hidden: true,
+        onSelect: () => {
+          const text = Selection.text(renderer)
+          if (!text) return
+          insert(Selection.quote(text))
+          renderer.clearSelection()
         },
       },
       {
@@ -773,6 +787,10 @@ export function Prompt(props: PromptProps) {
         draft.extmarkToPartIndex.set(extmarkId, partIndex)
       }),
     )
+  }
+
+  function insert(text: string) {
+    input.insertText(text)
   }
 
   async function pasteImage(file: { filename?: string; content: string; mime: string }) {

--- a/packages/opencode/src/cli/cmd/tui/util/selection.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/selection.ts
@@ -11,8 +11,21 @@ type Renderer = {
 }
 
 export namespace Selection {
+  export function text(renderer: Renderer) {
+    return renderer.getSelection()?.getSelectedText()
+  }
+
+  export function quote(text: string) {
+    return text
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n")
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n") + "\n\n"
+  }
+
   export function copy(renderer: Renderer, toast: Toast): boolean {
-    const text = renderer.getSelection()?.getSelectedText()
+    const text = Selection.text(renderer)
     if (!text) return false
 
     Clipboard.copy(text)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -670,6 +670,7 @@ export namespace Config {
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
+      input_quote_selection: z.string().optional().default("ctrl+q").describe("Quote selected text into input"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z
         .string()

--- a/packages/opencode/test/cli/tui/selection.test.ts
+++ b/packages/opencode/test/cli/tui/selection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { Selection } from "../../../src/cli/cmd/tui/util/selection"
+
+describe("Selection.quote", () => {
+  test("quotes each line and appends spacing", () => {
+    expect(Selection.quote("original\nfew\nlines")).toBe("> original\n> few\n> lines\n\n")
+  })
+
+  test("normalizes windows line endings", () => {
+    expect(Selection.quote("first\r\nsecond\rthird")).toBe("> first\n> second\n> third\n\n")
+  })
+
+  test("preserves blank lines inside selection", () => {
+    expect(Selection.quote("first\n\nthird")).toBe("> first\n> \n> third\n\n")
+  })
+})

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -159,6 +159,22 @@ test("migrates tui-specific keys from opencode.json when tui.json does not exist
   })
 })
 
+test("accepts input_quote_selection keybind", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "tui.json"), JSON.stringify({ keybinds: { input_quote_selection: "ctrl+q" } }, null, 2))
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await TuiConfig.get()
+      expect(config.keybinds?.input_quote_selection).toBe("ctrl+q")
+    },
+  })
+})
+
 test("migrates project legacy tui keys even when global tui.json already exists", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### Issue for this PR

Closes #21025

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Lets you select text in the transcript and press `Ctrl+Q` to insert it into the prompt as a blockquote. Each line gets a `> ` prefix, a trailing blank line is appended, and the terminal selection is cleared afterward. The hotkey is configurable through the existing keybind system (`input_quote_selection`).

Four files touched, all in `packages/opencode`:

`config.ts` gets the new keybind entry with `ctrl+q` as default.
`selection.ts` gains two helpers: `text()` to read the current selection and `quote()` to format it with `> ` prefixes and CRLF normalization.
`prompt/index.tsx` registers a hidden command (`prompt.quote_selection`) that reads the selection, quotes it, inserts at the cursor, and clears the selection.
`app.tsx` intercepts the keybind in the global selection handler before the existing logic can clear the selection out from under us.

Nothing outside this feature was changed. The prompt ref shape and plugin slot types are untouched.

### How did you verify your code works?

Tested manually in the TUI: selected multi-line output, pressed `Ctrl+Q`, confirmed the quoted block landed at cursor position with correct formatting.

### Screenshots / recordings


https://github.com/user-attachments/assets/6a318026-9367-418b-ba2a-76b4aa3a2ccb



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
