### PR TITLE
feat: desktop design preview

### DIFF
--- a/.opencode/plugin/design-preview.ts
+++ b/.opencode/plugin/design-preview.ts
@@ -1,0 +1,189 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import { tool } from "@opencode-ai/plugin"
+import path from "path"
+
+const STALE = 60_000
+const VISUAL_EXT = new Set([".tsx", ".jsx", ".ts", ".js", ".vue", ".svelte", ".html", ".css", ".scss", ".less"])
+const EDIT_TOOLS = new Set(["write", "edit", "multiedit", "patch"])
+
+const PRESETS: Record<string, { width: number; height: number }> = {
+  mobile: { width: 375, height: 812 },
+  tablet: { width: 768, height: 1024 },
+  desktop: { width: 1440, height: 900 },
+}
+
+async function read(dir: string) {
+  const file = Bun.file(path.join(dir, ".opencode", ".design-state.json"))
+  if (!(await file.exists())) return null
+  const data = await file.json().catch(() => null)
+  if (!data || !data.timestamp) return null
+  if (Date.now() - data.timestamp > STALE) return null
+  return data
+}
+
+async function command(dir: string, data: Record<string, unknown>) {
+  await Bun.write(
+    path.join(dir, ".opencode", ".design-command.json"),
+    JSON.stringify({ ...data, timestamp: Date.now() }),
+  )
+}
+
+export const server: Plugin = async (ctx) => {
+  const dir = ctx.directory
+
+  return {
+    tool: {
+      get_selected_element: tool({
+        description: `Get detailed information about the element currently selected by the user in the visual design editor. Returns tag name, classes, styles, source file location, and DOM path. Call this whenever the user refers to something they're looking at — words like 'this', 'that', 'the button', 'make it bigger' all mean the user is pointing at the selected element.`,
+        args: {},
+        async execute() {
+          const state = await read(dir)
+          if (!state?.selectedElement) return "No element is currently selected in the Design Preview. Ask the user to click on an element in the preview panel first."
+
+          const el = state.selectedElement
+          const lines: string[] = []
+
+          if (el.sourceFile) {
+            lines.push(`**Source:** ${el.sourceFile}${el.sourceLine ? `:${el.sourceLine}` : ""}`)
+          }
+
+          const tag = `<${el.tagName}${el.id ? `#${el.id}` : ""}${el.className ? `.${el.className.split(" ").join(".")}` : ""}>`
+          lines.push(`**Element:** ${tag}`)
+          lines.push(`**DOM Path:** ${el.domPath}`)
+
+          if (el.boundingRect) {
+            const r = el.boundingRect
+            lines.push(`**Size:** ${Math.round(r.width)}×${Math.round(r.height)}px at (${Math.round(r.x)}, ${Math.round(r.y)})`)
+          }
+
+          if (el.computedStyles && Object.keys(el.computedStyles).length > 0) {
+            const pairs = Object.entries(el.computedStyles)
+              .map(([k, v]) => `  ${k}: ${v}`)
+              .join("\n")
+            lines.push(`**Computed Styles:**\n${pairs}`)
+          }
+
+          return lines.join("\n")
+        },
+      }),
+
+      get_design_comments: tool({
+        description: `Get all design comments the user has pinned on elements in the visual preview. Each comment includes the target element info and the user's note. Use this to understand what changes the user wants across multiple elements.`,
+        args: {},
+        async execute() {
+          const state = await read(dir)
+          if (!state?.comments?.length) return "No design comments are currently pinned in the Design Preview."
+
+          return state.comments
+            .map((c: Record<string, any>, i: number) => {
+              const parts = [`${i + 1}. "${c.text}"`]
+              if (c.element?.tagName) parts.push(`   Element: <${c.element.tagName}${c.element.className ? `.${c.element.className}` : ""}>`)
+              if (c.element?.sourceFile) parts.push(`   Source: ${c.element.sourceFile}`)
+              if (c.element?.domPath) parts.push(`   Path: ${c.element.domPath}`)
+              return parts.join("\n")
+            })
+            .join("\n\n")
+        },
+      }),
+
+      update_element_styles: tool({
+        description: `Apply CSS style changes to the currently selected element in real-time for instant visual feedback. Use camelCase property names (e.g. backgroundColor, borderRadius). After calling this, also edit the source file to persist the change — this tool only changes the live preview temporarily.`,
+        args: {
+          styles: tool.schema.string().describe("JSON string of camelCase CSS properties, e.g. {\"backgroundColor\":\"#ff0000\",\"padding\":\"16px\"}"),
+        },
+        async execute(args) {
+          const parsed = JSON.parse(args.styles)
+          await command(dir, { type: "update-styles", styles: parsed })
+          return "Styles applied to the live preview. Remember to also edit the source file to persist these changes."
+        },
+      }),
+
+      select_element: tool({
+        description: `Select and highlight a specific element in the visual preview by CSS selector. Use this to show the user which element you're referring to before making changes.`,
+        args: {
+          selector: tool.schema.string().describe("CSS selector string, e.g. '.btn-primary', '#header', 'nav > ul > li:first-child'"),
+        },
+        async execute(args) {
+          await command(dir, { type: "select", selector: args.selector })
+          return `Selected element matching "${args.selector}" in the design preview.`
+        },
+      }),
+
+      set_viewport: tool({
+        description: `Change the viewport size of the design preview. Use 'mobile' (375×812), 'tablet' (768×1024), or 'desktop' (full width). Call this when discussing responsive design or when the user wants to check how something looks on a different screen size.`,
+        args: {
+          preset: tool.schema.string().optional().describe("Viewport preset: 'mobile', 'tablet', or 'desktop'"),
+          width: tool.schema.number().optional().describe("Custom viewport width in pixels"),
+          height: tool.schema.number().optional().describe("Custom viewport height in pixels"),
+        },
+        async execute(args) {
+          const p = args.preset ? PRESETS[args.preset] : undefined
+          const w = p?.width ?? args.width ?? 1440
+          const h = p?.height ?? args.height ?? 900
+          await command(dir, { type: "set-viewport", preset: args.preset, width: w, height: h })
+          return `Viewport set to ${w}×${h}${args.preset ? ` (${args.preset})` : ""}.`
+        },
+      }),
+    },
+
+    "experimental.chat.system.transform": async (_input, output) => {
+      const state = await read(dir)
+      if (!state) return
+
+      const lines: string[] = [
+        "",
+        "## Visual Design Editor",
+        "",
+        "The user has a live Design Preview panel open showing their running web app. You have access to design tools:",
+        "",
+        "- **get_selected_element** — Call this whenever the user says 'this', 'that', 'the button', 'make it bigger', or refers to anything visible. Returns element details, source file, and computed styles.",
+        "- **get_design_comments** — Read all comments the user pinned on the preview.",
+        "- **update_element_styles** — Apply CSS changes to the selected element instantly (preview only, not persisted).",
+        "- **select_element** — Highlight an element by CSS selector to show the user what you mean.",
+        "- **set_viewport** — Switch between mobile/tablet/desktop viewports.",
+        "",
+        "### Workflow",
+        "1. User selects element or describes a change",
+        "2. Call `get_selected_element` to see what they're pointing at",
+        "3. Read the source file indicated in the response",
+        "4. Edit the source file to make the change",
+        "5. Optionally call `update_element_styles` for instant visual feedback",
+        "",
+        "### Critical Rules",
+        "- When the user uses deictic references ('this', 'that', 'the header', etc.), ALWAYS call `get_selected_element` first.",
+        "- ALWAYS edit the actual source file to persist changes. The live preview is temporary.",
+      ]
+
+      if (state.selectedElement) {
+        const el = state.selectedElement
+        const tag = `<${el.tagName}${el.id ? `#${el.id}` : ""}${el.className ? `.${el.className.split(" ").join(".")}` : ""}>`
+        const src = el.sourceFile ? ` at \`${el.sourceFile}${el.sourceLine ? `:${el.sourceLine}` : ""}\`` : ""
+        lines.push("", `**Currently selected:** \`${tag}\`${src}`)
+      }
+
+      if (state.comments?.length) {
+        lines.push("", `**Design comments (${state.comments.length}):**`)
+        for (const c of state.comments) {
+          const on = c.element?.tagName ? ` on <${c.element.tagName}>` : ""
+          lines.push(`- "${c.text}"${on}`)
+        }
+      }
+
+      output.system.push(lines.join("\n"))
+    },
+
+    "tool.execute.after": async (input, _output) => {
+      if (!EDIT_TOOLS.has(input.tool)) return
+      const args = input.args
+      if (!args) return
+
+      const file = args.filePath ?? args.file_path ?? args.path ?? args.file
+      if (typeof file !== "string") return
+
+      const ext = path.extname(file)
+      if (!VISUAL_EXT.has(ext)) return
+
+      await command(dir, { type: "file-changed", filePath: file })
+    },
+  }
+}

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -56,6 +56,7 @@ const [serverPort, webPort] = await Promise.all([freePort(), freePort()])
 
 const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-e2e-"))
 const keepSandbox = process.env.OPENCODE_E2E_KEEP_SANDBOX === "1"
+const paid = process.env.OPENCODE_E2E_REQUIRE_PAID === "true" && !!process.env.OPENCODE_API_KEY
 
 const serverEnv = {
   ...process.env,
@@ -71,7 +72,9 @@ const serverEnv = {
   OPENCODE_E2E_PROJECT_DIR: repoDir,
   OPENCODE_E2E_SESSION_TITLE: "E2E Session",
   OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
-  OPENCODE_E2E_MODEL: process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano",
+<<<<<<< HEAD
+  OPENCODE_E2E_MODEL: paid ? (process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano") : "opencode/gpt-5-nano",
+  OPENCODE_E2E_REQUIRE_PAID: paid ? "true" : "false",
   OPENCODE_CLIENT: "app",
   OPENCODE_STRICT_CONFIG_DEPS: "true",
 } satisfies Record<string, string>

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -72,7 +72,6 @@ const serverEnv = {
   OPENCODE_E2E_PROJECT_DIR: repoDir,
   OPENCODE_E2E_SESSION_TITLE: "E2E Session",
   OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
-<<<<<<< HEAD
   OPENCODE_E2E_MODEL: paid ? (process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano") : "opencode/gpt-5-nano",
   OPENCODE_E2E_REQUIRE_PAID: paid ? "true" : "false",
   OPENCODE_CLIENT: "app",

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -111,7 +111,9 @@ function SessionProviders(props: ParentProps) {
     <TerminalProvider>
       <FileProvider>
         <PromptProvider>
-          <CommentsProvider>{props.children}</CommentsProvider>
+          <CommentsProvider>
+            {props.children}
+          </CommentsProvider>
         </PromptProvider>
       </FileProvider>
     </TerminalProvider>

--- a/packages/app/src/components/design-preview.test.ts
+++ b/packages/app/src/components/design-preview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { pickClasses } from "./design-preview/pick-classes"
+import { createResolver } from "./design-preview/resolve"
 
 describe("pickClasses", () => {
   test("prefers specific classes over utility tokens", () => {
@@ -14,5 +15,217 @@ describe("pickClasses", () => {
       "project-shell",
       "nav-item",
     ])
+  })
+})
+
+describe("createResolver", () => {
+  test("findTag locates the JSX usage inside the parent file", async () => {
+    const map = {
+      "src/sections/Certifications.jsx": `export function Certifications() {
+  return (
+    <GridSection>
+      <ScrollReveal className=\"fade\">Hello</ScrollReveal>
+    </GridSection>
+  )
+}`,
+    }
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: (input) => {
+          const content = map[input as keyof typeof map]
+          if (!content) return undefined
+          return { content: { type: "text", content } }
+        },
+      },
+      {
+        find: {
+          text: async () => ({ data: [] }),
+        },
+      },
+    )
+
+    await expect(lookup.findTag("src/sections/Certifications.jsx", "ScrollReveal")).resolves.toEqual({
+      file: "src/sections/Certifications.jsx",
+      line: 4,
+      comp: "ScrollReveal",
+    })
+  })
+
+  test("findTag prefers the matching instance when the parent renders the component multiple times", async () => {
+    const map = {
+      "src/sections/Certifications.jsx": `export function Certifications() {
+  return (
+    <GridSection>
+      <ScrollReveal className="fade">First</ScrollReveal>
+      <ScrollReveal className="focus">Second</ScrollReveal>
+    </GridSection>
+  )
+}`,
+    }
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: (input) => {
+          const content = map[input as keyof typeof map]
+          if (!content) return undefined
+          return { content: { type: "text", content } }
+        },
+      },
+      {
+        find: {
+          text: async () => ({ data: [] }),
+        },
+      },
+    )
+
+    await expect(
+      lookup.findTag("src/sections/Certifications.jsx", "ScrollReveal", {
+        text: "Second",
+        classes: "focus",
+      }),
+    ).resolves.toEqual({
+      file: "src/sections/Certifications.jsx",
+      line: 5,
+      comp: "ScrollReveal",
+    })
+  })
+
+  test("findTagInFiles keeps walking outward through wrapper components", async () => {
+    const map = {
+      "src/components/GridSection.jsx": `export default function GridSection({ children }) {
+  return <section>{children}</section>
+}`,
+      "src/sections/Hero.jsx": `export default function Hero() {
+  return (
+    <GridSection>
+      <Button className="hero-cta">Discuss Project</Button>
+    </GridSection>
+  )
+}`,
+    }
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: (input) => {
+          const content = map[input as keyof typeof map]
+          if (!content) return undefined
+          return { content: { type: "text", content } }
+        },
+      },
+      {
+        find: {
+          text: async () => ({ data: [] }),
+        },
+      },
+    )
+
+    await expect(
+      lookup.findTagInFiles(["src/components/GridSection.jsx", "src/sections/Hero.jsx"], "Button", {
+        text: "Discuss Project",
+        classes: "hero-cta",
+      }),
+    ).resolves.toEqual({
+      file: "src/sections/Hero.jsx",
+      line: 4,
+      comp: "Button",
+    })
+  })
+
+  test("findTagInFiles prefers the best ancestor match over an unrelated nearer file hit", async () => {
+    const map = {
+      "src/components/GridSection.jsx": `export default function GridSection({ children }) {
+  return (
+    <section>
+      <Button>Wrapper Action</Button>
+      {children}
+    </section>
+  )
+}`,
+      "src/sections/Hero.jsx": `export default function Hero() {
+  return (
+    <GridSection>
+      <Button className="hero-cta">Discuss Project</Button>
+    </GridSection>
+  )
+}`,
+    }
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: (input) => {
+          const content = map[input as keyof typeof map]
+          if (!content) return undefined
+          return { content: { type: "text", content } }
+        },
+      },
+      {
+        find: {
+          text: async () => ({ data: [] }),
+        },
+      },
+    )
+
+    await expect(
+      lookup.findTagInFiles(["src/components/GridSection.jsx", "src/sections/Hero.jsx"], "Button", {
+        text: "Discuss Project",
+        classes: "hero-cta",
+      }),
+    ).resolves.toEqual({
+      file: "src/sections/Hero.jsx",
+      line: 4,
+      comp: "Button",
+    })
+  })
+
+  test("findTagInFiles keeps scanning when a later ancestor has a stronger match", async () => {
+    const map = {
+      "src/components/GridSection.jsx": `export default function GridSection({ children }) {
+  return (
+    <section>
+      <Button className="hero-cta">Wrapper Action</Button>
+      {children}
+    </section>
+  )
+}`,
+      "src/sections/Hero.jsx": `export default function Hero() {
+  return (
+    <GridSection>
+      <Button className="hero-cta">Discuss Project</Button>
+    </GridSection>
+  )
+}`,
+    }
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: (input) => {
+          const content = map[input as keyof typeof map]
+          if (!content) return undefined
+          return { content: { type: "text", content } }
+        },
+      },
+      {
+        find: {
+          text: async () => ({ data: [] }),
+        },
+      },
+    )
+
+    await expect(
+      lookup.findTagInFiles(["src/components/GridSection.jsx", "src/sections/Hero.jsx"], "Button", {
+        text: "Discuss Project",
+        classes: "hero-cta",
+      }),
+    ).resolves.toEqual({
+      file: "src/sections/Hero.jsx",
+      line: 4,
+      comp: "Button",
+    })
   })
 })

--- a/packages/app/src/components/design-preview.test.ts
+++ b/packages/app/src/components/design-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { pickClasses } from "./design-preview/pick-classes"
 import { createResolver } from "./design-preview/resolve"
+import { choose, mode, need, rank } from "./design-preview/source"
 
 describe("pickClasses", () => {
   test("prefers specific classes over utility tokens", () => {
@@ -46,10 +47,11 @@ describe("createResolver", () => {
       },
     )
 
-    await expect(lookup.findTag("src/sections/Certifications.jsx", "ScrollReveal")).resolves.toEqual({
+    await expect(lookup.findTag("src/sections/Certifications.jsx", "ScrollReveal")).resolves.toMatchObject({
       file: "src/sections/Certifications.jsx",
       line: 4,
       comp: "ScrollReveal",
+      origin: "tag",
     })
   })
 
@@ -86,10 +88,11 @@ describe("createResolver", () => {
         text: "Second",
         classes: "focus",
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       file: "src/sections/Certifications.jsx",
       line: 5,
       comp: "ScrollReveal",
+      origin: "tag",
     })
   })
 
@@ -128,10 +131,11 @@ describe("createResolver", () => {
         text: "Discuss Project",
         classes: "hero-cta",
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       file: "src/sections/Hero.jsx",
       line: 4,
       comp: "Button",
+      origin: "tag",
     })
   })
 
@@ -175,10 +179,11 @@ describe("createResolver", () => {
         text: "Discuss Project",
         classes: "hero-cta",
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       file: "src/sections/Hero.jsx",
       line: 4,
       comp: "Button",
+      origin: "tag",
     })
   })
 
@@ -222,10 +227,112 @@ describe("createResolver", () => {
         text: "Discuss Project",
         classes: "hero-cta",
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       file: "src/sections/Hero.jsx",
       line: 4,
       comp: "Button",
+      origin: "tag",
+    })
+  })
+})
+
+describe("design preview source", () => {
+  test("keeps component definition as source fallback", () => {
+    const src = choose({
+      source: undefined,
+      definition: { file: "src/sections/Header.jsx", line: 22, component: "Header" },
+    })
+    expect(src).toEqual({ file: "src/sections/Header.jsx", line: 22, component: "Header" })
+  })
+
+  test("prefers definition when source has no file", () => {
+    const src = choose({
+      source: { component: "Header" },
+      definition: { file: "src/sections/Header.jsx", line: 22, component: "Header" },
+    })
+    expect(src).toEqual({ file: "src/sections/Header.jsx", line: 22, component: "Header" })
+  })
+
+  test("skips usage fallback when definition already exists in full enrich", () => {
+    expect(
+      need(
+        {
+          source: undefined,
+          definition: { file: "src/sections/Header.jsx", line: 22 },
+        },
+        true,
+      ),
+    ).toBe(false)
+  })
+
+  test("allows usage fallback when only opening usage", () => {
+    expect(
+      need(
+        {
+          source: undefined,
+          definition: { file: "src/sections/Header.jsx", line: 22 },
+        },
+        false,
+      ),
+    ).toBe(true)
+  })
+
+  test("still requires fallback when source has no file", () => {
+    expect(
+      need(
+        {
+          source: { component: "Header" },
+          definition: { file: "src/sections/Header.jsx", line: 22 },
+        },
+        false,
+      ),
+    ).toBe(true)
+  })
+
+  test("returns direct mode for high score", () => {
+    expect(mode({ file: "src/a.tsx", line: 1, score: 0.9 })).toBe("direct")
+  })
+
+  test("returns confirm mode for medium score", () => {
+    expect(mode({ file: "src/a.tsx", line: 1, score: 0.7 })).toBe("confirm")
+  })
+
+  test("returns deny mode for low score", () => {
+    expect(mode({ file: "src/a.tsx", line: 1, score: 0.3 })).toBe("deny")
+  })
+
+  test("rank falls back to confidence label", () => {
+    expect(rank({ confidence: "medium" })).toBe(0.7)
+  })
+})
+
+describe("resolver confidence", () => {
+  test("findDefinition marks ambiguous matches", async () => {
+    const lookup = createResolver(
+      {
+        normalize: (input) => input,
+        load: async () => {},
+        get: () => undefined,
+      },
+      {
+        find: {
+          text: async ({ pattern }) => {
+            if (!pattern.includes("Card")) return { data: [] }
+            return {
+              data: [
+                { path: { text: "src/ui/Card.tsx" }, line_number: 10 },
+                { path: { text: "src/marketing/Card.tsx" }, line_number: 8 },
+              ],
+            }
+          },
+        },
+      },
+    )
+
+    await expect(lookup.findDefinition("Card")).resolves.toMatchObject({
+      file: "src/ui/Card.tsx",
+      origin: "definition",
+      ambiguous: true,
     })
   })
 })

--- a/packages/app/src/components/design-preview.test.ts
+++ b/packages/app/src/components/design-preview.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { pickClasses } from "./design-preview/pick-classes"
+
+describe("pickClasses", () => {
+  test("prefers specific classes over utility tokens", () => {
+    expect(pickClasses("flex items-center rounded-md hero-card settings-panel")).toEqual([
+      "settings-panel",
+      "hero-card",
+    ])
+  })
+
+  test("strips variants before filtering utilities", () => {
+    expect(pickClasses("md:flex dark:bg-black lg:rounded-xl md:project-shell xl:nav-item")).toEqual([
+      "project-shell",
+      "nav-item",
+    ])
+  })
+})

--- a/packages/app/src/components/design-preview.tsx
+++ b/packages/app/src/components/design-preview.tsx
@@ -15,6 +15,15 @@ import { createResolver, type Hit } from "@/components/design-preview/resolve"
 
 const INJECT = createInjectionScript()
 
+type Source = {
+  file?: string
+  line?: number
+  column?: number
+  component?: string
+  owner?: string
+  _debug?: string[]
+}
+
 export type DesignElementInfo = {
   tag: string
   id?: string
@@ -25,11 +34,17 @@ export type DesignElementInfo = {
   path: string
   rect: { x: number; y: number; width: number; height: number }
   computedStyles?: Record<string, string>
-  source?: { file?: string; line?: number; column?: number; component?: string; _debug?: string[] }
+  source?: Source
+  definition?: Source
   searchHint?: string[]
   summary?: string
   framework?: string
 }
+
+type Query = Pick<
+  DesignElementInfo,
+  "component" | "classes" | "source" | "definition" | "ancestry" | "textContent" | "searchHint"
+>
 
 type Viewport = "desktop" | "tablet" | "mobile"
 
@@ -51,9 +66,11 @@ const cfg = {
   health: 5000,
   poll: 2000,
   minConfidence: 0.3,
+  minUsageConfidence: 0.6,
 }
 
 export type DesignPreviewProps = {
+  active?: boolean
   onOpenFile?: (path: string, line: number) => void
   onElementSelect?: (info: DesignElementInfo | undefined) => void
   onComment?: (input: { file: string; line: number; comment: string; component?: string }) => void
@@ -85,6 +102,7 @@ export function DesignPreview(props: DesignPreviewProps) {
   let observer: ResizeObserver | undefined
   let lastCmd = 0
   let webviewOpen = false
+  let opening = false
   let raf = 0
   let rev = 0
   let last: { x: number; y: number; width: number; height: number } | undefined
@@ -117,13 +135,19 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const active = createMemo(() => !!store.size || store.viewport !== "desktop")
   const preset = createMemo(() => store.size ?? VIEWPORTS[store.viewport])
+  const shown = createMemo(() => props.active ?? true)
   const supported = createMemo(() => !!platform.createDesignWebview)
   const bump = () => ++rev
+  const parked = { x: -10_000, y: -10_000, width: 1, height: 1 }
   const script = (name: string, arg?: string) => {
     return arg === undefined ? `window.${name} && window.${name}()` : `window.${name} && window.${name}(${arg})`
   }
   const run = (input: string) => platform.evalDesignWebview?.(input)
   const lookup = createResolver(files, sdk.client)
+  const select = (info: DesignElementInfo | undefined) => {
+    setStore("selected", info)
+    props.onElementSelect?.(info)
+  }
 
   const syncInspect = () => {
     if (!webviewOpen) return
@@ -158,14 +182,18 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const openWebview = async (target: string) => {
     if (!platform.createDesignWebview) return
+    if (webviewOpen || opening) return
     const r = getRect()
     if (r.width <= 0 || r.height <= 0) return
-    await platform.createDesignWebview(target, r.x, r.y, r.width, r.height, INJECT)
+    opening = true
+    await platform.createDesignWebview(target, r.x, r.y, r.width, r.height, INJECT).finally(() => {
+      opening = false
+    })
     webviewOpen = true
     last = r
     listed = ""
     setStore("status", "connected")
-    startFollow()
+    if (shown()) startFollow()
     syncSize()
     setTimeout(() => {
       sendWhitelist()
@@ -183,9 +211,17 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const syncSizeNow = () => {
     raf = 0
-    if (!webviewOpen || !platform.resizeDesignWebview) return
-    const r = getRect()
-    if (r.width <= 0 || r.height <= 0) return
+    if (!webviewOpen) {
+      const target = url()
+      if (!shown() || !target) return
+      const r = getRect()
+      if (r.width <= 0 || r.height <= 0) return
+      void openWebview(target)
+      return
+    }
+    if (!platform.resizeDesignWebview) return
+    const r = shown() ? getRect() : parked
+    if (shown() && (r.width <= 0 || r.height <= 0)) return
     if (same(r)) return
     last = r
     platform.resizeDesignWebview(r.x, r.y, r.width, r.height)
@@ -204,13 +240,13 @@ export function DesignPreview(props: DesignPreviewProps) {
     if (poke) clearTimeout(poke)
     if (reopen) clearTimeout(reopen)
     if (target !== url()) {
-      setStore("selected", undefined)
+      select(undefined)
       setStore("notes", [])
     }
     setUrl(target)
     layout.design.setUrl(target)
     await closeWebview()
-    await openWebview(target)
+    if (shown()) await openWebview(target)
   }
 
   const refresh = async () => {
@@ -222,7 +258,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     if (poke) clearTimeout(poke)
     if (reopen) clearTimeout(reopen)
     await closeWebview()
-    await openWebview(target)
+    if (shown()) await openWebview(target)
   }
 
   const disconnect = async () => {
@@ -237,7 +273,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     layout.design.setUrl("")
     setStore("status", "disconnected")
     setStore("framework", undefined)
-    setStore("selected", undefined)
+    select(undefined)
     setStore("notes", [])
   }
 
@@ -354,6 +390,8 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const idxCache = new Map<string, Hit | null>()
   const idxRun = new Map<string, Promise<Hit | null>>()
+  const usageCache = new Map<string, Hit | null>()
+  const usageRun = new Map<string, Promise<Hit | null>>()
   let cache = 0
 
   const queryIndex = async (comp: string | null | undefined, classes: string | undefined): Promise<Hit | null> => {
@@ -393,52 +431,251 @@ export function DesignPreview(props: DesignPreviewProps) {
     return run
   }
 
-  const setResolved = (info: DesignElementInfo, hit: Hit) => {
-    const next = {
-      ...info,
-      component: hit.comp ?? info.component ?? info.source?.component,
-      source: {
-        ...info.source,
-        file: hit.file,
-        line: hit.line,
-        component: hit.comp ?? info.component ?? info.source?.component,
-      },
-    } satisfies DesignElementInfo
-    if (store.selected?.path === info.path) setStore("selected", next)
-    return next
+  const queryUsageIndex = async (info: Query): Promise<Hit | null> => {
+    if (!platform.queryDesignUsageIndex) return null
+    const root = sdk.directory
+    if (!root) return null
+    const comp = info.component ?? info.source?.component ?? info.definition?.component
+    if (!comp) return null
+    const chain = info.ancestry ?? []
+    const idx = chain.indexOf(comp)
+    const owners = (idx === -1 ? chain : chain.slice(idx + 1)).filter(
+      (name, pos, all) => !!name && all.indexOf(name) === pos,
+    )
+    const key = `${root}\n${comp}\n${owners.join("\n")}`
+    if (usageCache.has(key)) return usageCache.get(key) ?? null
+    const pending = usageRun.get(key)
+    if (pending) return pending
+    const ver = cache
+    const run = platform
+      .queryDesignUsageIndex(root, comp, owners.length ? owners : null)
+      .then(
+        (result) => {
+          if (ver !== cache) return null
+          if (result && result.confidence >= cfg.minUsageConfidence) {
+            const hit = {
+              file: result.file,
+              line: result.line,
+              comp,
+              owner: result.owner ?? owners[0],
+            }
+            usageCache.set(key, hit)
+            console.log(
+              "[Design] Rust usage hit:",
+              result.file,
+              "line:",
+              result.line,
+              "owner:",
+              result.owner,
+              "confidence:",
+              result.confidence,
+            )
+            return hit
+          }
+          usageCache.set(key, null)
+          return null
+        },
+        () => {
+          if (ver !== cache) return null
+          usageCache.set(key, null)
+          return null
+        },
+      )
+      .finally(() => {
+        usageRun.delete(key)
+      })
+    usageRun.set(key, run)
+    return run
+  }
+
+  const sameSource = (a?: Source, b?: Source) => {
+    const af = a?.file ? lookup.normalizePath(a.file) : undefined
+    const bf = b?.file ? lookup.normalizePath(b.file) : undefined
+    if (!af || !bf) return false
+    return af === bf && (a?.line ?? 1) === (b?.line ?? 1)
+  }
+
+  const withSource = (src: Source | undefined, comp: string | undefined): Source | undefined => {
+    if (!src) return undefined
+    return {
+      ...src,
+      file: src.file ? lookup.normalizePath(src.file) : undefined,
+      component: comp ?? src.component,
+    }
+  }
+
+  const setLocation = (info: DesignElementInfo, slot: "source" | "definition", hit: Hit): DesignElementInfo => {
+    const comp = hit.comp ?? info.component ?? info.source?.component ?? info.definition?.component
+    const src = {
+      ...(slot === "source" ? info.source : info.definition),
+      file: hit.file,
+      line: hit.line,
+      component: comp,
+      owner: hit.owner,
+    }
+    return slot === "source" ? { ...info, component: comp, source: src } : { ...info, component: comp, definition: src }
+  }
+
+  const prime = (info: DesignElementInfo): DesignElementInfo => {
+    const comp = info.component ?? info.source?.component ?? info.definition?.component
+    const source = withSource(info.source, comp)
+    const definition = withSource(info.definition, comp)
+    if (!source?.file) return { ...info, component: comp, source, definition }
+    if (!lookup.isSourceFile(source.file)) {
+      return { ...info, component: comp, source: undefined, definition }
+    }
+    if (comp && lookup.fileDefinesComponent(source.file, comp)) {
+      return {
+        ...info,
+        component: comp,
+        source: undefined,
+        definition: definition ?? source,
+      }
+    }
+    return { ...info, component: comp, source, definition }
   }
 
   const openHit = (hit: Hit) => {
     props.onOpenFile?.(hit.file, hit.line)
+    select(undefined)
     return true
   }
 
-  const openResolved = (info: DesignElementInfo, hit: Hit) => {
-    setResolved(info, hit)
-    return openHit(hit)
+  const sourceLabel = (src: Source | undefined) => {
+    if (!src?.file) return ""
+    return `${src.file.split(/[\\/]/).pop()}:${src.line ?? 1}`
   }
 
-  const locate = async (info: DesignElementInfo): Promise<Hit | null> => {
-    const comp = info.component ?? info.source?.component
-    const idx = await queryIndex(comp, info.classes)
-    if (idx) return idx
+  const usageText = (src: Source | undefined, comp: string | undefined) => {
+    if (!src?.owner || src.owner === comp) return "Go to usage"
+    return `Go to usage in ${src.owner}`
+  }
+
+  const locateUsage = async (info: Query): Promise<Hit | null> => {
+    const comp = info.component ?? info.source?.component ?? info.definition?.component
+    if (!comp) return null
     const chain = info.ancestry ?? []
-    for (const name of chain) {
-      const next = await queryIndex(name, undefined)
-      if (next) return next
+    const idx = chain.indexOf(comp)
+    const owner = idx === -1 ? chain[1] : chain[idx + 1]
+    const file = info.source?.file ? lookup.normalizePath(info.source.file) : undefined
+    if (file && lookup.isSourceFile(file) && !lookup.fileDefinesComponent(file, comp)) {
+      return { file, line: info.source?.line ?? 1, comp, owner }
+    }
+    const rust = await queryUsageIndex(info)
+    if (rust) {
+      const exact = await lookup.findTag(rust.file, comp, {
+        text: info.textContent,
+        search: info.searchHint,
+        classes: info.classes,
+      })
+      if (exact) return { ...exact, owner: rust.owner }
+      return rust
+    }
+    const names = (idx === -1 ? chain : chain.slice(idx + 1)).filter(
+      (name, pos, all) => !!name && all.indexOf(name) === pos,
+    )
+    for (const name of names) {
+      const hits = await Promise.all([lookup.findDefinition(name), queryIndex(name, undefined)])
+      const files = hits.flatMap((hit) => {
+        if (!hit?.file) return []
+        const file = lookup.normalizePath(hit.file)
+        if (!lookup.isSourceFile(file)) return []
+        return [file]
+      })
+      if (!files.length) continue
+      const hit = await lookup.findTagInFiles(files, comp, {
+        text: info.textContent,
+        search: info.searchHint,
+        classes: info.classes,
+      })
+      if (hit) return { ...hit, owner: name }
+    }
+    return lookup.findUsage(comp)
+  }
+
+  const locateDefinition = async (info: Query): Promise<Hit | null> => {
+    const comp = info.component ?? info.source?.component ?? info.definition?.component
+    if (comp) {
+      const idx = await queryIndex(comp, info.classes)
+      if (idx) return idx
+      return lookup.findDefinition(comp)
+    }
+    for (const name of info.ancestry ?? []) {
+      const idx = await queryIndex(name, undefined)
+      if (idx) return idx
       const def = await lookup.findDefinition(name)
       if (def) return def
     }
-    return lookup.grepFallback(info)
+    return null
   }
 
-  const openComp = async (name: string) => {
-    const idx = await queryIndex(name, undefined)
-    if (idx) return openHit(idx)
-    const def = await lookup.findDefinition(name)
-    if (def) return openHit(def)
-    const use = await lookup.findUsage(name)
+  const enrich = async (info: DesignElementInfo, all = true) => {
+    let next = prime(info)
+    if (!next.source) {
+      const hit = await locateUsage(next)
+      if (hit) next = setLocation(next, "source", hit)
+    }
+    if (!next.source) {
+      const hit = await lookup.grepFallback(next)
+      if (hit) next = setLocation(next, "source", hit)
+    }
+    if (all && !next.definition) {
+      const hit = await locateDefinition(next)
+      if (hit && !sameSource(next.source, { file: hit.file, line: hit.line })) {
+        next = setLocation(next, "definition", hit)
+      }
+    }
+    if (!next.source && next.definition?.file) {
+      next = { ...next, source: { ...next.definition } }
+    }
+    if (next.definition && sameSource(next.source, next.definition)) {
+      next = { ...next, definition: undefined }
+    }
+    return next
+  }
+
+  const openUsage = async (info: DesignElementInfo) => {
+    const next = await enrich(info, false)
+    const comp = next.component ?? next.source?.component ?? next.definition?.component
+    const file = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
+    if (file && lookup.isSourceFile(file)) {
+      return openHit({ file, line: next.source?.line ?? 1, comp })
+    }
+    const def = next.definition?.file ? lookup.normalizePath(next.definition.file) : undefined
+    if (def && lookup.isSourceFile(def)) {
+      return openHit({ file: def, line: next.definition?.line ?? 1, comp })
+    }
+    return false
+  }
+
+  const openSelection = async (info: DesignElementInfo) => {
+    const next = await enrich(info)
+    const comp = next.component ?? next.source?.component ?? next.definition?.component
+    const def = next.definition?.file ? lookup.normalizePath(next.definition.file) : undefined
+    if (def && lookup.isSourceFile(def)) {
+      return openHit({ file: def, line: next.definition?.line ?? 1, comp })
+    }
+    const file = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
+    if (file && lookup.isSourceFile(file) && (!comp || lookup.fileDefinesComponent(file, comp))) {
+      return openHit({ file, line: next.source?.line ?? 1, comp })
+    }
+    if (file && lookup.isSourceFile(file)) {
+      return openHit({ file, line: next.source?.line ?? 1, comp })
+    }
+    return false
+  }
+
+  const openNode = async (name: string) => {
+    const chain = store.selected?.ancestry ?? []
+    const idx = chain.indexOf(name)
+    const info: Query =
+      name === store.selected?.component
+        ? store.selected
+        : { component: name, ancestry: idx === -1 ? [name] : chain.slice(idx) }
+    const use = await locateUsage(info)
     if (use) return openHit(use)
+    const def = await locateDefinition(info)
+    if (def) return openHit(def)
     return false
   }
 
@@ -446,6 +683,8 @@ export function DesignPreview(props: DesignPreviewProps) {
     cache++
     idxCache.clear()
     idxRun.clear()
+    usageCache.clear()
+    usageRun.clear()
     lookup.reset()
   }
 
@@ -503,62 +742,22 @@ export function DesignPreview(props: DesignPreviewProps) {
   }
 
   const handleDesignEvent = (e: { payload: string | DesignElementInfo }) => {
-    const info = parsePayload(e)
-    if (!info) return
+    const raw = parsePayload(e)
+    if (!raw) return
     const token = ++picked
 
-    const src = info.source
-    if (src?._debug) {
-      console.log("[Design] fiber debug:", src._debug.join(" → "))
+    if (raw.source?._debug) {
+      console.log("[Design] fiber debug:", raw.source._debug.join(" → "))
     }
 
-    setStore("selected", info)
-    props.onElementSelect?.(info)
+    const info = prime(raw)
+    select(info)
 
-    const comp = info.component ?? src?.component
-    const file = src?.file ? lookup.normalizePath(src.file) : undefined
-    const direct = (hit: Hit) => {
-      if (token !== picked) return false
-      return openResolved(info, hit)
-    }
-
-    // Library/node_modules source — strip it and find user code instead
-    if (file && !lookup.isSourceFile(file)) {
-      console.log("[Design] Source is library/bundled:", file, "for", comp, "— using index/grep to find user code")
-      info.source = undefined
-      setStore("selected", { ...info })
-      locate(info).then((hit) => {
-        if (hit) direct(hit)
-      })
-      return
-    }
-
-    // User source file, but it's the call site (e.g. home-client.tsx for <Header />), not the definition
-    if (comp && file && lookup.isSourceFile(file) && !lookup.fileDefinesComponent(file, comp)) {
-      console.log("[Design] Source", file, "is call site for", comp, "— checking index then searching")
-      locate(info).then((hit) => {
-        if (hit) {
-          direct(hit)
-          return
-        }
-        console.log("[Design] Definition not found, falling back to call site:", file)
-        direct({ file, line: src?.line ?? 1, comp })
-      })
-      return
-    }
-
-    if (file && lookup.isSourceFile(file)) {
-      console.log("[Design] Opening file:", file, "line:", src?.line, "component:", comp)
-      direct({ file, line: src?.line ?? 1, comp })
-      return
-    }
-
-    locate(info).then((hit) => {
-      if (hit) {
-        direct(hit)
-        return
-      }
-      console.log("[Design] No valid source for:", info.tag, comp ?? info.classes)
+    enrich(info).then((next) => {
+      if (token !== picked) return
+      select(next)
+      if (next.source?.file || next.definition?.file) return
+      console.log("[Design] No valid source for:", info.tag, info.component ?? info.classes)
     })
   }
 
@@ -749,15 +948,10 @@ export function DesignPreview(props: DesignPreviewProps) {
                   ...raw,
                   component: store.selected.component ?? raw.component,
                   source: store.selected.source ?? raw.source,
+                  definition: store.selected.definition ?? raw.definition,
                 }
               : raw
-          const file = info.source?.file ? lookup.normalizePath(info.source.file) : undefined
-          const comp = info.component ?? info.source?.component
-          const hit =
-            !file || !lookup.isSourceFile(file) || (comp ? !lookup.fileDefinesComponent(file, comp) : false)
-              ? await locate(info)
-              : null
-          const next = hit ? setResolved(info, hit) : info
+          const next = await enrich(info, false)
           setStore("notes", (prev) => [...prev, note(next, text)])
 
           const path = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
@@ -772,20 +966,32 @@ export function DesignPreview(props: DesignPreviewProps) {
           console.log("[Design] comment-submit error:", err)
         }
       })
+      const u6 = await listen("design:open-selected", async (e: { payload: string | DesignElementInfo }) => {
+        const raw = parsePayload(e)
+        if (!raw) return
+        const info =
+          store.selected?.path === raw.path
+            ? {
+                ...raw,
+                component: store.selected.component ?? raw.component,
+                source: store.selected.source ?? raw.source,
+                definition: store.selected.definition ?? raw.definition,
+              }
+            : raw
+        void openSelection(info)
+      })
       unlisten = () => {
         u1()
         u2()
         u3()
         u4()
         u5()
+        u6()
       }
     }
 
     if (!url()) detect()
-    else {
-      check()
-      if (url()) openWebview(url())
-    }
+    else check()
     buildIndex()
   })
 
@@ -820,7 +1026,7 @@ export function DesignPreview(props: DesignPreviewProps) {
         changed.clear()
         rustNames = []
         resetCache()
-        setStore("selected", undefined)
+        select(undefined)
         setStore("notes", [])
         sendWhitelist()
         if (sdk.directory) {
@@ -830,6 +1036,26 @@ export function DesignPreview(props: DesignPreviewProps) {
         detect()
       },
       { defer: true },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => [shown(), url()] as const,
+      ([next, target]) => {
+        if (!target) return
+        if (!next) {
+          stopFollow()
+          syncSize()
+          return
+        }
+        if (!webviewOpen) {
+          void openWebview(target)
+          return
+        }
+        startFollow()
+        syncSize()
+      },
     ),
   )
 
@@ -1053,7 +1279,7 @@ export function DesignPreview(props: DesignPreviewProps) {
                           "text-purple-400 font-medium": name === el().component,
                           "text-text-weak hover:underline": name !== el().component,
                         }}
-                        onClick={() => void openComp(name)}
+                        onClick={() => void openNode(name)}
                         title={`Navigate to ${name}`}
                       >
                         {name}
@@ -1084,32 +1310,37 @@ export function DesignPreview(props: DesignPreviewProps) {
                 })()}
                 {">"}
               </span>
-              <Show when={el().source?.file}>
-                {(file) => {
-                  const src = el().source!
-                  const comp = el().component ?? src.component
-                  const norm = lookup.normalizePath(file())
-                  const isDef = !comp || lookup.fileDefinesComponent(norm, comp)
-                  return (
-                    <button
-                      class="text-text-weak hover:text-text-strong underline shrink-0"
-                      title={isDef ? norm : `Call site: ${norm} — click to find ${comp} definition`}
-                      onClick={() => {
-                        if (comp && !isDef) {
-                          openComp(comp).then((found) => {
-                            if (!found) props.onOpenFile?.(norm, src.line ?? 1)
-                          })
-                        } else {
-                          props.onOpenFile?.(norm, src.line ?? 1)
-                        }
-                      }}
-                    >
-                      {isDef ? file().split("/").pop() : comp}
-                      {isDef ? `:${src.line ?? 1}` : ""}
-                    </button>
-                  )
-                }}
-              </Show>
+              {(() => {
+                const src = el().source
+                const def = el().definition
+                const comp = el().component ?? src?.component ?? def?.component
+                const file = src?.file ? lookup.normalizePath(src.file) : undefined
+                const use = !!file && !!comp && !lookup.fileDefinesComponent(file, comp)
+                const main = def?.file ? def : src
+                const text = def?.file || (!use && src?.file) ? "Go to definition" : usageText(src, comp)
+                return (
+                  <>
+                    <Show when={main?.file}>
+                      <button
+                        class="text-text-weak hover:text-text-strong underline shrink-0"
+                        title={main?.file}
+                        onClick={() => void openSelection(el())}
+                      >
+                        {`${text} (${sourceLabel(main)})`}
+                      </button>
+                    </Show>
+                    <Show when={use && src?.file}>
+                      <button
+                        class="text-text-weak hover:text-text-strong underline shrink-0"
+                        title={src?.file}
+                        onClick={() => void openUsage(el())}
+                      >
+                        {`${usageText(src, comp)} (${sourceLabel(src)})`}
+                      </button>
+                    </Show>
+                  </>
+                )
+              })()}
               <Show when={el().textContent}>
                 <span class="text-text-weaker text-11-regular truncate max-w-32" title={el().textContent}>
                   "{el().textContent}"
@@ -1127,8 +1358,7 @@ export function DesignPreview(props: DesignPreviewProps) {
                   class="size-5"
                   aria-label="Clear selection"
                   onClick={() => {
-                    setStore("selected", undefined)
-                    props.onElementSelect?.(undefined)
+                    select(undefined)
                   }}
                 />
               </div>

--- a/packages/app/src/components/design-preview.tsx
+++ b/packages/app/src/components/design-preview.tsx
@@ -1,0 +1,1490 @@
+import { createEffect, createMemo, createSignal, For, on, onCleanup, onMount, Show } from "solid-js"
+import { createStore } from "solid-js/store"
+import { Button } from "@opencode-ai/ui/button"
+import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { useFile } from "@/context/file"
+import { useLayout } from "@/context/layout"
+import { useSDK } from "@/context/sdk"
+import { usePlatform } from "@/context/platform"
+import { detectDevUrl } from "@/utils/detect-port"
+import { createInjectionScript } from "@/components/design-preview/injection"
+
+const INJECT = createInjectionScript()
+
+export type DesignElementInfo = {
+  tag: string
+  id?: string
+  classes?: string
+  component?: string
+  textContent?: string
+  ancestry?: string[]
+  path: string
+  rect: { x: number; y: number; width: number; height: number }
+  computedStyles?: Record<string, string>
+  source?: { file?: string; line?: number; column?: number; component?: string; _debug?: string[] }
+  searchHint?: string[]
+  summary?: string
+  framework?: string
+}
+
+type Viewport = "desktop" | "tablet" | "mobile"
+
+const VIEWPORTS: Record<Viewport, { width: number; height: number; label: string } | null> = {
+  desktop: null,
+  tablet: { width: 768, height: 1024, label: "Tablet" },
+  mobile: { width: 375, height: 812, label: "Mobile" },
+}
+
+export type DesignPreviewProps = {
+  onOpenFile?: (path: string, line: number) => void
+  onElementSelect?: (info: DesignElementInfo | undefined) => void
+  onComment?: (input: { file: string; line: number; comment: string; component?: string }) => void
+}
+
+type Note = {
+  text: string
+  element: {
+    tagName: string
+    className?: string
+    domPath: string
+    sourceFile?: string
+    sourceLine?: number
+    boundingRect: DesignElementInfo["rect"]
+  }
+}
+
+type Hit = {
+  file: string
+  line: number
+  comp?: string
+}
+
+export function DesignPreview(props: DesignPreviewProps) {
+  const files = useFile()
+  const layout = useLayout()
+  const sdk = useSDK()
+  const platform = usePlatform()
+
+  let container: HTMLDivElement | undefined
+  let placeholder: HTMLDivElement | undefined
+  let health: ReturnType<typeof setInterval> | undefined
+  let poller: ReturnType<typeof setInterval> | undefined
+  let observer: ResizeObserver | undefined
+  let lastCmd = 0
+  let webviewOpen = false
+  let raf = 0
+  let picked = 0
+  const changed = new Set<string>()
+  let change: ReturnType<typeof setTimeout> | undefined
+  let poke: ReturnType<typeof setTimeout> | undefined
+  let push: ReturnType<typeof setTimeout> | undefined
+  let reopen: ReturnType<typeof setTimeout> | undefined
+  let listed = ""
+  let sent = ""
+
+  const [store, setStore] = createStore({
+    viewport: "desktop" as Viewport,
+    size: undefined as { width: number; height: number; label: string } | undefined,
+    status: "disconnected" as "connected" | "disconnected" | "loading",
+    detecting: false,
+    framework: undefined as string | undefined,
+    selected: undefined as DesignElementInfo | undefined,
+    inspect: true,
+    notes: [] as Note[],
+  })
+
+  const [url, setUrl] = createSignal(layout.design.url())
+  const [input, setInput] = createSignal(layout.design.url())
+
+  const active = createMemo(() => !!store.size || store.viewport !== "desktop")
+  const preset = createMemo(() => store.size ?? VIEWPORTS[store.viewport])
+  const supported = createMemo(() => !!platform.createDesignWebview)
+
+  const syncInspect = () => {
+    if (!webviewOpen) return
+    platform.evalDesignWebview?.(
+      `window.__opencode_set_inspect_mode && window.__opencode_set_inspect_mode(${store.inspect})`,
+    )
+  }
+
+  const getRect = () => {
+    if (!placeholder) return { x: 0, y: 0, width: 0, height: 0 }
+    const rect = placeholder.getBoundingClientRect()
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+  }
+
+  const GAP = 8
+
+  const openWebview = async (target: string) => {
+    if (!platform.createDesignWebview) return
+    const r = getRect()
+    if (r.width <= 0 || r.height <= 0) return
+    await platform.createDesignWebview(target, r.x, r.y, r.width - GAP, r.height, INJECT)
+    webviewOpen = true
+    listed = ""
+    setStore("status", "connected")
+    syncSize()
+    setTimeout(() => {
+      sendWhitelist()
+      syncInspect()
+    }, 500)
+  }
+
+  const closeWebview = async () => {
+    if (!webviewOpen) return
+    webviewOpen = false
+    await platform.closeDesignWebview?.()
+  }
+
+  const syncSizeNow = () => {
+    raf = 0
+    if (!webviewOpen || !platform.resizeDesignWebview) return
+    const r = getRect()
+    if (r.width <= 0 || r.height <= 0) return
+    platform.resizeDesignWebview(r.x, r.y, r.width - GAP, r.height)
+  }
+
+  const syncSize = () => {
+    if (raf) return
+    raf = requestAnimationFrame(syncSizeNow)
+  }
+
+  const load = async (target: string) => {
+    if (!target) return
+    changed.clear()
+    if (poke) clearTimeout(poke)
+    if (reopen) clearTimeout(reopen)
+    if (target !== url()) {
+      setStore("selected", undefined)
+      setStore("notes", [])
+    }
+    setUrl(target)
+    layout.design.setUrl(target)
+    await closeWebview()
+    await openWebview(target)
+  }
+
+  const refresh = async () => {
+    const target = url()
+    if (!target) return
+    changed.clear()
+    if (poke) clearTimeout(poke)
+    if (reopen) clearTimeout(reopen)
+    await closeWebview()
+    await openWebview(target)
+  }
+
+  const disconnect = async () => {
+    changed.clear()
+    if (poke) clearTimeout(poke)
+    if (reopen) clearTimeout(reopen)
+    await closeWebview()
+    setUrl("")
+    setInput("")
+    layout.design.setUrl("")
+    setStore("status", "disconnected")
+    setStore("framework", undefined)
+    setStore("selected", undefined)
+    setStore("notes", [])
+  }
+
+  const submit = (e: Event) => {
+    e.preventDefault()
+    const val = input().trim()
+    if (!val) return
+    const target = val.startsWith("http") ? val : `http://${val}`
+    load(target)
+  }
+
+  const detect = async () => {
+    setStore("detecting", true)
+    const result = await detectDevUrl(sdk.directory, sdk.client).catch(() => null)
+    setStore("detecting", false)
+    if (!result) return
+    setStore("framework", result.framework)
+    setInput(result.url)
+    load(result.url)
+  }
+
+  const check = async () => {
+    const target = url()
+    if (!target) {
+      setStore("status", "disconnected")
+      return
+    }
+    try {
+      await fetch(target, { method: "HEAD", mode: "no-cors" })
+      if (store.status === "disconnected") setStore("status", "connected")
+    } catch {
+      setStore("status", "disconnected")
+    }
+  }
+
+  const parsePayload = (e: { payload: string | DesignElementInfo }): DesignElementInfo | undefined => {
+    if (!e.payload) return undefined
+    if (typeof e.payload === "string") {
+      try {
+        return JSON.parse(e.payload)
+      } catch {
+        return undefined
+      }
+    }
+    return e.payload
+  }
+
+  const note = (info: DesignElementInfo, text: string): Note => ({
+    text,
+    element: {
+      tagName: info.tag,
+      className: info.classes,
+      domPath: info.path,
+      sourceFile: info.source?.file ? normalizePath(info.source.file) : undefined,
+      sourceLine: info.source?.line,
+      boundingRect: info.rect,
+    },
+  })
+
+  const GENERIC_CLASSES = new Set([
+    "flex",
+    "flex-1",
+    "flex-col",
+    "flex-row",
+    "flex-wrap",
+    "flex-none",
+    "flex-auto",
+    "grid",
+    "block",
+    "inline",
+    "inline-flex",
+    "inline-block",
+    "hidden",
+    "contents",
+    "relative",
+    "absolute",
+    "fixed",
+    "sticky",
+    "w-full",
+    "w-auto",
+    "h-full",
+    "h-auto",
+    "w-screen",
+    "h-screen",
+    "p-0",
+    "p-1",
+    "p-2",
+    "p-3",
+    "p-4",
+    "p-5",
+    "p-6",
+    "p-8",
+    "p-10",
+    "p-12",
+    "p-16",
+    "px-0",
+    "px-1",
+    "px-2",
+    "px-3",
+    "px-4",
+    "px-5",
+    "px-6",
+    "px-8",
+    "py-0",
+    "py-1",
+    "py-2",
+    "py-3",
+    "py-4",
+    "py-5",
+    "py-6",
+    "py-8",
+    "pt-0",
+    "pb-0",
+    "pl-0",
+    "pr-0",
+    "m-0",
+    "m-1",
+    "m-2",
+    "m-3",
+    "m-4",
+    "m-auto",
+    "mx-0",
+    "mx-auto",
+    "my-0",
+    "my-auto",
+    "mt-0",
+    "mb-0",
+    "ml-0",
+    "mr-0",
+    "text-xs",
+    "text-sm",
+    "text-base",
+    "text-lg",
+    "text-xl",
+    "text-2xl",
+    "text-3xl",
+    "text-4xl",
+    "font-normal",
+    "font-medium",
+    "font-semibold",
+    "font-bold",
+    "text-left",
+    "text-center",
+    "text-right",
+    "rounded",
+    "rounded-sm",
+    "rounded-md",
+    "rounded-lg",
+    "rounded-xl",
+    "rounded-full",
+    "rounded-none",
+    "border",
+    "border-0",
+    "border-t",
+    "border-b",
+    "border-l",
+    "border-r",
+    "shadow",
+    "shadow-sm",
+    "shadow-md",
+    "shadow-lg",
+    "shadow-none",
+    "overflow-hidden",
+    "overflow-auto",
+    "overflow-scroll",
+    "overflow-visible",
+    "items-start",
+    "items-center",
+    "items-end",
+    "items-stretch",
+    "justify-start",
+    "justify-center",
+    "justify-end",
+    "justify-between",
+    "justify-around",
+    "gap-0",
+    "gap-1",
+    "gap-2",
+    "gap-3",
+    "gap-4",
+    "gap-5",
+    "gap-6",
+    "gap-8",
+    "cursor-pointer",
+    "cursor-default",
+    "cursor-not-allowed",
+    "opacity-0",
+    "opacity-50",
+    "opacity-100",
+    "transition",
+    "duration-150",
+    "duration-200",
+    "duration-300",
+    "ease-in",
+    "ease-out",
+    "container",
+    "group",
+    "peer",
+    "sr-only",
+    "not-sr-only",
+    "min-w-0",
+    "min-h-0",
+    "max-w-full",
+    "max-h-full",
+    "z-0",
+    "z-10",
+    "z-20",
+    "z-50",
+    "z-auto",
+    "top-0",
+    "bottom-0",
+    "left-0",
+    "right-0",
+    "inset-0",
+    "truncate",
+    "whitespace-nowrap",
+    "whitespace-pre",
+    "list-none",
+    "list-disc",
+    "list-decimal",
+    "pointer-events-none",
+    "pointer-events-auto",
+    "select-none",
+    "select-text",
+    "select-all",
+    "appearance-none",
+    "outline-none",
+    "ring-0",
+    "disabled",
+    "active",
+    "hover",
+    "focus",
+    "dark",
+  ])
+
+  const pickClasses = (classes: string | undefined): string[] => {
+    if (!classes) return []
+    const parts = classes
+      .trim()
+      .split(/\s+/)
+      .filter((c) => {
+        if (!c || c.length < 3) return false
+        if (GENERIC_CLASSES.has(c)) return false
+        // Skip pure color/sizing utilities
+        if (/^(bg|text|border|ring|fill|stroke)-(transparent|current|inherit|white|black)$/.test(c)) return false
+        if (/^(w|h|min-w|min-h|max-w|max-h)-\d/.test(c)) return false
+        if (
+          /^(text|bg|border)-(gray|red|blue|green|yellow|purple|pink|indigo|orange|teal|cyan|emerald|violet|rose|lime|sky|amber|fuchsia|slate|zinc|neutral|stone)-\d+$/.test(
+            c,
+          )
+        )
+          return false
+        if (/^(p|m)[trblxy]?-\d+$/.test(c)) return false
+        if (/^gap-\d+$/.test(c)) return false
+        return true
+      })
+    // Prefer longer/more-specific class names
+    return parts.sort((a, b) => b.length - a.length).slice(0, 3)
+  }
+
+  const normalizePath = (file: string): string => {
+    return files.normalize(
+      file
+        .replace(/^https?:\/\/[^/]+\//, "")
+        .replace(/^turbopack:\/\/\[project\]\//, "")
+        .replace(/^webpack-internal:\/\/\/\.?\//, "")
+        .replace(/^webpack:\/\/\/\.?\//, "")
+        .replace(/^webpack:\/\/[^/]*\/\.?\//, "")
+        .replace(/^\(.*?\)\/\.?\//, "")
+        .replace(/^\/@fs/, "")
+        .replace(/^\/@(id|vite)\//, "")
+        .replace(/\\/g, "/"),
+    )
+  }
+
+  const isSourceFile = (path: string): boolean => {
+    const name = path.split("/").pop() ?? ""
+    if (path.includes("node_modules/") || path.includes("node_modules\\")) return false
+    if (path.includes(".vite/deps/") || path.includes(".vite/chunks/")) return false
+    if (path.includes(".pnpm/") || path.includes(".yarn/cache")) return false
+    if (/^[0-9a-f]{4,}\.(js|mjs)$/.test(name)) return false
+    if (/\.[0-9a-f]{6,}\.(js|mjs)$/.test(name)) return false
+    if (/^(main|app|vendor|framework|commons|webpack|polyfills?)-[0-9a-f]+\.(js|mjs)$/.test(name)) return false
+    if (path.includes("static/chunks/") || path.includes("_next/") || path.includes(".next/")) return false
+    if (path.includes("/build/static/")) return false
+    if (/\.(tsx?|jsx?|vue|svelte|astro|html)$/.test(name)) return true
+    if (/\.(js|mjs)$/.test(name) && (path.includes("/dist/") || path.includes("/build/"))) return false
+    return true
+  }
+
+  const isUserFile = (path: string) =>
+    !path.includes("node_modules/") &&
+    !path.includes("node_modules\\") &&
+    !path.includes(".vite/deps/") &&
+    !path.includes(".vite/chunks/") &&
+    !path.includes(".pnpm/") &&
+    !path.includes(".yarn/cache") &&
+    /\.(tsx|jsx|ts|js|vue|svelte|html)$/.test(path)
+
+  let rustNames: string[] = []
+
+  const sendWhitelist = () => {
+    if (!webviewOpen) return
+    const json = JSON.stringify(rustNames)
+    if (json === listed) return
+    listed = json
+    platform.evalDesignWebview?.(
+      `window.__opencode_set_user_components && window.__opencode_set_user_components(${json})`,
+    )
+  }
+
+  const applyNames = (names: string[] | null | undefined, label: string) => {
+    resetCache()
+    rustNames = names ?? []
+    if (names?.length) {
+      console.log(`[Design] Rust index ${label}:`, names.length, "components")
+    }
+    sendWhitelist()
+  }
+
+  const buildIndex = async () => {
+    if (!platform.buildDesignIndex) return
+    const root = sdk.directory
+    if (!root) return
+    const names = await platform.buildDesignIndex(root).catch(() => null)
+    applyNames(names, "built")
+  }
+
+  const updateIndex = async (paths: string[]) => {
+    if (!paths.length) return
+    if (!platform.updateDesignIndex) {
+      await buildIndex()
+      return
+    }
+    const root = sdk.directory
+    if (!root) return
+    const names = await platform.updateDesignIndex(root, paths).catch(() => null)
+    if (!names) {
+      await buildIndex()
+      return
+    }
+    applyNames(names, "updated")
+  }
+
+  const idxCache = new Map<string, Hit | null>()
+  const idxRun = new Map<string, Promise<Hit | null>>()
+  const textCache = new Map<string, Hit | null>()
+  const textRun = new Map<string, Promise<Hit | null>>()
+  const defRun = new Map<string, Promise<Hit | null>>()
+  const useRun = new Map<string, Promise<Hit | null>>()
+  let cache = 0
+
+  const queryIndex = async (comp: string | null | undefined, classes: string | undefined): Promise<Hit | null> => {
+    if (!platform.queryDesignIndex) return null
+    const root = sdk.directory
+    if (!root) return null
+    const key = `${root}\n${comp ?? ""}\n${classes ?? ""}`
+    if (idxCache.has(key)) return idxCache.get(key) ?? null
+    const pending = idxRun.get(key)
+    if (pending) return pending
+    const cls = pickClasses(classes)
+    const ver = cache
+    const run = platform
+      .queryDesignIndex(root, comp ?? null, cls.length ? cls : null)
+      .then(
+        (result) => {
+          if (ver !== cache) return null
+          if (result && result.confidence > 0.3) {
+            console.log("[Design] Rust index hit:", result.file, "line:", result.line, "confidence:", result.confidence)
+            const hit = { file: result.file, line: result.line, comp: comp ?? undefined }
+            idxCache.set(key, hit)
+            return hit
+          }
+          idxCache.set(key, null)
+          return null
+        },
+        () => {
+          if (ver !== cache) return null
+          idxCache.set(key, null)
+          return null
+        },
+      )
+      .finally(() => {
+        idxRun.delete(key)
+      })
+    idxRun.set(key, run)
+    return run
+  }
+
+  const setResolved = (info: DesignElementInfo, hit: Hit) => {
+    const next = {
+      ...info,
+      component: hit.comp ?? info.component ?? info.source?.component,
+      source: {
+        ...info.source,
+        file: hit.file,
+        line: hit.line,
+        component: hit.comp ?? info.component ?? info.source?.component,
+      },
+    } satisfies DesignElementInfo
+    if (store.selected?.path === info.path) setStore("selected", next)
+    return next
+  }
+
+  const openHit = (hit: Hit) => {
+    props.onOpenFile?.(hit.file, hit.line)
+    return true
+  }
+
+  const openResolved = (info: DesignElementInfo, hit: Hit) => {
+    setResolved(info, hit)
+    return openHit(hit)
+  }
+
+  const locate = async (info: DesignElementInfo): Promise<Hit | null> => {
+    const comp = info.component ?? info.source?.component
+    const idx = await queryIndex(comp, info.classes)
+    if (idx) return idx
+    const chain = info.ancestry ?? []
+    for (const name of chain) {
+      const next = await queryIndex(name, undefined)
+      if (next) return next
+      const def = await findDefinition(name)
+      if (def) return def
+    }
+    return grepFallback(info)
+  }
+
+  const openComp = async (name: string) => {
+    const idx = await queryIndex(name, undefined)
+    if (idx) return openHit(idx)
+    const def = await findDefinition(name)
+    if (def) return openHit(def)
+    const use = await findUsage(name)
+    if (use) return openHit(use)
+    return false
+  }
+
+  const defCache = new Map<string, Hit | null>()
+  const usageCache = new Map<string, Hit | null>()
+
+  const resetCache = () => {
+    cache++
+    idxCache.clear()
+    idxRun.clear()
+    defCache.clear()
+    defRun.clear()
+    usageCache.clear()
+    useRun.clear()
+    textCache.clear()
+    textRun.clear()
+  }
+
+  const syncPreview = () => {
+    if (!webviewOpen || !platform.evalDesignWebview) return Promise.resolve(false)
+    return platform
+      .evalDesignWebview(
+        `window.__opencode_rebuild_map && window.__opencode_rebuild_map(); window.__opencode_sync && window.__opencode_sync();`,
+      )
+      .then(
+        () => true,
+        () => false,
+      )
+  }
+
+  const queueSync = (delay = 700, tries = 2) => {
+    if (poke) clearTimeout(poke)
+    poke = setTimeout(() => {
+      poke = undefined
+      void syncPreview().then((ok) => {
+        if (ok) {
+          if (reopen) clearTimeout(reopen)
+          reopen = undefined
+          return
+        }
+        if (tries > 0) {
+          queueSync(400, tries - 1)
+          return
+        }
+        if (!url()) return
+        if (reopen) clearTimeout(reopen)
+        reopen = setTimeout(() => {
+          reopen = undefined
+          if (!url()) return
+          void refresh()
+        }, 1500)
+      })
+    }, delay)
+  }
+
+  const indexed = (path?: string) => {
+    if (!path) return true
+    return /\.(tsx|jsx|ts|js|vue|svelte)$/i.test(path)
+  }
+
+  const queueReindex = (path?: string) => {
+    if (path) changed.add(path)
+    if (change) clearTimeout(change)
+    change = setTimeout(() => {
+      const paths = [...changed]
+      changed.clear()
+      change = undefined
+      const files = paths.filter(indexed)
+      const run = !paths.length ? buildIndex() : files.length ? updateIndex(files) : Promise.resolve()
+      void run.finally(() => {
+        queueSync()
+      })
+    }, 250)
+  }
+
+  // Check if a source file likely *defines* the component (vs just rendering it)
+  const fileDefinesComponent = (file: string, comp: string): boolean => {
+    if (!comp) return true
+    const name = (file.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
+    const lower = comp.toLowerCase()
+    // header.tsx defines Header, use-header.ts defines Header hook, etc.
+    if (name.toLowerCase() === lower) return true
+    if (name.toLowerCase().replace(/[-_]/g, "") === lower) return true
+    // index.tsx could define anything — accept it
+    if (name === "index") return true
+    // page.tsx, layout.tsx in Next.js are definitions
+    if (["page", "layout", "template", "loading", "error", "not-found"].includes(name)) return true
+    return false
+  }
+
+  // Search for the file where a component is defined (in user code, not node_modules)
+  const findDefinition = async (comp: string): Promise<Hit | null> => {
+    if (defCache.has(comp)) {
+      return defCache.get(comp) ?? null
+    }
+    const pending = defRun.get(comp)
+    if (pending) return pending
+    const patterns = [`function ${comp}`, `const ${comp}`, `export default function ${comp}`, `export function ${comp}`]
+    const ver = cache
+    const run = (async () => {
+      for (const pattern of patterns) {
+        const res = await sdk.client.find.text({ pattern }).catch(() => null)
+        if (ver !== cache) return null
+        const hits = res?.data ?? []
+        if (!hits.length) continue
+
+        const user = hits.filter((m) => isUserFile(m.path.text))
+        const exact = user.find((m) => {
+          const fname = (m.path.text.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
+          return (
+            fname.toLowerCase() === comp.toLowerCase() ||
+            fname.toLowerCase().replace(/[-_]/g, "") === comp.toLowerCase()
+          )
+        })
+        const match = exact ?? user[0]
+        if (match?.path.text) {
+          const line = match.line_number ?? 1
+          const hit = { file: match.path.text, line, comp }
+          defCache.set(comp, hit)
+          console.log("[Design] Found definition of", comp, "at:", match.path.text, "line:", line, "via:", pattern)
+          return hit
+        }
+      }
+      defCache.set(comp, null)
+      return null
+    })().finally(() => {
+      defRun.delete(comp)
+    })
+    defRun.set(comp, run)
+    return run
+  }
+
+  // Search for where a component is *used* in JSX (for library components like icons)
+  const findUsage = async (comp: string): Promise<Hit | null> => {
+    if (usageCache.has(comp)) {
+      return usageCache.get(comp) ?? null
+    }
+    const pending = useRun.get(comp)
+    if (pending) return pending
+    const ver = cache
+    const run = sdk.client.find
+      .text({ pattern: `<${comp}` })
+      .then(
+        (res) => {
+          if (ver !== cache) return null
+          const hits = res.data ?? []
+          const user = hits.filter((m) => isUserFile(m.path.text))
+          const match = user[0]
+          if (match?.path.text) {
+            const line = match.line_number ?? 1
+            const hit = { file: match.path.text, line, comp }
+            usageCache.set(comp, hit)
+            console.log("[Design] Found usage of <" + comp + "> at:", match.path.text, "line:", line)
+            return hit
+          }
+          usageCache.set(comp, null)
+          return null
+        },
+        () => {
+          if (ver !== cache) return null
+          usageCache.set(comp, null)
+          return null
+        },
+      )
+      .finally(() => {
+        useRun.delete(comp)
+      })
+    useRun.set(comp, run)
+    return run
+  }
+
+  // Search by text content in user source files
+  const findByText = async (text: string): Promise<Hit | null> => {
+    if (!text || text.length < 4) return null
+    if (textCache.has(text)) return textCache.get(text) ?? null
+    const pending = textRun.get(text)
+    if (pending) return pending
+    const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    const ver = cache
+    const run = sdk.client.find
+      .text({ pattern: escaped })
+      .then(
+        (res) => {
+          if (ver !== cache) return null
+          const hits = res.data ?? []
+          if (!hits.length) {
+            textCache.set(text, null)
+            return null
+          }
+
+          const match = hits.find((m) => isUserFile(m.path.text))
+          if (match?.path.text) {
+            console.log("[Design] Found by text content:", match.path.text, "line:", match.line_number)
+            const hit = { file: match.path.text, line: match.line_number ?? 1 }
+            textCache.set(text, hit)
+            return hit
+          }
+          textCache.set(text, null)
+          return null
+        },
+        () => {
+          if (ver !== cache) return null
+          textCache.set(text, null)
+          return null
+        },
+      )
+      .finally(() => {
+        textRun.delete(text)
+      })
+    textRun.set(text, run)
+    return run
+  }
+
+  const grepFallback = async (info: DesignElementInfo): Promise<Hit | null> => {
+    const comp = info.component ?? info.source?.component
+
+    // 1. Try component definition search in user code
+    if (comp) {
+      const def = await findDefinition(comp)
+      if (def) return def
+    }
+
+    // 2. Try JSX usage search (for library components: icons, UI libs)
+    if (comp) {
+      const use = await findUsage(comp)
+      if (use) return use
+    }
+
+    // 3. Try text content search
+    if (info.textContent) {
+      const text = await findByText(info.textContent)
+      if (text) return text
+    }
+
+    // 4. Fall back to search hints and CSS classes
+    const terms: string[] = []
+    const hints = info.searchHint ?? []
+    for (const h of hints) {
+      if (h.startsWith("#")) continue
+      if (h.length > 2 && !terms.includes(h)) terms.push(h)
+    }
+    const classes = pickClasses(info.classes)
+    for (const c of classes) {
+      if (!terms.includes(c)) terms.push(c)
+    }
+    if (!terms.length) return null
+
+    for (const term of terms) {
+      const res = await sdk.client.find.text({ pattern: term }).catch(() => null)
+      const hits = res?.data ?? []
+      if (!hits.length) continue
+
+      const match = hits.find((m) => isUserFile(m.path.text))
+      if (match?.path.text) {
+        console.log("[Design] grep fallback found:", match.path.text, "via term:", term)
+        return { file: match.path.text, line: match.line_number ?? 1 }
+      }
+    }
+    return null
+  }
+
+  const handleDesignEvent = (e: { payload: string | DesignElementInfo }) => {
+    const info = parsePayload(e)
+    if (!info) return
+    const token = ++picked
+
+    const src = info.source
+    if (src?._debug) {
+      console.log("[Design] fiber debug:", src._debug.join(" → "))
+    }
+
+    setStore("selected", info)
+    props.onElementSelect?.(info)
+
+    const comp = info.component ?? src?.component
+    const file = src?.file ? normalizePath(src.file) : undefined
+    const direct = (hit: Hit) => {
+      if (token !== picked) return false
+      return openResolved(info, hit)
+    }
+
+    // Library/node_modules source — strip it and find user code instead
+    if (file && !isSourceFile(file)) {
+      console.log("[Design] Source is library/bundled:", file, "for", comp, "— using index/grep to find user code")
+      info.source = undefined
+      setStore("selected", { ...info })
+      locate(info).then((hit) => {
+        if (hit) direct(hit)
+      })
+      return
+    }
+
+    // User source file, but it's the call site (e.g. home-client.tsx for <Header />), not the definition
+    if (comp && file && isSourceFile(file) && !fileDefinesComponent(file, comp)) {
+      console.log("[Design] Source", file, "is call site for", comp, "— checking index then searching")
+      locate(info).then((hit) => {
+        if (hit) {
+          direct(hit)
+          return
+        }
+        console.log("[Design] Definition not found, falling back to call site:", file)
+        direct({ file, line: src?.line ?? 1, comp })
+      })
+      return
+    }
+
+    if (file && isSourceFile(file)) {
+      console.log("[Design] Opening file:", file, "line:", src?.line, "component:", comp)
+      direct({ file, line: src?.line ?? 1, comp })
+      return
+    }
+
+    locate(info).then((hit) => {
+      if (hit) {
+        direct(hit)
+        return
+      }
+      console.log("[Design] No valid source for:", info.tag, comp ?? info.classes)
+    })
+  }
+
+  const snap = () => {
+    return {
+      selectedElement: store.selected
+        ? {
+            tagName: store.selected.tag,
+            className: store.selected.classes ?? "",
+            id: store.selected.id ?? "",
+            domPath: store.selected.path,
+            sourceFile: store.selected.source?.file,
+            sourceLine: store.selected.source?.line,
+            computedStyles: store.selected.computedStyles ?? {},
+            boundingRect: store.selected.rect,
+          }
+        : null,
+      comments: store.notes,
+      viewport: {
+        width: preset()?.width ?? 0,
+        height: preset()?.height ?? 0,
+        preset: store.viewport,
+      },
+      previewUrl: url(),
+    }
+  }
+
+  const save = () => {
+    if (push) clearTimeout(push)
+    push = undefined
+    const base = sdk.url
+    const state = snap()
+    const json = JSON.stringify(state)
+    if (json === sent) return
+    fetch(`${base}/experimental/design`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...state, timestamp: Date.now() }),
+    })
+      .then(() => {
+        sent = json
+      })
+      .catch(() => {})
+  }
+
+  const flush = () => {
+    if (push) clearTimeout(push)
+    push = setTimeout(save, 200)
+  }
+
+  const poll = async () => {
+    if (!url()) return
+    const base = sdk.url
+    const res = await fetch(`${base}/experimental/design`).catch(() => null)
+    if (!res?.ok) return
+    const data = await res.json().catch(() => null)
+    if (!data || !data.timestamp || data.timestamp <= lastCmd) return
+    lastCmd = data.timestamp
+
+    if (data.type === "update-styles" && data.styles && webviewOpen) {
+      const s = JSON.stringify(data.styles)
+      platform.evalDesignWebview?.(`window.__opencode_apply_styles && window.__opencode_apply_styles(${s})`)
+    }
+    if (data.type === "select" && data.selector && webviewOpen) {
+      const sel = JSON.stringify(data.selector)
+      platform.evalDesignWebview?.(`window.__opencode_select_element && window.__opencode_select_element(${sel})`)
+    }
+    if (data.type === "set-viewport" && data.width) {
+      const p = data.preset as Viewport | undefined
+      if (p === "desktop") {
+        setStore("viewport", "desktop")
+        setStore("size", undefined)
+        return
+      }
+      const base = p && VIEWPORTS[p] !== undefined ? VIEWPORTS[p] : null
+      const next = base && p ? p : "desktop"
+      setStore("viewport", next)
+      if (!data.height) {
+        setStore("size", undefined)
+        return
+      }
+      if (!base || base.width !== data.width || base.height !== data.height) {
+        setStore("size", {
+          width: data.width,
+          height: data.height,
+          label: base?.label ?? "Custom",
+        })
+        return
+      }
+      setStore("size", undefined)
+    }
+    if (data.type === "file-changed") {
+      queueReindex(typeof data.filePath === "string" ? data.filePath : undefined)
+    }
+  }
+
+  createEffect(on(() => store.selected, flush, { defer: true }))
+  createEffect(on(() => [store.viewport, store.size, url()] as const, flush, { defer: true }))
+  createEffect(on(() => store.notes, flush, { defer: true }))
+
+  let unlisten: (() => void) | undefined
+
+  onMount(async () => {
+    health = setInterval(check, 5000)
+    poller = setInterval(poll, 2000)
+
+    type Listener = (name: string, cb: (e: { payload: string }) => void | Promise<void>) => Promise<() => void>
+    const tauri = (globalThis as unknown as { __TAURI__?: { event?: { listen: Listener } } }).__TAURI__
+    if (supported() && tauri?.event) {
+      const { listen } = tauri.event
+      const u1 = await listen("design:element-select", handleDesignEvent)
+      const u2 = await listen("design:element-hover", () => {})
+      const u3 = await listen("design:debug-source", (e: { payload: string }) => {
+        try {
+          const data = typeof e.payload === "string" ? JSON.parse(e.payload) : e.payload
+          const lines: string[] = data.log ?? []
+          lines.forEach((l) => console.log(l))
+        } catch {
+          console.log("[Design] debug-source raw:", e.payload)
+        }
+      })
+      const u4 = await listen("design:component-list", async (e: { payload: string }) => {
+        try {
+          sendWhitelist()
+          const data = typeof e.payload === "string" ? JSON.parse(e.payload) : e.payload
+          const names: string[] = data.names ?? []
+          if (!names.length) return
+          console.log("[Design] Resolving", names.length, "component sources:", names.join(", "))
+          const resolved: Record<string, { file: string; line: number }> = {}
+          const hits = await Promise.all(
+            names.map(async (name) => {
+              const hit = (await queryIndex(name, undefined)) ?? (await findDefinition(name))
+              if (!hit) return
+              return [name, { file: hit.file, line: hit.line }] as const
+            }),
+          )
+          for (const hit of hits) {
+            if (!hit) continue
+            resolved[hit[0]] = hit[1]
+          }
+          const count = Object.keys(resolved).length
+          if (count > 0) {
+            console.log("[Design] Resolved", count, "sources, sending to child webview")
+            platform.evalDesignWebview?.(
+              `window.__opencode_resolve_sources && window.__opencode_resolve_sources(${JSON.stringify(resolved)})`,
+            )
+          }
+        } catch (err) {
+          console.log("[Design] component-list error:", err)
+        }
+      })
+      const u5 = await listen("design:comment-submit", async (e: { payload: string }) => {
+        try {
+          const data = typeof e.payload === "string" ? JSON.parse(e.payload) : e.payload
+          const text = typeof data?.comment === "string" ? data.comment.trim() : ""
+          const raw = data?.info as DesignElementInfo | undefined
+          if (!text || !raw) return
+          const info =
+            store.selected?.path === raw.path
+              ? {
+                  ...raw,
+                  component: store.selected.component ?? raw.component,
+                  source: store.selected.source ?? raw.source,
+                }
+              : raw
+          const file = info.source?.file ? normalizePath(info.source.file) : undefined
+          const comp = info.component ?? info.source?.component
+          const hit =
+            !file || !isSourceFile(file) || (comp ? !fileDefinesComponent(file, comp) : false)
+              ? await locate(info)
+              : null
+          const next = hit ? setResolved(info, hit) : info
+          setStore("notes", (prev) => [...prev, note(next, text)])
+
+          const path = next.source?.file ? normalizePath(next.source.file) : undefined
+          if (!path) return
+          props.onComment?.({
+            file: path,
+            line: next.source?.line ?? 1,
+            comment: text,
+            component: next.component ?? next.source?.component,
+          })
+        } catch (err) {
+          console.log("[Design] comment-submit error:", err)
+        }
+      })
+      unlisten = () => {
+        u1()
+        u2()
+        u3()
+        u4()
+        u5()
+      }
+    }
+
+    if (!url()) detect()
+    else {
+      check()
+      if (url()) openWebview(url())
+    }
+    buildIndex()
+  })
+
+  onCleanup(() => {
+    unlisten?.()
+    observer?.disconnect()
+    if (raf) cancelAnimationFrame(raf)
+    if (change) clearTimeout(change)
+    if (health) clearInterval(health)
+    if (poller) clearInterval(poller)
+    if (poke) clearTimeout(poke)
+    if (push) save()
+    if (reopen) clearTimeout(reopen)
+    closeWebview()
+  })
+
+  onMount(() => {
+    if (!placeholder) return
+    observer = new ResizeObserver(syncSize)
+    observer.observe(placeholder)
+  })
+
+  createEffect(
+    on(
+      () => sdk.directory,
+      () => {
+        changed.clear()
+        rustNames = []
+        resetCache()
+        setStore("selected", undefined)
+        setStore("notes", [])
+        sendWhitelist()
+        if (sdk.directory) {
+          buildIndex()
+        }
+        if (url()) return
+        detect()
+      },
+      { defer: true },
+    ),
+  )
+
+  // Sync inspect mode to child webview
+  createEffect(
+    on(
+      () => store.inspect,
+      () => {
+        syncInspect()
+      },
+      { defer: true },
+    ),
+  )
+
+  // Force resize when viewport preset changes or bottom panels appear/disappear
+  createEffect(
+    on(
+      () => [store.viewport, store.size, store.selected] as const,
+      () => {
+        syncSize()
+      },
+      { defer: true },
+    ),
+  )
+
+  // Clear selected overlay in child webview when selection is cleared
+  createEffect(
+    on(
+      () => store.selected,
+      (sel) => {
+        if (!webviewOpen || sel) return
+        platform.evalDesignWebview?.(`window.__opencode_clear_selection && window.__opencode_clear_selection()`)
+      },
+      { defer: true },
+    ),
+  )
+
+  const dot = createMemo(() => {
+    if (store.status === "connected") return "bg-green-500"
+    if (store.status === "loading") return "bg-yellow-500"
+    return "bg-gray-400"
+  })
+
+  if (!supported()) {
+    return (
+      <div class="flex flex-col h-full bg-background-base items-center justify-center">
+        <div class="text-14-regular text-text-weak max-w-64 text-center">
+          Design preview is only available in the desktop app.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div class="flex flex-col h-full bg-background-base border-x border-b border-border-weak-base">
+      {/* Toolbar */}
+      <div class="flex items-center gap-2 px-3 py-1.5 border-b border-border-weak-base bg-background-stronger shrink-0">
+        <div class={`size-2 rounded-full shrink-0 ${dot()}`} />
+
+        <form class="flex-1 min-w-0 flex items-center gap-1.5" onSubmit={submit}>
+          <input
+            type="text"
+            class="flex-1 min-w-0 h-6 px-2 text-12-regular bg-surface-panel border border-border-weak-base rounded-md text-text-strong placeholder:text-text-weaker outline-none focus:border-border-strong"
+            placeholder="http://localhost:3000"
+            value={input()}
+            onInput={(e) => setInput(e.currentTarget.value)}
+          />
+          <Tooltip value="Load URL" placement="top">
+            <IconButton type="submit" icon="enter" variant="ghost" class="size-6 shrink-0" aria-label="Load URL" />
+          </Tooltip>
+        </form>
+
+        <Tooltip value="Refresh" placement="top">
+          <IconButton icon="reset" variant="ghost" class="size-6 shrink-0" onClick={refresh} aria-label="Refresh" />
+        </Tooltip>
+
+        <Show when={url()}>
+          <Tooltip value="Disconnect" placement="top">
+            <IconButton
+              icon="close-small"
+              variant="ghost"
+              class="size-6 shrink-0"
+              onClick={disconnect}
+              aria-label="Disconnect"
+            />
+          </Tooltip>
+        </Show>
+
+        <Show when={store.framework}>
+          {(fw) => <span class="text-11-regular text-text-weak px-1 shrink-0">{fw()}</span>}
+        </Show>
+
+        <div class="flex items-center border border-border-weak-base rounded-md overflow-hidden shrink-0">
+          <Tooltip value="Desktop" placement="top">
+            <button
+              class="h-6 px-1.5 flex items-center justify-center text-icon-base hover:bg-surface-raised-base hover:text-icon-strong"
+              classList={{
+                "bg-surface-raised-base-active text-icon-strong": store.viewport === "desktop",
+              }}
+              onClick={() => {
+                setStore("viewport", "desktop")
+                setStore("size", undefined)
+              }}
+              aria-label="Desktop viewport"
+            >
+              <Icon name="square-arrow-top-right" size="small" />
+            </button>
+          </Tooltip>
+          <Tooltip value="Tablet (768×1024)" placement="top">
+            <button
+              class="h-6 px-1.5 flex items-center justify-center border-l border-border-weak-base text-icon-base hover:bg-surface-raised-base hover:text-icon-strong"
+              classList={{
+                "bg-surface-raised-base-active text-icon-strong": store.viewport === "tablet",
+              }}
+              onClick={() => {
+                setStore("viewport", "tablet")
+                setStore("size", undefined)
+              }}
+              aria-label="Tablet viewport"
+            >
+              <Icon name="sidebar" size="small" />
+            </button>
+          </Tooltip>
+          <Tooltip value="Mobile (375×812)" placement="top">
+            <button
+              class="h-6 px-1.5 flex items-center justify-center border-l border-border-weak-base text-icon-base hover:bg-surface-raised-base hover:text-icon-strong"
+              classList={{
+                "bg-surface-raised-base-active text-icon-strong": store.viewport === "mobile",
+              }}
+              onClick={() => {
+                setStore("viewport", "mobile")
+                setStore("size", undefined)
+              }}
+              aria-label="Mobile viewport"
+            >
+              <Icon name="task" size="small" />
+            </button>
+          </Tooltip>
+        </div>
+
+        <Tooltip value={store.inspect ? "Disable inspection" : "Inspect elements"} placement="top">
+          <Button
+            variant="ghost"
+            class="h-6 px-1.5 shrink-0"
+            classList={{
+              "bg-surface-raised-base-active text-text-strong": store.inspect,
+            }}
+            onClick={() => setStore("inspect", !store.inspect)}
+            aria-label="Toggle element inspection"
+          >
+            <Icon name="eye" size="small" />
+          </Button>
+        </Tooltip>
+      </div>
+
+      {/* Preview area — native webview is positioned on top of this placeholder */}
+      <div
+        ref={container}
+        class="flex-1 min-h-0 flex items-center justify-center bg-background-base overflow-hidden relative px-3 pb-3 pt-2"
+      >
+        <Show
+          when={url()}
+          fallback={
+            <div class="flex flex-col items-center gap-4 text-center p-8">
+              <div class="text-14-regular text-text-weak max-w-64">
+                {store.detecting ? "Detecting dev server..." : "No dev server detected"}
+              </div>
+              <div class="flex items-center gap-2">
+                <Button variant="ghost" size="small" onClick={detect} disabled={store.detecting}>
+                  {store.detecting ? "Detecting..." : "Auto-detect"}
+                </Button>
+              </div>
+            </div>
+          }
+        >
+          <Show when={active() && preset()}>
+            {(p) => (
+              <div class="absolute top-2 text-11-regular text-text-weaker">
+                {p().label} — {p().width}×{p().height}
+              </div>
+            )}
+          </Show>
+          <div
+            class="border border-border-weak-base bg-background-base rounded-xl overflow-hidden"
+            classList={{
+              "size-full mt-2": !active(),
+              "mt-4": active(),
+            }}
+            style={
+              active() && preset()
+                ? {
+                    width: `${preset()!.width}px`,
+                    height: `${preset()!.height}px`,
+                    "max-height": "calc(100% - 32px)",
+                  }
+                : undefined
+            }
+          >
+            <div ref={placeholder} class="size-full bg-transparent" />
+          </div>
+        </Show>
+      </div>
+
+      {/* Selected element info bar — outside the preview container so it's not behind the native webview */}
+      <Show when={store.selected}>
+        {(el) => (
+          <div class="shrink-0 border-t border-border-weak-base bg-background-stronger">
+            {/* Component ancestry breadcrumb */}
+            <Show when={el().ancestry && el().ancestry!.length > 0}>
+              <div class="px-3 py-1 flex items-center gap-1 text-11-regular border-b border-border-weak-base overflow-x-auto scrollbar-none">
+                <span class="text-text-weaker shrink-0">Tree:</span>
+                <For each={[...(el().ancestry ?? [])].reverse()}>
+                  {(name, idx) => (
+                    <>
+                      <Show when={idx() > 0}>
+                        <span class="text-text-weaker">›</span>
+                      </Show>
+                      <button
+                        class="font-mono hover:text-text-strong shrink-0 px-0.5 rounded cursor-pointer"
+                        classList={{
+                          "text-purple-400 font-medium": name === el().component,
+                          "text-text-weak hover:underline": name !== el().component,
+                        }}
+                        onClick={() => void openComp(name)}
+                        title={`Navigate to ${name}`}
+                      >
+                        {name}
+                      </button>
+                    </>
+                  )}
+                </For>
+              </div>
+            </Show>
+            {/* Element details */}
+            <div class="px-3 py-1.5 flex items-center gap-2 text-12-regular">
+              <Show when={el().component}>
+                <span class="text-purple-400 font-mono shrink-0">
+                  {"<"}
+                  {el().component}
+                  {">"}
+                </span>
+              </Show>
+              <span class="text-text-strong font-mono truncate">
+                {"<"}
+                {el().tag}
+                {el().id ? `#${el().id}` : ""}
+                {(() => {
+                  const c = el().classes
+                  if (!c) return ""
+                  const parts = c.split(" ")
+                  return ` class="${parts.slice(0, 3).join(" ")}${parts.length > 3 ? "…" : ""}"`
+                })()}
+                {">"}
+              </span>
+              <Show when={el().source?.file}>
+                {(file) => {
+                  const src = el().source!
+                  const comp = el().component ?? src.component
+                  const norm = normalizePath(file())
+                  const isDef = !comp || fileDefinesComponent(norm, comp)
+                  return (
+                    <button
+                      class="text-text-weak hover:text-text-strong underline shrink-0"
+                      title={isDef ? norm : `Call site: ${norm} — click to find ${comp} definition`}
+                      onClick={() => {
+                        if (comp && !isDef) {
+                          openComp(comp).then((found) => {
+                            if (!found) props.onOpenFile?.(norm, src.line ?? 1)
+                          })
+                        } else {
+                          props.onOpenFile?.(norm, src.line ?? 1)
+                        }
+                      }}
+                    >
+                      {isDef ? file().split("/").pop() : comp}
+                      {isDef ? `:${src.line ?? 1}` : ""}
+                    </button>
+                  )
+                }}
+              </Show>
+              <Show when={el().textContent}>
+                <span class="text-text-weaker text-11-regular truncate max-w-32" title={el().textContent}>
+                  "{el().textContent}"
+                </span>
+              </Show>
+              <Show when={!el().source?.file && !el().textContent && el().searchHint?.length}>
+                <span class="text-text-weaker text-11-regular truncate">
+                  search: {el().searchHint!.slice(0, 2).join(", ")}
+                </span>
+              </Show>
+              <div class="ml-auto flex items-center gap-1 shrink-0">
+                <IconButton
+                  icon="close-small"
+                  variant="ghost"
+                  class="size-5"
+                  aria-label="Clear selection"
+                  onClick={() => {
+                    setStore("selected", undefined)
+                    props.onElementSelect?.(undefined)
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/components/design-preview.tsx
+++ b/packages/app/src/components/design-preview.tsx
@@ -12,17 +12,11 @@ import { detectDevUrl } from "@/utils/detect-port"
 import { createInjectionScript } from "@/components/design-preview/injection"
 import { pickClasses } from "@/components/design-preview/pick-classes"
 import { createResolver, type Hit } from "@/components/design-preview/resolve"
+import { choose, grade, mode, need, rank, state, type SourceLoc } from "@/components/design-preview/source"
 
 const INJECT = createInjectionScript()
 
-type Source = {
-  file?: string
-  line?: number
-  column?: number
-  component?: string
-  owner?: string
-  _debug?: string[]
-}
+type Source = SourceLoc
 
 export type DesignElementInfo = {
   tag: string
@@ -67,6 +61,8 @@ const cfg = {
   poll: 2000,
   minConfidence: 0.3,
   minUsageConfidence: 0.6,
+  minOpen: 0.6,
+  minComment: 0.6,
 }
 
 export type DesignPreviewProps = {
@@ -128,6 +124,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     selected: undefined as DesignElementInfo | undefined,
     inspect: true,
     notes: [] as Note[],
+    pending: undefined as Hit | undefined,
   })
 
   const [url, setUrl] = createSignal(layout.design.url())
@@ -145,6 +142,7 @@ export function DesignPreview(props: DesignPreviewProps) {
   const run = (input: string) => platform.evalDesignWebview?.(input)
   const lookup = createResolver(files, sdk.client)
   const select = (info: DesignElementInfo | undefined) => {
+    setStore("pending", undefined)
     setStore("selected", info)
     props.onElementSelect?.(info)
   }
@@ -333,17 +331,20 @@ export function DesignPreview(props: DesignPreviewProps) {
     return e.payload
   }
 
-  const note = (info: DesignElementInfo, text: string): Note => ({
-    text,
-    element: {
-      tagName: info.tag,
-      className: info.classes,
-      domPath: info.path,
-      sourceFile: info.source?.file ? lookup.normalizePath(info.source.file) : undefined,
-      sourceLine: info.source?.line,
-      boundingRect: info.rect,
-    },
-  })
+  const note = (info: DesignElementInfo, text: string): Note => {
+    const src = choose(info)
+    return {
+      text,
+      element: {
+        tagName: info.tag,
+        className: info.classes,
+        domPath: info.path,
+        sourceFile: src?.file ? lookup.normalizePath(src.file) : undefined,
+        sourceLine: src?.line,
+        boundingRect: info.rect,
+      },
+    }
+  }
 
   let rustNames: string[] = []
 
@@ -411,7 +412,13 @@ export function DesignPreview(props: DesignPreviewProps) {
           if (ver !== cache) return null
           if (result && result.confidence > cfg.minConfidence) {
             console.log("[Design] Rust index hit:", result.file, "line:", result.line, "confidence:", result.confidence)
-            const hit = { file: result.file, line: result.line, comp: comp ?? undefined }
+            const hit = {
+              file: result.file,
+              line: result.line,
+              comp: comp ?? undefined,
+              origin: "rust-index",
+              score: result.confidence,
+            }
             idxCache.set(key, hit)
             return hit
           }
@@ -458,6 +465,8 @@ export function DesignPreview(props: DesignPreviewProps) {
               line: result.line,
               comp,
               owner: result.owner ?? owners[0],
+              origin: "usage-index",
+              score: result.confidence,
             }
             usageCache.set(key, hit)
             console.log(
@@ -512,6 +521,11 @@ export function DesignPreview(props: DesignPreviewProps) {
       line: hit.line,
       component: comp,
       owner: hit.owner,
+      origin: hit.origin,
+      confidence: hit.score !== undefined ? grade(hit.score) : undefined,
+      score: hit.score,
+      ambiguous: hit.ambiguous,
+      candidates: hit.candidates,
     }
     return slot === "source" ? { ...info, component: comp, source: src } : { ...info, component: comp, definition: src }
   }
@@ -536,9 +550,28 @@ export function DesignPreview(props: DesignPreviewProps) {
   }
 
   const openHit = (hit: Hit) => {
-    props.onOpenFile?.(hit.file, hit.line)
+    const file = lookup.normalizePath(hit.file)
+    const next = { ...hit, file }
+    const val = typeof next.score === "number" ? next.score : rank(next)
+    if (val < cfg.minOpen) return "blocked" as const
+    const gate = mode(next)
+    if (gate === "deny") return "blocked" as const
+    if (gate === "confirm") {
+      const prev = store.pending
+      const same =
+        prev &&
+        lookup.normalizePath(prev.file) === next.file &&
+        prev.line === next.line &&
+        (prev.comp ?? "") === (next.comp ?? "")
+      if (!same) {
+        setStore("pending", next)
+        return "pending" as const
+      }
+    }
+    setStore("pending", undefined)
+    props.onOpenFile?.(next.file, next.line)
     select(undefined)
-    return true
+    return "opened" as const
   }
 
   const sourceLabel = (src: Source | undefined) => {
@@ -546,9 +579,27 @@ export function DesignPreview(props: DesignPreviewProps) {
     return `${src.file.split(/[\\/]/).pop()}:${src.line ?? 1}`
   }
 
+  const sourceState = (src: Source | undefined) => {
+    return state(src)
+  }
+
   const usageText = (src: Source | undefined, comp: string | undefined) => {
     if (!src?.owner || src.owner === comp) return "Go to usage"
     return `Go to usage in ${src.owner}`
+  }
+
+  const sourceTone = (src: Source | undefined) => {
+    const lvl = sourceState(src)
+    if (lvl === "high") return "text-text-strong"
+    if (lvl === "medium") return "text-text-weak"
+    if (lvl === "low") return "text-text-secondary"
+    return "text-text-weaker"
+  }
+
+  const sourceBadge = (src: Source | undefined) => {
+    const lvl = sourceState(src)
+    if (lvl === "none") return "UNKNOWN"
+    return lvl.toUpperCase()
   }
 
   const locateUsage = async (info: Query): Promise<Hit | null> => {
@@ -559,7 +610,14 @@ export function DesignPreview(props: DesignPreviewProps) {
     const owner = idx === -1 ? chain[1] : chain[idx + 1]
     const file = info.source?.file ? lookup.normalizePath(info.source.file) : undefined
     if (file && lookup.isSourceFile(file) && !lookup.fileDefinesComponent(file, comp)) {
-      return { file, line: info.source?.line ?? 1, comp, owner }
+      return {
+        file,
+        line: info.source?.line ?? 1,
+        comp,
+        owner,
+        origin: info.source?.origin ?? "runtime",
+        score: info.source?.score ?? rank(info.source),
+      }
     }
     const rust = await queryUsageIndex(info)
     if (rust) {
@@ -568,7 +626,8 @@ export function DesignPreview(props: DesignPreviewProps) {
         search: info.searchHint,
         classes: info.classes,
       })
-      if (exact) return { ...exact, owner: rust.owner }
+      if (exact)
+        return { ...exact, owner: rust.owner, origin: exact.origin ?? "usage-index", score: exact.score ?? rust.score }
       return rust
     }
     const names = (idx === -1 ? chain : chain.slice(idx + 1)).filter(
@@ -588,7 +647,7 @@ export function DesignPreview(props: DesignPreviewProps) {
         search: info.searchHint,
         classes: info.classes,
       })
-      if (hit) return { ...hit, owner: name }
+      if (hit) return { ...hit, owner: name, origin: hit.origin ?? "usage-chain", score: hit.score ?? 0.62 }
     }
     return lookup.findUsage(comp)
   }
@@ -611,11 +670,11 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const enrich = async (info: DesignElementInfo, all = true) => {
     let next = prime(info)
-    if (!next.source) {
+    if (need(next, all)) {
       const hit = await locateUsage(next)
       if (hit) next = setLocation(next, "source", hit)
     }
-    if (!next.source) {
+    if (need(next, all)) {
       const hit = await lookup.grepFallback(next)
       if (hit) next = setLocation(next, "source", hit)
     }
@@ -625,7 +684,7 @@ export function DesignPreview(props: DesignPreviewProps) {
         next = setLocation(next, "definition", hit)
       }
     }
-    if (!next.source && next.definition?.file) {
+    if (!next.source?.file && next.definition?.file) {
       next = { ...next, source: { ...next.definition } }
     }
     if (next.definition && sameSource(next.source, next.definition)) {
@@ -639,11 +698,25 @@ export function DesignPreview(props: DesignPreviewProps) {
     const comp = next.component ?? next.source?.component ?? next.definition?.component
     const file = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
     if (file && lookup.isSourceFile(file)) {
-      return openHit({ file, line: next.source?.line ?? 1, comp })
+      const out = openHit({
+        file,
+        line: next.source?.line ?? 1,
+        comp,
+        origin: next.source?.origin,
+        score: next.source?.score ?? rank(next.source),
+      })
+      if (out !== "blocked") return out === "opened"
     }
     const def = next.definition?.file ? lookup.normalizePath(next.definition.file) : undefined
     if (def && lookup.isSourceFile(def)) {
-      return openHit({ file: def, line: next.definition?.line ?? 1, comp })
+      const out = openHit({
+        file: def,
+        line: next.definition?.line ?? 1,
+        comp,
+        origin: next.definition?.origin,
+        score: next.definition?.score ?? rank(next.definition),
+      })
+      if (out !== "blocked") return out === "opened"
     }
     return false
   }
@@ -653,14 +726,35 @@ export function DesignPreview(props: DesignPreviewProps) {
     const comp = next.component ?? next.source?.component ?? next.definition?.component
     const def = next.definition?.file ? lookup.normalizePath(next.definition.file) : undefined
     if (def && lookup.isSourceFile(def)) {
-      return openHit({ file: def, line: next.definition?.line ?? 1, comp })
+      const out = openHit({
+        file: def,
+        line: next.definition?.line ?? 1,
+        comp,
+        origin: next.definition?.origin,
+        score: next.definition?.score ?? rank(next.definition),
+      })
+      if (out !== "blocked") return out === "opened"
     }
     const file = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
     if (file && lookup.isSourceFile(file) && (!comp || lookup.fileDefinesComponent(file, comp))) {
-      return openHit({ file, line: next.source?.line ?? 1, comp })
+      const out = openHit({
+        file,
+        line: next.source?.line ?? 1,
+        comp,
+        origin: next.source?.origin,
+        score: next.source?.score ?? rank(next.source),
+      })
+      if (out !== "blocked") return out === "opened"
     }
     if (file && lookup.isSourceFile(file)) {
-      return openHit({ file, line: next.source?.line ?? 1, comp })
+      const out = openHit({
+        file,
+        line: next.source?.line ?? 1,
+        comp,
+        origin: next.source?.origin,
+        score: next.source?.score ?? rank(next.source),
+      })
+      if (out !== "blocked") return out === "opened"
     }
     return false
   }
@@ -673,9 +767,15 @@ export function DesignPreview(props: DesignPreviewProps) {
         ? store.selected
         : { component: name, ancestry: idx === -1 ? [name] : chain.slice(idx) }
     const use = await locateUsage(info)
-    if (use) return openHit(use)
+    if (use) {
+      const out = openHit(use)
+      if (out !== "blocked") return out === "opened"
+    }
     const def = await locateDefinition(info)
-    if (def) return openHit(def)
+    if (def) {
+      const out = openHit(def)
+      if (out !== "blocked") return out === "opened"
+    }
     return false
   }
 
@@ -769,8 +869,8 @@ export function DesignPreview(props: DesignPreviewProps) {
             className: store.selected.classes ?? "",
             id: store.selected.id ?? "",
             domPath: store.selected.path,
-            sourceFile: store.selected.source?.file,
-            sourceLine: store.selected.source?.line,
+            sourceFile: choose(store.selected)?.file,
+            sourceLine: choose(store.selected)?.line,
             computedStyles: store.selected.computedStyles ?? {},
             boundingRect: store.selected.rect,
           }
@@ -952,15 +1052,19 @@ export function DesignPreview(props: DesignPreviewProps) {
                 }
               : raw
           const next = await enrich(info, false)
+          const src = choose(next)
+          if (rank(src) < cfg.minComment) {
+            console.log("[Design] comment-submit skipped: low confidence")
+            return
+          }
           setStore("notes", (prev) => [...prev, note(next, text)])
-
-          const path = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
+          const path = src?.file ? lookup.normalizePath(src.file) : undefined
           if (!path) return
           props.onComment?.({
             file: path,
-            line: next.source?.line ?? 1,
+            line: src?.line ?? 1,
             comment: text,
-            component: next.component ?? next.source?.component,
+            component: next.component ?? src?.component,
           })
         } catch (err) {
           console.log("[Design] comment-submit error:", err)
@@ -1318,8 +1422,20 @@ export function DesignPreview(props: DesignPreviewProps) {
                 const use = !!file && !!comp && !lookup.fileDefinesComponent(file, comp)
                 const main = def?.file ? def : src
                 const text = def?.file || (!use && src?.file) ? "Go to definition" : usageText(src, comp)
+                const badge = sourceBadge(main)
+                const tone = sourceTone(main)
+                const pending = store.pending
+                const same = (value: Source | undefined) =>
+                  !!pending &&
+                  !!value?.file &&
+                  lookup.normalizePath(pending.file) === lookup.normalizePath(value.file) &&
+                  pending.line === (value.line ?? 1)
+                const canConfirm = same(main) || (use && same(src))
                 return (
                   <>
+                    <Show when={main}>
+                      <span class={`text-11-regular shrink-0 ${tone}`}>{badge}</span>
+                    </Show>
                     <Show when={main?.file}>
                       <button
                         class="text-text-weak hover:text-text-strong underline shrink-0"
@@ -1327,6 +1443,19 @@ export function DesignPreview(props: DesignPreviewProps) {
                         onClick={() => void openSelection(el())}
                       >
                         {`${text} (${sourceLabel(main)})`}
+                      </button>
+                    </Show>
+                    <Show when={canConfirm}>
+                      <button
+                        class="text-text-weak hover:text-text-strong underline shrink-0"
+                        onClick={() => {
+                          const hit = store.pending
+                          if (!hit) return
+                          const out = openHit(hit)
+                          if (out === "blocked") setStore("pending", undefined)
+                        }}
+                      >
+                        Confirm open
                       </button>
                     </Show>
                     <Show when={use && src?.file}>

--- a/packages/app/src/components/design-preview.tsx
+++ b/packages/app/src/components/design-preview.tsx
@@ -10,6 +10,8 @@ import { useSDK } from "@/context/sdk"
 import { usePlatform } from "@/context/platform"
 import { detectDevUrl } from "@/utils/detect-port"
 import { createInjectionScript } from "@/components/design-preview/injection"
+import { pickClasses } from "@/components/design-preview/pick-classes"
+import { createResolver, type Hit } from "@/components/design-preview/resolve"
 
 const INJECT = createInjectionScript()
 
@@ -37,6 +39,20 @@ const VIEWPORTS: Record<Viewport, { width: number; height: number; label: string
   mobile: { width: 375, height: 812, label: "Mobile" },
 }
 
+const cfg = {
+  gap: 8,
+  follow: 250,
+  ready: 500,
+  timeout: 3000,
+  sync: { delay: 700, retry: 400, tries: 2, reopen: 1500 },
+  reindex: 250,
+  save: 200,
+  saveRetry: 1000,
+  health: 5000,
+  poll: 2000,
+  minConfidence: 0.3,
+}
+
 export type DesignPreviewProps = {
   onOpenFile?: (path: string, line: number) => void
   onElementSelect?: (info: DesignElementInfo | undefined) => void
@@ -55,12 +71,6 @@ type Note = {
   }
 }
 
-type Hit = {
-  file: string
-  line: number
-  comp?: string
-}
-
 export function DesignPreview(props: DesignPreviewProps) {
   const files = useFile()
   const layout = useLayout()
@@ -71,10 +81,13 @@ export function DesignPreview(props: DesignPreviewProps) {
   let placeholder: HTMLDivElement | undefined
   let health: ReturnType<typeof setInterval> | undefined
   let poller: ReturnType<typeof setInterval> | undefined
+  let follow: ReturnType<typeof setInterval> | undefined
   let observer: ResizeObserver | undefined
   let lastCmd = 0
   let webviewOpen = false
   let raf = 0
+  let rev = 0
+  let last: { x: number; y: number; width: number; height: number } | undefined
   let picked = 0
   const changed = new Set<string>()
   let change: ReturnType<typeof setTimeout> | undefined
@@ -83,6 +96,10 @@ export function DesignPreview(props: DesignPreviewProps) {
   let reopen: ReturnType<typeof setTimeout> | undefined
   let listed = ""
   let sent = ""
+  let checkRun = false
+  let pollRun = false
+  let saveRun = false
+  let saveNext = false
 
   const [store, setStore] = createStore({
     viewport: "desktop" as Viewport,
@@ -101,40 +118,66 @@ export function DesignPreview(props: DesignPreviewProps) {
   const active = createMemo(() => !!store.size || store.viewport !== "desktop")
   const preset = createMemo(() => store.size ?? VIEWPORTS[store.viewport])
   const supported = createMemo(() => !!platform.createDesignWebview)
+  const bump = () => ++rev
+  const script = (name: string, arg?: string) => {
+    return arg === undefined ? `window.${name} && window.${name}()` : `window.${name} && window.${name}(${arg})`
+  }
+  const run = (input: string) => platform.evalDesignWebview?.(input)
+  const lookup = createResolver(files, sdk.client)
 
   const syncInspect = () => {
     if (!webviewOpen) return
-    platform.evalDesignWebview?.(
-      `window.__opencode_set_inspect_mode && window.__opencode_set_inspect_mode(${store.inspect})`,
-    )
+    run(script("__opencode_set_inspect_mode", JSON.stringify(store.inspect)))
   }
 
   const getRect = () => {
     if (!placeholder) return { x: 0, y: 0, width: 0, height: 0 }
     const rect = placeholder.getBoundingClientRect()
-    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+    return {
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.max(0, Math.round(rect.width - cfg.gap)),
+      height: Math.max(0, Math.round(rect.height)),
+    }
   }
 
-  const GAP = 8
+  const same = (next: { x: number; y: number; width: number; height: number }) => {
+    return !!last && next.x === last.x && next.y === last.y && next.width === last.width && next.height === last.height
+  }
+
+  const startFollow = () => {
+    if (follow) return
+    follow = setInterval(syncSize, cfg.follow)
+  }
+
+  const stopFollow = () => {
+    if (!follow) return
+    clearInterval(follow)
+    follow = undefined
+  }
 
   const openWebview = async (target: string) => {
     if (!platform.createDesignWebview) return
     const r = getRect()
     if (r.width <= 0 || r.height <= 0) return
-    await platform.createDesignWebview(target, r.x, r.y, r.width - GAP, r.height, INJECT)
+    await platform.createDesignWebview(target, r.x, r.y, r.width, r.height, INJECT)
     webviewOpen = true
+    last = r
     listed = ""
     setStore("status", "connected")
+    startFollow()
     syncSize()
     setTimeout(() => {
       sendWhitelist()
       syncInspect()
-    }, 500)
+    }, cfg.ready)
   }
 
   const closeWebview = async () => {
     if (!webviewOpen) return
     webviewOpen = false
+    last = undefined
+    stopFollow()
     await platform.closeDesignWebview?.()
   }
 
@@ -143,7 +186,9 @@ export function DesignPreview(props: DesignPreviewProps) {
     if (!webviewOpen || !platform.resizeDesignWebview) return
     const r = getRect()
     if (r.width <= 0 || r.height <= 0) return
-    platform.resizeDesignWebview(r.x, r.y, r.width - GAP, r.height)
+    if (same(r)) return
+    last = r
+    platform.resizeDesignWebview(r.x, r.y, r.width, r.height)
   }
 
   const syncSize = () => {
@@ -153,6 +198,8 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const load = async (target: string) => {
     if (!target) return
+    bump()
+    lastCmd = 0
     changed.clear()
     if (poke) clearTimeout(poke)
     if (reopen) clearTimeout(reopen)
@@ -169,6 +216,8 @@ export function DesignPreview(props: DesignPreviewProps) {
   const refresh = async () => {
     const target = url()
     if (!target) return
+    bump()
+    lastCmd = 0
     changed.clear()
     if (poke) clearTimeout(poke)
     if (reopen) clearTimeout(reopen)
@@ -177,6 +226,8 @@ export function DesignPreview(props: DesignPreviewProps) {
   }
 
   const disconnect = async () => {
+    bump()
+    lastCmd = 0
     changed.clear()
     if (poke) clearTimeout(poke)
     if (reopen) clearTimeout(reopen)
@@ -199,8 +250,13 @@ export function DesignPreview(props: DesignPreviewProps) {
   }
 
   const detect = async () => {
+    const stamp = rev
     setStore("detecting", true)
     const result = await detectDevUrl(sdk.directory, sdk.client).catch(() => null)
+    if (stamp !== rev) {
+      setStore("detecting", false)
+      return
+    }
     setStore("detecting", false)
     if (!result) return
     setStore("framework", result.framework)
@@ -209,16 +265,23 @@ export function DesignPreview(props: DesignPreviewProps) {
   }
 
   const check = async () => {
+    if (checkRun) return
     const target = url()
     if (!target) {
       setStore("status", "disconnected")
       return
     }
+    checkRun = true
+    const stamp = rev
     try {
-      await fetch(target, { method: "HEAD", mode: "no-cors" })
+      await fetch(target, { method: "HEAD", mode: "no-cors", signal: AbortSignal.timeout(cfg.timeout) })
+      if (stamp !== rev || target !== url()) return
       if (store.status === "disconnected") setStore("status", "connected")
     } catch {
+      if (stamp !== rev || target !== url()) return
       setStore("status", "disconnected")
+    } finally {
+      checkRun = false
     }
   }
 
@@ -240,251 +303,11 @@ export function DesignPreview(props: DesignPreviewProps) {
       tagName: info.tag,
       className: info.classes,
       domPath: info.path,
-      sourceFile: info.source?.file ? normalizePath(info.source.file) : undefined,
+      sourceFile: info.source?.file ? lookup.normalizePath(info.source.file) : undefined,
       sourceLine: info.source?.line,
       boundingRect: info.rect,
     },
   })
-
-  const GENERIC_CLASSES = new Set([
-    "flex",
-    "flex-1",
-    "flex-col",
-    "flex-row",
-    "flex-wrap",
-    "flex-none",
-    "flex-auto",
-    "grid",
-    "block",
-    "inline",
-    "inline-flex",
-    "inline-block",
-    "hidden",
-    "contents",
-    "relative",
-    "absolute",
-    "fixed",
-    "sticky",
-    "w-full",
-    "w-auto",
-    "h-full",
-    "h-auto",
-    "w-screen",
-    "h-screen",
-    "p-0",
-    "p-1",
-    "p-2",
-    "p-3",
-    "p-4",
-    "p-5",
-    "p-6",
-    "p-8",
-    "p-10",
-    "p-12",
-    "p-16",
-    "px-0",
-    "px-1",
-    "px-2",
-    "px-3",
-    "px-4",
-    "px-5",
-    "px-6",
-    "px-8",
-    "py-0",
-    "py-1",
-    "py-2",
-    "py-3",
-    "py-4",
-    "py-5",
-    "py-6",
-    "py-8",
-    "pt-0",
-    "pb-0",
-    "pl-0",
-    "pr-0",
-    "m-0",
-    "m-1",
-    "m-2",
-    "m-3",
-    "m-4",
-    "m-auto",
-    "mx-0",
-    "mx-auto",
-    "my-0",
-    "my-auto",
-    "mt-0",
-    "mb-0",
-    "ml-0",
-    "mr-0",
-    "text-xs",
-    "text-sm",
-    "text-base",
-    "text-lg",
-    "text-xl",
-    "text-2xl",
-    "text-3xl",
-    "text-4xl",
-    "font-normal",
-    "font-medium",
-    "font-semibold",
-    "font-bold",
-    "text-left",
-    "text-center",
-    "text-right",
-    "rounded",
-    "rounded-sm",
-    "rounded-md",
-    "rounded-lg",
-    "rounded-xl",
-    "rounded-full",
-    "rounded-none",
-    "border",
-    "border-0",
-    "border-t",
-    "border-b",
-    "border-l",
-    "border-r",
-    "shadow",
-    "shadow-sm",
-    "shadow-md",
-    "shadow-lg",
-    "shadow-none",
-    "overflow-hidden",
-    "overflow-auto",
-    "overflow-scroll",
-    "overflow-visible",
-    "items-start",
-    "items-center",
-    "items-end",
-    "items-stretch",
-    "justify-start",
-    "justify-center",
-    "justify-end",
-    "justify-between",
-    "justify-around",
-    "gap-0",
-    "gap-1",
-    "gap-2",
-    "gap-3",
-    "gap-4",
-    "gap-5",
-    "gap-6",
-    "gap-8",
-    "cursor-pointer",
-    "cursor-default",
-    "cursor-not-allowed",
-    "opacity-0",
-    "opacity-50",
-    "opacity-100",
-    "transition",
-    "duration-150",
-    "duration-200",
-    "duration-300",
-    "ease-in",
-    "ease-out",
-    "container",
-    "group",
-    "peer",
-    "sr-only",
-    "not-sr-only",
-    "min-w-0",
-    "min-h-0",
-    "max-w-full",
-    "max-h-full",
-    "z-0",
-    "z-10",
-    "z-20",
-    "z-50",
-    "z-auto",
-    "top-0",
-    "bottom-0",
-    "left-0",
-    "right-0",
-    "inset-0",
-    "truncate",
-    "whitespace-nowrap",
-    "whitespace-pre",
-    "list-none",
-    "list-disc",
-    "list-decimal",
-    "pointer-events-none",
-    "pointer-events-auto",
-    "select-none",
-    "select-text",
-    "select-all",
-    "appearance-none",
-    "outline-none",
-    "ring-0",
-    "disabled",
-    "active",
-    "hover",
-    "focus",
-    "dark",
-  ])
-
-  const pickClasses = (classes: string | undefined): string[] => {
-    if (!classes) return []
-    const parts = classes
-      .trim()
-      .split(/\s+/)
-      .filter((c) => {
-        if (!c || c.length < 3) return false
-        if (GENERIC_CLASSES.has(c)) return false
-        // Skip pure color/sizing utilities
-        if (/^(bg|text|border|ring|fill|stroke)-(transparent|current|inherit|white|black)$/.test(c)) return false
-        if (/^(w|h|min-w|min-h|max-w|max-h)-\d/.test(c)) return false
-        if (
-          /^(text|bg|border)-(gray|red|blue|green|yellow|purple|pink|indigo|orange|teal|cyan|emerald|violet|rose|lime|sky|amber|fuchsia|slate|zinc|neutral|stone)-\d+$/.test(
-            c,
-          )
-        )
-          return false
-        if (/^(p|m)[trblxy]?-\d+$/.test(c)) return false
-        if (/^gap-\d+$/.test(c)) return false
-        return true
-      })
-    // Prefer longer/more-specific class names
-    return parts.sort((a, b) => b.length - a.length).slice(0, 3)
-  }
-
-  const normalizePath = (file: string): string => {
-    return files.normalize(
-      file
-        .replace(/^https?:\/\/[^/]+\//, "")
-        .replace(/^turbopack:\/\/\[project\]\//, "")
-        .replace(/^webpack-internal:\/\/\/\.?\//, "")
-        .replace(/^webpack:\/\/\/\.?\//, "")
-        .replace(/^webpack:\/\/[^/]*\/\.?\//, "")
-        .replace(/^\(.*?\)\/\.?\//, "")
-        .replace(/^\/@fs/, "")
-        .replace(/^\/@(id|vite)\//, "")
-        .replace(/\\/g, "/"),
-    )
-  }
-
-  const isSourceFile = (path: string): boolean => {
-    const name = path.split("/").pop() ?? ""
-    if (path.includes("node_modules/") || path.includes("node_modules\\")) return false
-    if (path.includes(".vite/deps/") || path.includes(".vite/chunks/")) return false
-    if (path.includes(".pnpm/") || path.includes(".yarn/cache")) return false
-    if (/^[0-9a-f]{4,}\.(js|mjs)$/.test(name)) return false
-    if (/\.[0-9a-f]{6,}\.(js|mjs)$/.test(name)) return false
-    if (/^(main|app|vendor|framework|commons|webpack|polyfills?)-[0-9a-f]+\.(js|mjs)$/.test(name)) return false
-    if (path.includes("static/chunks/") || path.includes("_next/") || path.includes(".next/")) return false
-    if (path.includes("/build/static/")) return false
-    if (/\.(tsx?|jsx?|vue|svelte|astro|html)$/.test(name)) return true
-    if (/\.(js|mjs)$/.test(name) && (path.includes("/dist/") || path.includes("/build/"))) return false
-    return true
-  }
-
-  const isUserFile = (path: string) =>
-    !path.includes("node_modules/") &&
-    !path.includes("node_modules\\") &&
-    !path.includes(".vite/deps/") &&
-    !path.includes(".vite/chunks/") &&
-    !path.includes(".pnpm/") &&
-    !path.includes(".yarn/cache") &&
-    /\.(tsx|jsx|ts|js|vue|svelte|html)$/.test(path)
 
   let rustNames: string[] = []
 
@@ -493,9 +316,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     const json = JSON.stringify(rustNames)
     if (json === listed) return
     listed = json
-    platform.evalDesignWebview?.(
-      `window.__opencode_set_user_components && window.__opencode_set_user_components(${json})`,
-    )
+    run(script("__opencode_set_user_components", json))
   }
 
   const applyNames = (names: string[] | null | undefined, label: string) => {
@@ -533,10 +354,6 @@ export function DesignPreview(props: DesignPreviewProps) {
 
   const idxCache = new Map<string, Hit | null>()
   const idxRun = new Map<string, Promise<Hit | null>>()
-  const textCache = new Map<string, Hit | null>()
-  const textRun = new Map<string, Promise<Hit | null>>()
-  const defRun = new Map<string, Promise<Hit | null>>()
-  const useRun = new Map<string, Promise<Hit | null>>()
   let cache = 0
 
   const queryIndex = async (comp: string | null | undefined, classes: string | undefined): Promise<Hit | null> => {
@@ -554,7 +371,7 @@ export function DesignPreview(props: DesignPreviewProps) {
       .then(
         (result) => {
           if (ver !== cache) return null
-          if (result && result.confidence > 0.3) {
+          if (result && result.confidence > cfg.minConfidence) {
             console.log("[Design] Rust index hit:", result.file, "line:", result.line, "confidence:", result.confidence)
             const hit = { file: result.file, line: result.line, comp: comp ?? undefined }
             idxCache.set(key, hit)
@@ -609,50 +426,38 @@ export function DesignPreview(props: DesignPreviewProps) {
     for (const name of chain) {
       const next = await queryIndex(name, undefined)
       if (next) return next
-      const def = await findDefinition(name)
+      const def = await lookup.findDefinition(name)
       if (def) return def
     }
-    return grepFallback(info)
+    return lookup.grepFallback(info)
   }
 
   const openComp = async (name: string) => {
     const idx = await queryIndex(name, undefined)
     if (idx) return openHit(idx)
-    const def = await findDefinition(name)
+    const def = await lookup.findDefinition(name)
     if (def) return openHit(def)
-    const use = await findUsage(name)
+    const use = await lookup.findUsage(name)
     if (use) return openHit(use)
     return false
   }
-
-  const defCache = new Map<string, Hit | null>()
-  const usageCache = new Map<string, Hit | null>()
 
   const resetCache = () => {
     cache++
     idxCache.clear()
     idxRun.clear()
-    defCache.clear()
-    defRun.clear()
-    usageCache.clear()
-    useRun.clear()
-    textCache.clear()
-    textRun.clear()
+    lookup.reset()
   }
 
   const syncPreview = () => {
     if (!webviewOpen || !platform.evalDesignWebview) return Promise.resolve(false)
-    return platform
-      .evalDesignWebview(
-        `window.__opencode_rebuild_map && window.__opencode_rebuild_map(); window.__opencode_sync && window.__opencode_sync();`,
-      )
-      .then(
-        () => true,
-        () => false,
-      )
+    return platform.evalDesignWebview(`${script("__opencode_rebuild_map")}; ${script("__opencode_sync")};`).then(
+      () => true,
+      () => false,
+    )
   }
 
-  const queueSync = (delay = 700, tries = 2) => {
+  const queueSync = (delay = cfg.sync.delay, tries = cfg.sync.tries) => {
     if (poke) clearTimeout(poke)
     poke = setTimeout(() => {
       poke = undefined
@@ -663,7 +468,7 @@ export function DesignPreview(props: DesignPreviewProps) {
           return
         }
         if (tries > 0) {
-          queueSync(400, tries - 1)
+          queueSync(cfg.sync.retry, tries - 1)
           return
         }
         if (!url()) return
@@ -672,7 +477,7 @@ export function DesignPreview(props: DesignPreviewProps) {
           reopen = undefined
           if (!url()) return
           void refresh()
-        }, 1500)
+        }, cfg.sync.reopen)
       })
     }, delay)
   }
@@ -694,193 +499,7 @@ export function DesignPreview(props: DesignPreviewProps) {
       void run.finally(() => {
         queueSync()
       })
-    }, 250)
-  }
-
-  // Check if a source file likely *defines* the component (vs just rendering it)
-  const fileDefinesComponent = (file: string, comp: string): boolean => {
-    if (!comp) return true
-    const name = (file.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
-    const lower = comp.toLowerCase()
-    // header.tsx defines Header, use-header.ts defines Header hook, etc.
-    if (name.toLowerCase() === lower) return true
-    if (name.toLowerCase().replace(/[-_]/g, "") === lower) return true
-    // index.tsx could define anything — accept it
-    if (name === "index") return true
-    // page.tsx, layout.tsx in Next.js are definitions
-    if (["page", "layout", "template", "loading", "error", "not-found"].includes(name)) return true
-    return false
-  }
-
-  // Search for the file where a component is defined (in user code, not node_modules)
-  const findDefinition = async (comp: string): Promise<Hit | null> => {
-    if (defCache.has(comp)) {
-      return defCache.get(comp) ?? null
-    }
-    const pending = defRun.get(comp)
-    if (pending) return pending
-    const patterns = [`function ${comp}`, `const ${comp}`, `export default function ${comp}`, `export function ${comp}`]
-    const ver = cache
-    const run = (async () => {
-      for (const pattern of patterns) {
-        const res = await sdk.client.find.text({ pattern }).catch(() => null)
-        if (ver !== cache) return null
-        const hits = res?.data ?? []
-        if (!hits.length) continue
-
-        const user = hits.filter((m) => isUserFile(m.path.text))
-        const exact = user.find((m) => {
-          const fname = (m.path.text.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
-          return (
-            fname.toLowerCase() === comp.toLowerCase() ||
-            fname.toLowerCase().replace(/[-_]/g, "") === comp.toLowerCase()
-          )
-        })
-        const match = exact ?? user[0]
-        if (match?.path.text) {
-          const line = match.line_number ?? 1
-          const hit = { file: match.path.text, line, comp }
-          defCache.set(comp, hit)
-          console.log("[Design] Found definition of", comp, "at:", match.path.text, "line:", line, "via:", pattern)
-          return hit
-        }
-      }
-      defCache.set(comp, null)
-      return null
-    })().finally(() => {
-      defRun.delete(comp)
-    })
-    defRun.set(comp, run)
-    return run
-  }
-
-  // Search for where a component is *used* in JSX (for library components like icons)
-  const findUsage = async (comp: string): Promise<Hit | null> => {
-    if (usageCache.has(comp)) {
-      return usageCache.get(comp) ?? null
-    }
-    const pending = useRun.get(comp)
-    if (pending) return pending
-    const ver = cache
-    const run = sdk.client.find
-      .text({ pattern: `<${comp}` })
-      .then(
-        (res) => {
-          if (ver !== cache) return null
-          const hits = res.data ?? []
-          const user = hits.filter((m) => isUserFile(m.path.text))
-          const match = user[0]
-          if (match?.path.text) {
-            const line = match.line_number ?? 1
-            const hit = { file: match.path.text, line, comp }
-            usageCache.set(comp, hit)
-            console.log("[Design] Found usage of <" + comp + "> at:", match.path.text, "line:", line)
-            return hit
-          }
-          usageCache.set(comp, null)
-          return null
-        },
-        () => {
-          if (ver !== cache) return null
-          usageCache.set(comp, null)
-          return null
-        },
-      )
-      .finally(() => {
-        useRun.delete(comp)
-      })
-    useRun.set(comp, run)
-    return run
-  }
-
-  // Search by text content in user source files
-  const findByText = async (text: string): Promise<Hit | null> => {
-    if (!text || text.length < 4) return null
-    if (textCache.has(text)) return textCache.get(text) ?? null
-    const pending = textRun.get(text)
-    if (pending) return pending
-    const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-    const ver = cache
-    const run = sdk.client.find
-      .text({ pattern: escaped })
-      .then(
-        (res) => {
-          if (ver !== cache) return null
-          const hits = res.data ?? []
-          if (!hits.length) {
-            textCache.set(text, null)
-            return null
-          }
-
-          const match = hits.find((m) => isUserFile(m.path.text))
-          if (match?.path.text) {
-            console.log("[Design] Found by text content:", match.path.text, "line:", match.line_number)
-            const hit = { file: match.path.text, line: match.line_number ?? 1 }
-            textCache.set(text, hit)
-            return hit
-          }
-          textCache.set(text, null)
-          return null
-        },
-        () => {
-          if (ver !== cache) return null
-          textCache.set(text, null)
-          return null
-        },
-      )
-      .finally(() => {
-        textRun.delete(text)
-      })
-    textRun.set(text, run)
-    return run
-  }
-
-  const grepFallback = async (info: DesignElementInfo): Promise<Hit | null> => {
-    const comp = info.component ?? info.source?.component
-
-    // 1. Try component definition search in user code
-    if (comp) {
-      const def = await findDefinition(comp)
-      if (def) return def
-    }
-
-    // 2. Try JSX usage search (for library components: icons, UI libs)
-    if (comp) {
-      const use = await findUsage(comp)
-      if (use) return use
-    }
-
-    // 3. Try text content search
-    if (info.textContent) {
-      const text = await findByText(info.textContent)
-      if (text) return text
-    }
-
-    // 4. Fall back to search hints and CSS classes
-    const terms: string[] = []
-    const hints = info.searchHint ?? []
-    for (const h of hints) {
-      if (h.startsWith("#")) continue
-      if (h.length > 2 && !terms.includes(h)) terms.push(h)
-    }
-    const classes = pickClasses(info.classes)
-    for (const c of classes) {
-      if (!terms.includes(c)) terms.push(c)
-    }
-    if (!terms.length) return null
-
-    for (const term of terms) {
-      const res = await sdk.client.find.text({ pattern: term }).catch(() => null)
-      const hits = res?.data ?? []
-      if (!hits.length) continue
-
-      const match = hits.find((m) => isUserFile(m.path.text))
-      if (match?.path.text) {
-        console.log("[Design] grep fallback found:", match.path.text, "via term:", term)
-        return { file: match.path.text, line: match.line_number ?? 1 }
-      }
-    }
-    return null
+    }, cfg.reindex)
   }
 
   const handleDesignEvent = (e: { payload: string | DesignElementInfo }) => {
@@ -897,14 +516,14 @@ export function DesignPreview(props: DesignPreviewProps) {
     props.onElementSelect?.(info)
 
     const comp = info.component ?? src?.component
-    const file = src?.file ? normalizePath(src.file) : undefined
+    const file = src?.file ? lookup.normalizePath(src.file) : undefined
     const direct = (hit: Hit) => {
       if (token !== picked) return false
       return openResolved(info, hit)
     }
 
     // Library/node_modules source — strip it and find user code instead
-    if (file && !isSourceFile(file)) {
+    if (file && !lookup.isSourceFile(file)) {
       console.log("[Design] Source is library/bundled:", file, "for", comp, "— using index/grep to find user code")
       info.source = undefined
       setStore("selected", { ...info })
@@ -915,7 +534,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     }
 
     // User source file, but it's the call site (e.g. home-client.tsx for <Header />), not the definition
-    if (comp && file && isSourceFile(file) && !fileDefinesComponent(file, comp)) {
+    if (comp && file && lookup.isSourceFile(file) && !lookup.fileDefinesComponent(file, comp)) {
       console.log("[Design] Source", file, "is call site for", comp, "— checking index then searching")
       locate(info).then((hit) => {
         if (hit) {
@@ -928,7 +547,7 @@ export function DesignPreview(props: DesignPreviewProps) {
       return
     }
 
-    if (file && isSourceFile(file)) {
+    if (file && lookup.isSourceFile(file)) {
       console.log("[Design] Opening file:", file, "line:", src?.line, "component:", comp)
       direct({ file, line: src?.line ?? 1, comp })
       return
@@ -974,65 +593,94 @@ export function DesignPreview(props: DesignPreviewProps) {
     const state = snap()
     const json = JSON.stringify(state)
     if (json === sent) return
+    if (saveRun) {
+      saveNext = true
+      return
+    }
+    saveRun = true
+    saveNext = false
+    const stamp = rev
+    let failed = false
     fetch(`${base}/experimental/design`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(cfg.timeout),
       body: JSON.stringify({ ...state, timestamp: Date.now() }),
     })
       .then(() => {
+        if (stamp !== rev) return
         sent = json
       })
-      .catch(() => {})
+      .catch(() => {
+        failed = stamp === rev
+      })
+      .finally(() => {
+        saveRun = false
+        if (saveNext) {
+          push = setTimeout(save, cfg.save)
+          return
+        }
+        if (!failed || stamp !== rev) return
+        push = setTimeout(save, cfg.saveRetry)
+      })
   }
 
   const flush = () => {
     if (push) clearTimeout(push)
-    push = setTimeout(save, 200)
+    push = setTimeout(save, cfg.save)
   }
 
   const poll = async () => {
+    if (pollRun) return
     if (!url()) return
+    pollRun = true
+    const stamp = rev
     const base = sdk.url
-    const res = await fetch(`${base}/experimental/design`).catch(() => null)
-    if (!res?.ok) return
-    const data = await res.json().catch(() => null)
-    if (!data || !data.timestamp || data.timestamp <= lastCmd) return
-    lastCmd = data.timestamp
+    const path = lastCmd ? `${base}/experimental/design?since=${lastCmd}` : `${base}/experimental/design`
+    try {
+      const res = await fetch(path, { signal: AbortSignal.timeout(cfg.timeout) }).catch(() => null)
+      if (!res?.ok) return
+      const data = await res.json().catch(() => null)
+      if (stamp !== rev || !data || !data.timestamp || data.timestamp <= lastCmd) return
+      lastCmd = data.timestamp
 
-    if (data.type === "update-styles" && data.styles && webviewOpen) {
-      const s = JSON.stringify(data.styles)
-      platform.evalDesignWebview?.(`window.__opencode_apply_styles && window.__opencode_apply_styles(${s})`)
-    }
-    if (data.type === "select" && data.selector && webviewOpen) {
-      const sel = JSON.stringify(data.selector)
-      platform.evalDesignWebview?.(`window.__opencode_select_element && window.__opencode_select_element(${sel})`)
-    }
-    if (data.type === "set-viewport" && data.width) {
-      const p = data.preset as Viewport | undefined
-      if (p === "desktop") {
-        setStore("viewport", "desktop")
+      if (data.type === "update-styles" && data.styles && webviewOpen) {
+        const s = JSON.stringify(data.styles)
+        run(script("__opencode_apply_styles", s))
+      }
+      if (data.type === "select" && data.selector && webviewOpen) {
+        const sel = JSON.stringify(data.selector)
+        run(script("__opencode_select_element", sel))
+      }
+      if (data.type === "set-viewport" && data.width) {
+        const p = data.preset as Viewport | undefined
+        if (p === "desktop") {
+          setStore("viewport", "desktop")
+          setStore("size", undefined)
+          return
+        }
+        const base = p && VIEWPORTS[p] !== undefined ? VIEWPORTS[p] : null
+        const next = base && p ? p : "desktop"
+        setStore("viewport", next)
+        if (!data.height) {
+          setStore("size", undefined)
+          return
+        }
+        if (!base || base.width !== data.width || base.height !== data.height) {
+          setStore("size", {
+            width: data.width,
+            height: data.height,
+            label: base?.label ?? "Custom",
+          })
+          return
+        }
         setStore("size", undefined)
-        return
       }
-      const base = p && VIEWPORTS[p] !== undefined ? VIEWPORTS[p] : null
-      const next = base && p ? p : "desktop"
-      setStore("viewport", next)
-      if (!data.height) {
-        setStore("size", undefined)
-        return
+      if (data.type === "file-changed") {
+        queueReindex(typeof data.filePath === "string" ? data.filePath : undefined)
       }
-      if (!base || base.width !== data.width || base.height !== data.height) {
-        setStore("size", {
-          width: data.width,
-          height: data.height,
-          label: base?.label ?? "Custom",
-        })
-        return
-      }
-      setStore("size", undefined)
-    }
-    if (data.type === "file-changed") {
-      queueReindex(typeof data.filePath === "string" ? data.filePath : undefined)
+    } finally {
+      pollRun = false
     }
   }
 
@@ -1043,8 +691,8 @@ export function DesignPreview(props: DesignPreviewProps) {
   let unlisten: (() => void) | undefined
 
   onMount(async () => {
-    health = setInterval(check, 5000)
-    poller = setInterval(poll, 2000)
+    health = setInterval(check, cfg.health)
+    poller = setInterval(poll, cfg.poll)
 
     type Listener = (name: string, cb: (e: { payload: string }) => void | Promise<void>) => Promise<() => void>
     const tauri = (globalThis as unknown as { __TAURI__?: { event?: { listen: Listener } } }).__TAURI__
@@ -1071,7 +719,7 @@ export function DesignPreview(props: DesignPreviewProps) {
           const resolved: Record<string, { file: string; line: number }> = {}
           const hits = await Promise.all(
             names.map(async (name) => {
-              const hit = (await queryIndex(name, undefined)) ?? (await findDefinition(name))
+              const hit = (await queryIndex(name, undefined)) ?? (await lookup.findDefinition(name))
               if (!hit) return
               return [name, { file: hit.file, line: hit.line }] as const
             }),
@@ -1083,9 +731,7 @@ export function DesignPreview(props: DesignPreviewProps) {
           const count = Object.keys(resolved).length
           if (count > 0) {
             console.log("[Design] Resolved", count, "sources, sending to child webview")
-            platform.evalDesignWebview?.(
-              `window.__opencode_resolve_sources && window.__opencode_resolve_sources(${JSON.stringify(resolved)})`,
-            )
+            run(script("__opencode_resolve_sources", JSON.stringify(resolved)))
           }
         } catch (err) {
           console.log("[Design] component-list error:", err)
@@ -1105,16 +751,16 @@ export function DesignPreview(props: DesignPreviewProps) {
                   source: store.selected.source ?? raw.source,
                 }
               : raw
-          const file = info.source?.file ? normalizePath(info.source.file) : undefined
+          const file = info.source?.file ? lookup.normalizePath(info.source.file) : undefined
           const comp = info.component ?? info.source?.component
           const hit =
-            !file || !isSourceFile(file) || (comp ? !fileDefinesComponent(file, comp) : false)
+            !file || !lookup.isSourceFile(file) || (comp ? !lookup.fileDefinesComponent(file, comp) : false)
               ? await locate(info)
               : null
           const next = hit ? setResolved(info, hit) : info
           setStore("notes", (prev) => [...prev, note(next, text)])
 
-          const path = next.source?.file ? normalizePath(next.source.file) : undefined
+          const path = next.source?.file ? lookup.normalizePath(next.source.file) : undefined
           if (!path) return
           props.onComment?.({
             file: path,
@@ -1148,6 +794,7 @@ export function DesignPreview(props: DesignPreviewProps) {
     observer?.disconnect()
     if (raf) cancelAnimationFrame(raf)
     if (change) clearTimeout(change)
+    stopFollow()
     if (health) clearInterval(health)
     if (poller) clearInterval(poller)
     if (poke) clearTimeout(poke)
@@ -1166,6 +813,10 @@ export function DesignPreview(props: DesignPreviewProps) {
     on(
       () => sdk.directory,
       () => {
+        bump()
+        lastCmd = 0
+        sent = ""
+        saveNext = false
         changed.clear()
         rustNames = []
         resetCache()
@@ -1210,7 +861,7 @@ export function DesignPreview(props: DesignPreviewProps) {
       () => store.selected,
       (sel) => {
         if (!webviewOpen || sel) return
-        platform.evalDesignWebview?.(`window.__opencode_clear_selection && window.__opencode_clear_selection()`)
+        run(script("__opencode_clear_selection"))
       },
       { defer: true },
     ),
@@ -1437,8 +1088,8 @@ export function DesignPreview(props: DesignPreviewProps) {
                 {(file) => {
                   const src = el().source!
                   const comp = el().component ?? src.component
-                  const norm = normalizePath(file())
-                  const isDef = !comp || fileDefinesComponent(norm, comp)
+                  const norm = lookup.normalizePath(file())
+                  const isDef = !comp || lookup.fileDefinesComponent(norm, comp)
                   return (
                     <button
                       class="text-text-weak hover:text-text-strong underline shrink-0"

--- a/packages/app/src/components/design-preview/injection.test.ts
+++ b/packages/app/src/components/design-preview/injection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { createInjectionScript } from "./injection"
+
+describe("design preview injection", () => {
+  test("generates valid javascript", () => {
+    expect(() => new Function(createInjectionScript())).not.toThrow()
+  })
+
+  test("normalizes windows separators inside stripPath", () => {
+    expect(createInjectionScript()).toContain("f = f.replace(/\\\\/g, '/');")
+  })
+
+  test("includes sync hook for soft preview refreshes", () => {
+    expect(createInjectionScript()).toContain("window.__opencode_sync = function() {")
+  })
+})

--- a/packages/app/src/components/design-preview/injection.ts
+++ b/packages/app/src/components/design-preview/injection.ts
@@ -373,7 +373,15 @@ export function createInjectionScript(): string {
               file = resolvedSources[name].file || resolvedSources[name];
               line = resolvedSources[name].line || 1;
             }
-            componentMap.set(el, { name: name, chain: chain, file: file, line: line, column: col });
+            componentMap.set(el, {
+              name: name,
+              chain: chain,
+              file: file,
+              line: line,
+              column: col,
+              origin: file ? 'react-map' : 'react-name',
+              score: file ? 0.88 : 0.45,
+            });
             count++;
             if (!file && !unresolvedNames[name]) unresolvedNames[name] = 1;
           }
@@ -383,7 +391,15 @@ export function createInjectionScript(): string {
           var opts = el.__vue__.$options;
           var vn = opts.name || opts._componentTag;
           if (vn && vn[0] === vn[0].toUpperCase()) {
-            componentMap.set(el, { name: vn, chain: [vn], file: opts.__file || null, line: 1, column: null });
+            componentMap.set(el, {
+              name: vn,
+              chain: [vn],
+              file: opts.__file || null,
+              line: 1,
+              column: null,
+              origin: opts.__file ? 'vue-file' : 'vue-name',
+              score: opts.__file ? 0.9 : 0.45,
+            });
             count++;
             if (!opts.__file && !unresolvedNames[vn]) unresolvedNames[vn] = 1;
           }
@@ -393,7 +409,15 @@ export function createInjectionScript(): string {
           var vt = el.__vueParentComponent.type;
           var v3 = vt && (vt.name || vt.__name);
           if (v3 && v3[0] === v3[0].toUpperCase()) {
-            componentMap.set(el, { name: v3, chain: [v3], file: vt.__file || null, line: 1, column: null });
+            componentMap.set(el, {
+              name: v3,
+              chain: [v3],
+              file: vt.__file || null,
+              line: 1,
+              column: null,
+              origin: vt.__file ? 'vue3-file' : 'vue3-name',
+              score: vt.__file ? 0.9 : 0.45,
+            });
             count++;
             if (!vt.__file && !unresolvedNames[v3]) unresolvedNames[v3] = 1;
           }
@@ -403,7 +427,15 @@ export function createInjectionScript(): string {
           var loc = el.__svelte_meta.loc;
           var sn = (loc.file || '').split('/').pop().replace(/\\.svelte$/, '');
           if (sn && sn[0] === sn[0].toUpperCase()) {
-            componentMap.set(el, { name: sn, chain: [sn], file: loc.file, line: loc.line, column: loc.column });
+            componentMap.set(el, {
+              name: sn,
+              chain: [sn],
+              file: loc.file,
+              line: loc.line,
+              column: loc.column,
+              origin: 'svelte-meta',
+              score: 0.9,
+            });
             count++;
           }
           continue;
@@ -551,7 +583,15 @@ export function createInjectionScript(): string {
     function findSource(el) {
       var entry = mapLookup(el);
       if (entry && entry.file) {
-        return { file: entry.file, line: entry.line, column: entry.column, component: entry.name, _debug: ['map'] };
+        return {
+          file: entry.file,
+          line: entry.line,
+          column: entry.column,
+          component: entry.name,
+          origin: entry.origin || 'map',
+          score: typeof entry.score === 'number' ? entry.score : 0.88,
+          _debug: ['map'],
+        };
       }
       var log = [];
 
@@ -572,6 +612,8 @@ export function createInjectionScript(): string {
           line: parts[1] ? parseInt(parts[1], 10) : 1,
           column: parts[2] ? parseInt(parts[2], 10) : undefined,
           component: componentName(el),
+          origin: 'data-source-file',
+          score: 0.95,
           _debug: debugLines
         };
       }
@@ -588,7 +630,16 @@ export function createInjectionScript(): string {
             log.push('[Design]   _debugSource raw skipped: ' + raw);
           } else {
             var f = stripPath(raw);
-            if (!shouldSkip(f)) return { file: f, line: fb._debugSource.lineNumber, column: fb._debugSource.columnNumber, component: fiberName(fb) };
+            if (!shouldSkip(f)) {
+              return {
+                file: f,
+                line: fb._debugSource.lineNumber,
+                column: fb._debugSource.columnNumber,
+                component: fiberName(fb),
+                origin: 'react-debug-source',
+                score: 0.95,
+              };
+            }
             log.push('[Design]   _debugSource skipped: ' + f);
           }
         }
@@ -598,18 +649,37 @@ export function createInjectionScript(): string {
             log.push('[Design]   _debugOwner._debugSource raw skipped: ' + owRaw);
           } else {
             var owf = stripPath(owRaw);
-            if (!shouldSkip(owf)) return { file: owf, line: fb._debugOwner._debugSource.lineNumber, column: fb._debugOwner._debugSource.columnNumber, component: fiberName(fb) || fiberName(fb._debugOwner) };
+            if (!shouldSkip(owf)) {
+              return {
+                file: owf,
+                line: fb._debugOwner._debugSource.lineNumber,
+                column: fb._debugOwner._debugSource.columnNumber,
+                component: fiberName(fb) || fiberName(fb._debugOwner),
+                origin: 'react-owner-debug-source',
+                score: 0.92,
+              };
+            }
             log.push('[Design]   _debugOwner._debugSource skipped: ' + owf);
           }
         }
         if (fb._debugStack) {
           var p = parseStack(fb._debugStack);
-          if (p && !shouldSkip(p.file)) { if (!p.component) p.component = fiberName(fb); return p; }
+          if (p && !shouldSkip(p.file)) {
+            if (!p.component) p.component = fiberName(fb);
+            p.origin = 'react-debug-stack';
+            p.score = 0.62;
+            return p;
+          }
           if (p) log.push('[Design]   _debugStack skipped: ' + p.file);
         }
         if (fb._debugOwner && fb._debugOwner._debugStack) {
           var ows = parseStack(fb._debugOwner._debugStack);
-          if (ows && !shouldSkip(ows.file)) { if (!ows.component) ows.component = fiberName(fb._debugOwner) || fiberName(fb); return ows; }
+          if (ows && !shouldSkip(ows.file)) {
+            if (!ows.component) ows.component = fiberName(fb._debugOwner) || fiberName(fb);
+            ows.origin = 'react-owner-debug-stack';
+            ows.score = 0.6;
+            return ows;
+          }
           if (ows) log.push('[Design]   _debugOwner._debugStack skipped: ' + ows.file);
         }
         if (fb._debugInfo && Array.isArray(fb._debugInfo)) {
@@ -617,12 +687,26 @@ export function createInjectionScript(): string {
             var entry = fb._debugInfo[di];
             if (entry && entry.owner && entry.owner._debugSource) {
               var df = stripPath(entry.owner._debugSource.fileName);
-              if (!shouldSkip(df)) return { file: df, line: entry.owner._debugSource.lineNumber, column: entry.owner._debugSource.columnNumber, component: entry.owner.name || entry.name || fiberName(fb) };
+              if (!shouldSkip(df)) {
+                return {
+                  file: df,
+                  line: entry.owner._debugSource.lineNumber,
+                  column: entry.owner._debugSource.columnNumber,
+                  component: entry.owner.name || entry.name || fiberName(fb),
+                  origin: 'react-debug-info',
+                  score: 0.88,
+                };
+              }
               log.push('[Design]   _debugInfo[' + di + '] skipped: ' + df);
             }
             if (entry && entry.owner && entry.owner._debugStack) {
               var ip = parseStack(entry.owner._debugStack);
-              if (ip && !shouldSkip(ip.file)) { if (!ip.component) ip.component = entry.owner.name || entry.name; return ip; }
+              if (ip && !shouldSkip(ip.file)) {
+                if (!ip.component) ip.component = entry.owner.name || entry.name;
+                ip.origin = 'react-debug-info-stack';
+                ip.score = 0.58;
+                return ip;
+              }
             }
           }
         }
@@ -707,7 +791,7 @@ export function createInjectionScript(): string {
           if (opts && opts.__file) {
             log.push('[Design] FOUND Vue __file: ' + opts.__file);
             postDebugLog(log);
-            return { file: opts.__file, line: 1, _debug: debugLines };
+            return { file: opts.__file, line: 1, origin: 'vue-file', score: 0.9, _debug: debugLines };
           }
         }
         if (node.__vueParentComponent) {
@@ -715,7 +799,7 @@ export function createInjectionScript(): string {
           if (vtype && vtype.__file) {
             log.push('[Design] FOUND Vue __vueParentComponent.__file: ' + vtype.__file);
             postDebugLog(log);
-            return { file: vtype.__file, line: 1, _debug: debugLines };
+            return { file: vtype.__file, line: 1, origin: 'vue3-file', score: 0.9, _debug: debugLines };
           }
         }
         node = node.parentElement;
@@ -729,7 +813,7 @@ export function createInjectionScript(): string {
           if (loc) {
             log.push('[Design] FOUND Svelte __svelte_meta: ' + loc.file + ':' + loc.line);
             postDebugLog(log);
-            return { file: loc.file, line: loc.line, column: loc.column, _debug: debugLines };
+            return { file: loc.file, line: loc.line, column: loc.column, origin: 'svelte-meta', score: 0.9, _debug: debugLines };
           }
         }
         node = node.parentElement;
@@ -837,6 +921,18 @@ export function createInjectionScript(): string {
         searchHint: searchHint(el),
         framework: framework()
       };
+    }
+
+    function hot() {
+      if (window.__vite_plugin_react_preamble_installed__ || window.__VITE__) return true;
+      if (window.__webpack_hot_middleware_reporter__ || window.__webpack_require__) return true;
+      return false;
+    }
+
+    function hmr() {
+      queueMap(150);
+      queueSelection();
+      if (currentEl) post('element-select', readInfo(currentEl, true));
     }
 
     var currentEl = null;
@@ -1006,6 +1102,23 @@ export function createInjectionScript(): string {
       queueMap(1500);
     });
     mapObserver.observe(document.body, { childList: true, subtree: true });
+
+    if (hot()) {
+      window.addEventListener('vite:afterUpdate', hmr, true);
+      window.addEventListener('vite:beforeUpdate', function() { queueMap(60); }, true);
+      window.addEventListener('webpackHotUpdate', hmr, true);
+      window.addEventListener('message', function(e) {
+        var d = e && e.data;
+        if (!d) return;
+        if (typeof d === 'string' && d.indexOf('vite') !== -1 && d.indexOf('update') !== -1) {
+          hmr();
+          return;
+        }
+        if (typeof d === 'object' && (d.type === 'vite:afterUpdate' || d.type === 'webpackHotUpdate')) {
+          hmr();
+        }
+      }, true);
+    }
 
     queueMap(1500);
 

--- a/packages/app/src/components/design-preview/injection.ts
+++ b/packages/app/src/components/design-preview/injection.ts
@@ -1,0 +1,1185 @@
+export function createInjectionScript(): string {
+  return `
+(function() {
+  if (window.__opencode_design_injected) return;
+  window.__opencode_design_injected = true;
+
+  function init() {
+    var overlay = document.createElement('div');
+    overlay.id = '__opencode_hover_overlay';
+    overlay.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483646;border:2px solid #3b82f6;border-radius:2px;display:none;transition:all 0.05s ease;';
+    document.body.appendChild(overlay);
+
+    var selected = document.createElement('div');
+    selected.id = '__opencode_selected_overlay';
+    selected.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483645;border:2px solid #8b5cf6;border-radius:2px;background:rgba(139,92,246,0.08);display:none;';
+    document.body.appendChild(selected);
+
+    var label = document.createElement('div');
+    label.id = '__opencode_element_label';
+    label.style.cssText = 'position:fixed;pointer-events:none;z-index:2147483647;background:#1e1b4b;color:#e0e7ff;font-size:11px;font-family:monospace;padding:2px 6px;border-radius:3px;display:none;white-space:nowrap;';
+    document.body.appendChild(label);
+
+    // Comment button near selected element — bridges to main webview
+    var commentBtn = document.createElement('button');
+    commentBtn.id = '__opencode_comment_btn';
+    commentBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M10 4v12M4 10h12"/></svg>';
+    commentBtn.style.cssText = 'position:fixed;z-index:2147483647;display:none;width:28px;height:28px;border-radius:6px;border:2px solid #7c3aed;background:#7c3aed;color:#ffffff;cursor:pointer;padding:0;box-shadow:0 2px 10px rgba(0,0,0,0.5);transition:background 0.1s,border-color 0.1s;';
+    commentBtn.title = 'Add comment';
+    commentBtn.addEventListener('mouseenter', function() { commentBtn.style.background = '#6d28d9'; commentBtn.style.borderColor = '#6d28d9'; });
+    commentBtn.addEventListener('mouseleave', function() { commentBtn.style.background = '#7c3aed'; commentBtn.style.borderColor = '#7c3aed'; });
+    document.body.appendChild(commentBtn);
+
+    var commentBox = document.createElement('div');
+    commentBox.id = '__opencode_comment_box';
+    commentBox.style.cssText = 'position:fixed;z-index:2147483647;display:none;width:320px;max-width:calc(100vw - 16px);border-radius:14px;border:1px solid rgba(255,255,255,0.08);background:rgba(23,23,23,0.98);box-shadow:0 16px 48px rgba(0,0,0,0.45);padding:8px;box-sizing:border-box;';
+    document.body.appendChild(commentBox);
+
+    var commentInput = document.createElement('textarea');
+    commentInput.style.cssText = 'width:100%;min-height:92px;box-sizing:border-box;resize:vertical;padding:8px;border-radius:10px;border:1px solid rgba(255,255,255,0.12);background:#161616;color:#f5f5f5;font-size:12px;line-height:1.5;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
+    commentInput.placeholder = 'Add comment';
+    commentBox.appendChild(commentInput);
+
+    var commentMeta = document.createElement('div');
+    commentMeta.style.cssText = 'margin-top:8px;color:rgba(255,255,255,0.56);font-size:11px;line-height:1.4;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;';
+    commentBox.appendChild(commentMeta);
+
+    var commentActions = document.createElement('div');
+    commentActions.style.cssText = 'display:flex;justify-content:flex-end;gap:8px;margin-top:8px;';
+    commentBox.appendChild(commentActions);
+
+    var commentCancel = document.createElement('button');
+    commentCancel.type = 'button';
+    commentCancel.textContent = 'Cancel';
+    commentCancel.style.cssText = 'height:28px;padding:0 10px;border-radius:8px;border:1px solid rgba(255,255,255,0.12);background:transparent;color:rgba(255,255,255,0.8);font-size:12px;cursor:pointer;';
+    commentActions.appendChild(commentCancel);
+
+    var commentSubmit = document.createElement('button');
+    commentSubmit.type = 'button';
+    commentSubmit.textContent = 'Comment';
+    commentSubmit.style.cssText = 'height:28px;padding:0 10px;border-radius:8px;border:1px solid #f5f5f5;background:#f5f5f5;color:#111111;font-size:12px;font-weight:600;cursor:pointer;';
+    commentActions.appendChild(commentSubmit);
+
+    function isOverlay(el) {
+      return el === overlay || el === selected || el === label || el === commentBtn || el === commentBox || (el && el.closest && (el.closest('#__opencode_comment_btn') || el.closest('#__opencode_comment_box')));
+    }
+
+    function domPath(el) {
+      var parts = [];
+      var node = el;
+      while (node && node !== document.body && node !== document.documentElement) {
+        var tag = node.tagName.toLowerCase();
+        if (node.id) {
+          parts.unshift(tag + '#' + node.id);
+          break;
+        }
+        var parent = node.parentElement;
+        if (parent) {
+          var children = Array.from(parent.children).filter(function(c) { return c.tagName === node.tagName; });
+          if (children.length > 1) {
+            var idx = children.indexOf(node) + 1;
+            tag += ':nth-of-type(' + idx + ')';
+          }
+        }
+        parts.unshift(tag);
+        node = parent;
+      }
+      return parts.join(' > ');
+    }
+
+    function stripPath(f) {
+      if (!f) return f;
+      // Remove query strings (?t=123, ?v=abc, ?import, etc.)
+      f = f.replace(/\\?[^:]*$/, '');
+      // turbopack://[project]/src/app/page.tsx → src/app/page.tsx
+      f = f.replace(/^turbopack:\\/\\/\\[project\\]\\//, '');
+      // webpack-internal:///./src/app/page.tsx → src/app/page.tsx
+      f = f.replace(/^webpack-internal:\\/\\/\\/\\.?\\//, '');
+      // webpack:///./src/app/page.tsx → src/app/page.tsx
+      f = f.replace(/^webpack:\\/\\/\\/\\.?\\//, '');
+      // webpack://app-name/./src/... → src/...
+      f = f.replace(/^webpack:\\/\\/[^/]*\\/\\.?\\//, '');
+      // (app-pages-browser)/./src/... → src/...
+      f = f.replace(/^\\(.*?\\)\\/\\.?\\//, '');
+      // Vite: /@fs/absolute/path → /absolute/path
+      f = f.replace(/^\\/@fs/, '');
+      // Vite: /@id/ or /@vite/ prefixes
+      f = f.replace(/^\\/@(id|vite)\\//, '');
+      // file:// protocol
+      f = f.replace(/^file:\\/\\//, '');
+      // http://localhost:PORT/src/... → src/...
+      f = f.replace(/^https?:\\/\\/[^/]+\\//, '');
+      // Remove leading ./ if present
+      f = f.replace(/^\\.?\\//, '');
+      f = f.replace(/\\\\/g, '/');
+      return f;
+    }
+
+    var SKIP_PATTERNS = ['node_modules', '.vite/deps', '.vite/chunks', '.pnpm/', '.yarn/cache', 'react-dom', 'react.', 'webpack/runtime', 'turbopack-runtime', 'next/dist', 'scheduler.', 'react-refresh', 'hot-update', '__vite', 'svelte-hmr', 'vue-hot-reload', 'chunk-', '@vite/client'];
+
+    function shouldSkip(file) {
+      if (!file) return true;
+      for (var i = 0; i < SKIP_PATTERNS.length; i++) {
+        if (file.indexOf(SKIP_PATTERNS[i]) !== -1) return true;
+      }
+      return isBundled(file);
+    }
+
+    function isBundled(file) {
+      if (!file) return false;
+      var name = file.split('/').pop() || '';
+      // Hashed chunk files: abc123.js, 0a3f.js, main-abc123.js, layout-[hash].js
+      if (/^[0-9a-f]{4,}\.(js|mjs)$/.test(name)) return true;
+      if (/^(main|app|vendor|framework|commons|webpack|polyfills?)-[0-9a-f]+\.(js|mjs)$/.test(name)) return true;
+      if (/\.[0-9a-f]{6,}\.(js|mjs)$/.test(name)) return true;
+      // Next.js/turbopack chunks
+      if (file.indexOf('static/chunks/') !== -1) return true;
+      if (file.indexOf('_next/') !== -1) return true;
+      if (file.indexOf('.next/') !== -1) return true;
+      // Vite pre-bundled deps
+      if (file.indexOf('.vite/deps/') !== -1) return true;
+      if (file.indexOf('.vite/chunks/') !== -1) return true;
+      // Generic build output dirs
+      if (file.indexOf('/dist/') !== -1 && name.indexOf('.') !== -1 && !/\.(tsx?|jsx?|vue|svelte)$/.test(name)) return true;
+      if (file.indexOf('/build/static/') !== -1) return true;
+      return false;
+    }
+
+    function parseStack(stack) {
+      if (!stack) return null;
+      var str = typeof stack === 'string' ? stack : (stack.stack || String(stack));
+      var lines = str.split('\\n');
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        // Chrome/V8: at ComponentName (file:line:col) or at file:line:col
+        var m = line.match(/at\\s+(?:(\\S+)\\s+)?\\(?(.+?):(\\d+):(\\d+)\\)?/);
+        if (m && !shouldSkip(m[2])) {
+          return { file: stripPath(m[2]), line: parseInt(m[3], 10), column: parseInt(m[4], 10), component: m[1] || undefined };
+        }
+        // Firefox/Safari: ComponentName@file:line:col or file:line:col
+        var ff = line.match(/^(?:([^@]*)@)?(.+?):(\\d+):(\\d+)\\s*$/);
+        if (ff && !shouldSkip(ff[2])) {
+          return { file: stripPath(ff[2]), line: parseInt(ff[3], 10), column: parseInt(ff[4], 10), component: ff[1] || undefined };
+        }
+      }
+      return null;
+    }
+
+    function fiberName(fiber) {
+      if (!fiber || !fiber.type) return null;
+      var t = fiber.type;
+      // Direct function component
+      if (typeof t === 'function') return t.displayName || t.name || null;
+      // forwardRef: { $$typeof, render }
+      if (t.render && typeof t.render === 'function') return t.render.displayName || t.render.name || null;
+      // memo: { $$typeof, type }
+      if (t.type && typeof t.type === 'function') return t.type.displayName || t.type.name || null;
+      return null;
+    }
+
+    function hasLibraryIndicator(raw) {
+      if (!raw) return false;
+      if (raw.indexOf('node_modules') !== -1) return true;
+      if (raw.indexOf('.vite/deps') !== -1) return true;
+      if (raw.indexOf('.vite/chunks') !== -1) return true;
+      if (raw.indexOf('.pnpm/') !== -1) return true;
+      if (raw.indexOf('.yarn/cache') !== -1) return true;
+      if (raw.indexOf('/dist/') !== -1) return true;
+      if (raw.indexOf('/build/') !== -1) return true;
+      if (raw.indexOf('.next/') !== -1) return true;
+      if (raw.indexOf('_next/') !== -1) return true;
+      if (raw.indexOf('static/chunks/') !== -1) return true;
+      return false;
+    }
+
+    // Returns 'lib' if fiber source is in node_modules/library, 'user' if in user code, null if unknown
+    function fiberOrigin(fiber) {
+      // Check direct debug info
+      if (fiber._debugSource) {
+        var raw = fiber._debugSource.fileName;
+        if (hasLibraryIndicator(raw)) return 'lib';
+        var f = stripPath(raw);
+        return shouldSkip(f) ? 'lib' : 'user';
+      }
+      if (fiber._debugStack) {
+        var p = parseStack(fiber._debugStack);
+        if (p) return shouldSkip(p.file) ? 'lib' : 'user';
+      }
+      // Check owner debug info
+      if (fiber._debugOwner) {
+        if (fiber._debugOwner._debugSource) {
+          var owRaw = fiber._debugOwner._debugSource.fileName;
+          if (hasLibraryIndicator(owRaw)) return 'lib';
+          var owf = stripPath(owRaw);
+          return shouldSkip(owf) ? 'lib' : 'user';
+        }
+        if (fiber._debugOwner._debugStack) {
+          var ows = parseStack(fiber._debugOwner._debugStack);
+          if (ows) return shouldSkip(ows.file) ? 'lib' : 'user';
+        }
+      }
+      return null;
+    }
+
+    // User component whitelist — populated from main webview after project scan.
+    // Once loaded, ONLY whitelisted names are treated as user components.
+    // This replaces a static blocklist: we scan the project for real components instead.
+    var userComponents = null;
+
+    function isLibName(name) {
+      // Obvious non-component patterns
+      if (name.startsWith('$')) return true;
+      if (/^(motion|m)\.[a-z]/.test(name)) return true;
+      // Whitelist-based: if loaded, anything not in it is library code
+      if (userComponents) return !userComponents[name];
+      // No whitelist yet — let fiberOrigin decide (don't block anything by name)
+      return false;
+    }
+
+    var componentMap = typeof WeakMap !== 'undefined' ? new WeakMap() : null;
+    var resolvedSources = {};
+    var unresolvedNames = {};
+    var mapBuilt = false;
+
+    function fiberKey(el) {
+      var keys = Object.keys(el);
+      for (var i = 0; i < keys.length; i++) {
+        if (keys[i].indexOf('__reactFiber$') === 0 || keys[i].indexOf('__reactInternalInstance$') === 0) return keys[i];
+      }
+      return null;
+    }
+
+    function extractSource(fiber) {
+      if (fiber._debugSource) {
+        var raw = fiber._debugSource.fileName;
+        if (!hasLibraryIndicator(raw)) {
+          var f = stripPath(raw);
+          if (!shouldSkip(f)) return { file: f, line: fiber._debugSource.lineNumber, column: fiber._debugSource.columnNumber };
+        }
+      }
+      if (fiber._debugOwner && fiber._debugOwner._debugSource) {
+        var owRaw = fiber._debugOwner._debugSource.fileName;
+        if (!hasLibraryIndicator(owRaw)) {
+          var owf = stripPath(owRaw);
+          if (!shouldSkip(owf)) return { file: owf, line: fiber._debugOwner._debugSource.lineNumber, column: fiber._debugOwner._debugSource.columnNumber };
+        }
+      }
+      if (fiber._debugStack) {
+        var p = parseStack(fiber._debugStack);
+        if (p && !shouldSkip(p.file)) return { file: p.file, line: p.line, column: p.column };
+      }
+      if (fiber._debugOwner && fiber._debugOwner._debugStack) {
+        var ows = parseStack(fiber._debugOwner._debugStack);
+        if (ows && !shouldSkip(ows.file)) return { file: ows.file, line: ows.line, column: ows.column };
+      }
+      return null;
+    }
+
+    function analyzeChildren(root) {
+      var counts = {};
+      var heading = '';
+      var interactive = 0;
+      var media = 0;
+      var tags = ['h1','h2','h3','h4','h5','h6','p','button','a','img','video','canvas','input','form','ul','ol','li','table','textarea','select'];
+      var walk = document.createTreeWalker(root, 1);
+      var node;
+      var depth = 0;
+      while ((node = walk.nextNode()) && depth < 500) {
+        depth++;
+        var tag = node.tagName ? node.tagName.toLowerCase() : '';
+        if (tags.indexOf(tag) !== -1) {
+          counts[tag] = (counts[tag] || 0) + 1;
+          if (!heading && /^h[1-6]$/.test(tag)) {
+            var txt = (node.textContent || '').trim();
+            if (txt) heading = txt.length > 50 ? txt.slice(0, 50) + '…' : txt;
+          }
+          if (tag === 'button' || tag === 'a' || tag === 'input' || tag === 'textarea' || tag === 'select') interactive++;
+          if (tag === 'img' || tag === 'video' || tag === 'canvas') media++;
+        }
+      }
+      var parts = [];
+      if (heading) parts.push('heading "' + heading + '"');
+      var li = (counts['li'] || 0);
+      if (li > 1) parts.push(li + ' list items');
+      var form = counts['form'] || 0;
+      var inputs = (counts['input'] || 0) + (counts['textarea'] || 0) + (counts['select'] || 0);
+      if (form && inputs) parts.push('form with ' + inputs + ' fields');
+      else if (inputs > 1) parts.push(inputs + ' input fields');
+      var btns = counts['button'] || 0;
+      if (btns) parts.push(btns + ' button' + (btns > 1 ? 's' : ''));
+      var links = counts['a'] || 0;
+      if (links > 1) parts.push(links + ' links');
+      if (media) parts.push(media + ' media');
+      var tbl = counts['table'] || 0;
+      if (tbl) parts.push('table');
+      var para = counts['p'] || 0;
+      if (para > 1) parts.push(para + ' paragraphs');
+      return parts.length > 0 ? parts.join(', ') : '';
+    }
+
+    function buildComponentMap() {
+      if (!componentMap) return;
+      unresolvedNames = {};
+      var count = 0;
+      var walker = document.createTreeWalker(document.body, 1);
+      var el;
+      while ((el = walker.nextNode())) {
+        if (el.id && el.id.indexOf('__opencode_') === 0) continue;
+        var fk = fiberKey(el);
+        if (fk) {
+          var fiber = el[fk];
+          var name = null;
+          var chain = [];
+          var file = null;
+          var line = null;
+          var col = null;
+          var seen = {};
+          var depth = 0;
+          var fallback = null;
+          while (fiber && depth < 40) {
+            var fn = fiberName(fiber);
+            if (fn && fn !== 'anon' && fn.length > 1 && fn[0] === fn[0].toUpperCase() && !isLibName(fn)) {
+              var origin = fiberOrigin(fiber);
+              if (isUserName(fn, origin)) {
+                if (!name && (origin === 'user' || (userComponents && userComponents[fn]))) {
+                  name = fn;
+                  var src = extractSource(fiber);
+                  if (src) { file = src.file; line = src.line; col = src.column; }
+                } else if (!name && !fallback) {
+                  fallback = fn;
+                }
+                if (!seen[fn]) { seen[fn] = 1; chain.push(fn); }
+              }
+            }
+            depth++;
+            fiber = fiber.return;
+          }
+          if (!name) name = fallback;
+          if (name) {
+            if (!file && resolvedSources[name]) {
+              file = resolvedSources[name].file || resolvedSources[name];
+              line = resolvedSources[name].line || 1;
+            }
+            componentMap.set(el, { name: name, chain: chain, file: file, line: line, column: col });
+            count++;
+            if (!file && !unresolvedNames[name]) unresolvedNames[name] = 1;
+          }
+          continue;
+        }
+        if (el.__vue__) {
+          var opts = el.__vue__.$options;
+          var vn = opts.name || opts._componentTag;
+          if (vn && vn[0] === vn[0].toUpperCase()) {
+            componentMap.set(el, { name: vn, chain: [vn], file: opts.__file || null, line: 1, column: null });
+            count++;
+            if (!opts.__file && !unresolvedNames[vn]) unresolvedNames[vn] = 1;
+          }
+          continue;
+        }
+        if (el.__vueParentComponent) {
+          var vt = el.__vueParentComponent.type;
+          var v3 = vt && (vt.name || vt.__name);
+          if (v3 && v3[0] === v3[0].toUpperCase()) {
+            componentMap.set(el, { name: v3, chain: [v3], file: vt.__file || null, line: 1, column: null });
+            count++;
+            if (!vt.__file && !unresolvedNames[v3]) unresolvedNames[v3] = 1;
+          }
+          continue;
+        }
+        if (el.__svelte_meta && el.__svelte_meta.loc) {
+          var loc = el.__svelte_meta.loc;
+          var sn = (loc.file || '').split('/').pop().replace(/\\.svelte$/, '');
+          if (sn && sn[0] === sn[0].toUpperCase()) {
+            componentMap.set(el, { name: sn, chain: [sn], file: loc.file, line: loc.line, column: loc.column });
+            count++;
+          }
+          continue;
+        }
+      }
+      mapBuilt = true;
+      console.log('[Design] Component map built:', count, 'elements mapped');
+      var names = Object.keys(unresolvedNames);
+      if (names.length > 0) {
+        console.log('[Design] Requesting resolution for', names.length, 'components without source');
+        post('component-list', { names: names });
+      }
+    }
+
+    function mapLookup(el) {
+      if (!componentMap) return null;
+      var node = el;
+      var depth = 0;
+      while (node && node !== document.body && depth < 20) {
+        var entry = componentMap.get(node);
+        if (entry) {
+          if (!entry.file && resolvedSources[entry.name]) {
+            entry.file = resolvedSources[entry.name].file || resolvedSources[entry.name];
+            entry.line = resolvedSources[entry.name].line || 1;
+          }
+          return entry;
+        }
+        node = node.parentElement;
+        depth++;
+      }
+      return null;
+    }
+
+    // Returns true if name should be treated as a user component
+    function isUserName(name, origin) {
+      // Whitelist loaded: trust it — if name passed isLibName, it's in the whitelist
+      if (userComponents) return true;
+      // No whitelist: rely on fiber origin
+      if (origin === 'user') return true;
+      if (origin === 'lib') return false;
+      // Unknown origin, no whitelist — include as fallback
+      return true;
+    }
+
+    function componentName(el) {
+      var entry = mapLookup(el);
+      if (entry) return entry.name;
+      var fk = fiberKey(el);
+      if (!fk) return null;
+      var fiber = el[fk];
+      var depth = 0;
+      var fallback = null;
+      while (fiber && depth < 30) {
+        var name = fiberName(fiber);
+        if (name && name !== 'anon' && name.length > 1 && name[0] === name[0].toUpperCase() && !isLibName(name)) {
+          var origin = fiberOrigin(fiber);
+          if (origin === 'user') return name;
+          if (isUserName(name, origin) && !fallback) fallback = name;
+        }
+        depth++;
+        fiber = fiber.return;
+      }
+      return fallback;
+    }
+
+    // Collect full component ancestry: [nearest, ..., outermost]
+    function componentAncestry(el) {
+      var entry = mapLookup(el);
+      if (entry) return entry.chain;
+      var fk = fiberKey(el);
+      if (!fk) return [];
+      var fiber = el[fk];
+      var depth = 0;
+      var result = [];
+      var seen = {};
+      while (fiber && depth < 40) {
+        var name = fiberName(fiber);
+        if (name && name !== 'anon' && name.length > 1 && name[0] === name[0].toUpperCase() && !isLibName(name)) {
+          var origin = fiberOrigin(fiber);
+          if (isUserName(name, origin) && !seen[name]) {
+            seen[name] = 1;
+            result.push(name);
+          }
+        }
+        depth++;
+        fiber = fiber.return;
+      }
+      return result;
+    }
+
+    function fiberDebugKeys(fiber) {
+      if (!fiber) return {};
+      var out = {};
+      var all = Object.getOwnPropertyNames(fiber);
+      for (var i = 0; i < all.length; i++) {
+        var k = all[i];
+        if (k.indexOf('debug') !== -1 || k.indexOf('Debug') !== -1) {
+          var v = fiber[k];
+          if (v === null) out[k] = 'null';
+          else if (v === undefined) out[k] = 'undefined';
+          else if (typeof v === 'string') out[k] = v.slice(0, 300);
+          else if (typeof v === 'object' && v.stack) out[k] = '[Error] ' + String(v.stack).slice(0, 300);
+          else out[k] = typeof v;
+        }
+      }
+      return out;
+    }
+
+    function findSource(el) {
+      var entry = mapLookup(el);
+      if (entry && entry.file) {
+        return { file: entry.file, line: entry.line, column: entry.column, component: entry.name, _debug: ['map'] };
+      }
+      var log = [];
+
+      var tag = el.tagName.toLowerCase();
+      var cls = el.className && typeof el.className === 'string' ? el.className.trim() : '';
+      log.push('[Design] Clicked element: <' + tag + (cls ? ' class="' + cls.split(/[ \t]+/).slice(0,3).join(' ') + '"' : '') + '>');
+
+      var debugLines = [];
+
+      // 0. Check data-source-file attribute (some build tools inject this)
+      var srcAttr = el.getAttribute('data-source-file');
+      if (srcAttr) {
+        log.push('[Design] FOUND data-source-file: ' + srcAttr);
+        var parts = srcAttr.split(':');
+        postDebugLog(log);
+        return {
+          file: stripPath(parts[0]),
+          line: parts[1] ? parseInt(parts[1], 10) : 1,
+          column: parts[2] ? parseInt(parts[2], 10) : undefined,
+          component: componentName(el),
+          _debug: debugLines
+        };
+      }
+
+      // 1. React: find fiber on this DOM element, walk UP the fiber tree
+      var keys = Object.keys(el);
+      var reactKey = fiberKey(el);
+
+      // Helper: try to extract a user-code source from a single fiber node
+      function tryFiber(fb) {
+        if (fb._debugSource) {
+          var raw = fb._debugSource.fileName;
+          if (hasLibraryIndicator(raw)) {
+            log.push('[Design]   _debugSource raw skipped: ' + raw);
+          } else {
+            var f = stripPath(raw);
+            if (!shouldSkip(f)) return { file: f, line: fb._debugSource.lineNumber, column: fb._debugSource.columnNumber, component: fiberName(fb) };
+            log.push('[Design]   _debugSource skipped: ' + f);
+          }
+        }
+        if (fb._debugOwner && fb._debugOwner._debugSource) {
+          var owRaw = fb._debugOwner._debugSource.fileName;
+          if (hasLibraryIndicator(owRaw)) {
+            log.push('[Design]   _debugOwner._debugSource raw skipped: ' + owRaw);
+          } else {
+            var owf = stripPath(owRaw);
+            if (!shouldSkip(owf)) return { file: owf, line: fb._debugOwner._debugSource.lineNumber, column: fb._debugOwner._debugSource.columnNumber, component: fiberName(fb) || fiberName(fb._debugOwner) };
+            log.push('[Design]   _debugOwner._debugSource skipped: ' + owf);
+          }
+        }
+        if (fb._debugStack) {
+          var p = parseStack(fb._debugStack);
+          if (p && !shouldSkip(p.file)) { if (!p.component) p.component = fiberName(fb); return p; }
+          if (p) log.push('[Design]   _debugStack skipped: ' + p.file);
+        }
+        if (fb._debugOwner && fb._debugOwner._debugStack) {
+          var ows = parseStack(fb._debugOwner._debugStack);
+          if (ows && !shouldSkip(ows.file)) { if (!ows.component) ows.component = fiberName(fb._debugOwner) || fiberName(fb); return ows; }
+          if (ows) log.push('[Design]   _debugOwner._debugStack skipped: ' + ows.file);
+        }
+        if (fb._debugInfo && Array.isArray(fb._debugInfo)) {
+          for (var di = 0; di < fb._debugInfo.length; di++) {
+            var entry = fb._debugInfo[di];
+            if (entry && entry.owner && entry.owner._debugSource) {
+              var df = stripPath(entry.owner._debugSource.fileName);
+              if (!shouldSkip(df)) return { file: df, line: entry.owner._debugSource.lineNumber, column: entry.owner._debugSource.columnNumber, component: entry.owner.name || entry.name || fiberName(fb) };
+              log.push('[Design]   _debugInfo[' + di + '] skipped: ' + df);
+            }
+            if (entry && entry.owner && entry.owner._debugStack) {
+              var ip = parseStack(entry.owner._debugStack);
+              if (ip && !shouldSkip(ip.file)) { if (!ip.component) ip.component = entry.owner.name || entry.name; return ip; }
+            }
+          }
+        }
+        return null;
+      }
+
+      if (reactKey) {
+        log.push('[Design] Fiber key found: ' + reactKey);
+        log.push('[Design] Walking fiber tree:');
+        var fiber = el[reactKey];
+        var depth = 0;
+        var fallbackSrc = null;
+
+        while (fiber && depth < 30) {
+          var typeName = fiberName(fiber) || (typeof fiber.type === 'string' ? fiber.type : '?');
+          log.push('[Design]   depth=' + depth + ' type=' + typeName);
+          debugLines.push('d' + depth + ':' + typeName);
+
+          var src = tryFiber(fiber);
+          if (src) {
+            var origin = fiberOrigin(fiber);
+            var userComp = componentName(el);
+            src.component = userComp || src.component;
+            src._debug = debugLines;
+            if (origin === 'user') {
+              log.push('[Design]   FOUND user source: ' + src.file + ':' + src.line + ' component=' + src.component);
+              postDebugLog(log);
+              return src;
+            }
+            if (!fallbackSrc) {
+              fallbackSrc = src;
+              log.push('[Design]   stashed non-user source: ' + src.file + ':' + src.line + ' origin=' + origin);
+            }
+          }
+
+          depth++;
+          fiber = fiber.return;
+        }
+        if (fallbackSrc) {
+          log.push('[Design]   returning fallback source: ' + fallbackSrc.file);
+          postDebugLog(log);
+          return fallbackSrc;
+        }
+        log.push('[Design]   Fiber walk exhausted at depth=' + depth + ', no source found');
+      } else {
+        log.push('[Design] No fiber key found on element — checking for React keys: ' + keys.filter(function(k){ return k.startsWith('__react'); }).join(', '));
+        debugLines.push('no-fiber:' + el.tagName);
+      }
+
+      // 2. Try parent DOM elements
+      var node = el.parentElement;
+      var pd = 0;
+      while (node && node !== document.body && node !== document.documentElement && pd < 10) {
+        var pkeys = Object.keys(node);
+        for (var j = 0; j < pkeys.length; j++) {
+          if (pkeys[j].startsWith('__reactFiber$') || pkeys[j].startsWith('__reactInternalInstance$')) {
+            var pfiber = node[pkeys[j]];
+            while (pfiber) {
+              var psrc = tryFiber(pfiber);
+              if (psrc) {
+                var pcomp = componentName(el);
+                psrc.component = pcomp || psrc.component;
+                psrc._debug = debugLines;
+                log.push('[Design]   FOUND via parent DOM: ' + psrc.file + ':' + psrc.line);
+                postDebugLog(log);
+                return psrc;
+              }
+              pfiber = pfiber.return;
+            }
+            break;
+          }
+        }
+        pd++;
+        node = node.parentElement;
+      }
+
+      // 3. Vue
+      node = el;
+      while (node && node !== document.body) {
+        if (node.__vue__) {
+          var opts = node.__vue__.$options;
+          if (opts && opts.__file) {
+            log.push('[Design] FOUND Vue __file: ' + opts.__file);
+            postDebugLog(log);
+            return { file: opts.__file, line: 1, _debug: debugLines };
+          }
+        }
+        if (node.__vueParentComponent) {
+          var vtype = node.__vueParentComponent.type;
+          if (vtype && vtype.__file) {
+            log.push('[Design] FOUND Vue __vueParentComponent.__file: ' + vtype.__file);
+            postDebugLog(log);
+            return { file: vtype.__file, line: 1, _debug: debugLines };
+          }
+        }
+        node = node.parentElement;
+      }
+
+      // 4. Svelte
+      node = el;
+      while (node && node !== document.body) {
+        if (node.__svelte_meta) {
+          var loc = node.__svelte_meta.loc;
+          if (loc) {
+            log.push('[Design] FOUND Svelte __svelte_meta: ' + loc.file + ':' + loc.line);
+            postDebugLog(log);
+            return { file: loc.file, line: loc.line, column: loc.column, _debug: debugLines };
+          }
+        }
+        node = node.parentElement;
+      }
+
+      log.push('[Design] No source found anywhere');
+      postDebugLog(log);
+      return { _debug: debugLines };
+    }
+
+    function postDebugLog(lines) {
+      try {
+        var ti = window.__TAURI_INTERNALS__;
+        if (ti && ti.invoke) {
+          ti.invoke('design_bridge', { event: 'design:debug-source', payload: JSON.stringify({ log: lines }) }).catch(function() {});
+        }
+      } catch(e) {}
+    }
+
+    function framework() {
+      if (window.__NEXT_DATA__) return 'nextjs';
+      if (window.__NUXT__ || document.querySelector('[data-v-]')) return 'vue';
+      if (document.querySelector('[class*="svelte-"]')) return 'svelte';
+      return null;
+    }
+
+    function searchHint(el) {
+      var hints = [];
+      // data-testid is a strong, unique identifier
+      var testid = el.getAttribute('data-testid');
+      if (testid) hints.push(testid);
+      // data-source-file (some tooling adds this)
+      var srcFile = el.getAttribute('data-source-file');
+      if (srcFile) hints.push(srcFile);
+      // React component name is a great search term
+      var comp = componentName(el);
+      if (comp) hints.push(comp);
+      // aria-label often contains unique text
+      var aria = el.getAttribute('aria-label');
+      if (aria && aria.length > 2) hints.push(aria);
+      if (el.id) hints.push('#' + el.id);
+      if (el.className && typeof el.className === 'string') {
+        var cls = el.className.trim().split(/\\s+/);
+        for (var i = 0; i < Math.min(cls.length, 3); i++) {
+          if (cls[i] && cls[i].length > 2) hints.push(cls[i]);
+        }
+      }
+      var text = directText(el);
+      if (text && text.length > 3) hints.push(text);
+      return hints.length ? hints : undefined;
+    }
+
+    var STYLE_KEYS = [
+      'display','position','width','height','margin','padding',
+      'color','backgroundColor','fontSize','fontWeight',
+      'border','borderRadius','flexDirection','alignItems',
+      'justifyContent','gap','opacity','overflow','zIndex','boxShadow'
+    ];
+    var NOISE = {'none':1,'normal':1,'auto':1,'0px':1,'rgba(0, 0, 0, 0)':1,'start':1,'stretch':1,'':1,'visible':1,'static':1,'1':1};
+
+    function styles(el) {
+      var cs = window.getComputedStyle(el);
+      var out = {};
+      for (var i = 0; i < STYLE_KEYS.length; i++) {
+        var k = STYLE_KEYS[i];
+        var v = cs[k];
+        if (v && !NOISE[v]) out[k] = v;
+      }
+      return out;
+    }
+
+    function directText(el) {
+      // Get only the element's own text nodes, not deep children
+      var parts = [];
+      for (var i = 0; i < el.childNodes.length; i++) {
+        if (el.childNodes[i].nodeType === 3) {
+          var t = el.childNodes[i].textContent.trim();
+          if (t) parts.push(t);
+        }
+      }
+      if (parts.length) return parts.join(' ').slice(0, 60);
+      // Fall back to innerText if no direct text nodes but element is a leaf
+      if (el.children.length === 0 && el.textContent) return el.textContent.trim().slice(0, 60);
+      return null;
+    }
+
+    function info(el) {
+      var rect = el.getBoundingClientRect();
+      var src = findSource(el);
+      var comp = src && src.component ? src.component : componentName(el);
+      var text = directText(el);
+      var ancestors = componentAncestry(el);
+      return {
+        tag: el.tagName.toLowerCase(),
+        id: el.id || undefined,
+        classes: el.className && typeof el.className === 'string' ? el.className.trim() || undefined : undefined,
+        component: comp || undefined,
+        textContent: text || undefined,
+        ancestry: ancestors.length > 0 ? ancestors : undefined,
+        summary: comp ? analyzeChildren(el) : undefined,
+        path: domPath(el),
+        rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+        computedStyles: styles(el),
+        source: src,
+        searchHint: searchHint(el),
+        framework: framework()
+      };
+    }
+
+    var currentEl = null;
+    var currentInfo = null;
+    var hoverEl = null;
+    var hoverX = 0;
+    var hoverY = 0;
+    var hoverFrame = 0;
+    var inspectMode = true;
+    document.body.style.cursor = 'crosshair';
+
+    function readInfo(el, force) {
+      if (!el) return null;
+      if (!force && currentEl === el && currentInfo) {
+        var rect = el.getBoundingClientRect();
+        currentInfo.rect = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        return currentInfo;
+      }
+      currentInfo = info(el);
+      return currentInfo;
+    }
+
+    function selectElement(el) {
+      hideCommentBox();
+      currentEl = el;
+      currentInfo = readInfo(el, true);
+      showOverlay(el, selected);
+      positionCommentBtn(el);
+      return currentInfo;
+    }
+
+    function applyHover() {
+      hoverFrame = 0;
+      if (!inspectMode) {
+        hoverEl = null;
+        overlay.style.display = 'none';
+        label.style.display = 'none';
+        return;
+      }
+      var el = document.elementFromPoint(hoverX, hoverY);
+      if (!el || isOverlay(el)) {
+        hoverEl = null;
+        overlay.style.display = 'none';
+        label.style.display = 'none';
+        return;
+      }
+      if (el === hoverEl) return;
+      hoverEl = el;
+      showOverlay(el, overlay);
+      showLabel(el);
+    }
+
+    function post(type, payload) {
+      try {
+        var data = JSON.stringify(payload || {});
+        var ti = window.__TAURI_INTERNALS__;
+        if (ti && ti.invoke) {
+          ti.invoke('design_bridge', { event: 'design:' + type, payload: data }).catch(function() {});
+          return;
+        }
+        var ev = window.__TAURI__ && window.__TAURI__.event;
+        if (ev && ev.emit) {
+          ev.emit('design:' + type, data).catch(function() {});
+        }
+      } catch(e) {}
+    }
+
+    // Exposed for main webview to call via eval_design_webview
+    window.__opencode_set_inspect_mode = function(enabled) {
+      inspectMode = !!enabled;
+      if (!inspectMode) {
+        hoverEl = null;
+        overlay.style.display = 'none';
+        selected.style.display = 'none';
+        label.style.display = 'none';
+        commentBtn.style.display = 'none';
+        hideCommentBox(false);
+        document.body.style.cursor = '';
+      } else {
+        document.body.style.cursor = 'crosshair';
+        if (currentEl) {
+          showOverlay(currentEl, selected);
+          positionCommentBtn(currentEl);
+          if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+        }
+      }
+    };
+
+    window.__opencode_clear_selection = function() {
+      currentEl = null;
+      currentInfo = null;
+      hoverEl = null;
+      selected.style.display = 'none';
+      overlay.style.display = 'none';
+      label.style.display = 'none';
+      commentBtn.style.display = 'none';
+      hideCommentBox();
+    };
+
+
+
+    window.__opencode_set_user_components = function(names) {
+      if (!names || !names.length) {
+        userComponents = null;
+        console.log('[Design] User component whitelist cleared');
+        buildComponentMap();
+        return;
+      }
+      userComponents = {};
+      for (var i = 0; i < names.length; i++) userComponents[names[i]] = 1;
+      console.log('[Design] User component whitelist set:', names.length, 'components');
+      buildComponentMap();
+    };
+
+    window.__opencode_resolve_sources = function(map) {
+      if (!map) return;
+      var keys = Object.keys(map);
+      for (var i = 0; i < keys.length; i++) {
+        resolvedSources[keys[i]] = map[keys[i]];
+        delete unresolvedNames[keys[i]];
+      }
+      if (currentEl) currentInfo = info(currentEl);
+      console.log('[Design] Resolved', keys.length, 'component sources from main webview');
+    };
+
+    window.__opencode_rebuild_map = function() {
+      buildComponentMap();
+      if (currentEl) currentInfo = info(currentEl);
+    };
+
+    window.__opencode_sync = function() {
+      if (!inspectMode) return;
+      if (currentEl) {
+        currentInfo = info(currentEl);
+        showOverlay(currentEl, selected);
+        positionCommentBtn(currentEl);
+        if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+      }
+      if (hoverEl) {
+        showOverlay(hoverEl, overlay);
+        showLabel(hoverEl);
+      }
+    };
+
+
+    var mapTimer;
+    var mapObserver = new MutationObserver(function(mutations) {
+      var dominated = false;
+      for (var i = 0; i < mutations.length; i++) {
+        if (mutations[i].addedNodes.length || mutations[i].removedNodes.length) { dominated = true; break; }
+      }
+      if (!dominated) return;
+      clearTimeout(mapTimer);
+      mapTimer = setTimeout(buildComponentMap, 1500);
+    });
+    mapObserver.observe(document.body, { childList: true, subtree: true });
+
+    setTimeout(buildComponentMap, 1500);
+
+    function showOverlay(el, target) {
+      var rect = el.getBoundingClientRect();
+      target.style.left = rect.left + 'px';
+      target.style.top = rect.top + 'px';
+      target.style.width = rect.width + 'px';
+      target.style.height = rect.height + 'px';
+      target.style.display = 'block';
+    }
+
+    function showLabel(el) {
+      var rect = el.getBoundingClientRect();
+      var tag = el.tagName.toLowerCase();
+      var comp = componentName(el);
+      var text = '';
+      if (comp) {
+        text = '<' + comp + '>';
+        if (tag !== comp.toLowerCase()) text += ' ' + tag;
+      } else {
+        text = '<' + tag;
+        if (el.id) text += '#' + el.id;
+        if (el.className && typeof el.className === 'string') {
+          var cls = el.className.trim().split(/\\s+/).slice(0, 2).join('.');
+          if (cls) text += '.' + cls;
+        }
+        text += '>';
+      }
+      label.textContent = text;
+      label.style.left = rect.left + 'px';
+      label.style.top = Math.max(0, rect.top - 22) + 'px';
+      label.style.display = 'block';
+    }
+
+    function positionCommentBtn(el) {
+      if (!inspectMode) return;
+      var rect = el.getBoundingClientRect();
+      var left = rect.right + 6;
+      if (left + 32 > window.innerWidth) left = Math.max(4, rect.left - 34);
+      var top = Math.min(Math.max(4, rect.top), window.innerHeight - 32);
+      commentBtn.style.left = left + 'px';
+      commentBtn.style.top = top + 'px';
+      commentBtn.style.display = 'flex';
+      commentBtn.style.alignItems = 'center';
+      commentBtn.style.justifyContent = 'center';
+    }
+
+    function hideCommentBox(clear) {
+      commentBox.style.display = 'none';
+      commentBox.style.visibility = 'hidden';
+      if (clear !== false) commentInput.value = '';
+    }
+
+    function positionCommentBox(el) {
+      if (!el) return;
+      commentBox.style.display = 'block';
+      commentBox.style.visibility = 'hidden';
+      commentBox.style.left = '8px';
+      commentBox.style.top = '8px';
+
+      var rect = el.getBoundingClientRect();
+      var width = commentBox.offsetWidth || 320;
+      var height = commentBox.offsetHeight || 170;
+      var left = rect.right + 12;
+      if (left + width > window.innerWidth - 8) left = rect.left - width - 12;
+      if (left < 8) left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.left));
+      var top = rect.top;
+      if (top + height > window.innerHeight - 8) top = window.innerHeight - height - 8;
+      if (top < 8) top = 8;
+
+      commentBox.style.left = left + 'px';
+      commentBox.style.top = top + 'px';
+      commentBox.style.visibility = 'visible';
+    }
+
+    function commentLabel(el) {
+      var data = readInfo(el);
+      var comp = data.component || (data.source && data.source.component);
+      var label = 'Commenting on ' + (comp ? '<' + comp + '>' : '<' + data.tag + '>');
+      if (!data.source || !data.source.file) return label;
+      var file = stripPath(data.source.file).split('/').pop();
+      return label + ' · ' + file + ':' + (data.source.line || 1);
+    }
+
+    function showCommentBox(el) {
+      if (!el) return;
+      commentMeta.textContent = commentLabel(el);
+      positionCommentBox(el);
+      requestAnimationFrame(function() {
+        commentInput.focus();
+      });
+    }
+
+    function submitComment() {
+      if (!currentEl) return;
+      var comment = commentInput.value.trim();
+      if (!comment) return;
+      var data = readInfo(currentEl);
+      if (!data) return;
+      post('comment-submit', { comment: comment, info: data });
+      hideCommentBox();
+    }
+
+    commentInput.addEventListener('keydown', function(e) {
+      e.stopPropagation();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        hideCommentBox();
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        submitComment();
+      }
+    });
+
+    commentCancel.addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    commentCancel.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      hideCommentBox();
+    });
+
+    commentSubmit.addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    commentSubmit.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      submitComment();
+    });
+
+    // "+" click → open inline comment editor in the preview itself
+    commentBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!currentEl) return;
+      showCommentBox(currentEl);
+    });
+
+    document.addEventListener('mousemove', function(e) {
+      hoverX = e.clientX;
+      hoverY = e.clientY;
+      if (hoverFrame) return;
+      hoverFrame = requestAnimationFrame(applyHover);
+    }, true);
+
+    document.addEventListener('mouseleave', function() {
+      hoverEl = null;
+      overlay.style.display = 'none';
+      label.style.display = 'none';
+    }, true);
+
+    // Hide hover overlay on scroll, reposition selected overlay
+    var scrollTimer;
+    window.addEventListener('scroll', function() {
+      hoverEl = null;
+      overlay.style.display = 'none';
+      label.style.display = 'none';
+      if (inspectMode && currentEl) {
+        clearTimeout(scrollTimer);
+        scrollTimer = setTimeout(function() {
+          if (inspectMode && currentEl) {
+            showOverlay(currentEl, selected);
+            positionCommentBtn(currentEl);
+            if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+          }
+        }, 50);
+      }
+    }, true);
+
+    // Reposition selected overlay + comment button on window resize
+    window.addEventListener('resize', function() {
+      if (inspectMode && currentEl) {
+        showOverlay(currentEl, selected);
+        positionCommentBtn(currentEl);
+        if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+      }
+    });
+
+    document.addEventListener('click', function(e) {
+      if (!inspectMode) return;
+      var el = document.elementFromPoint(e.clientX, e.clientY);
+      if (!el || isOverlay(el)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+
+      post('element-select', selectElement(el));
+    }, true);
+
+    // Exposed for main webview to call via eval_design_webview
+    window.__opencode_apply_styles = function(styles) {
+      if (currentEl && styles) {
+        Object.assign(currentEl.style, styles);
+        currentInfo = info(currentEl);
+        showOverlay(currentEl, selected);
+      }
+    };
+
+    window.__opencode_select_element = function(selector) {
+      var target = document.querySelector(selector);
+      if (!target || isOverlay(target)) return;
+      var data = selectElement(target);
+      showLabel(target);
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      post('element-select', data);
+    };
+  }
+
+  function boot() {
+    if (document.body) {
+      init();
+      // Re-dispatch events that animations/intersection observers may depend on
+      try {
+        document.dispatchEvent(new Event('visibilitychange'));
+        window.dispatchEvent(new Event('load'));
+      } catch(e) {}
+    } else {
+      document.addEventListener('DOMContentLoaded', function() {
+        init();
+        try {
+          document.dispatchEvent(new Event('visibilitychange'));
+          window.dispatchEvent(new Event('load'));
+        } catch(e) {}
+      });
+    }
+  }
+
+  boot();
+})();
+`
+}

--- a/packages/app/src/components/design-preview/injection.ts
+++ b/packages/app/src/components/design-preview/injection.ts
@@ -30,6 +30,15 @@ export function createInjectionScript(): string {
     commentBtn.addEventListener('mouseleave', function() { commentBtn.style.background = '#7c3aed'; commentBtn.style.borderColor = '#7c3aed'; });
     document.body.appendChild(commentBtn);
 
+    var openBtn = document.createElement('button');
+    openBtn.id = '__opencode_open_btn';
+    openBtn.textContent = 'Open';
+    openBtn.style.cssText = 'position:fixed;z-index:2147483647;display:none;align-items:center;justify-content:center;height:28px;min-width:46px;border-radius:6px;border:2px solid rgba(255,255,255,0.16);background:rgba(17,17,17,0.94);color:#ffffff;cursor:pointer;padding:0 8px;box-sizing:border-box;box-shadow:0 2px 10px rgba(0,0,0,0.5);transition:background 0.1s,border-color 0.1s;font:600 11px/1 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;white-space:nowrap;appearance:none;-webkit-appearance:none;';
+    openBtn.title = 'Open';
+    openBtn.addEventListener('mouseenter', function() { openBtn.style.background = '#27272a'; openBtn.style.borderColor = 'rgba(255,255,255,0.28)'; });
+    openBtn.addEventListener('mouseleave', function() { openBtn.style.background = 'rgba(17,17,17,0.94)'; openBtn.style.borderColor = 'rgba(255,255,255,0.16)'; });
+    document.body.appendChild(openBtn);
+
     var commentBox = document.createElement('div');
     commentBox.id = '__opencode_comment_box';
     commentBox.style.cssText = 'position:fixed;z-index:2147483647;display:none;width:320px;max-width:calc(100vw - 16px);border-radius:14px;border:1px solid rgba(255,255,255,0.08);background:rgba(23,23,23,0.98);box-shadow:0 16px 48px rgba(0,0,0,0.45);padding:8px;box-sizing:border-box;';
@@ -61,7 +70,7 @@ export function createInjectionScript(): string {
     commentActions.appendChild(commentSubmit);
 
     function isOverlay(el) {
-      return el === overlay || el === selected || el === label || el === commentBtn || el === commentBox || (el && el.closest && (el.closest('#__opencode_comment_btn') || el.closest('#__opencode_comment_box')));
+      return el === overlay || el === selected || el === label || el === commentBtn || el === openBtn || el === commentBox || (el && el.closest && (el.closest('#__opencode_comment_btn') || el.closest('#__opencode_open_btn') || el.closest('#__opencode_comment_box')));
     }
 
     function domPath(el) {
@@ -836,6 +845,7 @@ export function createInjectionScript(): string {
     var hoverX = 0;
     var hoverY = 0;
     var hoverFrame = 0;
+    var syncFrame = 0;
     var inspectMode = true;
     document.body.style.cursor = 'crosshair';
 
@@ -854,9 +864,24 @@ export function createInjectionScript(): string {
       hideCommentBox();
       currentEl = el;
       currentInfo = readInfo(el, true);
-      showOverlay(el, selected);
-      positionCommentBtn(el);
+      syncSelection();
       return currentInfo;
+    }
+
+    function syncSelection() {
+      if (!inspectMode || !currentEl) return;
+      currentInfo = readInfo(currentEl);
+      showOverlay(currentEl, selected);
+      positionActionBtns(currentEl);
+      if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+    }
+
+    function queueSelection() {
+      if (syncFrame) return;
+      syncFrame = requestAnimationFrame(function() {
+        syncFrame = 0;
+        syncSelection();
+      });
     }
 
     function applyHover() {
@@ -898,24 +923,21 @@ export function createInjectionScript(): string {
     // Exposed for main webview to call via eval_design_webview
     window.__opencode_set_inspect_mode = function(enabled) {
       inspectMode = !!enabled;
-      if (!inspectMode) {
-        hoverEl = null;
-        overlay.style.display = 'none';
-        selected.style.display = 'none';
-        label.style.display = 'none';
-        commentBtn.style.display = 'none';
-        hideCommentBox(false);
-        document.body.style.cursor = '';
-      } else {
-        document.body.style.cursor = 'crosshair';
-        if (mapDirty || !mapBuilt) queueMap();
-        if (currentEl) {
-          showOverlay(currentEl, selected);
-          positionCommentBtn(currentEl);
-          if (commentBox.style.display === 'block') positionCommentBox(currentEl);
+        if (!inspectMode) {
+          hoverEl = null;
+          overlay.style.display = 'none';
+          selected.style.display = 'none';
+          label.style.display = 'none';
+          commentBtn.style.display = 'none';
+          openBtn.style.display = 'none';
+          hideCommentBox(false);
+          document.body.style.cursor = '';
+        } else {
+          document.body.style.cursor = 'crosshair';
+          if (mapDirty || !mapBuilt) queueMap();
+          syncSelection();
         }
-      }
-    };
+      };
 
     window.__opencode_clear_selection = function() {
       currentEl = null;
@@ -925,6 +947,9 @@ export function createInjectionScript(): string {
       overlay.style.display = 'none';
       label.style.display = 'none';
       commentBtn.style.display = 'none';
+      openBtn.style.display = 'none';
+      if (syncFrame) cancelAnimationFrame(syncFrame);
+      syncFrame = 0;
       hideCommentBox();
     };
 
@@ -950,7 +975,10 @@ export function createInjectionScript(): string {
         resolvedSources[keys[i]] = map[keys[i]];
         delete unresolvedNames[keys[i]];
       }
-      if (currentEl) currentInfo = info(currentEl);
+      if (currentEl) {
+        currentInfo = readInfo(currentEl, true);
+        queueSelection();
+      }
       console.log('[Design] Resolved', keys.length, 'component sources from main webview');
     };
 
@@ -961,12 +989,7 @@ export function createInjectionScript(): string {
 
     window.__opencode_sync = function() {
       if (!inspectMode) return;
-      if (currentEl) {
-        currentInfo = readInfo(currentEl);
-        showOverlay(currentEl, selected);
-        positionCommentBtn(currentEl);
-        if (commentBox.style.display === 'block') positionCommentBox(currentEl);
-      }
+      syncSelection();
       if (hoverEl) {
         showOverlay(hoverEl, overlay);
         showLabel(hoverEl);
@@ -1018,17 +1041,26 @@ export function createInjectionScript(): string {
       label.style.display = 'block';
     }
 
-    function positionCommentBtn(el) {
+    function positionActionBtns(el) {
       if (!inspectMode) return;
       var rect = el.getBoundingClientRect();
-      var left = rect.right + 6;
-      if (left + 32 > window.innerWidth) left = Math.max(4, rect.left - 34);
-      var top = Math.min(Math.max(4, rect.top), window.innerHeight - 32);
+      var pad = 4;
+      var gap = 6;
+      var size = 28;
+      var wide = Math.max(46, openBtn.offsetWidth || 46);
+      var total = size + gap + wide;
+      var left = Math.min(Math.max(pad, rect.right - total), Math.max(pad, window.innerWidth - total - pad));
+      var top = rect.top - size - gap;
+      if (top < pad) top = rect.top + gap;
+      top = Math.min(Math.max(pad, top), Math.max(pad, window.innerHeight - size - pad));
       commentBtn.style.left = left + 'px';
       commentBtn.style.top = top + 'px';
       commentBtn.style.display = 'flex';
       commentBtn.style.alignItems = 'center';
       commentBtn.style.justifyContent = 'center';
+      openBtn.style.left = (left + size + gap) + 'px';
+      openBtn.style.top = top + 'px';
+      openBtn.style.display = 'flex';
     }
 
     function hideCommentBox(clear) {
@@ -1128,6 +1160,15 @@ export function createInjectionScript(): string {
       showCommentBox(currentEl);
     });
 
+    openBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!currentEl) return;
+      var data = readInfo(currentEl, true);
+      if (!data) return;
+      post('open-selected', data);
+    });
+
     document.addEventListener('mousemove', function(e) {
       hoverX = e.clientX;
       hoverY = e.clientY;
@@ -1141,31 +1182,17 @@ export function createInjectionScript(): string {
       label.style.display = 'none';
     }, true);
 
-    // Hide hover overlay on scroll, reposition selected overlay
-    var scrollTimer;
+    // Hide hover overlay on scroll, reposition selected overlay immediately
     window.addEventListener('scroll', function() {
       hoverEl = null;
       overlay.style.display = 'none';
       label.style.display = 'none';
-      if (inspectMode && currentEl) {
-        clearTimeout(scrollTimer);
-        scrollTimer = setTimeout(function() {
-          if (inspectMode && currentEl) {
-            showOverlay(currentEl, selected);
-            positionCommentBtn(currentEl);
-            if (commentBox.style.display === 'block') positionCommentBox(currentEl);
-          }
-        }, 50);
-      }
+      queueSelection();
     }, true);
 
     // Reposition selected overlay + comment button on window resize
     window.addEventListener('resize', function() {
-      if (inspectMode && currentEl) {
-        showOverlay(currentEl, selected);
-        positionCommentBtn(currentEl);
-        if (commentBox.style.display === 'block') positionCommentBox(currentEl);
-      }
+      queueSelection();
     });
 
     document.addEventListener('click', function(e) {
@@ -1185,7 +1212,7 @@ export function createInjectionScript(): string {
       if (currentEl && styles) {
         Object.assign(currentEl.style, styles);
         currentInfo = info(currentEl);
-        showOverlay(currentEl, selected);
+        syncSelection();
       }
     };
 

--- a/packages/app/src/components/design-preview/injection.ts
+++ b/packages/app/src/components/design-preview/injection.ts
@@ -240,6 +240,10 @@ export function createInjectionScript(): string {
     var resolvedSources = {};
     var unresolvedNames = {};
     var mapBuilt = false;
+    var mapDirty = true;
+    var mapTimer = 0;
+    var mapIdle = 0;
+    var mapSync = false;
 
     function fiberKey(el) {
       var keys = Object.keys(el);
@@ -318,7 +322,7 @@ export function createInjectionScript(): string {
     }
 
     function buildComponentMap() {
-      if (!componentMap) return;
+      if (!componentMap || !document.body) return;
       unresolvedNames = {};
       var count = 0;
       var walker = document.createTreeWalker(document.body, 1);
@@ -403,6 +407,42 @@ export function createInjectionScript(): string {
         console.log('[Design] Requesting resolution for', names.length, 'components without source');
         post('component-list', { names: names });
       }
+    }
+
+    function runMap() {
+      mapTimer = 0;
+      mapIdle = 0;
+      if (!mapDirty || !componentMap || !document.body) return;
+      if (!inspectMode && mapBuilt) return;
+      mapDirty = false;
+      buildComponentMap();
+      if (!currentEl) {
+        mapSync = false;
+        return;
+      }
+      currentInfo = info(currentEl);
+      if (!mapSync) return;
+      mapSync = false;
+      post('element-select', currentInfo);
+    }
+
+    function queueMap(delay) {
+      if (!componentMap) return;
+      mapDirty = true;
+      if (!inspectMode && mapBuilt) return;
+      if (mapTimer) clearTimeout(mapTimer);
+      if (mapIdle && window.cancelIdleCallback) {
+        window.cancelIdleCallback(mapIdle);
+        mapIdle = 0;
+      }
+      mapTimer = setTimeout(function() {
+        mapTimer = 0;
+        if (window.requestIdleCallback) {
+          mapIdle = window.requestIdleCallback(runMap, { timeout: 500 });
+          return;
+        }
+        runMap();
+      }, delay || 0);
     }
 
     function mapLookup(el) {
@@ -868,6 +908,7 @@ export function createInjectionScript(): string {
         document.body.style.cursor = '';
       } else {
         document.body.style.cursor = 'crosshair';
+        if (mapDirty || !mapBuilt) queueMap();
         if (currentEl) {
           showOverlay(currentEl, selected);
           positionCommentBtn(currentEl);
@@ -893,13 +934,13 @@ export function createInjectionScript(): string {
       if (!names || !names.length) {
         userComponents = null;
         console.log('[Design] User component whitelist cleared');
-        buildComponentMap();
+        queueMap();
         return;
       }
       userComponents = {};
       for (var i = 0; i < names.length; i++) userComponents[names[i]] = 1;
       console.log('[Design] User component whitelist set:', names.length, 'components');
-      buildComponentMap();
+      queueMap();
     };
 
     window.__opencode_resolve_sources = function(map) {
@@ -914,14 +955,14 @@ export function createInjectionScript(): string {
     };
 
     window.__opencode_rebuild_map = function() {
-      buildComponentMap();
-      if (currentEl) currentInfo = info(currentEl);
+      mapSync = true;
+      queueMap();
     };
 
     window.__opencode_sync = function() {
       if (!inspectMode) return;
       if (currentEl) {
-        currentInfo = info(currentEl);
+        currentInfo = readInfo(currentEl);
         showOverlay(currentEl, selected);
         positionCommentBtn(currentEl);
         if (commentBox.style.display === 'block') positionCommentBox(currentEl);
@@ -933,19 +974,17 @@ export function createInjectionScript(): string {
     };
 
 
-    var mapTimer;
     var mapObserver = new MutationObserver(function(mutations) {
       var dominated = false;
       for (var i = 0; i < mutations.length; i++) {
         if (mutations[i].addedNodes.length || mutations[i].removedNodes.length) { dominated = true; break; }
       }
       if (!dominated) return;
-      clearTimeout(mapTimer);
-      mapTimer = setTimeout(buildComponentMap, 1500);
+      queueMap(1500);
     });
     mapObserver.observe(document.body, { childList: true, subtree: true });
 
-    setTimeout(buildComponentMap, 1500);
+    queueMap(1500);
 
     function showOverlay(el, target) {
       var rect = el.getBoundingClientRect();

--- a/packages/app/src/components/design-preview/pick-classes.ts
+++ b/packages/app/src/components/design-preview/pick-classes.ts
@@ -1,0 +1,37 @@
+export function pickClasses(classes: string | undefined): string[] {
+  if (!classes) return []
+  const parts = classes
+    .trim()
+    .split(/\s+/)
+    .map((c) => c.replace(/^(?:[^:]+:)+/, ""))
+    .filter((c) => {
+      if (!c || c.length < 3) return false
+      if (/^(hover|focus|active|disabled|dark)$/.test(c)) return false
+      if (
+        /^(flex(?:-(?:1|auto|none|col|row|wrap))?|grid|block|inline(?:-block|-flex)?|hidden|contents|relative|absolute|fixed|sticky|container|group|peer|truncate)$/.test(
+          c,
+        )
+      )
+        return false
+      if (/^(bg|text|border|ring|fill|stroke)-(transparent|current|inherit|white|black)$/.test(c)) return false
+      if (/^(w|h|min-w|min-h|max-w|max-h)-(?:\d|px|full|auto|screen|min|max|fit|\[|\d+\/\d+)/.test(c)) return false
+      if (/^(p|m)[trblxy]?-(?:\d+|px|auto|\[[^\]]+\])$/.test(c)) return false
+      if (/^gap-(?:\d+|px|\[[^\]]+\])$/.test(c)) return false
+      if (/^(text-(?:xs|sm|base|lg|xl|[2-9]xl|left|center|right)|font-(?:normal|medium|semibold|bold))$/.test(c))
+        return false
+      if (
+        /^(rounded(?:-[a-z0-9]+)?|border(?:-[trblxy])?(?:-\d+)?|shadow(?:-[a-z]+)?|overflow-(?:hidden|auto|scroll|visible)|items-(?:start|center|end|stretch)|justify-(?:start|center|end|between|around|evenly)|cursor-(?:pointer|default|not-allowed)|opacity-(?:0|25|50|75|100)|transition(?:-[a-z-]+)?|duration-\d+|ease-(?:linear|in|out|in-out)|min-(?:w|h)-0|max-(?:w|h)-full|z-(?:\d+|auto)|(?:top|bottom|left|right|inset)-(?:0|px|full|auto|\[[^\]]+\])|whitespace-(?:nowrap|pre)|list-(?:none|disc|decimal)|pointer-events-(?:none|auto)|select-(?:none|text|all)|appearance-none|outline-none|ring-0|sr-only|not-sr-only)$/.test(
+          c,
+        )
+      )
+        return false
+      if (
+        /^(text|bg|border)-(gray|red|blue|green|yellow|purple|pink|indigo|orange|teal|cyan|emerald|violet|rose|lime|sky|amber|fuchsia|slate|zinc|neutral|stone)-\d+$/.test(
+          c,
+        )
+      )
+        return false
+      return true
+    })
+  return parts.sort((a, b) => b.length - a.length).slice(0, 3)
+}

--- a/packages/app/src/components/design-preview/resolve.ts
+++ b/packages/app/src/components/design-preview/resolve.ts
@@ -1,10 +1,23 @@
 import { pickClasses } from "./pick-classes"
 
+const SCORE = {
+  index: 0.95,
+  tag: 0.9,
+  definition: 0.88,
+  usage: 0.65,
+  text: 0.05,
+  grep: 0.35,
+} as const
+
 export type Hit = {
   file: string
   line: number
   comp?: string
   owner?: string
+  origin?: string
+  score?: number
+  ambiguous?: boolean
+  candidates?: Array<{ file: string; line: number; component?: string; owner?: string }>
 }
 
 type Match = {
@@ -211,7 +224,8 @@ export function createResolver(files: Files, client: Client) {
           file,
           line: chosen.line,
           comp,
-          score: chosen.score,
+          origin: "tag",
+          score: chosen.score > 0 ? Math.min(0.95, SCORE.tag + Math.min(0.05, chosen.score * 0.005)) : SCORE.tag,
         }
         if (cur !== rev) return null
         tagCache.set(key, hit)
@@ -228,7 +242,7 @@ export function createResolver(files: Files, client: Client) {
   const findTag = async (input: string, comp: string, opts?: TagOpts): Promise<Hit | null> => {
     const hit = await scanTag(input, comp, opts)
     if (!hit) return null
-    return { file: hit.file, line: hit.line, comp: hit.comp }
+    return { file: hit.file, line: hit.line, comp: hit.comp, origin: "tag", score: hit.score ?? SCORE.tag }
   }
 
   const findTagInFiles = async (inputs: string[], comp: string, opts?: TagOpts): Promise<Hit | null> => {
@@ -243,7 +257,7 @@ export function createResolver(files: Files, client: Client) {
       if (!best || hit.score > best.score) best = hit
     }
     if (!best) return null
-    return { file: best.file, line: best.line, comp: best.comp }
+    return { file: best.file, line: best.line, comp: best.comp, origin: "tag", score: best.score ?? SCORE.tag }
   }
 
   const findDefinition = async (comp: string): Promise<Hit | null> => {
@@ -269,7 +283,22 @@ export function createResolver(files: Files, client: Client) {
         const match = exact ?? user[0]
         if (!match?.path.text) continue
 
-        const hit = { file: match.path.text, line: match.line_number ?? 1, comp }
+        const hit = {
+          file: match.path.text,
+          line: match.line_number ?? 1,
+          comp,
+          origin: "definition",
+          score: SCORE.definition,
+          ambiguous: user.length > 1,
+          candidates:
+            user.length > 1
+              ? user.slice(0, 5).map((item) => ({
+                  file: item.path.text,
+                  line: item.line_number ?? 1,
+                  component: comp,
+                }))
+              : undefined,
+        }
         defCache.set(comp, hit)
         console.log("[Design] Found definition of", comp, "at:", match.path.text, "line:", hit.line, "via:", pattern)
         return hit
@@ -299,7 +328,13 @@ export function createResolver(files: Files, client: Client) {
             useCache.set(comp, null)
             return null
           }
-          const hit = { file: match.path.text, line: match.line_number ?? 1, comp }
+          const hit = {
+            file: match.path.text,
+            line: match.line_number ?? 1,
+            comp,
+            origin: "usage",
+            score: SCORE.usage,
+          }
           useCache.set(comp, hit)
           console.log("[Design] Found usage of <" + comp + "> at:", match.path.text, "line:", hit.line)
           return hit
@@ -334,7 +369,12 @@ export function createResolver(files: Files, client: Client) {
             textCache.set(text, null)
             return null
           }
-          const hit = { file: match.path.text, line: match.line_number ?? 1 }
+          const hit = {
+            file: match.path.text,
+            line: match.line_number ?? 1,
+            origin: "text",
+            score: SCORE.text,
+          }
           textCache.set(text, hit)
           console.log("[Design] Found by text content:", match.path.text, "line:", match.line_number)
           return hit
@@ -381,7 +421,12 @@ export function createResolver(files: Files, client: Client) {
       const match = hits.find((m) => isUserFile(m.path.text))
       if (!match?.path.text) continue
       console.log("[Design] grep fallback found:", match.path.text, "via term:", pattern)
-      return { file: match.path.text, line: match.line_number ?? 1 }
+      return {
+        file: match.path.text,
+        line: match.line_number ?? 1,
+        origin: "grep",
+        score: SCORE.grep,
+      }
     }
 
     return null

--- a/packages/app/src/components/design-preview/resolve.ts
+++ b/packages/app/src/components/design-preview/resolve.ts
@@ -4,6 +4,7 @@ export type Hit = {
   file: string
   line: number
   comp?: string
+  owner?: string
 }
 
 type Match = {
@@ -13,6 +14,15 @@ type Match = {
 
 type Files = {
   normalize(input: string): string
+  load(input: string): Promise<void>
+  get(input: string):
+    | {
+        content?: {
+          type: string
+          content?: string
+        }
+      }
+    | undefined
 }
 
 type Client = {
@@ -24,9 +34,20 @@ type Client = {
 type Info = {
   component?: string
   source?: { component?: string }
+  definition?: { component?: string }
   textContent?: string
   searchHint?: string[]
   classes?: string
+}
+
+type TagOpts = {
+  text?: string
+  search?: string[]
+  classes?: string
+}
+
+type TagHit = Hit & {
+  score: number
 }
 
 export function createResolver(files: Files, client: Client) {
@@ -36,7 +57,13 @@ export function createResolver(files: Files, client: Client) {
   const defRun = new Map<string, Promise<Hit | null>>()
   const useCache = new Map<string, Hit | null>()
   const useRun = new Map<string, Promise<Hit | null>>()
+  const fileCache = new Map<string, string | null>()
+  const fileRun = new Map<string, Promise<string | null>>()
+  const tagCache = new Map<string, TagHit | null>()
+  const tagRun = new Map<string, Promise<TagHit | null>>()
   let rev = 0
+
+  const escape = (input: string) => input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 
   const normalizePath = (file: string) => {
     return files.normalize(
@@ -89,6 +116,134 @@ export function createResolver(files: Files, client: Client) {
     if (name === "index") return true
     if (["page", "layout", "template", "loading", "error", "not-found"].includes(name)) return true
     return false
+  }
+
+  const readText = async (input: string) => {
+    const file = normalizePath(input)
+    if (fileCache.has(file)) return fileCache.get(file) ?? null
+    const pending = fileRun.get(file)
+    if (pending) return pending
+    const cur = rev
+    const run = files
+      .load(file)
+      .then(() => {
+        if (cur !== rev) return null
+        const content = files.get(file)?.content
+        const text = content?.type === "text" && typeof content.content === "string" ? content.content : null
+        fileCache.set(file, text)
+        return text
+      })
+      .catch(() => {
+        if (cur !== rev) return null
+        fileCache.set(file, null)
+        return null
+      })
+      .finally(() => {
+        fileRun.delete(file)
+      })
+    fileRun.set(file, run)
+    return run
+  }
+
+  const scanTag = async (input: string, comp: string, opts?: TagOpts): Promise<TagHit | null> => {
+    const file = normalizePath(input)
+    const terms = [
+      opts?.text?.trim(),
+      ...(opts?.search ?? []).map((item) => (item.startsWith("#") ? item.slice(1) : item).trim()),
+      ...pickClasses(opts?.classes),
+    ].filter((item, idx, all): item is string => !!item && item.length > 1 && all.indexOf(item) === idx)
+    const key = `${file}\n${comp}\n${terms.join("\n")}`
+    if (tagCache.has(key)) return tagCache.get(key) ?? null
+    const pending = tagRun.get(key)
+    if (pending) return pending
+    const cur = rev
+    const run = readText(file)
+      .then((text) => {
+        if (cur !== rev) return null
+        if (!text) {
+          tagCache.set(key, null)
+          return null
+        }
+        const out: { index: number; line: number }[] = []
+        const re = new RegExp(`<${escape(comp)}(?=[\\s>/])`, "g")
+        let line = 1
+        let last = 0
+        let match: RegExpExecArray | null
+        while ((match = re.exec(text))) {
+          line += text.slice(last, match.index).split("\n").length - 1
+          out.push({ index: match.index, line })
+          last = match.index
+          if (match.index === re.lastIndex) re.lastIndex++
+        }
+        if (!out.length) {
+          if (cur !== rev) return null
+          tagCache.set(key, null)
+          return null
+        }
+        const focus = opts?.text?.trim()?.toLowerCase()
+        const score = (item: { index: number; line: number }) => {
+          const open = text.indexOf(">", item.index)
+          const end =
+            open === -1
+              ? Math.min(text.length, item.index + 1600)
+              : /\/\>\s*$/.test(text.slice(item.index, open + 1))
+                ? open + 1
+                : (() => {
+                    const close = text.indexOf(`</${comp}>`, open + 1)
+                    return close === -1 ? Math.min(text.length, item.index + 1600) : close + comp.length + 3
+                  })()
+          const area = text.slice(item.index, end).toLowerCase()
+          return terms.reduce((sum, term) => {
+            const low = term.toLowerCase()
+            if (!area.includes(low)) return sum
+            return sum + (low === focus ? 8 : low.length > 4 ? 3 : 2)
+          }, 0)
+        }
+        const chosen = out.slice(1).reduce<{ index: number; line: number; score: number }>(
+          (best, item) => {
+            const next = score(item)
+            if (next > best.score) return { ...item, score: next }
+            return best
+          },
+          { ...out[0], score: score(out[0]) },
+        )
+        const hit = {
+          file,
+          line: chosen.line,
+          comp,
+          score: chosen.score,
+        }
+        if (cur !== rev) return null
+        tagCache.set(key, hit)
+        console.log("[Design] Found <" + comp + "> in:", file, "line:", hit.line)
+        return hit
+      })
+      .finally(() => {
+        tagRun.delete(key)
+      })
+    tagRun.set(key, run)
+    return run
+  }
+
+  const findTag = async (input: string, comp: string, opts?: TagOpts): Promise<Hit | null> => {
+    const hit = await scanTag(input, comp, opts)
+    if (!hit) return null
+    return { file: hit.file, line: hit.line, comp: hit.comp }
+  }
+
+  const findTagInFiles = async (inputs: string[], comp: string, opts?: TagOpts): Promise<Hit | null> => {
+    const seen = new Set<string>()
+    let best: TagHit | null = null
+    for (const input of inputs) {
+      const file = normalizePath(input)
+      if (seen.has(file)) continue
+      seen.add(file)
+      const hit = await scanTag(file, comp, opts)
+      if (!hit) continue
+      if (!best || hit.score > best.score) best = hit
+    }
+    if (!best) return null
+    return { file: best.file, line: best.line, comp: best.comp }
   }
 
   const findDefinition = async (comp: string): Promise<Hit | null> => {
@@ -198,12 +353,12 @@ export function createResolver(files: Files, client: Client) {
   }
 
   const grepFallback = async (info: Info): Promise<Hit | null> => {
-    const comp = info.component ?? info.source?.component
+    const comp = info.component ?? info.source?.component ?? info.definition?.component
     if (comp) {
-      const def = await findDefinition(comp)
-      if (def) return def
       const use = await findUsage(comp)
       if (use) return use
+      const def = await findDefinition(comp)
+      if (def) return def
     }
     if (info.textContent) {
       const text = await findByText(info.textContent)
@@ -240,12 +395,18 @@ export function createResolver(files: Files, client: Client) {
     defRun.clear()
     useCache.clear()
     useRun.clear()
+    fileCache.clear()
+    fileRun.clear()
+    tagCache.clear()
+    tagRun.clear()
   }
 
   return {
     normalizePath,
     isSourceFile,
     fileDefinesComponent,
+    findTag,
+    findTagInFiles,
     findDefinition,
     findUsage,
     grepFallback,

--- a/packages/app/src/components/design-preview/resolve.ts
+++ b/packages/app/src/components/design-preview/resolve.ts
@@ -1,0 +1,254 @@
+import { pickClasses } from "./pick-classes"
+
+export type Hit = {
+  file: string
+  line: number
+  comp?: string
+}
+
+type Match = {
+  path: { text: string }
+  line_number?: number | null
+}
+
+type Files = {
+  normalize(input: string): string
+}
+
+type Client = {
+  find: {
+    text(input: { pattern: string }): Promise<{ data?: Match[] }>
+  }
+}
+
+type Info = {
+  component?: string
+  source?: { component?: string }
+  textContent?: string
+  searchHint?: string[]
+  classes?: string
+}
+
+export function createResolver(files: Files, client: Client) {
+  const textCache = new Map<string, Hit | null>()
+  const textRun = new Map<string, Promise<Hit | null>>()
+  const defCache = new Map<string, Hit | null>()
+  const defRun = new Map<string, Promise<Hit | null>>()
+  const useCache = new Map<string, Hit | null>()
+  const useRun = new Map<string, Promise<Hit | null>>()
+  let rev = 0
+
+  const normalizePath = (file: string) => {
+    return files.normalize(
+      file
+        .replace(/^https?:\/\/[^/]+\//, "")
+        .replace(/^turbopack:\/\/\[project\]\//, "")
+        .replace(/^webpack-internal:\/\/\/\.?\//, "")
+        .replace(/^webpack:\/\/\/\.?\//, "")
+        .replace(/^webpack:\/\/[^/]*\/\.?\//, "")
+        .replace(/^\(.*?\)\/\.?\//, "")
+        .replace(/^\/@fs/, "")
+        .replace(/^\/@(id|vite)\//, "")
+        .replace(/\\/g, "/"),
+    )
+  }
+
+  const isSourceFile = (path: string) => {
+    const name = path.split("/").pop() ?? ""
+    if (path.includes("node_modules/") || path.includes("node_modules\\")) return false
+    if (path.includes(".vite/deps/") || path.includes(".vite/chunks/")) return false
+    if (path.includes(".pnpm/") || path.includes(".yarn/cache")) return false
+    if (/^[0-9a-f]{4,}\.(js|mjs)$/.test(name)) return false
+    if (/\.[0-9a-f]{6,}\.(js|mjs)$/.test(name)) return false
+    if (/^(main|app|vendor|framework|commons|webpack|polyfills?)-[0-9a-f]+\.(js|mjs)$/.test(name)) return false
+    if (path.includes("static/chunks/") || path.includes("_next/") || path.includes(".next/")) return false
+    if (path.includes("/build/static/")) return false
+    if (/\.(tsx?|jsx?|vue|svelte|astro|html)$/.test(name)) return true
+    if (/\.(js|mjs)$/.test(name) && (path.includes("/dist/") || path.includes("/build/"))) return false
+    return true
+  }
+
+  const isUserFile = (path: string) => {
+    return (
+      !path.includes("node_modules/") &&
+      !path.includes("node_modules\\") &&
+      !path.includes(".vite/deps/") &&
+      !path.includes(".vite/chunks/") &&
+      !path.includes(".pnpm/") &&
+      !path.includes(".yarn/cache") &&
+      /\.(tsx|jsx|ts|js|vue|svelte|html)$/.test(path)
+    )
+  }
+
+  const fileDefinesComponent = (file: string, comp: string) => {
+    if (!comp) return true
+    const name = (file.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
+    const low = comp.toLowerCase()
+    if (name.toLowerCase() === low) return true
+    if (name.toLowerCase().replace(/[-_]/g, "") === low) return true
+    if (name === "index") return true
+    if (["page", "layout", "template", "loading", "error", "not-found"].includes(name)) return true
+    return false
+  }
+
+  const findDefinition = async (comp: string): Promise<Hit | null> => {
+    if (defCache.has(comp)) return defCache.get(comp) ?? null
+    const pending = defRun.get(comp)
+    if (pending) return pending
+    const patterns = [`function ${comp}`, `const ${comp}`, `export default function ${comp}`, `export function ${comp}`]
+    const cur = rev
+    const run = (async () => {
+      for (const pattern of patterns) {
+        const res = await client.find.text({ pattern }).catch(() => null)
+        if (cur !== rev) return null
+        const hits = res?.data ?? []
+        if (!hits.length) continue
+
+        const user = hits.filter((m) => isUserFile(m.path.text))
+        const exact = user.find((m) => {
+          const file = (m.path.text.split("/").pop() ?? "").replace(/\.(tsx?|jsx?|vue|svelte)$/, "")
+          return (
+            file.toLowerCase() === comp.toLowerCase() || file.toLowerCase().replace(/[-_]/g, "") === comp.toLowerCase()
+          )
+        })
+        const match = exact ?? user[0]
+        if (!match?.path.text) continue
+
+        const hit = { file: match.path.text, line: match.line_number ?? 1, comp }
+        defCache.set(comp, hit)
+        console.log("[Design] Found definition of", comp, "at:", match.path.text, "line:", hit.line, "via:", pattern)
+        return hit
+      }
+      defCache.set(comp, null)
+      return null
+    })().finally(() => {
+      defRun.delete(comp)
+    })
+    defRun.set(comp, run)
+    return run
+  }
+
+  const findUsage = async (comp: string): Promise<Hit | null> => {
+    if (useCache.has(comp)) return useCache.get(comp) ?? null
+    const pending = useRun.get(comp)
+    if (pending) return pending
+    const cur = rev
+    const run = client.find
+      .text({ pattern: `<${comp}` })
+      .then(
+        (res) => {
+          if (cur !== rev) return null
+          const hits = res.data ?? []
+          const match = hits.filter((m) => isUserFile(m.path.text))[0]
+          if (!match?.path.text) {
+            useCache.set(comp, null)
+            return null
+          }
+          const hit = { file: match.path.text, line: match.line_number ?? 1, comp }
+          useCache.set(comp, hit)
+          console.log("[Design] Found usage of <" + comp + "> at:", match.path.text, "line:", hit.line)
+          return hit
+        },
+        () => {
+          if (cur !== rev) return null
+          useCache.set(comp, null)
+          return null
+        },
+      )
+      .finally(() => {
+        useRun.delete(comp)
+      })
+    useRun.set(comp, run)
+    return run
+  }
+
+  const findByText = async (text: string): Promise<Hit | null> => {
+    if (!text || text.length < 4) return null
+    if (textCache.has(text)) return textCache.get(text) ?? null
+    const pending = textRun.get(text)
+    if (pending) return pending
+    const cur = rev
+    const run = client.find
+      .text({ pattern: text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") })
+      .then(
+        (res) => {
+          if (cur !== rev) return null
+          const hits = res.data ?? []
+          const match = hits.find((m) => isUserFile(m.path.text))
+          if (!match?.path.text) {
+            textCache.set(text, null)
+            return null
+          }
+          const hit = { file: match.path.text, line: match.line_number ?? 1 }
+          textCache.set(text, hit)
+          console.log("[Design] Found by text content:", match.path.text, "line:", match.line_number)
+          return hit
+        },
+        () => {
+          if (cur !== rev) return null
+          textCache.set(text, null)
+          return null
+        },
+      )
+      .finally(() => {
+        textRun.delete(text)
+      })
+    textRun.set(text, run)
+    return run
+  }
+
+  const grepFallback = async (info: Info): Promise<Hit | null> => {
+    const comp = info.component ?? info.source?.component
+    if (comp) {
+      const def = await findDefinition(comp)
+      if (def) return def
+      const use = await findUsage(comp)
+      if (use) return use
+    }
+    if (info.textContent) {
+      const text = await findByText(info.textContent)
+      if (text) return text
+    }
+
+    const terms: string[] = []
+    for (const name of info.searchHint ?? []) {
+      if (name.startsWith("#")) continue
+      if (name.length > 2 && !terms.includes(name)) terms.push(name)
+    }
+    for (const name of pickClasses(info.classes)) {
+      if (!terms.includes(name)) terms.push(name)
+    }
+    if (!terms.length) return null
+
+    for (const pattern of terms) {
+      const res = await client.find.text({ pattern }).catch(() => null)
+      const hits = res?.data ?? []
+      const match = hits.find((m) => isUserFile(m.path.text))
+      if (!match?.path.text) continue
+      console.log("[Design] grep fallback found:", match.path.text, "via term:", pattern)
+      return { file: match.path.text, line: match.line_number ?? 1 }
+    }
+
+    return null
+  }
+
+  const reset = () => {
+    rev++
+    textCache.clear()
+    textRun.clear()
+    defCache.clear()
+    defRun.clear()
+    useCache.clear()
+    useRun.clear()
+  }
+
+  return {
+    normalizePath,
+    isSourceFile,
+    fileDefinesComponent,
+    findDefinition,
+    findUsage,
+    grepFallback,
+    reset,
+  }
+}

--- a/packages/app/src/components/design-preview/source.ts
+++ b/packages/app/src/components/design-preview/source.ts
@@ -1,0 +1,64 @@
+export type Level = "high" | "medium" | "low" | "none"
+
+export type SourceLoc = {
+  file?: string
+  line?: number
+  column?: number
+  component?: string
+  owner?: string
+  origin?: string
+  confidence?: Level
+  score?: number
+  ambiguous?: boolean
+  candidates?: Array<{ file: string; line: number; component?: string; owner?: string }>
+  _debug?: string[]
+}
+
+type Info = {
+  source?: SourceLoc
+  definition?: SourceLoc
+}
+
+export const value = (lvl?: Level) => {
+  if (lvl === "high") return 0.9
+  if (lvl === "medium") return 0.7
+  if (lvl === "low") return 0.4
+  return 0
+}
+
+export const grade = (score?: number): Level => {
+  const n = score ?? 0
+  if (n >= 0.85) return "high"
+  if (n >= 0.6) return "medium"
+  if (n >= 0.35) return "low"
+  return "none"
+}
+
+export const rank = (src?: SourceLoc) => {
+  if (!src) return 0
+  if (typeof src.score === "number") return src.score
+  if (src.confidence) return value(src.confidence)
+  if (src.file) return 0.7
+  return 0
+}
+
+export const state = (src?: SourceLoc): Level => {
+  return grade(rank(src))
+}
+
+export const mode = (src?: SourceLoc) => {
+  const n = rank(src)
+  if (n >= 0.85) return "direct" as const
+  if (n >= 0.6) return "confirm" as const
+  return "deny" as const
+}
+
+export const choose = (info: Info) => {
+  if (info.source?.file) return info.source
+  if (info.definition?.file) return info.definition
+  return info.source ?? info.definition
+}
+
+export const need = (info: Info, all: boolean) => {
+  return !info.source?.file && (!all || !info.definition?.file)
+}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -98,6 +98,7 @@ const EXAMPLES = [
 ] as const
 
 const NON_EMPTY_TEXT = /[^\s\u200B]/
+const mention = /(^|[\s([{"'])@(\S*)$/
 
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
@@ -895,11 +896,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const shellMode = store.mode === "shell"
 
     if (!shellMode) {
-      const atMatch = rawText.substring(0, cursorPosition).match(/@(\S*)$/)
+      const atMatch = rawText.substring(0, cursorPosition).match(mention)
       const slashMatch = rawText.match(/^\/(\S*)$/)
 
       if (atMatch) {
-        atOnInput(atMatch[1])
+        atOnInput(atMatch[2])
         setStore("popover", "at")
       } else if (slashMatch) {
         slashOnInput(slashMatch[1])
@@ -941,12 +942,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         .map((p) => ("content" in p ? p.content : ""))
         .join("")
       const textBeforeCursor = rawText.substring(0, cursorPosition)
-      const atMatch = textBeforeCursor.match(/@(\S*)$/)
+      const atMatch = textBeforeCursor.match(mention)
       const pill = createPill(part)
       const gap = document.createTextNode(" ")
 
       if (atMatch) {
-        const start = atMatch.index ?? cursorPosition - atMatch[0].length
+        const start = cursorPosition - ((atMatch[2]?.length ?? 0) + 1)
         setRangeEdge(editorRef, range, "start", start)
         setRangeEdge(editorRef, range, "end", cursorPosition)
       }

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -178,7 +178,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return diffs.some((diff) => diff.file === path)
   }
 
-  const openComment = (item: { path: string; commentID?: string; commentOrigin?: "review" | "file" }) => {
+  const openComment = (item: { path: string; commentID?: string; commentOrigin?: "review" | "file" | "design" }) => {
     if (!item.commentID) return
 
     const focus = { file: item.path, id: item.commentID }
@@ -201,7 +201,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       schedule(attempts)
     }
 
-    const wantsReview = item.commentOrigin === "review" || (item.commentOrigin !== "file" && commentInReview(item.path))
+    const wantsReview =
+      item.commentOrigin === "review" || (item.commentOrigin === undefined && commentInReview(item.path))
     if (wantsReview) {
       if (!view().reviewPanel.opened()) view().reviewPanel.open()
       layout.fileTree.setTab("changes")

--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -124,6 +124,152 @@ describe("buildRequestParts", () => {
     expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/shared.ts")).toBe(true)
   })
 
+  test("ignores non-file @mentions in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-non-file-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Please ask @alice and me@work.com before merging.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_non_file_mentions",
+      sessionID: "ses_comment_non_file_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(1)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+  })
+
+  test("adds dotfile @mentions in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-dotfile-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Please update @.prettierrc and @.nvmrc.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_dotfile_mentions",
+      sessionID: "ses_comment_dotfile_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(3)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/.prettierrc")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/.nvmrc")).toBe(true)
+  })
+
+  test("adds extensionless file @mentions in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-extensionless-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Sync @Gemfile with @Procfile before merging.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_extensionless_mentions",
+      sessionID: "ses_comment_extensionless_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(3)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/Gemfile")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/Procfile")).toBe(true)
+  })
+
+  test("adds BUILD and WORKSPACE @mentions in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-bazel-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Update @BUILD and @WORKSPACE together.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_bazel_mentions",
+      sessionID: "ses_comment_bazel_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(3)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/BUILD")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/WORKSPACE")).toBe(true)
+  })
+
+  test("adds Containerfile and Tiltfile @mentions in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-containerfile-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Please sync @Containerfile and @Tiltfile.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_containerfile_mentions",
+      sessionID: "ses_comment_containerfile_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(3)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/Containerfile")).toBe(true)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/Tiltfile")).toBe(true)
+  })
+
+  test("ignores plain words ending with file in comment text", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "text", content: "look", start: 0, end: 4 }],
+      context: [
+        {
+          key: "ctx:comment-profile-mention",
+          type: "file",
+          path: "src/review.ts",
+          comment: "Please ask @profile owner before merge.",
+        },
+      ],
+      images: [],
+      text: "look",
+      messageID: "msg_comment_profile_mentions",
+      sessionID: "ses_comment_profile_mentions",
+      sessionDirectory: "/repo",
+    })
+
+    const files = result.requestParts.filter((part) => part.type === "file")
+    expect(files).toHaveLength(1)
+    expect(files.some((part) => part.type === "file" && part.url === "file:///repo/src/review.ts")).toBe(true)
+  })
+
   test("handles Windows paths correctly (simulated on macOS)", () => {
     const prompt: Prompt = [{ type: "file", path: "src\\foo.ts", content: "@src\\foo.ts", start: 0, end: 11 }]
 

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -41,10 +41,49 @@ const fileQuery = (selection: FileSelection | undefined) =>
 
 const mention = /(^|[\s([{"'])@(\S+)/g
 
+const names = new Set([
+  "dockerfile",
+  "makefile",
+  "readme",
+  "license",
+  "codeowners",
+  "containerfile",
+  "gemfile",
+  "procfile",
+  "rakefile",
+  "tiltfile",
+  "podfile",
+  "vagrantfile",
+  "jenkinsfile",
+  "brewfile",
+  "justfile",
+  ".env",
+  ".gitignore",
+  ".npmrc",
+])
+
+const caps = new Set(["BUILD", "WORKSPACE"])
+
+const fileMention = (value: string) => {
+  if (!value) return false
+  if (value.startsWith("/") || value.startsWith("\\\\") || /^[A-Za-z]:([\\/]|$)/.test(value)) return true
+  if (value.startsWith("./") || value.startsWith("../") || value.startsWith(".\\") || value.startsWith("..\\"))
+    return true
+  if (value.includes("/") || value.includes("\\")) return true
+  const lower = value.toLowerCase()
+  if (names.has(lower)) return true
+  if (caps.has(value)) return true
+  if (lower.startsWith(".") && lower.length > 1 && !lower.endsWith(".")) return true
+  if (/^[A-Z][A-Za-z0-9._-]*file$/.test(value)) return true
+  const idx = lower.lastIndexOf(".")
+  if (idx > 0 && idx < lower.length - 1) return true
+  return false
+}
+
 const parseCommentMentions = (comment: string) => {
   return Array.from(comment.matchAll(mention)).flatMap((match) => {
     const path = (match[2] ?? "").replace(/[.,!?;:)}\]"']+$/, "")
-    if (!path) return []
+    if (!fileMention(path)) return []
     return [path]
   })
 }

--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -15,7 +15,7 @@ type ContextFile = {
   selection?: FileSelection
   comment?: string
   commentID?: string
-  commentOrigin?: "review" | "file"
+  commentOrigin?: "review" | "file" | "design"
   preview?: string
 }
 

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -11,7 +11,7 @@ export type PromptHistoryComment = {
   selection: SelectedLineRange
   comment: string
   time: number
-  origin?: "review" | "file"
+  origin?: "review" | "file" | "design"
   preview?: string
 }
 

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -193,7 +193,7 @@ type CommentItem = {
   selection?: FileSelection
   comment?: string
   commentID?: string
-  commentOrigin?: "review" | "file"
+  commentOrigin?: "review" | "file" | "design"
   preview?: string
 }
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -435,25 +435,6 @@ export function SessionHeader() {
                 </TooltipKeybind>
 
                 <div class="hidden md:flex items-center gap-1 shrink-0">
-                  <Tooltip placement="bottom" value="Design Preview">
-                    <Button
-                      variant="ghost"
-                      class="titlebar-icon w-8 h-6 p-0 box-border"
-                      onClick={() => layout.design.toggle()}
-                      aria-label="Design Preview"
-                      aria-expanded={layout.design.opened()}
-                    >
-                      <Icon
-                        size="small"
-                        name="eye"
-                        classList={{
-                          "text-icon-strong": layout.design.opened(),
-                          "text-icon-weak": !layout.design.opened(),
-                        }}
-                      />
-                    </Button>
-                  </Tooltip>
-
                   <TooltipKeybind
                     title={language.t("command.review.toggle")}
                     keybind={command.keybind("review.toggle")}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -435,6 +435,25 @@ export function SessionHeader() {
                 </TooltipKeybind>
 
                 <div class="hidden md:flex items-center gap-1 shrink-0">
+                  <Tooltip placement="bottom" value="Design Preview">
+                    <Button
+                      variant="ghost"
+                      class="titlebar-icon w-8 h-6 p-0 box-border"
+                      onClick={() => layout.design.toggle()}
+                      aria-label="Design Preview"
+                      aria-expanded={layout.design.opened()}
+                    >
+                      <Icon
+                        size="small"
+                        name="eye"
+                        classList={{
+                          "text-icon-strong": layout.design.opened(),
+                          "text-icon-weak": !layout.design.opened(),
+                        }}
+                      />
+                    </Button>
+                  </Tooltip>
+
                   <TooltipKeybind
                     title={language.t("command.review.toggle")}
                     keybind={command.keybind("review.toggle")}

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -241,6 +241,21 @@ export const SettingsGeneral: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.general.row.preview.title")}
+          description={language.t("settings.general.row.preview.description")}
+        >
+          <div data-action="settings-preview">
+            <Switch
+              checked={settings.general.previewEnabled()}
+              onChange={(checked) => {
+                settings.general.setPreviewEnabled(checked)
+                if (checked) settings.general.setPreviewPrompted(true)
+              }}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.general.row.reasoningSummaries.title")}
           description={language.t("settings.general.row.reasoningSummaries.description")}
         >

--- a/packages/app/src/context/design-comments.ts
+++ b/packages/app/src/context/design-comments.ts
@@ -1,0 +1,52 @@
+import { createStore } from "solid-js/store"
+import { createSimpleContext } from "@opencode-ai/ui/context"
+
+export type DesignComment = {
+  id: string
+  text: string
+  element: {
+    tag: string
+    classes?: string
+    path: string
+    rect: { x: number; y: number; width: number; height: number }
+  }
+  source?: { file: string; line: number; column?: number }
+  position: { x: number; y: number }
+}
+
+let seq = 0
+
+export const { use: useDesignComments, provider: DesignCommentsProvider } = createSimpleContext({
+  name: "DesignComments",
+  gate: false,
+  init: () => {
+    const [store, setStore] = createStore({
+      items: [] as DesignComment[],
+    })
+
+    const add = (input: Omit<DesignComment, "id">) => {
+      const id = `dc-${Date.now()}-${++seq}`
+      const comment: DesignComment = { ...input, id }
+      setStore("items", (prev) => [...prev, comment])
+      return comment
+    }
+
+    const remove = (id: string) => {
+      setStore("items", (prev) => prev.filter((c) => c.id !== id))
+    }
+
+    const update = (id: string, text: string) => {
+      setStore("items", (prev) =>
+        prev.map((c) => (c.id === id ? { ...c, text } : c)),
+      )
+    }
+
+    const clear = () => {
+      setStore("items", [])
+    }
+
+    const list = () => store.items
+
+    return { add, remove, update, clear, list }
+  },
+})

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -252,6 +252,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         session: {
           width: DEFAULT_SESSION_WIDTH,
         },
+        design: {
+          opened: false,
+          url: "",
+        },
         mobileSidebar: {
           opened: false,
         },
@@ -688,6 +692,38 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             return
           }
           setStore("session", "width", width)
+        },
+      },
+      design: {
+        opened: createMemo(() => store.design?.opened ?? false),
+        url: createMemo(() => store.design?.url ?? ""),
+        open() {
+          if (!store.design) {
+            setStore("design", { opened: true, url: "" })
+            return
+          }
+          setStore("design", "opened", true)
+        },
+        close() {
+          if (!store.design) {
+            setStore("design", { opened: false, url: "" })
+            return
+          }
+          setStore("design", "opened", false)
+        },
+        toggle() {
+          if (!store.design) {
+            setStore("design", { opened: true, url: "" })
+            return
+          }
+          setStore("design", "opened", (x) => !x)
+        },
+        setUrl(url: string) {
+          if (!store.design) {
+            setStore("design", { opened: false, url })
+            return
+          }
+          setStore("design", "url", url)
         },
       },
       mobileSidebar: {

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -87,6 +87,31 @@ export type Platform = {
 
   /** Read image from clipboard (desktop only) */
   readClipboardImage?(): Promise<File | null>
+
+  /** Create a native child webview for design preview (desktop only) */
+  createDesignWebview?(url: string, x: number, y: number, width: number, height: number, script?: string): Promise<void>
+
+  /** Resize/reposition the design preview webview (desktop only) */
+  resizeDesignWebview?(x: number, y: number, width: number, height: number): Promise<void>
+
+  /** Close/destroy the design preview webview (desktop only) */
+  closeDesignWebview?(): Promise<void>
+
+  /** Evaluate JS in the design preview webview (desktop only) */
+  evalDesignWebview?(script: string): Promise<void>
+
+  /** Build component file index for design preview (desktop only) */
+  buildDesignIndex?(root: string): Promise<string[]>
+
+  /** Update component file index for changed files (desktop only) */
+  updateDesignIndex?(root: string, paths: string[]): Promise<string[]>
+
+  /** Query the design index for a component or class match (desktop only) */
+  queryDesignIndex?(
+    root: string,
+    component: string | null,
+    classes: string[] | null,
+  ): Promise<{ file: string; line: number; confidence: number } | null>
 }
 
 export type DisplayBackend = "auto" | "wayland"

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -112,6 +112,13 @@ export type Platform = {
     component: string | null,
     classes: string[] | null,
   ): Promise<{ file: string; line: number; confidence: number } | null>
+
+  /** Query the design usage index for JSX callsite match (desktop only) */
+  queryDesignUsageIndex?(
+    root: string,
+    component: string,
+    owners: string[] | null,
+  ): Promise<{ file: string; line: number; owner?: string | null; confidence: number } | null>
 }
 
 export type DisplayBackend = "auto" | "wayland"

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -44,7 +44,7 @@ export type FileContextItem = {
   selection?: FileSelection
   comment?: string
   commentID?: string
-  commentOrigin?: "review" | "file"
+  commentOrigin?: "review" | "file" | "design"
   preview?: string
 }
 

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -22,6 +22,8 @@ export interface Settings {
   general: {
     autoSave: boolean
     releaseNotes: boolean
+    previewEnabled: boolean
+    previewPrompted: boolean
     followup: "queue" | "steer"
     showReasoningSummaries: boolean
     shellToolPartsExpanded: boolean
@@ -88,6 +90,8 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
+    previewEnabled: false,
+    previewPrompted: false,
     followup: "steer",
     showReasoningSummaries: false,
     shellToolPartsExpanded: false,
@@ -154,6 +158,14 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         releaseNotes: withFallback(() => store.general?.releaseNotes, defaultSettings.general.releaseNotes),
         setReleaseNotes(value: boolean) {
           setStore("general", "releaseNotes", value)
+        },
+        previewEnabled: withFallback(() => store.general?.previewEnabled, defaultSettings.general.previewEnabled),
+        setPreviewEnabled(value: boolean) {
+          setStore("general", "previewEnabled", value)
+        },
+        previewPrompted: withFallback(() => store.general?.previewPrompted, defaultSettings.general.previewPrompted),
+        setPreviewPrompted(value: boolean) {
+          setStore("general", "previewPrompted", value)
         },
         followup: withFallback(
           () => (store.general?.followup === "queue" ? "steer" : store.general?.followup),

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -522,6 +522,17 @@ export const dict = {
   "session.tab.session": "Session",
   "session.tab.review": "Review",
   "session.tab.context": "Context",
+  "session.tab.preview": "Preview",
+  "session.preview.prompt.title": "Are you building UI right now?",
+  "session.preview.prompt.description":
+    "Preview helps you inspect components, open source locations, and leave design comments while working on interface code.",
+  "session.preview.prompt.action.enable": "Enable preview",
+  "session.preview.prompt.action.notNow": "Not now",
+  "session.preview.disabled.title": "Preview is disabled",
+  "session.preview.disabled.description":
+    "Enable Preview to inspect UI elements directly from this session. You can change this later in Settings > General.",
+  "session.preview.disabled.action.enable": "Enable preview",
+  "session.preview.disabled.action.learn": "What is this?",
   "session.panel.reviewAndFiles": "Review and files",
   "session.review.filesChanged": "{{count}} Files Changed",
   "session.review.change.one": "Change",
@@ -755,6 +766,8 @@ export const dict = {
 
   "settings.general.row.releaseNotes.title": "Release notes",
   "settings.general.row.releaseNotes.description": "Show What's New popups after updates",
+  "settings.general.row.preview.title": "Preview panel",
+  "settings.general.row.preview.description": "Enable the always-on Preview tab for UI inspection",
 
   "settings.updates.row.startup.title": "Check for updates on startup",
   "settings.updates.row.startup.description": "Automatically check for updates when OpenCode launches",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -43,6 +43,7 @@ import { useTerminal } from "@/context/terminal"
 import { type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
 import { createSessionComposerState, SessionComposerRegion } from "@/pages/session/composer"
 import {
+  DESIGN_TAB,
   createOpenReviewFile,
   createSessionTabs,
   createSizing,
@@ -57,7 +58,6 @@ import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
-import { DesignPreview } from "@/components/design-preview"
 import { Identifier } from "@/utils/id"
 import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
@@ -441,6 +441,8 @@ export default function Page() {
     normalizeTab,
     review: reviewTab,
     hasReview: canReview,
+    special: [DESIGN_TAB],
+    closableSpecial: [],
   })
   const contextOpen = tabState.contextOpen
   const openedTabs = tabState.openedTabs
@@ -1936,7 +1938,7 @@ export default function Page() {
           }}
         >
           <div class="flex-1 min-h-0 overflow-hidden relative">
-            <div class="size-full" style={{ display: layout.design.opened() ? "none" : undefined }}>
+            <div class="size-full">
               <Switch>
                 <Match when={params.id}>
                   <Show when={messagesReady()}>
@@ -1987,29 +1989,6 @@ export default function Page() {
                 </Match>
               </Switch>
             </div>
-            <Show when={layout.design.opened()}>
-              <DesignPreview
-                onOpenFile={(path, line) => {
-                  console.log("[Design] session.onOpenFile called:", path, "line:", line)
-                  const tab = file.tab(path)
-                  const range: SelectedLineRange = { start: line, end: line }
-                  tabs().open(tab)
-                  tabs().setActive(tab)
-                  file.setSelectedLines(path, range)
-                  void file.load(path).then(() => file.setSelectedLines(path, range))
-                  if (!view().reviewPanel.opened()) view().reviewPanel.open()
-                  layout.fileTree.setTab("all")
-                }}
-                onComment={(input) => {
-                  addCommentToContext({
-                    file: input.file,
-                    selection: { start: input.line, end: input.line },
-                    comment: input.comment,
-                    origin: "design",
-                  })
-                }}
-              />
-            </Show>
           </div>
 
           <SessionComposerRegion
@@ -2090,6 +2069,14 @@ export default function Page() {
           focusReviewDiff={focusReviewDiff}
           reviewSnap={ui.reviewSnap}
           size={size}
+          onDesignComment={(input) => {
+            addCommentToContext({
+              file: input.file,
+              selection: { start: input.line, end: input.line },
+              comment: input.comment,
+              origin: "design",
+            })
+          }}
         />
       </div>
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -57,6 +57,7 @@ import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
+import { DesignPreview } from "@/components/design-preview"
 import { Identifier } from "@/utils/id"
 import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
@@ -964,7 +965,7 @@ export default function Page() {
     selection: SelectedLineRange
     comment: string
     preview?: string
-    origin?: "review" | "file"
+    origin?: "review" | "file" | "design"
   }) => {
     const selection = selectionFromLines(input.selection)
     const preview = input.preview ?? selectionPreview(input.file, selection)
@@ -1934,56 +1935,81 @@ export default function Page() {
             width: sessionPanelWidth(),
           }}
         >
-          <div class="flex-1 min-h-0 overflow-hidden">
-            <Switch>
-              <Match when={params.id}>
-                <Show when={messagesReady()}>
-                  <MessageTimeline
-                    mobileChanges={mobileChanges()}
-                    mobileFallback={reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-8",
-                        header: "px-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                    actions={actions}
-                    scroll={ui.scroll}
-                    onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
-                    onScheduleScrollState={scheduleScrollState}
-                    onAutoScrollHandleScroll={autoScroll.handleScroll}
-                    onMarkScrollGesture={markScrollGesture}
-                    hasScrollGesture={hasScrollGesture}
-                    onUserScroll={markUserScroll}
-                    onTurnBackfillScroll={historyWindow.onScrollerScroll}
-                    onAutoScrollInteraction={autoScroll.handleInteraction}
-                    centered={centered()}
-                    setContentRef={(el) => {
-                      content = el
-                      autoScroll.contentRef(el)
+          <div class="flex-1 min-h-0 overflow-hidden relative">
+            <div class="size-full" style={{ display: layout.design.opened() ? "none" : undefined }}>
+              <Switch>
+                <Match when={params.id}>
+                  <Show when={messagesReady()}>
+                    <MessageTimeline
+                      mobileChanges={mobileChanges()}
+                      mobileFallback={reviewContent({
+                        diffStyle: "unified",
+                        classes: {
+                          root: "pb-8",
+                          header: "px-4",
+                          container: "px-4",
+                        },
+                        loadingClass: "px-4 py-4 text-text-weak",
+                        emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+                      })}
+                      actions={actions}
+                      scroll={ui.scroll}
+                      onResumeScroll={resumeScroll}
+                      setScrollRef={setScrollRef}
+                      onScheduleScrollState={scheduleScrollState}
+                      onAutoScrollHandleScroll={autoScroll.handleScroll}
+                      onMarkScrollGesture={markScrollGesture}
+                      hasScrollGesture={hasScrollGesture}
+                      onUserScroll={markUserScroll}
+                      onTurnBackfillScroll={historyWindow.onScrollerScroll}
+                      onAutoScrollInteraction={autoScroll.handleInteraction}
+                      centered={centered()}
+                      setContentRef={(el) => {
+                        content = el
+                        autoScroll.contentRef(el)
 
-                      const root = scroller
-                      if (root) scheduleScrollState(root)
-                    }}
-                    turnStart={historyWindow.turnStart()}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
-                      void historyWindow.loadAndReveal()
-                    }}
-                    renderedUserMessages={historyWindow.renderedUserMessages()}
-                    anchor={anchor}
-                  />
-                </Show>
-              </Match>
-              <Match when={true}>
-                <NewSessionView worktree={newSessionWorktree()} />
-              </Match>
-            </Switch>
+                        const root = scroller
+                        if (root) scheduleScrollState(root)
+                      }}
+                      turnStart={historyWindow.turnStart()}
+                      historyMore={historyMore()}
+                      historyLoading={historyLoading()}
+                      onLoadEarlier={() => {
+                        void historyWindow.loadAndReveal()
+                      }}
+                      renderedUserMessages={historyWindow.renderedUserMessages()}
+                      anchor={anchor}
+                    />
+                  </Show>
+                </Match>
+                <Match when={true}>
+                  <NewSessionView worktree={newSessionWorktree()} />
+                </Match>
+              </Switch>
+            </div>
+            <Show when={layout.design.opened()}>
+              <DesignPreview
+                onOpenFile={(path, line) => {
+                  console.log("[Design] session.onOpenFile called:", path, "line:", line)
+                  const tab = file.tab(path)
+                  const range: SelectedLineRange = { start: line, end: line }
+                  tabs().open(tab)
+                  tabs().setActive(tab)
+                  file.setSelectedLines(path, range)
+                  void file.load(path).then(() => file.setSelectedLines(path, range))
+                  if (!view().reviewPanel.opened()) view().reviewPanel.open()
+                  layout.fileTree.setTab("all")
+                }}
+                onComment={(input) => {
+                  addCommentToContext({
+                    file: input.file,
+                    selection: { start: input.line, end: input.line },
+                    comment: input.comment,
+                    origin: "design",
+                  })
+                }}
+              />
+            </Show>
           </div>
 
           <SessionComposerRegion

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -210,6 +210,7 @@ export function FileTabContent(props: { tab: string }) {
     tab: () => props.tab,
     view,
   })
+  let hold = 0
 
   const selectionPreview = (source: string, selection: FileSelection) => {
     return previewSelectedLines(source, {
@@ -397,7 +398,15 @@ export function FileTabContent(props: { tab: string }) {
     const restore = (loaded && !prev.loaded) || (ready && !prev.ready) || (active && loaded && !prev.active)
     prev = { loaded, ready, active }
     if (!restore) return
+    if (Date.now() < hold) return
     scrollSync.queueRestore()
+  })
+
+  createEffect(() => {
+    const range = selectedLines()
+    if (!range) return
+    if (range.start !== range.end) return
+    hold = Date.now() + 800
   })
 
   const renderFile = (source: string) => (
@@ -415,6 +424,7 @@ export function FileTabContent(props: { tab: string }) {
         selectedLines={activeSelection()}
         commentedLines={commentedLines()}
         onRendered={() => {
+          if (Date.now() < hold) return
           scrollSync.queueRestore()
         }}
         annotations={commentsUi.annotations()}

--- a/packages/app/src/pages/session/helpers.test.ts
+++ b/packages/app/src/pages/session/helpers.test.ts
@@ -178,4 +178,46 @@ describe("createSessionTabs", () => {
       dispose()
     })
   })
+
+  test("keeps preview special tabs non-closable", () => {
+    createRoot((dispose) => {
+      const [state] = createStore({
+        active: "design" as string | undefined,
+        all: ["design"],
+      })
+      const tabs = createMemo(() => ({ active: () => state.active, all: () => state.all }))
+      const result = createSessionTabs({
+        tabs,
+        pathFromTab: () => undefined,
+        normalizeTab: (tab) => tab,
+        special: ["design"],
+        closableSpecial: [],
+      })
+
+      expect(result.activeTab()).toBe("design")
+      expect(result.closableTab()).toBeUndefined()
+      dispose()
+    })
+  })
+
+  test("prefers context fallback before special preview tab", () => {
+    createRoot((dispose) => {
+      const [state] = createStore({
+        active: undefined as string | undefined,
+        all: ["context", "design"],
+      })
+      const tabs = createMemo(() => ({ active: () => state.active, all: () => state.all }))
+      const result = createSessionTabs({
+        tabs,
+        pathFromTab: () => undefined,
+        normalizeTab: (tab) => tab,
+        special: ["design"],
+        closableSpecial: [],
+      })
+
+      expect(result.activeTab()).toBe("context")
+      expect(result.closableTab()).toBe("context")
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -5,6 +5,8 @@ import { same } from "@/utils/same"
 
 const emptyTabs: string[] = []
 
+export const DESIGN_TAB = "design"
+
 type Tabs = {
   active: Accessor<string | undefined>
   all: Accessor<string[]>
@@ -16,6 +18,8 @@ type TabsInput = {
   normalizeTab: (tab: string) => string
   review?: Accessor<boolean>
   hasReview?: Accessor<boolean>
+  special?: readonly string[]
+  closableSpecial?: readonly string[]
 }
 
 export const getSessionKey = (dir: string | undefined, id: string | undefined) => `${dir ?? ""}${id ? `/${id}` : ""}`
@@ -23,6 +27,10 @@ export const getSessionKey = (dir: string | undefined, id: string | undefined) =
 export const createSessionTabs = (input: TabsInput) => {
   const review = input.review ?? (() => false)
   const hasReview = input.hasReview ?? (() => false)
+  const special = input.special ?? emptyTabs
+  const closable = input.closableSpecial ?? special
+  const isSpecial = (tab: string) => special.includes(tab)
+  const isClosable = (tab: string) => closable.includes(tab)
   const contextOpen = createMemo(() => input.tabs().active() === "context" || input.tabs().all().includes("context"))
   const openedTabs = createMemo(
     () => {
@@ -31,7 +39,7 @@ export const createSessionTabs = (input: TabsInput) => {
         .tabs()
         .all()
         .flatMap((tab) => {
-          if (tab === "context" || tab === "review") return []
+          if (tab === "context" || tab === "review" || isSpecial(tab)) return []
           const value = input.pathFromTab(tab) ? input.normalizeTab(tab) : tab
           if (seen.has(value)) return []
           seen.add(value)
@@ -45,12 +53,15 @@ export const createSessionTabs = (input: TabsInput) => {
     const active = input.tabs().active()
     if (active === "context") return active
     if (active === "review" && review()) return active
+    if (active && isSpecial(active)) return active
     if (active && input.pathFromTab(active)) return input.normalizeTab(active)
 
     const first = openedTabs()[0]
     if (first) return first
     if (contextOpen()) return "context"
     if (review() && hasReview()) return "review"
+    const special = input.tabs().all().find(isSpecial)
+    if (special) return special
     return "empty"
   })
   const activeFileTab = createMemo(() => {
@@ -61,6 +72,7 @@ export const createSessionTabs = (input: TabsInput) => {
   const closableTab = createMemo(() => {
     const active = activeTab()
     if (active === "context") return active
+    if (isSpecial(active)) return isClosable(active) ? active : undefined
     if (!openedTabs().includes(active)) return
     return active
   })
@@ -112,13 +124,14 @@ export const createOpenReviewFile = (input: {
     batch(() => {
       input.showAllFiles()
       const maybePromise = input.loadFile(path)
-      const open = () => {
-        const tab = input.tabForPath(path)
-        input.openTab(tab)
-        input.setActive(tab)
+      const tab = input.tabForPath(path)
+      input.openTab(tab)
+      input.setActive(tab)
+      if (maybePromise instanceof Promise) {
+        maybePromise.catch((err) => {
+          console.warn("[Session] Failed to load review file", path, err)
+        })
       }
-      if (maybePromise instanceof Promise) maybePromise.then(open)
-      else open()
     })
   }
 }

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -1,6 +1,8 @@
-import { For, Match, Show, Switch, createEffect, createMemo, onCleanup, type JSX } from "solid-js"
+import { For, Match, Show, Switch, createEffect, createMemo, on, onCleanup, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createMediaQuery } from "@solid-primitives/media"
+import { Button } from "@opencode-ai/ui/button"
+import { Dialog } from "@opencode-ai/ui/dialog"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
@@ -19,9 +21,18 @@ import { useCommand } from "@/context/command"
 import { useFile, type SelectedLineRange } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
+import { useSettings } from "@/context/settings"
+import { useSync } from "@/context/sync"
+import { DesignPreview } from "@/components/design-preview"
 import { createFileTabListSync } from "@/pages/session/file-tab-scroll"
 import { FileTabContent } from "@/pages/session/file-tabs"
-import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type Sizing } from "@/pages/session/helpers"
+import {
+  DESIGN_TAB,
+  createOpenSessionFileTab,
+  createSessionTabs,
+  getTabReorderIndex,
+  type Sizing,
+} from "@/pages/session/helpers"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
 
@@ -37,13 +48,16 @@ export function SessionSidePanel(props: {
   focusReviewDiff: (path: string) => void
   reviewSnap: boolean
   size: Sizing
+  onDesignComment?: (input: { file: string; line: number; comment: string; component?: string }) => void
 }) {
   const layout = useLayout()
+  const settings = useSettings()
+  const sync = useSync()
   const file = useFile()
   const language = useLanguage()
   const command = useCommand()
   const dialog = useDialog()
-  const { sessionKey, tabs, view } = useSessionLayout()
+  const { params, sessionKey, tabs, view } = useSessionLayout()
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
@@ -124,11 +138,58 @@ export function SessionSidePanel(props: {
     normalizeTab,
     review: reviewTab,
     hasReview: props.canReview,
+    special: [DESIGN_TAB],
+    closableSpecial: [],
   })
   const contextOpen = tabState.contextOpen
   const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
+  const designReady = createMemo(() => settings.general.previewEnabled())
+  let probe = 0
+
+  const enablePreview = () => {
+    dialog.close()
+    settings.general.setPreviewEnabled(true)
+    settings.general.setPreviewPrompted(true)
+    openReviewPanel()
+    if (activeTab() !== DESIGN_TAB) tabs().setActive(DESIGN_TAB)
+  }
+
+  const skipPreview = () => {
+    dialog.close()
+    settings.general.setPreviewEnabled(false)
+    settings.general.setPreviewPrompted(true)
+  }
+
+  const showPrompt = () => {
+    dialog.show(
+      () => (
+        <Dialog title={language.t("session.preview.prompt.title")} class="w-full max-w-[520px] mx-auto">
+          <div class="flex flex-col gap-6 p-6 pt-0">
+            <div class="text-14-regular text-text-weak">{language.t("session.preview.prompt.description")}</div>
+            <div class="flex justify-end gap-2">
+              <Button variant="ghost" size="large" onClick={skipPreview}>
+                {language.t("session.preview.prompt.action.notNow")}
+              </Button>
+              <Button variant="primary" size="large" onClick={enablePreview}>
+                {language.t("session.preview.prompt.action.enable")}
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      ),
+      () => {
+        if (settings.general.previewPrompted()) return
+        settings.general.setPreviewPrompted(true)
+      },
+    )
+  }
+
+  const onPreviewTab = () => {
+    openReviewPanel()
+    if (activeTab() !== DESIGN_TAB) tabs().setActive(DESIGN_TAB)
+  }
 
   const fileTreeTab = () => layout.fileTree.tab()
 
@@ -145,6 +206,17 @@ export function SessionSidePanel(props: {
   const [store, setStore] = createStore({
     activeDraggable: undefined as string | undefined,
   })
+
+  const openFileAt = (path: string, line: number) => {
+    const tab = file.tab(path)
+    const range: SelectedLineRange = { start: line, end: line }
+    tabs().open(tab)
+    tabs().setActive(tab)
+    file.setSelectedLines(path, range)
+    void file.load(path).then(() => file.setSelectedLines(path, range))
+    openReviewPanel()
+    layout.fileTree.setTab("all")
+  }
 
   const handleDragStart = (event: unknown) => {
     const id = getDraggableId(event)
@@ -186,6 +258,41 @@ export function SessionSidePanel(props: {
         }, {}),
     })
   })
+
+  createEffect(
+    on(
+      () => params.dir,
+      () => {
+        if (!isDesktop()) return
+        if (designReady()) return
+        if (settings.general.previewPrompted()) return
+        const run = ++probe
+        let live = true
+        onCleanup(() => {
+          live = false
+          probe++
+        })
+        const list = [".tsx", ".jsx", ".html", ".css", ".vue", ".svelte", ".astro"]
+        Promise.any(
+          list.map((item) =>
+            file.searchFiles(item).then((rows) => {
+              if (rows.length > 0) return true
+              throw new Error("no-hit")
+            }),
+          ),
+        )
+          .then(() => {
+            if (!live) return
+            if (run !== probe) return
+            if (designReady()) return
+            if (settings.general.previewPrompted()) return
+            showPrompt()
+          })
+          .catch(() => {})
+      },
+      { defer: true },
+    ),
+  )
 
   return (
     <Show when={isDesktop()}>
@@ -266,10 +373,15 @@ export function SessionSidePanel(props: {
                           </div>
                         </Tabs.Trigger>
                       </Show>
+                      <Tabs.Trigger value={DESIGN_TAB} onClick={onPreviewTab}>
+                        <div class="flex items-center gap-2">
+                          <div>{language.t("session.tab.preview")}</div>
+                        </div>
+                      </Tabs.Trigger>
                       <SortableProvider ids={openedTabs()}>
                         <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
                       </SortableProvider>
-                      <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
+                      <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center gap-1 pr-3">
                         <TooltipKeybind
                           title={language.t("command.file.open")}
                           keybind={command.keybind("file.open")}
@@ -320,6 +432,45 @@ export function SessionSidePanel(props: {
                       </Show>
                     </Tabs.Content>
                   </Show>
+
+                  <Tabs.Content
+                    value={DESIGN_TAB}
+                    forceMount
+                    class="flex flex-col h-full overflow-hidden contain-strict"
+                    classList={{ hidden: activeTab() !== DESIGN_TAB }}
+                  >
+                    <Show
+                      when={designReady()}
+                      fallback={
+                        <div class="h-full flex items-center justify-center p-6">
+                          <div class="max-w-[420px] w-full flex flex-col gap-4 rounded-lg border border-border-weaker-base bg-background-stronger p-4">
+                            <div class="text-14-medium text-text-strong">
+                              {language.t("session.preview.disabled.title")}
+                            </div>
+                            <div class="text-13-regular text-text-weak">
+                              {language.t("session.preview.disabled.description")}
+                            </div>
+                            <div class="flex items-center gap-2">
+                              <Button size="small" variant="primary" onClick={enablePreview}>
+                                {language.t("session.preview.disabled.action.enable")}
+                              </Button>
+                              <Show when={!settings.general.previewPrompted()}>
+                                <Button size="small" variant="ghost" onClick={showPrompt}>
+                                  {language.t("session.preview.disabled.action.learn")}
+                                </Button>
+                              </Show>
+                            </div>
+                          </div>
+                        </div>
+                      }
+                    >
+                      <DesignPreview
+                        active={activeTab() === DESIGN_TAB && reviewOpen() && designReady()}
+                        onOpenFile={openFileAt}
+                        onComment={props.onDesignComment}
+                      />
+                    </Show>
+                  </Tabs.Content>
 
                   <Show when={activeFileTab()} keyed>
                     {(tab) => <FileTabContent tab={tab} />}

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -13,7 +13,7 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/util/array"
-import { createSessionTabs } from "@/pages/session/helpers"
+import { createSessionTabs, DESIGN_TAB } from "@/pages/session/helpers"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -63,6 +63,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     normalizeTab,
     review: actions.review,
     hasReview,
+    special: [DESIGN_TAB],
+    closableSpecial: [],
   })
   const activeFileTab = tabState.activeFileTab
   const closableTab = tabState.closableTab

--- a/packages/app/src/utils/comment-note.ts
+++ b/packages/app/src/utils/comment-note.ts
@@ -5,7 +5,7 @@ export type PromptComment = {
   selection?: FileSelection
   comment: string
   preview?: string
-  origin?: "review" | "file"
+  origin?: "review" | "file" | "design"
 }
 
 function selection(selection: unknown) {
@@ -49,7 +49,7 @@ export function readCommentMetadata(value: unknown) {
     selection: selection((meta as { selection?: unknown }).selection),
     comment,
     preview: typeof preview === "string" ? preview : undefined,
-    origin: origin === "review" || origin === "file" ? origin : undefined,
+    origin: origin === "review" || origin === "file" || origin === "design" ? origin : undefined,
   } satisfies PromptComment
 }
 

--- a/packages/app/src/utils/detect-port.ts
+++ b/packages/app/src/utils/detect-port.ts
@@ -1,0 +1,110 @@
+type SDK = {
+  file: { read: (input: { path: string }) => Promise<{ data?: { content?: string; type?: string } }> }
+}
+
+type Result = {
+  url: string
+  framework?: string
+}
+
+const FRAMEWORKS: Record<string, { port: number; name: string }> = {
+  vite: { port: 5173, name: "Vite" },
+  next: { port: 3000, name: "Next.js" },
+  nuxt: { port: 3000, name: "Nuxt" },
+  "react-scripts": { port: 3000, name: "Create React App" },
+  "webpack-dev-server": { port: 8080, name: "Webpack" },
+  "webpack serve": { port: 8080, name: "Webpack" },
+  astro: { port: 4321, name: "Astro" },
+  remix: { port: 3000, name: "Remix" },
+  svelte: { port: 5173, name: "SvelteKit" },
+  turbo: { port: 3000, name: "Turborepo" },
+  bun: { port: 3000, name: "Bun" },
+  tsx: { port: 3000, name: "TSX" },
+}
+
+const PROBE_PORTS = [3000, 5173, 3001, 4321, 8080, 8000, 4200, 4173, 5174, 8888]
+
+function extractPort(script: string): number | undefined {
+  const match = script.match(/--port\s+(\d+)/) ?? script.match(/-p\s+(\d+)/) ?? script.match(/PORT[=:]\s*(\d+)/)
+  if (match) return parseInt(match[1], 10)
+  return undefined
+}
+
+function detect(scripts: Record<string, string>): { port: number; framework: string } | undefined {
+  const dev = scripts.dev ?? scripts.start ?? ""
+  if (!dev) return undefined
+
+  for (const [key, info] of Object.entries(FRAMEWORKS)) {
+    if (dev.includes(key)) {
+      const port = extractPort(dev) ?? info.port
+      return { port, framework: info.name }
+    }
+  }
+
+  return undefined
+}
+
+async function probePort(port: number): Promise<boolean> {
+  try {
+    await fetch(`http://localhost:${port}`, { method: "HEAD", mode: "no-cors", signal: AbortSignal.timeout(2500) })
+    return true
+  } catch {
+    try {
+      await fetch(`http://127.0.0.1:${port}`, { method: "HEAD", mode: "no-cors", signal: AbortSignal.timeout(2500) })
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+async function probe(ports: number[]): Promise<string | undefined> {
+  // Race all ports but with individual fallback per port
+  try {
+    return await Promise.any(
+      ports.map(async (port) => {
+        const ok = await probePort(port)
+        if (!ok) throw new Error("unreachable")
+        return `http://localhost:${port}`
+      }),
+    )
+  } catch {
+    return undefined
+  }
+}
+
+export async function detectDevUrl(_directory: string, client: SDK): Promise<Result | null> {
+  // 1. Try package.json detection (path is relative — SDK client has directory context)
+  let ports: number[] | undefined
+  try {
+    const res = await client.file.read({ path: "package.json" })
+    if (res.data?.content) {
+      const pkg = JSON.parse(res.data.content)
+      const scripts = pkg.scripts as Record<string, string> | undefined
+      if (scripts) {
+        const found = detect(scripts)
+        if (found) {
+          console.log("[Design] Detected framework:", found.framework, "port:", found.port)
+          // Probe the detected port first, then fall back to all ports
+          const ok = await probePort(found.port)
+          if (ok) return { url: `http://localhost:${found.port}`, framework: found.framework }
+          // The framework port isn't responding — prioritize it but try others too
+          ports = [found.port, ...PROBE_PORTS.filter((p) => p !== found.port)]
+        }
+      }
+    }
+  } catch (e) {
+    console.log("[Design] package.json read failed:", e)
+  }
+
+  // 2. Probe common ports
+  console.log("[Design] Probing ports:", (ports ?? PROBE_PORTS).join(", "))
+  const url = await probe(ports ?? PROBE_PORTS)
+  if (url) {
+    console.log("[Design] Found dev server at:", url)
+    return { url }
+  }
+
+  console.log("[Design] No dev server found")
+  return null
+}

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1098,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,6 +3171,7 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-web-kit",
  "process-wrap",
+ "rayon",
  "regex",
  "reqwest 0.12.24",
  "semver",
@@ -3960,6 +3967,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -371,6 +371,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +779,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1707,6 +1736,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,7 +2030,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2116,6 +2158,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3102,6 +3160,7 @@ dependencies = [
  "dirs",
  "futures",
  "gtk",
+ "ignore",
  "listeners",
  "objc2 0.6.3",
  "objc2-web-kit",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -3106,6 +3106,7 @@ dependencies = [
  "objc2 0.6.3",
  "objc2-web-kit",
  "process-wrap",
+ "regex",
  "reqwest 0.12.24",
  "semver",
  "serde",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ chrono = "0.4"
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 process-wrap = { version = "9.0.3", features = ["tokio1"] }
 ignore = "0.4"
+rayon = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_Threading", "Win32_System_Registry"] }

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ tracing-appender = "0.2"
 chrono = "0.4"
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 process-wrap = { version = "9.0.3", features = ["tokio1"] }
+ignore = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_Threading", "Win32_System_Registry"] }

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2.9.5", features = ["macos-private-api"] }
+tauri = { version = "2.9.5", features = ["macos-private-api", "unstable"] }
 tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2.4.6"
 tauri-plugin-shell = "2"
@@ -47,6 +47,7 @@ specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 dirs = "6.0.0"
+regex = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
@@ -73,3 +74,9 @@ specta-typescript = { git = "https://github.com/specta-rs/specta", rev = "591a5f
 tauri-specta = { git = "https://github.com/specta-rs/tauri-specta", rev = "6720b2848eff9a3e40af54c48d65f6d56b640c0b" }
 # TODO: https://github.com/tauri-apps/tauri/pull/14812
 tauri  = { git = "https://github.com/tauri-apps/tauri", rev = "4d5d78daf636feaac20c5bc48a6071491c4291ee" }
+
+[profile.dev]
+incremental = false
+
+[profile.test]
+incremental = false

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -47,6 +47,10 @@
       "identifier": "http:default",
       "allow": [{ "url": "http://*" }, { "url": "https://*" }, { "url": "http://*:*/*" }]
     },
-    "clipboard-manager:allow-read-image"
+    "clipboard-manager:allow-read-image",
+    "core:webview:allow-create-webview",
+    "core:webview:allow-webview-close",
+    "core:webview:allow-set-webview-position",
+    "core:webview:allow-set-webview-size"
   ]
 }

--- a/packages/desktop/src-tauri/capabilities/design-preview.json
+++ b/packages/desktop/src-tauri/capabilities/design-preview.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "design-preview-remote",
+  "description": "Allow the design-preview child webview to invoke bridge commands from remote localhost pages",
+  "windows": ["design-preview"],
+  "remote": {
+    "urls": ["http://localhost:*", "http://127.0.0.1:*"]
+  },
+  "permissions": [
+    "core:default",
+    "core:event:default"
+  ]
+}

--- a/packages/desktop/src-tauri/capabilities/design-preview.json
+++ b/packages/desktop/src-tauri/capabilities/design-preview.json
@@ -2,12 +2,9 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "design-preview-remote",
   "description": "Allow the design-preview child webview to invoke bridge commands from remote localhost pages",
-  "windows": ["design-preview"],
+  "webviews": ["design-preview"],
   "remote": {
     "urls": ["http://localhost:*", "http://127.0.0.1:*"]
   },
-  "permissions": [
-    "core:default",
-    "core:event:default"
-  ]
+  "permissions": ["core:default", "core:event:default"]
 }

--- a/packages/desktop/src-tauri/src/design_index.rs
+++ b/packages/desktop/src-tauri/src/design_index.rs
@@ -1,5 +1,6 @@
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -87,18 +88,50 @@ fn has_ext(path: &Path) -> bool {
         .is_some_and(|e| EXTENSIONS.contains(&e))
 }
 
-fn scan_dir(dir: &Path, files: &mut Vec<PathBuf>) {
+fn matcher(root: &Path) -> Option<Gitignore> {
+    let mut builder = GitignoreBuilder::new(root);
+    for name in [".gitignore", ".ignore"] {
+        let path = root.join(name);
+        if path.is_file() {
+            builder.add(path);
+        }
+    }
+    builder.build().ok()
+}
+
+fn blocked(root: &Path, path: &Path, dir: bool, ignore: Option<&Gitignore>) -> bool {
+    let rel = rel(path, root);
+    skip(&rel)
+        || ignore.is_some_and(|ignore| ignore.matched(&rel, dir).is_ignore())
+}
+
+fn scan_dir(dir: &Path, root: &Path, ignore: Option<&Gitignore>, files: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
-        if should_skip(&entry) {
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if should_skip(&entry) || blocked(root, &path, kind.is_dir(), ignore) {
             continue;
         }
-        let path = entry.path();
-        if path.is_dir() {
-            scan_dir(&path, files);
-        } else if has_ext(&path) {
+        if kind.is_symlink() {
+            let Ok(meta) = fs::metadata(&path) else {
+                continue;
+            };
+            if meta.is_dir() {
+                continue;
+            }
+            if meta.is_file() && has_ext(&path) && !blocked(root, &path, false, ignore) {
+                files.push(path);
+            }
+            continue;
+        }
+        if kind.is_dir() {
+            scan_dir(&path, root, ignore, files);
+        } else if kind.is_file() && has_ext(&path) {
             files.push(path);
         }
     }
@@ -141,9 +174,6 @@ fn resolve(root: &Path, input: &str) -> Option<(PathBuf, String)> {
         return None;
     }
     let rel = rel(&abs, root);
-    if skip(&rel) {
-        return None;
-    }
     Some((abs, rel))
 }
 
@@ -157,9 +187,6 @@ fn push_component(idx: &mut Index, rel: &str, name: &str, line: u32) {
         line: Some(line),
         component: Some(name.to_string()),
     });
-    if !idx.names.contains(&name.to_string()) {
-        idx.names.push(name.to_string());
-    }
 }
 
 fn trim(idx: &mut Index, rel: &str) {
@@ -178,6 +205,16 @@ fn sync(idx: &mut Index) {
     idx.names.sort();
 }
 
+fn lines(content: &str) -> Vec<usize> {
+    let mut out = vec![0];
+    out.extend(content.match_indices('\n').map(|(i, _)| i + 1));
+    out
+}
+
+fn line(lines: &[usize], offset: usize) -> u32 {
+    lines.partition_point(|start| *start <= offset) as u32
+}
+
 fn parse(path: &Path, root: &Path, idx: &mut Index) {
     let Ok(content) = fs::read_to_string(path) else {
         return;
@@ -188,6 +225,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         .nth(12000)
         .map(|(i, _)| &content[..i])
         .unwrap_or(&content);
+    let lines = lines(&content);
     let mut comp = None;
 
     // Extract exported component names
@@ -196,7 +234,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         if comp.is_none() {
             comp = Some(name.clone());
         }
-        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        let line = line(&lines, cap.get(0).unwrap().start());
         push_component(idx, &rel, &name, line);
     }
 
@@ -205,7 +243,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         if comp.is_none() {
             comp = Some(name.clone());
         }
-        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        let line = line(&lines, cap.get(0).unwrap().start());
         push_component(idx, &rel, &name, line);
     }
 
@@ -214,7 +252,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         if comp.is_none() {
             comp = Some(name.clone());
         }
-        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        let line = line(&lines, cap.get(0).unwrap().start());
         push_component(idx, &rel, &name, line);
     }
 
@@ -246,33 +284,39 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
     };
 
     for cap in class_re().captures_iter(slice) {
-        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        let line = line(&lines, cap.get(0).unwrap().start());
         add(&cap[1], line);
     }
 
     for cap in class_expr_re().captures_iter(slice) {
-        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        let line = line(&lines, cap.get(0).unwrap().start());
         add(&cap[1], line);
     }
 }
 
 fn build(root: &Path) -> Index {
     let mut files = Vec::new();
-    scan_dir(root, &mut files);
+    let ignore = matcher(root);
+    scan_dir(root, root, ignore.as_ref(), &mut files);
 
     let mut idx = Index::default();
     for file in &files {
         parse(file, root, &mut idx);
     }
+    sync(&mut idx);
     idx
 }
 
 fn apply(idx: &mut Index, root: &Path, paths: &[String]) {
+    let ignore = matcher(root);
     for raw in paths {
         let Some((path, rel)) = resolve(root, raw) else {
             continue;
         };
         trim(idx, &rel);
+        if blocked(root, &path, path.is_dir(), ignore.as_ref()) {
+            continue;
+        }
         if path.is_file() && has_ext(&path) {
             parse(&path, root, idx);
         }
@@ -280,10 +324,90 @@ fn apply(idx: &mut Index, root: &Path, paths: &[String]) {
     sync(idx);
 }
 
+fn score_classes(
+    idx: &Index,
+    classes: &[String],
+    allow: Option<&HashMap<String, u32>>,
+) -> Option<QueryResult> {
+    let mut seen = HashSet::new();
+    let names = classes
+        .iter()
+        .filter_map(|name| seen.insert(name.as_str()).then_some(name.as_str()))
+        .collect::<Vec<_>>();
+
+    let mut scores: HashMap<String, (u32, u32)> = HashMap::new();
+    for name in names.iter().copied() {
+        let Some(entries) = idx.classes.get(name) else {
+            continue;
+        };
+        let mut files = HashSet::new();
+        for entry in entries {
+            if !files.insert(entry.file.as_str()) {
+                continue;
+            }
+            if let Some(allow) = allow {
+                let Some(line) = allow.get(&entry.file).copied() else {
+                    continue;
+                };
+                let score = scores.entry(entry.file.clone()).or_insert((0, line));
+                score.0 += 1;
+                continue;
+            }
+            let score = scores
+                .entry(entry.file.clone())
+                .or_insert((0, entry.line.unwrap_or(1)));
+            score.0 += 1;
+        }
+    }
+
+    let total = names.len().max(1) as f32;
+    let (file, (score, line)) = scores.into_iter().max_by(|(a, (sa, _)), (b, (sb, _))| {
+        sa.cmp(sb).then_with(|| b.cmp(a))
+    })?;
+    Some(QueryResult {
+        file,
+        line,
+        confidence: (score as f32 / total).min(1.0),
+    })
+}
+
+fn query(idx: &Index, component: Option<&str>, classes: Option<&[String]>) -> Option<QueryResult> {
+    if let Some(name) = component {
+        if let Some(entries) = idx.components.get(name) {
+            if entries.len() > 1 {
+                if let Some(classes) = classes {
+                    let allow = entries
+                        .iter()
+                        .map(|entry| (entry.file.clone(), entry.line.unwrap_or(1)))
+                        .collect::<HashMap<_, _>>();
+                    return score_classes(idx, classes, Some(&allow));
+                }
+                return None;
+            }
+            if let Some(best) = entries.first() {
+                return Some(QueryResult {
+                    file: best.file.clone(),
+                    line: best.line.unwrap_or(1),
+                    confidence: 1.0,
+                });
+            }
+        }
+    }
+
+    if let Some(classes) = classes {
+        return score_classes(idx, classes, None);
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     fn temp() -> PathBuf {
         std::env::temp_dir().join(format!("opencode-design-index-{}", Uuid::new_v4()))
@@ -337,6 +461,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_keeps_line_numbers() {
+        let root = temp();
+        write(
+            &root,
+            "src/components/Hero.tsx",
+            "\n\nexport default function Hero() {\n  return <div className=\"hero\" />\n}\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(idx.components.get("Hero").unwrap()[0].line, Some(3));
+        assert_eq!(idx.classes.get("hero").unwrap()[0].line, Some(4));
+    }
+
+    #[test]
     fn apply_replaces_file_entries() {
         let root = temp();
         write(
@@ -377,6 +517,97 @@ mod tests {
         assert!(idx.components.get("Hero").is_none());
         assert!(idx.classes.get("hero").is_none());
         assert!(idx.names.is_empty());
+    }
+
+    #[test]
+    fn query_dedupes_class_hits_per_file() {
+        let root = temp();
+        write(
+            &root,
+            "src/components/A.tsx",
+            "export default function A() { return <div className=\"foo foo foo\" /> }\n",
+        );
+        write(
+            &root,
+            "src/components/B.tsx",
+            "export default function B() { return <div className=\"foo bar\" /> }\n",
+        );
+
+        let idx = build(&root);
+        let result = query(&idx, None, Some(&["foo".to_string(), "bar".to_string()])).unwrap();
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(result.file, "src/components/B.tsx");
+        assert_eq!(result.confidence, 1.0);
+    }
+
+    #[test]
+    fn query_breaks_ties_by_file_name() {
+        let root = temp();
+        write(
+            &root,
+            "src/components/Beta.tsx",
+            "export default function Beta() { return <div className=\"foo bar\" /> }\n",
+        );
+        write(
+            &root,
+            "src/components/Alpha.tsx",
+            "export default function Alpha() { return <div className=\"foo bar\" /> }\n",
+        );
+
+        let idx = build(&root);
+        let result = query(&idx, None, Some(&["foo".to_string(), "bar".to_string()])).unwrap();
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(result.file, "src/components/Alpha.tsx");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_skips_symlink_dirs() {
+        let root = temp();
+        let other = temp();
+        write(
+            &root,
+            "src/components/Hero.tsx",
+            "export default function Hero() { return null }\n",
+        );
+        write(
+            &other,
+            "linked/Leak.tsx",
+            "export default function Leak() { return null }\n",
+        );
+        fs::create_dir_all(root.join("src")).unwrap();
+        symlink(other.join("linked"), root.join("src/linked")).unwrap();
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+        fs::remove_dir_all(&other).unwrap();
+
+        assert!(idx.components.get("Hero").is_some());
+        assert!(idx.components.get("Leak").is_none());
+    }
+
+    #[test]
+    fn build_respects_gitignore() {
+        let root = temp();
+        write(&root, ".gitignore", "src/ignored/\n");
+        write(
+            &root,
+            "src/components/Hero.tsx",
+            "export default function Hero() { return null }\n",
+        );
+        write(
+            &root,
+            "src/ignored/Leak.tsx",
+            "export default function Leak() { return null }\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert!(idx.components.get("Hero").is_some());
+        assert!(idx.components.get("Leak").is_none());
     }
 }
 
@@ -490,70 +721,5 @@ pub fn query_design_index(
         return Ok(None);
     };
 
-    // 1. Try component name lookup
-    if let Some(name) = &component {
-        if let Some(entries) = idx.components.get(name) {
-            if entries.len() > 1 {
-                if let Some(cls) = &classes {
-                    let mut scores: HashMap<String, (u32, u32)> = HashMap::new();
-                    for entry in entries {
-                        scores.insert(entry.file.clone(), (0, entry.line.unwrap_or(1)));
-                    }
-                    for c in cls {
-                        if let Some(matches) = idx.classes.get(c.as_str()) {
-                            for entry in matches {
-                                if let Some(score) = scores.get_mut(&entry.file) {
-                                    score.0 += 1;
-                                }
-                            }
-                        }
-                    }
-                    if let Some((file, (score, line))) =
-                        scores.into_iter().max_by_key(|(_, (s, _))| *s)
-                    {
-                        if score > 0 {
-                            return Ok(Some(QueryResult {
-                                file,
-                                line,
-                                confidence: 1.0,
-                            }));
-                        }
-                    }
-                }
-                return Ok(None);
-            }
-            if let Some(best) = entries.first() {
-                return Ok(Some(QueryResult {
-                    file: best.file.clone(),
-                    line: best.line.unwrap_or(1),
-                    confidence: 1.0,
-                }));
-            }
-        }
-    }
-
-    // 2. Try class combination lookup
-    if let Some(cls) = &classes {
-        let mut scores: HashMap<String, (u32, u32)> = HashMap::new();
-        for c in cls {
-            if let Some(entries) = idx.classes.get(c.as_str()) {
-                for e in entries {
-                    let entry = scores
-                        .entry(e.file.clone())
-                        .or_insert((0, e.line.unwrap_or(1)));
-                    entry.0 += 1;
-                }
-            }
-        }
-        if let Some((file, (score, line))) = scores.into_iter().max_by_key(|(_, (s, _))| *s) {
-            let total = cls.len().max(1) as f32;
-            return Ok(Some(QueryResult {
-                file,
-                line,
-                confidence: score as f32 / total,
-            }));
-        }
-    }
-
-    Ok(None)
+    Ok(query(idx, component.as_deref(), classes.as_deref()))
 }

--- a/packages/desktop/src-tauri/src/design_index.rs
+++ b/packages/desktop/src-tauri/src/design_index.rs
@@ -1,4 +1,5 @@
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use rayon::prelude::*;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -22,10 +23,27 @@ pub struct QueryResult {
     pub confidence: f32,
 }
 
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageQueryResult {
+    pub file: String,
+    pub line: u32,
+    pub owner: Option<String>,
+    pub confidence: f32,
+}
+
+#[derive(Debug, Clone)]
+struct UsageEntry {
+    file: String,
+    line: u32,
+    owner: Option<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Index {
     components: HashMap<String, Vec<IndexEntry>>,
     classes: HashMap<String, Vec<IndexEntry>>,
+    usages: HashMap<String, Vec<UsageEntry>>,
     names: Vec<String>,
 }
 
@@ -74,6 +92,11 @@ fn class_re() -> &'static Regex {
 fn class_expr_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| Regex::new(r#"class(?:Name)?\s*=\s*\{[^}]*["'`]([^"'`]+)["'`]"#).unwrap())
+}
+
+fn usage_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"<([A-Z][A-Za-z0-9_]*)\b").unwrap())
 }
 
 fn should_skip(entry: &std::fs::DirEntry) -> bool {
@@ -189,6 +212,74 @@ fn push_component(idx: &mut Index, rel: &str, name: &str, line: u32) {
     });
 }
 
+fn push_usage(idx: &mut Index, rel: &str, name: &str, owner: Option<&str>, line: u32) {
+    let entries = idx.usages.entry(name.to_string()).or_default();
+    if entries
+        .iter()
+        .any(|entry| entry.file == rel && entry.line == line && entry.owner.as_deref() == owner)
+    {
+        return;
+    }
+    entries.push(UsageEntry {
+        file: rel.to_string(),
+        line,
+        owner: owner.map(|item| item.to_string()),
+    });
+}
+
+fn push_owner(owners: &mut Vec<(u32, bool, String)>, line: u32, name: &str, explicit: bool) {
+    if let Some(item) = owners
+        .iter_mut()
+        .find(|(item_line, _, item_name)| *item_line == line && item_name == name)
+    {
+        if explicit {
+            item.1 = true;
+        }
+        return;
+    }
+    owners.push((line, explicit, name.to_string()));
+}
+
+fn usage_enabled(path: &Path, content: &str) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|item| item.to_str())
+        .map(|item| item.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("tsx") | Some("jsx") | Some("vue") | Some("svelte") => true,
+        Some("js") => content.contains("</") || content.contains("/>") || content.contains("React.createElement"),
+        _ => false,
+    }
+}
+
+fn usage_ok(content: &str, at: usize) -> bool {
+    if at == 0 {
+        return true;
+    }
+    let prev = content.as_bytes()[at - 1];
+    !prev.is_ascii_alphanumeric()
+        && prev != b'_'
+        && prev != b'.'
+        && prev != b')'
+        && prev != b']'
+        && prev != b'"'
+        && prev != b'\''
+        && prev != b'`'
+}
+
+fn owner_at<'a>(owners: &'a [(u32, bool, String)], line: u32) -> Option<&'a str> {
+    owners
+        .iter()
+        .filter(|(item, _, _)| *item <= line)
+        .max_by(|(left_line, left_explicit, _), (right_line, right_explicit, _)| {
+            left_line
+                .cmp(right_line)
+                .then_with(|| left_explicit.cmp(right_explicit))
+        })
+        .or_else(|| owners.first())
+        .map(|(_, _, name)| name.as_str())
+}
+
 fn trim(idx: &mut Index, rel: &str) {
     idx.components.retain(|_, entries| {
         entries.retain(|entry| entry.file != rel);
@@ -198,6 +289,40 @@ fn trim(idx: &mut Index, rel: &str) {
         entries.retain(|entry| entry.file != rel);
         !entries.is_empty()
     });
+    idx.usages.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel);
+        !entries.is_empty()
+    });
+}
+
+fn trim_prefix(idx: &mut Index, rel: &str) {
+    idx.components.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel && !entry.file.starts_with(&(rel.to_string() + "/")));
+        !entries.is_empty()
+    });
+    idx.classes.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel && !entry.file.starts_with(&(rel.to_string() + "/")));
+        !entries.is_empty()
+    });
+    idx.usages.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel && !entry.file.starts_with(&(rel.to_string() + "/")));
+        !entries.is_empty()
+    });
+}
+
+fn merge(dst: &mut Index, mut src: Index) {
+    for (name, mut entries) in src.components.drain() {
+        dst.components
+            .entry(name)
+            .or_default()
+            .append(&mut entries);
+    }
+    for (name, mut entries) in src.classes.drain() {
+        dst.classes.entry(name).or_default().append(&mut entries);
+    }
+    for (name, mut entries) in src.usages.drain() {
+        dst.usages.entry(name).or_default().append(&mut entries);
+    }
 }
 
 fn sync(idx: &mut Index) {
@@ -227,6 +352,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         .unwrap_or(&content);
     let lines = lines(&content);
     let mut comp = None;
+    let mut owners = Vec::<(u32, bool, String)>::new();
 
     // Extract exported component names
     for cap in comp_re().captures_iter(slice) {
@@ -235,6 +361,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
             comp = Some(name.clone());
         }
         let line = line(&lines, cap.get(0).unwrap().start());
+        push_owner(&mut owners, line, &name, true);
         push_component(idx, &rel, &name, line);
     }
 
@@ -244,6 +371,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
             comp = Some(name.clone());
         }
         let line = line(&lines, cap.get(0).unwrap().start());
+        push_owner(&mut owners, line, &name, true);
         push_component(idx, &rel, &name, line);
     }
 
@@ -253,6 +381,7 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
             comp = Some(name.clone());
         }
         let line = line(&lines, cap.get(0).unwrap().start());
+        push_owner(&mut owners, line, &name, true);
         push_component(idx, &rel, &name, line);
     }
 
@@ -263,9 +392,12 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
             if comp.is_none() {
                 comp = Some(name.clone());
             }
+            push_owner(&mut owners, 1, &name, false);
             push_component(idx, &rel, &name, 1);
         }
     }
+
+    owners.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| right.1.cmp(&left.1)));
 
     // Extract class / className strings
     let mut add = |raw: &str, line: u32| {
@@ -292,6 +424,22 @@ fn parse(path: &Path, root: &Path, idx: &mut Index) {
         let line = line(&lines, cap.get(0).unwrap().start());
         add(&cap[1], line);
     }
+
+    if !usage_enabled(path, &content) {
+        return;
+    }
+
+    let usage = content.as_str();
+    for cap in usage_re().captures_iter(usage) {
+        let Some(mat) = cap.get(0) else {
+            continue;
+        };
+        if !usage_ok(usage, mat.start()) {
+            continue;
+        }
+        let line = line(&lines, mat.start());
+        push_usage(idx, &rel, &cap[1], owner_at(&owners, line), line);
+    }
 }
 
 fn build(root: &Path) -> Index {
@@ -299,28 +447,71 @@ fn build(root: &Path) -> Index {
     let ignore = matcher(root);
     scan_dir(root, root, ignore.as_ref(), &mut files);
 
-    let mut idx = Index::default();
-    for file in &files {
-        parse(file, root, &mut idx);
-    }
+    let mut idx = files
+        .par_iter()
+        .map(|path| {
+            let mut next = Index::default();
+            parse(path, root, &mut next);
+            next
+        })
+        .reduce(Index::default, |mut left, right| {
+            merge(&mut left, right);
+            left
+        });
     sync(&mut idx);
     idx
 }
 
 fn apply(idx: &mut Index, root: &Path, paths: &[String]) {
     let ignore = matcher(root);
+    let mut files = Vec::<PathBuf>::new();
+    let mut rels = Vec::<String>::new();
     for raw in paths {
-        let Some((path, rel)) = resolve(root, raw) else {
+        let Some((path, item)) = resolve(root, raw) else {
             continue;
         };
-        trim(idx, &rel);
         if blocked(root, &path, path.is_dir(), ignore.as_ref()) {
+            trim_prefix(idx, &item);
             continue;
         }
         if path.is_file() && has_ext(&path) {
-            parse(&path, root, idx);
+            trim(idx, &item);
+            files.push(path);
+            rels.push(item);
+            continue;
         }
+        if path.is_dir() {
+            trim_prefix(idx, &item);
+            let start = files.len();
+            scan_dir(&path, root, ignore.as_ref(), &mut files);
+            rels.extend(files[start..].iter().map(|next| rel(next, root)));
+            continue;
+        }
+        trim_prefix(idx, &item);
     }
+
+    let mut seen = HashSet::new();
+    files.retain(|path| seen.insert(path.to_string_lossy().to_string()));
+
+    rels.sort();
+    rels.dedup();
+    for rel in &rels {
+        trim(idx, rel);
+    }
+
+    let next = files
+        .par_iter()
+        .map(|path| {
+            let mut out = Index::default();
+            parse(path, root, &mut out);
+            out
+        })
+        .reduce(Index::default, |mut left, right| {
+            merge(&mut left, right);
+            left
+        });
+    merge(idx, next);
+
     sync(idx);
 }
 
@@ -399,6 +590,56 @@ fn query(idx: &Index, component: Option<&str>, classes: Option<&[String]>) -> Op
     }
 
     None
+}
+
+fn query_usage(idx: &Index, component: &str, owners: Option<&[String]>) -> Option<UsageQueryResult> {
+    let entries = idx.usages.get(component)?;
+    if entries.is_empty() {
+        return None;
+    }
+
+    if let Some(names) = owners {
+        let allow = names
+            .iter()
+            .enumerate()
+            .map(|(idx, name)| (name.as_str(), idx as u32))
+            .collect::<HashMap<_, _>>();
+        let best = entries
+            .iter()
+            .filter_map(|entry| {
+                let owner = entry.owner.as_deref()?;
+                let rank = allow.get(owner).copied()?;
+                Some((rank, entry))
+            })
+            .min_by(|(left_rank, left), (right_rank, right)| {
+                left_rank
+                    .cmp(right_rank)
+                    .then_with(|| left.file.cmp(&right.file))
+                    .then_with(|| left.line.cmp(&right.line))
+            });
+        if let Some((rank, entry)) = best {
+            let total = names.len().max(1) as f32;
+            let confidence = (1.0 - (rank as f32 / total)).max(0.2);
+            return Some(UsageQueryResult {
+                file: entry.file.clone(),
+                line: entry.line,
+                owner: entry.owner.clone(),
+                confidence,
+            });
+        }
+        return None;
+    }
+
+    if entries.len() > 1 {
+        return None;
+    }
+    let best = entries.first()?;
+    Some(UsageQueryResult {
+        file: best.file.clone(),
+        line: best.line,
+        owner: best.owner.clone(),
+        confidence: 0.6,
+    })
 }
 
 #[cfg(test)]
@@ -520,6 +761,31 @@ mod tests {
     }
 
     #[test]
+    fn apply_removes_deleted_directory_entries() {
+        let root = temp();
+        write(
+            &root,
+            "src/sections/Hero.tsx",
+            "export default function Hero() { return <div className=\"hero\" /> }\n",
+        );
+        write(
+            &root,
+            "src/sections/Footer.tsx",
+            "export default function Footer() { return <div className=\"footer\" /> }\n",
+        );
+
+        let mut idx = build(&root);
+        fs::remove_dir_all(root.join("src/sections")).unwrap();
+        apply(&mut idx, &root, &["src/sections".to_string()]);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert!(idx.components.get("Hero").is_none());
+        assert!(idx.components.get("Footer").is_none());
+        assert!(idx.classes.get("hero").is_none());
+        assert!(idx.classes.get("footer").is_none());
+    }
+
+    #[test]
     fn query_dedupes_class_hits_per_file() {
         let root = temp();
         write(
@@ -608,6 +874,172 @@ mod tests {
 
         assert!(idx.components.get("Hero").is_some());
         assert!(idx.components.get("Leak").is_none());
+    }
+
+    #[test]
+    fn parse_extracts_component_usages() {
+        let root = temp();
+        write(
+            &root,
+            "src/sections/Hero.tsx",
+            "export default function Hero() { return <GridSection><Button /></GridSection> }\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        let usages = idx.usages.get("Button").unwrap();
+        assert_eq!(usages[0].file, "src/sections/Hero.tsx");
+        assert_eq!(usages[0].owner.as_deref(), Some("Hero"));
+    }
+
+    #[test]
+    fn parse_ignores_ts_generics_for_usage() {
+        let root = temp();
+        write(
+            &root,
+            "src/lib/api.ts",
+            "export function run() { return fetcher<ButtonPayload>() }\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert!(idx.usages.get("ButtonPayload").is_none());
+    }
+
+    #[test]
+    fn parse_tracks_usage_owner_per_scope() {
+        let root = temp();
+        write(
+            &root,
+            "src/sections/Mixed.tsx",
+            "export function Hero() { return <Button>Hero CTA</Button> }\nexport function Footer() { return <Button>Footer CTA</Button> }\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        let usages = idx.usages.get("Button").unwrap();
+        let hero = usages
+            .iter()
+            .find(|entry| entry.line == 1)
+            .and_then(|entry| entry.owner.as_deref());
+        let footer = usages
+            .iter()
+            .find(|entry| entry.line == 2)
+            .and_then(|entry| entry.owner.as_deref());
+        assert_eq!(hero, Some("Hero"));
+        assert_eq!(footer, Some("Footer"));
+    }
+
+    #[test]
+    fn parse_extracts_usage_from_jsx_js() {
+        let root = temp();
+        write(
+            &root,
+            "src/sections/Hero.js",
+            "export function Hero(){return <Button>Go</Button>}\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        let usages = idx.usages.get("Button").unwrap();
+        assert_eq!(usages[0].owner.as_deref(), Some("Hero"));
+    }
+
+    #[test]
+    fn query_usage_prefers_owner_rank() {
+        let idx = Index {
+            usages: HashMap::from([(
+                "Button".to_string(),
+                vec![
+                    UsageEntry {
+                        file: "src/sections/Services.tsx".to_string(),
+                        line: 10,
+                        owner: Some("Services".to_string()),
+                    },
+                    UsageEntry {
+                        file: "src/sections/Hero.tsx".to_string(),
+                        line: 20,
+                        owner: Some("Hero".to_string()),
+                    },
+                ],
+            )]),
+            ..Default::default()
+        };
+
+        let out = query_usage(
+            &idx,
+            "Button",
+            Some(&["GridSection".to_string(), "Hero".to_string(), "Services".to_string()]),
+        )
+        .unwrap();
+        assert_eq!(out.file, "src/sections/Hero.tsx");
+        assert_eq!(out.owner.as_deref(), Some("Hero"));
+    }
+
+    #[test]
+    fn query_usage_returns_none_when_owner_filter_misses() {
+        let idx = Index {
+            usages: HashMap::from([(
+                "Button".to_string(),
+                vec![UsageEntry {
+                    file: "src/sections/Hero.tsx".to_string(),
+                    line: 20,
+                    owner: Some("Hero".to_string()),
+                }],
+            )]),
+            ..Default::default()
+        };
+
+        let out = query_usage(&idx, "Button", Some(&["Layout".to_string()]));
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn query_usage_returns_none_when_unfiltered_is_ambiguous() {
+        let idx = Index {
+            usages: HashMap::from([(
+                "Button".to_string(),
+                vec![
+                    UsageEntry {
+                        file: "src/sections/Hero.tsx".to_string(),
+                        line: 20,
+                        owner: Some("Hero".to_string()),
+                    },
+                    UsageEntry {
+                        file: "src/sections/Footer.tsx".to_string(),
+                        line: 5,
+                        owner: Some("Footer".to_string()),
+                    },
+                ],
+            )]),
+            ..Default::default()
+        };
+
+        let out = query_usage(&idx, "Button", None);
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn query_usage_returns_single_unfiltered_hit() {
+        let idx = Index {
+            usages: HashMap::from([(
+                "Button".to_string(),
+                vec![UsageEntry {
+                    file: "src/sections/Hero.tsx".to_string(),
+                    line: 20,
+                    owner: Some("Hero".to_string()),
+                }],
+            )]),
+            ..Default::default()
+        };
+
+        let out = query_usage(&idx, "Button", None).unwrap();
+        assert_eq!(out.file, "src/sections/Hero.tsx");
+        assert!((out.confidence - 0.6).abs() < f32::EPSILON);
     }
 }
 
@@ -722,4 +1154,24 @@ pub fn query_design_index(
     };
 
     Ok(query(idx, component.as_deref(), classes.as_deref()))
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn query_design_usage_index(
+    app: AppHandle,
+    root: String,
+    component: String,
+    owners: Option<Vec<String>>,
+) -> Result<Option<UsageQueryResult>, String> {
+    let state = app.state::<DesignIndexState>();
+    let lock = state
+        .0
+        .lock()
+        .map_err(|e: std::sync::PoisonError<_>| e.to_string())?;
+    let Some(idx) = lock.get(&root) else {
+        return Ok(None);
+    };
+
+    Ok(query_usage(idx, &component, owners.as_deref()))
 }

--- a/packages/desktop/src-tauri/src/design_index.rs
+++ b/packages/desktop/src-tauri/src/design_index.rs
@@ -1,0 +1,559 @@
+use regex::Regex;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use tauri::{AppHandle, Manager};
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexEntry {
+    pub file: String,
+    pub line: Option<u32>,
+    pub component: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryResult {
+    pub file: String,
+    pub line: u32,
+    pub confidence: f32,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Index {
+    components: HashMap<String, Vec<IndexEntry>>,
+    classes: HashMap<String, Vec<IndexEntry>>,
+    names: Vec<String>,
+}
+
+pub struct DesignIndexState(pub Mutex<HashMap<String, Index>>);
+
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    "target",
+    ".git",
+    ".turbo",
+    "coverage",
+    "__pycache__",
+    ".cache",
+];
+
+const EXTENSIONS: &[&str] = &["tsx", "jsx", "vue", "svelte", "ts", "js"];
+
+fn comp_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?m)export\s+(?:default\s+)?(?:function|const|let|class)\s+([A-Z]\w*)")
+            .unwrap()
+    })
+}
+
+fn default_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?m)export\s+default\s+([A-Z]\w*)").unwrap())
+}
+
+fn named_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?m)export\s*\{\s*([A-Z]\w*)").unwrap())
+}
+
+fn class_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"class(?:Name)?\s*=\s*["']([^"']+)["']"#).unwrap())
+}
+
+fn class_expr_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"class(?:Name)?\s*=\s*\{[^}]*["'`]([^"'`]+)["'`]"#).unwrap())
+}
+
+fn should_skip(entry: &std::fs::DirEntry) -> bool {
+    let name = entry.file_name();
+    let s = name.to_string_lossy();
+    s.starts_with('.') || SKIP_DIRS.contains(&s.as_ref())
+}
+
+fn has_ext(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| EXTENSIONS.contains(&e))
+}
+
+fn scan_dir(dir: &Path, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if should_skip(&entry) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            scan_dir(&path, files);
+        } else if has_ext(&path) {
+            files.push(path);
+        }
+    }
+}
+
+fn normalize_rel(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn windows(path: &str) -> bool {
+    path.starts_with("//") || path.as_bytes().get(1) == Some(&b':')
+}
+
+fn inside(root: &Path, path: &Path) -> bool {
+    let root = normalize_rel(&root.to_string_lossy())
+        .trim_end_matches('/')
+        .to_string();
+    let path = normalize_rel(&path.to_string_lossy());
+    let (root, path) = if windows(&root) {
+        (root.to_lowercase(), path.to_lowercase())
+    } else {
+        (root, path)
+    };
+    path == root || path.starts_with(&(root + "/"))
+}
+
+fn skip(path: &str) -> bool {
+    path.split('/')
+        .any(|part| part.starts_with('.') || SKIP_DIRS.contains(&part))
+}
+
+fn rel(path: &Path, root: &Path) -> String {
+    normalize_rel(&path.strip_prefix(root).unwrap_or(path).to_string_lossy())
+}
+
+fn resolve(root: &Path, input: &str) -> Option<(PathBuf, String)> {
+    let path = PathBuf::from(input);
+    let abs = if path.is_absolute() { path } else { root.join(path) };
+    if !inside(root, &abs) {
+        return None;
+    }
+    let rel = rel(&abs, root);
+    if skip(&rel) {
+        return None;
+    }
+    Some((abs, rel))
+}
+
+fn push_component(idx: &mut Index, rel: &str, name: &str, line: u32) {
+    let entries = idx.components.entry(name.to_string()).or_default();
+    if entries.iter().any(|entry| entry.file == rel) {
+        return;
+    }
+    entries.push(IndexEntry {
+        file: rel.to_string(),
+        line: Some(line),
+        component: Some(name.to_string()),
+    });
+    if !idx.names.contains(&name.to_string()) {
+        idx.names.push(name.to_string());
+    }
+}
+
+fn trim(idx: &mut Index, rel: &str) {
+    idx.components.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel);
+        !entries.is_empty()
+    });
+    idx.classes.retain(|_, entries| {
+        entries.retain(|entry| entry.file != rel);
+        !entries.is_empty()
+    });
+}
+
+fn sync(idx: &mut Index) {
+    idx.names = idx.components.keys().cloned().collect();
+    idx.names.sort();
+}
+
+fn parse(path: &Path, root: &Path, idx: &mut Index) {
+    let Ok(content) = fs::read_to_string(path) else {
+        return;
+    };
+    let rel = rel(path, root);
+    let slice = content
+        .char_indices()
+        .nth(12000)
+        .map(|(i, _)| &content[..i])
+        .unwrap_or(&content);
+    let mut comp = None;
+
+    // Extract exported component names
+    for cap in comp_re().captures_iter(slice) {
+        let name = cap[1].to_string();
+        if comp.is_none() {
+            comp = Some(name.clone());
+        }
+        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        push_component(idx, &rel, &name, line);
+    }
+
+    for cap in default_re().captures_iter(slice) {
+        let name = cap[1].to_string();
+        if comp.is_none() {
+            comp = Some(name.clone());
+        }
+        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        push_component(idx, &rel, &name, line);
+    }
+
+    for cap in named_re().captures_iter(slice) {
+        let name = cap[1].to_string();
+        if comp.is_none() {
+            comp = Some(name.clone());
+        }
+        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        push_component(idx, &rel, &name, line);
+    }
+
+    // Also try filename-based component (e.g. Hero.tsx → Hero)
+    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+        if stem.chars().next().is_some_and(|c| c.is_uppercase()) && stem != "index" {
+            let name = stem.to_string();
+            if comp.is_none() {
+                comp = Some(name.clone());
+            }
+            push_component(idx, &rel, &name, 1);
+        }
+    }
+
+    // Extract class / className strings
+    let mut add = |raw: &str, line: u32| {
+        for cls in raw.split_whitespace() {
+            if cls.len() > 2 {
+                idx.classes
+                    .entry(cls.to_string())
+                    .or_default()
+                    .push(IndexEntry {
+                        file: rel.clone(),
+                        line: Some(line),
+                        component: comp.clone(),
+                    });
+            }
+        }
+    };
+
+    for cap in class_re().captures_iter(slice) {
+        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        add(&cap[1], line);
+    }
+
+    for cap in class_expr_re().captures_iter(slice) {
+        let line = content[..cap.get(0).unwrap().start()].matches('\n').count() as u32 + 1;
+        add(&cap[1], line);
+    }
+}
+
+fn build(root: &Path) -> Index {
+    let mut files = Vec::new();
+    scan_dir(root, &mut files);
+
+    let mut idx = Index::default();
+    for file in &files {
+        parse(file, root, &mut idx);
+    }
+    idx
+}
+
+fn apply(idx: &mut Index, root: &Path, paths: &[String]) {
+    for raw in paths {
+        let Some((path, rel)) = resolve(root, raw) else {
+            continue;
+        };
+        trim(idx, &rel);
+        if path.is_file() && has_ext(&path) {
+            parse(&path, root, idx);
+        }
+    }
+    sync(idx);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn temp() -> PathBuf {
+        std::env::temp_dir().join(format!("opencode-design-index-{}", Uuid::new_v4()))
+    }
+
+    fn write(root: &Path, rel: &str, content: &str) -> PathBuf {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn normalize_rel_uses_forward_slashes() {
+        assert_eq!(
+            normalize_rel(r"src\components\Hero.tsx"),
+            "src/components/Hero.tsx"
+        );
+    }
+
+    #[test]
+    fn parse_finds_default_and_named_exports() {
+        let root = temp();
+        write(
+            &root,
+            "src/components/index.tsx",
+            "const Hero = () => null\nexport default Hero\nfunction Card() { return null }\nexport { Card }\n",
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(idx.components.get("Hero").unwrap()[0].file, "src/components/index.tsx");
+        assert_eq!(idx.components.get("Card").unwrap()[0].file, "src/components/index.tsx");
+    }
+
+    #[test]
+    fn parse_handles_large_utf8_files() {
+        let root = temp();
+        let pad = "a".repeat(11_999);
+        write(
+            &root,
+            "src/components/Hero.tsx",
+            &format!("{pad}é\nexport default function Hero() {{ return null }}\n"),
+        );
+
+        let idx = build(&root);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert_eq!(idx.components.get("Hero").unwrap()[0].file, "src/components/Hero.tsx");
+    }
+
+    #[test]
+    fn apply_replaces_file_entries() {
+        let root = temp();
+        write(
+            &root,
+            "src/components/index.tsx",
+            "export default Hero\nconst Hero = () => null\n<div className=\"hero\" />\n",
+        );
+
+        let mut idx = build(&root);
+        write(
+            &root,
+            "src/components/index.tsx",
+            "export default Card\nconst Card = () => null\n<div className=\"card\" />\n",
+        );
+        apply(&mut idx, &root, &["src/components/index.tsx".to_string()]);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert!(idx.components.get("Hero").is_none());
+        assert!(idx.classes.get("hero").is_none());
+        assert_eq!(idx.components.get("Card").unwrap()[0].file, "src/components/index.tsx");
+        assert_eq!(idx.classes.get("card").unwrap()[0].file, "src/components/index.tsx");
+    }
+
+    #[test]
+    fn apply_removes_deleted_file_entries() {
+        let root = temp();
+        let path = write(
+            &root,
+            "src/components/index.tsx",
+            "export default Hero\nconst Hero = () => null\n<div className=\"hero\" />\n",
+        );
+
+        let mut idx = build(&root);
+        fs::remove_file(path).unwrap();
+        apply(&mut idx, &root, &["src/components/index.tsx".to_string()]);
+        fs::remove_dir_all(&root).unwrap();
+
+        assert!(idx.components.get("Hero").is_none());
+        assert!(idx.classes.get("hero").is_none());
+        assert!(idx.names.is_empty());
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn build_design_index(app: AppHandle, root: String) -> Result<Vec<String>, String> {
+    let dir = PathBuf::from(&root);
+    if !dir.is_dir() {
+        if let Ok(mut lock) = app.state::<DesignIndexState>().0.lock() {
+            lock.remove(&root);
+        }
+        return Err(format!("Not a directory: {root}"));
+    }
+
+    let dir2 = dir.clone();
+    let idx = tauri::async_runtime::spawn_blocking(move || build(&dir2))
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let names = idx.names.clone();
+    let count = idx.components.len();
+    let cls = idx.classes.len();
+    let files = idx
+        .components
+        .values()
+        .flat_map(|entries| entries.iter().map(|entry| entry.file.as_str()))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+
+    let state = app.state::<DesignIndexState>();
+    let mut lock = state.0.lock().map_err(|e| e.to_string())?;
+    lock.insert(root, idx);
+
+    tracing::info!(
+        "Design index built: {} components, {} class entries from {} files",
+        count,
+        cls,
+        files
+    );
+    Ok(names)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_design_index(
+    app: AppHandle,
+    root: String,
+    paths: Vec<String>,
+) -> Result<Vec<String>, String> {
+    let dir = PathBuf::from(&root);
+    if !dir.is_dir() {
+        if let Ok(mut lock) = app.state::<DesignIndexState>().0.lock() {
+            lock.remove(&root);
+        }
+        return Err(format!("Not a directory: {root}"));
+    }
+
+    if paths.is_empty() {
+        return build_design_index(app, root).await;
+    }
+
+    let cur = {
+        let state = app.state::<DesignIndexState>();
+        let lock = state.0.lock().map_err(|e| e.to_string())?;
+        lock.get(&root).cloned()
+    };
+
+    let dir2 = dir.clone();
+    let len = paths.len();
+    let idx = tauri::async_runtime::spawn_blocking(move || {
+        let Some(mut idx) = cur else {
+            return build(&dir2);
+        };
+        apply(&mut idx, &dir2, &paths);
+        idx
+    })
+    .await
+    .map_err(|err| err.to_string())?;
+
+    let names = idx.names.clone();
+    let count = idx.components.len();
+    let cls = idx.classes.len();
+
+    let state = app.state::<DesignIndexState>();
+    let mut lock = state.0.lock().map_err(|e| e.to_string())?;
+    lock.insert(root, idx);
+
+    tracing::info!(
+        "Design index updated: {} files, {} components, {} class entries",
+        len,
+        count,
+        cls
+    );
+    Ok(names)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn query_design_index(
+    app: AppHandle,
+    root: String,
+    component: Option<String>,
+    classes: Option<Vec<String>>,
+) -> Result<Option<QueryResult>, String> {
+    let state = app.state::<DesignIndexState>();
+    let lock = state
+        .0
+        .lock()
+        .map_err(|e: std::sync::PoisonError<_>| e.to_string())?;
+    let Some(idx) = lock.get(&root) else {
+        return Ok(None);
+    };
+
+    // 1. Try component name lookup
+    if let Some(name) = &component {
+        if let Some(entries) = idx.components.get(name) {
+            if entries.len() > 1 {
+                if let Some(cls) = &classes {
+                    let mut scores: HashMap<String, (u32, u32)> = HashMap::new();
+                    for entry in entries {
+                        scores.insert(entry.file.clone(), (0, entry.line.unwrap_or(1)));
+                    }
+                    for c in cls {
+                        if let Some(matches) = idx.classes.get(c.as_str()) {
+                            for entry in matches {
+                                if let Some(score) = scores.get_mut(&entry.file) {
+                                    score.0 += 1;
+                                }
+                            }
+                        }
+                    }
+                    if let Some((file, (score, line))) =
+                        scores.into_iter().max_by_key(|(_, (s, _))| *s)
+                    {
+                        if score > 0 {
+                            return Ok(Some(QueryResult {
+                                file,
+                                line,
+                                confidence: 1.0,
+                            }));
+                        }
+                    }
+                }
+                return Ok(None);
+            }
+            if let Some(best) = entries.first() {
+                return Ok(Some(QueryResult {
+                    file: best.file.clone(),
+                    line: best.line.unwrap_or(1),
+                    confidence: 1.0,
+                }));
+            }
+        }
+    }
+
+    // 2. Try class combination lookup
+    if let Some(cls) = &classes {
+        let mut scores: HashMap<String, (u32, u32)> = HashMap::new();
+        for c in cls {
+            if let Some(entries) = idx.classes.get(c.as_str()) {
+                for e in entries {
+                    let entry = scores
+                        .entry(e.file.clone())
+                        .or_insert((0, e.line.unwrap_or(1)));
+                    entry.0 += 1;
+                }
+            }
+        }
+        if let Some((file, (score, line))) = scores.into_iter().max_by_key(|(_, (s, _))| *s) {
+            let total = cls.len().max(1) as f32;
+            return Ok(Some(QueryResult {
+                file,
+                line,
+                confidence: score as f32 / total,
+            }));
+        }
+    }
+
+    Ok(None)
+}

--- a/packages/desktop/src-tauri/src/design_webview.rs
+++ b/packages/desktop/src-tauri/src/design_webview.rs
@@ -1,0 +1,102 @@
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewBuilder, WebviewUrl};
+use tauri::webview::PageLoadEvent;
+
+const LABEL: &str = "design-preview";
+
+pub struct DesignWebviewState(pub Mutex<Option<Webview>>);
+
+#[tauri::command]
+#[specta::specta]
+pub fn create_design_webview(
+    app: AppHandle,
+    url: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    script: Option<String>,
+) -> Result<(), String> {
+    let state = app.state::<DesignWebviewState>();
+    let mut slot = state.0.lock().map_err(|e| e.to_string())?;
+
+    if let Some(old) = slot.take() {
+        let _ = old.close();
+    }
+
+    let window = app
+        .get_window(crate::windows::MainWindow::LABEL)
+        .ok_or("main window not found")?;
+
+    let parsed = tauri::Url::parse(&url).map_err(|e| format!("{e}"))?;
+    let mut builder = WebviewBuilder::new(LABEL, WebviewUrl::External(parsed))
+        .user_agent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36");
+
+    if let Some(js) = script {
+        builder = builder.on_page_load(move |webview, payload| {
+            if matches!(payload.event(), PageLoadEvent::Finished) {
+                let _ = webview.eval(&js);
+            }
+        });
+    }
+
+    let webview = window
+        .add_child(
+            builder,
+            LogicalPosition::new(x, y),
+            LogicalSize::new(width, height),
+        )
+        .map_err(|e: tauri::Error| e.to_string())?;
+
+    *slot = Some(webview);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn resize_design_webview(
+    app: AppHandle,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    let state = app.state::<DesignWebviewState>();
+    let slot = state.0.lock().map_err(|e| e.to_string())?;
+    let wv = slot.as_ref().ok_or("design webview not open")?;
+    wv.set_position(LogicalPosition::new(x, y))
+        .map_err(|e: tauri::Error| e.to_string())?;
+    wv.set_size(LogicalSize::new(width, height))
+        .map_err(|e: tauri::Error| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn close_design_webview(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<DesignWebviewState>();
+    let mut slot = state.0.lock().map_err(|e| e.to_string())?;
+    if let Some(wv) = slot.take() {
+        wv.close().map_err(|e: tauri::Error| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn eval_design_webview(app: AppHandle, script: String) -> Result<(), String> {
+    let state = app.state::<DesignWebviewState>();
+    let slot = state.0.lock().map_err(|e| e.to_string())?;
+    let wv = slot.as_ref().ok_or("design webview not open")?;
+    wv.eval(&script).map_err(|e: tauri::Error| e.to_string())?;
+    Ok(())
+}
+
+/// Bridge command: child webview calls this via __TAURI_INTERNALS__.invoke,
+/// and we re-emit the payload as a Tauri event that the main webview picks up.
+#[tauri::command]
+#[specta::specta]
+pub fn design_bridge(app: AppHandle, event: String, payload: String) -> Result<(), String> {
+    app.emit(&event, payload).map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/packages/desktop/src-tauri/src/design_webview.rs
+++ b/packages/desktop/src-tauri/src/design_webview.rs
@@ -1,10 +1,82 @@
+use serde_json::Value;
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewBuilder, WebviewUrl};
 use tauri::webview::PageLoadEvent;
+use tauri::{
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewBuilder, WebviewUrl,
+};
 
 const LABEL: &str = "design-preview";
+const MAX_PAYLOAD: usize = 262_144;
+const MAX_COMMENT: usize = 8_192;
+const EVENTS: [&str; 5] = [
+    "design:element-select",
+    "design:debug-source",
+    "design:component-list",
+    "design:comment-submit",
+    "design:open-selected",
+];
 
 pub struct DesignWebviewState(pub Mutex<Option<Webview>>);
+
+fn validate_payload(event: &str, input: &str) -> Result<Value, String> {
+    if input.len() > MAX_PAYLOAD {
+        return Err("design bridge payload too large".into());
+    }
+
+    let value: Value = serde_json::from_str(input).map_err(|_| "invalid design bridge payload")?;
+
+    match event {
+        "design:element-select" | "design:open-selected" => {
+            if value.is_object() {
+                return Ok(value);
+            }
+            Err("invalid design bridge payload shape".into())
+        }
+        "design:debug-source" => {
+            let Some(log) = value.get("log") else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            let Some(list) = log.as_array() else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            if list.iter().any(|line| !line.is_string()) {
+                return Err("invalid design bridge payload shape".into());
+            }
+            Ok(value)
+        }
+        "design:component-list" => {
+            let Some(names) = value.get("names") else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            let Some(list) = names.as_array() else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            if list.iter().any(|name| !name.is_string()) {
+                return Err("invalid design bridge payload shape".into());
+            }
+            Ok(value)
+        }
+        "design:comment-submit" => {
+            let Some(comment) = value.get("comment") else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            let Some(text) = comment.as_str() else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            if text.len() > MAX_COMMENT {
+                return Err("design bridge comment too large".into());
+            }
+            let Some(info) = value.get("info") else {
+                return Err("invalid design bridge payload shape".into());
+            };
+            if !info.is_object() {
+                return Err("invalid design bridge payload shape".into());
+            }
+            Ok(value)
+        }
+        _ => Err("design bridge event not allowed".into()),
+    }
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -97,6 +169,16 @@ pub fn eval_design_webview(app: AppHandle, script: String) -> Result<(), String>
 #[tauri::command]
 #[specta::specta]
 pub fn design_bridge(app: AppHandle, event: String, payload: String) -> Result<(), String> {
-    app.emit(&event, payload).map_err(|e| e.to_string())?;
+    if !EVENTS.contains(&event.as_str()) {
+        return Err("design bridge event not allowed".into());
+    }
+
+    validate_payload(&event, &payload)?;
+
+    app.get_window(crate::windows::MainWindow::LABEL)
+        .ok_or("main window not found")?
+        .emit(&event, payload)
+        .map_err(|e| e.to_string())?;
+
     Ok(())
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod cli;
 mod constants;
+mod design_index;
+mod design_webview;
 #[cfg(target_os = "linux")]
 pub mod linux_display;
 #[cfg(target_os = "linux")]
@@ -348,6 +350,8 @@ pub fn run() {
             // ensuring all buffered logs are flushed on shutdown.
             handle.manage(logging::init(&log_dir));
 
+            handle.manage(design_webview::DesignWebviewState(std::sync::Mutex::new(None)));
+            handle.manage(design_index::DesignIndexState(std::sync::Mutex::new(Default::default())));
             builder.mount_events(&handle);
             tauri::async_runtime::spawn(initialize(handle));
 
@@ -387,7 +391,15 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             check_app_exists,
             wsl_path,
             resolve_app_path,
-            open_path
+            open_path,
+            design_webview::create_design_webview,
+            design_webview::resize_design_webview,
+            design_webview::close_design_webview,
+            design_webview::eval_design_webview,
+            design_webview::design_bridge,
+            design_index::build_design_index,
+            design_index::update_design_index,
+            design_index::query_design_index
         ])
         .events(tauri_specta::collect_events![
             LoadingWindowComplete,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -399,7 +399,8 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             design_webview::design_bridge,
             design_index::build_design_index,
             design_index::update_design_index,
-            design_index::query_design_index
+            design_index::query_design_index,
+            design_index::query_design_usage_index
         ])
         .events(tauri_specta::collect_events![
             LoadingWindowComplete,

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -30,7 +30,13 @@ export const commands = {
 	file: string,
 	line: number,
 	confidence: number,
-} | null>("query_design_index", { root, component, classes }),
+	} | null>("query_design_index", { root, component, classes }),
+	queryDesignUsageIndex: (root: string, component: string, owners: string[] | null) => __TAURI_INVOKE<{
+	file: string,
+	line: number,
+	owner: string | null,
+	confidence: number,
+	} | null>("query_design_usage_index", { root, component, owners }),
 };
 
 /** Events */
@@ -82,4 +88,3 @@ function makeEvent<T>(name: string) {
 
     return Object.assign(fn, base);
 }
-

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -19,6 +19,18 @@ export const commands = {
 	wslPath: (path: string, mode: "windows" | "linux" | null) => __TAURI_INVOKE<string>("wsl_path", { path, mode }),
 	resolveAppPath: (appName: string) => __TAURI_INVOKE<string | null>("resolve_app_path", { appName }),
 	openPath: (path: string, appName: string | null) => __TAURI_INVOKE<null>("open_path", { path, appName }),
+	createDesignWebview: (url: string, x: number, y: number, width: number, height: number, script: string | null) => __TAURI_INVOKE<null>("create_design_webview", { url, x, y, width, height, script }),
+	resizeDesignWebview: (x: number, y: number, width: number, height: number) => __TAURI_INVOKE<null>("resize_design_webview", { x, y, width, height }),
+	closeDesignWebview: () => __TAURI_INVOKE<null>("close_design_webview"),
+	evalDesignWebview: (script: string) => __TAURI_INVOKE<null>("eval_design_webview", { script }),
+	designBridge: (event: string, payload: string) => __TAURI_INVOKE<null>("design_bridge", { event, payload }),
+	buildDesignIndex: (root: string) => __TAURI_INVOKE<string[]>("build_design_index", { root }),
+	updateDesignIndex: (root: string, paths: string[]) => __TAURI_INVOKE<string[]>("update_design_index", { root, paths }),
+	queryDesignIndex: (root: string, component: string | null, classes: string[] | null) => __TAURI_INVOKE<{
+	file: string,
+	line: number,
+	confidence: number,
+} | null>("query_design_index", { root, component, classes }),
 };
 
 /** Events */
@@ -33,6 +45,12 @@ export type InitStep = { phase: "server_waiting" } | { phase: "sqlite_waiting" }
 export type LinuxDisplayBackend = "wayland" | "auto";
 
 export type LoadingWindowComplete = null;
+
+export type QueryResult = {
+		file: string,
+		line: number,
+		confidence: number,
+	};
 
 export type ServerReadyData = {
 		url: string,

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -30,13 +30,13 @@ export const commands = {
 	file: string,
 	line: number,
 	confidence: number,
-	} | null>("query_design_index", { root, component, classes }),
+} | null>("query_design_index", { root, component, classes }),
 	queryDesignUsageIndex: (root: string, component: string, owners: string[] | null) => __TAURI_INVOKE<{
 	file: string,
 	line: number,
 	owner: string | null,
 	confidence: number,
-	} | null>("query_design_usage_index", { root, component, owners }),
+} | null>("query_design_usage_index", { root, component, owners }),
 };
 
 /** Events */
@@ -66,6 +66,13 @@ export type ServerReadyData = {
 
 export type SqliteMigrationProgress = { type: "InProgress"; value: number } | { type: "Done" };
 
+export type UsageQueryResult = {
+		file: string,
+		line: number,
+		owner: string | null,
+		confidence: number,
+	};
+
 export type WslConfig = {
 		enabled: boolean,
 	};
@@ -88,3 +95,4 @@ function makeEvent<T>(name: string) {
 
     return Object.assign(fn, base);
 }
+

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -380,6 +380,28 @@ const createPlatform = (): Platform => {
       return commands.checkAppExists(appName)
     },
 
+    async createDesignWebview(url: string, x: number, y: number, width: number, height: number, script?: string) {
+      await commands.createDesignWebview(url, x, y, width, height, script ?? null)
+    },
+    async resizeDesignWebview(x: number, y: number, width: number, height: number) {
+      await commands.resizeDesignWebview(x, y, width, height)
+    },
+    async closeDesignWebview() {
+      await commands.closeDesignWebview()
+    },
+    async evalDesignWebview(script: string) {
+      await commands.evalDesignWebview(script)
+    },
+    async buildDesignIndex(root: string) {
+      return await commands.buildDesignIndex(root)
+    },
+    async updateDesignIndex(root: string, paths: string[]) {
+      return await commands.updateDesignIndex(root, paths)
+    },
+    async queryDesignIndex(root: string, component: string | null, classes: string[] | null) {
+      return await commands.queryDesignIndex(root, component, classes)
+    },
+
     async readClipboardImage() {
       const image = await readImage().catch(() => null)
       if (!image) return null

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -401,6 +401,9 @@ const createPlatform = (): Platform => {
     async queryDesignIndex(root: string, component: string | null, classes: string[] | null) {
       return await commands.queryDesignIndex(root, component, classes)
     },
+    async queryDesignUsageIndex(root: string, component: string, owners: string[] | null) {
+      return await commands.queryDesignUsageIndex(root, component, owners)
+    },
 
     async readClipboardImage() {
       const image = await readImage().catch(() => null)

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -128,7 +128,6 @@ function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   const mouseEnabled = !Flag.OPENCODE_DISABLE_MOUSE && (_config.mouse ?? true)
 
   return {
-    externalOutputMode: "passthrough",
     targetFps: 60,
     gatherStats: false,
     exitOnCtrlC: false,

--- a/packages/opencode/src/server/routes/experimental.test.ts
+++ b/packages/opencode/src/server/routes/experimental.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+import { tmpdir } from "node:os"
+import { Instance } from "@/project/instance"
+import { ProjectID } from "@/project/schema"
+import { ExperimentalRoutes } from "./experimental"
+
+describe("ExperimentalRoutes", () => {
+  let dir = ""
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "opencode-experimental-"))
+    ExperimentalRoutes.reset()
+    await Instance.reload({
+      directory: dir,
+      worktree: dir,
+      project: {
+        id: ProjectID.global,
+        worktree: dir,
+        sandboxes: [dir],
+        time: {
+          created: 1,
+          updated: 1,
+        },
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await Instance.disposeAll()
+    ExperimentalRoutes.reset()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test("POST /design persists the latest design state", async () => {
+    const app = ExperimentalRoutes()
+    const body = {
+      selectedElement: {
+        tagName: "button",
+        domPath: "body > button",
+      },
+      timestamp: 123,
+    }
+
+    const res = await Instance.provide({
+      directory: dir,
+      fn: () =>
+        app.request("http://localhost/design", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBe(true)
+    expect(await Bun.file(path.join(dir, ".opencode", ".design-state.json")).json()).toEqual(body)
+  })
+
+  test("GET /design returns the latest command payload", async () => {
+    const app = ExperimentalRoutes()
+    const body = {
+      type: "select",
+      selector: ".hero",
+      timestamp: 456,
+    }
+
+    await Bun.write(path.join(dir, ".opencode", ".design-command.json"), JSON.stringify(body))
+
+    const res = await Instance.provide({
+      directory: dir,
+      fn: () => app.request("http://localhost/design"),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(body)
+  })
+})

--- a/packages/opencode/src/server/routes/experimental.test.ts
+++ b/packages/opencode/src/server/routes/experimental.test.ts
@@ -76,4 +76,23 @@ describe("ExperimentalRoutes", () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual(body)
   })
+
+  test("GET /design returns null when command is not newer than since", async () => {
+    const app = ExperimentalRoutes()
+    const body = {
+      type: "select",
+      selector: ".hero",
+      timestamp: 456,
+    }
+
+    await Bun.write(path.join(dir, ".opencode", ".design-command.json"), JSON.stringify(body))
+
+    const res = await Instance.provide({
+      directory: dir,
+      fn: () => app.request("http://localhost/design?since=456"),
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+  })
 })

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import { mkdir } from "node:fs/promises"
 import z from "zod"
 import { ProviderID, ModelID } from "../../provider/schema"
 import { ToolRegistry } from "../../tool/registry"
@@ -15,6 +16,9 @@ import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { WorkspaceRoutes } from "./workspace"
+import { Log } from "../../util/log"
+
+const log = Log.create({ service: "experimental" })
 
 const ConsoleOrgOption = z.object({
   accountID: z.string(),
@@ -36,6 +40,34 @@ const ConsoleSwitchBody = z.object({
 
 export const ExperimentalRoutes = lazy(() =>
   new Hono()
+    .post("/design", validator("json", z.record(z.string(), z.any())), async (c) => {
+      try {
+        const dir = Instance.directory
+        const body = c.req.valid("json")
+        const folder = `${dir}/.opencode`
+        await mkdir(folder, { recursive: true })
+        await Bun.write(`${folder}/.design-state.json`, JSON.stringify(body))
+        return c.json(true)
+      } catch (err) {
+        const msg = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        log.error("POST /design failed", { error: msg })
+        return c.json({ error: msg }, 500)
+      }
+    })
+    .get("/design", async (c) => {
+      try {
+        const dir = Instance.directory
+        const target = `${dir}/.opencode/.design-command.json`
+        const file = Bun.file(target)
+        if (!(await file.exists())) return c.json(null)
+        const data = await file.json().catch(() => null)
+        return c.json(data)
+      } catch (err) {
+        const msg = err instanceof Error ? (err.stack ?? err.message) : String(err)
+        log.error("GET /design failed", { error: msg })
+        return c.json({ error: msg }, 500)
+      }
+    })
     .get(
       "/console",
       describeRoute({

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -57,10 +57,14 @@ export const ExperimentalRoutes = lazy(() =>
     .get("/design", async (c) => {
       try {
         const dir = Instance.directory
+        const since = Number(c.req.query("since") ?? 0)
         const target = `${dir}/.opencode/.design-command.json`
         const file = Bun.file(target)
         if (!(await file.exists())) return c.json(null)
         const data = await file.json().catch(() => null)
+        if (Number.isFinite(since) && since > 0 && typeof data?.timestamp === "number" && data.timestamp <= since) {
+          return c.json(null)
+        }
         return c.json(data)
       } catch (err) {
         const msg = err instanceof Error ? (err.stack ?? err.message) : String(err)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1090,7 +1090,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                         let r: LSP.Range | undefined
                         if ("range" in symbol) r = symbol.range
                         else if ("location" in symbol) r = symbol.location.range
-                        if (r?.start?.line && r?.start?.line === start) {
+                        if (r?.start?.line !== undefined && r.start.line === start) {
                           start = r.start.line
                           end = r?.end?.line ?? start
                           break

--- a/packages/ui/src/components/file.tsx
+++ b/packages/ui/src/components/file.tsx
@@ -120,15 +120,22 @@ type MouseHit = {
   side?: DiffSelectionSide
 }
 
+type SelectionOpts = {
+  root?: ShadowRoot
+  text?: Range
+  reveal?: boolean
+}
+
 type ViewerConfig = {
   enableLineSelection: () => boolean
   selectedLines: () => SelectedLineRange | null | undefined
   commentedLines: () => SelectedLineRange[]
   onLineSelectionEnd: (range: SelectedLineRange | null) => void
+  revealSelectedLines?: () => boolean
 
   // mode-specific callbacks
   lineFromMouseEvent: (event: MouseEvent) => MouseHit
-  setSelectedLines: (range: SelectedLineRange | null, preserve?: { root: ShadowRoot; text: Range }) => void
+  setSelectedLines: (range: SelectedLineRange | null, opts?: SelectionOpts) => void
   updateSelection: (preserveTextSelection: boolean) => void
   buildDragSelection: () => SelectedLineRange | undefined
   buildClickSelection: () => SelectedLineRange | undefined
@@ -281,7 +288,7 @@ function useFileViewer(config: ViewerConfig) {
   })
 
   createEffect(() => {
-    config.setSelectedLines(config.selectedLines() ?? null)
+    config.setSelectedLines(config.selectedLines() ?? null, { reveal: config.revealSelectedLines?.() === true })
   })
 
   createEffect(() => {
@@ -360,6 +367,7 @@ type ModeConfig = {
   selectedLines: () => SelectedLineRange | null | undefined
   commentedLines: () => SelectedLineRange[] | undefined
   onLineSelectionEnd: (range: SelectedLineRange | null) => void
+  revealSelectedLines?: () => boolean
 }
 
 type RenderTarget = {
@@ -382,6 +390,7 @@ function useModeViewer(config: ModeConfig, adapter: ModeAdapter) {
     selectedLines: config.selectedLines,
     commentedLines: () => config.commentedLines() ?? [],
     onLineSelectionEnd: config.onLineSelectionEnd,
+    revealSelectedLines: config.revealSelectedLines,
     ...adapter,
   })
 }
@@ -675,6 +684,8 @@ function ViewerShell(props: {
 function TextViewer<T>(props: TextFileProps<T>) {
   let instance: PierreFile<T> | VirtualizedFile<T> | undefined
   let viewer!: Viewer
+  let reveal = false
+  let revealFrame: number | undefined
 
   const [local, others] = splitProps(props, textKeys)
 
@@ -711,12 +722,36 @@ function TextViewer<T>(props: TextFileProps<T>) {
 
   const lineFromMouseEvent = (event: MouseEvent): MouseHit => mouseHit(event, parseLine)
 
-  const applySelection = (range: SelectedLineRange | null) => {
+  const showSelection = (range: SelectedLineRange | null, tries = 3) => {
+    if (revealFrame !== undefined) cancelAnimationFrame(revealFrame)
+    revealFrame = undefined
+    if (!range) return
+    const line = Math.min(range.start, range.end)
+    if (line < 1 || line !== Math.max(range.start, range.end)) return
+
+    const run = (left: number) => {
+      revealFrame = requestAnimationFrame(() => {
+        revealFrame = undefined
+        const root = viewer.getRoot()
+        const target = root?.querySelector(`[data-line="${line}"]`)
+        if (target instanceof HTMLElement) {
+          target.scrollIntoView({ block: "nearest", inline: "nearest" })
+          return
+        }
+        if (left > 0) run(left - 1)
+      })
+    }
+
+    run(tries)
+  }
+
+  const applySelection = (range: SelectedLineRange | null, opts?: SelectionOpts) => {
     const current = instance
     if (!current) return false
 
     if (virtual()) {
       current.setSelectedLines(range)
+      if (opts?.reveal) showSelection(range)
       return true
     }
 
@@ -751,12 +786,15 @@ function TextViewer<T>(props: TextFileProps<T>) {
     })()
 
     current.setSelectedLines(normalized)
+    if (opts?.reveal) showSelection(normalized)
     return true
   }
 
-  const setSelectedLines = (range: SelectedLineRange | null) => {
+  const setSelectedLines = (range: SelectedLineRange | null, opts?: SelectionOpts) => {
     viewer.lastSelection = range
-    applySelection(range)
+    reveal = opts?.reveal === true
+    if (applySelection(range, { reveal })) reveal = false
+    restoreShadowTextSelection(opts?.root, opts?.text)
   }
 
   const adapter: ModeAdapter = {
@@ -798,6 +836,7 @@ function TextViewer<T>(props: TextFileProps<T>) {
       selectedLines: () => local.selectedLines,
       commentedLines: () => local.commentedLines,
       onLineSelectionEnd: (range) => local.onLineSelectionEnd?.(range),
+      revealSelectedLines: () => true,
     },
     adapter,
   )
@@ -823,7 +862,7 @@ function TextViewer<T>(props: TextFileProps<T>) {
         return root.querySelectorAll("[data-line]").length >= lineCount()
       },
       onReady: () => {
-        applySelection(viewer.lastSelection)
+        if (applySelection(viewer.lastSelection, { reveal })) reveal = false
         viewer.find.refresh({ reset: true })
         local.onRendered?.()
       },
@@ -878,6 +917,7 @@ function TextViewer<T>(props: TextFileProps<T>) {
     instance?.cleanUp()
     instance = undefined
     virtuals.cleanup()
+    if (revealFrame !== undefined) cancelAnimationFrame(revealFrame)
   })
 
   return <ViewerShell mode="text" viewer={viewer} class={local.class} classList={local.classList} />
@@ -899,7 +939,7 @@ function DiffViewer<T>(props: DiffFileProps<T>) {
 
   const lineFromMouseEvent = (event: MouseEvent): MouseHit => mouseHit(event, findDiffLineNumber, diffMouseSide)
 
-  const setSelectedLines = (range: SelectedLineRange | null, preserve?: { root: ShadowRoot; text: Range }) => {
+  const setSelectedLines = (range: SelectedLineRange | null, opts?: SelectionOpts) => {
     const active = instance
     if (!active) return
 
@@ -911,7 +951,7 @@ function DiffViewer<T>(props: DiffFileProps<T>) {
 
     viewer.lastSelection = fixed
     active.setSelectedLines(fixed)
-    restoreShadowTextSelection(preserve?.root, preserve?.text)
+    restoreShadowTextSelection(opts?.root, opts?.text)
   }
 
   const adapter: ModeAdapter = {

--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -9,6 +9,8 @@ import { useI18n } from "../context/i18n"
 
 installLineCommentStyles()
 
+const mentionPattern = /(^|[\s([{"'])@(\S*)$/
+
 export type LineCommentVariant = "default" | "editor" | "add"
 
 function InlineGlyph(props: { icon: "comment" | "plus" }) {
@@ -267,12 +269,12 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
     if (textarea.selectionStart !== textarea.selectionEnd) return
 
     const end = textarea.selectionStart
-    const match = textarea.value.slice(0, end).match(/@(\S*)$/)
+    const match = textarea.value.slice(0, end).match(mentionPattern)
     if (!match) return
 
     return {
-      query: match[1] ?? "",
-      start: end - match[0].length,
+      query: match[2] ?? "",
+      start: end - ((match[2]?.length ?? 0) + 1),
       end,
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #20543

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds a desktop Design Preview flow in the session side panel, backed by a dedicated Tauri webview bridge.
- Adds design index and source-resolution improvements (including confidence-aware open/comment behavior and preview sync hardening).
- Adds experimental `/design` route support and plugin bridge tools used by preview automation (`get_selected_element`, `get_design_comments`, `update_element_styles`, `select_element`, `set_viewport`).

### How did you verify your code works?

- `bun run build` in `packages/app`
- `bun run typecheck` from repo root

### Screenshots / recordings

_No visual styling changes. This is functional preview integration across app/desktop/bridge._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR