### PR TITLE
fix(websearch): remove 'deep' option from search type and update descriptions

### DIFF
--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -21,7 +21,7 @@ interface McpSearchRequest {
       query: string
       numResults?: number
       livecrawl?: "fallback" | "preferred"
-      type?: "auto" | "fast" | "deep"
+      type?: "auto" | "fast"
       contextMaxCharacters?: number
     }
   }
@@ -52,11 +52,9 @@ export const WebSearchTool = Tool.define("websearch", async () => {
           "Live crawl mode - 'fallback': use live crawling as backup if cached content unavailable, 'preferred': prioritize live crawling (default: 'fallback')",
         ),
       type: z
-        .enum(["auto", "fast", "deep"])
+        .enum(["auto", "fast"])
         .optional()
-        .describe(
-          "Search type - 'auto': balanced search (default), 'fast': quick results, 'deep': comprehensive search",
-        ),
+        .describe("Search type - 'auto': balanced search (default), 'fast': quick results"),
       contextMaxCharacters: z
         .number()
         .optional()

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -6,7 +6,7 @@
 
 Usage notes:
   - Supports live crawling modes: 'fallback' (backup if cached unavailable) or 'preferred' (prioritize live crawling)
-  - Search types: 'auto' (balanced), 'fast' (quick results), 'deep' (comprehensive search)
+  - Search types: 'auto' (balanced search, default), 'fast' (quick results)
   - Configurable context length for optimal LLM integration
   - Domain filtering and advanced search options available
 


### PR DESCRIPTION
### Issue for this PR

Closes #21044

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a mismatch in the websearch tool config.

We were advertising `deep` as a valid search type, but the Exa backend only accepts `auto` and `fast`. So if a user passed `deep`, it failed at runtime with a validation error from the backend.

This change removes `deep` from the tool schema and updates the tool description text to match what the backend actually supports. That way we don’t present an option that can never work.

### How did you verify your code works?

- Reproduced the issue first using type: "deep" and confirmed backend rejection
- Updated schema/docs to only allow auto and fast.
- Ran bun `turbo typecheck`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR