### PR TITLE
fix(tui): add fallback exit handler for routes without dedicated exit handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -333,6 +333,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     renderer.clearSelection()
   })
 
+  // Fallback exit handler for routes without their own exit handling (e.g. plugin routes).
+  // Home and session routes handle app_exit in their own components, so skip those here.
+  useKeyboard((evt) => {
+    if (evt.defaultPrevented) return
+    if (route.data.type === "home" || route.data.type === "session") return
+    if (!keybind.match("app_exit", evt)) return
+    exit()
+    evt.preventDefault()
+    evt.stopPropagation()
+  })
+
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback
   renderer.console.onCopySelection = async (text: string) => {
     if (!text || text.length === 0) return


### PR DESCRIPTION
### Issue for this PR

Closes #20069

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin routes registered via `api.route.register()` don't have their own
`app_exit` keyboard handler. Since `exitOnCtrlC` is disabled globally, and the
existing handlers (dialog, session, selection) all skip plugin routes, users
get trapped with no way to exit except killing the process.

This adds an app-level fallback in `app.tsx` that fires for any route type that
isn't `home` or `session` (both of which already handle `app_exit` in their own
components). This way future route types also get exit coverage automatically,
rather than needing to be added to an allowlist.

See also #20515, which addresses the same issue but checks for `route === "plugin"`
specifically. This approach uses a negative guard instead so it doesn't need
updating when new route types are introduced.

### How did you verify your code works?

- Full test suite: 1827 pass / 17 skip / 0 fail
- Typecheck: all 13 packages pass
- Manually confirmed that Ctrl+C, Ctrl+D, and leader+q exit from a plugin route

### Screenshots / recordings

N/A — keyboard behavior, no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR