### PR TITLE
fix(opencode): improve console login transport errors

### DIFF
--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -146,29 +146,17 @@ const accountErrorFromCause = (cause: unknown, message: string): AccountError =>
   }
 
   if (HttpClientError.isHttpClientError(cause)) {
-    return accountErrorFromHttpClientError(cause, message)
+    switch (cause.reason._tag) {
+      case "TransportError": {
+        return AccountTransportError.fromHttpClientError(cause.reason)
+      }
+      default: {
+        return new AccountServiceError({ message, cause })
+      }
+    }
   }
 
   return new AccountServiceError({ message, cause })
-}
-
-const accountErrorFromHttpClientError = (
-  error: HttpClientError.HttpClientError,
-  message: string,
-): AccountError => {
-  switch (error.reason._tag) {
-    case "TransportError": {
-      return new AccountTransportError({
-        method: error.request.method,
-        url: error.request.url,
-        description: error.reason.description,
-        cause: error.reason.cause,
-      })
-    }
-    default: {
-      return new AccountServiceError({ message, cause: error })
-    }
-  }
 }
 
 export namespace Account {

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -1,5 +1,5 @@
 import { Cache, Clock, Duration, Effect, Layer, Option, Schema, SchemaGetter, ServiceMap } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { FetchHttpClient, HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 
 import { makeRuntime } from "@/effect/run-service"
 import { withTransientReadRetry } from "@/util/effect-http-client"
@@ -13,6 +13,7 @@ import {
   Info,
   RefreshToken,
   AccountServiceError,
+  AccountTransportError,
   Login,
   Org,
   OrgID,
@@ -31,6 +32,7 @@ export {
   type AccountError,
   AccountRepoError,
   AccountServiceError,
+  AccountTransportError,
   AccessToken,
   RefreshToken,
   DeviceCode,
@@ -133,10 +135,19 @@ const isTokenFresh = (tokenExpiry: number | null, now: number) =>
 
 const mapAccountServiceError =
   (message = "Account service operation failed") =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, AccountServiceError, R> =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, AccountError, R> =>
     effect.pipe(
       Effect.mapError((cause) =>
-        cause instanceof AccountServiceError ? cause : new AccountServiceError({ message, cause }),
+        cause instanceof AccountServiceError || cause instanceof AccountTransportError
+          ? cause
+          : HttpClientError.isHttpClientError(cause) && cause.reason._tag === "TransportError"
+            ? new AccountTransportError({
+                method: cause.request.method,
+                url: cause.request.url,
+                description: cause.reason.description,
+                cause: cause.reason.cause,
+              })
+            : new AccountServiceError({ message, cause }),
       ),
     )
 

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -4,6 +4,7 @@ import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } fr
 import { makeRuntime } from "@/effect/run-service"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { AccountRepo, type AccountRow } from "./repo"
+import { normalizeServerUrl } from "./url"
 import {
   type AccountError,
   AccessToken,
@@ -187,10 +188,11 @@ export namespace Account {
         )
 
       const refreshToken = Effect.fnUntraced(function* (row: AccountRow) {
+        const server = normalizeServerUrl(row.url)
         const now = yield* Clock.currentTimeMillis
 
         const response = yield* executeEffectOk(
-          HttpClientRequest.post(`${row.url}/auth/device/token`).pipe(
+          HttpClientRequest.post(`${server}/auth/device/token`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.schemaBodyJson(TokenRefreshRequest)(
               new TokenRefreshRequest({
@@ -256,8 +258,9 @@ export namespace Account {
       })
 
       const fetchOrgs = Effect.fnUntraced(function* (url: string, accessToken: AccessToken) {
+        const server = normalizeServerUrl(url)
         const response = yield* executeReadOk(
-          HttpClientRequest.get(`${url}/api/orgs`).pipe(
+          HttpClientRequest.get(`${server}/api/orgs`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
           ),
@@ -269,8 +272,9 @@ export namespace Account {
       })
 
       const fetchUser = Effect.fnUntraced(function* (url: string, accessToken: AccessToken) {
+        const server = normalizeServerUrl(url)
         const response = yield* executeReadOk(
-          HttpClientRequest.get(`${url}/api/user`).pipe(
+          HttpClientRequest.get(`${server}/api/user`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
           ),
@@ -326,9 +330,10 @@ export namespace Account {
         if (Option.isNone(resolved)) return Option.none()
 
         const { account, accessToken } = resolved.value
+        const server = normalizeServerUrl(account.url)
 
         const response = yield* executeRead(
-          HttpClientRequest.get(`${account.url}/api/config`).pipe(
+          HttpClientRequest.get(`${server}/api/config`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
             HttpClientRequest.setHeaders({ "x-org-id": orgID }),
@@ -346,8 +351,9 @@ export namespace Account {
       })
 
       const login = Effect.fn("Account.login")(function* (server: string) {
+        const normalizedServer = normalizeServerUrl(server)
         const response = yield* executeEffectOk(
-          HttpClientRequest.post(`${server}/auth/device/code`).pipe(
+          HttpClientRequest.post(`${normalizedServer}/auth/device/code`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.schemaBodyJson(ClientId)(new ClientId({ client_id: clientId })),
           ),
@@ -359,8 +365,8 @@ export namespace Account {
         return new Login({
           code: parsed.device_code,
           user: parsed.user_code,
-          url: `${server}${parsed.verification_uri_complete}`,
-          server,
+          url: `${normalizedServer}${parsed.verification_uri_complete}`,
+          server: normalizedServer,
           expiry: parsed.expires_in,
           interval: parsed.interval,
         })

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -188,11 +188,10 @@ export namespace Account {
         )
 
       const refreshToken = Effect.fnUntraced(function* (row: AccountRow) {
-        const server = normalizeServerUrl(row.url)
         const now = yield* Clock.currentTimeMillis
 
         const response = yield* executeEffectOk(
-          HttpClientRequest.post(`${server}/auth/device/token`).pipe(
+          HttpClientRequest.post(`${row.url}/auth/device/token`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.schemaBodyJson(TokenRefreshRequest)(
               new TokenRefreshRequest({
@@ -258,9 +257,8 @@ export namespace Account {
       })
 
       const fetchOrgs = Effect.fnUntraced(function* (url: string, accessToken: AccessToken) {
-        const server = normalizeServerUrl(url)
         const response = yield* executeReadOk(
-          HttpClientRequest.get(`${server}/api/orgs`).pipe(
+          HttpClientRequest.get(`${url}/api/orgs`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
           ),
@@ -272,9 +270,8 @@ export namespace Account {
       })
 
       const fetchUser = Effect.fnUntraced(function* (url: string, accessToken: AccessToken) {
-        const server = normalizeServerUrl(url)
         const response = yield* executeReadOk(
-          HttpClientRequest.get(`${server}/api/user`).pipe(
+          HttpClientRequest.get(`${url}/api/user`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
           ),
@@ -330,10 +327,9 @@ export namespace Account {
         if (Option.isNone(resolved)) return Option.none()
 
         const { account, accessToken } = resolved.value
-        const server = normalizeServerUrl(account.url)
 
         const response = yield* executeRead(
-          HttpClientRequest.get(`${server}/api/config`).pipe(
+          HttpClientRequest.get(`${account.url}/api/config`).pipe(
             HttpClientRequest.acceptJson,
             HttpClientRequest.bearerToken(accessToken),
             HttpClientRequest.setHeaders({ "x-org-id": orgID }),

--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -137,19 +137,39 @@ const mapAccountServiceError =
   (message = "Account service operation failed") =>
   <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, AccountError, R> =>
     effect.pipe(
-      Effect.mapError((cause) =>
-        cause instanceof AccountServiceError || cause instanceof AccountTransportError
-          ? cause
-          : HttpClientError.isHttpClientError(cause) && cause.reason._tag === "TransportError"
-            ? new AccountTransportError({
-                method: cause.request.method,
-                url: cause.request.url,
-                description: cause.reason.description,
-                cause: cause.reason.cause,
-              })
-            : new AccountServiceError({ message, cause }),
-      ),
+      Effect.mapError((cause) => accountErrorFromCause(cause, message)),
     )
+
+const accountErrorFromCause = (cause: unknown, message: string): AccountError => {
+  if (cause instanceof AccountServiceError || cause instanceof AccountTransportError) {
+    return cause
+  }
+
+  if (HttpClientError.isHttpClientError(cause)) {
+    return accountErrorFromHttpClientError(cause, message)
+  }
+
+  return new AccountServiceError({ message, cause })
+}
+
+const accountErrorFromHttpClientError = (
+  error: HttpClientError.HttpClientError,
+  message: string,
+): AccountError => {
+  switch (error.reason._tag) {
+    case "TransportError": {
+      return new AccountTransportError({
+        method: error.request.method,
+        url: error.request.url,
+        description: error.reason.description,
+        cause: error.reason.cause,
+      })
+    }
+    default: {
+      return new AccountServiceError({ message, cause: error })
+    }
+  }
+}
 
 export namespace Account {
   export interface Interface {

--- a/packages/opencode/src/account/repo.ts
+++ b/packages/opencode/src/account/repo.ts
@@ -61,7 +61,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
         if (!state?.active_account_id) return
         const account = db.select().from(AccountTable).where(eq(AccountTable.id, state.active_account_id)).get()
         if (!account) return
-        return { ...account, url: normalizeServerUrl(account.url), active_org_id: state.active_org_id ?? null }
+        return { ...account, active_org_id: state.active_org_id ?? null }
       }
 
       const state = (db: DbClient, accountID: AccountID, orgID: Option.Option<OrgID>) => {
@@ -86,7 +86,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
             .select()
             .from(AccountTable)
             .all()
-            .map((row: AccountRow) => decode({ ...row, url: normalizeServerUrl(row.url), active_org_id: null })),
+            .map((row: AccountRow) => decode({ ...row, active_org_id: null })),
         ),
       )
 
@@ -106,9 +106,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
 
       const getRow = Effect.fn("AccountRepo.getRow")((accountID: AccountID) =>
         query((db) => db.select().from(AccountTable).where(eq(AccountTable.id, accountID)).get()).pipe(
-          Effect.map((row) =>
-            row == null ? Option.none() : Option.some({ ...row, url: normalizeServerUrl(row.url) }),
-          ),
+          Effect.map(Option.fromNullishOr),
         ),
       )
 

--- a/packages/opencode/src/account/repo.ts
+++ b/packages/opencode/src/account/repo.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, Option, Schema, ServiceMap } from "effect"
 import { Database } from "@/storage/db"
 import { AccountStateTable, AccountTable } from "./account.sql"
 import { AccessToken, AccountID, AccountRepoError, Info, OrgID, RefreshToken } from "./schema"
+import { normalizeServerUrl } from "./url"
 
 export type AccountRow = (typeof AccountTable)["$inferSelect"]
 
@@ -60,7 +61,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
         if (!state?.active_account_id) return
         const account = db.select().from(AccountTable).where(eq(AccountTable.id, state.active_account_id)).get()
         if (!account) return
-        return { ...account, active_org_id: state.active_org_id ?? null }
+        return { ...account, url: normalizeServerUrl(account.url), active_org_id: state.active_org_id ?? null }
       }
 
       const state = (db: DbClient, accountID: AccountID, orgID: Option.Option<OrgID>) => {
@@ -85,7 +86,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
             .select()
             .from(AccountTable)
             .all()
-            .map((row: AccountRow) => decode({ ...row, active_org_id: null })),
+            .map((row: AccountRow) => decode({ ...row, url: normalizeServerUrl(row.url), active_org_id: null })),
         ),
       )
 
@@ -105,7 +106,9 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
 
       const getRow = Effect.fn("AccountRepo.getRow")((accountID: AccountID) =>
         query((db) => db.select().from(AccountTable).where(eq(AccountTable.id, accountID)).get()).pipe(
-          Effect.map(Option.fromNullishOr),
+          Effect.map((row) =>
+            row == null ? Option.none() : Option.some({ ...row, url: normalizeServerUrl(row.url) }),
+          ),
         ),
       )
 
@@ -125,11 +128,13 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
 
       const persistAccount = Effect.fn("AccountRepo.persistAccount")((input) =>
         tx((db) => {
+          const url = normalizeServerUrl(input.url)
+
           db.insert(AccountTable)
             .values({
               id: input.id,
               email: input.email,
-              url: input.url,
+              url,
               access_token: input.accessToken,
               refresh_token: input.refreshToken,
               token_expiry: input.expiry,
@@ -138,7 +143,7 @@ export class AccountRepo extends ServiceMap.Service<AccountRepo, AccountRepo.Ser
               target: AccountTable.id,
               set: {
                 email: input.email,
-                url: input.url,
+                url,
                 access_token: input.accessToken,
                 refresh_token: input.refreshToken,
                 token_expiry: input.expiry,

--- a/packages/opencode/src/account/schema.ts
+++ b/packages/opencode/src/account/schema.ts
@@ -75,6 +75,17 @@ export class AccountTransportError extends Schema.TaggedErrorClass<AccountTransp
       cause: error.cause,
     })
   }
+
+  override get message(): string {
+    return [
+      `Could not reach ${this.method} ${this.url}.`,
+      `This failed before the server returned an HTTP response.`,
+      this.description,
+      `Check your network, proxy, or VPN configuration and try again.`,
+    ]
+      .filter(Boolean)
+      .join("\n")
+  }
 }
 
 export type AccountError = AccountRepoError | AccountServiceError | AccountTransportError

--- a/packages/opencode/src/account/schema.ts
+++ b/packages/opencode/src/account/schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+import type * as HttpClientError from "effect/unstable/http/HttpClientError"
 
 import { withStatics } from "@/util/schema"
 
@@ -65,7 +66,16 @@ export class AccountTransportError extends Schema.TaggedErrorClass<AccountTransp
   url: Schema.String,
   description: Schema.optional(Schema.String),
   cause: Schema.optional(Schema.Defect),
-}) {}
+}) {
+  static fromHttpClientError(error: HttpClientError.TransportError): AccountTransportError {
+    return new AccountTransportError({
+      method: error.request.method,
+      url: error.request.url,
+      description: error.description,
+      cause: error.cause,
+    })
+  }
+}
 
 export type AccountError = AccountRepoError | AccountServiceError | AccountTransportError
 

--- a/packages/opencode/src/account/schema.ts
+++ b/packages/opencode/src/account/schema.ts
@@ -60,7 +60,14 @@ export class AccountServiceError extends Schema.TaggedErrorClass<AccountServiceE
   cause: Schema.optional(Schema.Defect),
 }) {}
 
-export type AccountError = AccountRepoError | AccountServiceError
+export class AccountTransportError extends Schema.TaggedErrorClass<AccountTransportError>()("AccountTransportError", {
+  method: Schema.String,
+  url: Schema.String,
+  description: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect),
+}) {}
+
+export type AccountError = AccountRepoError | AccountServiceError | AccountTransportError
 
 export class Login extends Schema.Class<Login>("Login")({
   code: DeviceCode,

--- a/packages/opencode/src/account/url.ts
+++ b/packages/opencode/src/account/url.ts
@@ -1,0 +1,8 @@
+export const normalizeServerUrl = (input: string): string => {
+  const url = new URL(input)
+  url.search = ""
+  url.hash = ""
+
+  const pathname = url.pathname.replace(/\/+$/, "")
+  return pathname.length === 0 ? url.origin : `${url.origin}${pathname}`
+}

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -1,13 +1,47 @@
+import { HttpClientError } from "effect/unstable/http"
+import { AccountServiceError } from "@/account"
 import { ConfigMarkdown } from "@/config/markdown"
+import { activeProxyEnvVars } from "@/util/network"
 import { errorFormat } from "@/util/error"
 import { Config } from "../config/config"
 import { MCP } from "../mcp"
 import { Provider } from "../provider/provider"
 import { UI } from "./ui"
 
+const findTransportError = (input: unknown): HttpClientError.TransportError | undefined => {
+  let current = input
+  const seen = new Set<object>()
+
+  while (typeof current === "object" && current !== null && !seen.has(current)) {
+    if (current instanceof HttpClientError.TransportError) return current
+    seen.add(current)
+    current = Reflect.get(current, "cause")
+  }
+}
+
+const formatProxyHint = () => {
+  const envVars = activeProxyEnvVars()
+  if (envVars.length === 0) return undefined
+  return `Proxy environment variables are set (${envVars.join(", ")}). If that proxy is unavailable, unset them and try again.`
+}
+
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
+  if (input instanceof AccountServiceError) {
+    const transportError = findTransportError(input)
+    if (transportError) {
+      return [
+        `Could not reach ${transportError.methodAndUrl}.`,
+        `This failed before the server returned an HTTP response.`,
+        formatProxyHint(),
+      ]
+        .filter(Boolean)
+        .join("\n")
+    }
+
+    return input.message
+  }
   if (Provider.ModelNotFoundError.isInstance(input)) {
     const { providerID, modelID, suggestions } = input.data
     return [

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -9,14 +9,7 @@ import { UI } from "./ui"
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
-  if (input instanceof AccountTransportError) {
-    return [
-      `Could not reach ${input.method} ${input.url}.`,
-      `This failed before the server returned an HTTP response.`,
-      `Check your network, proxy, or VPN configuration and try again.`,
-    ].join("\n")
-  }
-  if (input instanceof AccountServiceError) {
+  if (input instanceof AccountTransportError || input instanceof AccountServiceError) {
     return input.message
   }
   if (Provider.ModelNotFoundError.isInstance(input)) {

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -1,7 +1,6 @@
 import { HttpClientError } from "effect/unstable/http"
 import { AccountServiceError } from "@/account"
 import { ConfigMarkdown } from "@/config/markdown"
-import { activeProxyEnvVars } from "@/util/network"
 import { errorFormat } from "@/util/error"
 import { Config } from "../config/config"
 import { MCP } from "../mcp"
@@ -19,12 +18,6 @@ const findTransportError = (input: unknown): HttpClientError.TransportError | un
   }
 }
 
-const formatProxyHint = () => {
-  const envVars = activeProxyEnvVars()
-  if (envVars.length === 0) return undefined
-  return `Proxy environment variables are set (${envVars.join(", ")}). If that proxy is unavailable, unset them and try again.`
-}
-
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
@@ -34,9 +27,8 @@ export function FormatError(input: unknown) {
       return [
         `Could not reach ${transportError.methodAndUrl}.`,
         `This failed before the server returned an HTTP response.`,
-        formatProxyHint(),
+        `Check your network, proxy, or VPN configuration and try again.`,
       ]
-        .filter(Boolean)
         .join("\n")
     }
 

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -1,5 +1,4 @@
-import { HttpClientError } from "effect/unstable/http"
-import { AccountServiceError } from "@/account"
+import { AccountServiceError, AccountTransportError } from "@/account"
 import { ConfigMarkdown } from "@/config/markdown"
 import { errorFormat } from "@/util/error"
 import { Config } from "../config/config"
@@ -7,31 +6,17 @@ import { MCP } from "../mcp"
 import { Provider } from "../provider/provider"
 import { UI } from "./ui"
 
-const findTransportError = (input: unknown): HttpClientError.TransportError | undefined => {
-  let current = input
-  const seen = new Set<object>()
-
-  while (typeof current === "object" && current !== null && !seen.has(current)) {
-    if (current instanceof HttpClientError.TransportError) return current
-    seen.add(current)
-    current = Reflect.get(current, "cause")
-  }
-}
-
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
+  if (input instanceof AccountTransportError) {
+    return [
+      `Could not reach ${input.method} ${input.url}.`,
+      `This failed before the server returned an HTTP response.`,
+      `Check your network, proxy, or VPN configuration and try again.`,
+    ].join("\n")
+  }
   if (input instanceof AccountServiceError) {
-    const transportError = findTransportError(input)
-    if (transportError) {
-      return [
-        `Could not reach ${transportError.methodAndUrl}.`,
-        `This failed before the server returned an HTTP response.`,
-        `Check your network, proxy, or VPN configuration and try again.`,
-      ]
-        .join("\n")
-    }
-
     return input.message
   }
   if (Provider.ModelNotFoundError.isInstance(input)) {

--- a/packages/opencode/src/util/network.ts
+++ b/packages/opencode/src/util/network.ts
@@ -1,3 +1,5 @@
+const proxyEnvVarNames = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] as const
+
 export function online() {
   const nav = globalThis.navigator
   if (!nav || typeof nav.onLine !== "boolean") return true
@@ -5,5 +7,9 @@ export function online() {
 }
 
 export function proxied() {
-  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
+  return activeProxyEnvVars().length > 0
+}
+
+export function activeProxyEnvVars() {
+  return proxyEnvVarNames.filter((name) => process.env[name])
 }

--- a/packages/opencode/src/util/network.ts
+++ b/packages/opencode/src/util/network.ts
@@ -1,5 +1,3 @@
-const proxyEnvVarNames = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] as const
-
 export function online() {
   const nav = globalThis.navigator
   if (!nav || typeof nav.onLine !== "boolean") return true
@@ -7,9 +5,5 @@ export function online() {
 }
 
 export function proxied() {
-  return activeProxyEnvVars().length > 0
-}
-
-export function activeProxyEnvVars() {
-  return proxyEnvVarNames.filter((name) => process.env[name])
+  return !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy)
 }

--- a/packages/opencode/test/account/repo.test.ts
+++ b/packages/opencode/test/account/repo.test.ts
@@ -56,6 +56,32 @@ it.live("persistAccount inserts and getRow retrieves", () =>
   }),
 )
 
+it.live("persistAccount normalizes trailing slashes in stored server URLs", () =>
+  Effect.gen(function* () {
+    const id = AccountID.make("user-1")
+
+    yield* AccountRepo.use((r) =>
+      r.persistAccount({
+        id,
+        email: "test@example.com",
+        url: "https://control.example.com/",
+        accessToken: AccessToken.make("at_123"),
+        refreshToken: RefreshToken.make("rt_456"),
+        expiry: Date.now() + 3600_000,
+        orgID: Option.none(),
+      }),
+    )
+
+    const row = yield* AccountRepo.use((r) => r.getRow(id))
+    const active = yield* AccountRepo.use((r) => r.active())
+    const list = yield* AccountRepo.use((r) => r.list())
+
+    expect(Option.getOrThrow(row).url).toBe("https://control.example.com")
+    expect(Option.getOrThrow(active).url).toBe("https://control.example.com")
+    expect(list[0]?.url).toBe("https://control.example.com")
+  }),
+)
+
 it.live("persistAccount sets the active account and org", () =>
   Effect.gen(function* () {
     const id1 = AccountID.make("user-1")

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -1,10 +1,20 @@
 import { expect } from "bun:test"
 import { Duration, Effect, Layer, Option, Schema } from "effect"
-import { HttpClient, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientError, HttpClientResponse } from "effect/unstable/http"
 
 import { AccountRepo } from "../../src/account/repo"
 import { Account } from "../../src/account"
-import { AccessToken, AccountID, DeviceCode, Login, Org, OrgID, RefreshToken, UserCode } from "../../src/account/schema"
+import {
+  AccessToken,
+  AccountID,
+  AccountTransportError,
+  DeviceCode,
+  Login,
+  Org,
+  OrgID,
+  RefreshToken,
+  UserCode,
+} from "../../src/account/schema"
 import { Database } from "../../src/storage/db"
 import { testEffect } from "../lib/effect"
 
@@ -83,6 +93,28 @@ it.live("login normalizes trailing slashes in the provided server URL", () =>
     expect(seen).toEqual(["POST https://one.example.com/auth/device/code"])
     expect(result.server).toBe("https://one.example.com")
     expect(result.url).toBe("https://one.example.com/device?user_code=user-code")
+  }),
+)
+
+it.live("login maps transport failures to account transport errors", () =>
+  Effect.gen(function* () {
+    const client = HttpClient.make((req) =>
+      Effect.fail(
+        new HttpClientError.HttpClientError({
+          reason: new HttpClientError.TransportError({ request: req }),
+        }),
+      ),
+    )
+
+    const error = yield* Effect.flip(
+      Account.Service.use((s) => s.login("https://one.example.com")).pipe(Effect.provide(live(client))),
+    )
+
+    expect(error).toBeInstanceOf(AccountTransportError)
+    if (error instanceof AccountTransportError) {
+      expect(error.method).toBe("POST")
+      expect(error.url).toBe("https://one.example.com/auth/device/code")
+    }
   }),
 )
 

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -57,6 +57,35 @@ const deviceTokenClient = (body: unknown, status = 400) =>
 const poll = (body: unknown, status = 400) =>
   Account.Service.use((s) => s.poll(login())).pipe(Effect.provide(live(deviceTokenClient(body, status))))
 
+it.live("login normalizes trailing slashes in the provided server URL", () =>
+  Effect.gen(function* () {
+    const seen: Array<string> = []
+    const client = HttpClient.make((req) =>
+      Effect.gen(function* () {
+        seen.push(`${req.method} ${req.url}`)
+
+        if (req.url === "https://one.example.com/auth/device/code") {
+          return json(req, {
+            device_code: "device-code",
+            user_code: "user-code",
+            verification_uri_complete: "/device?user_code=user-code",
+            expires_in: 600,
+            interval: 5,
+          })
+        }
+
+        return json(req, {}, 404)
+      }),
+    )
+
+    const result = yield* Account.Service.use((s) => s.login("https://one.example.com/")).pipe(Effect.provide(live(client)))
+
+    expect(seen).toEqual(["POST https://one.example.com/auth/device/code"])
+    expect(result.server).toBe("https://one.example.com")
+    expect(result.url).toBe("https://one.example.com/device?user_code=user-code")
+  }),
+)
+
 it.live("orgsByAccount groups orgs per account", () =>
   Effect.gen(function* () {
     yield* AccountRepo.use((r) =>

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -1,28 +1,11 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { HttpClientError, HttpClientRequest } from "effect/unstable/http"
 
 import { AccountServiceError } from "../../src/account/schema"
 import { FormatError } from "../../src/cli/error"
 
-const proxyEnvVarNames = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] as const
-const originalEnv = new Map(proxyEnvVarNames.map((name) => [name, process.env[name]]))
-
-afterEach(() => {
-  for (const name of proxyEnvVarNames) {
-    const value = originalEnv.get(name)
-    if (value === undefined) {
-      delete process.env[name]
-      continue
-    }
-
-    process.env[name] = value
-  }
-})
-
 describe("cli.error", () => {
-  test("formats account transport errors with a proxy hint when proxy env vars are set", () => {
-    process.env.HTTPS_PROXY = "http://proxy.internal:8080"
-
+  test("formats account transport errors clearly", () => {
     const error = new AccountServiceError({
       message: "HTTP request failed",
       cause: new HttpClientError.TransportError({
@@ -34,6 +17,6 @@ describe("cli.error", () => {
 
     expect(formatted).toContain("Could not reach POST https://console.opencode.ai/auth/device/code.")
     expect(formatted).toContain("This failed before the server returned an HTTP response.")
-    expect(formatted).toContain("HTTPS_PROXY")
+    expect(formatted).toContain("Check your network, proxy, or VPN configuration and try again.")
   })
 })

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { HttpClientError, HttpClientRequest } from "effect/unstable/http"
+
+import { AccountServiceError } from "../../src/account/schema"
+import { FormatError } from "../../src/cli/error"
+
+const proxyEnvVarNames = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"] as const
+const originalEnv = new Map(proxyEnvVarNames.map((name) => [name, process.env[name]]))
+
+afterEach(() => {
+  for (const name of proxyEnvVarNames) {
+    const value = originalEnv.get(name)
+    if (value === undefined) {
+      delete process.env[name]
+      continue
+    }
+
+    process.env[name] = value
+  }
+})
+
+describe("cli.error", () => {
+  test("formats account transport errors with a proxy hint when proxy env vars are set", () => {
+    process.env.HTTPS_PROXY = "http://proxy.internal:8080"
+
+    const error = new AccountServiceError({
+      message: "HTTP request failed",
+      cause: new HttpClientError.TransportError({
+        request: HttpClientRequest.post("https://console.opencode.ai/auth/device/code"),
+      }),
+    })
+
+    const formatted = FormatError(error)
+
+    expect(formatted).toContain("Could not reach POST https://console.opencode.ai/auth/device/code.")
+    expect(formatted).toContain("This failed before the server returned an HTTP response.")
+    expect(formatted).toContain("HTTPS_PROXY")
+  })
+})

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -1,16 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { HttpClientError, HttpClientRequest } from "effect/unstable/http"
-
-import { AccountServiceError } from "../../src/account/schema"
+import { AccountTransportError } from "../../src/account/schema"
 import { FormatError } from "../../src/cli/error"
 
 describe("cli.error", () => {
   test("formats account transport errors clearly", () => {
-    const error = new AccountServiceError({
-      message: "HTTP request failed",
-      cause: new HttpClientError.TransportError({
-        request: HttpClientRequest.post("https://console.opencode.ai/auth/device/code"),
-      }),
+    const error = new AccountTransportError({
+      method: "POST",
+      url: "https://console.opencode.ai/auth/device/code",
     })
 
     const formatted = FormatError(error)


### PR DESCRIPTION
## Summary
- normalize console account server URLs so trailing slashes do not produce double-slash device links or get saved as distinct account URLs
- show a clearer CLI error when console login fails before any HTTP response, including a proxy-environment hint when proxy vars are set
- cover the login URL normalization and proxy-hinted transport error behavior with focused tests

## Testing
- bun test --timeout 30000 test/account/service.test.ts test/account/repo.test.ts test/cli/error.test.ts
- bun run typecheck