### PR TITLE
fix(opencode): Move pty connection to custom auth check on server for node-ws

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -174,6 +174,7 @@ export const Terminal = (props: TerminalProps) => {
   const auth = server.current?.http
   const username = auth?.username ?? "opencode"
   const password = auth?.password ?? ""
+  const basic = password ? btoa(`${username}:${password}`) : ""
   let container!: HTMLDivElement
   const [local, others] = splitProps(props, ["pty", "class", "classList", "autoFocus", "onConnect", "onConnectError"])
   const id = local.pty.id
@@ -518,9 +519,8 @@ export const Terminal = (props: TerminalProps) => {
         const next = new URL(url + `/pty/${id}/connect`)
         next.searchParams.set("directory", directory)
         next.searchParams.set("cursor", String(seek))
+        if (basic) next.searchParams.set("auth", basic)
         next.protocol = next.protocol === "https:" ? "wss:" : "ws:"
-        next.username = username
-        next.password = password
 
         const socket = new WebSocket(next)
         socket.binaryType = "arraybuffer"

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,6 +42,12 @@ export namespace Server {
     return false
   }
 
+  // scope a separate auth check to just `/pty/:id/connect`.
+  const pty = (path: string) => {
+    const part = path.split("/")
+    return part.length === 4 && part[1] === "pty" && part[2] && part[3] === "connect"
+  }
+
   export const Default = lazy(() => create({}).app)
 
   export function ControlPlaneRoutes(upgrade: UpgradeWebSocket, app = new Hono(), opts?: { cors?: string[] }): Hono {
@@ -54,6 +60,16 @@ export namespace Server {
         const password = Flag.OPENCODE_SERVER_PASSWORD
         if (!password) return next()
         const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+        const auth = c.req.query("auth")
+        if (
+          // allow websocket upgrades through when they provide the expected derived credential.
+          c.req.method === "GET" &&
+          c.req.header("upgrade")?.toLowerCase() === "websocket" &&
+          pty(c.req.path) &&
+          auth === Buffer.from(`${username}:${password}`).toString("base64")
+        ) {
+          return next()
+        }
         return basicAuth({ username, password })(c, next)
       })
       .use(async (c, next) => {


### PR DESCRIPTION
### Issue for this PR

Closes #21480
Closes #21469
Closes #21440
Closes #21541

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- restore working PTY websocket connectivity after the Bun -> Node websocket migration
- scope websocket auth handling to `/pty/:id/connect` instead of relying on browser/webview Basic auth during upgrade

This is not the cleanest fix, but to make a small PR that does fix the issue its the best, without reverting to using the `hono/bun` dep.

### How did you verify your code works?

Tested my dev desktop build and the terminal works as it should

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR