### PR TITLE
fix(cli): notify user when auto-update completes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -875,6 +875,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     exit()
   })
 
+  sdk.event.on("installation.updated", async (evt) => {
+    const version = evt.properties.version
+
+    await DialogAlert.show(
+      dialog,
+      "Update Complete",
+      `Successfully updated to OpenCode v${version}. The new version will be used the next time you start opencode.`,
+    )
+  })
+
   const plugin = createMemo(() => {
     if (!ready()) return
     if (route.data.type !== "plugin") return


### PR DESCRIPTION
### Issue for this PR

Closes #21037

### Type of change

- [x] Bug fix

### What does this PR do?

The `upgrade()` function in `src/cli/upgrade.ts` publishes `Installation.Event.Updated` after a successful auto-upgrade, but no subscriber exists in the TUI for this event. The TUI only subscribes to `installation.update-available`, which handles the prompt-to-update flow. This means patch auto-updates happen silently with no user notification.

Added an event listener in `src/cli/cmd/tui/app.tsx` for `installation.updated` that shows an alert dialog with the new version number, informing the user that opencode has been updated and the new version will be used on next start.

### How did you verify your code works?

Typecheck passes. To test manually: downgrade to a previous version (`opencode upgrade 1.3.13`), then run `opencode`. It should auto-update to the latest version and show an alert dialog.

### Screenshots / recordings

N/A - simple event listener addition

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR