### PR TITLE
fix(opencode): align batch tool execution with active turn filtering

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -196,7 +196,12 @@ export namespace LLM {
       },
     )
 
-    const tools = await resolveTools(input)
+    const tools = filterTools({
+      tools: input.tools,
+      agent: input.agent,
+      permission: input.permission,
+      enabled: input.user.tools,
+    })
 
     // LiteLLM and some Anthropic proxies require the tools parameter to be present
     // when message history contains tool calls, even if no tools are being used.
@@ -334,12 +339,17 @@ export namespace LLM {
     })
   }
 
-  function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {
+  export function filterTools(input: {
+    tools: Record<string, Tool>
+    agent: Agent.Info
+    permission?: Permission.Ruleset
+    enabled?: Record<string, boolean>
+  }) {
     const disabled = Permission.disabled(
       Object.keys(input.tools),
       Permission.merge(input.agent.permission, input.permission ?? []),
     )
-    return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+    return Record.filter(input.tools, (_, k) => input.enabled?.[k] !== false && !disabled.has(k))
   }
 
   // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -396,13 +396,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       }) {
         using _ = log.time("resolveTools")
         const tools: Record<string, AITool> = {}
+        let allow: string[] = []
 
         const context = (args: any, options: ToolExecutionOptions): Tool.Context => ({
           sessionID: input.session.id,
           abort: options.abortSignal!,
           messageID: input.processor.message.id,
           callID: options.toolCallId,
-          extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck },
+          extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck, allow },
           agent: input.agent.name,
           messages: input.messages,
           metadata: (val) =>
@@ -546,6 +547,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             )
           tools[key] = item
         }
+
+        allow = Object.keys(
+          LLM.filterTools({
+            tools,
+            agent: input.agent,
+            permission: input.session.permission,
+            enabled: input.tools,
+          }),
+        )
 
         return tools
       })

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -3,6 +3,7 @@ import { Tool } from "./tool"
 import { ProviderID, ModelID } from "../provider/schema"
 import { errorMessage } from "../util/error"
 import DESCRIPTION from "./batch.txt"
+import { Agent } from "../agent/agent"
 
 const DISALLOWED = new Set(["batch"])
 const FILTERED_FROM_SUGGESTIONS = new Set(["invalid", "patch", ...DISALLOWED])
@@ -35,11 +36,32 @@ export const BatchTool = Tool.define("batch", async () => {
       const { Session } = await import("../session")
       const { PartID } = await import("../session/schema")
 
+      const raw = ctx.extra?.["model"]
+      const info = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined
+      const api =
+        info?.["api"] && typeof info["api"] === "object" ? (info["api"] as Record<string, unknown>) : undefined
+      const model =
+        typeof info?.["providerID"] === "string" && typeof api?.["id"] === "string"
+          ? {
+              providerID: ProviderID.make(info["providerID"]),
+              modelID: ModelID.make(api["id"]),
+            }
+          : {
+              providerID: ProviderID.make(""),
+              modelID: ModelID.make(""),
+            }
+      const allow = new Set(
+        (Array.isArray(ctx.extra?.["allow"]) ? ctx.extra["allow"] : []).filter(
+          (item): item is string => typeof item === "string",
+        ),
+      )
+      const ag = await Agent.get(ctx.agent)
+
       const toolCalls = params.tool_calls.slice(0, 25)
       const discardedCalls = params.tool_calls.slice(25)
 
       const { ToolRegistry } = await import("./registry")
-      const availableTools = await ToolRegistry.tools({ modelID: ModelID.make(""), providerID: ProviderID.make("") })
+      const availableTools = await ToolRegistry.tools(model, ag)
       const toolMap = new Map(availableTools.map((t) => [t.id, t]))
 
       const executeCall = async (call: (typeof toolCalls)[0]) => {
@@ -47,6 +69,10 @@ export const BatchTool = Tool.define("batch", async () => {
         const partID = PartID.ascending()
 
         try {
+          if (allow.size && !allow.has(call.tool)) {
+            throw new Error(`Tool '${call.tool}' is not enabled in this turn. Use only currently available tools.`)
+          }
+
           if (DISALLOWED.has(call.tool)) {
             throw new Error(
               `Tool '${call.tool}' is not allowed in batch. Disallowed tools: ${Array.from(DISALLOWED).join(", ")}`,

--- a/packages/opencode/test/tool/batch.test.ts
+++ b/packages/opencode/test/tool/batch.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import * as fs from "fs/promises"
+import { BatchTool } from "../../src/tool/batch"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import { SessionID, MessageID } from "../../src/session/schema"
+
+const baseCtx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("tool.batch", () => {
+  test("uses the current model tool set for apply_patch", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const batch = await BatchTool.init()
+        const file = path.join(tmp.path, "made.txt")
+
+        await batch.execute(
+          {
+            tool_calls: [
+              {
+                tool: "apply_patch",
+                parameters: {
+                  patchText: "*** Begin Patch\n*** Add File: made.txt\n+hello\n*** End Patch",
+                },
+              },
+            ],
+          },
+          {
+            ...baseCtx,
+            extra: {
+              allow: ["batch", "apply_patch"],
+              model: {
+                providerID: "openai",
+                api: { id: "gpt-5.2" },
+              },
+            },
+          },
+        )
+
+        expect(await fs.readFile(file, "utf-8")).toBe("hello\n")
+      },
+    })
+  })
+
+  test("rejects tools that are not enabled for the turn", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const batch = await BatchTool.init()
+        const file = path.join(tmp.path, "blocked.txt")
+
+        await batch.execute(
+          {
+            tool_calls: [
+              {
+                tool: "apply_patch",
+                parameters: {
+                  patchText: "*** Begin Patch\n*** Add File: blocked.txt\n+hello\n*** End Patch",
+                },
+              },
+            ],
+          },
+          {
+            ...baseCtx,
+            extra: {
+              allow: ["batch"],
+              model: {
+                providerID: "openai",
+                api: { id: "gpt-5.2" },
+              },
+            },
+          },
+        )
+
+        await expect(fs.access(file)).rejects.toThrow()
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #21367

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [ ] New feature
- [ ] Documentation

### What does this PR do?

`batch` was resolving tools independently from the turn tool set, so it could miss model-gated tools like `apply_patch` and drift from the tools actually exposed to the model.

This change:
- reuses `LLM.filterTools()` as the shared turn filter
- threads the filtered tool IDs through `SessionPrompt` via `extra.allow`
- resolves `ToolRegistry.tools(...)` in `batch` with the active `{ providerID, modelID }`
- rejects batched subcalls that were not enabled in the active turn

This keeps external / MCP tools out of `batch` and makes batched execution match normal tool execution.

### How did you verify your code works?

- `cd packages/opencode`
- `bun test test/tool/batch.test.ts test/tool/apply_patch.test.ts`
- `bun typecheck`
- added regression coverage for:
  - `batch -> apply_patch` under a GPT-5-style patch turn
  - rejecting `apply_patch` when the turn allowlist excludes it

### Screenshots / recordings

N/A — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR