### PR TITLE
feat(ui): display image attachments from tool results

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -707,6 +707,35 @@
 
 [data-component="tool-part-wrapper"] {
   width: 100%;
+
+  [data-slot="tool-image-attachments"] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 0;
+  }
+
+  [data-slot="tool-image-attachment"] {
+    width: 48px;
+    height: 48px;
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--surface-weak);
+    border: 1px solid var(--border-weak-base);
+    cursor: pointer;
+    padding: 0;
+    transition: border-color 0.15s ease;
+
+    &:hover {
+      border-color: var(--border-strong-base);
+    }
+  }
+
+  [data-slot="tool-image-attachment"] img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 [data-component="dock-prompt"][data-kind="permission"] {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1237,6 +1237,7 @@ function ToolFileAccordion(props: { path: string; actions?: JSX.Element; childre
 PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
+  const dialog = useDialog()
   const part = () => props.part as ToolPart
   if (part().tool === "todowrite") return null
 
@@ -1267,6 +1268,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   })
 
   const render = createMemo(() => ToolRegistry.render(part().tool) ?? GenericTool)
+
+  const imageAttachments = createMemo(() => {
+    if (part().state.status !== "completed") return []
+    return ((part().state as any).attachments as FilePart[] | undefined)?.filter((a) => kind(a) === "image") ?? []
+  })
 
   return (
     <Show when={!hideQuestion()}>
@@ -1309,6 +1315,23 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
             />
           </Match>
         </Switch>
+        <Show when={imageAttachments().length > 0}>
+          <div data-slot="tool-image-attachments">
+            <For each={imageAttachments()}>
+              {(file) => {
+                const name = file.filename ?? i18n.t("ui.message.attachment.alt")
+                return (
+                  <button
+                    data-slot="tool-image-attachment"
+                    onClick={() => dialog.show(() => <ImagePreview src={file.url} alt={name} />)}
+                  >
+                    <img src={file.url} alt={name} />
+                  </button>
+                )
+              }}
+            </For>
+          </div>
+        </Show>
       </div>
     </Show>
   )


### PR DESCRIPTION
### Issue for this PR

Closes #21227

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tool results can include image attachments (typed as `FilePart` with an image mime type), but the UI currently doesn't display them. This PR adds clickable image thumbnails below completed tool results.

### How did you verify your code works?
Tested with MCP tools and the built-in webfetch tool that return image attachments. Verified:
- Thumbnails appear below the tool result when images are present
- Clicking opens full-size preview in the dialog
- Non-image attachments are unaffected
- No rendering when tool is still running

### Screenshots / recordings

<img width="1111" height="718" alt="Screenshot 2026-04-07 at 11 17 25 AM" src="https://github.com/user-attachments/assets/c02a52e4-e73b-41ad-baba-31c36fd57f24" />
<img width="1264" height="711" alt="Screenshot 2026-04-07 at 11 17 12 AM" src="https://github.com/user-attachments/assets/ca5919ce-a9f5-48c3-aaa0-a8500855b2b6" />
<img width="1055" height="746" alt="Screenshot 2026-04-07 at 11 30 47 AM" src="https://github.com/user-attachments/assets/b0e3b3a0-d5fd-4297-846b-955c34c9dfc1" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
