### PR TITLE
fix(tui): keep prompt mounted during permission and question modals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1159,28 +1159,26 @@ export function Session() {
               <Show when={session()?.parentID}>
                 <SubagentFooter />
               </Show>
-              <Show when={visible()}>
-                <TuiPluginRuntime.Slot
-                  name="session_prompt"
-                  mode="replace"
-                  session_id={route.sessionID}
+              <TuiPluginRuntime.Slot
+                name="session_prompt"
+                mode="replace"
+                session_id={route.sessionID}
+                visible={visible()}
+                disabled={disabled()}
+                on_submit={toBottom}
+                ref={bind}
+              >
+                <Prompt
                   visible={visible()}
-                  disabled={disabled()}
-                  on_submit={toBottom}
                   ref={bind}
-                >
-                  <Prompt
-                    visible={visible()}
-                    ref={bind}
-                    disabled={disabled()}
-                    onSubmit={() => {
-                      toBottom()
-                    }}
-                    sessionID={route.sessionID}
-                    right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
-                  />
-                </TuiPluginRuntime.Slot>
-              </Show>
+                  disabled={disabled()}
+                  onSubmit={() => {
+                    toBottom()
+                  }}
+                  sessionID={route.sessionID}
+                  right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
+                />
+              </TuiPluginRuntime.Slot>
             </box>
           </Show>
           <Toast />


### PR DESCRIPTION
### Issue for this PR

Closes #21120

### Type of change

- [x] Bug fix

### What does this PR do?

The TUI prompt input loses any text typed while the agent is working as soon as a permission or question modal appears.

The root cause is in `tui/routes/session/index.tsx`. The `visible()` memo is:
```typescript
const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
```

When a permission fires, `visible()` becomes `false`, and the `<Show when={visible()}>` wrapper unmounts the entire `Prompt` component. The local state holding the typed text is destroyed. After the modal is dismissed, `Prompt` remounts from scratch with an empty input.

The fix removes the `<Show when={visible()}>` wrapper. The `Prompt` component already handles `visible={false}` correctly — it blurs the input and hides its `<box visible={props.visible !== false}>` — so no separate `<Show>` guard is needed. The `visible={visible()}` prop is still forwarded to both `TuiPluginRuntime.Slot` and `Prompt`, preserving all existing hide/blur behavior while keeping the component tree (and its typed text) alive across modal interactions.

### How did you verify your code works?

- `cd packages/opencode && bun run typecheck` passes cleanly
- Traced the flow: `permissions().length > 0` → `visible()` = false → `Prompt`'s internal `createEffect` blurs the input and `<box visible={false}>` hides it, while `store.prompt.input` remains intact. On dismiss, `visible()` = true → box shows again, input refocuses with the text still present.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR