### PR TITLE
fix(tui): guard against undefined agents and mcp state during bootstrap

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -20,7 +20,7 @@ export function DialogAgent() {
   return (
     <DialogSelect
       title="Select agent"
-      current={local.agent.current().name}
+      current={local.agent.current()?.name ?? ""}
       options={options()}
       onSelect={(option) => {
         local.agent.set(option.value)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -40,7 +40,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const [agentStore, setAgentStore] = createStore<{
         current: string
       }>({
-        current: agents()[0].name,
+        current: agents()[0]?.name ?? "",
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -74,7 +74,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (next < 0) next = agents().length - 1
             if (next >= agents().length) next = 0
             const value = agents()[next]
-            setAgentStore("current", value.name)
+            if (value) setAgentStore("current", value.name)
           })
         },
         color(name: string) {

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/footer.tsx
@@ -19,7 +19,7 @@ function Directory(props: { api: TuiPluginApi }) {
 
 function Mcp(props: { api: TuiPluginApi }) {
   const theme = () => props.api.theme.current
-  const list = createMemo(() => props.api.state.mcp())
+  const list = createMemo(() => props.api.state.mcp() ?? [])
   const has = createMemo(() => list().length > 0)
   const err = createMemo(() => list().some((item) => item.status === "failed"))
   const count = createMemo(() => list().filter((item) => item.status === "connected").length)

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/mcp.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/mcp.tsx
@@ -6,7 +6,7 @@ const id = "internal:sidebar-mcp"
 function View(props: { api: TuiPluginApi }) {
   const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
-  const list = createMemo(() => props.api.state.mcp())
+  const list = createMemo(() => props.api.state.mcp() ?? [])
   const on = createMemo(() => list().filter((item) => item.status === "connected").length)
   const bad = createMemo(
     () =>

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -187,6 +187,7 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       return sync.data.lsp.map((item) => ({ id: item.id, root: item.root, status: item.status }))
     },
     mcp() {
+      if (!sync.data.mcp) return []
       return Object.entries(sync.data.mcp)
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([name, item]) => ({


### PR DESCRIPTION
### Issue for this PR
#20588, #20628.


Closes #
Fixes #20588, #20628.


### Type of change

- [x] Bug fix

### What does this PR do?

- Guard TUI components against undefined/empty sync.data.agent and sync.data.mcp during async bootstrap
- Prevents fatal crash when plugins (e.g. oh-my-openagent) slow down agent/MCP resolution

Disclaimer: I made this fix with the help of opencode itself with claude opus 4.6, but _I have spent time understanding what it is doing AND tested it to work in my local setup_
All changes are defensive null guards. *No behavioral change when data is present.*


### Problem
The TUI crashes with a fatal TypeError when plugins like oh-my-openagent are loaded:
TypeError: undefined is not an object (evaluating 'list2().length')
    at <anonymous> (/$bunfs/root/src/index.js:496761:41)
    at runComputation (/$bunfs/root/src/index.js:472905:24)
    at updateComputation (/$bunfs/root/src/index.js:472888:17)
    at readSignal (/$bunfs/root/src/index.js:472810:24)
    at <anonymous> (/$bunfs/root/src/index.js:473750:49)
    at runComputation (/$bunfs/root/src/index.js:472905:24)
    at updateComputation (/$bunfs/root/src/index.js:472888:17)
    at createMemo (/$bunfs/root/src/index.js:472393:22)
    at Show (/$bunfs/root/src/index.js:473750:36)
Running from source reveals the crash originates in footer.tsx:30 and local.tsx:43.

### Root Cause
SyncProvider initializes sync.data with empty defaults (agent: [], mcp: {}) and calls bootstrap() asynchronously via onMount. SolidJS continues rendering child components (LocalProvider, footer, sidebar) before bootstrap resolves.

Without plugins, the server responds fast enough that the timing window is negligible. When oh-my-openagent is loaded, its config handler performs model resolution, skill discovery, and provider caching, which delays the sdk.client.app.agents() response. This widens the window where sync.data fields are still in their initial empty state, and the TUI crashes accessing:
- agents()[0].name — agents() is [], so agents()[0] is undefined
- state.mcp().length — sync.data.mcp can be undefined after reconcile()
- local.agent.current().name — current() returns undefined when agents list is empty


### Files Changed and Why


| File | Line | Before | After | Why |
|------|------|--------|-------|-----|
| `context/local.tsx` | 43 | `agents()[0].name` | `agents()[0]?.name ?? ""` | `agents()` is `[]` before bootstrap resolves, so `agents()[0]` is `undefined`. Accessing `.name` on `undefined` throws the fatal TypeError. |
| `context/local.tsx` | 77 | `setAgentStore("current", value.name)` | `if (value) setAgentStore("current", value.name)` | `agents()[next]` can be `undefined` if the list is empty when user cycles agents via keybind before bootstrap completes. |
| `plugin/api.tsx` | 190 | `Object.entries(sync.data.mcp)` | `if (!sync.data.mcp) return []` before the `Object.entries` call | `sync.data.mcp` can be `undefined` after `reconcile(undefined)` from a server response where `x.data` is `undefined`. `Object.entries(undefined)` throws. |
| `feature-plugins/home/footer.tsx` | 22 | `props.api.state.mcp()` | `props.api.state.mcp() ?? []` | This is the exact crash site from the stack trace (`list2().length`). `state.mcp()` returns `undefined` before bootstrap, and line 23 calls `.length` on it. |
| `feature-plugins/sidebar/mcp.tsx` | 9 | `props.api.state.mcp()` | `props.api.state.mcp() ?? []` | Same pattern as footer — sidebar MCP view calls `.length`, `.filter()`, `.some()` on the result, all of which crash on `undefined`. |
| `component/dialog-agent.tsx` | 23 | `local.agent.current().name` | `local.agent.current()?.name ?? ""` | `current()` returns `agents().find(...) ?? agents()[0]` — both return `undefined` when agents list is empty. Accessing `.name` crashes. |

### How did you verify your code works?
I ran opencode from my fork and didn't face the crash and got my prompt screen.


### Screenshots / recordings
<img width="559" height="655" alt="image" src="https://github.com/user-attachments/assets/13724c03-e441-4b2b-9f86-61f9525ce846" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


