### PR TITLE
fix(app): Shift+Enter newline not working on Windows with IME active

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1191,8 +1191,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     // Handle Shift+Enter BEFORE IME check - Shift+Enter is never used for IME input
-    // and should always insert a newline regardless of composition state
-    if (event.key === "Enter" && event.shiftKey) {
+    // and should always insert a newline regardless of composition state.
+    // On Windows, IME may report event.key as "Process" instead of "Enter" during
+    // composition, so we also check event.code which reflects the physical key.
+    if ((event.key === "Enter" || event.code === "Enter") && event.shiftKey) {
       addPart({ type: "text", content: "\n", start: 0, end: 0 })
       event.preventDefault()
       return


### PR DESCRIPTION
## Issue for this PR

Closes #8038

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

On Windows, when an IME (Korean / Chinese / Japanese) is active and the user is in the middle of composing a character, pressing Shift+Enter does nothing — it neither inserts a newline nor submits. The same key combination works fine on macOS.

The reason is that during IME composition on Windows, the browser reports `event.key` as `"Process"` (a placeholder meaning "the IME is processing this") instead of `"Enter"`. The existing handler in `packages/app/src/components/prompt-input.tsx` only checks `event.key === "Enter"`, so the Shift+Enter branch is skipped entirely and the keypress falls through.

The fix adds an `event.code === "Enter"` check alongside it. `event.code` reflects the *physical* key pressed and is unaffected by IME state, so it stays `"Enter"` whether or not an IME is composing. macOS does not exhibit this behavior because its IMEs release composition immediately on Shift+Enter, which is why this was never noticed on Mac.

The check is intentionally placed *before* the IME composing guard further down, matching the existing comment in the code that says Shift+Enter should never be treated as IME input. Normal Enter (without Shift) is unaffected — it still hits the IME composing check below and properly defers to composition confirmation.

```diff
-    if (event.key === "Enter" && event.shiftKey) {
+    if ((event.key === "Enter" || event.code === "Enter") && event.shiftKey) {
```

## How did you verify your code works?

- Inspected the existing key handler in `prompt-input.tsx` and confirmed Shift+Enter is handled before the IME composing guard, so adding `event.code` does not affect the normal Enter / IME confirm path.
- Verified `event.code` is supported in all modern browsers and reliably reports `"Enter"` regardless of IME state.
- The existing e2e test `packages/app/e2e/prompt/prompt-multiline.spec.ts` exercises Shift+Enter on a non-IME setup and continues to pass since the new condition is a strict superset of the previous one.
- Manual reproduction of the original bug requires a Windows machine with a Korean/CJK IME enabled in composition state, which I cannot run from this environment — flagging this so a maintainer can validate on Windows.

## Screenshots / recordings

N/A — no visual change.

## Checklist

- [x] I have tested my changes locally (logic-level; Windows IME repro requires a Windows host)
- [x] I have not included unrelated changes in this PR