### PR TITLE
docs: add opencode-claude-commands to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -52,6 +52,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                          |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                          |
+| [opencode-claude-commands](https://github.com/braydenbabbitt/opencode-claude-commands)             | Use Claude slash commands and skills defined in `.claude/` configs                                |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR
N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Simply adds a new available plugin that I created to allow usage of commands and skills defined in `.claude` directories/configs natively in opencode

### How did you verify your code works?

I have been using the plugin all day and has worked great for me. I also have a robust test suite in the plugin repo

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
