### PR TITLE
feat: Context usage tool + New Session tool

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/packages/opencode/.npmrc
+++ b/packages/opencode/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -52,6 +52,7 @@ import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider, useExit } from "./context/exit"
 import { Session as SessionApi } from "@/session/session"
 import { TuiEvent } from "./event"
+import { MessageID, PartID } from "@/session/schema"
 import { KVProvider, useKV } from "./context/kv"
 import { Provider } from "@/provider/provider"
 import { ArgsProvider, useArgs, type Args } from "./context/args"
@@ -794,6 +795,39 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       type: "session",
       sessionID: evt.properties.sessionID,
     })
+  })
+
+  event.on(TuiEvent.SessionNew.type, async (evt) => {
+    const model = local.model.current()
+    if (!model) return
+
+    // Abort the old session
+    await sdk.client.session.abort({ sessionID: evt.properties.sessionID }).catch(() => {})
+
+    // Create and navigate to the new session
+    const res = await sdk.client.session.create({})
+    if (res.error) return
+    const id = res.data.id
+
+    route.navigate({ type: "session", sessionID: id })
+
+    // Auto-send the initial message
+    sdk.client.session
+      .prompt({
+        sessionID: id,
+        ...model,
+        messageID: MessageID.ascending(),
+        agent: local.agent.current().name,
+        model,
+        parts: [
+          {
+            id: PartID.ascending(),
+            type: "text" as const,
+            text: evt.properties.message,
+          },
+        ],
+      })
+      .catch(() => {})
   })
 
   event.on("session.deleted", (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -800,6 +800,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
   event.on(TuiEvent.SessionNew.type, async (evt) => {
     const model = local.model.current()
     if (!model) return
+    const agent = local.agent.current()
+    if (!agent) return
 
     // Abort the old session
     await sdk.client.session.abort({ sessionID: evt.properties.sessionID }).catch(() => {})
@@ -817,7 +819,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         sessionID: id,
         ...model,
         messageID: MessageID.ascending(),
-        agent: local.agent.current().name,
+        agent: agent.name,
         model,
         parts: [
           {

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -52,9 +52,9 @@ export const TuiEvent = {
   ),
   SessionNew: BusEvent.define(
     "tui.session.new",
-    z.object({
-      message: z.string().describe("Initial message to send in the new session"),
-      sessionID: SessionID.zod.describe("Session ID of the current session to abort"),
+    Schema.Struct({
+      message: Schema.String.annotate({ description: "Initial message to send in the new session" }),
+      sessionID: SessionID.annotate({ description: "Session ID of the current session to abort" }),
     }),
   ),
 }

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -50,4 +50,11 @@ export const TuiEvent = {
       sessionID: SessionID.annotate({ description: "Session ID to navigate to" }),
     }),
   ),
+  SessionNew: BusEvent.define(
+    "tui.session.new",
+    z.object({
+      message: z.string().describe("Initial message to send in the new session"),
+      sessionID: SessionID.zod.describe("Session ID of the current session to abort"),
+    }),
+  ),
 }

--- a/packages/opencode/src/tool/context.ts
+++ b/packages/opencode/src/tool/context.ts
@@ -1,0 +1,56 @@
+import z from "zod"
+import { Effect } from "effect"
+import * as Tool from "./tool"
+import type { Provider } from "../provider"
+import DESCRIPTION from "./context.txt"
+
+const parameters = z.object({})
+
+type Metadata = {
+  total?: number
+  limit?: number
+  percentage?: number | null
+  tokens?: unknown
+}
+
+export const ContextUsageTool = Tool.define<typeof parameters, Metadata, never>(
+  "check_context_usage",
+  Effect.gen(function* () {
+    return {
+      description: DESCRIPTION,
+      parameters,
+      execute: (_params: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          const model = ctx.extra?.model as Provider.Model | undefined
+          const last = ctx.messages.filter((msg) => msg.info.role === "assistant" && msg.info.tokens.output > 0).at(-1)
+
+          if (!last || last.info.role !== "assistant") {
+            return {
+              title: "No usage data",
+              metadata: {},
+              output: "No context usage data available yet.",
+            }
+          }
+
+          const tokens = last.info.tokens
+          const total = tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+          const limit = model?.limit.context
+          const percentage = limit ? Math.round((total / limit) * 100) : null
+
+          return {
+            title: percentage !== null ? `${percentage}% used` : `${total.toLocaleString()} tokens`,
+            metadata: {
+              total,
+              limit,
+              percentage,
+              tokens,
+            },
+            output:
+              percentage !== null
+                ? `Context usage: ${total.toLocaleString()} tokens (${percentage}% of ${limit?.toLocaleString()} context limit)`
+                : `Context usage: ${total.toLocaleString()} tokens (context limit unknown)`,
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/context.ts
+++ b/packages/opencode/src/tool/context.ts
@@ -1,10 +1,9 @@
-import z from "zod"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
-import type { Provider } from "../provider"
+import type { Provider } from "../provider/provider"
 import DESCRIPTION from "./context.txt"
 
-const parameters = z.object({})
+export const Parameters = Schema.Struct({})
 
 type Metadata = {
   total?: number
@@ -13,13 +12,13 @@ type Metadata = {
   tokens?: unknown
 }
 
-export const ContextUsageTool = Tool.define<typeof parameters, Metadata, never>(
+export const ContextUsageTool = Tool.define<typeof Parameters, Metadata, never>(
   "check_context_usage",
   Effect.gen(function* () {
     return {
       description: DESCRIPTION,
-      parameters,
-      execute: (_params: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) =>
+      parameters: Parameters,
+      execute: (_params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
         Effect.gen(function* () {
           const model = ctx.extra?.model as Provider.Model | undefined
           const last = ctx.messages.filter((msg) => msg.info.role === "assistant" && msg.info.tokens.output > 0).at(-1)

--- a/packages/opencode/src/tool/context.txt
+++ b/packages/opencode/src/tool/context.txt
@@ -1,0 +1,1 @@
+Check your current context window usage. Returns the total token count, the percentage of the context window used, and the context limit. Use this to monitor how much of your context window remains before deciding whether to compact or adjust your approach.

--- a/packages/opencode/src/tool/new-session.ts
+++ b/packages/opencode/src/tool/new-session.ts
@@ -1,0 +1,37 @@
+import z from "zod"
+import { Effect } from "effect"
+import * as Tool from "./tool"
+import { Bus } from "../bus"
+import { TuiEvent } from "../cli/cmd/tui/event"
+import DESCRIPTION from "./new-session.txt"
+
+const parameters = z.object({
+  initial_message: z.string().describe("The message to send as the first user message in the new session"),
+})
+
+type Metadata = {}
+
+export const NewSessionTool = Tool.define<typeof parameters, Metadata, Bus.Service>(
+  "new_session",
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters,
+      execute: (args: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          yield* bus.publish(TuiEvent.SessionNew, {
+            message: args.initial_message,
+            sessionID: ctx.sessionID,
+          })
+
+          return {
+            title: "Starting new session",
+            metadata: {},
+            output: `New session requested with message: "${args.initial_message}". Current session will be terminated.`,
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/new-session.ts
+++ b/packages/opencode/src/tool/new-session.ts
@@ -1,25 +1,26 @@
-import z from "zod"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { Bus } from "../bus"
 import { TuiEvent } from "../cli/cmd/tui/event"
 import DESCRIPTION from "./new-session.txt"
 
-const parameters = z.object({
-  initial_message: z.string().describe("The message to send as the first user message in the new session"),
+export const Parameters = Schema.Struct({
+  initial_message: Schema.String.annotate({
+    description: "The message to send as the first user message in the new session",
+  }),
 })
 
 type Metadata = {}
 
-export const NewSessionTool = Tool.define<typeof parameters, Metadata, Bus.Service>(
+export const NewSessionTool = Tool.define<typeof Parameters, Metadata, Bus.Service>(
   "new_session",
   Effect.gen(function* () {
     const bus = yield* Bus.Service
 
     return {
       description: DESCRIPTION,
-      parameters,
-      execute: (args: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) =>
+      parameters: Parameters,
+      execute: (args: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
         Effect.gen(function* () {
           yield* bus.publish(TuiEvent.SessionNew, {
             message: args.initial_message,

--- a/packages/opencode/src/tool/new-session.txt
+++ b/packages/opencode/src/tool/new-session.txt
@@ -1,0 +1,5 @@
+Stop the current session and start a new one with the given initial message. Use this when you need to start fresh in a new session, for example after completing a large task and the user wants to move on to something unrelated, or when context is getting too large and you want to continue work in a clean session.
+
+The current session will be aborted immediately and a new session will be created with the initial_message sent as the first user message. The new session will begin processing automatically.
+
+IMPORTANT: After calling this tool, do not call any other tools or generate further output - the current session is being terminated.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -46,6 +46,7 @@ import { Bus } from "../bus"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
+import { ContextUsageTool } from "./context"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -201,6 +202,7 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          context: Tool.init(ContextUsageTool),
         })
 
         return {
@@ -217,6 +219,7 @@ export const layer: Layer.Layer<
             tool.task,
             tool.fetch,
             tool.todo,
+            tool.context,
             tool.search,
             tool.skill,
             tool.patch,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -115,6 +115,8 @@ export const layer: Layer.Layer<
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const contexttool = yield* ContextUsageTool
+    const newsessiontool = yield* NewSessionTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -204,8 +206,8 @@ export const layer: Layer.Layer<
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
-          context: Tool.init(ContextUsageTool),
-          session: Tool.init(NewSessionTool),
+          context: Tool.init(contexttool),
+          session: Tool.init(newsessiontool),
         })
 
         return {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -47,6 +47,7 @@ import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
 import { ContextUsageTool } from "./context"
+import { NewSessionTool } from "./new-session"
 
 const log = Log.create({ service: "tool.registry" })
 
@@ -184,6 +185,7 @@ export const layer: Layer.Layer<
         yield* config.get()
         const questionEnabled =
           ["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT) || Flag.OPENCODE_ENABLE_QUESTION_TOOL
+        const tui = ["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT)
 
         const tool = yield* Effect.all({
           invalid: Tool.init(invalid),
@@ -203,6 +205,7 @@ export const layer: Layer.Layer<
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
           context: Tool.init(ContextUsageTool),
+          session: Tool.init(NewSessionTool),
         })
 
         return {
@@ -220,6 +223,7 @@ export const layer: Layer.Layer<
             tool.fetch,
             tool.todo,
             tool.context,
+            ...(tui ? [tool.session] : []),
             tool.search,
             tool.skill,
             tool.patch,

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -22,6 +22,7 @@ import type {
   EventSubscribeResponses,
   EventTuiCommandExecute,
   EventTuiPromptAppend,
+  EventTuiSessionNew,
   EventTuiSessionSelect,
   EventTuiToastShow,
   ExperimentalConsoleGetResponses,
@@ -4062,7 +4063,12 @@ export class Tui extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+      body?:
+        | EventTuiPromptAppend
+        | EventTuiCommandExecute
+        | EventTuiToastShow
+        | EventTuiSessionSelect
+        | EventTuiSessionNew
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -420,6 +420,20 @@ export type EventTuiSessionSelect = {
   }
 }
 
+export type EventTuiSessionNew = {
+  type: "tui.session.new"
+  properties: {
+    /**
+     * Initial message to send in the new session
+     */
+    message: string
+    /**
+     * Session ID of the current session to abort
+     */
+    sessionID: string
+  }
+}
+
 export type EventMcpToolsChanged = {
   type: "mcp.tools.changed"
   properties: {
@@ -1137,6 +1151,7 @@ export type GlobalEvent = {
     | EventTuiCommandExecute
     | EventTuiToastShow
     | EventTuiSessionSelect
+    | EventTuiSessionNew
     | EventMcpToolsChanged
     | EventMcpBrowserOpenFailed
     | EventCommandExecuted
@@ -2080,6 +2095,7 @@ export type Event =
   | EventTuiCommandExecute
   | EventTuiToastShow
   | EventTuiSessionSelect
+  | EventTuiSessionNew
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
@@ -5263,7 +5279,7 @@ export type TuiShowToastResponses = {
 export type TuiShowToastResponse = TuiShowToastResponses[keyof TuiShowToastResponses]
 
 export type TuiPublishData = {
-  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect | EventTuiSessionNew
   path?: never
   query?: {
     directory?: string


### PR DESCRIPTION
Adds two new tools: check context usage and start new session. This offers hooks for a custom way to roll through sessions and not use the auto compaction tool. I use this via md files and find it much more useful. The context I have from session 1 is still at good quality even at session 50 whereas with auto compaction session 1 context is already at degraded quality at session 3.

### Issue for this PR

Closes #10113

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Local build and have been using it for a while now. Works great for me, automated long running tasks with no context degradation like with auto compaction.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
