### PR TITLE
fix(app): recover from malformed session diffs

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -36,7 +36,7 @@ import { usePlatform } from "@/context/platform"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { promptEnabled, promptProbe } from "@/testing/prompt"
-import { sessionDiffs } from "@/context/global-sync/session-cache"
+import { sessionDiffIncludes } from "@/context/global-sync/session-diff"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
 import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
@@ -174,8 +174,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const sessionID = params.id
     if (!sessionID) return false
 
-    const diffs = sessionDiffs(sync.data.session_diff[sessionID])
-    return diffs.some((diff) => diff.file === path)
+    return sessionDiffIncludes(sync.data.session_diff[sessionID], path)
   }
 
   const openComment = (item: { path: string; commentID?: string; commentOrigin?: "review" | "file" }) => {

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -36,6 +36,7 @@ import { usePlatform } from "@/context/platform"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { promptEnabled, promptProbe } from "@/testing/prompt"
+import { sessionDiffs } from "@/context/global-sync/session-cache"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
 import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
@@ -173,8 +174,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const sessionID = params.id
     if (!sessionID) return false
 
-    const diffs = sync.data.session_diff[sessionID]
-    if (!diffs) return false
+    const diffs = sessionDiffs(sync.data.session_diff[sessionID])
     return diffs.some((diff) => diff.file === path)
   }
 

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -291,7 +291,7 @@ describe("applyDirectoryEvent", () => {
     expect(todos).toEqual([dropped.id])
   })
 
-  test("normalizes non-array session diffs", () => {
+  test("drops malformed session diffs so they can be re-fetched", () => {
     const [store, setStore] = createStore(baseState())
 
     applyDirectoryEvent({
@@ -309,8 +309,7 @@ describe("applyDirectoryEvent", () => {
       loadLsp() {},
     })
 
-    expect(store.session_diff.ses_1).toEqual([])
-    expect(Array.isArray(store.session_diff.ses_1)).toBe(true)
+    expect(store.session_diff.ses_1).toBeUndefined()
   })
 
   test("cleanupDroppedSessionCaches clears part-only orphan state", () => {

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -291,6 +291,28 @@ describe("applyDirectoryEvent", () => {
     expect(todos).toEqual([dropped.id])
   })
 
+  test("normalizes non-array session diffs", () => {
+    const [store, setStore] = createStore(baseState())
+
+    applyDirectoryEvent({
+      event: {
+        type: "session.diff",
+        properties: {
+          sessionID: "ses_1",
+          diff: {},
+        },
+      },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.session_diff.ses_1).toEqual([])
+    expect(Array.isArray(store.session_diff.ses_1)).toBe(true)
+  })
+
   test("cleanupDroppedSessionCaches clears part-only orphan state", () => {
     const [store, setStore] = createStore(
       baseState({

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -13,7 +13,8 @@ import type {
 } from "@opencode-ai/sdk/v2/client"
 import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
-import { dropSessionCaches, sessionDiffs } from "./session-cache"
+import { dropSessionCaches } from "./session-cache"
+import { hasSessionDiffs, sessionDiffs } from "./session-diff"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -162,7 +163,12 @@ export function applyDirectoryEvent(input: {
     }
     case "session.diff": {
       const props = event.properties as { sessionID: string; diff: unknown }
-      input.setStore("session_diff", props.sessionID, sessionDiffs(props.diff))
+      const value = sessionDiffs(props.diff)
+      if (hasSessionDiffs(props.diff)) {
+        input.setStore("session_diff", props.sessionID, value)
+        break
+      }
+      input.setStore("session_diff", props.sessionID, undefined)
       break
     }
     case "todo.updated": {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -13,7 +13,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client"
 import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
-import { dropSessionCaches } from "./session-cache"
+import { dropSessionCaches, sessionDiffs } from "./session-cache"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -161,8 +161,8 @@ export function applyDirectoryEvent(input: {
       break
     }
     case "session.diff": {
-      const props = event.properties as { sessionID: string; diff: FileDiff[] }
-      input.setStore("session_diff", props.sessionID, reconcile(props.diff, { key: "file" }))
+      const props = event.properties as { sessionID: string; diff: unknown }
+      input.setStore("session_diff", props.sessionID, sessionDiffs(props.diff))
       break
     }
     case "todo.updated": {

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -8,7 +8,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
-import { dropSessionCaches, pickSessionCacheEvictions } from "./session-cache"
+import { dropSessionCaches, pickSessionCacheEvictions, hasSessionDiffs, sessionDiffs } from "./session-cache"
 
 const msg = (id: string, sessionID: string) =>
   ({
@@ -30,6 +30,16 @@ const part = (id: string, sessionID: string, messageID: string) =>
   }) as Part
 
 describe("app session cache", () => {
+  test("sessionDiffs only accepts arrays", () => {
+    const list = [{ file: "a.ts" }] as FileDiff[]
+
+    expect(sessionDiffs(list)).toBe(list)
+    expect(sessionDiffs({})).toEqual([])
+    expect(sessionDiffs(undefined)).toEqual([])
+    expect(hasSessionDiffs(list)).toBe(true)
+    expect(hasSessionDiffs({})).toBe(false)
+  })
+
   test("dropSessionCaches clears orphaned parts without message rows", () => {
     const store: {
       session_status: Record<string, SessionStatus | undefined>

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -8,7 +8,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
-import { dropSessionCaches, pickSessionCacheEvictions, hasSessionDiffs, sessionDiffs } from "./session-cache"
+import { dropSessionCaches, pickSessionCacheEvictions } from "./session-cache"
 
 const msg = (id: string, sessionID: string) =>
   ({
@@ -30,16 +30,6 @@ const part = (id: string, sessionID: string, messageID: string) =>
   }) as Part
 
 describe("app session cache", () => {
-  test("sessionDiffs only accepts arrays", () => {
-    const list = [{ file: "a.ts" }] as FileDiff[]
-
-    expect(sessionDiffs(list)).toBe(list)
-    expect(sessionDiffs({})).toEqual([])
-    expect(sessionDiffs(undefined)).toEqual([])
-    expect(hasSessionDiffs(list)).toBe(true)
-    expect(hasSessionDiffs({})).toBe(false)
-  })
-
   test("dropSessionCaches clears orphaned parts without message rows", () => {
     const store: {
       session_status: Record<string, SessionStatus | undefined>

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -10,17 +10,9 @@ import type {
 
 export const SESSION_CACHE_LIMIT = 40
 
-export function sessionDiffs(value: unknown): FileDiff[] {
-  return Array.isArray(value) ? value : []
-}
-
-export function hasSessionDiffs(value: unknown) {
-  return Array.isArray(value)
-}
-
 type SessionCache = {
-  session_status: Record<string, SessionStatus | undefined>
   session_diff: Record<string, FileDiff[] | undefined>
+  session_status: Record<string, SessionStatus | undefined>
   todo: Record<string, Todo[] | undefined>
   message: Record<string, Message[] | undefined>
   part: Record<string, Part[] | undefined>

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -10,6 +10,14 @@ import type {
 
 export const SESSION_CACHE_LIMIT = 40
 
+export function sessionDiffs(value: unknown): FileDiff[] {
+  return Array.isArray(value) ? value : []
+}
+
+export function hasSessionDiffs(value: unknown) {
+  return Array.isArray(value)
+}
+
 type SessionCache = {
   session_status: Record<string, SessionStatus | undefined>
   session_diff: Record<string, FileDiff[] | undefined>

--- a/packages/app/src/context/global-sync/session-diff.test.ts
+++ b/packages/app/src/context/global-sync/session-diff.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import type { FileDiff } from "@opencode-ai/sdk/v2/client"
+import {
+  hasSessionDiffs,
+  sessionDiffCount,
+  sessionDiffIncludes,
+  sessionDiffs,
+  shouldFetchSessionDiff,
+} from "./session-diff"
+
+describe("session diff helpers", () => {
+  test("normalize unknown values to arrays", () => {
+    const list = [{ file: "a.ts", before: "", after: "", additions: 1, deletions: 0 }] as FileDiff[]
+
+    expect(sessionDiffs(list)).toEqual(list)
+    expect(sessionDiffs({})).toEqual([])
+    expect(sessionDiffs([{}])).toEqual([])
+    expect(sessionDiffs(undefined)).toEqual([])
+    expect(hasSessionDiffs(list)).toBe(true)
+    expect(hasSessionDiffs({})).toBe(false)
+    expect(hasSessionDiffs([{}])).toBe(false)
+  })
+
+  test("model the crash-prone consumer operations safely", () => {
+    const list = [{ file: "a.ts", before: "", after: "", additions: 1, deletions: 0 }] as FileDiff[]
+
+    expect(sessionDiffCount(list)).toBe(1)
+    expect(sessionDiffCount({})).toBe(0)
+    expect(sessionDiffIncludes(list, "a.ts")).toBe(true)
+    expect(sessionDiffIncludes({}, "a.ts")).toBe(false)
+  })
+
+  test("marks malformed cache entries for refetch", () => {
+    expect(shouldFetchSessionDiff({}, false)).toBe(true)
+    expect(shouldFetchSessionDiff([{}], false)).toBe(true)
+    expect(shouldFetchSessionDiff(undefined, false)).toBe(true)
+    expect(shouldFetchSessionDiff([], false)).toBe(false)
+    expect(shouldFetchSessionDiff([], true)).toBe(true)
+  })
+})

--- a/packages/app/src/context/global-sync/session-diff.ts
+++ b/packages/app/src/context/global-sync/session-diff.ts
@@ -1,0 +1,47 @@
+import type { FileDiff } from "@opencode-ai/sdk/v2/client"
+
+function isSessionDiff(value: unknown): value is FileDiff {
+  if (!value || typeof value !== "object") return false
+  const item = value as Record<string, unknown>
+  if (typeof item.file !== "string") return false
+  if (typeof item.before !== "string") return false
+  if (typeof item.after !== "string") return false
+  if (typeof item.additions !== "number") return false
+  if (typeof item.deletions !== "number") return false
+  if (
+    item.status !== undefined &&
+    item.status !== "added" &&
+    item.status !== "deleted" &&
+    item.status !== "modified"
+  ) {
+    return false
+  }
+  return true
+}
+
+function parseSessionDiffs(value: unknown) {
+  if (!Array.isArray(value)) return
+  if (!value.every(isSessionDiff)) return
+  return value
+}
+
+export function sessionDiffs(value: unknown): FileDiff[] {
+  return parseSessionDiffs(value) ?? []
+}
+
+export function hasSessionDiffs(value: unknown) {
+  return parseSessionDiffs(value) !== undefined
+}
+
+export function shouldFetchSessionDiff(value: unknown, force?: boolean) {
+  if (force) return true
+  return !hasSessionDiffs(value)
+}
+
+export function sessionDiffCount(value: unknown) {
+  return sessionDiffs(value).length
+}
+
+export function sessionDiffIncludes(value: unknown, path: string) {
+  return sessionDiffs(value).some((diff) => diff.file === path)
+}

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -48,7 +48,7 @@ export type State = {
     [sessionID: string]: SessionStatus
   }
   session_diff: {
-    [sessionID: string]: FileDiff[]
+    [sessionID: string]: FileDiff[] | undefined
   }
   todo: {
     [sessionID: string]: Todo[]

--- a/packages/app/src/context/sync-session-diff.test.ts
+++ b/packages/app/src/context/sync-session-diff.test.ts
@@ -1,44 +1,11 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { FileDiff } from "@opencode-ai/sdk/v2/client"
 import type { State } from "./global-sync/types"
+import { createSyncContextValue } from "./sync"
 
-type SyncValue = {
-  session: {
-    diff: (sessionID: string, opts?: { force?: boolean }) => Promise<void> | undefined
-  }
-}
-
-let initSyncForTest: () => SyncValue
-let currentGlobalSync: unknown
-let currentSDK: unknown
-
-beforeAll(async () => {
-  let capturedInit: (() => SyncValue) | undefined
-
-  mock.module("@opencode-ai/ui/context", () => ({
-    createSimpleContext: (input: { init: () => SyncValue }) => {
-      capturedInit = input.init
-      return {
-        use: () => undefined,
-        provider: () => undefined,
-      }
-    },
-  }))
-
-  mock.module("./global-sync", () => ({
-    useGlobalSync: () => currentGlobalSync,
-  }))
-
-  mock.module("./sdk", () => ({
-    useSDK: () => currentSDK,
-  }))
-
-  await import("./sync")
-  if (!capturedInit) throw new Error("Failed to capture sync context init")
-  initSyncForTest = capturedInit
-})
+type SyncDeps = Parameters<typeof createSyncContextValue>[0]
 
 function baseState(): State {
   return {
@@ -84,7 +51,7 @@ describe("sync session diff recovery", () => {
       return count === 1 ? ({ data: {} } as const) : ({ data: valid } as const)
     })
 
-    currentGlobalSync = {
+    const globalSync = {
       child: () => [store, setStore],
       data: {
         project: [],
@@ -95,7 +62,7 @@ describe("sync session diff recovery", () => {
       },
     }
 
-    currentSDK = {
+    const sdk = {
       directory: "/tmp/project",
       client: {
         session: {
@@ -106,7 +73,10 @@ describe("sync session diff recovery", () => {
 
     await new Promise<void>((resolve, reject) => {
       createRoot((dispose) => {
-        const sync = initSyncForTest()
+        const sync = createSyncContextValue({
+          globalSync: globalSync as unknown as SyncDeps["globalSync"],
+          sdk: sdk as unknown as SyncDeps["sdk"],
+        })
         void (async () => {
           try {
             await sync.session.diff(sessionID)

--- a/packages/app/src/context/sync-session-diff.test.ts
+++ b/packages/app/src/context/sync-session-diff.test.ts
@@ -1,0 +1,132 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import type { FileDiff } from "@opencode-ai/sdk/v2/client"
+import type { State } from "./global-sync/types"
+
+type SyncValue = {
+  session: {
+    diff: (sessionID: string, opts?: { force?: boolean }) => Promise<void> | undefined
+  }
+}
+
+let initSyncForTest: () => SyncValue
+let currentGlobalSync: unknown
+let currentSDK: unknown
+
+beforeAll(async () => {
+  let capturedInit: (() => SyncValue) | undefined
+
+  mock.module("@opencode-ai/ui/context", () => ({
+    createSimpleContext: (input: { init: () => SyncValue }) => {
+      capturedInit = input.init
+      return {
+        use: () => undefined,
+        provider: () => undefined,
+      }
+    },
+  }))
+
+  mock.module("./global-sync", () => ({
+    useGlobalSync: () => currentGlobalSync,
+  }))
+
+  mock.module("./sdk", () => ({
+    useSDK: () => currentSDK,
+  }))
+
+  await import("./sync")
+  if (!capturedInit) throw new Error("Failed to capture sync context init")
+  initSyncForTest = capturedInit
+})
+
+function baseState(): State {
+  return {
+    status: "complete",
+    agent: [],
+    command: [],
+    project: "",
+    projectMeta: undefined,
+    icon: undefined,
+    provider_ready: false,
+    provider: { all: [], connected: [], default: {} },
+    config: {},
+    path: { state: "", config: "", worktree: "", directory: "/tmp/project", home: "" },
+    session: [],
+    sessionTotal: 0,
+    session_status: {},
+    session_diff: {},
+    todo: {},
+    permission: {},
+    question: {},
+    mcp_ready: false,
+    mcp: {},
+    lsp_ready: false,
+    lsp: [],
+    vcs: undefined,
+    limit: 5,
+    message: {},
+    part: {},
+  }
+}
+
+describe("sync session diff recovery", () => {
+  test("re-fetches malformed cached diffs until a valid array is stored", async () => {
+    const sessionID = "ses_1"
+    const valid = [{ file: "a.ts", before: "", after: "", additions: 1, deletions: 0 }] as FileDiff[]
+    const [store, setStore] = createStore({
+      ...baseState(),
+      session_diff: { [sessionID]: {} as State["session_diff"][string] },
+    })
+
+    const diff = mock(async () => {
+      const count = diff.mock.calls.length
+      return count === 1 ? ({ data: {} } as const) : ({ data: valid } as const)
+    })
+
+    currentGlobalSync = {
+      child: () => [store, setStore],
+      data: {
+        project: [],
+        session_todo: {},
+      },
+      todo: {
+        set() {},
+      },
+    }
+
+    currentSDK = {
+      directory: "/tmp/project",
+      client: {
+        session: {
+          diff,
+        },
+      },
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      createRoot((dispose) => {
+        const sync = initSyncForTest()
+        void (async () => {
+          try {
+            await sync.session.diff(sessionID)
+            expect(diff).toHaveBeenCalledTimes(1)
+            expect(store.session_diff[sessionID]).toBeUndefined()
+
+            await sync.session.diff(sessionID)
+            expect(diff).toHaveBeenCalledTimes(2)
+            expect(store.session_diff[sessionID]).toEqual(valid)
+
+            await sync.session.diff(sessionID)
+            expect(diff).toHaveBeenCalledTimes(2)
+            resolve()
+          } catch (error) {
+            reject(error)
+          } finally {
+            dispose()
+          }
+        })()
+      })
+    })
+  })
+})

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -166,109 +166,109 @@ function setOptimisticRemove(setStore: (...args: unknown[]) => void, input: Opti
   })
 }
 
-export const { use: useSync, provider: SyncProvider } = createSimpleContext({
-  name: "Sync",
-  init: () => {
-    const globalSync = useGlobalSync()
-    const sdk = useSDK()
+export function createSyncContextValue(input: {
+  globalSync: ReturnType<typeof useGlobalSync>
+  sdk: ReturnType<typeof useSDK>
+}) {
+  const { globalSync, sdk } = input
 
-    type Child = ReturnType<(typeof globalSync)["child"]>
-    type Setter = Child[1]
+  type Child = ReturnType<(typeof globalSync)["child"]>
+  type Setter = Child[1]
 
-    const current = createMemo(() => globalSync.child(sdk.directory))
-    const target = (directory?: string) => {
-      if (!directory || directory === sdk.directory) return current()
-      return globalSync.child(directory)
+  const current = createMemo(() => globalSync.child(sdk.directory))
+  const target = (directory?: string) => {
+    if (!directory || directory === sdk.directory) return current()
+    return globalSync.child(directory)
+  }
+  const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
+  const initialMessagePageSize = 80
+  const historyMessagePageSize = 200
+  const inflight = new Map<string, Promise<void>>()
+  const inflightDiff = new Map<string, Promise<void>>()
+  const inflightTodo = new Map<string, Promise<void>>()
+  const optimistic = new Map<string, Map<string, OptimisticItem>>()
+  const maxDirs = 30
+  const seen = new Map<string, Set<string>>()
+  const [meta, setMeta] = createStore({
+    limit: {} as Record<string, number>,
+    cursor: {} as Record<string, string | undefined>,
+    complete: {} as Record<string, boolean>,
+    loading: {} as Record<string, boolean>,
+  })
+
+  const getSession = (sessionID: string) => {
+    const store = current()[0]
+    const match = Binary.search(store.session, sessionID, (s) => s.id)
+    if (match.found) return store.session[match.index]
+    return undefined
+  }
+
+  const setOptimistic = (directory: string, sessionID: string, item: OptimisticItem) => {
+    const key = keyFor(directory, sessionID)
+    const list = optimistic.get(key)
+    if (list) {
+      list.set(item.message.id, { message: item.message, parts: sortParts(item.parts) })
+      return
     }
-    const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
-    const initialMessagePageSize = 80
-    const historyMessagePageSize = 200
-    const inflight = new Map<string, Promise<void>>()
-    const inflightDiff = new Map<string, Promise<void>>()
-    const inflightTodo = new Map<string, Promise<void>>()
-    const optimistic = new Map<string, Map<string, OptimisticItem>>()
-    const maxDirs = 30
-    const seen = new Map<string, Set<string>>()
-    const [meta, setMeta] = createStore({
-      limit: {} as Record<string, number>,
-      cursor: {} as Record<string, string | undefined>,
-      complete: {} as Record<string, boolean>,
-      loading: {} as Record<string, boolean>,
-    })
+    optimistic.set(key, new Map([[item.message.id, { message: item.message, parts: sortParts(item.parts) }]]))
+  }
 
-    const getSession = (sessionID: string) => {
-      const store = current()[0]
-      const match = Binary.search(store.session, sessionID, (s) => s.id)
-      if (match.found) return store.session[match.index]
-      return undefined
-    }
-
-    const setOptimistic = (directory: string, sessionID: string, item: OptimisticItem) => {
-      const key = keyFor(directory, sessionID)
-      const list = optimistic.get(key)
-      if (list) {
-        list.set(item.message.id, { message: item.message, parts: sortParts(item.parts) })
-        return
-      }
-      optimistic.set(key, new Map([[item.message.id, { message: item.message, parts: sortParts(item.parts) }]]))
-    }
-
-    const clearOptimistic = (directory: string, sessionID: string, messageID?: string) => {
-      const key = keyFor(directory, sessionID)
-      if (!messageID) {
-        optimistic.delete(key)
-        return
-      }
-
-      const list = optimistic.get(key)
-      if (!list) return
-      list.delete(messageID)
-      if (list.size === 0) optimistic.delete(key)
+  const clearOptimistic = (directory: string, sessionID: string, messageID?: string) => {
+    const key = keyFor(directory, sessionID)
+    if (!messageID) {
+      optimistic.delete(key)
+      return
     }
 
-    const getOptimistic = (directory: string, sessionID: string) => [
-      ...(optimistic.get(keyFor(directory, sessionID))?.values() ?? []),
-    ]
+    const list = optimistic.get(key)
+    if (!list) return
+    list.delete(messageID)
+    if (list.size === 0) optimistic.delete(key)
+  }
 
-    const seenFor = (directory: string) => {
-      const existing = seen.get(directory)
-      if (existing) {
-        seen.delete(directory)
-        seen.set(directory, existing)
-        return existing
-      }
-      const created = new Set<string>()
-      seen.set(directory, created)
-      while (seen.size > maxDirs) {
-        const first = seen.keys().next().value
-        if (!first) break
-        const stale = [...(seen.get(first) ?? [])]
-        seen.delete(first)
-        const [, setStore] = globalSync.child(first, { bootstrap: false })
-        evict(first, setStore, stale)
-      }
-      return created
+  const getOptimistic = (directory: string, sessionID: string) => [
+    ...(optimistic.get(keyFor(directory, sessionID))?.values() ?? []),
+  ]
+
+  const seenFor = (directory: string) => {
+    const existing = seen.get(directory)
+    if (existing) {
+      seen.delete(directory)
+      seen.set(directory, existing)
+      return existing
     }
-
-    const clearMeta = (directory: string, sessionIDs: string[]) => {
-      if (sessionIDs.length === 0) return
-      for (const sessionID of sessionIDs) {
-        clearOptimistic(directory, sessionID)
-      }
-      setMeta(
-        produce((draft) => {
-          for (const sessionID of sessionIDs) {
-            const key = keyFor(directory, sessionID)
-            delete draft.limit[key]
-            delete draft.cursor[key]
-            delete draft.complete[key]
-            delete draft.loading[key]
-          }
-        }),
-      )
+    const created = new Set<string>()
+    seen.set(directory, created)
+    while (seen.size > maxDirs) {
+      const first = seen.keys().next().value
+      if (!first) break
+      const stale = [...(seen.get(first) ?? [])]
+      seen.delete(first)
+      const [, setStore] = globalSync.child(first, { bootstrap: false })
+      evict(first, setStore, stale)
     }
+    return created
+  }
 
-    const evict = (directory: string, setStore: Setter, sessionIDs: string[]) => {
+  const clearMeta = (directory: string, sessionIDs: string[]) => {
+    if (sessionIDs.length === 0) return
+    for (const sessionID of sessionIDs) {
+      clearOptimistic(directory, sessionID)
+    }
+    setMeta(
+      produce((draft) => {
+        for (const sessionID of sessionIDs) {
+          const key = keyFor(directory, sessionID)
+          delete draft.limit[key]
+          delete draft.cursor[key]
+          delete draft.complete[key]
+          delete draft.loading[key]
+        }
+      }),
+    )
+  }
+
+  const evict = (directory: string, setStore: Setter, sessionIDs: string[]) => {
       if (sessionIDs.length === 0) return
       clearSessionPrefetch(directory, sessionIDs)
       for (const sessionID of sessionIDs) {
@@ -282,7 +282,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       clearMeta(directory, sessionIDs)
     }
 
-    const touch = (directory: string, setStore: Setter, sessionID: string) => {
+  const touch = (directory: string, setStore: Setter, sessionID: string) => {
       const stale = pickSessionCacheEvictions({
         seen: seenFor(directory),
         keep: sessionID,
@@ -291,7 +291,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       evict(directory, setStore, stale)
     }
 
-    const fetchMessages = async (input: {
+  const fetchMessages = async (input: {
       client: typeof sdk.client
       sessionID: string
       limit: number
@@ -312,9 +312,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       }
     }
 
-    const tracked = (directory: string, sessionID: string) => seen.get(directory)?.has(sessionID) ?? false
+  const tracked = (directory: string, sessionID: string) => seen.get(directory)?.has(sessionID) ?? false
 
-    const loadMessages = async (input: {
+  const loadMessages = async (input: {
       directory: string
       client: typeof sdk.client
       setStore: Setter
@@ -368,26 +368,26 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         })
     }
 
-    return {
-      get data() {
-        return current()[0]
-      },
-      get set(): Setter {
-        return current()[1]
-      },
-      get status() {
-        return current()[0].status
-      },
-      get ready() {
-        return current()[0].status !== "loading"
-      },
-      get project() {
-        const store = current()[0]
-        const match = Binary.search(globalSync.data.project, store.project, (p) => p.id)
-        if (match.found) return globalSync.data.project[match.index]
-        return undefined
-      },
-      session: {
+  return {
+    get data() {
+      return current()[0]
+    },
+    get set(): Setter {
+      return current()[1]
+    },
+    get status() {
+      return current()[0].status
+    },
+    get ready() {
+      return current()[0].status !== "loading"
+    },
+    get project() {
+      const store = current()[0]
+      const match = Binary.search(globalSync.data.project, store.project, (p) => p.id)
+      if (match.found) return globalSync.data.project[match.index]
+      return undefined
+    },
+    session: {
         get: getSession,
         optimistic: {
           add(input: { directory?: string; sessionID: string; message: Message; parts: Part[] }) {
@@ -614,10 +614,19 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           )
         },
       },
-      absolute,
-      get directory() {
-        return current()[0].path.directory
-      },
-    }
+    absolute,
+    get directory() {
+      return current()[0].path.directory
+    },
+  }
+}
+
+export const { use: useSync, provider: SyncProvider } = createSimpleContext({
+  name: "Sync",
+  init: () => {
+    return createSyncContextValue({
+      globalSync: useGlobalSync(),
+      sdk: useSDK(),
+    })
   },
 })

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -12,7 +12,13 @@ import {
 import { useGlobalSync } from "./global-sync"
 import { useSDK } from "./sdk"
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
-import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
+import {
+  SESSION_CACHE_LIMIT,
+  dropSessionCaches,
+  hasSessionDiffs,
+  pickSessionCacheEvictions,
+  sessionDiffs,
+} from "./global-sync/session-cache"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -503,13 +509,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           const client = sdk.client
           const [store, setStore] = globalSync.child(directory)
           touch(directory, setStore, sessionID)
-          if (store.session_diff[sessionID] !== undefined && !opts?.force) return
+          if (hasSessionDiffs(store.session_diff[sessionID]) && !opts?.force) return
 
           const key = keyFor(directory, sessionID)
           return runInflight(inflightDiff, key, () =>
             retry(() => client.session.diff({ sessionID })).then((diff) => {
               if (!tracked(directory, sessionID)) return
-              setStore("session_diff", sessionID, reconcile(diff.data ?? [], { key: "file" }))
+              setStore("session_diff", sessionID, sessionDiffs(diff.data))
             }),
           )
         },

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -12,13 +12,8 @@ import {
 import { useGlobalSync } from "./global-sync"
 import { useSDK } from "./sdk"
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
-import {
-  SESSION_CACHE_LIMIT,
-  dropSessionCaches,
-  hasSessionDiffs,
-  pickSessionCacheEvictions,
-  sessionDiffs,
-} from "./global-sync/session-cache"
+import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
+import { hasSessionDiffs, sessionDiffs, shouldFetchSessionDiff } from "./global-sync/session-diff"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -509,12 +504,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           const client = sdk.client
           const [store, setStore] = globalSync.child(directory)
           touch(directory, setStore, sessionID)
-          if (hasSessionDiffs(store.session_diff[sessionID]) && !opts?.force) return
+          if (!shouldFetchSessionDiff(store.session_diff[sessionID], opts?.force)) return
 
           const key = keyFor(directory, sessionID)
           return runInflight(inflightDiff, key, () =>
             retry(() => client.session.diff({ sessionID })).then((diff) => {
               if (!tracked(directory, sessionID)) return
+              if (!hasSessionDiffs(diff.data)) {
+                setStore("session_diff", sessionID, undefined)
+                return
+              }
               setStore("session_diff", sessionID, sessionDiffs(diff.data))
             }),
           )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -32,7 +32,7 @@ import { useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
-import { hasSessionDiffs, sessionDiffCount, sessionDiffs, shouldFetchSessionDiff } from "@/context/global-sync/session-diff"
+import { sessionDiffCount, sessionDiffs, shouldFetchSessionDiff } from "@/context/global-sync/session-diff"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
@@ -51,6 +51,7 @@ import {
   shouldFocusTerminalOnKeyDown,
 } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
+import { sessionReviewDiffsReady, shouldLoadSessionReviewDiff } from "@/pages/session/review-diff-state"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
@@ -467,10 +468,11 @@ export default function Page() {
     return sync.session.history.loading(id)
   })
   const diffsReady = createMemo(() => {
-    const id = params.id
-    if (!id) return true
-    if (!hasSessionReview()) return true
-    return hasSessionDiffs(sync.data.session_diff[id])
+    return sessionReviewDiffsReady({
+      sessionID: params.id,
+      hasSessionReview: hasSessionReview(),
+      sessionDiff: params.id ? sync.data.session_diff[params.id] : undefined,
+    })
   })
 
   const userMessages = createMemo(
@@ -1371,10 +1373,16 @@ export default function Page() {
     const id = params.id
     if (!id) return
 
-    if (!wantsReview()) return
-    if (!shouldFetchSessionDiff(sync.data.session_diff[id])) return
-    if (sync.status === "loading") return
-
+    if (
+      !shouldLoadSessionReviewDiff({
+        sessionID: id,
+        wantsReview: wantsReview(),
+        sessionDiff: sync.data.session_diff[id],
+        syncStatus: sync.status,
+      })
+    ) {
+      return
+    }
     void sync.session.diff(id)
   })
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -32,6 +32,7 @@ import { useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
+import { hasSessionDiffs, sessionDiffs } from "@/context/global-sync/session-cache"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
@@ -430,7 +431,7 @@ export default function Page() {
 
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const isChildSession = createMemo(() => !!info()?.parentID)
-  const diffs = createMemo(() => (params.id ? (sync.data.session_diff[params.id] ?? []) : []))
+  const diffs = createMemo(() => (params.id ? sessionDiffs(sync.data.session_diff[params.id]) : []))
   const sessionCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
   const hasSessionReview = createMemo(() => sessionCount() > 0)
   const canReview = createMemo(() => !!sync.project)
@@ -467,7 +468,7 @@ export default function Page() {
     const id = params.id
     if (!id) return true
     if (!hasSessionReview()) return true
-    return sync.data.session_diff[id] !== undefined
+    return hasSessionDiffs(sync.data.session_diff[id])
   })
 
   const userMessages = createMemo(
@@ -1369,7 +1370,7 @@ export default function Page() {
     if (!id) return
 
     if (!wantsReview()) return
-    if (sync.data.session_diff[id] !== undefined) return
+    if (hasSessionDiffs(sync.data.session_diff[id])) return
     if (sync.status === "loading") return
 
     void sync.session.diff(id)
@@ -1387,7 +1388,7 @@ export default function Page() {
 
         const id = params.id
         if (!id) return
-        if (!untrack(() => sync.data.session_diff[id] !== undefined)) return
+        if (!untrack(() => hasSessionDiffs(sync.data.session_diff[id]))) return
 
         diffFrame = requestAnimationFrame(() => {
           diffFrame = undefined

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -32,7 +32,7 @@ import { useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
 import { useComments } from "@/context/comments"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
-import { hasSessionDiffs, sessionDiffs } from "@/context/global-sync/session-cache"
+import { hasSessionDiffs, sessionDiffCount, sessionDiffs, shouldFetchSessionDiff } from "@/context/global-sync/session-diff"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
@@ -432,7 +432,9 @@ export default function Page() {
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const isChildSession = createMemo(() => !!info()?.parentID)
   const diffs = createMemo(() => (params.id ? sessionDiffs(sync.data.session_diff[params.id]) : []))
-  const sessionCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
+  const sessionCount = createMemo(() =>
+    Math.max(info()?.summary?.files ?? 0, params.id ? sessionDiffCount(sync.data.session_diff[params.id]) : 0),
+  )
   const hasSessionReview = createMemo(() => sessionCount() > 0)
   const canReview = createMemo(() => !!sync.project)
   const reviewTab = createMemo(() => isDesktop())
@@ -1370,7 +1372,7 @@ export default function Page() {
     if (!id) return
 
     if (!wantsReview()) return
-    if (hasSessionDiffs(sync.data.session_diff[id])) return
+    if (!shouldFetchSessionDiff(sync.data.session_diff[id])) return
     if (sync.status === "loading") return
 
     void sync.session.diff(id)
@@ -1388,7 +1390,7 @@ export default function Page() {
 
         const id = params.id
         if (!id) return
-        if (!untrack(() => hasSessionDiffs(sync.data.session_diff[id]))) return
+        if (untrack(() => shouldFetchSessionDiff(sync.data.session_diff[id]))) return
 
         diffFrame = requestAnimationFrame(() => {
           diffFrame = undefined

--- a/packages/app/src/pages/session/review-diff-state.test.ts
+++ b/packages/app/src/pages/session/review-diff-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import type { FileDiff } from "@opencode-ai/sdk/v2/client"
+import { sessionReviewDiffsReady, shouldLoadSessionReviewDiff } from "./review-diff-state"
+
+describe("session review diff state", () => {
+  test("keeps malformed review diffs in a not-ready state", () => {
+    const valid = [{ file: "a.ts", before: "", after: "", additions: 1, deletions: 0 }] as FileDiff[]
+
+    expect(
+      sessionReviewDiffsReady({
+        sessionID: "ses_1",
+        hasSessionReview: true,
+        sessionDiff: {} as never,
+      }),
+    ).toBe(false)
+    expect(
+      sessionReviewDiffsReady({
+        sessionID: "ses_1",
+        hasSessionReview: true,
+        sessionDiff: valid,
+      }),
+    ).toBe(true)
+    expect(
+      sessionReviewDiffsReady({
+        sessionID: "ses_1",
+        hasSessionReview: false,
+        sessionDiff: {} as never,
+      }),
+    ).toBe(true)
+  })
+
+  test("requests review diffs when review is open and cache is malformed", () => {
+    const valid = [{ file: "a.ts", before: "", after: "", additions: 1, deletions: 0 }] as FileDiff[]
+
+    expect(
+      shouldLoadSessionReviewDiff({
+        sessionID: "ses_1",
+        wantsReview: true,
+        sessionDiff: {} as never,
+        syncStatus: "complete",
+      }),
+    ).toBe(true)
+    expect(
+      shouldLoadSessionReviewDiff({
+        sessionID: "ses_1",
+        wantsReview: true,
+        sessionDiff: valid,
+        syncStatus: "complete",
+      }),
+    ).toBe(false)
+    expect(
+      shouldLoadSessionReviewDiff({
+        sessionID: "ses_1",
+        wantsReview: true,
+        sessionDiff: {} as never,
+        syncStatus: "loading",
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/pages/session/review-diff-state.ts
+++ b/packages/app/src/pages/session/review-diff-state.ts
@@ -1,0 +1,25 @@
+import { hasSessionDiffs, shouldFetchSessionDiff } from "@/context/global-sync/session-diff"
+import type { State } from "@/context/global-sync/types"
+
+export function sessionReviewDiffsReady(input: {
+  sessionID?: string
+  hasSessionReview: boolean
+  sessionDiff: State["session_diff"][string] | undefined
+}) {
+  if (!input.sessionID) return true
+  if (!input.hasSessionReview) return true
+  return hasSessionDiffs(input.sessionDiff)
+}
+
+export function shouldLoadSessionReviewDiff(input: {
+  sessionID?: string
+  wantsReview: boolean
+  sessionDiff: State["session_diff"][string] | undefined
+  syncStatus: State["status"]
+}) {
+  if (!input.sessionID) return false
+  if (!input.wantsReview) return false
+  if (!shouldFetchSessionDiff(input.sessionDiff)) return false
+  if (input.syncStatus === "loading") return false
+  return true
+}

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -13,7 +13,7 @@ type Data = {
     [sessionID: string]: SessionStatus
   }
   session_diff: {
-    [sessionID: string]: FileDiff[]
+    [sessionID: string]: FileDiff[] | undefined
   }
   session_diff_preload?: {
     [sessionID: string]: PreloadMultiFileDiffResult<any>[]


### PR DESCRIPTION
### Issue for this PR

Closes #21100

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The app currently assumes `session_diff` is either missing or a valid diff array. If malformed cached or event payloads get into that slot, session review paths can treat the state as loaded and eventually call array methods on invalid values.

This change keeps the fix narrowly scoped to that bug path:
- validate `session_diff` payloads before they are treated as loaded
- store malformed realtime or fetched diff payloads as `undefined` so review can refetch instead of freezing on bad state
- harden the app readers that inspect session diffs during review/comment flows
- add targeted regression tests for diff validation, malformed event handling, sync recovery, and session review readiness/fetch gating

### How did you verify your code works?

- `cd packages/app && PATH=/tmp/bun-1.3.11/bin:$PATH bun test --preload ./happydom.ts src/context/sync-session-diff.test.ts src/context/global-sync/session-diff.test.ts src/context/global-sync/event-reducer.test.ts src/pages/session/review-diff-state.test.ts`
- `cd packages/app && PATH=/tmp/bun-1.3.11/bin:$PATH bun typecheck`
- `cd packages/app && PATH=/tmp/bun-1.3.11/bin:$PATH bun run test:unit`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
