### PR TITLE
fix(config): respect OPENCODE_CONFIG and OPENCODE_CONFIG_DIR env vars

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1219,14 +1219,16 @@ export namespace Config {
         })
 
         const loadGlobal = Effect.fnUntraced(function* () {
+          const configBase = Flag.OPENCODE_CONFIG_DIR || Global.Path.config
+
           let result: Info = pipe(
             {},
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "config.json"))),
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "opencode.json"))),
-            mergeDeep(yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "config.json"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "opencode.json"))),
+            mergeDeep(yield* loadFile(path.join(configBase, "opencode.jsonc"))),
           )
 
-          const legacy = path.join(Global.Path.config, "config")
+          const legacy = path.join(configBase, "config")
           if (existsSync(legacy)) {
             yield* Effect.promise(() =>
               import(pathToFileURL(legacy).href, { with: { type: "toml" } })
@@ -1235,11 +1237,15 @@ export namespace Config {
                   if (provider && model) result.model = `${provider}/${model}`
                   result["$schema"] = "https://opencode.ai/config.json"
                   result = mergeDeep(result, rest)
-                  await fsNode.writeFile(path.join(Global.Path.config, "config.json"), JSON.stringify(result, null, 2))
+                  await fsNode.writeFile(path.join(configBase, "config.json"), JSON.stringify(result, null, 2))
                   await fsNode.unlink(legacy)
                 })
                 .catch(() => {}),
             )
+          }
+
+          if (Flag.OPENCODE_CONFIG) {
+            result = mergeDeep(result, yield* loadFile(Flag.OPENCODE_CONFIG))
           }
 
           return result

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -14,7 +14,7 @@ export namespace Flag {
   export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
   export const OPENCODE_AUTO_HEAP_SNAPSHOT = truthy("OPENCODE_AUTO_HEAP_SNAPSHOT")
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
-  export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
+  export declare const OPENCODE_CONFIG: string | undefined
   export declare const OPENCODE_PURE: boolean
   export declare const OPENCODE_TUI_CONFIG: string | undefined
   export declare const OPENCODE_CONFIG_DIR: string | undefined
@@ -117,6 +117,17 @@ Object.defineProperty(Flag, "OPENCODE_TUI_CONFIG", {
 Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
   get() {
     return process.env["OPENCODE_CONFIG_DIR"]
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_CONFIG
+// This must be evaluated at access time, not module load time,
+// because tests and external tooling may set this env var at runtime
+Object.defineProperty(Flag, "OPENCODE_CONFIG", {
+  get() {
+    return process.env["OPENCODE_CONFIG"]
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2362,3 +2362,88 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+test("loadGlobal respects OPENCODE_CONFIG env var", async () => {
+  await using tmp = await tmpdir()
+  const customConfigPath = path.join(tmp.path, "custom-config.json")
+  await Filesystem.write(
+    customConfigPath,
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      username: "custom-user-from-env",
+      model: "custom/model",
+    }),
+  )
+
+  const prevConfig = process.env.OPENCODE_CONFIG
+  const prevManagedConfig = process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+  try {
+    process.env.OPENCODE_CONFIG = customConfigPath
+    delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.username).toBe("custom-user-from-env")
+        expect(config.model).toBe("custom/model")
+      },
+    })
+  } finally {
+    if (prevConfig !== undefined) {
+      process.env.OPENCODE_CONFIG = prevConfig
+    } else {
+      delete process.env.OPENCODE_CONFIG
+    }
+    if (prevManagedConfig !== undefined) {
+      process.env.OPENCODE_TEST_MANAGED_CONFIG = prevManagedConfig
+    } else {
+      delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+    }
+    await Config.invalidate()
+  }
+})
+
+test("loadGlobal respects OPENCODE_CONFIG_DIR env var", async () => {
+  await using tmp = await tmpdir()
+  const customConfigDir = path.join(tmp.path, "custom-config-dir")
+  await fs.mkdir(customConfigDir, { recursive: true })
+  await Filesystem.write(
+    path.join(customConfigDir, "opencode.json"),
+    JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      username: "custom-user-from-config-dir",
+      model: "custom/model-from-dir",
+    }),
+  )
+
+  const prevConfigDir = process.env.OPENCODE_CONFIG_DIR
+  const prevManagedConfig = process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+  try {
+    process.env.OPENCODE_CONFIG_DIR = customConfigDir
+    delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.username).toBe("custom-user-from-config-dir")
+        expect(config.model).toBe("custom/model-from-dir")
+      },
+    })
+  } finally {
+    if (prevConfigDir !== undefined) {
+      process.env.OPENCODE_CONFIG_DIR = prevConfigDir
+    } else {
+      delete process.env.OPENCODE_CONFIG_DIR
+    }
+    if (prevManagedConfig !== undefined) {
+      process.env.OPENCODE_TEST_MANAGED_CONFIG = prevManagedConfig
+    } else {
+      delete process.env.OPENCODE_TEST_MANAGED_CONFIG
+    }
+    await Config.invalidate()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #21083

### Type of change

- [x] Bug fix

### What does this PR do?

loadGlobal() was hardcoded to use Global.Path.config and ignored the
OPENCODE_CONFIG and OPENCODE_CONFIG_DIR environment variables. This PR:

1. Makes Flag.OPENCODE_CONFIG a dynamic getter (evaluated at access time,
   not module load time) to match OPENCODE_CONFIG_DIR behavior
2. Updates loadGlobal() to use Flag.OPENCODE_CONFIG_DIR as the config base
3. Adds explicit override via Flag.OPENCODE_CONFIG after loading base config

The root cause was that OPENCODE_CONFIG was a static assignment that locked
in the env var value at module load time. Tests setting the env var after
module initialization had no effect.

### How did you verify your code works?

Added two new tests in test/config/config.test.ts:
- loadGlobal respects OPENCODE_CONFIG env var
- loadGlobal respects OPENCODE_CONFIG_DIR env var

Both tests pass with the fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR