### PR TITLE
ui: fix sticky session diffs header

### DIFF
--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -94,9 +94,15 @@
 
   [data-slot="session-turn-diffs-header"] {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 8px;
+    padding-top: 4px;
     padding-bottom: 12px;
+    position: sticky;
+    top: var(--sticky-accordion-top, 0px);
+    z-index: 20;
+    background-color: var(--background-stronger);
+    height: 44px;
   }
 
   [data-slot="session-turn-diffs-label"] {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -447,7 +447,7 @@ export function SessionTurn(
                   <div data-component="session-turn-diffs-content">
                     <Accordion
                       multiple
-                      style={{ "--sticky-accordion-offset": "40px" }}
+                      style={{ "--sticky-accordion-offset": "44px" }}
                       value={expanded()}
                       onChange={(value) => setState("expanded", Array.isArray(value) ? value : value ? [value] : [])}
                     >


### PR DESCRIPTION
Before

<img width="354" height="150" alt="image" src="https://github.com/user-attachments/assets/684fb99c-febe-4303-bb07-92f8088a2357" />

After

<img width="263" height="155" alt="image" src="https://github.com/user-attachments/assets/7a16ead6-48e9-4592-9d6d-fa06afdc89fa" />