### PR TITLE
fix(tui): reset terminal state on crash/exit (Windows)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -6,6 +6,16 @@ import { TuiConfig } from "@/config/tui"
 import { Instance } from "@/project/instance"
 import { existsSync } from "fs"
 
+function resetTerminal() {
+  if (!process.stdout.isTTY) return
+  process.stdout.write(
+    "\x1b[0m" +    // reset all attributes (colors, bold, etc.)
+    "\x1b[?25h" +  // show cursor
+    "\x1b[?1049l" + // exit alternate screen buffer
+    "\x1b[?7h",    // re-enable auto-wrap
+  )
+}
+
 export const AttachCommand = cmd({
   command: "attach <url>",
   describe: "attach to a running opencode server",
@@ -83,6 +93,7 @@ export const AttachCommand = cmd({
       })
     } finally {
       unguard?.()
+      resetTerminal()
     }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -21,6 +21,19 @@ declare global {
   const OPENCODE_WORKER_PATH: string
 }
 
+function resetTerminal() {
+  if (!process.stdout.isTTY) return
+  process.stdout.write(
+    "\x1b[0m" +    // reset all attributes (colors, bold, etc.)
+    "\x1b[?25h" +  // show cursor
+    "\x1b[?1049l" + // exit alternate screen buffer
+    "\x1b[?7h",    // re-enable auto-wrap
+  )
+}
+
+// Backstop: runs even on process.exit() or uncaught crash
+process.on("exit", resetTerminal)
+
 type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
 
 function createWorkerFetch(client: RpcClient): typeof fetch {
@@ -226,6 +239,7 @@ export const TuiThreadCommand = cmd({
       }
     } finally {
       unguard?.()
+      resetTerminal()
     }
     process.exit(0)
   },


### PR DESCRIPTION
## Problem

On Windows (PowerShell), when OpenCode exits unexpectedly or crashes, the terminal is left in a broken state. Raw ANSI escape sequences appear as literal text at the bottom of the screen (e.g. `555;59;86m`) and the cursor may be hidden, requiring the user to close and reopen PowerShell.

Reported in #21277.

## Root cause

The `finally` blocks in `thread.ts` and `attach.ts` call `unguard?.()` which restores the Windows console mode, but they never send ANSI reset sequences. If the renderer (`@opentui/solid`) crashes before it can clean up, the alternate screen buffer and all ANSI attributes remain active.

## Fix

Added a `resetTerminal()` function in both `thread.ts` and `attach.ts` that sends:

| Sequence | Effect |
|---|---|
| `\x1b[0m` | Reset all attributes (colors, bold, italic, etc.) |
| `\x1b[?25h` | Restore cursor visibility |
| `\x1b[?1049l` | Exit alternate screen buffer |
| `\x1b[?7h` | Re-enable auto-wrap mode |

In `thread.ts`, also registered a `process.on('exit')` handler as a backstop that fires even on `process.exit()` or uncaught exceptions, before the `finally` block has a chance to run.

## Testing

Reproduced on Windows 10 / PowerShell 5.1 / OpenCode 1.3.17 by forcing a crash. After this fix, the terminal restores cleanly on exit.