### PR TITLE
docs(providers): add Rapid-MLX local provider section

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1550,6 +1550,45 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### Rapid-MLX
+
+You can configure opencode to use local models through [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX), an OpenAI-compatible inference server for Apple Silicon built on `mlx-lm`.
+
+```bash
+pip install rapid-mlx
+rapid-mlx serve mlx-community/Qwen3.5-4B-MLX-4bit
+```
+
+```json title="opencode.json" "rapid-mlx" {5, 6, 8, 10-14}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "rapid-mlx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rapid-MLX (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8000/v1"
+      },
+      "models": {
+        "mlx-community/Qwen3.5-4B-MLX-4bit": {
+          "name": "Qwen3.5 4B (MLX)"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `rapid-mlx` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider. `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server.
+- `models` is a map of model IDs to their configurations.
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.


### PR DESCRIPTION
### Issue for this PR

N/A — new provider documentation addition.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a Rapid-MLX section to the Providers docs page
(`packages/web/src/content/docs/providers.mdx`), alphabetized between
OpenRouter and SAP AI Core.

[Rapid-MLX](https://github.com/raullenchai/Rapid-MLX) is an
OpenAI-compatible inference server for Apple Silicon built on `mlx-lm`.
It works with the existing `@ai-sdk/openai-compatible` provider — the
section shows a complete `opencode.json` config snippet following the
same pattern as the existing LM Studio section.

A companion PR is open at anomalyco/models.dev#1361 to add the
`rapid-mlx` entry to the canonical provider TOML database.

### How did you verify your code works?

- Verified the `opencode.json` config snippet works locally against a
  running Rapid-MLX server (model list + chat completions).
- Confirmed the section renders correctly in MDX by checking the
  existing LM Studio section as a structural template.
- Single-file docs change, no code modifications.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR