### PR TITLE
fix(tui): animate thinking spinner correctly

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/spinner.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/spinner.tsx
@@ -14,7 +14,7 @@ export function Spinner(props: { children?: JSX.Element; color?: RGBA }) {
   return (
     <Show when={kv.get("animations_enabled", true)} fallback={<text fg={color()}>⋯ {props.children}</text>}>
       <box flexDirection="row" gap={1}>
-        <spinner frames={frames} interval={80} color={color()} />
+        <spinner frames={frames} interval={80} color={color()} autoplay={true} />
         <Show when={props.children}>
           <text fg={color()}>{props.children}</text>
         </Show>


### PR DESCRIPTION
### Issue for this PR

Fixes #20978

### Type of change

- [x] Bug fix

### What does this PR do?

The thinking spinner appeared but didn't animate - it stayed static instead of cycling through frames.

Added `autoplay={true}` explicitly to the spinner element to ensure the animation starts immediately when the component is created.

### How did you verify your code works?

- Visual inspection of spinner animation
- Follows existing package patterns

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR