### PR TITLE
feat: clickable command_list button

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1245,9 +1245,16 @@ export function Prompt(props: PromptProps) {
                       </text>
                     </Match>
                   </Switch>
-                  <text fg={theme.text}>
-                    {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
-                  </text>
+                  <box
+                    onMouseUp={() => {
+                      if (renderer.getSelection()?.getSelectedText()) return
+                      command.show()
+                    }}
+                  >
+                    <text fg={theme.text}>
+                      {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
+                    </text>
+                  </box>
                 </Match>
                 <Match when={store.mode === "shell"}>
                   <text fg={theme.text}>


### PR DESCRIPTION
### Issue for this PR

Closes #none

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the command_list keybind text a clickable button. No styling/visual changes

### How did you verify your code works?

ran `bun dev` and made sure it worked

### Screenshots / recordings

https://github.com/user-attachments/assets/d4f4e82a-dd36-42aa-8943-1c14dfe114ae

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR