### PR TITLE
fix(provider): treat empty small_model as disabled

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1547,6 +1547,8 @@ export namespace Provider {
       const getSmallModel = Effect.fn("Provider.getSmallModel")(function* (providerID: ProviderID) {
         const cfg = yield* config.get()
 
+        if (cfg.small_model === "") return undefined
+
         if (cfg.small_model) {
           const parsed = parseModel(cfg.small_model)
           return yield* getModel(parsed.providerID, parsed.modelID)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -977,6 +977,30 @@ test("getSmallModel respects config small_model override", async () => {
   })
 })
 
+test("getSmallModel returns undefined when config small_model is empty", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          small_model: "",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const model = await Provider.getSmallModel(ProviderID.anthropic)
+      expect(model).toBeUndefined()
+    },
+  })
+})
+
 test("provider.sort prioritizes preferred models", () => {
   const models = [
     { id: "random-model", name: "Random" },


### PR DESCRIPTION
### Issue for this PR

Closes #4579

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`small_model: ""` was still falling back to the default small model, which could trigger unexpected Haiku requests.

This change treats an explicit empty `small_model` as disabled and adds a regression test for that case.

### How did you verify your code works?

- `bun test test/provider/provider.test.ts -t "getSmallModel"`
- `bun typecheck`
- commit hook `bun turbo typecheck`

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR