### PR TITLE
docs(ecosystem): add opencode-ccs-sync plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -38,6 +38,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
+| [opencode-ccs-sync](https://github.com/JasonLandbridge/opencode-ccs-sync)                          | Automatically sync live CCS providers and selected models into OpenCode by convention             |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -38,7 +38,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
-| [opencode-ccs-sync](https://github.com/JasonLandbridge/opencode-ccs-sync)                          | Automatically sync live CCS providers and selected models into OpenCode by convention             |
+| [opencode-ccs-sync](https://github.com/JasonLandbridge/opencode-ccs-sync)                          | An OpenCode plugin that reads your Claude Code Switch (CCS) configuration and automatically syncs the providers into your OpenCode config             |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control         |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds `opencode-ccs-sync` to the OpenCode ecosystem plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

The new entry links to the plugin repository and describes it as a convention-based CCS to OpenCode sync plugin. The goal is to make the plugin discoverable from the official ecosystem page alongside the other community plugins.

### How did you verify your code works?

- verified the docs source file update in `packages/web/src/content/docs/ecosystem.mdx`
- confirmed the new plugin row is inserted in the Plugins table in the expected position

### Screenshots / recordings

_Not applicable - docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR