### PR TITLE
feat(opencode): add TUI session list/get API and parent family context usage

### DIFF
--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -261,6 +261,9 @@ Command behavior:
 
 ### KV, state, client, events
 
+- `api.state.session.list()` returns the loaded session list.
+- `api.state.session.get(sessionID)` returns a loaded session by id when available.
+
 - `api.kv` is the shared app KV store backed by `state/kv.json`. It is not plugin-namespaced.
 - `api.kv` exposes `ready`.
 - `api.tuiConfig` and `api.state` are live host objects/getters, not frozen snapshots.

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
-import { createMemo } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
+import { Locale } from "@/util/locale"
 
 const id = "internal:sidebar-context"
 
@@ -11,25 +12,60 @@ const money = new Intl.NumberFormat("en-US", {
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
-  const msg = createMemo(() => props.api.state.session.messages(props.session_id))
-  const cost = createMemo(() => msg().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0))
+  const rows = createMemo(() => {
+    const cur = props.api.state.session.get(props.session_id)
+    if (!cur) return []
 
-  const state = createMemo(() => {
-    const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
-    if (!last) {
-      return {
-        tokens: 0,
-        percent: null,
-      }
-    }
+    const root = cur.parentID ?? cur.id
+    return props.api.state.session
+      .list()
+      .filter((item) => item.id === root || item.parentID === root)
+      .toSorted((a, b) => {
+        if (a.id === root) return -1
+        if (b.id === root) return 1
+        return a.time.created - b.time.created
+      })
+      .map((item, index) => {
+        const msg = props.api.state.session.messages(item.id)
+        const last = msg.findLast(
+          (entry): entry is AssistantMessage => entry.role === "assistant" && entry.tokens.output > 0,
+        )
+        const cost = msg.reduce((sum, entry) => sum + (entry.role === "assistant" ? entry.cost : 0), 0)
+        const tokens = last
+          ? last.tokens.input +
+            last.tokens.output +
+            last.tokens.reasoning +
+            last.tokens.cache.read +
+            last.tokens.cache.write
+          : 0
+        const model = last
+          ? props.api.state.provider.find((entry) => entry.id === last.providerID)?.models[last.modelID]
+          : undefined
+        const name = (() => {
+          if (item.id === root) return "Parent"
+          const hit = item.title.match(/@(\w+) subagent/)
+          if (hit?.[1]) return Locale.titlecase(hit[1])
+          return `Child ${index}`
+        })()
+        return {
+          id: item.id,
+          name,
+          tokens,
+          percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+          cost,
+        }
+      })
+  })
 
-    const tokens =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    return {
-      tokens,
-      percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
-    }
+  const total = createMemo(() => {
+    return rows().reduce(
+      (sum, item) => {
+        sum.tokens += item.tokens
+        sum.cost += item.cost
+        return sum
+      },
+      { tokens: 0, cost: 0 },
+    )
   })
 
   return (
@@ -37,9 +73,30 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <text fg={theme().text}>
         <b>Context</b>
       </text>
-      <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
-      <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <Show when={rows().length <= 1}>
+        <text fg={theme().textMuted}>{Locale.number(total().tokens)} tokens</text>
+        <text fg={theme().textMuted}>{rows()[0]?.percent ?? 0}% used</text>
+        <text fg={theme().textMuted}>{money.format(total().cost)} spent</text>
+      </Show>
+      <Show when={rows().length > 1}>
+        <text fg={theme().textMuted}>{Locale.number(total().tokens)} tokens total</text>
+        <text fg={theme().textMuted}>{money.format(total().cost)} spent</text>
+        <box paddingTop={1} gap={1}>
+          <For each={rows()}>
+            {(item) => (
+              <box flexDirection="row" justifyContent="space-between" gap={1}>
+                <text fg={theme().text} wrapMode="none">
+                  {item.name}
+                </text>
+                <text fg={theme().textMuted} wrapMode="none">
+                  {Locale.number(item.tokens)}
+                  <Show when={item.percent !== null}> ({item.percent}%)</Show>
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+      </Show>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -161,6 +161,12 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       count() {
         return sync.data.session.length
       },
+      list() {
+        return sync.data.session
+      },
+      get(sessionID) {
+        return sync.session.get(sessionID)
+      },
       diff(sessionID) {
         return sync.data.session_diff[sessionID] ?? []
       },

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -297,6 +297,8 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       },
       session: {
         count: opts.state?.session?.count ?? (() => 0),
+        list: opts.state?.session?.list ?? (() => []),
+        get: opts.state?.session?.get ?? (() => undefined),
         diff: opts.state?.session?.diff ?? (() => []),
         todo: opts.state?.session?.todo ?? (() => []),
         messages: opts.state?.session?.messages ?? (() => []),

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -11,6 +11,7 @@ import type {
   Provider,
   PermissionRequest,
   QuestionRequest,
+  Session,
   SessionStatus,
   TextPart,
   Workspace,
@@ -278,6 +279,8 @@ export type TuiState = {
   }
   session: {
     count: () => number
+    list: () => ReadonlyArray<Session>
+    get: (sessionID: string) => Session | undefined
     diff: (sessionID: string) => ReadonlyArray<TuiSidebarFileItem>
     todo: (sessionID: string) => ReadonlyArray<TuiSidebarTodoItem>
     messages: (sessionID: string) => ReadonlyArray<Message>


### PR DESCRIPTION
### Issue for this PR

Closes #20644 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds `state.session.list` and `state.session.get` to the TUI plugin state API so plugins can access sessions directly.  
It also updates the TUI sidebar context flow to show family context usage for parent sessions.  
Finally, the TUI plugin test fixture is updated to include default `list/get` methods so typecheck stays green with the new API contract.

### How did you verify your code works?
I ran local typecheck in `packages/opencode`:
- `bun run typecheck`
It passed after updating the fixture.
### Screenshots / recordings
Before: 
<img width="2565" height="1254" alt="image" src="https://github.com/user-attachments/assets/e54952ce-5540-42a7-a34c-892e2e2b612b" />

After:
<img width="2565" height="1254" alt="image" src="https://github.com/user-attachments/assets/f3e2e59c-25fb-4474-b7d0-d3a0dffcdfbd" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


