### PR TITLE
fix: retry transient HTTP errors (500/502/503/504) for all providers

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -31,13 +31,6 @@ export namespace ProviderError {
   // Status codes that are always transient and safe to retry regardless of provider
   const RETRYABLE_CODES = new Set([429, 500, 502, 503, 504, 529])
 
-  function isOpenAiErrorRetryable(e: APICallError) {
-    const status = e.statusCode
-    if (!status) return e.isRetryable
-    // openai sometimes returns 404 for models that are actually available
-    return status === 404 || RETRYABLE_CODES.has(status) || e.isRetryable
-  }
-
   // Providers not reliably handled in this function:
   // - z.ai: can accept overflow silently (needs token-count/context-window checks)
   function isOverflow(message: string) {
@@ -189,9 +182,10 @@ export namespace ProviderError {
       type: "api_error",
       message: m,
       statusCode: input.error.statusCode,
-      isRetryable: input.providerID.startsWith("openai")
-        ? isOpenAiErrorRetryable(input.error)
-        : (input.error.statusCode !== undefined && RETRYABLE_CODES.has(input.error.statusCode)) || input.error.isRetryable,
+      isRetryable:
+        (input.error.statusCode !== undefined && RETRYABLE_CODES.has(input.error.statusCode)) ||
+        (input.providerID.startsWith("openai") && input.error.statusCode === 404) ||
+        input.error.isRetryable,
       responseHeaders: input.error.responseHeaders,
       responseBody: input.error.responseBody,
       metadata,

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -28,11 +28,14 @@ export namespace ProviderError {
     /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
   ]
 
+  // Status codes that are always transient and safe to retry regardless of provider
+  const RETRYABLE_CODES = new Set([429, 500, 502, 503, 504, 529])
+
   function isOpenAiErrorRetryable(e: APICallError) {
     const status = e.statusCode
     if (!status) return e.isRetryable
     // openai sometimes returns 404 for models that are actually available
-    return status === 404 || e.isRetryable
+    return status === 404 || RETRYABLE_CODES.has(status) || e.isRetryable
   }
 
   // Providers not reliably handled in this function:
@@ -188,7 +191,7 @@ export namespace ProviderError {
       statusCode: input.error.statusCode,
       isRetryable: input.providerID.startsWith("openai")
         ? isOpenAiErrorRetryable(input.error)
-        : input.error.isRetryable,
+        : (input.error.statusCode !== undefined && RETRYABLE_CODES.has(input.error.statusCode)) || input.error.isRetryable,
       responseHeaders: input.error.responseHeaders,
       responseBody: input.error.responseBody,
       metadata,


### PR DESCRIPTION
Closes #21420
Closes #19394

### Type of change

- [x] Bug fix

### What does this PR do?

When Anthropic's API returns a transient server error (HTTP 500, 502, 503, or 504), OpenCode immediately fails instead of retrying. This happens because `parseAPICallError()` in `packages/opencode/src/provider/error.ts` delegates `isRetryable` entirely to the Vercel AI SDK for non-OpenAI providers. The `@ai-sdk/anthropic` package only sets `isRetryable: true` for status 429 and 529 — all other 5xx codes get `isRetryable: false`, so `SessionRetry.retryable()` returns `undefined` and the retry loop exits immediately.

The fix adds a module-level `RETRYABLE_CODES` constant (`Set([429, 500, 502, 503, 504, 529])`) and checks it explicitly in both the OpenAI and non-OpenAI paths of `parseAPICallError()`. These codes are universally transient across all providers (standard HTTP semantics), so there are no false positives — non-transient codes like 401, 403, 422, and 501 remain unaffected.

OpenAI already had a partial override for 404 via `isOpenAiErrorRetryable()`; this PR generalises that pattern properly across all providers.

### How did you verify your code works?

- Traced the full error → retry flow from `LLM.stream()` throw through `MessageV2.fromError()` → `parseAPICallError()` → `SessionRetry.retryable()` → `processor.ts` retry loop.
- Confirmed `@ai-sdk/anthropic` source: 429 and 529 are the only codes it marks `isRetryable: true`.
- Verified that `RETRYABLE_CODES` covers the exact RFC 7231 / Anthropic-documented transient codes and excludes all non-transient codes.

### Screenshots / recordings

_N/A — backend-only change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR