### PR TITLE
fix: correct .opencode/ config directory precedence

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -16,13 +16,13 @@ export namespace ConfigPaths {
     return [
       Global.Path.config,
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-        ? await Array.fromAsync(
+        ? (await Array.fromAsync(
             Filesystem.up({
               targets: [".opencode"],
               start: directory,
               stop: worktree,
             }),
-          )
+          )).reverse()
         : []),
       ...(await Array.fromAsync(
         Filesystem.up({

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1765,6 +1765,42 @@ test("local .opencode config can override MCP from project config", async () => 
   })
 })
 
+test("child .opencode config overrides parent .opencode config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Parent .opencode directory with one username
+      const parentOpencode = path.join(dir, ".opencode")
+      await fs.mkdir(parentOpencode, { recursive: true })
+      await Filesystem.write(
+        path.join(parentOpencode, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          username: "parent-wins",
+        }),
+      )
+      // Child directory with its own .opencode
+      const childDir = path.join(dir, "child")
+      const childOpencode = path.join(childDir, ".opencode")
+      await fs.mkdir(childOpencode, { recursive: true })
+      await Filesystem.write(
+        path.join(childOpencode, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          username: "child-should-win",
+        }),
+      )
+    },
+  })
+  const childDir = path.join(tmp.path, "child")
+  await Instance.provide({
+    directory: childDir,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.username).toBe("child-should-win")
+    },
+  })
+})
+
 test("project config overrides remote well-known config", async () => {
   const originalFetch = globalThis.fetch
   let fetchedUrl: string | undefined


### PR DESCRIPTION
### Issue for this PR

Closes #21307

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ConfigPaths.directories()` uses `Filesystem.up()` to collect `.opencode/` config dirs from child to parent. These get fed into `mergeDeep` where later entries win. Since `up()` yields child-first, the parent dir ends up last in the array and wins the merge. That's backwards.

The fix: `.reverse()` the array so parent comes first, child comes last. Child config wins the merge, which is the expected behavior. This matches how `projectFiles` already handles the same precedence problem using `{ rootFirst: true }`.

### How did you verify your code works?

Added a test that creates nested `.opencode/` dirs (parent with `username: "parent-wins"`, child with `username: "child-should-win"`), loads config from the child dir, and asserts child wins.

All 76 config tests pass including the new one: `bun test packages/opencode/test/config/config.test.ts`

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR