### PR TITLE
fix(session): use parentID instead of timestamp for loop exit condition

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1377,7 +1377,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               lastAssistant?.finish &&
               !["tool-calls"].includes(lastAssistant.finish) &&
               !hasToolCalls &&
-              lastUser.id < lastAssistant.id
+              lastAssistant.parentID === lastUser.id
             ) {
               log.info("exiting loop", { sessionID })
               break

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -333,17 +333,29 @@ it.live("loop exits when assistant parentID matches user message even with clock
       const sessions = yield* Session.Service
       const chat = yield* sessions.create({ title: "Clock skew test" })
 
-      // Simulate client clock being ahead: create assistant message first (server time),
-      // then create user message with a "future" timestamp that would sort after the assistant
-      const assistantTime = Date.now() - 1000 // 1 second in the past
-      const userTime = Date.now() + 1000 // 1 second in the future
+      // Simulate client clock being ahead: assistant ID sorts before user ID
+      // but assistant.parentID still points to the user message
+      const assistantTime = Date.now() - 1000
+      const userTime = Date.now() + 1000
 
-      // Create assistant message with older timestamp
-      const assistantID = Identifier.create("message", false, assistantTime)
+      // Create user message first (needed for parentID reference)
+      const userID = MessageID.make(Identifier.create("message", false, userTime))
+      const userMsg: MessageV2.User = {
+        id: userID,
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: userTime },
+      }
+      yield* sessions.updateMessage(userMsg)
+
+      // Create assistant message with older timestamp but parentID = user.id
+      const assistantID = MessageID.make(Identifier.create("message", false, assistantTime))
       const assistant: MessageV2.Assistant = {
-        id: MessageID.make(assistantID),
+        id: assistantID,
         role: "assistant",
-        parentID: MessageID.make(Identifier.create("message", false, userTime)),
+        parentID: userID,
         sessionID: chat.id,
         mode: "build",
         agent: "build",
@@ -356,21 +368,15 @@ it.live("loop exits when assistant parentID matches user message even with clock
         finish: "stop",
       }
       yield* sessions.updateMessage(assistant)
-
-      // Create user message with newer timestamp (simulating client clock ahead)
-      const userID = Identifier.create("message", false, userTime)
-      const userMsg: MessageV2.User = {
-        id: MessageID.make(userID),
-        role: "user",
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: assistant.id,
         sessionID: chat.id,
-        agent: "build",
-        model: ref,
-        time: { created: userTime },
-      }
-      yield* sessions.updateMessage(userMsg)
+        type: "text",
+        text: "hi there",
+      })
 
-      // The loop should still exit because it checks parentID === user.id,
-      // not ID ordering
+      // The loop should exit because it checks parentID === user.id, not ID ordering
       const result = yield* prompt.loop({ sessionID: chat.id })
       expect(result.info.role).toBe("assistant")
       if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -34,6 +34,7 @@ import { ToolRegistry } from "../../src/tool/registry"
 import { Truncate } from "../../src/tool/truncate"
 import { Log } from "../../src/util/log"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Identifier } from "../../src/id/id"
 import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
@@ -316,6 +317,60 @@ it.live("loop exits immediately when last assistant has stop finish", () =>
       const chat = yield* sessions.create({ title: "Pinned" })
       yield* seed(chat.id, { finish: "stop" })
 
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")
+      expect(yield* llm.calls).toBe(0)
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop exits when assistant parentID matches user message even with clock skew", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Clock skew test" })
+
+      // Simulate client clock being ahead: create assistant message first (server time),
+      // then create user message with a "future" timestamp that would sort after the assistant
+      const assistantTime = Date.now() - 1000 // 1 second in the past
+      const userTime = Date.now() + 1000 // 1 second in the future
+
+      // Create assistant message with older timestamp
+      const assistantID = Identifier.create("message", false, assistantTime)
+      const assistant: MessageV2.Assistant = {
+        id: MessageID.make(assistantID),
+        role: "assistant",
+        parentID: MessageID.make(Identifier.create("message", false, userTime)),
+        sessionID: chat.id,
+        mode: "build",
+        agent: "build",
+        cost: 0,
+        path: { cwd: "/tmp", root: "/tmp" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ref.modelID,
+        providerID: ref.providerID,
+        time: { created: assistantTime },
+        finish: "stop",
+      }
+      yield* sessions.updateMessage(assistant)
+
+      // Create user message with newer timestamp (simulating client clock ahead)
+      const userID = Identifier.create("message", false, userTime)
+      const userMsg: MessageV2.User = {
+        id: MessageID.make(userID),
+        role: "user",
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        time: { created: userTime },
+      }
+      yield* sessions.updateMessage(userMsg)
+
+      // The loop should still exit because it checks parentID === user.id,
+      // not ID ordering
       const result = yield* prompt.loop({ sessionID: chat.id })
       expect(result.info.role).toBe("assistant")
       if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")


### PR DESCRIPTION
### Issue for this PR
Closes #21335

### Type of change
- [x] Bug fix

### What does this PR do?
The Web UI triggers duplicate assistant responses when sending a prompt. The processing loop fails to exit because its condition `lastUser.id < lastAssistant.id` relies on timestamp-based ID ordering. Since the Web UI generates user message IDs client-side and the server generates assistant IDs independently, clock skew between the two breaks the exit condition, causing the loop to continue generating responses.

The fix replaces the ID ordering check with `lastAssistant.parentID === lastUser.id`, which directly verifies the assistant message belongs to the current user prompt. This field is already populated and does not require any schema changes.

The TUI is not affected because it uses the synchronous `session.prompt` endpoint rather than `session.promptAsync`.

### How did you verify your code works?
Added a test case in `packages/opencode/test/session/prompt-effect.test.ts` that simulates clock skew by creating messages with timestamps that would sort incorrectly under the old logic. The test confirms the loop exits correctly using the `parentID` check regardless of ID ordering.

The existing test "loop exits immediately when last assistant has stop finish" continues to pass since the seeded assistant message already has `parentID` set to the user message ID.

### Screenshots / recordings
_N/A - no UI changes_

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR