### PR TITLE
fix(session): accept directory when creating sessions

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -206,9 +206,11 @@ export const SessionRoutes = lazy(() =>
         },
       }),
       validator("json", Session.create.schema.optional()),
+      validator("query", z.object({ directory: z.string().optional() }).optional()),
       async (c) => {
         const body = c.req.valid("json") ?? {}
-        const session = await Session.create(body)
+        const query = c.req.valid("query")
+        const session = await Session.create({ ...body, ...query })
         return c.json(session)
       },
     )

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -206,7 +206,7 @@ export const SessionRoutes = lazy(() =>
         },
       }),
       validator("json", Session.create.schema.optional()),
-      validator("query", z.object({ directory: z.string().optional() }).optional()),
+      validator("query", z.object({ directory: z.string().optional() })),
       async (c) => {
         const body = c.req.valid("json") ?? {}
         const query = c.req.valid("query")

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -314,6 +314,7 @@ export namespace Session {
 
   export interface Interface {
     readonly create: (input?: {
+      directory?: string
       parentID?: SessionID
       title?: string
       permission?: Permission.Ruleset
@@ -493,12 +494,13 @@ export namespace Session {
         }).pipe(Effect.withSpan("Session.updatePart"))
 
       const create = Effect.fn("Session.create")(function* (input?: {
+        directory?: string
         parentID?: SessionID
         title?: string
         permission?: Permission.Ruleset
         workspaceID?: WorkspaceID
       }) {
-        const directory = yield* InstanceState.directory
+        const directory = input?.directory ?? (yield* InstanceState.directory)
         return yield* createNext({
           parentID: input?.parentID,
           directory,
@@ -688,6 +690,7 @@ export namespace Session {
   export const create = fn(
     z
       .object({
+        directory: z.string().optional(),
         parentID: SessionID.zod.optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -27,6 +27,7 @@ import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
+import { Filesystem } from "@/util/filesystem"
 
 import type { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
@@ -500,7 +501,7 @@ export namespace Session {
         permission?: Permission.Ruleset
         workspaceID?: WorkspaceID
       }) {
-        const directory = input?.directory ?? (yield* InstanceState.directory)
+        const directory = input?.directory ? Filesystem.resolve(input.directory) : yield* InstanceState.directory
         return yield* createNext({
           parentID: input?.parentID,
           directory,

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -35,6 +35,29 @@ async function user(sessionID: SessionID, text: string) {
 }
 
 describe("session action routes", () => {
+  test("create route accepts directory query param", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const dir = `${tmp.path}/custom-worktree`
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.Default()
+
+        const res = await app.request(`/session?directory=${encodeURIComponent(dir)}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ title: "custom-dir" }),
+        })
+
+        expect(res.status).toBe(200)
+        const session = (await res.json()) as Session.Info
+        expect(session.directory).toBe(dir)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
   test("abort route calls SessionPrompt.cancel", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -6,6 +6,7 @@ import { Session } from "../../src/session"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
+import { Filesystem } from "../../src/util/filesystem"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -53,7 +54,7 @@ describe("session action routes", () => {
 
         expect(res.status).toBe(200)
         const session = (await res.json()) as Session.Info
-        expect(session.directory).toBe(dir)
+        expect(session.directory).toBe(Filesystem.resolve(dir))
 
         await Session.remove(session.id)
       },

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises"
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
@@ -38,6 +39,7 @@ describe("session action routes", () => {
   test("create route accepts directory query param", async () => {
     await using tmp = await tmpdir({ git: true })
     const dir = `${tmp.path}/custom-worktree`
+    await mkdir(dir, { recursive: true })
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #12918

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This makes session creation honor an explicit directory override.

Specifically:
- `Session.create` now accepts an optional `directory`
- `POST /session` now accepts `?directory=...` and forwards it into session creation
- supplied directories are canonicalized through `Filesystem.resolve(...)` before being persisted
- a regression test covers the route-level override path

Why this works:
- upstream already supports directory-scoped session listing and `createNext` already persists an explicit directory
- the missing piece was exposing that directory through `Session.create` and the create route
- the change stays backward-compatible because callers still fall back to `InstanceState.directory` when no override is provided

This is intentionally narrower than #9365, which tackles broader per-session working-directory behavior across the system.

### How did you verify your code works?

- ran `bun test ./test/server/session-actions.test.ts` from `packages/opencode`
- pre-push hook typecheck passed when pushing the branch

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR