### PR TITLE
style(app): redesign jump-to-bottom button per figma spec

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -577,10 +577,18 @@ export function MessageTimeline(props: {
           }}
         >
           <button
-            class="pointer-events-auto size-8 flex items-center justify-center rounded-full bg-background-base border border-border-base shadow-sm text-text-base hover:bg-background-stronger transition-colors"
+            class="pointer-events-auto flex items-center justify-center w-10 h-8 bg-transparent border-none cursor-pointer p-0 group"
             onClick={props.onResumeScroll}
           >
-            <Icon name="arrow-down-to-line" />
+            <div
+              class="flex items-center justify-center w-8 h-6 rounded-[6px] border border-[var(--gray-dark-7)] bg-[color-mix(in_srgb,var(--gray-dark-3)_80%,transparent)] backdrop-blur-[0.75px] transition-colors group-hover:border-[var(--gray-dark-8)] [--icon-base:var(--gray-dark-10)] group-hover:[--icon-base:var(--gray-dark-11)]"
+              style={{
+                "box-shadow":
+                  "0 51px 60px 0 rgba(0,0,0,0.13), 0 15.375px 18.088px 0 rgba(0,0,0,0.19), 0 6.386px 7.513px 0 rgba(0,0,0,0.25), 0 2.31px 2.717px 0 rgba(0,0,0,0.38)",
+              }}
+            >
+              <Icon name="arrow-down-to-line" size="small" />
+            </div>
           </button>
         </div>
         <ScrollView


### PR DESCRIPTION
## summary
- Redesign jump-to-bottom button to match updated figma spec
- Shrink visual element to 32x24 with a 40x32 click target
- Use design system tokens (`--gray-dark-7/8` for border, `--gray-dark-3` for bg, `--gray-dark-10/11` for icon color)
- Add layered box-shadow, backdrop blur, and hover state for border + icon color

## testing
- Scroll up in a session to trigger the jump-to-bottom button
- Verify default and hover states match the figma spec