### PR TITLE
docs: document OPENCODE_API_KEY env var for Zen/Go providers

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
@@ -8,6 +8,7 @@ import { formatDateUTC, formatDateForTable } from "../../common"
 import styles from "./key-section.module.css"
 import { Actor } from "@opencode-ai/console-core/actor.js"
 import { useI18n } from "~/context/i18n"
+import { useLanguage } from "~/context/language"
 import { formError, localizeError } from "~/lib/form-error"
 
 const removeKey = action(async (form: FormData) => {
@@ -48,6 +49,7 @@ const listKeys = query(async (workspaceID: string) => {
 export function KeySection() {
   const params = useParams()
   const i18n = useI18n()
+  const language = useLanguage()
   const keys = createAsync(() => listKeys(params.id!))
   const submission = useSubmission(createKey)
   const [store, setStore] = createStore({ show: false })
@@ -78,7 +80,12 @@ export function KeySection() {
       <div data-slot="section-title">
         <h2>{i18n.t("workspace.keys.title")}</h2>
         <div data-slot="title-row">
-          <p>{i18n.t("workspace.keys.subtitle")}</p>
+          <p>
+            {i18n.t("workspace.keys.subtitle")}{" "}
+            <a target="_blank" href={language.route("/docs/providers#opencode-zen")}>
+              {i18n.t("common.learnMore")}
+            </a>
+          </p>
           <button data-color="primary" onClick={() => show()}>
             {i18n.t("workspace.keys.create")}
           </button>

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -555,6 +555,7 @@ OpenCode can be configured using environment variables.
 
 | Variable                              | Type    | Description                                       |
 | ------------------------------------- | ------- | ------------------------------------------------- |
+| `OPENCODE_API_KEY`                    | string  | API key for OpenCode Zen/Go provider              |
 | `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
 | `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
 | `OPENCODE_CONFIG`                     | string  | Path to config file                               |

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -82,6 +82,14 @@ If you are new, we recommend starting with OpenCode Zen.
 
 It works like any other provider in OpenCode and is completely optional to use.
 
+#### Environment Variable
+
+For CI, scripts, or headless usage, you can set the `OPENCODE_API_KEY` environment variable instead of using `/connect`.
+
+```bash
+OPENCODE_API_KEY=your-key opencode run "Hello world"
+```
+
 ---
 
 ## OpenCode Go
@@ -113,6 +121,14 @@ tested and verified to work well with OpenCode.
    ```
 
 It works like any other provider in OpenCode and is completely optional to use.
+
+#### Environment Variable
+
+For CI, scripts, or headless usage, you can set the `OPENCODE_API_KEY` environment variable instead of using `/connect`.
+
+```bash
+OPENCODE_API_KEY=your-key opencode run "Hello world"
+```
 
 ---
 


### PR DESCRIPTION
Add `OPENCODE_API_KEY` to the CLI env vars table, add environment variable sections to the Zen and Go provider docs, and add a "Learn more" link to the API Keys page in the console.

### Issue for this PR

Closes #21189

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Documents `OPENCODE_API_KEY` a bit better. I've noticed when trying to use opencode headlessly that there is a lack of information on how to configure Zen's API key non-interactively.

### How did you verify your code works?

Ran the dev server for the docs. I tried to also run the console, but I couldn't figure out how to login (got an error).

### Screenshots / recordings

<img width="1079" height="348" alt="image" src="https://github.com/user-attachments/assets/e511421b-2d53-4c1d-a2f7-88547a2156a9" />

<img width="844" height="877" alt="image" src="https://github.com/user-attachments/assets/a625a456-ad19-404f-a02b-d129e53d487d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
