### PR TITLE
fix(opencode): prefer bundled ruby tools in ruby projects

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -3,6 +3,7 @@ import { Npm } from "@/npm"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
 import { Process } from "../util/process"
+import { bundle } from "../util/ruby"
 import { which } from "../util/which"
 import { Flag } from "@/flag/flag"
 
@@ -259,6 +260,8 @@ export const rubocop: Info = {
   name: "rubocop",
   extensions: [".rb", ".rake", ".gemspec", ".ru"],
   async enabled() {
+    const cmd = await bundle("rubocop", ["--autocorrect", "$FILE"])
+    if (cmd) return cmd
     const match = which("rubocop")
     if (!match) return false
     return [match, "--autocorrect", "$FILE"]
@@ -269,6 +272,8 @@ export const standardrb: Info = {
   name: "standardrb",
   extensions: [".rb", ".rake", ".gemspec", ".ru"],
   async enabled() {
+    const cmd = await bundle("standardrb", ["--fix", "$FILE"])
+    if (cmd) return cmd
     const match = which("standardrb")
     if (!match) return false
     return [match, "--fix", "$FILE"]

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -10,6 +10,7 @@ import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { Archive } from "../util/archive"
 import { Process } from "../util/process"
+import { bundle } from "../util/ruby"
 import { which } from "../util/which"
 import { Module } from "@opencode-ai/util/module"
 import { spawn } from "./launch"
@@ -387,6 +388,14 @@ export namespace LSPServer {
     root: NearestRoot(["Gemfile"]),
     extensions: [".rb", ".rake", ".gemspec", ".ru"],
     async spawn(root) {
+      const cmd = await bundle("rubocop", ["--lsp"], root)
+      if (cmd) {
+        return {
+          process: spawn(cmd[0]!, cmd.slice(1), {
+            cwd: root,
+          }),
+        }
+      }
       let bin = which("rubocop")
       if (!bin) {
         const ruby = which("ruby")

--- a/packages/opencode/src/util/ruby.ts
+++ b/packages/opencode/src/util/ruby.ts
@@ -1,0 +1,17 @@
+import { Instance } from "@/project/instance"
+import { Filesystem } from "@/util/filesystem"
+import { Process } from "@/util/process"
+import { which } from "@/util/which"
+
+export async function bundle(cmd: string, args: string[], cwd = Instance.directory) {
+  const bin = which("bundle")
+  if (!bin) return
+  const files = await Filesystem.findUp(["Gemfile.lock", "Gemfile"], cwd, Instance.worktree)
+  if (files.length === 0) return
+  const out = await Process.run([bin, "exec", cmd, "--version"], {
+    cwd,
+    nothrow: true,
+  })
+  if (out.code !== 0) return
+  return [bin, "exec", cmd, ...args]
+}

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -1,13 +1,25 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Effect, Layer } from "effect"
+import { Instance } from "../../src/project/instance"
 import { provideTmpdirInstance } from "../fixture/fixture"
+import { tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Format } from "../../src/format"
 import * as Formatter from "../../src/format/formatter"
 
 const it = testEffect(Layer.mergeAll(Format.defaultLayer, CrossSpawnSpawner.defaultLayer, NodeFileSystem.layer))
+
+async function cmd(dir: string, name: string, body: string) {
+  const ext = process.platform === "win32" ? ".cmd" : ""
+  const file = path.join(dir, name + ext)
+  await fs.writeFile(file, process.platform === "win32" ? body : `#!/bin/sh\n${body}`)
+  if (process.platform !== "win32") await fs.chmod(file, 0o755)
+  return file
+}
 
 describe("Format", () => {
   it.live("status() returns built-in formatters when no config overrides", () =>
@@ -168,4 +180,29 @@ describe("Format", () => {
       },
     ),
   )
+
+  test("prefers bundle exec for standardrb in Bundler projects", async () => {
+    await using tmp = await tmpdir()
+    const dir = path.join(tmp.path, "bin")
+    await fs.mkdir(dir)
+    const body =
+      process.platform === "win32"
+        ? '@echo off\r\nif "%~1"=="exec" if "%~2"=="standardrb" if "%~3"=="--version" exit /b 0\r\nexit /b 1\r\n'
+        : 'if [ "$1" = "exec" ] && [ "$2" = "standardrb" ] && [ "$3" = "--version" ]; then\n  exit 0\nfi\nexit 1\n'
+    const bundle = await cmd(dir, "bundle", body)
+    const prev = process.env.PATH
+    process.env.PATH = [dir, prev].filter(Boolean).join(path.delimiter)
+    await Bun.write(path.join(tmp.path, "Gemfile.lock"), "")
+
+    try {
+      const result = await Instance.provide({
+        directory: tmp.path,
+        fn: () => Formatter.standardrb.enabled(),
+      })
+      expect(result).toEqual([bundle, "exec", "standardrb", "--fix", "$FILE"])
+    } finally {
+      process.env.PATH = prev
+      await Instance.disposeAll()
+    }
+  })
 })

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, spyOn, test } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import * as Lsp from "../../src/lsp/index"
 import { LSPServer } from "../../src/lsp/server"
 import { Instance } from "../../src/project/instance"
+import { Process } from "../../src/util/process"
 import { tmpdir } from "../fixture/fixture"
+
+async function cmd(dir: string, name: string, body: string) {
+  const ext = process.platform === "win32" ? ".cmd" : ""
+  const file = path.join(dir, name + ext)
+  await fs.writeFile(file, process.platform === "win32" ? body : `#!/bin/sh\n${body}`)
+  if (process.platform !== "win32") await fs.chmod(file, 0o755)
+  return file
+}
 
 describe("lsp.spawn", () => {
   test("does not spawn builtin LSP for files outside instance", async () => {
@@ -49,6 +59,35 @@ describe("lsp.spawn", () => {
       expect(spy).toHaveBeenCalledTimes(1)
     } finally {
       spy.mockRestore()
+      await Instance.disposeAll()
+    }
+  })
+
+  test("uses bundle exec for ruby-lsp in Bundler projects", async () => {
+    await using tmp = await tmpdir()
+    const dir = path.join(tmp.path, "bin")
+    await fs.mkdir(dir)
+    const body =
+      process.platform === "win32"
+        ? '@echo off\r\nif "%~1"=="exec" if "%~2"=="rubocop" if "%~3"=="--version" exit /b 0\r\nif "%~1"=="exec" if "%~2"=="rubocop" if "%~3"=="--lsp" powershell -NoProfile -Command "Start-Sleep -Seconds 30"\r\nexit /b 1\r\n'
+        : 'if [ "$1" = "exec" ] && [ "$2" = "rubocop" ] && [ "$3" = "--version" ]; then\n  exit 0\nfi\nif [ "$1" = "exec" ] && [ "$2" = "rubocop" ] && [ "$3" = "--lsp" ]; then\n  while :; do sleep 1; done\nfi\nexit 1\n'
+    const bundle = await cmd(dir, "bundle", body)
+    const prev = process.env.PATH
+    process.env.PATH = [dir, prev].filter(Boolean).join(path.delimiter)
+    await Bun.write(path.join(tmp.path, "Gemfile"), 'source "https://rubygems.org"\n')
+
+    let handle: Awaited<ReturnType<typeof LSPServer.Rubocop.spawn>> | undefined
+    try {
+      handle = await Instance.provide({
+        directory: tmp.path,
+        fn: () => LSPServer.Rubocop.spawn(tmp.path),
+      })
+      expect(handle).toBeDefined()
+      expect(handle!.process.spawnfile).toBe(bundle)
+      expect(handle!.process.spawnargs.slice(1)).toEqual(["exec", "rubocop", "--lsp"])
+    } finally {
+      if (handle?.process) await Process.stop(handle.process)
+      process.env.PATH = prev
       await Instance.disposeAll()
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #17972

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ruby projects often install `rubocop` and `standardrb` through Bundler, so bare commands fail or time out even when the tools are present. This change prefers `bundle exec` for the Ruby formatter and `rubocop --lsp` paths when the project is managed by Bundler, then falls back to the existing bare command behavior otherwise.

### How did you verify your code works?

- `bun test test/format/format.test.ts test/lsp/index.test.ts`
- `bun typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR