### PR TITLE
fix(session): use parentID instead of timestamp for loop exit condition

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1374,7 +1374,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               lastAssistant?.finish &&
               !["tool-calls"].includes(lastAssistant.finish) &&
               !hasToolCalls &&
-              lastUser.id < lastAssistant.id
+              (
+                // Use parentID to determine if assistant message is a response to the last user message.
+                // This is more reliable than timestamp comparison when client/server clocks are out of sync.
+                lastAssistant.parentID === lastUser.id ||
+                // Fallback to timestamp comparison for backward compatibility with messages
+                // that may not have parentID set.
+                (!lastAssistant.parentID && lastUser.id < lastAssistant.id)
+              )
             ) {
               log.info("exiting loop", { sessionID })
               break


### PR DESCRIPTION
## Issue for this PR

Closes #14935

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

Fixes duplicate assistant responses caused by clock skew between client and server systems.

### Problem

When client and server have different system times (clock skew), the prompt loop's exit condition `lastUser.id < lastAssistant.id` fails because message IDs are timestamp-based. This causes the loop to continue and generate a second assistant response for the same user message.

The issue occurs when:
- Client clock is faster/slower than server clock by 5+ seconds
- Different timezone configurations between client and server
- NTP sync issues on either side

### Solution

Replace timestamp-based comparison with explicit `parentID` relationship check. The assistant message's `parentID` field already stores the ID of the user message it responds to, making this a more reliable indicator than timestamp comparison.

**Changes:**
- Modified loop exit condition in `packages/opencode/src/session/prompt.ts`
- Added parentID check as primary exit condition
- Kept timestamp comparison as fallback for backward compatibility

## How did you verify your code works?

I reproduced and verified the fix in my local environment:

1. **Setup**: OpenChamber 1.9.3 + OpenCode 1.3.17
2. **Reproduction**: Adjusted server time to be 10 seconds faster than client
3. **Before fix**: Sending a message produced two different assistant responses
4. **After fix**: Only one assistant response is generated
5. **Additional testing**: Also tested with server time 10 seconds slower - works correctly

The fix uses the existing `parentID` field which is already populated correctly, so no database migration or data changes are needed.

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<!-- Triggering compliance check rerun -->
