### PR TITLE
fix(opencode): hash embedded UI theme preload CSP

### DIFF
--- a/packages/opencode/src/server/instance.ts
+++ b/packages/opencode/src/server/instance.ts
@@ -35,11 +35,17 @@ const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   : // @ts-expect-error - generated file at build time
     import("opencode-web-ui.gen.ts").then((module) => module.default as Record<string, string>).catch(() => null)
 
-const DEFAULT_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+const THEME_PRELOAD_SCRIPT =
+  /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i
 
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
+
+export const themePreloadScriptHash = (html: string) => {
+  const match = html.match(THEME_PRELOAD_SCRIPT)
+  if (!match) return ""
+  return createHash("sha256").update(match[2]).digest("base64")
+}
 
 export const InstanceRoutes = (app?: Hono) =>
   (app ?? new Hono())
@@ -288,7 +294,9 @@ export const InstanceRoutes = (app?: Hono) =>
         if (await file.exists()) {
           c.header("Content-Type", file.type)
           if (file.type.startsWith("text/html")) {
-            c.header("Content-Security-Policy", DEFAULT_CSP)
+            const html = await file.text()
+            c.header("Content-Security-Policy", csp(themePreloadScriptHash(html)))
+            return c.body(html)
           }
           return c.body(await file.arrayBuffer())
         } else {
@@ -302,12 +310,8 @@ export const InstanceRoutes = (app?: Hono) =>
             host: "app.opencode.ai",
           },
         })
-        const match = response.headers.get("content-type")?.includes("text/html")
-          ? (await response.clone().text()).match(
-              /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
-            )
-          : undefined
-        const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
+        const text = response.headers.get("content-type")?.includes("text/html") ? await response.clone().text() : ""
+        const hash = text ? themePreloadScriptHash(text) : ""
         response.headers.set("Content-Security-Policy", csp(hash))
         return response
       }

--- a/packages/opencode/test/server/instance-csp.test.ts
+++ b/packages/opencode/test/server/instance-csp.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { createHash } from "node:crypto"
+import { themePreloadScriptHash } from "../../src/server/instance"
+
+describe("instance web csp", () => {
+  test("hashes the inline theme preload script", () => {
+    const html = `<html><script id="oc-theme-preload-script">console.log("x")</script></html>`
+    const hash = createHash("sha256").update(`console.log("x")`).digest("base64")
+    expect(themePreloadScriptHash(html)).toBe(hash)
+  })
+
+  test("embedded html path uses the hashed csp", async () => {
+    const src = await Bun.file(new URL("../../src/server/instance.ts", import.meta.url)).text()
+    expect(src).toContain(`c.header("Content-Security-Policy", csp(themePreloadScriptHash(html)))`)
+    expect(src).not.toContain(`c.header("Content-Security-Policy", DEFAULT_CSP)`)
+  })
+})


### PR DESCRIPTION
Fixes #21088.

## Summary
- hash the inline `oc-theme-preload-script` for embedded HTML, not just proxied HTML
- reuse the same helper for both HTML paths
- add a small regression test for the embedded CSP path

## Verification
- `bun test test/server/instance-csp.test.ts`
- `bun run typecheck`
- validated on a Hetzner Ubuntu server that reproduces the remote/Tailscale access flow
