### PR TITLE
fix(snapshot): remove --sparse flag from git add for older git compat

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -193,7 +193,7 @@ export namespace Snapshot {
               { concurrency: 8 },
             )).filter((item): item is string => Boolean(item))
             yield* sync(large)
-            const result = yield* git([...cfg, ...args(["add", "--sparse", "."])], { cwd: state.directory })
+            const result = yield* git([...cfg, ...args(["add", "."])], { cwd: state.directory })
             if (result.code !== 0) {
               log.warn("failed to add snapshot files", {
                 exitCode: result.code,


### PR DESCRIPTION
### Issue for this PR

Closes #21302

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The snapshot system calls `git add --sparse .` to stage files into its internal git directory. The `--sparse` flag was introduced in git 2.34 and doesn't exist in older versions. Users running git <2.34 (like the reporter on git 2.22) get `error: unknown option 'sparse'`, which causes snapshot creation to fail.

The fix removes `--sparse` from the `git add` command. This flag is safe to remove because:

1. The snapshot system uses its own separate git directory (not the user's repo)
2. Sparse checkout is never configured on this internal git directory
3. `--sparse` only has an effect when sparse checkout is enabled, so it was a no-op on modern git anyway
4. `git add .` behaves identically to `git add --sparse .` when sparse checkout is not configured

One line change in `packages/opencode/src/snapshot/index.ts`.

### How did you verify your code works?

- Confirmed `--sparse` is the only reference to sparse checkout in the entire codebase (no sparse-checkout config anywhere)
- Verified that `git add .` and `git add --sparse .` produce identical results when sparse checkout is not enabled
- Confirmed `--sparse` was introduced in git 2.34 per git release notes

### Screenshots / recordings

_N/A - no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR