### PR TITLE
fix: migrate sessions when project ID changes after git init

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -318,6 +318,21 @@ export namespace Project {
               .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
               .run(),
           )
+
+          // Migrate sessions from stale project entries with the same worktree
+          // This handles the case where project ID changes (e.g. after `git init`)
+          yield* db((d) => {
+            const stales = d
+              .select({ id: ProjectTable.id })
+              .from(ProjectTable)
+              .where(eq(ProjectTable.worktree, data.worktree))
+              .all()
+              .filter((row) => row.id !== data.id)
+            for (const stale of stales) {
+              d.update(SessionTable).set({ project_id: data.id }).where(eq(SessionTable.project_id, stale.id)).run()
+              d.delete(ProjectTable).where(eq(ProjectTable.id, stale.id)).run()
+            }
+          })
         }
 
         yield* emitUpdated(result)


### PR DESCRIPTION
## Summary

Fixes #21230 — sessions disappear from TUI after `git init` in a project directory.

## Problem

When `git init` runs in a directory that already has opencode sessions, the project ID changes (from global project to git root commit hash). A new project entry is created, but sessions linked to the old project ID are not migrated. The TUI filters by the new project ID and shows zero sessions.

## Fix

Added a migration step in `Project.fromDirectory()` (after the existing global→project migration on line 313) that:

1. Finds stale project entries with the same `worktree` but a different `id`
2. Migrates all sessions from stale projects to the current project
3. Deletes the stale project entries

This is a 12-line addition in `packages/opencode/src/project/project.ts`.

## Testing

Manually verified on a real database with 19 orphaned sessions. After the fix, all sessions correctly appear in the TUI.