### PR TITLE
fix(acp): forward session title updates to ACP clients via session_info_update

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -529,6 +529,26 @@ export namespace ACP {
           }
           return
         }
+
+        case "session.updated": {
+          const props = event.properties
+          const session = this.sessionManager.tryGet(props.sessionID)
+          if (!session) return
+          if (!props.info.title) return
+          await this.connection
+            .sessionUpdate({
+              sessionId: session.id,
+              update: {
+                sessionUpdate: "session_info_update",
+                title: props.info.title,
+                updatedAt: new Date(props.info.time.updated).toISOString(),
+              },
+            })
+            .catch((error) => {
+              log.error("failed to send session_info_update to ACP", { error })
+            })
+          return
+        }
       }
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #21013

### Type of change

- [x] Bug fix

### What does this PR do?

The ACP protocol defines `session_info_update` as a valid `SessionUpdate` notification with `title` and `updatedAt` fields, but the OpenCode ACP agent never emitted it.

`Session.setTitle()` (called from `session/prompt.ts` after the first assistant turn generates a title) fires a `session.updated` bus event via `SyncEvent.run(Event.Updated, { sessionID, info: { title } })`. The `handleEvent` switch in `acp/agent.ts` only handled three event types — `permission.asked`, `message.part.updated`, and `message.part.delta` — so the title update was silently dropped and ACP clients never learned the session title had changed.

The fix adds a `case "session.updated"` that:
1. Looks up the session via `sessionManager.tryGet(props.sessionID)` — skips events for sessions not owned by this ACP connection
2. Guards on `props.info.title` being non-empty — avoids spamming clients on unrelated session patches (e.g. `time.updated` touches)
3. Calls `connection.sessionUpdate({ sessionId, update: { sessionUpdate: "session_info_update", title, updatedAt } })`

### How did you verify your code works?

- `cd packages/opencode && bun run typecheck` passes with no errors
- Traced the event path: `Session.setTitle()` → `patch()` → `SyncEvent.run(Event.Updated, ...)` → `handleEvent("session.updated")` → `connection.sessionUpdate(session_info_update)`
- `SessionInfoUpdate` and the `"session_info_update"` literal are both present in `@agentclientprotocol/sdk@0.16.1`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR