### PR TITLE
feat: Add basePath support on web app - Closes #7624

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -74,6 +74,7 @@ declare global {
       updaterEnabled?: boolean
       deepLinks?: string[]
       wsl?: boolean
+      basePath?: string
     }
     api?: {
       setTitlebar?: (theme: { mode: "light" | "dark" }) => Promise<void>
@@ -295,6 +296,7 @@ export function AppInterface(props: {
               <Dynamic
                 component={props.router ?? Router}
                 root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
+                base={window.__OPENCODE__?.basePath?.replace(/\/$/, "") ?? ""}
               >
                 <Route path="/" component={HomeRoute} />
                 <Route path="/:dir" component={DirectoryLayout}>

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -11,6 +11,18 @@ import { ServerConnection } from "./context/server"
 
 const DEFAULT_SERVER_URL_KEY = "opencode.settings.dat:defaultServerUrl"
 
+const ensureOnBasePath = () => {
+  const basePath = window.__OPENCODE__?.basePath ?? "/"
+
+  if (basePath !== "/" && !location.pathname.startsWith(basePath)) {
+    const newUrl = new URL(location.href)
+    newUrl.pathname = `${basePath}${location.pathname.slice(1)}`
+    location.replace(newUrl.toString())
+  }
+}
+
+ensureOnBasePath()
+
 const getLocale = () => {
   if (typeof navigator !== "object") return "en" as const
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
@@ -101,6 +113,11 @@ const getCurrentUrl = () => {
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
+
+  if(window.__OPENCODE__?.basePath) {
+    return new URL(window.__OPENCODE__.basePath, location.origin).href.replace(/\/$/, "")
+  }
+
   return location.origin
 }
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3,6 +3,7 @@ import desktopPlugin from "./vite"
 
 export default defineConfig({
   plugins: [desktopPlugin] as any,
+  base: "./",
   server: {
     host: "0.0.0.0",
     allowedHosts: true,

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -44,7 +44,7 @@ export const WebCommand = cmd({
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
+      const localhostUrl = `http://localhost:${server.port}${opts.basePath}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
 
       // Show network IPs for remote access
@@ -54,7 +54,7 @@ export const WebCommand = cmd({
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            `http://${ip}:${server.port}${opts.basePath}`,
           )
         }
       }
@@ -70,7 +70,7 @@ export const WebCommand = cmd({
       // Open localhost in browser
       open(localhostUrl.toString()).catch(() => {})
     } else {
-      const displayUrl = server.url.toString()
+      const displayUrl = new URL(opts.basePath, server.url).toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
       open(displayUrl).catch(() => {})
     }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -12,6 +12,11 @@ const options = {
     describe: "hostname to listen on",
     default: "127.0.0.1",
   },
+  "base-path": {
+    type: "string" as const,
+    describe: "base path to serve the web app on (default: /)",
+    default: "/",
+  },
   mdns: {
     type: "boolean" as const,
     describe: "enable mDNS service discovery (defaults hostname to 0.0.0.0)",
@@ -40,6 +45,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const config = await Config.getGlobal()
   const portExplicitlySet = process.argv.includes("--port")
   const hostnameExplicitlySet = process.argv.includes("--hostname")
+  const basePathExplicitlySet = process.argv.includes("--base-path")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
   const corsExplicitlySet = process.argv.includes("--cors")
@@ -52,9 +58,11 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
     : mdns && !config?.server?.hostname
       ? "0.0.0.0"
       : (config?.server?.hostname ?? args.hostname)
+  const basePath = basePathExplicitlySet ? args["base-path"] : (config?.server?.basePath ?? args["base-path"])
+  const normalizedBasePath = basePath.length > 1 ? `/${basePath.replace(/^\/|\/$/g, "")}/` : "/"
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  return { hostname, port, basePath: normalizedBasePath, mdns, mdnsDomain, cors }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -771,6 +771,7 @@ export namespace Config {
     .object({
       port: z.number().int().positive().optional().describe("Port to listen on"),
       hostname: z.string().optional().describe("Hostname to listen on"),
+      basePath: z.string().optional().describe("Base path to serve the web app on (default: /)"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
       mdnsDomain: z.string().optional().describe("Custom domain name for mDNS service (default: opencode.local)"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),

--- a/packages/opencode/src/server/context.ts
+++ b/packages/opencode/src/server/context.ts
@@ -1,0 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const requestContext = new AsyncLocalStorage<{
+  basePath: string
+}>();

--- a/packages/opencode/src/server/instance.ts
+++ b/packages/opencode/src/server/instance.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono"
 import { proxy } from "hono/proxy"
 import type { UpgradeWebSocket } from "hono/ws"
 import z from "zod"
-import { createHash } from "node:crypto"
+import { randomBytes } from "node:crypto"
 import { Log } from "../util/log"
 import { Format } from "../format"
 import { TuiRoutes } from "./routes/tui"
@@ -15,6 +15,7 @@ import { Global } from "../global"
 import { LSP } from "../lsp"
 import { Command } from "../command"
 import { Flag } from "../flag/flag"
+import { requestContext } from "./context"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { Snapshot } from "@/snapshot"
@@ -36,11 +37,61 @@ const embeddedUIPromise = Flag.OPENCODE_DISABLE_EMBEDDED_WEB_UI
   : // @ts-expect-error - generated file at build time
     import("opencode-web-ui.gen.ts").then((module) => module.default as Record<string, string>).catch(() => null)
 
-const DEFAULT_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+const DEFAULT_CSP = (nonce: string) =>
+  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
 
-const csp = (hash = "") =>
-  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
+const createHtmlRewriter = (options: {
+  basePath: string
+  nonce: string
+}) => {
+  const normalizeBasePath = (src: string) => {
+    if (src.startsWith("/")) {
+      return `${options.basePath}${src.replace(/^\//, "")}`
+    } else if (src.startsWith("./")) {
+      return `${options.basePath}${src.replace(/^\.\//, "")}`
+    }
+
+    return src
+  }
+
+  return new HTMLRewriter().on('link,meta,script', {
+    element(el) {
+      switch (el.tagName) {
+        case "link":
+          const href = el.getAttribute("href")
+          if (href) {
+            el.setAttribute("href", normalizeBasePath(href))
+          }
+          break
+        case "meta":
+          const content = el.getAttribute("content")
+          if (content && el.getAttribute("property")?.endsWith(":image")) {
+            el.setAttribute("content", normalizeBasePath(content))
+          }
+          break
+        case "script":
+          const src = el.getAttribute("src")
+          if (src) {
+            el.setAttribute("src", normalizeBasePath(src))
+          }
+          break
+
+        default:
+          break
+      }
+    }
+  }).on("head", {
+    element(el) {
+      el.prepend(`<script nonce="${options.nonce}">window.__OPENCODE__ = Object.assign(window.__OPENCODE__ ?? {}, ${JSON.stringify({basePath: options.basePath})})</script>`, { html: true })
+    }
+  }).on("script#oc-theme-preload-script", {
+    element(el) {
+      if(!el.getAttribute("src")) {
+        el.setAttribute("nonce", options.nonce)
+      }
+    }
+  })
+}
 
 export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()) =>
   app
@@ -281,6 +332,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()
     .all("/*", async (c) => {
       const embeddedWebUI = await embeddedUIPromise
       const path = c.req.path
+      const basePath = requestContext.getStore()?.basePath ?? "/"
 
       if (embeddedWebUI) {
         const match = embeddedWebUI[path.replace(/^\//, "")] ?? embeddedWebUI["index.html"] ?? null
@@ -289,8 +341,15 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()
         if (await file.exists()) {
           c.header("Content-Type", file.type)
           if (file.type.startsWith("text/html")) {
-            c.header("Content-Security-Policy", DEFAULT_CSP)
+            const nonce = randomBytes(16).toString("base64")
+
+            c.header("Content-Security-Policy", DEFAULT_CSP(nonce))
+
+            const rewriter = createHtmlRewriter({ basePath, nonce })
+
+            return c.body(rewriter.transform(await file.text()))
           }
+
           return c.body(await file.arrayBuffer())
         } else {
           return c.json({ error: "Not Found" }, 404)
@@ -303,13 +362,17 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()
             host: "app.opencode.ai",
           },
         })
-        const match = response.headers.get("content-type")?.includes("text/html")
-          ? (await response.clone().text()).match(
-              /<script\b(?![^>]*\bsrc\s*=)[^>]*\bid=(['"])oc-theme-preload-script\1[^>]*>([\s\S]*?)<\/script>/i,
-            )
-          : undefined
-        const hash = match ? createHash("sha256").update(match[2]).digest("base64") : ""
-        response.headers.set("Content-Security-Policy", csp(hash))
+
+        if(response.headers.get("content-type")?.includes("text/html")) {
+          const nonce = randomBytes(16).toString("base64")
+
+          response.headers.set("Content-Security-Policy", DEFAULT_CSP(nonce))
+
+          const rewriter = createHtmlRewriter({ basePath, nonce })
+
+          return rewriter.transform(response.clone())
+        }
+
         return response
       }
     })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -16,6 +16,7 @@ import { errors } from "./error"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
+import { requestContext } from "./context"
 import { errorHandler } from "./middleware"
 import { InstanceRoutes } from "./instance"
 import { initProjectors } from "./projectors"
@@ -44,7 +45,7 @@ export namespace Server {
 
   export const Default = lazy(() => create({}).app)
 
-  export function ControlPlaneRoutes(upgrade: UpgradeWebSocket, app = new Hono(), opts?: { cors?: string[] }): Hono {
+  export function ControlPlaneRoutes(upgrade: UpgradeWebSocket, app = new Hono(), opts?: { cors?: string[] }) {
     return app
       .onError(errorHandler(log))
       .use((c, next) => {
@@ -237,6 +238,7 @@ export namespace Server {
 
   function create(opts: { cors?: string[] }) {
     const app = new Hono()
+
     const ws = createNodeWebSocket({ app })
     return {
       app: ControlPlaneRoutes(ws.upgradeWebSocket, app, opts),
@@ -273,14 +275,30 @@ export namespace Server {
   export async function listen(opts: {
     port: number
     hostname: string
+    basePath?: string
     mdns?: boolean
     mdnsDomain?: string
     cors?: string[]
   }): Promise<Listener> {
+    const basePath = opts.basePath ?? "/"
     const built = create(opts)
     const start = (port: number) =>
       new Promise<ServerType>((resolve, reject) => {
-        const server = createAdaptorServer({ fetch: built.app.fetch })
+        const server = createAdaptorServer({
+          fetch: (request, env) => {
+            return requestContext.run({ basePath }, () => {
+              const url = new URL(request.url)
+
+              if(basePath !== "/" && url.pathname.startsWith(basePath)) {
+                url.pathname = url.pathname.slice(basePath.length - 1)
+
+                return built.app.fetch(new Request(url.toString(), request), env)
+              }
+
+              return built.app.fetch(request, env)
+            })
+          }
+        })
         built.ws.injectWebSocket(server)
         const fail = (err: Error) => {
           cleanup()
@@ -308,6 +326,7 @@ export namespace Server {
     const next = new URL("http://localhost")
     next.hostname = opts.hostname
     next.port = String(addr.port)
+    next.pathname = basePath
     url = next
 
     const mdns =

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -37,6 +37,7 @@ function setup() {
     mdns: false,
     port: 0,
     hostname: "127.0.0.1",
+    basePath: "/",
     mdnsDomain: "opencode.local",
     cors: [],
   })
@@ -68,6 +69,8 @@ describe("tui thread", () => {
       fork: false,
       port: 0,
       hostname: "127.0.0.1",
+      "base-path": "/",
+      basePath: "/",
       mdns: false,
       "mdns-domain": "opencode.local",
       mdnsDomain: "opencode.local",

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1133,6 +1133,10 @@ export type ServerConfig = {
    */
   hostname?: string
   /**
+   * Base path to serve the web app on (default: /)
+   */
+  basePath?: string
+  /**
    * Enable mDNS service discovery
    */
   mdns?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10578,6 +10578,10 @@
             "description": "Hostname to listen on",
             "type": "string"
           },
+          "basePath": {
+            "description": "Base path to serve the web app on (default: /)",
+            "type": "string"
+          },
           "mdns": {
             "description": "Enable mDNS service discovery",
             "type": "boolean"

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -293,6 +293,7 @@ You can configure server settings for the `opencode serve` and `opencode web` co
   "server": {
     "port": 4096,
     "hostname": "0.0.0.0",
+    "basePath": "/my-base/sub-path/",
     "mdns": true,
     "mdnsDomain": "myproject.local",
     "cors": ["http://localhost:5173"]
@@ -304,6 +305,7 @@ Available options:
 
 - `port` - Port to listen on.
 - `hostname` - Hostname to listen on. When `mdns` is enabled and no hostname is set, defaults to `0.0.0.0`.
+- `basePath` - BasePath to serve the web app on (useful when running as a part of an ingress network or similar), defaults to `0.0.0.0`.
 - `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
 - `mdnsDomain` - Custom domain name for mDNS service. Defaults to `opencode.local`. Useful for running multiple instances on the same network.
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -22,6 +22,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | --------------- | ----------------------------------- | ---------------- |
 | `--port`        | Port to listen on                   | `4096`           |
 | `--hostname`    | Hostname to listen on               | `127.0.0.1`      |
+| `--base-path`   | Base path to serve the web app on   | `/`              |
 | `--mdns`        | Enable mDNS discovery               | `false`          |
 | `--mdns-domain` | Custom domain name for mDNS service | `opencode.local` |
 | `--cors`        | Additional browser origins to allow | `[]`             |


### PR DESCRIPTION
Allow serving web app within a subPath of a host

- Make app build with relative basepath
- Initialize app router with basepath if defined from server
- Add `--base-path` CLI param and `server.basePath` option
- Remove basePath in Server before processing routing
- Add basePath  in requestContext for easy access in handlers
- Normalize CSP on `nonce` for easily handling inline scripts
- Use built-in Bun `HTMLRewriter` for manipulating HTML basepath before serving to client

### Issue for this PR

Closes #7624

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add support for serving the web app under a basePath. This is useful when serving OpenCode on web through an ingress / proxy setup, where you might have https://www.mydomain.com/apps/opencode/

How to test:

(`dev` still works as before, but the new basePath functionality only works in built binary until the new app is deployed to https://app.opencode.ai)

```shell
bun packages/opencode/script/build.ts --single

./packages/opencode/dist/opencode-linux-x64/bin/opencode web --base-path /my-base/sub-path/
```

Will open on http://127.0.0.1:4096/my-base/sub-path/

Alternatively, configure `opencode.json` with:

```json
{
  "server": {
    "basePath": "/my-base/sub-path/"
  }
}
```

----------

This is solved with combining changes in:

## Web App

1. Configure Vite to build with relative basePath, where assets will load relatively from the current path
2. Load `__OPENCODE__.basePath` if defined from the server, use to initialize Solid Router and as base for API calls to server

## Opencode Server app

1. Add `server.basePath` config option and `--base-path` CLI argument
2. Configure Server listener to remove basePath before Hono app route handling, making it transparent `/my-base/path/global/event => /global/event`
3. To avoid complicating the Hono setup, passing around `Hono<Env>` types, a simple `AsyncLocalStorage` - `requestContext` holds the `basePath` context to use for nested handlers
4. When serving the HTML, Bun's built-in `HTMLRewriter` handles:
   - Rewriting of the basePaths on links in the HTML
   - Adding script `nonce`
   - Add `basePath` to/initialize `window.__OPENCODE__`
5. Switch to using a `nonce` for CSP, to simplify multiple inline scripts being allowed in the CSP

### How did you verify your code works?

I have tested built binary:

`./script/build.ts --single`

With no basePath, `--base-path /various/levels/` as well as through config `server.basePath` option. This looks to work very well

----------

When running `bun dev`, this works quite well, and does not break, however since this proxies to `https://app.opencode.ai` - the referenced JS assets are not updated with the new basePath handling, and the basePath is ignored until this app is deployed with these changes (works as if there is no basePath defined)


### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
