### PR TITLE
fix(opencode): use local time for log timestamps and filenames

### DIFF
--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -28,6 +28,17 @@ export namespace Locale {
     }
   }
 
+  export function localDatetime(input?: number): string {
+    const date = input !== undefined ? new Date(input) : new Date()
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, "0")
+    const day = String(date.getDate()).padStart(2, "0")
+    const hour = String(date.getHours()).padStart(2, "0")
+    const minute = String(date.getMinutes()).padStart(2, "0")
+    const second = String(date.getSeconds()).padStart(2, "0")
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}`
+  }
+
   export function number(num: number): string {
     if (num >= 1000000) {
       return (num / 1000000).toFixed(1) + "M"

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -4,6 +4,7 @@ import { createWriteStream } from "fs"
 import { Global } from "../global"
 import z from "zod"
 import { Glob } from "./glob"
+import { Locale } from "./locale"
 
 export namespace Log {
   export const Level = z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).meta({ ref: "LogLevel", description: "Log level" })
@@ -61,10 +62,7 @@ export namespace Log {
     if (options.level) level = options.level
     cleanup(Global.Path.log)
     if (options.print) return
-    logpath = path.join(
-      Global.Path.log,
-      options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
-    )
+    logpath = path.join(Global.Path.log, options.dev ? "dev.log" : Locale.localDatetime().replace(/:/g, "") + ".log")
     await fs.truncate(logpath).catch(() => {})
     const stream = createWriteStream(logpath, { flags: "a" })
     write = async (msg: any) => {
@@ -124,7 +122,7 @@ export namespace Log {
       const next = new Date()
       const diff = next.getTime() - last
       last = next.getTime()
-      return [next.toISOString().split(".")[0], "+" + diff + "ms", prefix, message].filter(Boolean).join(" ") + "\n"
+      return [Locale.localDatetime(next.getTime()), "+" + diff + "ms", prefix, message].filter(Boolean).join(" ") + "\n"
     }
     const result: Logger = {
       debug(message?: any, extra?: Record<string, any>) {


### PR DESCRIPTION
### Issue for this PR

Closes #21330

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`log.ts` used `toISOString()` in two places, which outputs UTC time. For users outside UTC, log filenames and log entry timestamps don't match their local time, making it hard to correlate logs with what they were doing.

This PR adds `Locale.localDatetime()` to `locale.ts` that formats local time as `YYYY-MM-DDTHH:mm:ss` using local time methods, then replaces both `toISOString()` calls in `log.ts` with it.

### How did you verify your code works?

Ran opencode locally (UTC+8), confirmed log filename and timestamps inside the file now show local time instead of UTC.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR