### PR TITLE
feat: add footerShowSubagents config option for TUI agent display

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -2,6 +2,7 @@ import { createStore } from "solid-js/store"
 import { batch, createEffect, createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
+import { useTuiConfig } from "@tui/context/tui-config"
 import { uniqueBy } from "remeda"
 import path from "path"
 import { Global } from "@/global"
@@ -35,7 +36,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     const agent = iife(() => {
-      const agents = createMemo(() => sync.data.agent.filter((x) => x.mode !== "subagent" && !x.hidden))
+      const tuiConfig = useTuiConfig()
+      const showSubagents = () => tuiConfig.footerShowSubagents ?? false
+      const agents = createMemo(() => 
+        sync.data.agent.filter((x) => {
+          if (x.hidden) return false
+          if (showSubagents()) return true
+          return x.mode !== "subagent"
+        })
+      )
       const visibleAgents = createMemo(() => sync.data.agent.filter((x) => !x.hidden))
       const [agentStore, setAgentStore] = createStore<{
         current: string

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -23,6 +23,10 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  footerShowSubagents: z
+    .boolean()
+    .optional()
+    .describe("Show subagents in footer tab selector (default: false, only shows primary agents)"),
 })
 
 export const TuiInfo = z


### PR DESCRIPTION
```markdown
Add a new TUI configuration option to control whether subagents are shown in the footer agent tab selector.

When set to false (default), only primary agents are displayed, providing a cleaner workflow for users with many agents from plugins. When set to true, all non-hidden agents (including subagents) are displayed.

This allows users with heavy multi-agent setups to restore the previous primary-only visibility while keeping the new subagent orchestration features for those who want full visibility.

Fixes: #12530, #4764

### Issue for this PR

Closes #12530, #4764

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add a new TUI configuration option `footerShowSubagents` to control whether subagents are shown in the footer agent tab selector.

**Problem:** Since v1.3.4, the footer agent display includes all agents (primary + subagents), making manual switching slow for users with many custom agents and plugins like compound-engineering.

**Solution:** Add a configuration option (default: false) to restore the previous clean primary-only agent display while keeping the new subagent orchestration features available for those who want full visibility.

Users can now configure this in tui.json:
```json
{
  "footerShowSubagents": false
}