### PR TITLE
fix(ui): restore sticky positioning on diffs header

### DIFF
--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -97,6 +97,10 @@
     align-items: baseline;
     gap: 8px;
     padding-bottom: 12px;
+    position: sticky;
+    top: var(--sticky-accordion-top, 0px);
+    z-index: 20;
+    background-color: var(--background-stronger);
   }
 
   [data-slot="session-turn-diffs-label"] {


### PR DESCRIPTION
## summary
- Restores `position: sticky` on the "Modified files" header in the session turn diffs section
- Regression from #20348 which replaced the `Collapsible` wrapper with a plain header div but dropped the sticky CSS rules

## testing
- Open a session with enough file edits to scroll, verify the "N Changed files" header sticks to the top while scrolling through diffs