### PR TITLE
docs(providers): add Rapid-MLX local provider section

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1550,6 +1550,45 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### Rapid-MLX
+
+You can configure opencode to use local models through [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX), an OpenAI-compatible inference server for Apple Silicon built on `mlx-lm`.
+
+```bash
+pip install rapid-mlx
+rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit
+```
+
+```json title="opencode.json" "rapid-mlx" {5, 6, 8, 10-14}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "rapid-mlx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rapid-MLX (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8000/v1"
+      },
+      "models": {
+        "mlx-community/Qwen3.5-4B-MLX-4bit": {
+          "name": "Qwen3.5 4B (MLX)"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `rapid-mlx` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider. `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server.
+- `models` is a map of model IDs to their configurations.
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.


### PR DESCRIPTION
## Summary

Adds a Rapid-MLX section to the Providers docs page.
[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an
OpenAI-compatible inference server for Apple Silicon built on
`mlx-lm`, exposing the standard chat completions API on
`http://127.0.0.1:8000/v1`.

## Why

The Providers page already documents llama.cpp, LM Studio, and Ollama
as local OpenAI-compatible options. Rapid-MLX fills the
Apple-Silicon-native MLX gap. It works with the existing
`@ai-sdk/openai-compatible` provider — no code changes, just a
docs addition.

## Companion PR

A separate PR is open at anomalyco/models.dev#1361 that adds the
`rapid-mlx` entry to the canonical provider TOML database. This
opencode docs PR documents the manual `opencode.json` config.

## Scope

Docs only. Single-file change to `packages/web/src/content/docs/providers.mdx`.