### PR TITLE
fix(lsp): remove CMakeLists.txt and Makefile from clangd root markers

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -245,7 +245,7 @@ export namespace LSP {
               })
 
             if (!handle) return undefined
-            log.info("spawned lsp server", { serverID: server.id })
+            log.info("spawned lsp server", { serverID: server.id, root })
 
             const client = await LSPClient.create({
               serverID: server.id,

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -867,7 +867,7 @@ export namespace LSPServer {
 
   export const Clangd: Info = {
     id: "clangd",
-    root: NearestRoot(["compile_commands.json", "compile_flags.txt", ".clangd", "CMakeLists.txt", "Makefile"]),
+    root: NearestRoot(["compile_commands.json", "compile_flags.txt", ".clangd"]),
     extensions: [".c", ".cpp", ".cc", ".cxx", ".c++", ".h", ".hpp", ".hh", ".hxx", ".h++"],
     async spawn(root) {
       const args = ["--background-index", "--clang-tidy"]


### PR DESCRIPTION
### Issue for this PR

Closes #21446

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

clangd does not read `CMakeLists.txt` or `Makefile` — they are irrelevant to it. Both also appear in every subdirectory by design, so NearestRoot returns a different root for each subdirectory, spawning a new clangd instance every time a file from a new module is opened. Each instance independently indexes the full project, wasting memory and CPU.

Tested with abseil-cpp (22 CMakeLists.txt): opening 3 modules spawns 3 clangd at ~330MB each (998MB total). With this fix, one clangd at ~330MB.

Removed both from the marker list. Also added `root` to the spawn log to make this easier to debug.

### How did you verify your code works?

```bash
git clone --depth=1 https://github.com/abseil/abseil-cpp /tmp/abseil-cpp
cd /tmp/abseil-cpp
cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DABSL_BUILD_TESTING=OFF
ln -s build/compile_commands.json .
opencode
```

In the opencode session, read files from different modules:
```
> read absl/strings/str_split.cc
> read absl/base/log_severity.cc
> read absl/time/clock.cc
```

Before: 3 clangd instances (~330MB each)
After: 1 clangd instance (~330MB)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR