### PR TITLE
fix(skill): recover malformed skill names

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -41,7 +41,12 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
     description,
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
-      const skill = await Skill.get(params.name)
+      const name = params.name.trim()
+      const clean = name.replace(/^[^a-z0-9_-]+|[^a-z0-9_-]+$/gi, "")
+      const skill =
+        (await Skill.get(params.name)) ??
+        (name !== params.name ? await Skill.get(name) : undefined) ??
+        (clean !== name ? await Skill.get(clean) : undefined)
 
       if (!skill) {
         const available = await Skill.all().then((x) => x.map((skill) => skill.name).join(", "))
@@ -50,8 +55,8 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
 
       await ctx.ask({
         permission: "skill",
-        patterns: [params.name],
-        always: [params.name],
+        patterns: [skill.name],
+        always: [skill.name],
         metadata: {},
       })
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -164,4 +164,52 @@ Use this skill.
       process.env.OPENCODE_TEST_HOME = home
     }
   })
+
+  test("execute repairs malformed skill names when the cleaned name exists", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        const skillDir = path.join(dir, ".opencode", "skill", "rpa-vision")
+        await Bun.write(
+          path.join(skillDir, "SKILL.md"),
+          `---
+name: rpa-vision
+description: Skill for tool tests.
+---
+
+# RPA Vision
+`,
+        )
+      },
+    })
+
+    const home = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const tool = await SkillTool.init()
+          const requests: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+          const ctx: Tool.Context = {
+            ...baseCtx,
+            ask: async (req) => {
+              requests.push(req)
+            },
+          }
+
+          const result = await tool.execute({ name: "}rpa-vision " }, ctx)
+
+          expect(requests.length).toBe(1)
+          expect(requests[0].patterns).toEqual(["rpa-vision"])
+          expect(requests[0].always).toEqual(["rpa-vision"])
+          expect(result.metadata.name).toBe("rpa-vision")
+          expect(result.output).toContain(`<skill_content name="rpa-vision">`)
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = home
+    }
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #21279

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `skill` tool previously required an exact skill name match, so malformed model output like `"}rpa-vision "` failed even when `rpa-vision` existed.

This retries lookup with a trimmed and cleaned name when the exact lookup misses, then uses the resolved canonical skill name for permission checks. It keeps the change local to the skill tool and adds a regression test for the reported case.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/skill.test.ts`
- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR