### PR TITLE
fix(tui): prevent scroll snap when reading history during LLM response

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -153,6 +153,7 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [userScrolledUp, setUserScrolledUp] = createSignal(false)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -178,6 +179,7 @@ export function Session() {
       .sync(route.sessionID)
       .then(() => {
         if (scroll) scroll.scrollBy(100_000)
+        setUserScrolledUp(false)
       })
       .catch((e) => {
         console.error(e)
@@ -303,6 +305,7 @@ export function Session() {
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)
+      setUserScrolledUp(false)
     }, 50)
   }
 
@@ -645,6 +648,7 @@ export function Session() {
       hidden: true,
       onSelect: (dialog) => {
         scroll.scrollBy(-scroll.height / 2)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -667,6 +671,7 @@ export function Session() {
       disabled: true,
       onSelect: (dialog) => {
         scroll.scrollBy(-1)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -689,6 +694,7 @@ export function Session() {
       hidden: true,
       onSelect: (dialog) => {
         scroll.scrollBy(-scroll.height / 4)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -711,6 +717,7 @@ export function Session() {
       hidden: true,
       onSelect: (dialog) => {
         scroll.scrollTo(0)
+        setUserScrolledUp(true)
         dialog.clear()
       },
     },
@@ -722,6 +729,7 @@ export function Session() {
       hidden: true,
       onSelect: (dialog) => {
         scroll.scrollTo(scroll.scrollHeight)
+        setUserScrolledUp(false)
         dialog.clear()
       },
     },
@@ -1047,7 +1055,7 @@ export function Session() {
                   foregroundColor: theme.border,
                 },
               }}
-              stickyScroll={true}
+              stickyScroll={!userScrolledUp()}
               stickyStart="bottom"
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}


### PR DESCRIPTION
### Issue for this PR

- [x] Closes #4196

### Type of change

- [x] Bug fix

### What does this PR do?

When a user scrolls up to read chat history while an LLM is still streaming, the view snaps back to the bottom on every token update. This is because `stickyScroll={true}` on the message scrollbox forces scroll-to-bottom regardless of user scroll state.

The fix adds a `userScrolledUp` signal that tracks when the user has manually scrolled away from the bottom. The `stickyScroll` prop is now reactive (`!userScrolledUp()`), so auto-scroll only engages when the user is at the bottom.

Upward scroll commands (Page Up, Line Up, Half Page Up, First Message) set the flag. Commands that return to bottom (toBottom(), Last Message) and session sync reset it.

### How did you verify your code works?

- `bun run typecheck` passes in all 13 packages
- Logic review — changes follow existing TUI patterns and mirror `packages/ui/src/hooks/create-auto-scroll.tsx` from the web app, which implements the same behavior for the web client

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR