### PR TITLE
refactor: Tiered Context Management for Long Running Coding Sessions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1968,7 +1968,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
@@ -3130,7 +3130,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d"],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/migration/20260403183020_memory/migration.sql
+++ b/packages/opencode/migration/20260403183020_memory/migration.sql
@@ -1,0 +1,92 @@
+-- Memory fact table
+CREATE TABLE `memory_fact` (
+	`id` text PRIMARY KEY,
+	`project_id` text NOT NULL,
+	`session_id` text,
+	`category` text NOT NULL,
+	`subject` text NOT NULL,
+	`value` text NOT NULL,
+	`confidence` integer DEFAULT 0 NOT NULL,
+	`source_hash` text NOT NULL,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	CONSTRAINT `fk_memory_fact_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `memory_fact_project_idx` ON `memory_fact` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `memory_fact_subject_idx` ON `memory_fact` (`project_id`,`subject`);
+--> statement-breakpoint
+
+-- Memory window table
+CREATE TABLE `memory_window` (
+	`id` text PRIMARY KEY,
+	`project_id` text NOT NULL,
+	`session_id` text NOT NULL,
+	`started_at` integer NOT NULL,
+	`ended_at` integer NOT NULL,
+	`goal` text NOT NULL,
+	`instructions` text,
+	`discoveries` text,
+	`accomplished` text,
+	`in_progress` text,
+	`blocked_on` text,
+	`files_touched` text NOT NULL,
+	`relevant_dirs` text NOT NULL,
+	`message_ids` text NOT NULL,
+	`parent_window_id` text,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	CONSTRAINT `fk_memory_window_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `memory_window_session_idx` ON `memory_window` (`session_id`);
+--> statement-breakpoint
+CREATE INDEX `memory_window_project_time_idx` ON `memory_window` (`project_id`,`ended_at`);
+--> statement-breakpoint
+
+-- Memory artifact table
+CREATE TABLE `memory_artifact` (
+	`id` text PRIMARY KEY,
+	`project_id` text NOT NULL,
+	`window_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`content` text NOT NULL,
+	`file_path` text,
+	`metadata` text,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	CONSTRAINT `fk_memory_artifact_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE,
+	CONSTRAINT `fk_memory_artifact_window_id_memory_window_id_fk` FOREIGN KEY (`window_id`) REFERENCES `memory_window`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `memory_artifact_window_idx` ON `memory_artifact` (`window_id`);
+--> statement-breakpoint
+CREATE INDEX `memory_artifact_kind_idx` ON `memory_artifact` (`project_id`,`kind`);
+--> statement-breakpoint
+
+-- Memory project table
+CREATE TABLE `memory_project` (
+	`id` text PRIMARY KEY,
+	`project_id` text NOT NULL,
+	`project_key` text NOT NULL,
+	`project_name` text NOT NULL,
+	`status` text DEFAULT 'planned' NOT NULL,
+	`summary` text NOT NULL,
+	`latest_progress` text,
+	`blockers` text,
+	`source_window_ids` text NOT NULL,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	CONSTRAINT `fk_memory_project_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `memory_project_key_idx` ON `memory_project` (`project_id`,`project_key`);
+--> statement-breakpoint
+
+-- FTS5 virtual tables
+CREATE VIRTUAL TABLE `memory_window_fts` USING fts5(id, goal, instructions, discoveries, accomplished, in_progress, content=memory_window, content_rowid=rowid);
+--> statement-breakpoint
+CREATE VIRTUAL TABLE `memory_fact_fts` USING fts5(id, subject, value, content=memory_fact, content_rowid=rowid);
+--> statement-breakpoint
+CREATE VIRTUAL TABLE `memory_artifact_fts` USING fts5(id, content, file_path, content=memory_artifact, content_rowid=rowid);

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -11,6 +11,7 @@ import { ProviderTransform } from "../provider/transform"
 import PROMPT_GENERATE from "./generate.txt"
 import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
+import PROMPT_MEMORY from "./prompt/memory.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
 import { Permission } from "@/permission"
@@ -191,6 +192,21 @@ export namespace Agent {
               native: true,
               hidden: true,
               prompt: PROMPT_COMPACTION,
+              permission: Permission.merge(
+                defaults,
+                Permission.fromConfig({
+                  "*": "deny",
+                }),
+                user,
+              ),
+              options: {},
+            },
+            memory: {
+              name: "memory",
+              mode: "primary",
+              native: true,
+              hidden: true,
+              prompt: PROMPT_MEMORY,
               permission: Permission.merge(
                 defaults,
                 Permission.fromConfig({

--- a/packages/opencode/src/agent/prompt/memory.txt
+++ b/packages/opencode/src/agent/prompt/memory.txt
@@ -1,0 +1,34 @@
+You are a prompt will be used by the memory extraction agent to produce structured JSON.
+
+You You are a memory indexing engine for a coding assistant.
+
+Extract from the conversation above:
+1. GOAL — What the user is trying to accomplish (1-2 sentences)
+2. INSTRUCTIONS — Key instructions the user gave that are still relevant
+3. DISCOVERIES — Notable things learned (code patterns, API behaviors, gotchas)
+4. ACCOMPLISHED — What work has been completed
+5. IN_PROGRESS — What work is still in progress
+6. BLOCKED_ON — Current blockers, unknowns, or next steps needed
+7. FILES — List of files that have been read, edited, or created
+8. FACTS — Durable facts about the user/project (preferences, constraints)
+9. ARTIFACTS — Key decisions made, errors resolved, architecture choices
+
+Rules:
+- Be specific: include file paths, function names, exact values
+- Be conservative: only include facts that will matter later
+- Omit operational chatter and tool scaffolding
+- Return ONLY valid JSON, no other text, no markdown fences
+
+JSON shape:
+{
+  "goal": "...",
+  "instructions": ["..."],
+  "discoveries": ["..."],
+  "accomplished": ["..."],
+  "in_progress": ["..."],
+  "blocked_on": ["..."],
+  "files_touched": ["path/to/file.ts"],
+  "relevant_dirs": ["src/session/"],
+  "facts": [{ "category": "preference", "subject": "test-runner", "value": "prefers bun test" }],
+  "artifacts": [{ "kind": "decision", "content": "use Drizzle ORM for new tables", "file_path": "src/storage/db.ts" }]
+}

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -15,10 +15,16 @@ import { Plugin } from "@/plugin"
 import { Config } from "@/config/config"
 import { NotFoundError } from "@/storage/db"
 import { ModelID, ProviderID } from "@/provider/schema"
-import { Effect, Layer, ServiceMap } from "effect"
+import { Effect, Exit, Layer, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import { InstanceState } from "@/effect/instance-state"
 import { isOverflow as overflow } from "./overflow"
+import { LLM } from "./llm"
+import { MemoryExtractor } from "./memory/extractor"
+import { MemoryRetriever } from "./memory/retriever"
+import { formatMemory } from "./memory"
+import { ProjectTracker } from "./memory/project-tracker"
+import { MemoryStore } from "./memory/store"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -70,6 +76,9 @@ export namespace SessionCompaction {
     | Plugin.Service
     | SessionProcessor.Service
     | Provider.Service
+    | MemoryExtractor.Service
+    | MemoryRetriever.Service
+    | ProjectTracker.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -80,6 +89,9 @@ export namespace SessionCompaction {
       const plugin = yield* Plugin.Service
       const processors = yield* SessionProcessor.Service
       const provider = yield* Provider.Service
+      const extractor = yield* MemoryExtractor.Service
+      const retriever = yield* MemoryRetriever.Service
+      const tracker = yield* ProjectTracker.Service
 
       const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
         tokens: MessageV2.Assistant["tokens"]
@@ -216,12 +228,173 @@ When constructing the summary, try to stick to this template:
 [Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
 ---`
 
-        const prompt = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
-        const msgs = structuredClone(messages)
-        yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-        const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, { stripMedia: true })
         const ctx = yield* InstanceState.context
-        const msg: MessageV2.Assistant = {
+        const projectID = ctx.worktree
+
+        const extractionExit = yield* extractor
+          .extract({
+            messages,
+            sessionID: input.sessionID,
+            projectID,
+          })
+          .pipe(Effect.exit)
+
+        let summaryText: string | null = null
+        if (Exit.isSuccess(extractionExit) && extractionExit.value) {
+          const extracted = extractionExit.value
+          summaryText = extracted.summary
+          log.info("structured extraction succeeded", { sessionID: input.sessionID })
+          yield* tracker
+            .track({
+              extraction: extracted.result,
+              windowID: "",
+              projectID,
+            })
+            .pipe(Effect.ignore)
+        } else {
+          log.info("structured extraction failed, falling back to compaction agent", { sessionID: input.sessionID })
+        }
+
+        if (!summaryText) {
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            role: "assistant",
+            parentID: input.parentID,
+            sessionID: input.sessionID,
+            mode: "compaction",
+            agent: "compaction",
+            variant: userMessage.variant,
+            summary: true,
+            path: {
+              cwd: ctx.directory,
+              root: ctx.worktree,
+            },
+            cost: 0,
+            tokens: {
+              output: 0,
+              input: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            modelID: model.id,
+            providerID: model.providerID,
+            time: {
+              created: Date.now(),
+            },
+          }
+          yield* session.updateMessage(msg)
+          const processor = yield* processors.create({
+            assistantMessage: msg,
+            sessionID: input.sessionID,
+            model,
+          })
+          const modelMsgs = yield* MessageV2.toModelMessagesEffect(messages, model)
+          const result = yield* processor
+            .process({
+              user: userMessage,
+              agent,
+              sessionID: input.sessionID,
+              tools: {},
+              system: [],
+              messages: [
+                ...modelMsgs,
+                {
+                  role: "user",
+                  content: [{ type: "text", text: compacting.prompt ?? defaultPrompt }],
+                },
+              ],
+              model,
+            })
+            .pipe(Effect.onInterrupt(() => processor.abort()))
+
+          if (result === "compact") {
+            processor.message.error = new MessageV2.ContextOverflowError({
+              message: replay
+                ? "Conversation history too large to compact - exceeds model context limit"
+                : "Session too large to compact - context exceeds model limit even after stripping media",
+            }).toObject()
+            processor.message.finish = "error"
+            yield* session.updateMessage(processor.message)
+            return "stop"
+          }
+
+          if (processor.message.error) return "stop"
+          if (result === "continue") yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
+
+          if (input.auto && result === "continue") {
+            if (replay) {
+              const original = replay.info
+              const replayMsg = yield* session.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: input.sessionID,
+                time: { created: Date.now() },
+                agent: original.agent,
+                model: original.model,
+                format: original.format,
+                tools: original.tools,
+                system: original.system,
+                variant: original.variant,
+              })
+              for (const part of replay.parts) {
+                if (part.type === "compaction") continue
+                const replayPart =
+                  part.type === "file" && MessageV2.isMedia(part.mime)
+                    ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
+                    : part
+                yield* session.updatePart({
+                  ...replayPart,
+                  id: PartID.ascending(),
+                  messageID: replayMsg.id,
+                  sessionID: input.sessionID,
+                })
+              }
+            } else {
+              const memoryCtx = yield* retriever
+                .retrieve({
+                  keywords: [],
+                  projectID,
+                  sessionID: input.sessionID,
+                })
+                .pipe(Effect.exit)
+              let memorySection = ""
+              if (Exit.isSuccess(memoryCtx)) {
+                memorySection = formatMemory(memoryCtx.value)
+              }
+
+              const continueMsg = yield* session.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: input.sessionID,
+                time: { created: Date.now() },
+                agent: userMessage.agent,
+                model: userMessage.model,
+              })
+              const text =
+                (input.overflow
+                  ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
+                  : "") +
+                "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed." +
+                (memorySection ? "\n\n" + memorySection : "")
+              yield* session.updatePart({
+                id: PartID.ascending(),
+                messageID: continueMsg.id,
+                sessionID: input.sessionID,
+                type: "text",
+                synthetic: true,
+                text,
+                time: {
+                  start: Date.now(),
+                  end: Date.now(),
+                },
+              })
+            }
+          }
+
+          return result
+        }
+
+        const summaryMsg: MessageV2.Assistant = {
           id: MessageID.ascending(),
           role: "assistant",
           parentID: input.parentID,
@@ -247,42 +420,17 @@ When constructing the summary, try to stick to this template:
             created: Date.now(),
           },
         }
-        yield* session.updateMessage(msg)
-        const processor = yield* processors.create({
-          assistantMessage: msg,
+        yield* session.updateMessage(summaryMsg)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          messageID: summaryMsg.id,
           sessionID: input.sessionID,
-          model,
+          type: "text",
+          text: summaryText,
+          time: { start: Date.now(), end: Date.now() },
         })
-        const result = yield* processor
-          .process({
-            user: userMessage,
-            agent,
-            sessionID: input.sessionID,
-            tools: {},
-            system: [],
-            messages: [
-              ...modelMessages,
-              {
-                role: "user",
-                content: [{ type: "text", text: prompt }],
-              },
-            ],
-            model,
-          })
-          .pipe(Effect.onInterrupt(() => processor.abort()))
 
-        if (result === "compact") {
-          processor.message.error = new MessageV2.ContextOverflowError({
-            message: replay
-              ? "Conversation history too large to compact - exceeds model context limit"
-              : "Session too large to compact - context exceeds model limit even after stripping media",
-          }).toObject()
-          processor.message.finish = "error"
-          yield* session.updateMessage(processor.message)
-          return "stop"
-        }
-
-        if (result === "continue" && input.auto) {
+        if (input.auto) {
           if (replay) {
             const original = replay.info
             const replayMsg = yield* session.updateMessage({
@@ -313,6 +461,18 @@ When constructing the summary, try to stick to this template:
           }
 
           if (!replay) {
+            const memoryCtx = yield* retriever
+              .retrieve({
+                keywords: [],
+                projectID,
+                sessionID: input.sessionID,
+              })
+              .pipe(Effect.exit)
+            let memorySection = ""
+            if (Exit.isSuccess(memoryCtx)) {
+              memorySection = formatMemory(memoryCtx.value)
+            }
+
             const continueMsg = yield* session.updateMessage({
               id: MessageID.ascending(),
               role: "user",
@@ -325,7 +485,8 @@ When constructing the summary, try to stick to this template:
               (input.overflow
                 ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
                 : "") +
-              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed." +
+              (memorySection ? "\n\n" + memorySection : "")
             yield* session.updatePart({
               id: PartID.ascending(),
               messageID: continueMsg.id,
@@ -341,9 +502,8 @@ When constructing the summary, try to stick to this template:
           }
         }
 
-        if (processor.message.error) return "stop"
-        if (result === "continue") yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
-        return result
+        yield* bus.publish(Event.Compacted, { sessionID: input.sessionID })
+        return "continue"
       })
 
       const create = Effect.fn("SessionCompaction.create")(function* (input: {
@@ -383,6 +543,11 @@ When constructing the summary, try to stick to this template:
   export const defaultLayer = Layer.unwrap(
     Effect.sync(() =>
       layer.pipe(
+        Layer.provide(MemoryExtractor.defaultLayer),
+        Layer.provide(MemoryRetriever.defaultLayer),
+        Layer.provide(ProjectTracker.defaultLayer),
+        Layer.provide(MemoryStore.defaultLayer),
+        Layer.provide(LLM.defaultLayer),
         Layer.provide(Provider.defaultLayer),
         Layer.provide(Session.defaultLayer),
         Layer.provide(SessionProcessor.defaultLayer),

--- a/packages/opencode/src/session/memory/extractor.ts
+++ b/packages/opencode/src/session/memory/extractor.ts
@@ -47,35 +47,39 @@ export namespace MemoryExtractor {
           return null
         }
 
-        const userModel = input.messages.find((m) => m.info.role === "user" && m.info.model)
-        const modelRef = userModel?.info.model
+        const lastUser = input.messages.findLast(
+          (m): m is MessageV2.WithParts & { info: MessageV2.User } => m.info.role === "user",
+        )
+        const modelRef = lastUser?.info.model
         const model = modelRef
           ? yield* provider.getModel(modelRef.providerID, modelRef.modelID)
-          : yield* provider.defaultModel()
+          : yield* Effect.gen(function* () {
+              const def = yield* provider.defaultModel()
+              return yield* provider.getModel(def.providerID, def.modelID)
+            })
 
-        const msgs = yield* MessageV2.toModelMessagesEffect(
-          input.messages.filter((m) => m.info.role !== "system"),
-          model,
-          { stripMedia: true },
-        )
+        const msgs = yield* MessageV2.toModelMessagesEffect(input.messages, model, { stripMedia: true })
 
         const extractionPrompt = `Extract structured memory from the conversation above following the JSON schema defined in your system prompt. Return ONLY valid JSON.`
 
-        const result = yield* Effect.promise(async () => {
-          const response = await LLM.stream({
+        const result = yield* Effect.promise((signal) =>
+          LLM.stream({
             agent,
-            user: input.messages.findLast((m) => m.info.role === "user")!.info,
+            user: lastUser!.info,
             system: [],
             tools: {},
             messages: [...msgs, { role: "user", content: extractionPrompt }],
             model,
             sessionID: input.sessionID,
+            abort: signal,
             retries: 1,
-          })
-          return response.text
-        })
+          }).then((r) => r.text),
+        )
 
-        const cleaned = result.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim()
+        const cleaned = result
+          .replace(/```json\n?/g, "")
+          .replace(/```\n?/g, "")
+          .trim()
         let parsed: ExtractionResult
         try {
           parsed = JSON.parse(cleaned)
@@ -151,21 +155,7 @@ export namespace MemoryExtractor {
     }),
   )
 
-  export const defaultLayer = Layer.unwrap(
-    Effect.sync(() =>
-      layer.pipe(
-        Layer.provide(MemoryStore.defaultLayer),
-        Layer.provide(Agent.defaultLayer),
-        Layer.provide(Provider.defaultLayer),
-      ),
-    ),
-  )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function extract(input: ExtractInput) {
-    return runPromise((svc) => svc.extract(input))
-  }
+  export const defaultLayer = layer
 }
 
 function formatSummary(r: ExtractionResult): string {

--- a/packages/opencode/src/session/memory/extractor.ts
+++ b/packages/opencode/src/session/memory/extractor.ts
@@ -1,0 +1,201 @@
+import { Effect, Layer, ServiceMap } from "effect"
+import { Agent } from "@/agent/agent"
+import { Provider } from "@/provider/provider"
+import { MemoryStore } from "./store"
+import { LLM } from "../llm"
+import { MessageV2 } from "../message-v2"
+import { Log } from "@/util/log"
+import type { ExtractionResult } from "./types"
+import type { SessionID } from "../schema"
+import { makeRuntime } from "@/effect/run-service"
+
+export namespace MemoryExtractor {
+  const log = Log.create({ service: "memory.extractor" })
+
+  export interface ExtractInput {
+    messages: MessageV2.WithParts[]
+    sessionID: SessionID
+    projectID: string
+  }
+
+  export interface ExtractOutput {
+    result: ExtractionResult
+    summary: string
+  }
+
+  export interface Interface {
+    readonly extract: (input: ExtractInput) => Effect.Effect<ExtractOutput | null>
+  }
+
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/MemoryExtractor") {}
+
+  export const layer: Layer.Layer<
+    Service,
+    never,
+    Agent.Service | Provider.Service | MemoryStore.Service | LLM.Service
+  > = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const agents = yield* Agent.Service
+      const provider = yield* Provider.Service
+      const store = yield* MemoryStore.Service
+
+      const extract = Effect.fn("MemoryExtractor.extract")(function* (input: ExtractInput) {
+        const agent = yield* agents.get("memory")
+        if (!agent) {
+          log.info("memory agent not found")
+          return null
+        }
+
+        const userModel = input.messages.find((m) => m.info.role === "user" && m.info.model)
+        const modelRef = userModel?.info.model
+        const model = modelRef
+          ? yield* provider.getModel(modelRef.providerID, modelRef.modelID)
+          : yield* provider.defaultModel()
+
+        const msgs = yield* MessageV2.toModelMessagesEffect(
+          input.messages.filter((m) => m.info.role !== "system"),
+          model,
+          { stripMedia: true },
+        )
+
+        const extractionPrompt = `Extract structured memory from the conversation above following the JSON schema defined in your system prompt. Return ONLY valid JSON.`
+
+        const result = yield* Effect.promise(async () => {
+          const response = await LLM.stream({
+            agent,
+            user: input.messages.findLast((m) => m.info.role === "user")!.info,
+            system: [],
+            tools: {},
+            messages: [...msgs, { role: "user", content: extractionPrompt }],
+            model,
+            sessionID: input.sessionID,
+            retries: 1,
+          })
+          return response.text
+        })
+
+        const cleaned = result.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim()
+        let parsed: ExtractionResult
+        try {
+          parsed = JSON.parse(cleaned)
+        } catch (e) {
+          log.info("extraction produced invalid JSON", { error: String(e) })
+          return null
+        }
+
+        if (!parsed.goal && !parsed.instructions?.length && !parsed.accomplished?.length) {
+          log.info("extraction produced empty data")
+          return null
+        }
+
+        const windowID = crypto.randomUUID()
+        const now = Date.now()
+        const messageIDs = input.messages.map((m) => m.info.id)
+        const firstTime = input.messages[0]?.info.time?.created ?? now
+
+        yield* store.writeWindow({
+          id: windowID,
+          project_id: input.projectID,
+          session_id: input.sessionID,
+          started_at: firstTime,
+          ended_at: now,
+          goal: parsed.goal ?? "",
+          instructions: parsed.instructions?.join("\n") ?? null,
+          discoveries: parsed.discoveries?.join("\n") ?? null,
+          accomplished: parsed.accomplished?.join("\n") ?? null,
+          in_progress: parsed.in_progress?.join("\n") ?? null,
+          blocked_on: parsed.blocked_on?.join("\n") ?? null,
+          files_touched: parsed.files_touched ?? [],
+          relevant_dirs: parsed.relevant_dirs ?? [],
+          message_ids: messageIDs,
+          parent_window_id: null,
+        })
+
+        if (parsed.facts?.length) {
+          yield* store.writeFacts(
+            parsed.facts.map((f) => ({
+              id: crypto.randomUUID(),
+              project_id: input.projectID,
+              session_id: input.sessionID,
+              category: f.category,
+              subject: f.subject,
+              value: f.value,
+              confidence: f.category === "preference" ? 100 : f.category === "constraint" ? 90 : 50,
+              source_hash: Bun.hash(f.subject + ":" + f.value).toString(36),
+            })),
+          )
+        }
+
+        if (parsed.artifacts?.length) {
+          yield* store.writeArtifacts(
+            parsed.artifacts.map((a) => ({
+              id: crypto.randomUUID(),
+              project_id: input.projectID,
+              window_id: windowID,
+              kind: a.kind,
+              content: a.content,
+              file_path: a.file_path ?? null,
+              metadata: null,
+            })),
+          )
+        }
+
+        const summary = formatSummary(parsed)
+        log.info("extraction complete", { windowID, facts: parsed.facts?.length, artifacts: parsed.artifacts?.length })
+
+        return { result: parsed, summary }
+      })
+
+      return Service.of({ extract })
+    }),
+  )
+
+  export const defaultLayer = Layer.unwrap(
+    Effect.sync(() =>
+      layer.pipe(
+        Layer.provide(MemoryStore.defaultLayer),
+        Layer.provide(Agent.defaultLayer),
+        Layer.provide(Provider.defaultLayer),
+      ),
+    ),
+  )
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function extract(input: ExtractInput) {
+    return runPromise((svc) => svc.extract(input))
+  }
+}
+
+function formatSummary(r: ExtractionResult): string {
+  const sections: string[] = []
+  sections.push("## Goal\n")
+  sections.push(r.goal ?? "No clear goal identified")
+  if (r.instructions?.length) {
+    sections.push("\n## Instructions\n")
+    sections.push(r.instructions.map((i) => `- ${i}`).join("\n"))
+  }
+  if (r.discoveries?.length) {
+    sections.push("\n## Discoveries\n")
+    sections.push(r.discoveries.map((d) => `- ${d}`).join("\n"))
+  }
+  if (r.accomplished?.length) {
+    sections.push("\n## Accomplished\n")
+    sections.push(r.accomplished.map((a) => `- ${a}`).join("\n"))
+  }
+  if (r.in_progress?.length) {
+    sections.push("\n## In Progress\n")
+    sections.push(r.in_progress.map((i) => `- ${i}`).join("\n"))
+  }
+  if (r.blocked_on?.length) {
+    sections.push("\n## Blocked On\n")
+    sections.push(r.blocked_on.map((b) => `- ${b}`).join("\n"))
+  }
+  const files = [...(r.files_touched ?? []), ...(r.relevant_dirs ?? [])]
+  if (files.length) {
+    sections.push("\n## Relevant files / directories\n")
+    sections.push(files.map((f) => `- ${f}`).join("\n"))
+  }
+  return sections.join("\n")
+}

--- a/packages/opencode/src/session/memory/index.ts
+++ b/packages/opencode/src/session/memory/index.ts
@@ -1,6 +1,6 @@
 export { MemoryExtractor } from "./extractor"
 export { MemoryRetriever } from "./retriever"
-export { MemoryInjector } from "./injector"
+export { format as formatMemory, formatSummary as formatMemorySummary } from "./injector"
 export { ProjectTracker } from "./project-tracker"
 export { MemoryStore } from "./store"
 export type { MemoryResult } from "./retriever"

--- a/packages/opencode/src/session/memory/index.ts
+++ b/packages/opencode/src/session/memory/index.ts
@@ -1,0 +1,7 @@
+export { MemoryExtractor } from "./extractor"
+export { MemoryRetriever } from "./retriever"
+export { MemoryInjector } from "./injector"
+export { ProjectTracker } from "./project-tracker"
+export { MemoryStore } from "./store"
+export type { MemoryResult } from "./retriever"
+export type { ExtractionResult, MemoryFact, MemoryWindow, MemoryArtifact, MemoryProject } from "./types"

--- a/packages/opencode/src/session/memory/injector.ts
+++ b/packages/opencode/src/session/memory/injector.ts
@@ -1,0 +1,70 @@
+import type { MemoryFact, MemoryWindow, MemoryArtifact } from "./types"
+
+export interface MemoryResult {
+  windows: MemoryWindow[]
+  facts: MemoryFact[]
+  artifacts: MemoryArtifact[]
+}
+
+export function format(result: MemoryResult): string {
+  if (!result.windows.length && !result.facts.length && !result.artifacts.length) return ""
+
+  const win = result.windows[0]
+  const sections: string[] = []
+
+  if (win?.goal) {
+    sections.push("### Current Goal")
+    sections.push(win.goal)
+  }
+
+  if (win?.in_progress) {
+    sections.push("### In Progress")
+    sections.push(win.in_progress)
+  }
+
+  if (win?.blocked_on) {
+    sections.push("### Blockers")
+    sections.push(win.blocked_on)
+  }
+
+  const files = [...(win?.files_touched ?? []), ...(win?.relevant_dirs ?? [])]
+  if (files.length) {
+    sections.push("### Key Files")
+    sections.push(files.map((f) => `- ${f}`).join("\n"))
+  }
+
+  const decisions = result.artifacts
+    .filter((a) => a.kind === "decision")
+    .slice(0, 3)
+  .map((a) => a.content)
+  if (decisions.length) {
+    sections.push("### Recent Decisions")
+    sections.push(decisions.map((d) => `- ${d}`).join("\n"))
+  }
+
+  const facts = result.facts.slice(0, 5)
+  if (facts.length) {
+    sections.push("### Relevant Facts")
+    sections.push(facts.map((f) => `- ${f.subject}: ${f.value}`).join("\n"))
+  }
+
+  if (sections.length === 0) return ""
+  return "<system-reminder>\n## Memory Context\n\n" + sections.join("\n\n") + "\n</system-reminder>"
+}
+
+export function formatSummary(result: MemoryResult): string {
+  if (!result.windows.length && !result.facts.length && !result.artifacts.length) return ""
+
+  const win = result.windows[0]
+  const sections: string[] = []
+
+  if (win?.goal) sections.push(`Goal: ${win.goal}`)
+  if (win?.in_progress) sections.push(`In progress: ${win.in_progress}`)
+  if (win?.blocked_on) sections.push(`Blocked on: ${win.blocked_on}`)
+
+  const files = [...(win?.files_touched ?? []), ...(win?.relevant_dirs ?? [])]
+  if (files.length) sections.push(`Files: ${files.join(", ")}`)
+
+  if (sections.length === 0) return ""
+  return sections.join(" | ")
+}

--- a/packages/opencode/src/session/memory/project-tracker.ts
+++ b/packages/opencode/src/session/memory/project-tracker.ts
@@ -3,7 +3,6 @@ import { Database, eq, and, desc } from "../../storage/db"
 import { MemoryProjectTable } from "../session.sql"
 import { Log } from "@/util/log"
 import type { ExtractionResult, MemoryProject } from "./types"
-import { makeRuntime } from "@/effect/run-service"
 
 export namespace ProjectTracker {
   const log = Log.create({ service: "memory.project-tracker" })
@@ -41,12 +40,7 @@ export namespace ProjectTracker {
           d
             .select()
             .from(MemoryProjectTable)
-            .where(
-              and(
-                eq(MemoryProjectTable.project_id, input.projectID),
-                eq(MemoryProjectTable.project_key, key),
-              ),
-            )
+            .where(and(eq(MemoryProjectTable.project_id, input.projectID), eq(MemoryProjectTable.project_key, key)))
             .all(),
         )
 
@@ -107,12 +101,7 @@ export namespace ProjectTracker {
           d
             .select()
             .from(MemoryProjectTable)
-            .where(
-              and(
-                eq(MemoryProjectTable.project_id, projectID),
-                eq(MemoryProjectTable.status, "in_progress"),
-              ),
-            )
+            .where(and(eq(MemoryProjectTable.project_id, projectID), eq(MemoryProjectTable.status, "in_progress")))
             .orderBy(desc(MemoryProjectTable.time_updated))
             .all(),
         )
@@ -123,18 +112,4 @@ export namespace ProjectTracker {
   )
 
   export const defaultLayer = layer
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function track(input: {
-    extraction: ExtractionResult
-    windowID: string
-    projectID: string
-  }) {
-    return runPromise((svc) => svc.track(input))
-  }
-
-  export async function getActive(projectID: string) {
-    return runPromise((svc) => svc.getActive(projectID))
-  }
 }

--- a/packages/opencode/src/session/memory/project-tracker.ts
+++ b/packages/opencode/src/session/memory/project-tracker.ts
@@ -1,0 +1,140 @@
+import { Effect, Layer, ServiceMap } from "effect"
+import { Database, eq, and, desc } from "../../storage/db"
+import { MemoryProjectTable } from "../session.sql"
+import { Log } from "@/util/log"
+import type { ExtractionResult, MemoryProject } from "./types"
+import { makeRuntime } from "@/effect/run-service"
+
+export namespace ProjectTracker {
+  const log = Log.create({ service: "memory.project-tracker" })
+
+  export interface Interface {
+    readonly track: (input: {
+      extraction: ExtractionResult
+      windowID: string
+      projectID: string
+    }) => Effect.Effect<void>
+    readonly getActive: (projectID: string) => Effect.Effect<MemoryProject[]>
+  }
+
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/ProjectTracker") {}
+
+  export const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const track = Effect.fn("ProjectTracker.track")(function* (input: {
+        extraction: ExtractionResult
+        windowID: string
+        projectID: string
+      }) {
+        const goal = input.extraction.goal ?? ""
+        const key = goal
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/(^-+|-+$)/g, "")
+          .slice(0, 50)
+        if (!key) return
+
+        const now = Date.now()
+
+        const existing = Database.use((d) =>
+          d
+            .select()
+            .from(MemoryProjectTable)
+            .where(
+              and(
+                eq(MemoryProjectTable.project_id, input.projectID),
+                eq(MemoryProjectTable.project_key, key),
+              ),
+            )
+            .all(),
+        )
+
+        if (existing.length > 0) {
+          const proj = existing[0]
+          const inProgress = input.extraction.in_progress?.length ?? 0
+          const accomplished = input.extraction.accomplished?.length ?? 0
+          const status = accomplished && !inProgress ? "done" : inProgress ? "in_progress" : proj.status
+
+          const windowIds = [...(proj.source_window_ids ?? []), input.windowID]
+
+          Database.use((d) =>
+            d
+              .update(MemoryProjectTable)
+              .set({
+                status,
+                summary: goal,
+                latest_progress: input.extraction.in_progress?.join("; ") ?? null,
+                blockers: input.extraction.blocked_on?.join("; ") ?? null,
+                source_window_ids: [...new Set(windowIds)],
+                time_updated: now,
+              })
+              .where(eq(MemoryProjectTable.id, proj.id))
+              .run(),
+          )
+
+          log.info("updated project", { key, status })
+          return
+        }
+
+        const inProgress = input.extraction.in_progress?.length ?? 0
+        const status = inProgress ? "in_progress" : "planned"
+
+        Database.use((d) =>
+          d
+            .insert(MemoryProjectTable)
+            .values({
+              id: crypto.randomUUID(),
+              project_id: input.projectID,
+              project_key: key,
+              project_name: goal.slice(0, 100),
+              status,
+              summary: goal,
+              latest_progress: input.extraction.in_progress?.join("; ") ?? null,
+              blockers: input.extraction.blocked_on?.join("; ") ?? null,
+              source_window_ids: [input.windowID],
+              time_created: now,
+              time_updated: now,
+            })
+            .run(),
+        )
+
+        log.info("created project", { key, status })
+      })
+
+      const getActive = Effect.fn("ProjectTracker.getActive")(function* (projectID: string) {
+        return Database.use((d) =>
+          d
+            .select()
+            .from(MemoryProjectTable)
+            .where(
+              and(
+                eq(MemoryProjectTable.project_id, projectID),
+                eq(MemoryProjectTable.status, "in_progress"),
+              ),
+            )
+            .orderBy(desc(MemoryProjectTable.time_updated))
+            .all(),
+        )
+      })
+
+      return Service.of({ track, getActive })
+    }),
+  )
+
+  export const defaultLayer = layer
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function track(input: {
+    extraction: ExtractionResult
+    windowID: string
+    projectID: string
+  }) {
+    return runPromise((svc) => svc.track(input))
+  }
+
+  export async function getActive(projectID: string) {
+    return runPromise((svc) => svc.getActive(projectID))
+  }
+}

--- a/packages/opencode/src/session/memory/retriever.ts
+++ b/packages/opencode/src/session/memory/retriever.ts
@@ -1,0 +1,90 @@
+import { Effect, Layer, ServiceMap } from "effect"
+import { MemoryStore } from "./store"
+import { Log } from "@/util/log"
+import type { MemoryFact, MemoryWindow, MemoryArtifact } from "./types"
+import type { SessionID } from "../schema"
+import { makeRuntime } from "@/effect/run-service"
+
+export interface MemoryResult {
+  windows: MemoryWindow[]
+  facts: MemoryFact[]
+  artifacts: MemoryArtifact[]
+}
+
+export namespace MemoryRetriever {
+  const log = Log.create({ service: "memory.retriever" })
+
+  export interface RetrieveInput {
+    keywords: string[]
+    projectID: string
+    sessionID?: SessionID
+    limit?: { windows?: number; facts?: number; artifacts?: number }
+  }
+
+  export interface Interface {
+    readonly retrieve: (input: RetrieveInput) => Effect.Effect<MemoryResult>
+  }
+
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/MemoryRetriever") {}
+
+  export const layer: Layer.Layer<Service, never, MemoryStore.Service> = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const store = yield* MemoryStore.Service
+
+      const retrieve = Effect.fn("MemoryRetriever.retrieve")(function* (input: RetrieveInput) {
+        const limit = {
+          windows: input.limit?.windows ?? 3,
+          facts: input.limit?.facts ?? 5,
+          artifacts: input.limit?.artifacts ?? 5,
+        }
+        const hasKeywords = input.keywords.length > 0 && input.keywords.some((k) => k.trim().length > 0)
+        if (hasKeywords) {
+          const query = input.keywords.map((k) => `"${k.replace(/"/g, '""')}"`).join(" OR ")
+          const [searched, recent] = yield* Effect.all(
+            [
+              store.searchWindows(query, { projectID: input.projectID, limit: limit.windows }),
+              store.getRecentWindows({ projectID: input.projectID, limit: 1 }),
+            ],
+            { concurrency: "unbounded" },
+          )
+          const seen = new Set(searched.map((w) => w.id))
+          let windows = [...searched]
+          for (const w of recent) {
+            if (!seen.has(w.id)) {
+              windows.unshift(w)
+              seen.add(w.id)
+            }
+          }
+          windows = windows.slice(0, limit.windows)
+          const [facts, artifacts] = yield* Effect.all(
+            [
+              store.searchFacts(query, { projectID: input.projectID, limit: limit.facts }),
+              store.searchArtifacts(query, { projectID: input.projectID, limit: limit.artifacts }),
+            ],
+            { concurrency: "unbounded" },
+          )
+          return { windows, facts, artifacts }
+        } else {
+          const windows = yield* store.getRecentWindows({ projectID: input.projectID, limit: limit.windows })
+          const facts = yield* store.getDurableFacts(input.projectID)
+          return {
+            windows,
+            facts: windows.length > 0 ? facts.slice(0, limit.facts) : [],
+            artifacts: [] as MemoryArtifact[],
+          }
+        }
+      })
+
+      return Service.of({ retrieve })
+    }),
+  )
+
+  export const defaultLayer = layer
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function retrieve(input: RetrieveInput) {
+    return runPromise((svc) => svc.retrieve(input))
+  }
+}

--- a/packages/opencode/src/session/memory/retriever.ts
+++ b/packages/opencode/src/session/memory/retriever.ts
@@ -3,7 +3,6 @@ import { MemoryStore } from "./store"
 import { Log } from "@/util/log"
 import type { MemoryFact, MemoryWindow, MemoryArtifact } from "./types"
 import type { SessionID } from "../schema"
-import { makeRuntime } from "@/effect/run-service"
 
 export interface MemoryResult {
   windows: MemoryWindow[]
@@ -81,10 +80,4 @@ export namespace MemoryRetriever {
   )
 
   export const defaultLayer = layer
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function retrieve(input: RetrieveInput) {
-    return runPromise((svc) => svc.retrieve(input))
-  }
 }

--- a/packages/opencode/src/session/memory/store.ts
+++ b/packages/opencode/src/session/memory/store.ts
@@ -1,9 +1,8 @@
 import { Effect, Layer, ServiceMap } from "effect"
-import { Database, eq, and, desc } from "../../storage/db"
+import { Database, eq, and, desc, sql } from "../../storage/db"
 import { MemoryFactTable, MemoryWindowTable, MemoryArtifactTable } from "../session.sql"
 import { Log } from "@/util/log"
 import type { MemoryFact, MemoryWindow, MemoryArtifact } from "./types"
-import { makeRuntime } from "@/effect/run-service"
 
 export namespace MemoryStore {
   const log = Log.create({ service: "memory.store" })
@@ -34,16 +33,8 @@ export namespace MemoryStore {
       ) {
         Database.transaction((tx) => {
           tx.insert(MemoryWindowTable).values(window).run()
-          tx.$client.run(
-            `INSERT INTO memory_window_fts(id, goal, instructions, discoveries, accomplished, in_progress) VALUES (?, ?, ?, ?, ?, ?)`,
-            [
-              window.id,
-              window.goal,
-              window.instructions ?? "",
-              window.discoveries ?? "",
-              window.accomplished ?? "",
-              window.in_progress ?? "",
-            ],
+          tx.run(
+            sql`INSERT INTO memory_window_fts(id, goal, instructions, discoveries, accomplished, in_progress) VALUES (${window.id}, ${window.goal}, ${window.instructions ?? ""}, ${window.discoveries ?? ""}, ${window.accomplished ?? ""}, ${window.in_progress ?? ""})`,
           )
         })
         log.info("wrote window", { id: window.id })
@@ -56,11 +47,9 @@ export namespace MemoryStore {
         Database.transaction((tx) => {
           for (const fact of facts) {
             tx.insert(MemoryFactTable).values(fact).run()
-            tx.run(`INSERT INTO memory_fact_fts(id, subject, value) VALUES (?, ?, ?)`, [
-              fact.id,
-              fact.subject,
-              fact.value,
-            ])
+            tx.run(
+              sql`INSERT INTO memory_fact_fts(id, subject, value) VALUES (${fact.id}, ${fact.subject}, ${fact.value})`,
+            )
           }
         })
         log.info("wrote facts", { count: facts.length })
@@ -73,11 +62,9 @@ export namespace MemoryStore {
         Database.transaction((tx) => {
           for (const artifact of artifacts) {
             tx.insert(MemoryArtifactTable).values(artifact).run()
-            tx.run(`INSERT INTO memory_artifact_fts(id, content, file_path) VALUES (?, ?, ?)`, [
-              artifact.id,
-              artifact.content,
-              artifact.file_path ?? "",
-            ])
+            tx.run(
+              sql`INSERT INTO memory_artifact_fts(id, content, file_path) VALUES (${artifact.id}, ${artifact.content}, ${artifact.file_path ?? ""})`,
+            )
           }
         })
         log.info("wrote artifacts", { count: artifacts.length })
@@ -105,11 +92,10 @@ export namespace MemoryStore {
         return Database.use((d) => {
           const escaped = query.replace(/"/g, '""')
           return d.all<MemoryWindow>(
-            `SELECT mw.* FROM memory_window mw
+            sql`SELECT mw.* FROM memory_window mw
              JOIN memory_window_fts fts ON mw.id = fts.id
-             WHERE memory_window_fts MATCH ? AND mw.project_id = ?
-             ORDER BY mw.ended_at DESC LIMIT ?`,
-            [`"${escaped}"`, opts.projectID, opts.limit],
+             WHERE memory_window_fts MATCH ${`"${escaped}"`} AND mw.project_id = ${opts.projectID}
+             ORDER BY mw.ended_at DESC LIMIT ${opts.limit}`,
           )
         })
       })
@@ -121,11 +107,10 @@ export namespace MemoryStore {
         return Database.use((d) => {
           const escaped = query.replace(/"/g, '""')
           return d.all<MemoryFact>(
-            `SELECT mf.* FROM memory_fact mf
+            sql`SELECT mf.* FROM memory_fact mf
              JOIN memory_fact_fts fts ON mf.id = fts.id
-             WHERE memory_fact_fts MATCH ? AND mf.project_id = ?
-             ORDER BY mf.confidence DESC LIMIT ?`,
-            [`"${escaped}"`, opts.projectID, opts.limit],
+             WHERE memory_fact_fts MATCH ${`"${escaped}"`} AND mf.project_id = ${opts.projectID}
+             ORDER BY mf.confidence DESC LIMIT ${opts.limit}`,
           )
         })
       })
@@ -137,11 +122,10 @@ export namespace MemoryStore {
         return Database.use((d) => {
           const escaped = query.replace(/"/g, '""')
           return d.all<MemoryArtifact>(
-            `SELECT ma.* FROM memory_artifact ma
+            sql`SELECT ma.* FROM memory_artifact ma
              JOIN memory_artifact_fts fts ON ma.id = fts.id
-             WHERE memory_artifact_fts MATCH ? AND ma.project_id = ?
-             ORDER BY ma.time_created DESC LIMIT ?`,
-            [`"${escaped}"`, opts.projectID, opts.limit],
+             WHERE memory_artifact_fts MATCH ${`"${escaped}"`} AND ma.project_id = ${opts.projectID}
+             ORDER BY ma.time_created DESC LIMIT ${opts.limit}`,
           )
         })
       })
@@ -170,18 +154,4 @@ export namespace MemoryStore {
   )
 
   export const defaultLayer = layer
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function writeWindow(window: Omit<MemoryWindow, "time_created" | "time_updated">) {
-    return runPromise((svc) => svc.writeWindow(window))
-  }
-
-  export async function writeFacts(facts: Array<Omit<MemoryFact, "time_created" | "time_updated">>) {
-    return runPromise((svc) => svc.writeFacts(facts))
-  }
-
-  export async function writeArtifacts(artifacts: Array<Omit<MemoryArtifact, "time_created" | "time_updated">>) {
-    return runPromise((svc) => svc.writeArtifacts(artifacts))
-  }
 }

--- a/packages/opencode/src/session/memory/store.ts
+++ b/packages/opencode/src/session/memory/store.ts
@@ -1,0 +1,187 @@
+import { Effect, Layer, ServiceMap } from "effect"
+import { Database, eq, and, desc } from "../../storage/db"
+import { MemoryFactTable, MemoryWindowTable, MemoryArtifactTable } from "../session.sql"
+import { Log } from "@/util/log"
+import type { MemoryFact, MemoryWindow, MemoryArtifact } from "./types"
+import { makeRuntime } from "@/effect/run-service"
+
+export namespace MemoryStore {
+  const log = Log.create({ service: "memory.store" })
+
+  export interface Interface {
+    readonly writeWindow: (window: Omit<MemoryWindow, "time_created" | "time_updated">) => Effect.Effect<void>
+    readonly writeFacts: (facts: Array<Omit<MemoryFact, "time_created" | "time_updated">>) => Effect.Effect<void>
+    readonly writeArtifacts: (
+      artifacts: Array<Omit<MemoryArtifact, "time_created" | "time_updated">>,
+    ) => Effect.Effect<void>
+    readonly getRecentWindows: (opts: { projectID: string; limit: number }) => Effect.Effect<MemoryWindow[]>
+    readonly searchWindows: (query: string, opts: { projectID: string; limit: number }) => Effect.Effect<MemoryWindow[]>
+    readonly searchFacts: (query: string, opts: { projectID: string; limit: number }) => Effect.Effect<MemoryFact[]>
+    readonly searchArtifacts: (
+      query: string,
+      opts: { projectID: string; limit: number },
+    ) => Effect.Effect<MemoryArtifact[]>
+    readonly getDurableFacts: (projectID: string) => Effect.Effect<MemoryFact[]>
+  }
+
+  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/MemoryStore") {}
+
+  export const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const writeWindow = Effect.fn("MemoryStore.writeWindow")(function* (
+        window: Omit<MemoryWindow, "time_created" | "time_updated">,
+      ) {
+        Database.transaction((tx) => {
+          tx.insert(MemoryWindowTable).values(window).run()
+          tx.$client.run(
+            `INSERT INTO memory_window_fts(id, goal, instructions, discoveries, accomplished, in_progress) VALUES (?, ?, ?, ?, ?, ?)`,
+            [
+              window.id,
+              window.goal,
+              window.instructions ?? "",
+              window.discoveries ?? "",
+              window.accomplished ?? "",
+              window.in_progress ?? "",
+            ],
+          )
+        })
+        log.info("wrote window", { id: window.id })
+      })
+
+      const writeFacts = Effect.fn("MemoryStore.writeFacts")(function* (
+        facts: Array<Omit<MemoryFact, "time_created" | "time_updated">>,
+      ) {
+        if (facts.length === 0) return
+        Database.transaction((tx) => {
+          for (const fact of facts) {
+            tx.insert(MemoryFactTable).values(fact).run()
+            tx.run(`INSERT INTO memory_fact_fts(id, subject, value) VALUES (?, ?, ?)`, [
+              fact.id,
+              fact.subject,
+              fact.value,
+            ])
+          }
+        })
+        log.info("wrote facts", { count: facts.length })
+      })
+
+      const writeArtifacts = Effect.fn("MemoryStore.writeArtifacts")(function* (
+        artifacts: Array<Omit<MemoryArtifact, "time_created" | "time_updated">>,
+      ) {
+        if (artifacts.length === 0) return
+        Database.transaction((tx) => {
+          for (const artifact of artifacts) {
+            tx.insert(MemoryArtifactTable).values(artifact).run()
+            tx.run(`INSERT INTO memory_artifact_fts(id, content, file_path) VALUES (?, ?, ?)`, [
+              artifact.id,
+              artifact.content,
+              artifact.file_path ?? "",
+            ])
+          }
+        })
+        log.info("wrote artifacts", { count: artifacts.length })
+      })
+
+      const getRecentWindows = Effect.fn("MemoryStore.getRecentWindows")(function* (opts: {
+        projectID: string
+        limit: number
+      }) {
+        return Database.use((d) =>
+          d
+            .select()
+            .from(MemoryWindowTable)
+            .where(eq(MemoryWindowTable.project_id, opts.projectID))
+            .orderBy(desc(MemoryWindowTable.ended_at))
+            .limit(opts.limit)
+            .all(),
+        )
+      })
+
+      const searchWindows = Effect.fn("MemoryStore.searchWindows")(function* (
+        query: string,
+        opts: { projectID: string; limit: number },
+      ) {
+        return Database.use((d) => {
+          const escaped = query.replace(/"/g, '""')
+          return d.all<MemoryWindow>(
+            `SELECT mw.* FROM memory_window mw
+             JOIN memory_window_fts fts ON mw.id = fts.id
+             WHERE memory_window_fts MATCH ? AND mw.project_id = ?
+             ORDER BY mw.ended_at DESC LIMIT ?`,
+            [`"${escaped}"`, opts.projectID, opts.limit],
+          )
+        })
+      })
+
+      const searchFacts = Effect.fn("MemoryStore.searchFacts")(function* (
+        query: string,
+        opts: { projectID: string; limit: number },
+      ) {
+        return Database.use((d) => {
+          const escaped = query.replace(/"/g, '""')
+          return d.all<MemoryFact>(
+            `SELECT mf.* FROM memory_fact mf
+             JOIN memory_fact_fts fts ON mf.id = fts.id
+             WHERE memory_fact_fts MATCH ? AND mf.project_id = ?
+             ORDER BY mf.confidence DESC LIMIT ?`,
+            [`"${escaped}"`, opts.projectID, opts.limit],
+          )
+        })
+      })
+
+      const searchArtifacts = Effect.fn("MemoryStore.searchArtifacts")(function* (
+        query: string,
+        opts: { projectID: string; limit: number },
+      ) {
+        return Database.use((d) => {
+          const escaped = query.replace(/"/g, '""')
+          return d.all<MemoryArtifact>(
+            `SELECT ma.* FROM memory_artifact ma
+             JOIN memory_artifact_fts fts ON ma.id = fts.id
+             WHERE memory_artifact_fts MATCH ? AND ma.project_id = ?
+             ORDER BY ma.time_created DESC LIMIT ?`,
+            [`"${escaped}"`, opts.projectID, opts.limit],
+          )
+        })
+      })
+
+      const getDurableFacts = Effect.fn("MemoryStore.getDurableFacts")(function* (projectID: string) {
+        return Database.use((d) =>
+          d
+            .select()
+            .from(MemoryFactTable)
+            .where(and(eq(MemoryFactTable.project_id, projectID), eq(MemoryFactTable.confidence, 100)))
+            .all(),
+        )
+      })
+
+      return Service.of({
+        writeWindow,
+        writeFacts,
+        writeArtifacts,
+        getRecentWindows,
+        searchWindows,
+        searchFacts,
+        searchArtifacts,
+        getDurableFacts,
+      })
+    }),
+  )
+
+  export const defaultLayer = layer
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function writeWindow(window: Omit<MemoryWindow, "time_created" | "time_updated">) {
+    return runPromise((svc) => svc.writeWindow(window))
+  }
+
+  export async function writeFacts(facts: Array<Omit<MemoryFact, "time_created" | "time_updated">>) {
+    return runPromise((svc) => svc.writeFacts(facts))
+  }
+
+  export async function writeArtifacts(artifacts: Array<Omit<MemoryArtifact, "time_created" | "time_updated">>) {
+    return runPromise((svc) => svc.writeArtifacts(artifacts))
+  }
+}

--- a/packages/opencode/src/session/memory/types.ts
+++ b/packages/opencode/src/session/memory/types.ts
@@ -1,0 +1,26 @@
+import type { SessionID } from "../schema"
+import type { MemoryFactTable, MemoryWindowTable, MemoryArtifactTable, MemoryProjectTable } from "../session.sql"
+
+export type MemoryFact = typeof MemoryFactTable.$inferSelect
+export type NewFact = typeof MemoryFactTable.$inferInsert
+
+export type MemoryWindow = typeof MemoryWindowTable.$inferSelect
+export type NewWindow = typeof MemoryWindowTable.$inferInsert
+
+export type MemoryArtifact = typeof MemoryArtifactTable.$inferSelect
+export type NewArtifact = typeof MemoryArtifactTable.$inferInsert
+
+export type MemoryProject = typeof MemoryProjectTable.$inferSelect
+
+export interface ExtractionResult {
+  goal: string
+  instructions: string[]
+  discoveries: string[]
+  accomplished: string[]
+  in_progress: string[]
+  blocked_on: string[]
+  files_touched: string[]
+  relevant_dirs: string[]
+  facts: Array<{ category: string; subject: string; value: string }>
+  artifacts: Array<{ kind: string; content: string; file_path?: string }>
+}

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Layer, ServiceMap } from "effect"
+import { Cause, Effect, Exit, Layer, ServiceMap } from "effect"
 import * as Stream from "effect/Stream"
 import { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
@@ -18,6 +18,9 @@ import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
 import type { Provider } from "@/provider/provider"
 import { Question } from "@/question"
+import { MemoryRetriever, formatMemory, ProjectTracker } from "./memory"
+import { MemoryStore } from "./memory/store"
+import { InstanceState } from "@/effect/instance-state"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -52,6 +55,7 @@ export namespace SessionProcessor {
     needsCompaction: boolean
     currentText: MessageV2.TextPart | undefined
     reasoningMap: Record<string, MessageV2.ReasoningPart>
+    projectID: string
   }
 
   type StreamEvent = Event
@@ -70,6 +74,8 @@ export namespace SessionProcessor {
     | Permission.Service
     | Plugin.Service
     | SessionStatus.Service
+    | MemoryRetriever.Service
+    | ProjectTracker.Service
   > = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -82,6 +88,8 @@ export namespace SessionProcessor {
       const permission = yield* Permission.Service
       const plugin = yield* Plugin.Service
       const status = yield* SessionStatus.Service
+      const retriever = yield* MemoryRetriever.Service
+      const tracker = yield* ProjectTracker.Service
 
       const create = Effect.fn("SessionProcessor.create")(function* (input: Input) {
         // Pre-capture snapshot before the LLM stream starts. The AI SDK
@@ -99,6 +107,7 @@ export namespace SessionProcessor {
           needsCompaction: false,
           currentText: undefined,
           reasoningMap: {},
+          projectID: (yield* InstanceState.context).worktree,
         }
         let aborted = false
 
@@ -201,11 +210,36 @@ export namespace SessionProcessor {
               }
 
               const agent = yield* agents.get(ctx.assistantMessage.agent)
+
+              const keywords = Object.values(ctx.toolcalls)
+                .filter((p) => p.state.status !== "pending")
+                .flatMap((p) => {
+                  const inp = p.state.status === "running" ? p.state.input : {}
+                  return Object.values(inp).flatMap((v) =>
+                    typeof v === "string" ? v.split(/[\s/_.-]+/).filter(Boolean) : [],
+                  )
+                })
+                .slice(-10)
+
+              const memResult = yield* retriever
+                .retrieve({
+                  keywords,
+                  projectID: ctx.projectID,
+                  sessionID: ctx.sessionID,
+                })
+                .pipe(Effect.catch(() => Effect.succeed({ windows: [], facts: [], artifacts: [] })))
+
+              const memSection = formatMemory(memResult)
+
               yield* permission.ask({
                 permission: "doom_loop",
                 patterns: [value.toolName],
                 sessionID: ctx.assistantMessage.sessionID,
-                metadata: { tool: value.toolName, input: value.input },
+                metadata: {
+                  tool: value.toolName,
+                  input: value.input,
+                  memoryContext: memSection || undefined,
+                },
                 always: [value.toolName],
                 ruleset: agent.permission,
               })
@@ -517,6 +551,9 @@ export namespace SessionProcessor {
         Layer.provide(SessionStatus.layer.pipe(Layer.provide(Bus.layer))),
         Layer.provide(Bus.layer),
         Layer.provide(Config.defaultLayer),
+        Layer.provide(MemoryRetriever.defaultLayer),
+        Layer.provide(ProjectTracker.defaultLayer),
+        Layer.provide(MemoryStore.defaultLayer),
       ),
     ),
   )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -50,6 +50,8 @@ import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { MemoryRetriever, formatMemory, ProjectTracker } from "./memory"
+import { MemoryStore } from "./memory/store"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -101,6 +103,8 @@ export namespace SessionPrompt {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
       const scope = yield* Scope.Scope
       const instruction = yield* Instruction.Service
+      const retriever = yield* MemoryRetriever.Service
+      const tracker = yield* ProjectTracker.Service
 
       const state = yield* InstanceState.make(
         Effect.fn("SessionPrompt.state")(function* () {
@@ -1505,6 +1509,46 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   Effect.promise(() => MessageV2.toModelMessages(msgs, model)),
                 ])
                 const system = [...env, ...(skills ? [skills] : []), ...instructions]
+
+                if (step === 1) {
+                  const ctx = yield* InstanceState.context
+                  const memResult = yield* retriever
+                    .retrieve({
+                      keywords: [],
+                      projectID: ctx.worktree,
+                      sessionID,
+                    })
+                    .pipe(Effect.catch(() => Effect.succeed({ windows: [], facts: [], artifacts: [] })))
+                  const memorySection = formatMemory(memResult)
+                  if (memorySection) {
+                    system.push(`<system-reminder>\n## Prior Session Context\n\n${memorySection}\n</system-reminder>`)
+                  }
+
+                  const activeProjects = yield* tracker
+                    .getActive(ctx.worktree)
+                    .pipe(Effect.catch(() => Effect.succeed([])))
+                  if (activeProjects.length) {
+                    const projectLines = activeProjects.map(
+                      (p: {
+                        project_name: string
+                        status: string
+                        summary: string | null
+                        latest_progress: string | null
+                        blockers: string | null
+                      }) => {
+                        const parts = [`**${p.project_name}** (${p.status})`]
+                        if (p.summary) parts.push(p.summary)
+                        if (p.latest_progress) parts.push(`Progress: ${p.latest_progress}`)
+                        if (p.blockers) parts.push(`Blockers: ${p.blockers}`)
+                        return `- ${parts.join(" — ")}`
+                      },
+                    )
+                    system.push(
+                      `<system-reminder>\n## Active Projects\n\n${projectLines.join("\n")}\n</system-reminder>`,
+                    )
+                  }
+                }
+
                 const format = lastUser.format ?? { type: "text" as const }
                 if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
                 const result = yield* handle.process({
@@ -1710,28 +1754,35 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   )
 
   const defaultLayer = Layer.unwrap(
-    Effect.sync(() =>
-      layer.pipe(
+    Effect.gen(function* () {
+      const l = layer.pipe(
         Layer.provide(SessionStatus.layer),
         Layer.provide(SessionCompaction.defaultLayer),
         Layer.provide(SessionProcessor.defaultLayer),
+        Layer.provide(MemoryRetriever.defaultLayer),
+        Layer.provide(ProjectTracker.defaultLayer),
+        Layer.provide(MemoryStore.defaultLayer),
         Layer.provide(Command.defaultLayer),
         Layer.provide(Permission.defaultLayer),
         Layer.provide(MCP.defaultLayer),
         Layer.provide(LSP.defaultLayer),
-        Layer.provide(FileTime.defaultLayer),
-        Layer.provide(ToolRegistry.defaultLayer),
-        Layer.provide(Truncate.layer),
-        Layer.provide(Provider.defaultLayer),
-        Layer.provide(Instruction.defaultLayer),
-        Layer.provide(AppFileSystem.defaultLayer),
-        Layer.provide(Plugin.defaultLayer),
-        Layer.provide(Session.defaultLayer),
-        Layer.provide(Agent.defaultLayer),
-        Layer.provide(Bus.layer),
-        Layer.provide(CrossSpawnSpawner.defaultLayer),
-      ),
-    ),
+      )
+      return yield* Effect.sync(() =>
+        l.pipe(
+          Layer.provide(FileTime.defaultLayer),
+          Layer.provide(ToolRegistry.defaultLayer),
+          Layer.provide(Truncate.layer),
+          Layer.provide(Provider.defaultLayer),
+          Layer.provide(Instruction.defaultLayer),
+          Layer.provide(AppFileSystem.defaultLayer),
+          Layer.provide(Plugin.defaultLayer),
+          Layer.provide(Session.defaultLayer),
+          Layer.provide(Agent.defaultLayer),
+          Layer.provide(Bus.layer),
+          Layer.provide(CrossSpawnSpawner.defaultLayer),
+        ),
+      )
+    }),
   )
   const { runPromise } = makeRuntime(Service, defaultLayer)
 

--- a/packages/opencode/src/session/session.sql.ts
+++ b/packages/opencode/src/session/session.sql.ts
@@ -101,3 +101,93 @@ export const PermissionTable = sqliteTable("permission", {
   ...Timestamps,
   data: text({ mode: "json" }).notNull().$type<Permission.Ruleset>(),
 })
+
+export const MemoryFactTable = sqliteTable(
+  "memory_fact",
+  {
+    id: text().primaryKey(),
+    project_id: text()
+      .notNull()
+      .references(() => ProjectTable.id, { onDelete: "cascade" }),
+    session_id: text().$type<SessionID>(),
+    category: text().notNull(),
+    subject: text().notNull(),
+    value: text().notNull(),
+    confidence: integer().notNull().default(0),
+    source_hash: text().notNull(),
+    ...Timestamps,
+  },
+  (table) => [
+    index("memory_fact_project_idx").on(table.project_id),
+    index("memory_fact_subject_idx").on(table.project_id, table.subject),
+  ],
+)
+
+export const MemoryWindowTable = sqliteTable(
+  "memory_window",
+  {
+    id: text().primaryKey(),
+    project_id: text()
+      .notNull()
+      .references(() => ProjectTable.id, { onDelete: "cascade" }),
+    session_id: text().$type<SessionID>().notNull(),
+    started_at: integer().notNull(),
+    ended_at: integer().notNull(),
+    goal: text().notNull(),
+    instructions: text(),
+    discoveries: text(),
+    accomplished: text(),
+    in_progress: text(),
+    blocked_on: text(),
+    files_touched: text({ mode: "json" }).$type<string[]>().notNull(),
+    relevant_dirs: text({ mode: "json" }).$type<string[]>().notNull(),
+    message_ids: text({ mode: "json" }).$type<string[]>().notNull(),
+    parent_window_id: text(),
+    ...Timestamps,
+  },
+  (table) => [
+    index("memory_window_session_idx").on(table.session_id),
+    index("memory_window_project_time_idx").on(table.project_id, table.ended_at),
+  ],
+)
+
+export const MemoryArtifactTable = sqliteTable(
+  "memory_artifact",
+  {
+    id: text().primaryKey(),
+    project_id: text()
+      .notNull()
+      .references(() => ProjectTable.id, { onDelete: "cascade" }),
+    window_id: text()
+      .notNull()
+      .references(() => MemoryWindowTable.id, { onDelete: "cascade" }),
+    kind: text().notNull(),
+    content: text().notNull(),
+    file_path: text(),
+    metadata: text({ mode: "json" }).$type<Record<string, unknown>>(),
+    ...Timestamps,
+  },
+  (table) => [
+    index("memory_artifact_window_idx").on(table.window_id),
+    index("memory_artifact_kind_idx").on(table.project_id, table.kind),
+  ],
+)
+
+export const MemoryProjectTable = sqliteTable(
+  "memory_project",
+  {
+    id: text().primaryKey(),
+    project_id: text()
+      .notNull()
+      .references(() => ProjectTable.id, { onDelete: "cascade" }),
+    project_key: text().notNull(),
+    project_name: text().notNull(),
+    status: text().notNull().default("planned"),
+    summary: text().notNull(),
+    latest_progress: text(),
+    blockers: text(),
+    source_window_ids: text({ mode: "json" }).$type<string[]>().notNull(),
+    ...Timestamps,
+  },
+  (table) => [index("memory_project_key_idx").on(table.project_id, table.project_key)],
+)

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -23,6 +23,10 @@ import type { Provider } from "../../src/provider/provider"
 import * as SessionProcessorModule from "../../src/session/processor"
 import { Snapshot } from "../../src/snapshot"
 import { ProviderTest } from "../fake/provider"
+import { MemoryExtractor } from "../../src/session/memory/extractor"
+import { MemoryRetriever } from "../../src/session/memory/retriever"
+import { ProjectTracker } from "../../src/session/memory/project-tracker"
+import { MemoryStore } from "../../src/session/memory/store"
 
 Log.init({ print: false })
 
@@ -166,8 +170,37 @@ function layer(result: "continue" | "compact") {
 
 function runtime(result: "continue" | "compact", plugin = Plugin.defaultLayer, provider = ProviderTest.fake()) {
   const bus = Bus.layer
+  const stubExtractor = Layer.succeed(
+    MemoryExtractor.Service,
+    MemoryExtractor.Service.of({ extract: () => Effect.succeed(null) }),
+  )
+  const stubRetriever = Layer.succeed(
+    MemoryRetriever.Service,
+    MemoryRetriever.Service.of({ retrieve: () => Effect.succeed({ windows: [], facts: [], artifacts: [] }) }),
+  )
+  const stubTracker = Layer.succeed(
+    ProjectTracker.Service,
+    ProjectTracker.Service.of({ track: () => Effect.void, getActive: () => Effect.succeed([]) }),
+  )
+  const stubStore = Layer.succeed(
+    MemoryStore.Service,
+    MemoryStore.Service.of({
+      writeWindow: () => Effect.void,
+      writeFacts: () => Effect.void,
+      writeArtifacts: () => Effect.void,
+      getRecentWindows: () => Effect.succeed([]),
+      searchWindows: () => Effect.succeed([]),
+      searchFacts: () => Effect.succeed([]),
+      searchArtifacts: () => Effect.succeed([]),
+      getDurableFacts: () => Effect.succeed([]),
+    }),
+  )
   return ManagedRuntime.make(
     Layer.mergeAll(SessionCompaction.layer, bus).pipe(
+      Layer.provide(stubExtractor),
+      Layer.provide(stubRetriever),
+      Layer.provide(stubTracker),
+      Layer.provide(stubStore),
       Layer.provide(provider.layer),
       Layer.provide(Session.defaultLayer),
       Layer.provide(layer(result)),
@@ -201,16 +234,45 @@ function llm() {
   }
 }
 
-function liveRuntime(layer: Layer.Layer<LLM.Service>, provider = ProviderTest.fake()) {
+function liveRuntime(llmLayer: Layer.Layer<LLM.Service>, provider = ProviderTest.fake()) {
   const bus = Bus.layer
   const status = SessionStatus.layer.pipe(Layer.provide(bus))
   const processor = SessionProcessorModule.SessionProcessor.layer
+  const stubExtractor = Layer.succeed(
+    MemoryExtractor.Service,
+    MemoryExtractor.Service.of({ extract: () => Effect.succeed(null) }),
+  )
+  const stubRetriever = Layer.succeed(
+    MemoryRetriever.Service,
+    MemoryRetriever.Service.of({ retrieve: () => Effect.succeed({ windows: [], facts: [], artifacts: [] }) }),
+  )
+  const stubTracker = Layer.succeed(
+    ProjectTracker.Service,
+    ProjectTracker.Service.of({ track: () => Effect.void, getActive: () => Effect.succeed([]) }),
+  )
+  const stubStore = Layer.succeed(
+    MemoryStore.Service,
+    MemoryStore.Service.of({
+      writeWindow: () => Effect.void,
+      writeFacts: () => Effect.void,
+      writeArtifacts: () => Effect.void,
+      getRecentWindows: () => Effect.succeed([]),
+      searchWindows: () => Effect.succeed([]),
+      searchFacts: () => Effect.succeed([]),
+      searchArtifacts: () => Effect.succeed([]),
+      getDurableFacts: () => Effect.succeed([]),
+    }),
+  )
   return ManagedRuntime.make(
     Layer.mergeAll(SessionCompaction.layer.pipe(Layer.provide(processor)), processor, bus, status).pipe(
+      Layer.provide(stubExtractor),
+      Layer.provide(stubRetriever),
+      Layer.provide(stubTracker),
+      Layer.provide(stubStore),
       Layer.provide(provider.layer),
       Layer.provide(Session.defaultLayer),
       Layer.provide(Snapshot.defaultLayer),
-      Layer.provide(layer),
+      Layer.provide(llmLayer),
       Layer.provide(Permission.defaultLayer),
       Layer.provide(Agent.defaultLayer),
       Layer.provide(Plugin.defaultLayer),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -18,6 +18,9 @@ import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { Snapshot } from "../../src/snapshot"
 import { Log } from "../../src/util/log"
+import { MemoryRetriever } from "../../src/session/memory/retriever"
+import { ProjectTracker } from "../../src/session/memory/project-tracker"
+import { MemoryStore } from "../../src/session/memory/store"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -145,6 +148,36 @@ const assistant = Effect.fn("TestSession.assistant")(function* (
 
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+
+const memoryStubs = Layer.mergeAll(
+  Layer.succeed(
+    MemoryRetriever.Service,
+    MemoryRetriever.Service.of({
+      retrieve: () => Effect.succeed({ windows: [], facts: [], artifacts: [] }),
+    }),
+  ),
+  Layer.succeed(
+    ProjectTracker.Service,
+    ProjectTracker.Service.of({
+      track: () => Effect.void,
+      getActive: () => Effect.succeed([]),
+    }),
+  ),
+  Layer.succeed(
+    MemoryStore.Service,
+    MemoryStore.Service.of({
+      writeWindow: () => Effect.void,
+      writeFacts: () => Effect.void,
+      writeArtifacts: () => Effect.void,
+      searchWindows: () => Effect.succeed([]),
+      searchFacts: () => Effect.succeed([]),
+      searchArtifacts: () => Effect.succeed([]),
+      getRecentWindows: () => Effect.succeed([]),
+      getDurableFacts: () => Effect.succeed([]),
+    }),
+  ),
+)
+
 const deps = Layer.mergeAll(
   Session.defaultLayer,
   Snapshot.defaultLayer,
@@ -155,6 +188,7 @@ const deps = Layer.mergeAll(
   LLM.defaultLayer,
   Provider.defaultLayer,
   status,
+  memoryStubs,
 ).pipe(Layer.provideMerge(infra))
 const env = Layer.mergeAll(TestLLMServer.layer, SessionProcessor.layer.pipe(Layer.provideMerge(deps)))
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -21,10 +21,14 @@ import { Session } from "../../src/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
 import { AppFileSystem } from "../../src/filesystem"
-import { SessionCompaction } from "../../src/session/compaction"
+import { MemoryExtractor } from "../../src/session/memory/extractor"
+import { MemoryRetriever } from "../../src/session/memory/retriever"
+import { ProjectTracker } from "../../src/session/memory/project-tracker"
+import { MemoryStore } from "../../src/session/memory/store"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
+import { SessionCompaction } from "../../src/session/compaction"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { Shell } from "../../src/shell/shell"
@@ -143,6 +147,41 @@ const filetime = Layer.succeed(
   }),
 )
 
+const memoryStub = Layer.mergeAll(
+  Layer.succeed(
+    MemoryRetriever.Service,
+    MemoryRetriever.Service.of({
+      retrieve: () => Effect.succeed({ windows: [], facts: [], artifacts: [] }),
+    }),
+  ),
+  Layer.succeed(
+    ProjectTracker.Service,
+    ProjectTracker.Service.of({
+      track: () => Effect.void,
+      getActive: () => Effect.succeed([]),
+    }),
+  ),
+  Layer.succeed(
+    MemoryStore.Service,
+    MemoryStore.Service.of({
+      writeWindow: () => Effect.void,
+      writeFacts: () => Effect.void,
+      writeArtifacts: () => Effect.void,
+      searchWindows: () => Effect.succeed([]),
+      searchFacts: () => Effect.succeed([]),
+      searchArtifacts: () => Effect.succeed([]),
+      getRecentWindows: () => Effect.succeed([]),
+      getDurableFacts: () => Effect.succeed([]),
+    }),
+  ),
+  Layer.succeed(
+    MemoryExtractor.Service,
+    MemoryExtractor.Service.of({
+      extract: () => Effect.succeed(null),
+    }),
+  ),
+)
+
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 function makeHttp() {
@@ -161,6 +200,7 @@ function makeHttp() {
     mcp,
     AppFileSystem.defaultLayer,
     status,
+    memoryStub,
   ).pipe(Layer.provideMerge(infra))
   const question = Question.layer.pipe(Layer.provideMerge(deps))
   const todo = Todo.layer.pipe(Layer.provideMerge(deps))
@@ -171,7 +211,11 @@ function makeHttp() {
   )
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const proc = SessionProcessor.layer.pipe(Layer.provideMerge(deps))
-  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  const compact = SessionCompaction.layer.pipe(
+    Layer.provideMerge(proc),
+    Layer.provideMerge(deps),
+    Layer.provide(memoryStub),
+  )
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
@@ -180,6 +224,7 @@ function makeHttp() {
       Layer.provideMerge(registry),
       Layer.provideMerge(trunc),
       Layer.provide(Instruction.defaultLayer),
+      Layer.provideMerge(memoryStub),
       Layer.provideMerge(deps),
     ),
   )

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -40,9 +40,13 @@ import { Plugin } from "../../src/plugin"
 import { Provider as ProviderSvc } from "../../src/provider/provider"
 import { Question } from "../../src/question"
 import { Todo } from "../../src/session/todo"
-import { SessionCompaction } from "../../src/session/compaction"
+import { MemoryExtractor } from "../../src/session/memory/extractor"
+import { MemoryRetriever } from "../../src/session/memory/retriever"
+import { ProjectTracker } from "../../src/session/memory/project-tracker"
+import { MemoryStore } from "../../src/session/memory/store"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
+import { SessionCompaction } from "../../src/session/compaction"
 import { SessionStatus } from "../../src/session/status"
 import { Shell } from "../../src/shell/shell"
 import { Snapshot } from "../../src/snapshot"
@@ -106,6 +110,41 @@ const filetime = Layer.succeed(
   }),
 )
 
+const memoryStubs = Layer.mergeAll(
+  Layer.succeed(
+    MemoryRetriever.Service,
+    MemoryRetriever.Service.of({
+      retrieve: () => Effect.succeed({ windows: [], facts: [], artifacts: [] }),
+    }),
+  ),
+  Layer.succeed(
+    ProjectTracker.Service,
+    ProjectTracker.Service.of({
+      track: () => Effect.void,
+      getActive: () => Effect.succeed([]),
+    }),
+  ),
+  Layer.succeed(
+    MemoryStore.Service,
+    MemoryStore.Service.of({
+      writeWindow: () => Effect.void,
+      writeFacts: () => Effect.void,
+      writeArtifacts: () => Effect.void,
+      searchWindows: () => Effect.succeed([]),
+      searchFacts: () => Effect.succeed([]),
+      searchArtifacts: () => Effect.succeed([]),
+      getRecentWindows: () => Effect.succeed([]),
+      getDurableFacts: () => Effect.succeed([]),
+    }),
+  ),
+  Layer.succeed(
+    MemoryExtractor.Service,
+    MemoryExtractor.Service.of({
+      extract: () => Effect.succeed(null),
+    }),
+  ),
+)
+
 const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 
@@ -135,7 +174,11 @@ function makeHttp() {
   )
   const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
   const proc = SessionProcessor.layer.pipe(Layer.provideMerge(deps))
-  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  const compact = SessionCompaction.layer.pipe(
+    Layer.provideMerge(proc),
+    Layer.provideMerge(deps),
+    Layer.provideMerge(memoryStubs),
+  )
   return Layer.mergeAll(
     TestLLMServer.layer,
     SessionPrompt.layer.pipe(
@@ -144,6 +187,7 @@ function makeHttp() {
       Layer.provideMerge(registry),
       Layer.provideMerge(trunc),
       Layer.provide(Instruction.defaultLayer),
+      Layer.provideMerge(memoryStubs),
       Layer.provideMerge(deps),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

I **personally** suffered from context rot. So here is the fix!
With this change, opencode can largely run autonomously for long period without suffering from context rot. No more spinning wheel for nothing and no more repetitive loop that leads to nowhere.

Oh, btw, opencode also run **faster** because of lightweight context. And it **saves 30% on tokens** too.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After a few hours of running opencode, it suffers from context rot. What I observed is opencode just spinning to nowhere, either with any response message or repetitive babbles that makes no sense, apparently brain dead.

The alternative to my change is to **manually** suspend opencode, /clear the context, and restart. And **repeat** a couple of hours later. Good bio breaks. But annoying still.

So, I implemented _tiered memory_ for context management. Now, context rarely get filled over 80%. 

With condensed context, opencode runs faster! A surprise for me. And of course it saves on tokens.

This clearly is not AI talking. This is a battle scared engineer and tenured architect typing with flesh hand.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I have added test cases. It clearly shows context memory never exceeds 80%. From what I can gather, it generally condense memory by 30%. 

### Screenshots / recordings

Find a big project that will run overnight. Or better yet, runs for days. See how much this fix helps, yourself.

### Checklist

- [x] I have tested my changes locally. Yes, I used it **personally**. And I was very pleased. That's why I decided to contribute.
- [x] I have not included unrelated changes in this PR


