### PR TITLE
fix(acp): harden legacy config option transitions

### DIFF
--- a/packages/opencode/src/acp/README.md
+++ b/packages/opencode/src/acp/README.md
@@ -93,6 +93,7 @@ This implementation follows the ACP specification v1:
 - `session/load` - Resume existing sessions (basic support)
 - Working directory context (`cwd`)
 - MCP server configuration support
+- Legacy `setSessionMode` and `unstable_setSessionModel` remain available for transition use, but are deprecated in favor of `session/set_config_option`
 
 ✅ **Prompting**
 

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1288,6 +1288,9 @@ export namespace ACP {
       }
     }
 
+    /**
+     * @deprecated Prefer `setSessionConfigOption` with `configId: "model"`.
+     */
     async unstable_setSessionModel(params: SetSessionModelRequest) {
       const session = this.sessionManager.get(params.sessionId)
       const providers = await this.sdk.config
@@ -1295,11 +1298,26 @@ export namespace ACP {
         .then((x) => x.data!.providers)
 
       const selection = parseModelSelection(params.modelId, providers)
+      assertModelSelection(params.modelId, providers, selection)
       this.sessionManager.setModel(session.id, selection.model)
       this.sessionManager.setVariant(session.id, selection.variant)
 
       const entries = sortProvidersByName(providers)
       const availableVariants = modelVariantsFromProviders(entries, selection.model)
+
+      this.options(session.id, session.cwd)
+        .then((configOptions) => {
+          this.connection.sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "config_option_update",
+              configOptions,
+            },
+          })
+        })
+        .catch((error) => {
+          log.error("failed to send config_option_update after model change", { error })
+        })
 
       return {
         _meta: buildVariantMeta({
@@ -1310,6 +1328,9 @@ export namespace ACP {
       }
     }
 
+    /**
+     * @deprecated Prefer `setSessionConfigOption` with `configId: "mode"`.
+     */
     async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse | void> {
       const session = this.sessionManager.get(params.sessionId)
       const availableModes = await this.loadAvailableModes(session.cwd)
@@ -1317,23 +1338,38 @@ export namespace ACP {
         throw new Error(`Agent not found: ${params.modeId}`)
       }
       this.sessionManager.setMode(params.sessionId, params.modeId)
+
+      this.options(session.id, session.cwd)
+        .then((configOptions) => {
+          this.connection.sessionUpdate({
+            sessionId: session.id,
+            update: {
+              sessionUpdate: "config_option_update",
+              configOptions,
+            },
+          })
+        })
+        .catch((error) => {
+          log.error("failed to send config_option_update after mode change", { error })
+        })
     }
 
     async setSessionConfigOption(params: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse> {
       const session = this.sessionManager.get(params.sessionId)
-      const providers = await this.sdk.config
-        .providers({ directory: session.cwd }, { throwOnError: true })
-        .then((x) => x.data!.providers)
-      const entries = sortProvidersByName(providers)
+      const dir = session.cwd
 
       if (params.configId === "model") {
         if (typeof params.value !== "string") throw RequestError.invalidParams("model value must be a string")
+        const providers = await this.sdk.config
+          .providers({ directory: dir }, { throwOnError: true })
+          .then((x) => x.data!.providers)
         const selection = parseModelSelection(params.value, providers)
+        assertModelSelection(params.value, providers, selection)
         this.sessionManager.setModel(session.id, selection.model)
         this.sessionManager.setVariant(session.id, selection.variant)
       } else if (params.configId === "mode") {
         if (typeof params.value !== "string") throw RequestError.invalidParams("mode value must be a string")
-        const availableModes = await this.loadAvailableModes(session.cwd)
+        const availableModes = await this.loadAvailableModes(dir)
         if (!availableModes.some((mode) => mode.id === params.value)) {
           throw RequestError.invalidParams(JSON.stringify({ error: `Mode not found: ${params.value}` }))
         }
@@ -1342,19 +1378,24 @@ export namespace ACP {
         throw RequestError.invalidParams(JSON.stringify({ error: `Unknown config option: ${params.configId}` }))
       }
 
-      const updatedSession = this.sessionManager.get(session.id)
-      const model = updatedSession.model ?? (await defaultModel(this.config, session.cwd))
+      return { configOptions: await this.options(session.id, dir) }
+    }
+
+    private async options(sessionId: string, dir: string): Promise<SetSessionConfigOptionResponse["configOptions"]> {
+      const session = this.sessionManager.get(sessionId)
+      const providers = await this.sdk.config
+        .providers({ directory: dir }, { throwOnError: true })
+        .then((x) => x.data!.providers)
+      const entries = sortProvidersByName(providers)
+      const model = session.model ?? (await defaultModel(this.config, dir))
       const availableVariants = modelVariantsFromProviders(entries, model)
-      const currentModelId = formatModelIdWithVariant(model, updatedSession.variant, availableVariants, true)
+      const currentModelId = formatModelIdWithVariant(model, session.variant, availableVariants, true)
       const availableModels = buildAvailableModels(entries, { includeVariants: true })
-      const modeState = await this.resolveModeState(session.cwd, session.id)
+      const modeState = await this.resolveModeState(dir, sessionId)
       const modes = modeState.currentModeId
         ? { availableModes: modeState.availableModes, currentModeId: modeState.currentModeId }
         : undefined
-
-      return {
-        configOptions: buildConfigOptions({ currentModelId, availableModels, modes }),
-      }
+      return buildConfigOptions({ currentModelId, availableModels, modes })
     }
 
     async prompt(params: PromptRequest) {
@@ -1811,6 +1852,24 @@ export namespace ACP {
     }
 
     return { model: parsed, variant: undefined }
+  }
+
+  function assertModelSelection(
+    modelId: string,
+    providers: Array<{ id: string; models: Record<string, { variants?: Record<string, any> }> }>,
+    selection: { model: { providerID: ProviderID; modelID: ModelID }; variant?: string },
+  ) {
+    const provider = providers.find((p) => p.id === selection.model.providerID)
+    if (!provider) {
+      throw RequestError.invalidParams(JSON.stringify({ error: `Model not found: ${modelId}` }))
+    }
+    const info = provider.models[selection.model.modelID]
+    if (!info) {
+      throw RequestError.invalidParams(JSON.stringify({ error: `Model not found: ${modelId}` }))
+    }
+    if (selection.variant && !info.variants?.[selection.variant]) {
+      throw RequestError.invalidParams(JSON.stringify({ error: `Model variant not found: ${modelId}` }))
+    }
   }
 
   function buildConfigOptions(input: {

--- a/packages/opencode/test/acp/agent-interface.test.ts
+++ b/packages/opencode/test/acp/agent-interface.test.ts
@@ -33,6 +33,7 @@ describe("acp.agent interface compliance", () => {
     // Optional but checked by SDK router
     "loadSession",
     "setSessionMode",
+    "setSessionConfigOption",
     "authenticate",
     // Unstable - SDK checks these with unstable_ prefix
     "listSessions",


### PR DESCRIPTION
This follows up on #14098 after #21134 landed the main configOptions migration.

## Summary
- validate model selections in session/set_config_option and unstable_setSessionModel before mutating session state
- emit config_option_update notifications from legacy setSessionMode and unstable_setSessionModel so transitional clients stay in sync
- mark legacy mode/model setters as deprecated and cover setSessionConfigOption in the ACP interface test

## Why
#21134 fixed the main ACP Session Config Options support, but a few transition details were still useful on top:
- invalid model values could still be accepted and stored until a later failure path
- clients using the legacy setters would not receive the newer config_option_update notification
- the deprecated transition paths were not explicitly documented in code/tests

## Related
- Closes #14098
- Follow-up to #21134

## Verification
- bun typecheck
- bun test test/acp/agent-interface.test.ts