### PR TITLE
fix(session): fire tool.execute.after hook after MCP output assembly

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -452,12 +452,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
                   execute(args, opts),
                 )
-                yield* plugin.trigger(
-                  "tool.execute.after",
-                  { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
-                  result,
-                )
-
                 const textParts: string[] = []
                 const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []
                 for (const contentItem of result.content) {
@@ -489,10 +483,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   ...(truncated.truncated && { outputPath: truncated.outputPath }),
                 }
 
+                const assembled = { title: key, output: truncated.content, metadata }
+                yield* plugin.trigger(
+                  "tool.execute.after",
+                  { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+                  assembled,
+                )
+
                 const output = {
                   title: "",
-                  metadata,
-                  output: truncated.content,
+                  metadata: assembled.metadata,
+                  output: assembled.output,
                   attachments: attachments.map((attachment) => ({
                     ...attachment,
                     id: PartID.ascending(),


### PR DESCRIPTION
### Issue for this PR

Closes #21149

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tool.execute.after` fires for MCP tools before the output text is assembled from the raw `CallToolResult.content[]` array. Plugins receive the raw SDK result instead of the `{title, output, metadata}` shape declared in the `Hooks` type definition.

Any plugin that tries to transform `output.output` gets `undefined`, and the text assembly at L502-536 rebuilds the output from `result.content` independently of any hook mutations. The hook is effectively a no-op for MCP tool output transformation.

This moves the trigger call to after text assembly and truncation, passing an `assembled` object that matches the declared type contract. The return statement references the assembled object so plugin mutations are reflected in the final tool output.

### How did you verify your code works?

- Typecheck: all packages pass (the `npm-package-arg` error in `shared.ts` is pre-existing on dev)
- The change is limited to MCP tool execution in `prompt.ts`. Native tools (bash, read, etc.) are unaffected — they have their own hook paths
- Confirmed that the assembled object shape matches the `Hooks` type definition in `packages/plugin/src/index.ts`

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR