### PR TITLE
fix(provider): route top-level gateway routing options to gateway namespace

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -902,31 +902,59 @@ export namespace ProviderTransform {
     amazon: "bedrock",
   }
 
+  // Gateway-native routing/caching controls that always belong in providerOptions.gateway,
+  // regardless of whether the user nested them under a `gateway` key.
+  // Sourced from GatewayProviderOptions in @ai-sdk/gateway.
+  const GATEWAY_ROUTING_KEYS = new Set([
+    "only",
+    "order",
+    "user",
+    "tags",
+    "models",
+    "byok",
+    "zeroDataRetention",
+    "disallowPromptTraining",
+    "hipaaCompliant",
+    "quotaEntityId",
+    "providerTimeouts",
+  ])
+
   export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
     if (model.api.npm === "@ai-sdk/gateway") {
       // Gateway providerOptions are split across two namespaces:
       // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
       // - `<upstream slug>`: provider-specific model options (anthropic/openai/...)
-      // We keep `gateway` as-is and route every other top-level option under the
-      // model-derived upstream slug.
+      // We keep `gateway` as-is. Top-level keys that are known gateway routing controls
+      // are merged into `gateway`; all other top-level keys go under the upstream slug.
       const i = model.api.id.indexOf("/")
       const rawSlug = i > 0 ? model.api.id.slice(0, i) : undefined
       const slug = rawSlug ? (SLUG_OVERRIDES[rawSlug] ?? rawSlug) : undefined
       const gateway = options.gateway
-      const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "gateway"))
-      const has = Object.keys(rest).length > 0
+      const rest = Object.entries(options).filter(([k]) => k !== "gateway")
+      const gatewayRest = Object.fromEntries(rest.filter(([k]) => GATEWAY_ROUTING_KEYS.has(k)))
+      const providerRest = Object.fromEntries(rest.filter(([k]) => !GATEWAY_ROUTING_KEYS.has(k)))
 
       const result: Record<string, any> = {}
-      if (gateway !== undefined) result.gateway = gateway
 
-      if (has) {
+      // Merge explicit `gateway` key with any top-level gateway routing keys
+      const hasGatewayRest = Object.keys(gatewayRest).length > 0
+      if (gateway !== undefined || hasGatewayRest) {
+        result.gateway =
+          gateway && typeof gateway === "object" && !Array.isArray(gateway)
+            ? { ...gateway, ...gatewayRest }
+            : hasGatewayRest
+              ? gatewayRest
+              : gateway
+      }
+
+      const hasProviderRest = Object.keys(providerRest).length > 0
+      if (hasProviderRest) {
         if (slug) {
-          // Route model-specific options under the provider slug
-          result[slug] = rest
-        } else if (gateway && typeof gateway === "object" && !Array.isArray(gateway)) {
-          result.gateway = { ...gateway, ...rest }
+          result[slug] = providerRest
+        } else if (result.gateway && typeof result.gateway === "object" && !Array.isArray(result.gateway)) {
+          result.gateway = { ...result.gateway, ...providerRest }
         } else {
-          result.gateway = rest
+          result.gateway = providerRest
         }
       }
 


### PR DESCRIPTION
### Issue for this PR

Closes #21130

### Type of change

- [x] Bug fix

### What does this PR do?

When using the `vercel` provider (backed by `@ai-sdk/gateway`), routing options like `only`, `order`, and `zeroDataRetention` set directly in model options were silently ignored. The `providerOptions()` transform in `transform.ts` routed every top-level option that wasn't already under a `gateway:` key into the upstream provider slug namespace (e.g., `providerOptions.moonshotai.only`). The `@ai-sdk/gateway` SDK reads routing controls from `providerOptions.gateway`, so these options had no effect.

**Root cause**: `providerOptions()` for `@ai-sdk/gateway` models filtered only the `gateway` key and put everything else under `result[slug]`. Options like `only: ["bedrock"]` ended up as `providerOptions.moonshotai.only` instead of `providerOptions.gateway.only`.

**Fix**: Add a `GATEWAY_ROUTING_KEYS` set containing the known `GatewayProviderOptions` keys from `@ai-sdk/gateway` (`only`, `order`, `user`, `tags`, `models`, `byok`, `zeroDataRetention`, `disallowPromptTraining`, `hipaaCompliant`, `quotaEntityId`, `providerTimeouts`). In `providerOptions()`, top-level keys that match this set are merged into the `gateway` namespace alongside any explicit `gateway: {}` block. All other top-level options continue to be routed under the upstream provider slug as before. Both the old nested format (`options.gateway.only`) and the flat format (`options.only`) now work correctly.

### How did you verify your code works?

- `bun run typecheck` passes (all 13 packages, full turbo)
- `bun test test/provider/` passes (243 tests)
- Traced the transform logic for all combinations:
  - `options.only = ["bedrock"]` → `providerOptions.gateway.only` ✅
  - `options.gateway = { only: [...] }` (existing workaround) → still works ✅
  - Mixed: `gateway: { caching: "auto" }` (from base options) + `only` from model options → both merged into `gateway` ✅
  - Non-gateway model-specific options (`topP`, `temperature`) → still routed to provider slug ✅

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR