### PR TITLE
fix(config): load .env from config dir for {env:VAR} substitution

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -4,6 +4,7 @@ import z from "zod"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 import { NamedError } from "@opencode-ai/util/error"
 import { Filesystem } from "@/util/filesystem"
+import { Env } from "@/env"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
 
@@ -74,10 +75,20 @@ export namespace ConfigPaths {
     return typeof input === "string" ? path.dirname(input) : input.dir
   }
 
-  /** Apply {env:VAR} and {file:path} substitutions to config text. */
+  /** Apply {env:VAR} and {file:path} substitutions to config text. {env:VAR} resolves from shell environment first, then .env in the config directory. */
   async function substitute(text: string, input: ParseSource, missing: "error" | "empty" = "error") {
+    const localEnv: Record<string, string> = {}
+    const dotenvContent = await Filesystem.readText(path.join(dir(input), ".env")).catch(() => "")
+    for (const line of dotenvContent.split("\n")) {
+      const match = line.match(/^([^#=\s][^=]*)=(.*)$/)
+      if (match) {
+        const [, key, val] = match
+        localEnv[key.trim()] = val.trim().replace(/^["']|["']$/g, "")
+      }
+    }
+
     text = text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-      return process.env[varName] || ""
+      return Env.get(varName) ?? localEnv[varName] ?? ""
     })
 
     const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))


### PR DESCRIPTION
substitute() only checked process.env for {env:VAR} tokens. If opencode is installed globally it never sees the project .env.

### Issue for this PR

Closes #21187
Related: #10458

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Without this fix the only way to provide tokens for MCP servers configured
via `{env:VAR}` in `opencode.json` is to export them globally in the shell
or hardcode them directly in the config file. Hardcoding secrets in a
git-tracked config is a security risk — accidental commits leak credentials.

This change makes `substitute()` in `config/paths.ts` read a `.env` file
from the same directory as the config file being parsed. Variables found
there act as a fallback: shell/system env always takes priority so existing
workflows are not affected.

Also switches from raw `process.env` to `Env.get()` to respect the existing
per-instance environment isolation.

### How did you verify your code works?

Defined a test variable only in the project `.env` (not exported to shell).
Confirmed `{env:VAR}` in `opencode.json` resolved correctly at startup.
Also verified projects with no `.env` file work the same as before.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
