### PR TITLE
feat(tui): allow fork from AI messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -23,7 +23,6 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
     const messages = sync.data.message[props.sessionID] ?? []
     const result = [] as DialogSelectOption<string>[]
     for (const message of messages) {
-      if (message.role === "system") continue
       const part = (sync.data.part[message.id] ?? []).find(
         (x) => x.type === "text" && !x.synthetic && !x.ignored,
       ) as TextPart

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -23,7 +23,7 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
     const messages = sync.data.message[props.sessionID] ?? []
     const result = [] as DialogSelectOption<string>[]
     for (const message of messages) {
-      if (message.role !== "user") continue
+      if (message.role === "system") continue
       const part = (sync.data.part[message.id] ?? []).find(
         (x) => x.type === "text" && !x.synthetic && !x.ignored,
       ) as TextPart


### PR DESCRIPTION
### Issue for this PR

Closes #8689

### Type of change

- [x] New feature

### What does this PR do?

The TUI fork dialog previously only allowed forking from user messages due to a role filter (). This change removes that filter entirely, allowing users to fork from both user and assistant messages.

Note: The message.role type only allows 'user' or 'assistant', so any role check against 'system' was redundant.

### How did you verify your code works?

Code compiles successfully. The change removes a redundant conditional that was preventing assistant messages from appearing in the fork dialog.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR