### PR TITLE
fix(tui): ensure input text visible at small window sizes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -896,7 +896,8 @@ export function Prompt(props: PromptProps) {
             paddingLeft={2}
             paddingRight={2}
             paddingTop={1}
-            flexShrink={0}
+            minHeight={0}
+            flexShrink={1}
             backgroundColor={theme.backgroundElement}
             flexGrow={1}
           >


### PR DESCRIPTION
### Issue for this PR

Fixes #4332

### Type of change

- [x] Bug fix

### What does this PR do?

The prompt component had `flexShrink={0}` which prevented the textarea container from shrinking when the window is small. This caused text to become invisible or clipped at small terminal sizes (80x24, 80x40).

Changed the textarea container box to use:
- `minHeight={0}` to allow shrinking below content size
- `flexShrink={1}` to allow responsive shrinking

This follows the same pattern used in home.tsx for components that need to shrink responsively while maintaining minimum visibility.

### How did you verify your code works?

- Visual inspection at various terminal sizes
- Follows existing design system patterns

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR