### PR TITLE
electron: implement server env probe for in-process server

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -518,6 +518,7 @@ export const Terminal = (props: TerminalProps) => {
         const next = new URL(url + `/pty/${id}/connect`)
         next.searchParams.set("directory", directory)
         next.searchParams.set("cursor", String(seek))
+        next.searchParams.set("token", btoa(`${username}:${password}`))
         next.protocol = next.protocol === "https:" ? "wss:" : "ws:"
         next.username = username
         next.password = password

--- a/packages/desktop-electron/electron.vite.config.ts
+++ b/packages/desktop-electron/electron.vite.config.ts
@@ -43,8 +43,8 @@ export default defineConfig({
         enforce: "post",
         async closeBundle() {
           for (const l of await fs.readdir(OPENCODE_SERVER_DIST)) {
-            if (l.endsWith(".js")) continue
-            await fs.writeFile(`./out/main/${l}`, await fs.readFile(`${OPENCODE_SERVER_DIST}/${l}`))
+            if (!l.endsWith(".wasm")) continue
+            await fs.writeFile(`./out/main/chunks/${l}`, await fs.readFile(`${OPENCODE_SERVER_DIST}/${l}`))
           }
         },
       },

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -36,7 +36,7 @@ import { parseMarkdown } from "./markdown"
 import { createMenu } from "./menu"
 import { getDefaultServerUrl, getWslConfig, setDefaultServerUrl, setWslConfig, spawnLocalServer } from "./server"
 import { createLoadingWindow, createMainWindow, setBackgroundColor, setDockIcon } from "./windows"
-import { Server } from "virtual:opencode-server"
+import type { Server } from "virtual:opencode-server"
 
 const initEmitter = new EventEmitter()
 let initStep: InitStep = { phase: "server_waiting" }

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -1,5 +1,6 @@
-import { Server, Log } from "virtual:opencode-server"
+import { app } from "electron"
 import { DEFAULT_SERVER_URL_KEY, WSL_ENABLED_KEY } from "./constants"
+import { getUserShell, loadShellEnv } from "./shell-env"
 import { store } from "./store"
 
 export type WslConfig = { enabled: boolean }
@@ -30,6 +31,8 @@ export function setWslConfig(config: WslConfig) {
 }
 
 export async function spawnLocalServer(hostname: string, port: number, password: string) {
+  prepareServerEnv(password)
+  const { Log, Server } = await import("virtual:opencode-server")
   await Log.init({ level: "WARN" })
   const listener = await Server.listen({
     port,
@@ -52,6 +55,23 @@ export async function spawnLocalServer(hostname: string, port: number, password:
   })()
 
   return { listener, health: { wait } }
+}
+
+function prepareServerEnv(password: string) {
+  const env = {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+    ),
+    OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
+    OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
+    OPENCODE_CLIENT: "desktop",
+    OPENCODE_SERVER_USERNAME: "opencode",
+    OPENCODE_SERVER_PASSWORD: password,
+    XDG_STATE_HOME: app.getPath("userData"),
+  }
+  const shell = process.platform === "win32" ? null : getUserShell()
+  const shellEnv = shell ? (loadShellEnv(shell) ?? {}) : {}
+  Object.assign(process.env, { ...env, ...shellEnv })
 }
 
 export async function checkHealth(url: string, password?: string | null): Promise<boolean> {

--- a/packages/desktop-electron/src/main/server.ts
+++ b/packages/desktop-electron/src/main/server.ts
@@ -58,10 +58,11 @@ export async function spawnLocalServer(hostname: string, port: number, password:
 }
 
 function prepareServerEnv(password: string) {
+  const shell = process.platform === "win32" ? null : getUserShell()
+  const shellEnv = shell ? (loadShellEnv(shell) ?? {}) : {}
   const env = {
-    ...Object.fromEntries(
-      Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
-    ),
+    ...process.env,
+    ...shellEnv,
     OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
     OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
     OPENCODE_CLIENT: "desktop",
@@ -69,9 +70,7 @@ function prepareServerEnv(password: string) {
     OPENCODE_SERVER_PASSWORD: password,
     XDG_STATE_HOME: app.getPath("userData"),
   }
-  const shell = process.platform === "win32" ? null : getUserShell()
-  const shellEnv = shell ? (loadShellEnv(shell) ?? {}) : {}
-  Object.assign(process.env, { ...env, ...shellEnv })
+  Object.assign(process.env, env)
 }
 
 export async function checkHealth(url: string, password?: string | null): Promise<boolean> {

--- a/packages/desktop-electron/src/main/shell-env.ts
+++ b/packages/desktop-electron/src/main/shell-env.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from "node:child_process"
 import { basename } from "node:path"
 
-const SHELL_ENV_TIMEOUT = 5_000
+const TIMEOUT = 5_000
 
-type Probe = { type: "Loaded"; value: Record<string, string> } | { type: "Timeout" } | { type: "Unavailable" }
+type Probe = { type: "loaded"; value: Record<string, string> } | { type: "timeout" } | { type: "unavailable" }
 
 export function getUserShell() {
   return process.env.SHELL || "/bin/sh"
@@ -20,32 +20,32 @@ export function parseShellEnv(out: Buffer) {
   return env
 }
 
-function probeShellEnv(shell: string, mode: "-il" | "-l"): Probe {
+function probe(shell: string, mode: "-il" | "-l"): Probe {
   const out = spawnSync(shell, [mode, "-c", "env -0"], {
     stdio: ["ignore", "pipe", "ignore"],
-    timeout: SHELL_ENV_TIMEOUT,
+    timeout: TIMEOUT,
     windowsHide: true,
   })
 
   const err = out.error as NodeJS.ErrnoException | undefined
   if (err) {
-    if (err.code === "ETIMEDOUT") return { type: "Timeout" }
-    console.log(`[cli] Shell env probe failed for ${shell} ${mode}: ${err.message}`)
-    return { type: "Unavailable" }
+    if (err.code === "ETIMEDOUT") return { type: "timeout" }
+    console.log(`[server] Shell env probe failed for ${shell} ${mode}: ${err.message}`)
+    return { type: "unavailable" }
   }
 
   if (out.status !== 0) {
-    console.log(`[cli] Shell env probe exited with non-zero status for ${shell} ${mode}`)
-    return { type: "Unavailable" }
+    console.log(`[server] Shell env probe exited with non-zero status for ${shell} ${mode}`)
+    return { type: "unavailable" }
   }
 
   const env = parseShellEnv(out.stdout)
   if (Object.keys(env).length === 0) {
-    console.log(`[cli] Shell env probe returned empty env for ${shell} ${mode}`)
-    return { type: "Unavailable" }
+    console.log(`[server] Shell env probe returned empty env for ${shell} ${mode}`)
+    return { type: "unavailable" }
   }
 
-  return { type: "Loaded", value: env }
+  return { type: "loaded", value: env }
 }
 
 export function isNushell(shell: string) {
@@ -56,27 +56,27 @@ export function isNushell(shell: string) {
 
 export function loadShellEnv(shell: string) {
   if (isNushell(shell)) {
-    console.log(`[cli] Skipping shell env probe for nushell: ${shell}`)
+    console.log(`[server] Skipping shell env probe for nushell: ${shell}`)
     return null
   }
 
-  const interactive = probeShellEnv(shell, "-il")
-  if (interactive.type === "Loaded") {
-    console.log(`[cli] Loaded shell environment with -il (${Object.keys(interactive.value).length} vars)`)
+  const interactive = probe(shell, "-il")
+  if (interactive.type === "loaded") {
+    console.log(`[server] Loaded shell environment with -il (${Object.keys(interactive.value).length} vars)`)
     return interactive.value
   }
-  if (interactive.type === "Timeout") {
-    console.warn(`[cli] Interactive shell env probe timed out: ${shell}`)
+  if (interactive.type === "timeout") {
+    console.warn(`[server] Interactive shell env probe timed out: ${shell}`)
     return null
   }
 
-  const login = probeShellEnv(shell, "-l")
-  if (login.type === "Loaded") {
-    console.log(`[cli] Loaded shell environment with -l (${Object.keys(login.value).length} vars)`)
+  const login = probe(shell, "-l")
+  if (login.type === "loaded") {
+    console.log(`[server] Loaded shell environment with -l (${Object.keys(login.value).length} vars)`)
     return login.value
   }
 
-  console.warn(`[cli] Falling back to app environment: ${shell}`)
+  console.warn(`[server] Falling back to app environment: ${shell}`)
   return null
 }
 

--- a/packages/desktop-electron/src/main/shell-env.ts
+++ b/packages/desktop-electron/src/main/shell-env.ts
@@ -3,7 +3,7 @@ import { basename } from "node:path"
 
 const TIMEOUT = 5_000
 
-type Probe = { type: "loaded"; value: Record<string, string> } | { type: "timeout" } | { type: "unavailable" }
+type Probe = { type: "Loaded"; value: Record<string, string> } | { type: "Timeout" } | { type: "Unavailable" }
 
 export function getUserShell() {
   return process.env.SHELL || "/bin/sh"
@@ -29,23 +29,23 @@ function probe(shell: string, mode: "-il" | "-l"): Probe {
 
   const err = out.error as NodeJS.ErrnoException | undefined
   if (err) {
-    if (err.code === "ETIMEDOUT") return { type: "timeout" }
+    if (err.code === "ETIMEDOUT") return { type: "Timeout" }
     console.log(`[server] Shell env probe failed for ${shell} ${mode}: ${err.message}`)
-    return { type: "unavailable" }
+    return { type: "Unavailable" }
   }
 
   if (out.status !== 0) {
     console.log(`[server] Shell env probe exited with non-zero status for ${shell} ${mode}`)
-    return { type: "unavailable" }
+    return { type: "Unavailable" }
   }
 
   const env = parseShellEnv(out.stdout)
   if (Object.keys(env).length === 0) {
     console.log(`[server] Shell env probe returned empty env for ${shell} ${mode}`)
-    return { type: "unavailable" }
+    return { type: "Unavailable" }
   }
 
-  return { type: "loaded", value: env }
+  return { type: "Loaded", value: env }
 }
 
 export function isNushell(shell: string) {
@@ -61,17 +61,17 @@ export function loadShellEnv(shell: string) {
   }
 
   const interactive = probe(shell, "-il")
-  if (interactive.type === "loaded") {
+  if (interactive.type === "Loaded") {
     console.log(`[server] Loaded shell environment with -il (${Object.keys(interactive.value).length} vars)`)
     return interactive.value
   }
-  if (interactive.type === "timeout") {
+  if (interactive.type === "Timeout") {
     console.warn(`[server] Interactive shell env probe timed out: ${shell}`)
     return null
   }
 
   const login = probe(shell, "-l")
-  if (login.type === "loaded") {
+  if (login.type === "Loaded") {
     console.log(`[server] Loaded shell environment with -l (${Object.keys(login.value).length} vars)`)
     return login.value
   }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -54,6 +54,9 @@ export namespace Server {
         const password = Flag.OPENCODE_SERVER_PASSWORD
         if (!password) return next()
         const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+
+        if (c.req.query("token")) c.req.raw.headers.set("authorization", `Basic ${c.req.query("token")}`)
+
         return basicAuth({ username, password })(c, next)
       })
       .use(async (c, next) => {


### PR DESCRIPTION
Adapts the existing env probe logic to work with the in-process server by 1. Dynamic importing the server so that top-level envs aren't resolved until the probe is done, 2. Providing the same default envs that were passed to the CLI (OPENCODE_CLIENT, XDG_STATE_HOME, etc), and 3. Patching the server auth handler to allow providing a `token` query param instead of just relying on `Authorization` headers, as it seems that either the Node server or chrome isn't translating from username + password to basic auth header properly.
The CLI-less betas that have been working prior to this PR have actually had no auth on their servers since `OPENCODE_SERVER_USERNAME` and `OPENCODE_SERVER_PASSWORD` weren't being set in the global `process.env`.
When the server's Effect migration is 100% complete we'll be able to handle this much more nicely as we can provide `Config` layers that don't modify the global env, or even provide credentials via dedicated servers.