### PR TITLE
fix(sdk): narrow prompt part input id type

### DIFF
--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -6,7 +6,7 @@ import type { AgentPart, FileAttachmentPart, ImageAttachmentPart, Prompt } from 
 import { Identifier } from "@/utils/id"
 import { createCommentMetadata, formatCommentNote } from "@/utils/comment-note"
 
-type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: string }
+type PromptRequestPart = (TextPartInput | FilePartInput | AgentPartInput) & { id: `prt${string}` }
 
 type ContextFile = {
   key: string

--- a/packages/app/src/utils/id.ts
+++ b/packages/app/src/utils/id.ts
@@ -19,25 +19,25 @@ export namespace Identifier {
     return z.string().startsWith(prefixes[prefix])
   }
 
-  export function ascending(prefix: Prefix, given?: string) {
+  export function ascending<K extends Prefix>(prefix: K, given?: string) {
     return generateID(prefix, false, given)
   }
 
-  export function descending(prefix: Prefix, given?: string) {
+  export function descending<K extends Prefix>(prefix: K, given?: string) {
     return generateID(prefix, true, given)
   }
 }
 
-function generateID(prefix: Prefix, descending: boolean, given?: string): string {
+function generateID<K extends Prefix>(prefix: K, descending: boolean, given?: string): `${(typeof prefixes)[K]}${string}` {
   if (!given) {
-    return create(prefix, descending)
+    return create(prefix, descending) as `${(typeof prefixes)[K]}${string}`
   }
 
   if (!given.startsWith(prefixes[prefix])) {
     throw new Error(`ID ${given} does not start with ${prefixes[prefix]}`)
   }
 
-  return given
+  return given as `${(typeof prefixes)[K]}${string}`
 }
 
 function create(prefix: Prefix, descending: boolean, timestamp?: number): string {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -705,7 +705,7 @@ export function Prompt(props: PromptProps) {
           variant,
           parts: [
             {
-              id: PartID.ascending(),
+              id: PartID.ascending() as `prt${string}`,
               type: "text",
               text: inputText,
             },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/part.ts
@@ -8,9 +8,9 @@ export function strip(part: Item & { id: string; messageID: string; sessionID: s
   return rest
 }
 
-export function assign(part: Item): Item & { id: PartID } {
+export function assign(part: Item): Item & { id: `prt${string}` } {
   return {
     ...part,
-    id: PartID.ascending(),
+    id: PartID.ascending() as `prt${string}`,
   }
 }

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -9,6 +9,20 @@ import path from "path"
 
 import { createClient } from "@hey-api/openapi-ts"
 
+async function patchPartInputIDs(file: string) {
+  let content = await Bun.file(file).text()
+  if (!content.includes("export type PartIDInput = `prt${string}`")) {
+    content = content.replace(
+      "export type TextPartInput = {\n",
+      "export type PartIDInput = `prt${string}`\n\nexport type TextPartInput = {\n",
+    )
+  }
+  for (const name of ["TextPartInput", "FilePartInput", "AgentPartInput", "SubtaskPartInput"]) {
+    content = content.replace(new RegExp(`(export type ${name} = \\{\\n)  id\\?: string`), `$1  id?: PartIDInput`)
+  }
+  await Bun.write(file, content)
+}
+
 await $`bun dev generate > ${dir}/openapi.json`.cwd(path.resolve(dir, "../../opencode"))
 
 await createClient({
@@ -38,6 +52,7 @@ await createClient({
   ],
 })
 
+await patchPartInputIDs("./src/v2/gen/types.gen.ts")
 await $`bun prettier --write src/gen`
 await $`bun prettier --write src/v2`
 await $`rm -rf dist`

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -20,6 +20,11 @@ async function patchPartInputIDs(file: string) {
   for (const name of ["TextPartInput", "FilePartInput", "AgentPartInput", "SubtaskPartInput"]) {
     content = content.replace(new RegExp(`(export type ${name} = \\{\\n)  id\\?: string`), `$1  id?: PartIDInput`)
   }
+  // SessionCommandData has an inline part type with the same prt constraint
+  content = content.replace(
+    /(export type SessionCommandData[\s\S]*?parts\?\: Array<\{\n\s+)id\?: string/,
+    "$1id?: PartIDInput",
+  )
   await Bun.write(file, content)
 }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1401,8 +1401,10 @@ export type VcsInfo = {
   branch: string
 }
 
+export type PartIDInput = `prt${string}`
+
 export type TextPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "text"
   text: string
   synthetic?: boolean
@@ -1417,7 +1419,7 @@ export type TextPartInput = {
 }
 
 export type FilePartInput = {
-  id?: string
+  id?: PartIDInput
   type: "file"
   mime: string
   filename?: string
@@ -1426,7 +1428,7 @@ export type FilePartInput = {
 }
 
 export type AgentPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "agent"
   name: string
   source?: {
@@ -1437,7 +1439,7 @@ export type AgentPartInput = {
 }
 
 export type SubtaskPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "subtask"
   prompt: string
   description: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3851,7 +3851,7 @@ export type SessionCommandData = {
     command: string
     variant?: string
     parts?: Array<{
-      id?: string
+      id?: PartIDInput
       type: "file"
       mime: string
       filename?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1834,8 +1834,10 @@ export type McpResource = {
   client: string
 }
 
+export type PartIDInput = `prt${string}`
+
 export type TextPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "text"
   text: string
   synthetic?: boolean
@@ -1850,7 +1852,7 @@ export type TextPartInput = {
 }
 
 export type FilePartInput = {
-  id?: string
+  id?: PartIDInput
   type: "file"
   mime: string
   filename?: string
@@ -1859,7 +1861,7 @@ export type FilePartInput = {
 }
 
 export type AgentPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "agent"
   name: string
   source?: {
@@ -1870,7 +1872,7 @@ export type AgentPartInput = {
 }
 
 export type SubtaskPartInput = {
-  id?: string
+  id?: PartIDInput
   type: "subtask"
   prompt: string
   description: string


### PR DESCRIPTION
### Issue for this PR

Closes #21311

### Type of change

- [x] Bug fix

### What does this PR do?

The server rejects part IDs that don't start with `prt`, but the generated SDK types had `id?: string`. This adds a `PartIDInput = \`prt\${string}\`` type and uses it for `TextPartInput`, `FilePartInput`, `AgentPartInput`, and `SubtaskPartInput`. A post-processing step in the build script keeps this correct when types are regenerated. Downstream call sites in `packages/app` and `packages/opencode` were updated to match.

### How did you verify your code works?

Full turbo typecheck passes across all 13 packages. The `id` field type now matches the OpenAPI schema pattern `^prt.*`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR