### PR TITLE
tweak: add newline between <content> and first line of read tool output to prevent confusion

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -185,7 +185,7 @@ export const ReadTool = Tool.defineEffect(
         )
       }
 
-      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
+      let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>" + "\n"].join("\n")
       output += file.raw.map((line, i) => `${i + file.offset}: ${line}`).join("\n")
 
       const last = file.offset + file.raw.length - 1


### PR DESCRIPTION
Ex:

This:
```
<content>1: <p align="center">
2:   <a href="https://opencode.ai">
3:     <picture>
4:       <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
</content>
```

Becomes this:

```
<content>
1: <p align="center">
2:   <a href="https://opencode.ai">
3:     <picture>
4:       <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
</content>
```