### PR TITLE
fix(config): respect OPENCODE_CONFIG and OPENCODE_CONFIG_DIR env vars

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1219,14 +1219,16 @@ export namespace Config {
         })
 
         const loadGlobal = Effect.fnUntraced(function* () {
+          const configBase = Flag.OPENCODE_CONFIG_DIR || Global.Path.config
+
           let result: Info = pipe(
             {},
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "config.json"))),
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "opencode.json"))),
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "config.json"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "opencode.json"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "opencode.jsonc"))),
           )
 
-          const legacy = path.join(Global.Path.config, "config")
+          const legacy = path.join(configBase, "config")
           if (existsSync(legacy)) {
             yield* Effect.promise(() =>
               import(pathToFileURL(legacy).href, { with: { type: "toml" } })
@@ -1235,11 +1237,15 @@ export namespace Config {
                   if (provider && model) result.model = `${provider}/${model}`
                   result["$schema"] = "https://opencode.ai/config.json"
                   result = mergeDeep(result, rest)
-                  await fsNode.writeFile(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
+                  await fsNode.writeFile(path.join(configBase, "config.json"), JSON.stringify(result, null, 2))
                   await fsNode.unlink(legacy)
                 })
                 .catch(() => {}),
             )
+          }
+
+          if (Flag.OPENCODE_CONFIG) {
+            result = mergeDeep(result, yield* loadFile(Flag.OPENCODE_CONFIG))
           }
 
           return result

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2362,3 +2362,88 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+test("loadGlobal respects OPENCODE_CONFIG env var", async () => {
+  await using tmp = await tmpdir()
+  const customConfigPath = path.join(tmp.path, "custom-config.json")
+  await Filesystem.write(
+    customConfigPath,
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      username: "custom-user-from-env",
+      model: "custom/model",
+    }),
+  )
+
+  const prevConfig = process.env.OPENCODE_CONFIG
+  const prevManagedConfig = process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+  try {
+    process.env.OPENCODE_CONFIG = customConfigPath
+    delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.username).toBe("custom-user-from-env")
+        expect(config.model).toBe("custom/model")
+      },
+    })
+  } finally {
+    if (prevConfig !== undefined) {
+      process.env.OPENCODE_CONFIG = prevConfig
+    } else {
+      delete process.env.OPENCODE_CONFIG
+    }
+    if (prevManagedConfig !== undefined) {
+      process.env.OPENCODE_TEST_MANAGED_CONFIG = prevManagedConfig
+    } else {
+      delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+    }
+    await Config.invalidate()
+  }
+})
+
+test("loadGlobal respects OPENCODE_CONFIG_DIR env var", async () => {
+  await using tmp = await tmpdir()
+  const customConfigDir = path.join(tmp.path, "custom-config-dir")
+  await fs.mkdir(customConfigDir, { recursive: true })
+  await Filesystem.write(
+    path.join(customConfigDir, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      username: "custom-user-from-config-dir",
+      model: "custom/model-from-dir",
+    }),
+  )
+
+  const prevConfigDir = process.env.OPENCODE_CONFIG_DIR
+  const prevManagedConfig = process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+  try {
+    process.env.OPENCODE_CONFIG_DIR = customConfigDir
+    delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.username).toBe("custom-user-from-config-dir")
+        expect(config.model).toBe("custom/model-from-dir")
+      },
+    })
+  } finally {
+    if (prevConfigDir !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = prevConfigDir
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
+    if (prevManagedConfig !== undefined) {
+      process.env.OPENCODE_TEST_MANAGED_CONFIG = prevManagedConfig
+    } else {
+      delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+    }
+    await Config.invalidate()
+  }
+})


### PR DESCRIPTION
Fixes #21083

## Summary

This PR makes `loadGlobal()` respect `OPENCODE_CONFIG` and `OPENCODE_CONFIG_DIR` environment variables, consistent with `loadInstanceState()` behavior.

## Changes

In `packages/opencode/src/config/config.ts`:
- Added `configBase = Flag.OPENCODE_CONFIG_DIR || Global.Path.config` to respect `OPENCODE_CONFIG_DIR`
- Added explicit override via `Flag.OPENCODE_CONFIG` after loading base config files
- All hardcoded uses of `Global.Path.config` now use `configBase`

## Test Coverage

Added two new test cases in `packages/opencode/test/config/config.test.ts`:
- `OPENCODE_CONFIG_DIR` loads config from specified directory
- `OPENCODE_CONFIG` overrides base config with explicit file