### PR TITLE
fix(skill): gracefully handle invalid skills and display generic message in TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
@@ -24,8 +24,10 @@ export function DialogSkill(props: DialogSkillProps) {
       title: skill.name.padEnd(maxWidth),
       description: skill.description?.replace(/\s+/g, " ").trim(),
       value: skill.name,
-      category: "Skills",
+      category: skill.status === "invalid" ? "Invalid skills" : "Skills",
+      footer: skill.status === "invalid" ? "Invalid" : undefined,
       onSelect: () => {
+        if (skill.status === "invalid") return
         props.onSelect(skill.name)
         dialog.clear()
       },

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -30,6 +30,8 @@ export namespace Skill {
     description: z.string(),
     location: z.string(),
     content: z.string(),
+    status: z.enum(["ok", "invalid"]).optional(),
+    error: z.string().optional(),
   })
   export type Info = z.infer<typeof Info>
 
@@ -53,6 +55,7 @@ export namespace Skill {
 
   type State = {
     skills: Record<string, Info>
+    invalid: Info[]
     dirs: Set<string>
   }
 
@@ -75,7 +78,16 @@ export namespace Skill {
             : `Failed to parse skill ${match}`
           const { Session } = yield* Effect.promise(() => import("@/session"))
           yield* bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-          log.error("failed to load skill", { skill: match, err })
+          log.error("failed to parse skill frontmatter", { skill: match, error: message, err })
+          state.dirs.add(path.dirname(match))
+          state.invalid.push({
+            name: path.basename(path.dirname(match)),
+            description: "invalid SKILL.md",
+            location: match,
+            content: "",
+            status: "invalid",
+            error: message,
+          })
           return undefined
         }),
       ),
@@ -84,7 +96,20 @@ export namespace Skill {
     if (!md) return
 
     const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
-    if (!parsed.success) return
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? "Invalid skill frontmatter"
+      log.warn("invalid skill frontmatter", { skill: match, error: message })
+      state.dirs.add(path.dirname(match))
+      state.invalid.push({
+        name: path.basename(path.dirname(match)),
+        description: "invalid SKILL.md",
+        location: match,
+        content: "",
+        status: "invalid",
+        error: message,
+      })
+      return
+    }
 
     if (state.skills[parsed.data.name]) {
       log.warn("duplicate skill name", {
@@ -100,6 +125,7 @@ export namespace Skill {
       description: parsed.data.description,
       location: match,
       content: md.content,
+      status: "ok",
     }
   })
 
@@ -184,7 +210,7 @@ export namespace Skill {
       }
     }
 
-    log.info("init", { count: Object.keys(state.skills).length })
+    log.info("init", { count: Object.keys(state.skills).length, invalid: state.invalid.length })
   })
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Skill") {}
@@ -198,7 +224,7 @@ export namespace Skill {
       const fsys = yield* AppFileSystem.Service
       const state = yield* InstanceState.make(
         Effect.fn("Skill.state")(function* (ctx) {
-          const s: State = { skills: {}, dirs: new Set() }
+          const s: State = { skills: {}, invalid: [], dirs: new Set() }
           yield* loadSkills(s, config, discovery, bus, fsys, ctx.directory, ctx.worktree)
           return s
         }),
@@ -211,7 +237,7 @@ export namespace Skill {
 
       const all = Effect.fn("Skill.all")(function* () {
         const s = yield* InstanceState.get(state)
-        return Object.values(s.skills)
+        return [...Object.values(s.skills), ...s.invalid]
       })
 
       const dirs = Effect.fn("Skill.dirs")(function* () {
@@ -244,13 +270,19 @@ export namespace Skill {
         "<available_skills>",
         ...list
           .sort((a, b) => a.name.localeCompare(b.name))
-          .flatMap((skill) => [
-            "  <skill>",
-            `    <name>${skill.name}</name>`,
-            `    <description>${skill.description}</description>`,
-            `    <location>${pathToFileURL(skill.location).href}</location>`,
-            "  </skill>",
-          ]),
+          .flatMap((skill) => {
+            const status = skill.status ?? "ok"
+            const error = skill.error ? `    <error>${skill.error}</error>` : null
+            return [
+              "  <skill>",
+              `    <name>${skill.name}</name>`,
+              `    <description>${skill.description}</description>`,
+              `    <location>${pathToFileURL(skill.location).href}</location>`,
+              `    <status>${status}</status>`,
+              error,
+              "  </skill>",
+            ].filter(Boolean)
+          }),
         "</available_skills>",
       ].join("\n")
     }
@@ -259,7 +291,10 @@ export namespace Skill {
       "## Available Skills",
       ...list
         .toSorted((a, b) => a.name.localeCompare(b.name))
-        .map((skill) => `- **${skill.name}**: ${skill.description}`),
+        .map((skill) => {
+          const tag = skill.status === "invalid" ? " (invalid)" : ""
+          return `- **${skill.name}**${tag}: ${skill.description}`
+        }),
     ].join("\n")
   }
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -154,7 +154,39 @@ Just some content without YAML frontmatter.
     directory: tmp.path,
     fn: async () => {
       const skills = await Skill.all()
-      expect(skills).toEqual([])
+      expect(skills).toHaveLength(1)
+      expect(skills[0].name).toBe("no-frontmatter")
+      expect(skills[0].status).toBe("invalid")
+    },
+  })
+})
+
+test("captures invalid skill frontmatter", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".opencode", "skill", "bad-frontmatter")
+      await fs.mkdir(skillDir, { recursive: true })
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: bad-frontmatter
+description: This frontmatter is invalid
+This line breaks YAML
+---
+\n# Bad Skill\n`,
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills).toHaveLength(1)
+      expect(skills[0].status).toBe("invalid")
+      expect(skills[0].name).toBe("bad-frontmatter")
+      expect(skills[0].description).toBe("invalid SKILL.md")
     },
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5228,6 +5228,8 @@ export type AppSkillsResponses = {
     description: string
     location: string
     content: string
+    status?: "ok" | "invalid"
+    error?: string
   }>
 }
 


### PR DESCRIPTION

### Issue for this PR

Closes #21393

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR improves skill discovery and error handling by making invalid skills visible instead of silently dropping them. Previously, when skill files had parsing errors or invalid frontmatter, they would be completely ignored, making it difficult for users to understand why their skills weren't working.

The changes include:
- Extended skill response/info to include optional `status` (`ok`/`invalid`) and `error` fields
- Modified skill discovery to preserve invalid skills and include them in `Skill.all()` output
- Updated the TUI skill picker to categorize invalid skills separately, show an "Invalid" indicator, and prevent their selection
- Added comprehensive test coverage for invalid skill scenarios

### How did you verify your code works?

- Added unit tests that verify invalid skills are captured and marked with appropriate status
- Tested the TUI skill picker to ensure invalid skills are displayed but not selectable
- Verified that error messages are properly surfaced to help users debug skill issues
- Confirmed that valid skills continue to work normally

### Screenshots / recordings

N/A - This is a backend functionality improvement with TUI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Co-authored-by: OpenCode <anomalyco@users.noreply.github.com>
