### PR TITLE
feat(opencode): add GitHub Copilot usage surfaces

### DIFF
--- a/bin/opencode
+++ b/bin/opencode
@@ -1,0 +1,1 @@
+/Users/mac/Documents/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -30,6 +30,7 @@ import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
+import { DialogUsage } from "@tui/component/dialog-usage"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
@@ -659,6 +660,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
       onSelect: () => {
         dialog.replace(() => <DialogStatus />)
+      },
+      category: "System",
+    },
+    {
+      title: "View usage",
+      value: "opencode.usage",
+      slash: {
+        name: "usage",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogUsage />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-usage.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-usage.tsx
@@ -1,0 +1,101 @@
+import { TextAttributes } from "@opentui/core"
+import { useDialog } from "@tui/ui/dialog"
+import { useTheme } from "@tui/context/theme"
+import { useLocal } from "@tui/context/local"
+import { Auth } from "@/auth"
+import { CopilotUsage, UsageError } from "@/plugin/github-copilot/usage"
+import { createMemo, createSignal, onMount, Show } from "solid-js"
+
+export function DialogUsage() {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const local = useLocal()
+  const [state, setState] = createSignal<
+    | { type: "loading" }
+    | {
+        type: "ready"
+        used: string
+        remaining: string
+        total: string
+        reset: string
+      }
+    | { type: "error"; message: string }
+  >({ type: "loading" })
+
+  const model = createMemo(() => local.model.current())
+
+  onMount(() => {
+    const current = model()
+    if (!current || !current.providerID.includes("github-copilot")) {
+      setState({
+        type: "error",
+        message: "当前模型不是 GitHub Copilot，Usage 暂不可用。",
+      })
+      return
+    }
+
+    Auth.get("github-copilot")
+      .then((auth) => {
+        if (!auth || auth.type !== "oauth") throw new UsageError("not_logged_in")
+        return CopilotUsage.get({
+          token: auth.refresh,
+          enterpriseUrl: auth.enterpriseUrl,
+        })
+      })
+      .then((usage) => {
+        const sum = CopilotUsage.brief({ usage })
+        setState({
+          type: "ready",
+          used: sum.used,
+          remaining: sum.remaining,
+          total: sum.total,
+          reset: sum.reset,
+        })
+      })
+      .catch((err) => {
+        setState({
+          type: "error",
+          message: CopilotUsage.explain(err),
+        })
+      })
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Usage
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+
+      <Show when={state().type === "loading"}>
+        <text fg={theme.textMuted}>正在查询 Copilot 额度...</text>
+      </Show>
+
+      <Show when={state().type === "error" && state().type !== "loading"}>
+        <text fg={theme.error}>{(state() as { type: "error"; message: string }).message}</text>
+      </Show>
+
+      <Show when={state().type === "ready" && state().type !== "loading"}>
+        <box gap={0}>
+          <text fg={theme.text}>
+            使用额度: <span style={{ fg: theme.textMuted }}>{(state() as { type: "ready"; used: string }).used}</span>
+          </text>
+          <text fg={theme.text}>
+            剩余额度:{" "}
+            <span style={{ fg: theme.textMuted }}>{(state() as { type: "ready"; remaining: string }).remaining}</span>
+          </text>
+          <text fg={theme.text}>
+            总额度: <span style={{ fg: theme.textMuted }}>{(state() as { type: "ready"; total: string }).total}</span>
+          </text>
+          <text fg={theme.text}>
+            刷新时间: <span style={{ fg: theme.textMuted }}>{(state() as { type: "ready"; reset: string }).reset}</span>
+          </text>
+        </box>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/usage.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/usage.tsx
@@ -1,0 +1,121 @@
+import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
+import { Auth } from "@/auth"
+import { CopilotUsage, UsageError } from "@/plugin/github-copilot/usage"
+import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
+
+const id = "internal:sidebar-usage"
+
+function View(props: { api: TuiPluginApi; session_id: string }) {
+  const theme = () => props.api.theme.current
+  const msg = createMemo(() => props.api.state.session.messages(props.session_id))
+  const [used, setUsed] = createSignal("--")
+  const [total, setTotal] = createSignal("--")
+  const [pct, setPct] = createSignal<number | undefined>()
+  const provider = createMemo(() => {
+    const item = msg().at(-1)
+    if (!item) return
+    if (item.role === "assistant") return item.providerID
+    if (item.role === "user") return item.model.providerID
+    return
+  })
+  const active = createMemo(() => provider()?.includes("github-copilot") === true)
+  let last = 0
+
+  const update = (force = false) => {
+    if (!active()) {
+      setUsed("不可用")
+      setTotal("")
+      setPct(undefined)
+      return
+    }
+    if (!force && Date.now() - last < 15_000) return
+    last = Date.now()
+    Auth.get("github-copilot")
+      .then((auth) => {
+        if (!auth || auth.type !== "oauth") throw new UsageError("not_logged_in")
+        return CopilotUsage.get({
+          token: auth.refresh,
+          enterpriseUrl: auth.enterpriseUrl,
+        })
+      })
+      .then((data) => {
+        const sum = CopilotUsage.brief({ usage: data })
+        setUsed(sum.used)
+        setTotal(sum.total === "无限" ? "∞" : sum.total)
+        setPct(sum.percent)
+      })
+      .catch(() => {
+        setUsed("--")
+        setTotal("--")
+        setPct(undefined)
+      })
+  }
+
+  onMount(() => {
+    update(true)
+  })
+  const timer = setInterval(() => update(), 5 * 60 * 1000)
+  onCleanup(() => clearInterval(timer))
+
+  createEffect(() => {
+    const list = msg()
+    const item = list.at(-1)
+    if (!item || item.role !== "assistant") return
+    if (!item.time.completed) return
+    if (!item.providerID.includes("github-copilot")) return
+    update()
+  })
+
+  createEffect(() => {
+    active()
+    update(true)
+  })
+
+  const bar = createMemo(() => {
+    const val = pct()
+    if (typeof val !== "number") {
+      return {
+        left: "──────────────",
+        right: "",
+        color: theme().textMuted,
+      }
+    }
+    const max = 14
+    const fill = Math.round((Math.max(0, Math.min(100, val)) / 100) * max)
+    return {
+      left: "█".repeat(fill),
+      right: "░".repeat(Math.max(max - fill, 0)),
+      color: val >= 90 ? theme().error : val >= 75 ? theme().warning : theme().success,
+    }
+  })
+
+  return (
+    <box>
+      <text fg={theme().text}>
+        <b>Usage</b>
+      </text>
+      <text fg={theme().textMuted}>
+        <span style={{ fg: bar().color }}>{bar().left}</span>
+        <span style={{ fg: theme().textMuted }}>{bar().right}</span> {total() ? `${used()}/${total()}` : used()}
+      </text>
+    </box>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 120,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: TuiPluginModule & { id: string } = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/usage.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/usage.tsx
@@ -1,22 +1,24 @@
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
 import { Auth } from "@/auth"
 import { CopilotUsage, UsageError } from "@/plugin/github-copilot/usage"
+import { useLocal } from "@tui/context/local"
 import { createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 
 const id = "internal:sidebar-usage"
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
+  const local = useLocal()
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const [used, setUsed] = createSignal("--")
   const [total, setTotal] = createSignal("--")
   const [pct, setPct] = createSignal<number | undefined>()
   const provider = createMemo(() => {
+    const current = local.model.current()
+    if (current) return current.providerID
     const item = msg().at(-1)
-    if (!item) return
-    if (item.role === "assistant") return item.providerID
-    if (item.role === "user") return item.model.providerID
-    return
+    if (item?.role === "assistant") return item.providerID
+    if (item?.role === "user") return item.model.providerID
   })
   const active = createMemo(() => provider()?.includes("github-copilot") === true)
   let last = 0

--- a/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
+++ b/packages/opencode/src/cli/cmd/tui/plugin/internal.ts
@@ -1,6 +1,7 @@
 import HomeFooter from "../feature-plugins/home/footer"
 import HomeTips from "../feature-plugins/home/tips"
 import SidebarContext from "../feature-plugins/sidebar/context"
+import SidebarUsage from "../feature-plugins/sidebar/usage"
 import SidebarMcp from "../feature-plugins/sidebar/mcp"
 import SidebarLsp from "../feature-plugins/sidebar/lsp"
 import SidebarTodo from "../feature-plugins/sidebar/todo"
@@ -18,6 +19,7 @@ export const INTERNAL_TUI_PLUGINS: InternalTuiPlugin[] = [
   HomeFooter,
   HomeTips,
   SidebarContext,
+  SidebarUsage,
   SidebarMcp,
   SidebarLsp,
   SidebarTodo,

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -63,6 +63,7 @@ export namespace Command {
   export const Default = {
     INIT: "init",
     REVIEW: "review",
+    USAGE: "usage",
   } as const
 
   export interface Interface {
@@ -102,7 +103,6 @@ export namespace Command {
           subtask: true,
           hints: hints(PROMPT_REVIEW),
         }
-
         for (const [name, command] of Object.entries(cfg.command ?? {})) {
           commands[name] = {
             name,

--- a/packages/opencode/src/command/template/usage.txt
+++ b/packages/opencode/src/command/template/usage.txt
@@ -1,0 +1,1 @@
+Show current GitHub Copilot usage and quota information.

--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -39,6 +39,9 @@ function fix(model: Model): Model {
 
 export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
   const sdk = input.client
+  const synth = (part: unknown) =>
+    typeof part === "object" && part !== null && "synthetic" in part && part.synthetic === true
+
   return {
     provider: {
       id: "github-copilot",
@@ -330,6 +333,15 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         .catch(() => undefined)
 
       if (parts?.data.parts?.some((part) => part.type === "compaction")) {
+        output.headers["x-initiator"] = "agent"
+        return
+      }
+
+      if (
+        parts?.data.parts?.length &&
+        parts.data.parts.some((part) => part.type === "text") &&
+        parts.data.parts.every(synth)
+      ) {
         output.headers["x-initiator"] = "agent"
         return
       }

--- a/packages/opencode/src/plugin/github-copilot/usage.ts
+++ b/packages/opencode/src/plugin/github-copilot/usage.ts
@@ -115,7 +115,19 @@ export namespace CopilotUsage {
 }
 
 function val(v?: number) {
-  return typeof v === "number" ? v.toString() : "-"
+  if (typeof v !== "number") return "-"
+  if (Number.isInteger(v)) return v.toString()
+  return v.toFixed(2)
+}
+
+function rem(item?: Quota) {
+  if (!item) return
+  if (typeof item.quota_remaining === "number") return item.quota_remaining
+  if (typeof item.remaining === "number") return item.remaining
+}
+
+function num(v: number) {
+  return Math.round(v * 100) / 100
 }
 
 function pick(data: Usage) {
@@ -133,8 +145,7 @@ function pick(data: Usage) {
 function left(item?: Quota) {
   if (!item) return "-"
   if (item.unlimited === true) return "无限"
-  const v = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
-  return val(v)
+  return val(rem(item))
 }
 
 function cap(item?: Quota) {
@@ -147,20 +158,20 @@ function use(item?: Quota) {
   if (!item) return "-"
   if (item.unlimited === true) return "-"
   if (typeof item.entitlement !== "number") return "-"
-  const r = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
+  const r = rem(item)
   if (typeof r !== "number") return "-"
-  return String(Math.max(item.entitlement - r, 0))
+  return val(Math.max(item.entitlement - r, 0))
 }
 
 function pct(item?: Quota) {
   if (!item) return undefined
   if (item.unlimited === true) return undefined
   if (typeof item.percent_remaining === "number") {
-    return Math.max(0, Math.min(100, 100 - item.percent_remaining))
+    return num(Math.max(0, Math.min(100, 100 - item.percent_remaining)))
   }
   if (typeof item.entitlement !== "number") return undefined
-  const r = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
+  const r = rem(item)
   if (typeof r !== "number") return undefined
   const used = Math.max(item.entitlement - r, 0)
-  return Math.max(0, Math.min(100, (used / item.entitlement) * 100))
+  return num(Math.max(0, Math.min(100, (used / item.entitlement) * 100)))
 }

--- a/packages/opencode/src/plugin/github-copilot/usage.ts
+++ b/packages/opencode/src/plugin/github-copilot/usage.ts
@@ -1,0 +1,166 @@
+import { Installation } from "@/installation"
+import { z } from "zod"
+
+const API_VERSION = "2025-04-01"
+
+function normalize(url: string) {
+  return url.replace(/^https?:\/\//, "").replace(/\/$/, "")
+}
+
+function base(url?: string) {
+  if (!url) return "https://api.github.com"
+  return `https://api.${normalize(url)}`
+}
+
+const quota = z
+  .object({
+    entitlement: z.number().optional(),
+    overage_count: z.number().optional(),
+    overage_permitted: z.boolean().optional(),
+    percent_remaining: z.number().optional(),
+    quota_id: z.string().optional(),
+    quota_remaining: z.number().optional(),
+    remaining: z.number().optional(),
+    unlimited: z.boolean().optional(),
+  })
+  .passthrough()
+
+const usage = z
+  .object({
+    copilot_plan: z.string().optional(),
+    quota_reset_date: z.string().optional(),
+    quota_snapshots: z
+      .object({
+        premium_interactions: quota.optional(),
+        chat: quota.optional(),
+        completions: quota.optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .passthrough()
+
+type Usage = z.infer<typeof usage>
+type Quota = z.infer<typeof quota>
+
+export class UsageError extends Error {
+  constructor(
+    readonly code: "not_logged_in" | "token_invalid" | "forbidden" | "not_found" | "bad_response" | "request_failed",
+    readonly status?: number,
+  ) {
+    super(code)
+  }
+}
+
+export namespace CopilotUsage {
+  export async function get(input: { token?: string; enterpriseUrl?: string }) {
+    if (!input.token) throw new UsageError("not_logged_in")
+
+    const res = await fetch(`${base(input.enterpriseUrl)}/copilot_internal/user`, {
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `token ${input.token}`,
+        "User-Agent": `opencode/${Installation.VERSION}`,
+        "X-GitHub-Api-Version": API_VERSION,
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (res.status === 401) throw new UsageError("token_invalid", res.status)
+    if (res.status === 403) throw new UsageError("forbidden", res.status)
+    if (res.status === 404) throw new UsageError("not_found", res.status)
+    if (!res.ok) throw new UsageError("request_failed", res.status)
+
+    const json = await res.json()
+    const parsed = usage.safeParse(json)
+    if (!parsed.success) throw new UsageError("bad_response", res.status)
+    return parsed.data
+  }
+
+  export function format(input: { usage: Usage; raw?: boolean }) {
+    const data = input.usage
+    const sum = brief({ usage: data })
+    const out = [
+      `使用额度: ${sum.used}`,
+      `剩余额度: ${sum.remaining}`,
+      `总额度: ${sum.total}`,
+      `刷新时间: ${sum.reset}`,
+    ]
+
+    if (!input.raw) return out.join("\n")
+    return `${out.join("\n")}\n\n\`\`\`json\n${JSON.stringify(data, null, 2)}\n\`\`\``
+  }
+
+  export function explain(err: unknown) {
+    if (!(err instanceof UsageError)) return "请求 Copilot usage 失败。请稍后重试。"
+    if (err.code === "not_logged_in") return "未检测到 GitHub Copilot 登录。请先在 OpenCode 中连接 GitHub Copilot。"
+    if (err.code === "token_invalid") return "GitHub token 已失效或已过期。请重新登录 GitHub Copilot。"
+    if (err.code === "forbidden") return "当前账号没有访问 Copilot usage 的权限，或未开通 Copilot/Premium。"
+    if (err.code === "not_found") return "未找到 Copilot usage 接口，可能是账号/企业环境不支持该端点。"
+    if (err.code === "bad_response") return "GitHub 返回了无法识别的 usage 数据格式。"
+    return `GitHub 接口请求失败（HTTP ${err.status ?? "unknown"}）。`
+  }
+
+  export function brief(input: { usage: Usage }) {
+    const item = pick(input.usage)
+    return {
+      used: use(item),
+      remaining: left(item),
+      total: cap(item),
+      percent: pct(item),
+      reset: input.usage.quota_reset_date ?? "-",
+    }
+  }
+}
+
+function val(v?: number) {
+  return typeof v === "number" ? v.toString() : "-"
+}
+
+function pick(data: Usage) {
+  const list = [
+    data.quota_snapshots?.premium_interactions,
+    data.quota_snapshots?.chat,
+    data.quota_snapshots?.completions,
+  ].filter((x): x is Quota => Boolean(x))
+  if (!list.length) return undefined
+  const finite = list.find((x) => x.unlimited !== true && (x.entitlement ?? 0) > 0)
+  if (finite) return finite
+  return list[0]
+}
+
+function left(item?: Quota) {
+  if (!item) return "-"
+  if (item.unlimited === true) return "无限"
+  const v = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
+  return val(v)
+}
+
+function cap(item?: Quota) {
+  if (!item) return "-"
+  if (item.unlimited === true) return "无限"
+  return val(item.entitlement)
+}
+
+function use(item?: Quota) {
+  if (!item) return "-"
+  if (item.unlimited === true) return "-"
+  if (typeof item.entitlement !== "number") return "-"
+  const r = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
+  if (typeof r !== "number") return "-"
+  return String(Math.max(item.entitlement - r, 0))
+}
+
+function pct(item?: Quota) {
+  if (!item) return undefined
+  if (item.unlimited === true) return undefined
+  if (typeof item.percent_remaining === "number") {
+    return Math.max(0, Math.min(100, 100 - item.percent_remaining))
+  }
+  if (typeof item.entitlement !== "number") return undefined
+  const r = typeof item.remaining === "number" ? item.remaining : item.quota_remaining
+  if (typeof r !== "number") return undefined
+  const used = Math.max(item.entitlement - r, 0)
+  return Math.max(0, Math.min(100, (used / item.entitlement) * 100))
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -50,6 +50,8 @@ import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { Auth } from "@/auth"
+import { CopilotUsage, UsageError } from "@/plugin/github-copilot/usage"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1581,17 +1583,107 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         },
       )
 
-      const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
-        log.info("command", input)
-        const cmd = yield* commands.get(input.command)
-        if (!cmd) {
-          const available = (yield* commands.list()).map((c) => c.name)
-          const hint = available.length ? ` Available commands: ${available.join(", ")}` : ""
-          const error = new NamedError.Unknown({ message: `Command not found: "${input.command}".${hint}` })
-          yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
-          throw error
-        }
-        const agentName = cmd.agent ?? input.agent ?? (yield* agents.defaultAgent())
+      const usage: (input: CommandInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.usage")(
+        function* (input: CommandInput) {
+          const ctx = yield* InstanceState.context
+          const session = yield* sessions.get(input.sessionID)
+          if (session.revert) {
+            yield* Effect.promise(() => SessionRevert.cleanup(session))
+          }
+
+          const mode = input.agent ?? (yield* agents.defaultAgent())
+          const model = input.model ? Provider.parseModel(input.model) : yield* lastModel(input.sessionID)
+          const raw = /\braw\b|--raw\b/.test(input.arguments)
+          const cmd = ["/usage", input.arguments.trim()].filter(Boolean).join(" ")
+
+          const user: MessageV2.User = {
+            id: input.messageID ?? MessageID.ascending(),
+            sessionID: input.sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: mode,
+            model: { providerID: model.providerID, modelID: model.modelID },
+          }
+          yield* sessions.updateMessage(user)
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: user.id,
+            sessionID: user.sessionID,
+            type: "text",
+            text: cmd,
+            synthetic: true,
+          } satisfies MessageV2.TextPart)
+
+          const msg: MessageV2.Assistant = {
+            id: MessageID.ascending(),
+            sessionID: input.sessionID,
+            parentID: user.id,
+            mode,
+            agent: mode,
+            cost: 0,
+            path: { cwd: ctx.directory, root: ctx.worktree },
+            time: { created: Date.now() },
+            role: "assistant",
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            modelID: model.modelID,
+            providerID: model.providerID,
+          }
+          yield* sessions.updateMessage(msg)
+
+          const info = yield* Effect.promise(() => Auth.get("github-copilot")).pipe(Effect.orDie)
+          const text = yield* Effect.promise(async () => {
+            if (!model.providerID.includes("github-copilot")) {
+              return "当前模型不是 GitHub Copilot，Usage 暂不可用。"
+            }
+            if (!info || info.type !== "oauth") {
+              return CopilotUsage.explain(new UsageError("not_logged_in"))
+            }
+            const result = await CopilotUsage.get({
+              token: info.refresh,
+              enterpriseUrl: info.enterpriseUrl,
+            }).catch((err) => err)
+            if (result instanceof Error) return CopilotUsage.explain(result)
+            return CopilotUsage.format({ usage: result, raw })
+          })
+
+          msg.time.completed = Date.now()
+          const done = yield* sessions.updateMessage(msg)
+          const part = yield* sessions.updatePart({
+            id: PartID.ascending(),
+            messageID: msg.id,
+            sessionID: msg.sessionID,
+            type: "text",
+            text,
+          } satisfies MessageV2.TextPart)
+          return {
+            info: done,
+            parts: [part],
+          }
+        },
+      )
+
+      const command: (input: CommandInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.command")(
+        function* (input: CommandInput) {
+          log.info("command", input)
+          if (input.command === Command.Default.USAGE) {
+            const result = yield* usage(input)
+            yield* bus.publish(Command.Event.Executed, {
+              name: input.command,
+              sessionID: input.sessionID,
+              arguments: input.arguments,
+              messageID: result.info.id,
+            })
+            return result
+          }
+          const cmd = yield* commands.get(input.command)
+          if (!cmd) {
+            const available = (yield* commands.list()).map((c) => c.name)
+            const hint = available.length ? ` Available commands: ${available.join(", ")}` : ""
+            const error = new NamedError.Unknown({ message: `Command not found: "${input.command}".${hint}` })
+            yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
+            throw error
+          }
+          const agentName = cmd.agent ?? input.agent ?? (yield* agents.defaultAgent())
 
         const raw = input.arguments.match(argsRegex) ?? []
         const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
@@ -1695,7 +1787,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           messageID: result.info.id,
         })
         return result
-      })
+        },
+      )
 
       return Service.of({
         assertNotBusy,

--- a/packages/opencode/test/plugin/github-copilot-headers.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-headers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { CopilotAuthPlugin } from "../../src/plugin/github-copilot/copilot"
+
+function fake(parts: Array<{ type: string; synthetic?: boolean }>, parent?: string) {
+  const client = {
+    session: {
+      message: async () => ({
+        data: {
+          parts,
+        },
+      }),
+      get: async () => ({
+        data: {
+          parentID: parent,
+        },
+      }),
+    },
+  }
+
+  return {
+    client,
+    directory: "/tmp",
+  } as unknown as PluginInput
+}
+
+async function run(input: PluginInput) {
+  const hooks = await CopilotAuthPlugin(input)
+  const hook = hooks["chat.headers"]
+  if (!hook) throw new Error("missing chat.headers hook")
+
+  const out = { headers: {} as Record<string, string> }
+  await hook(
+    {
+      sessionID: "ses_1",
+      agent: "build",
+      model: {
+        providerID: "github-copilot",
+        modelID: "gpt-5.3-codex",
+        api: {
+          npm: "@ai-sdk/openai-compatible",
+        },
+      },
+      provider: {
+        source: "config",
+        info: {} as never,
+        options: {},
+      },
+      message: {
+        id: "msg_1",
+        sessionID: "ses_1",
+      },
+    } as unknown as Parameters<NonNullable<(typeof hooks)["chat.headers"]>>[0],
+    out,
+  )
+  return out.headers["x-initiator"]
+}
+
+describe("plugin.github-copilot.chat.headers", () => {
+  test("marks compaction continuation synthetic user message as agent initiated", async () => {
+    const val = await run(fake([{ type: "text", synthetic: true }]))
+    expect(val).toBe("agent")
+  })
+
+  test("marks compaction part message as agent initiated", async () => {
+    const val = await run(fake([{ type: "compaction" }]))
+    expect(val).toBe("agent")
+  })
+
+  test("marks subagent session messages as agent initiated", async () => {
+    const val = await run(fake([{ type: "text" }], "ses_parent"))
+    expect(val).toBe("agent")
+  })
+
+  test("keeps normal primary user message as user initiated", async () => {
+    const val = await run(fake([{ type: "text" }]))
+    expect(val).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/plugin/github-copilot-usage.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-usage.test.ts
@@ -74,7 +74,7 @@ test("formats summary and raw output", () => {
 
   const raw = CopilotUsage.format({ usage, raw: true })
   expect(raw).toContain("```json")
-  expect(raw).toContain("\"copilot_plan\": \"pro\"")
+  expect(raw).toContain('"copilot_plan": "pro"')
 })
 
 test("formats unlimited quota as infinite", () => {
@@ -93,6 +93,31 @@ test("formats unlimited quota as infinite", () => {
   expect(text).toContain("使用额度: -")
   expect(text).toContain("剩余额度: 无限")
   expect(text).toContain("总额度: 无限")
+})
+
+test("prefers precise quota values and keeps two decimals", () => {
+  const usage = {
+    quota_reset_date: "2026-05-01",
+    quota_snapshots: {
+      premium_interactions: {
+        entitlement: 1500,
+        remaining: 1327,
+        quota_remaining: 1327.56,
+        percent_remaining: 88.50399999999999,
+        unlimited: false,
+      },
+    },
+  }
+
+  const sum = CopilotUsage.brief({ usage })
+  expect(sum.used).toBe("172.44")
+  expect(sum.remaining).toBe("1327.56")
+  expect(sum.total).toBe("1500")
+  expect(sum.percent).toBe(11.5)
+
+  const text = CopilotUsage.format({ usage })
+  expect(text).toContain("使用额度: 172.44")
+  expect(text).toContain("剩余额度: 1327.56")
 })
 
 test("maps known errors to readable messages", () => {

--- a/packages/opencode/test/plugin/github-copilot-usage.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-usage.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, mock, test } from "bun:test"
+import { CopilotUsage, UsageError } from "@/plugin/github-copilot/usage"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("requests usage from GitHub API with GitHub token", async () => {
+  let url = ""
+  let auth = ""
+
+  globalThis.fetch = mock((input, init) => {
+    url = String(input)
+    auth = String((init?.headers as Record<string, string>)?.Authorization ?? "")
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          copilot_plan: "business",
+          quota_reset_date: "2026-04-30",
+          quota_snapshots: {
+            premium_interactions: { entitlement: 300, remaining: 240, percent_remaining: 80, unlimited: false },
+          },
+        }),
+        { status: 200 },
+      ),
+    )
+  }) as unknown as typeof fetch
+
+  const result = await CopilotUsage.get({ token: "ghu_test" })
+  expect(url).toBe("https://api.github.com/copilot_internal/user")
+  expect(auth).toBe("token ghu_test")
+  expect(result.copilot_plan).toBe("business")
+})
+
+test("formats summary and raw output", () => {
+  const usage = {
+    copilot_plan: "pro",
+    quota_reset_date: "2026-04-30",
+    quota_snapshots: {
+      premium_interactions: {
+        entitlement: 300,
+        remaining: 150,
+        percent_remaining: 50,
+        unlimited: false,
+        overage_permitted: true,
+        overage_count: 12,
+      },
+      chat: {
+        entitlement: 1000,
+        remaining: 850,
+        percent_remaining: 85,
+        unlimited: false,
+        overage_permitted: false,
+        overage_count: 0,
+      },
+      completions: {
+        entitlement: 5000,
+        remaining: 4200,
+        percent_remaining: 84,
+        unlimited: false,
+        overage_permitted: false,
+        overage_count: 0,
+      },
+    },
+  }
+
+  const text = CopilotUsage.format({ usage })
+  expect(text).toContain("使用额度: 150")
+  expect(text).toContain("剩余额度: 150")
+  expect(text).toContain("总额度: 300")
+  expect(text).toContain("刷新时间: 2026-04-30")
+
+  const raw = CopilotUsage.format({ usage, raw: true })
+  expect(raw).toContain("```json")
+  expect(raw).toContain("\"copilot_plan\": \"pro\"")
+})
+
+test("formats unlimited quota as infinite", () => {
+  const text = CopilotUsage.format({
+    usage: {
+      quota_reset_date: "2026-05-01",
+      quota_snapshots: {
+        chat: {
+          entitlement: 0,
+          remaining: 0,
+          unlimited: true,
+        },
+      },
+    },
+  })
+  expect(text).toContain("使用额度: -")
+  expect(text).toContain("剩余额度: 无限")
+  expect(text).toContain("总额度: 无限")
+})
+
+test("maps known errors to readable messages", () => {
+  expect(CopilotUsage.explain(new UsageError("not_logged_in"))).toContain("未检测到")
+  expect(CopilotUsage.explain(new UsageError("token_invalid"))).toContain("失效")
+  expect(CopilotUsage.explain(new UsageError("forbidden"))).toContain("权限")
+  expect(CopilotUsage.explain(new UsageError("not_found"))).toContain("未找到")
+  expect(CopilotUsage.explain(new UsageError("request_failed", 502))).toContain("HTTP 502")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a small GitHub Copilot usage feature set to `opencode`. It introduces a reusable usage client, exposes the data through the `/usage` command, and surfaces the same information in the TUI sidebar and a dedicated dialog. It also fixes Copilot header initiation for synthetic compaction continuation messages so those requests are still marked as agent-initiated.

### How did you verify your code works?

- Ran `bun test test/plugin/github-copilot-headers.test.ts test/plugin/github-copilot-usage.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR