### PR TITLE
feat: support disabled flag on individual provider models

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -792,6 +792,7 @@ export namespace Config {
         .record(
           z.string(),
           ModelsDev.Model.partial().extend({
+            disabled: z.boolean().optional().describe("Hide this model from the model picker"),
             variants: z
               .record(
                 z.string(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1261,6 +1261,7 @@ export namespace Provider {
                 delete provider.models[modelID]
               if (model.status === "alpha" && !Flag.OPENCODE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
               if (model.status === "deprecated") delete provider.models[modelID]
+              if (configProvider?.models?.[modelID]?.disabled === true) delete provider.models[modelID]
               if (
                 (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
                 (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))


### PR DESCRIPTION
### Issue for this PR

Closes #21035

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `disabled` boolean to the per-model config schema so users can hide specific models from the picker without removing the entire provider.

Two changes:

1. `config.ts` — adds `disabled: z.boolean().optional()` to the model entry schema (same pattern as the existing variant-level `disabled` field)
2. `provider.ts` — adds one check in the final filter loop: `if (configProvider?.models?.[modelID]?.disabled === true) delete provider.models[modelID]` (same pattern as the existing `blacklist`/`deprecated` filters)

Use case: GitHub Copilot exposes many models in models.dev but only a subset are available on a given subscription tier. This lets users trim the list to what they actually have access to.

```json
"github-copilot": {
  "models": {
    "gpt-5.4": { "disabled": true },
    "grok-code-fast-1": { "disabled": true }
  }
}
```

### How did you verify your code works?

Reviewed the existing filter loop and schema patterns. The change follows the exact same delete-from-map approach used by `blacklist`, `deprecated`, and `alpha` model filtering. No existing tests broken.

### Screenshots / recordings

_N/A — no UI changes, models simply no longer appear in the picker when disabled._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR