### PR TITLE
fix(tui): use sentence case for theme mode items

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -675,7 +675,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       category: "System",
     },
     {
-      title: "Toggle Theme Mode",
+      title: "Toggle theme mode",
       value: "theme.switch_mode",
       onSelect: (dialog) => {
         setMode(mode() === "dark" ? "light" : "dark")
@@ -684,7 +684,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       category: "System",
     },
     {
-      title: locked() ? "Unlock Theme Mode" : "Lock Theme Mode",
+      title: locked() ? "Unlock theme mode" : "Lock theme mode",
       value: "theme.mode.lock",
       onSelect: (dialog) => {
         if (locked()) unlock()


### PR DESCRIPTION
### Issue for this PR

Fixes #21191

### Type of change

- [x] Bug fix

### What does this PR do?

Change "Toggle Theme Mode" to "Toggle theme mode" and similar inconsistent capitalizations in the command palette to use sentence case consistently.

### How did you verify your code works?

- Visual inspection of command palette items
- No behavioral changes, only text case

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR