### PR TITLE
fix(tui): resolve keyboard shortcuts failing with non-English IME

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -38,6 +38,7 @@ import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { DialogWorkspaceList } from "@tui/component/dialog-workspace-list"
 import { DialogConsoleOrg } from "@tui/component/dialog-console-org"
 import { KeybindProvider, useKeybind } from "@tui/context/keybind"
+import { Keybind } from "@/util/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
@@ -310,7 +311,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     // - Ctrl+C copies and dismisses selection
     // - Esc dismisses selection
     // - Most other key input dismisses selection and is passed through
-    if (evt.ctrl && evt.name === "c") {
+    const keyName = Keybind.resolveKeyName(evt)
+    if (evt.ctrl && keyName === "c") {
       if (!Selection.copy(renderer, toast)) {
         renderer.clearSelection()
         return

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -13,6 +13,7 @@ import { DialogModel } from "./dialog-model"
 import { useKeyboard } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { useToast } from "../ui/toast"
+import { Keybind } from "@/util/keybind"
 import { CONSOLE_MANAGED_ICON, isConsoleManagedProvider } from "@tui/util/provider-origin"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
@@ -166,7 +167,7 @@ function AutoMethod(props: AutoMethodProps) {
   const toast = useToast()
 
   useKeyboard((evt) => {
-    if (evt.name === "c" && !evt.ctrl && !evt.meta) {
+    if (Keybind.resolveKeyName(evt) === "c" && !evt.ctrl && !evt.meta) {
       const code = props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4,5}/)?.[0] ?? props.authorization.url
       Clipboard.copy(code)
         .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))

--- a/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/error-component.tsx
@@ -4,6 +4,7 @@ import { Clipboard } from "@tui/util/clipboard"
 import { createSignal } from "solid-js"
 import { Installation } from "@/installation"
 import { win32FlushInputBuffer } from "../win32"
+import { Keybind } from "@/util/keybind"
 import { getScrollAcceleration } from "../util/scroll"
 
 export function ErrorComponent(props: {
@@ -25,7 +26,7 @@ export function ErrorComponent(props: {
   }
 
   useKeyboard((evt) => {
-    if (evt.ctrl && evt.name === "c") {
+    if (evt.ctrl && Keybind.resolveKeyName(evt) === "c") {
       handleExit()
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -36,6 +36,7 @@ import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 import { CONSOLE_MANAGED_ICON, consoleManagedProviderLabel } from "@tui/util/provider-origin"
+import { Keybind } from "@/util/keybind"
 
 export type PromptProps = {
   sessionID?: string
@@ -406,7 +407,7 @@ export function Prompt(props: PromptProps) {
     useKeyboard(
       (evt) => {
         if (!input.focused) return
-        if (evt.name === "v" && evt.ctrl && evt.eventType === "release") {
+        if (Keybind.resolveKeyName(evt) === "v" && evt.ctrl && evt.eventType === "release") {
           command.trigger("prompt.paste")
         }
       },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -3,6 +3,7 @@ import { createMemo, createSignal, For, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
+import { Keybind } from "@/util/keybind"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
@@ -189,12 +190,13 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       return
     }
 
-    if (evt.name === "left" || evt.name === "h") {
+    const keyName = Keybind.resolveKeyName(evt)
+    if (evt.name === "left" || keyName === "h") {
       evt.preventDefault()
       selectTab((store.tab - 1 + tabs()) % tabs())
     }
 
-    if (evt.name === "right" || evt.name === "l") {
+    if (evt.name === "right" || keyName === "l") {
       evt.preventDefault()
       selectTab((store.tab + 1) % tabs())
     }
@@ -228,12 +230,12 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         return
       }
 
-      if (evt.name === "up" || evt.name === "k") {
+      if (evt.name === "up" || keyName === "k") {
         evt.preventDefault()
         moveTo((store.selected - 1 + total) % total)
       }
 
-      if (evt.name === "down" || evt.name === "j") {
+      if (evt.name === "down" || keyName === "j") {
         evt.preventDefault()
         moveTo((store.selected + 1) % total)
       }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -193,8 +193,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   useKeyboard((evt) => {
     setStore("input", "keyboard")
 
-    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
-    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
+    const keyName = Keybind.resolveKeyName(evt)
+    if (evt.name === "up" || (evt.ctrl && keyName === "p")) move(-1)
+    if (evt.name === "down" || (evt.ctrl && keyName === "n")) move(1)
     if (evt.name === "pageup") move(-10)
     if (evt.name === "pagedown") move(10)
     if (evt.name === "home") moveTo(0)

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { Flag } from "@/flag/flag"
 import { Selection } from "@tui/util/selection"
+import { Keybind } from "@/util/keybind"
 
 export function Dialog(
   props: ParentProps<{
@@ -76,8 +77,9 @@ function init() {
   useKeyboard((evt) => {
     if (store.stack.length === 0) return
     if (evt.defaultPrevented) return
-    if ((evt.name === "escape" || (evt.ctrl && evt.name === "c")) && renderer.getSelection()?.getSelectedText()) return
-    if (evt.name === "escape" || (evt.ctrl && evt.name === "c")) {
+    const keyName = Keybind.resolveKeyName(evt)
+    if ((evt.name === "escape" || (evt.ctrl && keyName === "c")) && renderer.getSelection()?.getSelectedText()) return
+    if (evt.name === "escape" || (evt.ctrl && keyName === "c")) {
       if (renderer.getSelection()) {
         renderer.clearSelection()
       }

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -21,9 +21,33 @@ export namespace Keybind {
    * Convert OpenTUI's ParsedKey to our Keybind.Info format.
    * This helper ensures all required fields are present and avoids manual object creation.
    */
+
+  // IME character → QWERTY physical key mappings.
+  // To add a new layout, append entries to this map (e.g. Russian ЙЦУКЕН, Japanese Kana).
+  const IME_TO_LATIN: Record<string, string> = {
+    // Korean 2-Set (두벌식)
+    "ㅂ": "q", "ㅈ": "w", "ㄷ": "e", "ㄱ": "r", "ㅅ": "t",
+    "ㅛ": "y", "ㅕ": "u", "ㅑ": "i", "ㅐ": "o", "ㅔ": "p",
+    "ㅁ": "a", "ㄴ": "s", "ㅇ": "d", "ㄹ": "f", "ㅎ": "g",
+    "ㅗ": "h", "ㅓ": "j", "ㅏ": "k", "ㅣ": "l",
+    "ㅋ": "z", "ㅌ": "x", "ㅊ": "c", "ㅍ": "v",
+    "ㅠ": "b", "ㅜ": "n", "ㅡ": "m",
+    "ㅃ": "q", "ㅉ": "w", "ㄸ": "e", "ㄲ": "r", "ㅆ": "t",
+    "ㅒ": "o", "ㅖ": "p",
+  }
+
+  /** Use physical key (baseCode) when available, falling back to IME layout mapping. */
+  export function resolveKeyName(key: ParsedKey): string {
+    if (key.baseCode) {
+      return String.fromCodePoint(key.baseCode)
+    }
+    return IME_TO_LATIN[key.name] ?? key.name
+  }
+
   export function fromParsedKey(key: ParsedKey, leader = false): Info {
+    const name = resolveKeyName(key)
     return {
-      name: key.name === " " ? "space" : key.name,
+      name: name === " " ? "space" : name,
       ctrl: key.ctrl,
       meta: key.meta,
       shift: key.shift,


### PR DESCRIPTION
### Issue for this PR

Closes #21163

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

With Korean IME on, all keyboard shortcuts break. Ctrl+C becomes Ctrl+ㅊ, Ctrl+X becomes Ctrl+ㅌ, and so on. I dug into this by adding debug logging to the key event handler and got:

`name="ㅊ" ctrl=true baseCode=undefined raw="\x1b[12618;5u" source=kitty`

So the terminal sends the Korean character instead of "c", and `evt.name === "c"` never matches. I also checked if Kitty protocol's `baseCode` could give us the physical key, but most terminals (VSCode, macOS Terminal) just don't send it.

My fix adds `resolveKeyName()` in keybind.ts that:
1. Uses `baseCode` if the terminal sends it (future-proof)
2. Falls back to a Korean 2-Set Jamo → QWERTY mapping table
3. Returns the original name for English/unmapped input

I also updated the hardcoded `evt.name === "c"` checks in 6 TUI components to go through `resolveKeyName()`.

The mapping table is easy to extend — other layouts just need their entries appended to the same map.

### How did you verify your code works?

Built the binary locally and tested with Korean 2-Set IME on macOS. Ctrl+C exits, Ctrl+X opens leader key, normal Korean typing works fine, English shortcuts unchanged. Type check passes.

### Screenshots / recordings

N/A — keyboard input change, no visual difference

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR