### PR TITLE
feat(app): add setting to show full project name in sidebar

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -343,6 +343,18 @@ export const SettingsGeneral: Component = () => {
             />
           </div>
         </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.sidebarShowProjectName.title")}
+          description={language.t("settings.general.row.sidebarShowProjectName.description")}
+        >
+          <div data-action="settings-sidebar-show-project-name">
+            <Switch
+              checked={settings.appearance.sidebarShowProjectName()}
+              onChange={(checked) => settings.appearance.setSidebarShowProjectName(checked)}
+            />
+          </div>
+        </SettingsRow>
       </SettingsList>
     </div>
   )

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -34,6 +34,7 @@ export interface Settings {
     fontSize: number
     mono: string
     sans: string
+    sidebarShowProjectName: boolean
   }
   keybinds: Record<string, string>
   permissions: {
@@ -100,6 +101,7 @@ const defaultSettings: Settings = {
     fontSize: 14,
     mono: "",
     sans: "",
+    sidebarShowProjectName: false,
   },
   keybinds: {},
   permissions: {
@@ -202,6 +204,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         uiFont: withFallback(() => store.appearance?.sans, defaultSettings.appearance.sans),
         setUIFont(value: string) {
           setStore("appearance", "sans", value.trim() ? value : "")
+        },
+        sidebarShowProjectName: withFallback(
+          () => store.appearance?.sidebarShowProjectName,
+          defaultSettings.appearance.sidebarShowProjectName,
+        ),
+        setSidebarShowProjectName(value: boolean) {
+          setStore("appearance", "sidebarShowProjectName", value)
         },
       },
       keybinds: {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -747,6 +747,9 @@ export const dict = {
   "settings.general.row.editToolPartsExpanded.title": "Expand edit tool parts",
   "settings.general.row.editToolPartsExpanded.description":
     "Show edit, write, and patch tool parts expanded by default in the timeline",
+  "settings.general.row.sidebarShowProjectName.title": "Show project name in sidebar",
+  "settings.general.row.sidebarShowProjectName.description":
+    "Display the project name as text instead of a single-letter icon in the sidebar",
 
   "settings.general.row.wayland.title": "Use native Wayland",
   "settings.general.row.wayland.description": "Disable X11 fallback on Wayland. Requires restart.",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1808,13 +1808,15 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
+  const rail = createMemo(() => (settings.appearance.sidebarShowProjectName() ? 96 : 64))
+
   createEffect(() => {
-    const sidebarWidth = layout.sidebar.opened() ? layout.sidebar.width() : 48
+    const sidebarWidth = layout.sidebar.opened() ? layout.sidebar.width() : rail()
     document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
   })
 
-  const side = createMemo(() => Math.max(layout.sidebar.width(), 244))
-  const panel = createMemo(() => Math.max(side() - 64, 0))
+  const side = createMemo(() => Math.max(layout.sidebar.width(), rail() + 180))
+  const panel = createMemo(() => Math.max(side() - rail(), 0))
 
   const loadedSessionDirs = new Set<string>()
 
@@ -2367,6 +2369,7 @@ export default function Layout(props: ParentProps) {
       renderPanel={() =>
         mobile ? <SidebarPanel project={currentProject} mobile /> : <SidebarPanel project={currentProject} merged />
       }
+      railWidth={rail()}
     />
   )
 
@@ -2461,7 +2464,7 @@ export default function Layout(props: ParentProps) {
                   !state.sizing,
               }}
               style={{
-                "--main-left": layout.sidebar.opened() ? `${side()}px` : "4rem",
+                "--main-left": layout.sidebar.opened() ? `${side()}px` : `${rail()}px`,
               }}
             >
               <main

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -10,6 +10,8 @@ import { useLayout, type LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useNotification } from "@/context/notification"
+import { useSettings } from "@/context/settings"
+import { getFilename } from "@opencode-ai/util/path"
 import { ProjectIcon, SessionItem, type SessionItemProps } from "./sidebar-items"
 import { childMapByParent, displayName, sortedRootSessions } from "./helpers"
 
@@ -77,6 +79,9 @@ const ProjectTile = (props: {
 }): JSX.Element => {
   const notification = useNotification()
   const layout = useLayout()
+  const settings = useSettings()
+  const projectName = createMemo(() => props.project.name || getFilename(props.project.worktree))
+  const showName = createMemo(() => settings.appearance.sidebarShowProjectName())
   const unseenCount = createMemo(() =>
     props.dirs().reduce((total, directory) => total + notification.project.unseenCount(directory), 0),
   )
@@ -103,7 +108,8 @@ const ProjectTile = (props: {
         data-action="project-switch"
         data-project={base64Encode(props.project.worktree)}
         classList={{
-          "flex items-center justify-center size-10 p-1 rounded-lg overflow-hidden transition-colors cursor-default": true,
+          "flex items-center justify-center p-1 rounded-lg overflow-hidden transition-colors cursor-default": true,
+          [showName() ? "w-full h-10" : "size-10"]: true,
           "bg-transparent border-2 border-icon-strong-base hover:bg-surface-base-hover": props.selected(),
           "bg-transparent border border-transparent hover:bg-surface-base-hover hover:border-border-weak-base":
             !props.selected() && !props.active(),
@@ -146,7 +152,11 @@ const ProjectTile = (props: {
         }}
         onBlur={() => props.setOpen(false)}
       >
-        <ProjectIcon project={props.project} notify />
+        <Show when={showName()} fallback={<ProjectIcon project={props.project} notify />}>
+          <div class="size-full rounded flex items-center justify-center">
+            <span class="text-11-medium leading-tight text-center truncate w-full px-1">{projectName()}</span>
+          </div>
+        </Show>
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content>

--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -31,6 +31,7 @@ export const SidebarContent = (props: {
   helpLabel: Accessor<string>
   onOpenHelp: () => void
   renderPanel: () => JSX.Element
+  railWidth: number
 }): JSX.Element => {
   const expanded = createMemo(() => !!props.mobile || props.opened())
   const placement = () => (props.mobile ? "bottom" : "right")
@@ -50,7 +51,8 @@ export const SidebarContent = (props: {
     <div class="flex h-full w-full min-w-0 overflow-hidden">
       <div
         data-component="sidebar-rail"
-        class="w-16 shrink-0 bg-background-base flex flex-col items-center overflow-hidden"
+        class="shrink-0 bg-background-base flex flex-col items-center overflow-hidden"
+        style={{ width: `${props.railWidth}px` }}
         onMouseMove={props.aimMove}
       >
         <div class="flex-1 min-h-0 w-full">


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When running OpenCode Desktop with multiple projects in the sidebar, each project is represented by a single-letter avatar icon. If many projects share the same first letter (e.g. all starting with "C"), they become indistinguishable.

This PR adds a new **"Show project name in sidebar"** toggle in Settings > Appearance that displays the full project name as text instead of the single-letter avatar. When enabled, the sidebar rail widens from 64px to 96px to accommodate the longer names, with truncation for very long project names.

### How did you verify your code works?

- Ran `bun turbo typecheck` - all 13 packages pass with no errors
- Verified the toggle appears in Settings > Appearance section
- Verified the sidebar rail width adjusts when toggling the setting

### Screenshots / recordings

**Before:**
<img width="124" height="258" alt="before" src="https://github.com/user-attachments/assets/048c03ea-32cf-4ef9-bc7d-abfa0ca2fb74" />

**After:**
<img width="168" height="256" alt="after" src="https://github.com/user-attachments/assets/acc1a7ed-ca72-449c-8f3c-f5c2084d85a0" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR