### PR TITLE
feat(config): add OPENCODE_DISABLE_GLOBAL_CONFIG flag

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1219,6 +1219,7 @@ export namespace Config {
         })
 
         const loadGlobal = Effect.fnUntraced(function* () {
+          if (Flag.OPENCODE_DISABLE_GLOBAL_CONFIG) return {} as Info
           let result: Info = pipe(
             {},
             mergeDeep(yield* loadFile(path.join(Global.Path.config, "config.json"))),

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -16,6 +16,7 @@ export namespace Flag {
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
   export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
   export declare const OPENCODE_PURE: boolean
+  export declare const OPENCODE_DISABLE_GLOBAL_CONFIG: boolean
   export declare const OPENCODE_TUI_CONFIG: string | undefined
   export declare const OPENCODE_CONFIG_DIR: string | undefined
   export declare const OPENCODE_PLUGIN_META_FILE: string | undefined
@@ -128,6 +129,17 @@ Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
 Object.defineProperty(Flag, "OPENCODE_PURE", {
   get() {
     return truthy("OPENCODE_PURE")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_DISABLE_GLOBAL_CONFIG
+// This must be evaluated at access time, not module load time,
+// because external tooling may set this env var at runtime
+Object.defineProperty(Flag, "OPENCODE_DISABLE_GLOBAL_CONFIG", {
+  get() {
+    return truthy("OPENCODE_DISABLE_GLOBAL_CONFIG")
   },
   enumerable: true,
   configurable: false,


### PR DESCRIPTION
### Issue for this PR
  Closes #21264

  ### Type of change
  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Adds a new `OPENCODE_DISABLE_GLOBAL_CONFIG` environment variable that skips loading global config files
  (`~/.config/opencode/config.json`, `opencode.json`, `opencode.jsonc`) when set to `1` or `true`.

  This is useful when embedding OpenCode as a subprocess via `opencode serve` — the host application provides all configuration through
  `OPENCODE_CONFIG_CONTENT`, and global user-level config files can interfere with the intended configuration.

  The flag only affects `loadGlobal()` — project-level `.opencode/` directories (agents, skills, plugins), `OPENCODE_CONFIG`,
  `OPENCODE_CONFIG_CONTENT`, well-known, account, and managed configs are not affected.

  Example usage:
  ```bash
  OPENCODE_DISABLE_GLOBAL_CONFIG=1 \
  OPENCODE_CONFIG_CONTENT='{"provider":{...}}' \
  opencode serve --port 4096

  How did you verify your code works?

  1. Set OPENCODE_DISABLE_GLOBAL_CONFIG=1 with OPENCODE_CONFIG_CONTENT and ran opencode serve — confirmed global config loading logs
  disappeared, only OPENCODE_CONFIG_CONTENT was loaded
  2. Without the flag — confirmed behavior is identical to before (no regression)
  3. Verified .opencode/agents/ and .opencode/skills/ still load correctly with the flag set

  Screenshots / recordings

  N/A — no UI changes.

  Checklist

  - I have tested my changes locally
  - I have not included unrelated changes in this PR

  把 `#xxx` 替换成你创建的 issue 编号就行。