### PR TITLE
feat: Subagent Start and Stop events

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -341,6 +341,43 @@ export const Event = {
       error: MessageV2.Assistant.fields.error,
     }),
   ),
+  SubagentStarted: BusEvent.define(
+    "session.subagent.started",
+    Schema.Struct({
+      sessionID: SessionID,
+      parentID: SessionID,
+      agent: Schema.String,
+      description: Schema.String,
+      model: Schema.Struct({
+        modelID: ModelID,
+        providerID: ProviderID,
+      }),
+      time: Schema.Struct({ start: Schema.Number }),
+    }),
+  ),
+  SubagentStopped: BusEvent.define(
+    "session.subagent.stopped",
+    Schema.Struct({
+      sessionID: SessionID,
+      parentID: SessionID,
+      agent: Schema.String,
+      description: Schema.String,
+      model: Schema.Struct({
+        modelID: ModelID,
+        providerID: ProviderID,
+      }),
+      time: Schema.Struct({ start: Schema.Number, end: Schema.Number }),
+      tokens: Schema.Struct({
+        input: Schema.Number,
+        output: Schema.Number,
+        reasoning: Schema.Number,
+        cache: Schema.Struct({ read: Schema.Number, write: Schema.Number }),
+      }),
+      cost: Schema.Number,
+      status: Schema.Literal("completed", "cancelled", "failed"),
+      error: Schema.optional(Schema.String),
+    }),
+  ),
 }
 
 export function plan(input: { slug: string; time: { created: number } }, instance: InstanceContext) {

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -374,7 +374,7 @@ export const Event = {
         cache: Schema.Struct({ read: Schema.Number, write: Schema.Number }),
       }),
       cost: Schema.Number,
-      status: Schema.Literal("completed", "cancelled", "failed"),
+      status: Schema.Literals(["completed", "cancelled", "failed"]),
       error: Schema.optional(Schema.String),
     }),
   ),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -6,8 +6,9 @@ import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
-import { Effect, Exit, Schema } from "effect"
+import { Cause, Effect, Exit, Schema } from "effect"
 import { EffectBridge } from "@/effect/bridge"
+import { Bus } from "@/bus"
 
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): Effect.Effect<void>
@@ -34,6 +35,7 @@ export const TaskTool = Tool.define(
     const agent = yield* Agent.Service
     const config = yield* Config.Service
     const sessions = yield* Session.Service
+    const bus = yield* Bus.Service
 
     const run = Effect.fn("TaskTool.execute")(function* (
       params: Schema.Schema.Type<typeof Parameters>,
@@ -121,12 +123,24 @@ export const TaskTool = Tool.define(
       if (!ops) return yield* Effect.fail(new Error("TaskTool requires promptOps in ctx.extra"))
       const runCancel = yield* EffectBridge.make()
 
+      const start = Date.now()
+      yield* bus.publish(Session.Event.SubagentStarted, {
+        sessionID: nextSession.id,
+        parentID: ctx.sessionID,
+        agent: next.name,
+        description: params.description,
+        model: { modelID: model.modelID, providerID: model.providerID },
+        time: { start },
+      })
+
       const messageID = MessageID.ascending()
       const cancel = ops.cancel(nextSession.id)
 
       function onAbort() {
         runCancel.fork(cancel)
       }
+
+      let last: MessageV2.Assistant | undefined
 
       return yield* Effect.acquireUseRelease(
         Effect.sync(() => {
@@ -150,6 +164,8 @@ export const TaskTool = Tool.define(
               },
               parts,
             })
+
+            if (result.info.role === "assistant") last = result.info
 
             return {
               title: params.description,
@@ -176,6 +192,38 @@ export const TaskTool = Tool.define(
               }),
             ),
           ),
+      ).pipe(
+        Effect.onExit((exit) =>
+          bus.publish(Session.Event.SubagentStopped, {
+            sessionID: nextSession.id,
+            parentID: ctx.sessionID,
+            agent: next.name,
+            description: params.description,
+            model: { modelID: model.modelID, providerID: model.providerID },
+            time: { start, end: Date.now() },
+            tokens: {
+              input: last?.tokens.input ?? 0,
+              output: last?.tokens.output ?? 0,
+              reasoning: last?.tokens.reasoning ?? 0,
+              cache: {
+                read: last?.tokens.cache.read ?? 0,
+                write: last?.tokens.cache.write ?? 0,
+              },
+            },
+            cost: last?.cost ?? 0,
+            status: Exit.isSuccess(exit)
+              ? "completed"
+              : Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)
+                ? "cancelled"
+                : ctx.abort.aborted
+                  ? "cancelled"
+                  : "failed",
+            error:
+              Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause) && !ctx.abort.aborted
+                ? String(Cause.squash(exit.cause))
+                : undefined,
+          }),
+        ),
       )
     })
 

--- a/packages/opencode/test/session/task-events.test.ts
+++ b/packages/opencode/test/session/task-events.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Bus } from "../../src/bus"
+import { Session } from "../../src/session"
+import { SessionID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const sessionID = SessionID.descending()
+const parentID = SessionID.descending()
+const modelID = ModelID.make("claude-3-5-sonnet")
+const providerID = ProviderID.make("anthropic")
+
+describe("subagent lifecycle events", () => {
+  test("SubagentStarted schema validates correct payload", () => {
+    const result = Session.Event.SubagentStarted.properties.safeParse({
+      sessionID,
+      parentID,
+      agent: "general",
+      description: "do a thing",
+      model: { modelID, providerID },
+      time: { start: Date.now() },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test("SubagentStopped schema validates completed payload", () => {
+    const result = Session.Event.SubagentStopped.properties.safeParse({
+      sessionID,
+      parentID,
+      agent: "general",
+      description: "do a thing",
+      model: { modelID, providerID },
+      time: { start: Date.now() - 1000, end: Date.now() },
+      tokens: { input: 100, output: 200, reasoning: 0, cache: { read: 10, write: 5 } },
+      cost: 0.002,
+      status: "completed" as const,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe("completed")
+      expect(result.data.error).toBeUndefined()
+    }
+  })
+
+  test("SubagentStopped schema validates failed payload with error field", () => {
+    const result = Session.Event.SubagentStopped.properties.safeParse({
+      sessionID,
+      parentID,
+      agent: "general",
+      description: "do a thing",
+      model: { modelID, providerID },
+      time: { start: Date.now() - 500, end: Date.now() },
+      tokens: { input: 50, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      cost: 0,
+      status: "failed" as const,
+      error: "context limit exceeded",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe("failed")
+      expect(result.data.error).toBe("context limit exceeded")
+    }
+  })
+
+  test("SubagentStopped schema rejects invalid status", () => {
+    const result = Session.Event.SubagentStopped.properties.safeParse({
+      sessionID,
+      parentID,
+      agent: "general",
+      description: "test",
+      model: { modelID: ModelID.make("m"), providerID: ProviderID.make("p") },
+      time: { start: 0, end: 1 },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      cost: 0,
+      status: "error", // invalid — not in enum
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test("Bus publish/subscribe round-trip for SubagentStarted", async () => {
+    await using tmp = await tmpdir()
+    const evts: Array<ReturnType<typeof Session.Event.SubagentStarted.properties.parse>> = []
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        Bus.subscribe(Session.Event.SubagentStarted, (evt) => {
+          evts.push(evt.properties)
+        })
+        await Bus.publish(Session.Event.SubagentStarted, {
+          sessionID,
+          parentID,
+          agent: "general",
+          description: "do a thing",
+          model: { modelID, providerID },
+          time: { start: Date.now() },
+        })
+        await Bun.sleep(10)
+      },
+    })
+
+    expect(evts).toHaveLength(1)
+    expect(evts[0].sessionID).toBe(sessionID)
+    expect(evts[0].agent).toBe("general")
+    expect(evts[0].description).toBe("do a thing")
+    expect(evts[0].model.providerID).toBe(providerID)
+  })
+
+  test("Bus publish/subscribe round-trip for SubagentStopped", async () => {
+    await using tmp = await tmpdir()
+    const evts: Array<ReturnType<typeof Session.Event.SubagentStopped.properties.parse>> = []
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        Bus.subscribe(Session.Event.SubagentStopped, (evt) => {
+          evts.push(evt.properties)
+        })
+        const start = Date.now()
+        await Bus.publish(Session.Event.SubagentStopped, {
+          sessionID,
+          parentID,
+          agent: "general",
+          description: "do a thing",
+          model: { modelID, providerID },
+          time: { start, end: start + 500 },
+          tokens: { input: 100, output: 200, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 0.001,
+          status: "completed",
+        })
+        await Bun.sleep(10)
+      },
+    })
+
+    expect(evts).toHaveLength(1)
+    expect(evts[0].status).toBe("completed")
+    expect(evts[0].tokens.input).toBe(100)
+    expect(evts[0].tokens.output).toBe(200)
+    expect(evts[0].cost).toBe(0.001)
+  })
+})

--- a/packages/opencode/test/session/task-events.test.ts
+++ b/packages/opencode/test/session/task-events.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { Instance } from "../../src/project/instance"
+import { Exit, Schema } from "effect"
 import { Bus } from "../../src/bus"
-import { Session } from "../../src/session"
+import { Session } from "../../src/session/session"
 import { SessionID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
-import { tmpdir } from "../fixture/fixture"
+import { WithInstance } from "../../src/project/with-instance"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 
 afterEach(async () => {
-  await Instance.disposeAll()
+  await disposeAllInstances()
 })
 
 const sessionID = SessionID.descending()
@@ -15,9 +16,12 @@ const parentID = SessionID.descending()
 const modelID = ModelID.make("claude-3-5-sonnet")
 const providerID = ProviderID.make("anthropic")
 
+const decodeStarted = Schema.decodeUnknownExit(Session.Event.SubagentStarted.properties)
+const decodeStopped = Schema.decodeUnknownExit(Session.Event.SubagentStopped.properties)
+
 describe("subagent lifecycle events", () => {
   test("SubagentStarted schema validates correct payload", () => {
-    const result = Session.Event.SubagentStarted.properties.safeParse({
+    const result = decodeStarted({
       sessionID,
       parentID,
       agent: "general",
@@ -25,11 +29,11 @@ describe("subagent lifecycle events", () => {
       model: { modelID, providerID },
       time: { start: Date.now() },
     })
-    expect(result.success).toBe(true)
+    expect(Exit.isSuccess(result)).toBe(true)
   })
 
   test("SubagentStopped schema validates completed payload", () => {
-    const result = Session.Event.SubagentStopped.properties.safeParse({
+    const result = decodeStopped({
       sessionID,
       parentID,
       agent: "general",
@@ -40,15 +44,15 @@ describe("subagent lifecycle events", () => {
       cost: 0.002,
       status: "completed" as const,
     })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe("completed")
-      expect(result.data.error).toBeUndefined()
+    expect(Exit.isSuccess(result)).toBe(true)
+    if (Exit.isSuccess(result)) {
+      expect(result.value.status).toBe("completed")
+      expect(result.value.error).toBeUndefined()
     }
   })
 
   test("SubagentStopped schema validates failed payload with error field", () => {
-    const result = Session.Event.SubagentStopped.properties.safeParse({
+    const result = decodeStopped({
       sessionID,
       parentID,
       agent: "general",
@@ -60,15 +64,15 @@ describe("subagent lifecycle events", () => {
       status: "failed" as const,
       error: "context limit exceeded",
     })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.status).toBe("failed")
-      expect(result.data.error).toBe("context limit exceeded")
+    expect(Exit.isSuccess(result)).toBe(true)
+    if (Exit.isSuccess(result)) {
+      expect(result.value.status).toBe("failed")
+      expect(result.value.error).toBe("context limit exceeded")
     }
   })
 
   test("SubagentStopped schema rejects invalid status", () => {
-    const result = Session.Event.SubagentStopped.properties.safeParse({
+    const result = decodeStopped({
       sessionID,
       parentID,
       agent: "general",
@@ -79,14 +83,14 @@ describe("subagent lifecycle events", () => {
       cost: 0,
       status: "error", // invalid — not in enum
     })
-    expect(result.success).toBe(false)
+    expect(Exit.isFailure(result)).toBe(true)
   })
 
   test("Bus publish/subscribe round-trip for SubagentStarted", async () => {
     await using tmp = await tmpdir()
-    const evts: Array<ReturnType<typeof Session.Event.SubagentStarted.properties.parse>> = []
+    const evts: Array<Schema.Schema.Type<typeof Session.Event.SubagentStarted.properties>> = []
 
-    await Instance.provide({
+    await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
         Bus.subscribe(Session.Event.SubagentStarted, (evt) => {
@@ -113,9 +117,9 @@ describe("subagent lifecycle events", () => {
 
   test("Bus publish/subscribe round-trip for SubagentStopped", async () => {
     await using tmp = await tmpdir()
-    const evts: Array<ReturnType<typeof Session.Event.SubagentStopped.properties.parse>> = []
+    const evts: Array<Schema.Schema.Type<typeof Session.Event.SubagentStopped.properties>> = []
 
-    await Instance.provide({
+    await WithInstance.provide({
       directory: tmp.path,
       fn: async () => {
         Bus.subscribe(Session.Event.SubagentStopped, (evt) => {

--- a/packages/opencode/test/tool/task-lifecycle-events.test.ts
+++ b/packages/opencode/test/tool/task-lifecycle-events.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Agent } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
 import { Config } from "../../src/config/config"
-import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
-import { Instance } from "../../src/project/instance"
-import { Session } from "../../src/session"
+import { Session } from "../../src/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID } from "../../src/session/schema"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
+import * as Truncate from "../../src/tool/truncate"
 import { ToolRegistry } from "../../src/tool/registry"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -20,11 +20,12 @@ const ref = { providerID: ProviderID.make("test"), modelID: ModelID.make("test-m
 const it = testEffect(
   Layer.mergeAll(
     Agent.defaultLayer,
+    Bus.layer,
     Config.defaultLayer,
     CrossSpawnSpawner.defaultLayer,
     Session.defaultLayer,
     ToolRegistry.defaultLayer,
-    Bus.layer,
+    Truncate.defaultLayer,
   ),
 )
 
@@ -57,7 +58,7 @@ const seed = Effect.fn("seed")(function* (title = "Pinned") {
   return { chat, assistant }
 })
 
-function reply(input: Parameters<typeof SessionPrompt.prompt>[0], text: string): MessageV2.WithParts {
+function reply(input: Parameters<SessionPrompt.Interface["prompt"]>[0], text: string): MessageV2.WithParts {
   const id = MessageID.ascending()
   return {
     info: {
@@ -89,7 +90,9 @@ function reply(input: Parameters<typeof SessionPrompt.prompt>[0], text: string):
 
 function stubOps(opts?: { text?: string; fail?: Error; abort?: AbortController }): TaskPromptOps {
   return {
-    cancel() {},
+    cancel(_sessionID) {
+      return Effect.void
+    },
     resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
     prompt: (input) =>
       Effect.gen(function* () {
@@ -114,7 +117,7 @@ describe("tool.task lifecycle events", () => {
         const offB = yield* bus.subscribeCallback(Session.Event.SubagentStopped, (e) => seen.push(e))
 
         const tool = yield* TaskTool
-        const def = yield* Effect.promise(() => tool.init())
+        const def = yield* tool.init()
 
         yield* def.execute(
           { description: "Run subagent", prompt: "do work", subagent_type: "general" },
@@ -155,7 +158,7 @@ describe("tool.task lifecycle events", () => {
         const offB = yield* bus.subscribeCallback(Session.Event.SubagentStopped, (e) => seen.push(e))
 
         const tool = yield* TaskTool
-        const def = yield* Effect.promise(() => tool.init())
+        const def = yield* tool.init()
 
         yield* def
           .execute(
@@ -197,7 +200,7 @@ describe("tool.task lifecycle events", () => {
         const ctrl = new AbortController()
 
         const tool = yield* TaskTool
-        const def = yield* Effect.promise(() => tool.init())
+        const def = yield* tool.init()
 
         yield* def
           .execute(

--- a/packages/opencode/test/tool/task-lifecycle-events.test.ts
+++ b/packages/opencode/test/tool/task-lifecycle-events.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import { Agent } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Instance } from "../../src/project/instance"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Session } from "../../src/session"
+import { TaskTool } from "../../src/tool/task"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  mock.restore()
+  await Instance.disposeAll()
+})
+
+const ref = {
+  providerID: ProviderID.make("test"),
+  modelID: ModelID.make("test-model"),
+}
+
+function ctx(input: { sessionID: SessionID; messageID: MessageID; abort: AbortSignal }) {
+  return {
+    sessionID: input.sessionID,
+    messageID: input.messageID,
+    agent: "build",
+    abort: input.abort,
+    messages: [],
+    metadata: () => {},
+    ask: async () => {},
+    extra: { bypassAgentCheck: true },
+  }
+}
+
+function fakeParent(sessionID: SessionID, messageID: MessageID, path: string) {
+  return {
+    info: {
+      id: messageID,
+      role: "assistant" as const,
+      parentID: MessageID.make("msg_user"),
+      sessionID,
+      modelID: ref.modelID,
+      providerID: ref.providerID,
+      mode: "build",
+      agent: "build",
+      path: { cwd: path, root: path },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: Date.now() },
+    },
+    parts: [],
+  } as any
+}
+
+test("TaskTool emits started then stopped with completed status", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const seen: Array<{ type: string; properties: any }> = []
+      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
+      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
+
+      const parent = SessionID.descending()
+      const parentMsg = MessageID.make("msg_parent")
+
+      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
+
+      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
+      spyOn(SessionPrompt, "prompt").mockResolvedValue({
+        info: {
+          id: MessageID.make("msg_child"),
+          role: "assistant" as const,
+          parentID: MessageID.make("msg_user"),
+          sessionID: SessionID.descending(),
+          modelID: ref.modelID,
+          providerID: ref.providerID,
+          mode: "general",
+          agent: "general",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0.42,
+          tokens: { input: 11, output: 22, reasoning: 3, cache: { read: 4, write: 5 } },
+          time: { created: Date.now(), completed: Date.now() + 5 },
+        },
+        parts: [{ type: "text", text: "done" }],
+      } as any)
+
+      const tool = await TaskTool.init({ agent: await Agent.get("build") })
+      await tool.execute(
+        { description: "Run subagent", prompt: "do work", subagent_type: "general" },
+        ctx({ sessionID: parent, messageID: parentMsg, abort: AbortSignal.any([]) }),
+      )
+
+      await Bun.sleep(10)
+      offA()
+      offB()
+
+      expect(seen).toHaveLength(2)
+      expect(seen[0].type).toBe("session.subagent.started")
+      expect(seen[1].type).toBe("session.subagent.stopped")
+      expect(seen[1].properties.status).toBe("completed")
+      expect(seen[1].properties.tokens.input).toBe(11)
+      expect(seen[1].properties.cost).toBe(0.42)
+      expect(seen[1].properties.sessionID).toBe(seen[0].properties.sessionID)
+      expect(seen[1].properties.parentID).toBe(parent)
+    },
+  })
+})
+
+test("TaskTool emits stopped with failed status when prompt throws", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const seen: Array<{ type: string; properties: any }> = []
+      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
+      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
+
+      const parent = SessionID.descending()
+      const parentMsg = MessageID.make("msg_parent")
+
+      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
+      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
+      spyOn(SessionPrompt, "prompt").mockRejectedValue(new Error("boom"))
+
+      const tool = await TaskTool.init({ agent: await Agent.get("build") })
+      await expect(
+        tool.execute(
+          { description: "Run subagent", prompt: "do work", subagent_type: "general" },
+          ctx({ sessionID: parent, messageID: parentMsg, abort: AbortSignal.any([]) }),
+        ),
+      ).rejects.toThrow("boom")
+
+      await Bun.sleep(10)
+      offA()
+      offB()
+
+      expect(seen).toHaveLength(2)
+      expect(seen[0].type).toBe("session.subagent.started")
+      expect(seen[1].type).toBe("session.subagent.stopped")
+      expect(seen[1].properties.status).toBe("failed")
+      expect(seen[1].properties.error).toContain("boom")
+    },
+  })
+})
+
+test("TaskTool emits stopped with cancelled status when abort signal is triggered", async () => {
+  await using tmp = await tmpdir({ git: true })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const seen: Array<{ type: string; properties: any }> = []
+      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
+      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
+
+      const parent = SessionID.descending()
+      const parentMsg = MessageID.make("msg_parent")
+      const ctrl = new AbortController()
+
+      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
+      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
+      spyOn(SessionPrompt, "prompt").mockImplementation(async () => {
+        ctrl.abort()
+        throw new Error("aborted")
+      })
+
+      const tool = await TaskTool.init({ agent: await Agent.get("build") })
+      await expect(
+        tool.execute(
+          { description: "Run subagent", prompt: "do work", subagent_type: "general" },
+          ctx({ sessionID: parent, messageID: parentMsg, abort: ctrl.signal }),
+        ),
+      ).rejects.toThrow()
+
+      await Bun.sleep(10)
+      offA()
+      offB()
+
+      expect(seen).toHaveLength(2)
+      expect(seen[0].type).toBe("session.subagent.started")
+      expect(seen[1].type).toBe("session.subagent.stopped")
+      expect(seen[1].properties.status).toBe("cancelled")
+      expect(seen[1].properties.error).toBeUndefined()
+    },
+  })
+})

--- a/packages/opencode/test/tool/task-lifecycle-events.test.ts
+++ b/packages/opencode/test/tool/task-lifecycle-events.test.ts
@@ -133,6 +133,7 @@ describe("tool.task lifecycle events", () => {
           },
         )
 
+        yield* Effect.sleep("10 millis")
         offA()
         offB()
 

--- a/packages/opencode/test/tool/task-lifecycle-events.test.ts
+++ b/packages/opencode/test/tool/task-lifecycle-events.test.ts
@@ -95,9 +95,9 @@ function stubOps(opts?: { text?: string; fail?: Error; abort?: AbortController }
       Effect.gen(function* () {
         if (opts?.abort) {
           opts.abort.abort()
-          return yield* Effect.fail(new Error("aborted"))
+          return yield* Effect.die(new Error("aborted"))
         }
-        if (opts?.fail) return yield* Effect.fail(opts.fail)
+        if (opts?.fail) return yield* Effect.die(opts.fail)
         return reply(input, opts?.text ?? "done")
       }),
   }

--- a/packages/opencode/test/tool/task-lifecycle-events.test.ts
+++ b/packages/opencode/test/tool/task-lifecycle-events.test.ts
@@ -1,190 +1,230 @@
-import { afterEach, expect, mock, spyOn, test } from "bun:test"
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { Bus } from "../../src/bus"
-import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Config } from "../../src/config/config"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Instance } from "../../src/project/instance"
-import { MessageV2 } from "../../src/session/message-v2"
-import { MessageID, SessionID } from "../../src/session/schema"
-import { SessionPrompt } from "../../src/session/prompt"
 import { Session } from "../../src/session"
-import { TaskTool } from "../../src/tool/task"
-import { tmpdir } from "../fixture/fixture"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { SessionPrompt } from "../../src/session/prompt"
+import { MessageID, PartID } from "../../src/session/schema"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
+import { ToolRegistry } from "../../src/tool/registry"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
-afterEach(async () => {
-  mock.restore()
-  await Instance.disposeAll()
+const ref = { providerID: ProviderID.make("test"), modelID: ModelID.make("test-model") }
+
+const it = testEffect(
+  Layer.mergeAll(
+    Agent.defaultLayer,
+    Config.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Session.defaultLayer,
+    ToolRegistry.defaultLayer,
+    Bus.layer,
+  ),
+)
+
+const seed = Effect.fn("seed")(function* (title = "Pinned") {
+  const sessions = yield* Session.Service
+  const chat = yield* sessions.create({ title })
+  const user = yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  const assistant: MessageV2.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+  }
+  yield* sessions.updateMessage(assistant)
+  return { chat, assistant }
 })
 
-const ref = {
-  providerID: ProviderID.make("test"),
-  modelID: ModelID.make("test-model"),
-}
-
-function ctx(input: { sessionID: SessionID; messageID: MessageID; abort: AbortSignal }) {
+function reply(input: Parameters<typeof SessionPrompt.prompt>[0], text: string): MessageV2.WithParts {
+  const id = MessageID.ascending()
   return {
-    sessionID: input.sessionID,
-    messageID: input.messageID,
-    agent: "build",
-    abort: input.abort,
-    messages: [],
-    metadata: () => {},
-    ask: async () => {},
-    extra: { bypassAgentCheck: true },
+    info: {
+      id,
+      role: "assistant",
+      parentID: input.messageID ?? MessageID.ascending(),
+      sessionID: input.sessionID,
+      mode: input.agent ?? "general",
+      agent: input.agent ?? "general",
+      cost: 0.42,
+      path: { cwd: "/tmp", root: "/tmp" },
+      tokens: { input: 11, output: 22, reasoning: 3, cache: { read: 4, write: 5 } },
+      modelID: input.model?.modelID ?? ref.modelID,
+      providerID: input.model?.providerID ?? ref.providerID,
+      time: { created: Date.now() },
+      finish: "stop",
+    },
+    parts: [
+      {
+        id: PartID.ascending(),
+        messageID: id,
+        sessionID: input.sessionID,
+        type: "text",
+        text,
+      },
+    ],
   }
 }
 
-function fakeParent(sessionID: SessionID, messageID: MessageID, path: string) {
+function stubOps(opts?: { text?: string; fail?: Error; abort?: AbortController }): TaskPromptOps {
   return {
-    info: {
-      id: messageID,
-      role: "assistant" as const,
-      parentID: MessageID.make("msg_user"),
-      sessionID,
-      modelID: ref.modelID,
-      providerID: ref.providerID,
-      mode: "build",
-      agent: "build",
-      path: { cwd: path, root: path },
-      cost: 0,
-      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-      time: { created: Date.now() },
-    },
-    parts: [],
-  } as any
+    cancel() {},
+    resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (opts?.abort) {
+          opts.abort.abort()
+          return yield* Effect.fail(new Error("aborted"))
+        }
+        if (opts?.fail) return yield* Effect.fail(opts.fail)
+        return reply(input, opts?.text ?? "done")
+      }),
+  }
 }
 
-test("TaskTool emits started then stopped with completed status", async () => {
-  await using tmp = await tmpdir({ git: true })
+describe("tool.task lifecycle events", () => {
+  it.live("emits started then stopped with completed status", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const bus = yield* Bus.Service
+        const seen: Array<{ type: string; properties: any }> = []
+        const offA = yield* bus.subscribeCallback(Session.Event.SubagentStarted, (e) => seen.push(e))
+        const offB = yield* bus.subscribeCallback(Session.Event.SubagentStopped, (e) => seen.push(e))
 
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      const seen: Array<{ type: string; properties: any }> = []
-      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
-      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
+        const tool = yield* TaskTool
+        const def = yield* Effect.promise(() => tool.init())
 
-      const parent = SessionID.descending()
-      const parentMsg = MessageID.make("msg_parent")
-
-      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
-
-      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
-      spyOn(SessionPrompt, "prompt").mockResolvedValue({
-        info: {
-          id: MessageID.make("msg_child"),
-          role: "assistant" as const,
-          parentID: MessageID.make("msg_user"),
-          sessionID: SessionID.descending(),
-          modelID: ref.modelID,
-          providerID: ref.providerID,
-          mode: "general",
-          agent: "general",
-          path: { cwd: tmp.path, root: tmp.path },
-          cost: 0.42,
-          tokens: { input: 11, output: 22, reasoning: 3, cache: { read: 4, write: 5 } },
-          time: { created: Date.now(), completed: Date.now() + 5 },
-        },
-        parts: [{ type: "text", text: "done" }],
-      } as any)
-
-      const tool = await TaskTool.init({ agent: await Agent.get("build") })
-      await tool.execute(
-        { description: "Run subagent", prompt: "do work", subagent_type: "general" },
-        ctx({ sessionID: parent, messageID: parentMsg, abort: AbortSignal.any([]) }),
-      )
-
-      await Bun.sleep(10)
-      offA()
-      offB()
-
-      expect(seen).toHaveLength(2)
-      expect(seen[0].type).toBe("session.subagent.started")
-      expect(seen[1].type).toBe("session.subagent.stopped")
-      expect(seen[1].properties.status).toBe("completed")
-      expect(seen[1].properties.tokens.input).toBe(11)
-      expect(seen[1].properties.cost).toBe(0.42)
-      expect(seen[1].properties.sessionID).toBe(seen[0].properties.sessionID)
-      expect(seen[1].properties.parentID).toBe(parent)
-    },
-  })
-})
-
-test("TaskTool emits stopped with failed status when prompt throws", async () => {
-  await using tmp = await tmpdir({ git: true })
-
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      const seen: Array<{ type: string; properties: any }> = []
-      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
-      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
-
-      const parent = SessionID.descending()
-      const parentMsg = MessageID.make("msg_parent")
-
-      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
-      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
-      spyOn(SessionPrompt, "prompt").mockRejectedValue(new Error("boom"))
-
-      const tool = await TaskTool.init({ agent: await Agent.get("build") })
-      await expect(
-        tool.execute(
+        yield* def.execute(
           { description: "Run subagent", prompt: "do work", subagent_type: "general" },
-          ctx({ sessionID: parent, messageID: parentMsg, abort: AbortSignal.any([]) }),
-        ),
-      ).rejects.toThrow("boom")
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps({ text: "result text" }), bypassAgentCheck: true },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
 
-      await Bun.sleep(10)
-      offA()
-      offB()
+        offA()
+        offB()
 
-      expect(seen).toHaveLength(2)
-      expect(seen[0].type).toBe("session.subagent.started")
-      expect(seen[1].type).toBe("session.subagent.stopped")
-      expect(seen[1].properties.status).toBe("failed")
-      expect(seen[1].properties.error).toContain("boom")
-    },
-  })
-})
+        expect(seen).toHaveLength(2)
+        expect(seen[0].type).toBe("session.subagent.started")
+        expect(seen[1].type).toBe("session.subagent.stopped")
+        expect(seen[1].properties.status).toBe("completed")
+        expect(seen[1].properties.parentID).toBe(chat.id)
+        expect(seen[1].properties.tokens.input).toBe(11)
+        expect(seen[1].properties.cost).toBe(0.42)
+        expect(seen[1].properties.sessionID).toBe(seen[0].properties.sessionID)
+      }),
+    ),
+  )
 
-test("TaskTool emits stopped with cancelled status when abort signal is triggered", async () => {
-  await using tmp = await tmpdir({ git: true })
+  it.live("emits stopped with failed status when prompt fails", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const bus = yield* Bus.Service
+        const seen: Array<{ type: string; properties: any }> = []
+        const offA = yield* bus.subscribeCallback(Session.Event.SubagentStarted, (e) => seen.push(e))
+        const offB = yield* bus.subscribeCallback(Session.Event.SubagentStopped, (e) => seen.push(e))
 
-  await Instance.provide({
-    directory: tmp.path,
-    fn: async () => {
-      const seen: Array<{ type: string; properties: any }> = []
-      const offA = Bus.subscribe(Session.Event.SubagentStarted, (evt) => seen.push(evt))
-      const offB = Bus.subscribe(Session.Event.SubagentStopped, (evt) => seen.push(evt))
+        const tool = yield* TaskTool
+        const def = yield* Effect.promise(() => tool.init())
 
-      const parent = SessionID.descending()
-      const parentMsg = MessageID.make("msg_parent")
-      const ctrl = new AbortController()
+        yield* def
+          .execute(
+            { description: "Run subagent", prompt: "do work", subagent_type: "general" },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps: stubOps({ fail: new Error("boom") }), bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
 
-      spyOn(MessageV2, "get").mockReturnValue(fakeParent(parent, parentMsg, tmp.path))
-      spyOn(SessionPrompt, "resolvePromptParts").mockResolvedValue([{ type: "text", text: "do work" }] as any)
-      spyOn(SessionPrompt, "prompt").mockImplementation(async () => {
-        ctrl.abort()
-        throw new Error("aborted")
-      })
+        yield* Effect.sleep("10 millis")
+        offA()
+        offB()
 
-      const tool = await TaskTool.init({ agent: await Agent.get("build") })
-      await expect(
-        tool.execute(
-          { description: "Run subagent", prompt: "do work", subagent_type: "general" },
-          ctx({ sessionID: parent, messageID: parentMsg, abort: ctrl.signal }),
-        ),
-      ).rejects.toThrow()
+        expect(seen).toHaveLength(2)
+        expect(seen[0].type).toBe("session.subagent.started")
+        expect(seen[1].type).toBe("session.subagent.stopped")
+        expect(seen[1].properties.status).toBe("failed")
+        expect(seen[1].properties.error).toContain("boom")
+      }),
+    ),
+  )
 
-      await Bun.sleep(10)
-      offA()
-      offB()
+  it.live("emits stopped with cancelled status when abort signal fires", () =>
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const bus = yield* Bus.Service
+        const seen: Array<{ type: string; properties: any }> = []
+        const offA = yield* bus.subscribeCallback(Session.Event.SubagentStarted, (e) => seen.push(e))
+        const offB = yield* bus.subscribeCallback(Session.Event.SubagentStopped, (e) => seen.push(e))
+        const ctrl = new AbortController()
 
-      expect(seen).toHaveLength(2)
-      expect(seen[0].type).toBe("session.subagent.started")
-      expect(seen[1].type).toBe("session.subagent.stopped")
-      expect(seen[1].properties.status).toBe("cancelled")
-      expect(seen[1].properties.error).toBeUndefined()
-    },
-  })
+        const tool = yield* TaskTool
+        const def = yield* Effect.promise(() => tool.init())
+
+        yield* def
+          .execute(
+            { description: "Run subagent", prompt: "do work", subagent_type: "general" },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: ctrl.signal,
+              extra: { promptOps: stubOps({ abort: ctrl }), bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
+
+        yield* Effect.sleep("10 millis")
+        offA()
+        offB()
+
+        expect(seen).toHaveLength(2)
+        expect(seen[0].type).toBe("session.subagent.started")
+        expect(seen[1].type).toBe("session.subagent.stopped")
+        expect(seen[1].properties.status).toBe("cancelled")
+        expect(seen[1].properties.error).toBeUndefined()
+      }),
+    ),
+  )
 })

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -4,6 +4,7 @@ import { Agent } from "../../src/agent/agent"
 import { Config } from "@/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Session } from "@/session/session"
+import { Bus } from "../../src/bus"
 import { MessageV2 } from "../../src/session/message-v2"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
@@ -31,6 +32,7 @@ const it = testEffect(
     Session.defaultLayer,
     Truncate.defaultLayer,
     ToolRegistry.defaultLayer,
+    Bus.layer,
   ),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #16627

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds plugin events to hook into just before a subagent is started and after it completes/stops. The events can be used in line with other plugin events, allowing users to configure plugins which are triggered at these events

### How did you verify your code works?
I have run it locally on my branch and confirmed both events are fired in a subagent cycle. I have also done what I can to add comprehensive test coverage.

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
