### PR TITLE
fix(tui): only show org switch affordances when useful

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -630,19 +630,23 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       category: "Provider",
     },
-    {
-      title: "Switch org",
-      value: "console.org.switch",
-      suggested: Boolean(sync.data.console_state.activeOrgName),
-      slash: {
-        name: "org",
-        aliases: ["orgs", "switch-org"],
-      },
-      onSelect: () => {
-        dialog.replace(() => <DialogConsoleOrg />)
-      },
-      category: "Provider",
-    },
+    ...(sync.data.console_state.switchableOrgCount > 1
+      ? [
+          {
+            title: "Switch org",
+            value: "console.org.switch",
+            suggested: Boolean(sync.data.console_state.activeOrgName),
+            slash: {
+              name: "org",
+              aliases: ["orgs", "switch-org"],
+            },
+            onSelect: () => {
+              dialog.replace(() => <DialogConsoleOrg />)
+            },
+            category: "Provider",
+          },
+        ]
+      : []),
     {
       title: "View status",
       keybind: "status_view",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -96,6 +96,7 @@ export function Prompt(props: PromptProps) {
   const shell = createMemo(() => props.placeholders?.shell ?? [])
   const [auto, setAuto] = createSignal<AutocompleteRef>()
   const activeOrgName = createMemo(() => sync.data.console_state.activeOrgName)
+  const canSwitchOrgs = createMemo(() => sync.data.console_state.switchableOrgCount > 1)
   const currentProviderLabel = createMemo(() => {
     const current = local.model.current()
     const provider = local.model.parsed().provider
@@ -1118,7 +1119,13 @@ export function Prompt(props: PromptProps) {
                 <box flexDirection="row" gap={1} alignItems="center">
                   {props.right}
                   <Show when={activeOrgName()}>
-                    <text fg={theme.textMuted} onMouseUp={() => command.trigger("console.org.switch")}>
+                    <text
+                      fg={theme.textMuted}
+                      onMouseUp={() => {
+                        if (!canSwitchOrgs()) return
+                        command.trigger("console.org.switch")
+                      }}
+                    >
                       {`${CONSOLE_MANAGED_ICON} ${activeOrgName()}`}
                     </text>
                   </Show>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1469,6 +1469,7 @@ export namespace Config {
             consoleState: {
               consoleManagedProviders: Array.from(consoleManagedProviders),
               activeOrgName,
+              switchableOrgCount: 0,
             },
           }
         })

--- a/packages/opencode/src/config/console-state.ts
+++ b/packages/opencode/src/config/console-state.ts
@@ -3,6 +3,7 @@ import z from "zod"
 export const ConsoleState = z.object({
   consoleManagedProviders: z.array(z.string()),
   activeOrgName: z.string().optional(),
+  switchableOrgCount: z.number().int().nonnegative(),
 })
 
 export type ConsoleState = z.infer<typeof ConsoleState>
@@ -10,4 +11,5 @@ export type ConsoleState = z.infer<typeof ConsoleState>
 export const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
   activeOrgName: undefined,
+  switchableOrgCount: 0,
 }

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -54,7 +54,11 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(await Config.getConsoleState())
+        const [consoleState, groups] = await Promise.all([Config.getConsoleState(), Account.orgsByAccount()])
+        return c.json({
+          ...consoleState,
+          switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
+        })
       },
     )
     .get(


### PR DESCRIPTION
## Summary
- add `switchableOrgCount` to console state metadata
- only show the `Switch org` command when more than one org is available
- only make the footer org chip interactive when switching actually makes sense

## Verification
- bun run --cwd packages/opencode typecheck