### PR TITLE
fix(opencode): scale prune thresholds to model context size

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -32,16 +32,24 @@ export namespace SessionCompaction {
     ),
   }
 
-  export const PRUNE_MINIMUM = 20_000
-  export const PRUNE_PROTECT = 40_000
+  const PRUNE_MINIMUM_DEFAULT = 20_000
+  const PRUNE_PROTECT_DEFAULT = 40_000
   const PRUNE_PROTECTED_TOOLS = ["skill"]
+
+  /** Scale prune thresholds to model context size.
+   *  Keeps the defaults for ≤200K models, scales up for larger contexts. */
+  export function pruneThresholds(contextLimit: number) {
+    const protect = Math.max(PRUNE_PROTECT_DEFAULT, Math.round(contextLimit * 0.2))
+    const minimum = Math.max(PRUNE_MINIMUM_DEFAULT, Math.round(protect * 0.5))
+    return { protect, minimum }
+  }
 
   export interface Interface {
     readonly isOverflow: (input: {
       tokens: MessageV2.Assistant["tokens"]
       model: Provider.Model
     }) => Effect.Effect<boolean>
-    readonly prune: (input: { sessionID: SessionID }) => Effect.Effect<void>
+    readonly prune: (input: { sessionID: SessionID; contextLimit?: number }) => Effect.Effect<void>
     readonly process: (input: {
       parentID: MessageID
       messages: MessageV2.WithParts[]
@@ -88,12 +96,17 @@ export namespace SessionCompaction {
         return overflow({ cfg: yield* config.get(), tokens: input.tokens, model: input.model })
       })
 
-      // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
+      // goes backwards through parts until there are `protect` tokens worth of tool
       // calls, then erases output of older tool calls to free context space
-      const prune = Effect.fn("SessionCompaction.prune")(function* (input: { sessionID: SessionID }) {
+      const prune = Effect.fn("SessionCompaction.prune")(function* (input: {
+        sessionID: SessionID
+        contextLimit?: number
+      }) {
         const cfg = yield* config.get()
         if (cfg.compaction?.prune === false) return
         log.info("pruning")
+
+        const { protect, minimum } = pruneThresholds(input.contextLimit ?? 0)
 
         const msgs = yield* session
           .messages({ sessionID: input.sessionID })
@@ -118,7 +131,7 @@ export namespace SessionCompaction {
                 if (part.state.time.compacted) break loop
                 const estimate = Token.estimate(part.state.output)
                 total += estimate
-                if (total > PRUNE_PROTECT) {
+                if (total > protect) {
                   pruned += estimate
                   toPrune.push(part)
                 }
@@ -127,7 +140,7 @@ export namespace SessionCompaction {
         }
 
         log.info("found", { pruned, total })
-        if (pruned > PRUNE_MINIMUM) {
+        if (pruned > minimum) {
           for (const part of toPrune) {
             if (part.state.status === "completed") {
               part.state.time.compacted = Date.now()
@@ -400,7 +413,7 @@ When constructing the summary, try to stick to this template:
     return runPromise((svc) => svc.isOverflow(input))
   }
 
-  export async function prune(input: { sessionID: SessionID }) {
+  export async function prune(input: { sessionID: SessionID; contextLimit?: number }) {
     return runPromise((svc) => svc.prune(input))
   }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1560,7 +1560,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
-          yield* compaction.prune({ sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
+          const pruneModelRef = yield* lastModel(sessionID).pipe(Effect.option)
+          const pruneContextLimit = yield* (
+            Option.isSome(pruneModelRef)
+              ? provider.getModel(pruneModelRef.value.providerID, pruneModelRef.value.modelID).pipe(
+                  Effect.map((m) => m.limit.context),
+                  Effect.orElseSucceed(() => 0),
+                )
+              : Effect.succeed(0)
+          )
+          yield* compaction.prune({ sessionID, contextLimit: pruneContextLimit }).pipe(Effect.ignore, Effect.forkIn(scope))
           return yield* lastAssistant(sessionID)
         },
       )

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1238,3 +1238,29 @@ describe("session.getUsage", () => {
     expect(result.tokens.cache.write).toBe(300)
   })
 })
+
+describe("session.compaction.pruneThresholds", () => {
+  test("uses defaults for small context", () => {
+    const result = SessionCompaction.pruneThresholds(200_000)
+    expect(result.protect).toBe(40_000)
+    expect(result.minimum).toBe(20_000)
+  })
+
+  test("scales up for 1M context", () => {
+    const result = SessionCompaction.pruneThresholds(1_000_000)
+    expect(result.protect).toBe(200_000)
+    expect(result.minimum).toBe(100_000)
+  })
+
+  test("scales up for 2M context", () => {
+    const result = SessionCompaction.pruneThresholds(2_000_000)
+    expect(result.protect).toBe(400_000)
+    expect(result.minimum).toBe(200_000)
+  })
+
+  test("falls back to defaults when context is 0", () => {
+    const result = SessionCompaction.pruneThresholds(0)
+    expect(result.protect).toBe(40_000)
+    expect(result.minimum).toBe(20_000)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #21208

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`PRUNE_PROTECT` (40K) and `PRUNE_MINIMUM` (20K) are hardcoded constants that worked for 200K context models but are too aggressive for 1M+. At 1M context, only 4% of tool output is protected — results from recent turns get cleared well before context is full.

Adds `pruneThresholds(contextLimit)` that scales proportionally:
- `protect = max(40K, context × 0.2)`
- `minimum = max(20K, protect × 0.5)`

Preserves existing behavior for ≤200K models. The context limit is resolved from the session's last user message model via `provider.getModel`, falling back to 0 (default thresholds) when unavailable.

### How did you verify your code works?

- 4 new unit tests for `pruneThresholds` (200K, 1M, 2M, fallback)
- All 42 compaction tests pass
- Typecheck passes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR