### PR TITLE
feat: queue follow-ups before dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ brew install --cask opencode-desktop
 scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
-When a session is already running in the web or desktop app, follow-up prompts can stay above the composer instead of being sent immediately. Set `Follow-up behavior` to `Queue` or `Steer` in `Settings > General`. Queued follow-ups can be sent immediately, edited, or deleted. Drag-and-drop reordering is not supported yet.
+When a session is already running in the web or desktop app, follow-up prompts can stay above the composer instead of being sent immediately. Set `Follow-up behavior` to `Queue` or `Steer` in `Settings > General`. Queued follow-ups can be reordered with drag-and-drop, sent immediately, edited, or deleted.
 
 #### Installation Directory
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ brew install --cask opencode-desktop
 scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
+When a session is already running in the web or desktop app, follow-up prompts can stay above the composer instead of being sent immediately. Set `Follow-up behavior` to `Queue` or `Steer` in `Settings > General`. Queued follow-ups can be sent immediately, edited, or deleted. Drag-and-drop reordering is not supported yet.
+
 #### Installation Directory
 
 The install script respects the following priority order for the installation path:

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -115,7 +115,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -142,7 +142,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.64",
         "@ai-sdk/openai": "3.0.48",
@@ -166,7 +166,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -190,7 +190,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@opencode-ai/app": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -223,7 +223,7 @@
     },
     "packages/desktop-electron": {
       "name": "@opencode-ai/desktop-electron",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@opencode-ai/app": "workspace:*",
         "@opencode-ai/ui": "workspace:*",
@@ -255,7 +255,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@opencode-ai/ui": "workspace:*",
         "@opencode-ai/util": "workspace:*",
@@ -284,7 +284,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -300,7 +300,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -436,7 +436,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "zod": "catalog:",
@@ -470,7 +470,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -485,7 +485,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -520,7 +520,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/sdk": "workspace:*",
@@ -569,7 +569,7 @@
     },
     "packages/util": {
       "name": "@opencode-ai/util",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "zod": "catalog:",
       },
@@ -580,7 +580,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -19,6 +19,7 @@ const optimisticSeeded: boolean[] = []
 const storedSessions: Record<string, Array<{ id: string; title?: string }>> = {}
 const promoted: Array<{ directory: string; sessionID: string }> = []
 const sentShell: string[] = []
+const sentPrompts: string[] = []
 const syncedDirectories: string[] = []
 
 let params: { id?: string } = {}
@@ -45,7 +46,10 @@ const clientFor = (directory: string) => {
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
-      promptAsync: async () => ({ data: undefined }),
+      promptAsync: async () => {
+        sentPrompts.push(directory)
+        return { data: undefined }
+      },
       command: async () => ({ data: undefined }),
       abort: async () => ({ data: undefined }),
     },
@@ -210,6 +214,7 @@ beforeEach(() => {
   promoted.length = 0
   params = {}
   sentShell.length = 0
+  sentPrompts.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
@@ -341,5 +346,63 @@ describe("prompt submit worktree selection", () => {
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("queues followups locally instead of sending them immediately", async () => {
+    params = { id: "session-1" }
+
+    const drafts: Array<{
+      sessionID: string
+      sessionDirectory: string
+      agent: string
+      model: { providerID: string; modelID: string }
+      prompt: Prompt
+    }> = []
+    let submitted = 0
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => true,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      shouldQueue: () => true,
+      onQueue: (draft) =>
+        drafts.push({
+          sessionID: draft.sessionID,
+          sessionDirectory: draft.sessionDirectory,
+          agent: draft.agent,
+          model: draft.model,
+          prompt: draft.prompt,
+        }),
+      onSubmit: () => {
+        submitted += 1
+      },
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+
+    await submit.handleSubmit(event)
+
+    expect(drafts).toEqual([
+      {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+        prompt: promptValue,
+      },
+    ])
+    expect(optimistic).toEqual([])
+    expect(sentPrompts).toEqual([])
+    expect(submitted).toBe(0)
   })
 })

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -175,6 +175,12 @@ export const SettingsGeneral: Component = () => {
       label: language.label(locale),
     })),
   )
+  const modes = createMemo(
+    (): { value: "queue" | "steer"; label: string }[] => [
+      { value: "queue", label: language.t("settings.general.row.followup.option.queue") },
+      { value: "steer", label: language.t("settings.general.row.followup.option.steer") },
+    ],
+  )
 
   const noneSound = { id: "none", label: "sound.option.none" } as const
   const soundOptions = [noneSound, ...SOUND_OPTIONS]
@@ -238,6 +244,23 @@ export const SettingsGeneral: Component = () => {
           <div data-action="settings-auto-accept-permissions">
             <Switch checked={accepting()} disabled={!dir()} onChange={toggleAccept} />
           </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.followup.title")}
+          description={language.t("settings.general.row.followup.description")}
+        >
+          <Select
+            data-action="settings-followup"
+            options={modes()}
+            current={modes().find((item) => item.value === settings.general.followup())}
+            value={(item) => item.value}
+            label={(item) => item.label}
+            onSelect={(item) => item && settings.general.setFollowup(item.value)}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
+          />
         </SettingsRow>
 
         <SettingsRow

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -88,7 +88,7 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
-    followup: "steer",
+    followup: "queue",
     showReasoningSummaries: false,
     shellToolPartsExpanded: false,
     editToolPartsExpanded: false,
@@ -136,11 +136,6 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
       root.style.setProperty("--font-family-sans", sansFontFamily(store.appearance?.sans))
     })
 
-    createEffect(() => {
-      if (store.general?.followup !== "queue") return
-      setStore("general", "followup", "steer")
-    })
-
     return {
       ready,
       get current() {
@@ -155,12 +150,9 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         setReleaseNotes(value: boolean) {
           setStore("general", "releaseNotes", value)
         },
-        followup: withFallback(
-          () => (store.general?.followup === "queue" ? "steer" : store.general?.followup),
-          defaultSettings.general.followup,
-        ),
+        followup: withFallback(() => store.general?.followup, defaultSettings.general.followup),
         setFollowup(value: "queue" | "steer") {
-          setStore("general", "followup", value === "queue" ? "steer" : value)
+          setStore("general", "followup", value)
         },
         showReasoningSummaries: withFallback(
           () => store.general?.showReasoningSummaries,

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -42,6 +42,7 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
 import { createSessionComposerState, SessionComposerRegion } from "@/pages/session/composer"
+import { removeFollowup, type FollowupItem } from "@/pages/session/followup-state"
 import {
   createOpenReviewFile,
   createSessionTabs,
@@ -64,7 +65,6 @@ import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
 
 const emptyUserMessages: UserMessage[] = []
-type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 const emptyFollowups: FollowupItem[] = []
 
@@ -1630,7 +1630,7 @@ export default function Page() {
       })
       if (!ok) return
 
-      setFollowup("items", input.sessionID, (items) => (items ?? []).filter((entry) => entry.id !== input.id))
+      setFollowup("items", input.sessionID, (items) => removeFollowup(items, input.id))
       if (input.manual) resumeScroll()
     },
   }))
@@ -1696,13 +1696,22 @@ export default function Page() {
     const item = queuedFollowups().find((entry) => entry.id === id)
     if (!item) return
 
-    setFollowup("items", sessionID, (items) => (items ?? []).filter((entry) => entry.id !== id))
+    setFollowup("items", sessionID, (items) => removeFollowup(items, id))
     setFollowup("failed", sessionID, (value) => (value === id ? undefined : value))
     setFollowup("edit", sessionID, {
       id: item.id,
       prompt: item.prompt,
       context: item.context,
     })
+  }
+
+  const deleteFollowup = (id: string) => {
+    const sessionID = params.id
+    if (!sessionID) return
+    if (followupBusy(sessionID)) return
+
+    setFollowup("items", sessionID, (items) => removeFollowup(items, id))
+    setFollowup("failed", sessionID, (value) => (value === id ? undefined : value))
   }
 
   const clearFollowupEdit = () => {
@@ -2009,6 +2018,7 @@ export default function Page() {
                       void sendFollowup(params.id!, id, { manual: true })
                     },
                     onEdit: editFollowup,
+                    onDelete: deleteFollowup,
                     onEditLoaded: clearFollowupEdit,
                   }
                 : undefined

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -42,7 +42,7 @@ import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
 import { createSessionComposerState, SessionComposerRegion } from "@/pages/session/composer"
-import { removeFollowup, type FollowupItem } from "@/pages/session/followup-state"
+import { moveFollowup, removeFollowup, type FollowupItem } from "@/pages/session/followup-state"
 import {
   createOpenReviewFile,
   createSessionTabs,
@@ -1714,6 +1714,14 @@ export default function Page() {
     setFollowup("failed", sessionID, (value) => (value === id ? undefined : value))
   }
 
+  const reorderFollowup = (from: string, to: string) => {
+    const sessionID = params.id
+    if (!sessionID) return
+    if (followupBusy(sessionID)) return
+
+    setFollowup("items", sessionID, (items) => moveFollowup(items, from, to))
+  }
+
   const clearFollowupEdit = () => {
     const id = params.id
     if (!id) return
@@ -2019,6 +2027,7 @@ export default function Page() {
                     },
                     onEdit: editFollowup,
                     onDelete: deleteFollowup,
+                    onReorder: reorderFollowup,
                     onEditLoaded: clearFollowupEdit,
                   }
                 : undefined

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -36,6 +36,7 @@ export function SessionComposerRegion(props: {
     onSend: (id: string) => void
     onEdit: (id: string) => void
     onDelete: (id: string) => void
+    onReorder: (from: string, to: string) => void
     onEditLoaded: () => void
   }
   revert?: {
@@ -246,6 +247,7 @@ export function SessionComposerRegion(props: {
                   onSend={props.followup!.onSend}
                   onEdit={props.followup!.onEdit}
                   onDelete={props.followup!.onDelete}
+                  onReorder={props.followup!.onReorder}
                 />
               </Show>
               <Show

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -35,6 +35,7 @@ export function SessionComposerRegion(props: {
     onAbort: () => void
     onSend: (id: string) => void
     onEdit: (id: string) => void
+    onDelete: (id: string) => void
     onEditLoaded: () => void
   }
   revert?: {
@@ -244,6 +245,7 @@ export function SessionComposerRegion(props: {
                   sending={props.followup!.sending}
                   onSend={props.followup!.onSend}
                   onEdit={props.followup!.onEdit}
+                  onDelete={props.followup!.onDelete}
                 />
               </Show>
               <Show

--- a/packages/app/src/pages/session/composer/session-followup-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-followup-dock.tsx
@@ -10,6 +10,7 @@ export function SessionFollowupDock(props: {
   sending?: string
   onSend: (id: string) => void
   onEdit: (id: string) => void
+  onDelete: (id: string) => void
 }) {
   const language = useLanguage()
   const [store, setStore] = createStore({
@@ -98,6 +99,15 @@ export function SessionFollowupDock(props: {
                   onClick={() => props.onEdit(item.id)}
                 >
                   {language.t("session.followupDock.edit")}
+                </Button>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  class="shrink-0"
+                  disabled={!!props.sending}
+                  onClick={() => props.onDelete(item.id)}
+                >
+                  {language.t("common.delete")}
                 </Button>
               </div>
             )}

--- a/packages/app/src/pages/session/composer/session-followup-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-followup-dock.tsx
@@ -1,9 +1,65 @@
-import { For, Show, createMemo } from "solid-js"
+import { For, Show, createMemo, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
+import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
+import { createSortable } from "@thisbeyond/solid-dnd"
+import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { Button } from "@opencode-ai/ui/button"
 import { DockTray } from "@opencode-ai/ui/dock-surface"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { useLanguage } from "@/context/language"
+import { ConstrainDragYAxis, getDraggableId } from "@/utils/solid-dnd"
+
+function Row(props: {
+  item: { id: string; text: string }
+  disabled: boolean
+  onSend: (id: string) => void
+  onEdit: (id: string) => void
+  onDelete: (id: string) => void
+}): JSX.Element {
+  const language = useLanguage()
+  const sortable = createSortable(props.item.id)
+
+  return (
+    <div use:sortable class="min-w-0" classList={{ "opacity-0": sortable.isActiveDraggable }}>
+      <div
+        class="flex items-center gap-2 min-w-0 py-1"
+        classList={{
+          "cursor-default": props.disabled,
+          "cursor-grab active:cursor-grabbing": !props.disabled,
+        }}
+      >
+        <span class="min-w-0 flex-1 truncate text-13-regular text-text-strong">{props.item.text}</span>
+        <Button
+          size="small"
+          variant="secondary"
+          class="shrink-0"
+          disabled={props.disabled}
+          onClick={() => props.onSend(props.item.id)}
+        >
+          {language.t("session.followupDock.sendNow")}
+        </Button>
+        <Button
+          size="small"
+          variant="ghost"
+          class="shrink-0"
+          disabled={props.disabled}
+          onClick={() => props.onEdit(props.item.id)}
+        >
+          {language.t("session.followupDock.edit")}
+        </Button>
+        <Button
+          size="small"
+          variant="ghost"
+          class="shrink-0"
+          disabled={props.disabled}
+          onClick={() => props.onDelete(props.item.id)}
+        >
+          {language.t("common.delete")}
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 export function SessionFollowupDock(props: {
   items: { id: string; text: string }[]
@@ -11,10 +67,12 @@ export function SessionFollowupDock(props: {
   onSend: (id: string) => void
   onEdit: (id: string) => void
   onDelete: (id: string) => void
+  onReorder: (from: string, to: string) => void
 }) {
   const language = useLanguage()
   const [store, setStore] = createStore({
     collapsed: false,
+    active: undefined as string | undefined,
   })
 
   const toggle = () => setStore("collapsed", (value) => !value)
@@ -25,6 +83,26 @@ export function SessionFollowupDock(props: {
     }),
   )
   const preview = createMemo(() => props.items[0]?.text ?? "")
+  const ids = createMemo(() => props.items.map((item) => item.id))
+  const disabled = createMemo(() => !!props.sending)
+
+  const start = (event: unknown) => {
+    if (disabled()) return
+    const id = getDraggableId(event)
+    if (!id) return
+    setStore("active", id)
+  }
+
+  const over = (event: DragEvent) => {
+    const from = event.draggable?.id?.toString()
+    const to = event.droppable?.id?.toString()
+    if (!from || !to || from === to || disabled()) return
+    props.onReorder(from, to)
+  }
+
+  const end = () => {
+    setStore("active", undefined)
+  }
 
   return (
     <DockTray
@@ -77,42 +155,38 @@ export function SessionFollowupDock(props: {
       </Show>
 
       <Show when={!store.collapsed}>
-        <div class="px-3 pb-7 flex flex-col gap-1.5 max-h-42 overflow-y-auto no-scrollbar">
-          <For each={props.items}>
-            {(item) => (
-              <div class="flex items-center gap-2 min-w-0 py-1">
-                <span class="min-w-0 flex-1 truncate text-13-regular text-text-strong">{item.text}</span>
-                <Button
-                  size="small"
-                  variant="secondary"
-                  class="shrink-0"
-                  disabled={!!props.sending}
-                  onClick={() => props.onSend(item.id)}
-                >
-                  {language.t("session.followupDock.sendNow")}
-                </Button>
-                <Button
-                  size="small"
-                  variant="ghost"
-                  class="shrink-0"
-                  disabled={!!props.sending}
-                  onClick={() => props.onEdit(item.id)}
-                >
-                  {language.t("session.followupDock.edit")}
-                </Button>
-                <Button
-                  size="small"
-                  variant="ghost"
-                  class="shrink-0"
-                  disabled={!!props.sending}
-                  onClick={() => props.onDelete(item.id)}
-                >
-                  {language.t("common.delete")}
-                </Button>
-              </div>
-            )}
-          </For>
-        </div>
+        <DragDropProvider onDragStart={start} onDragOver={over} onDragEnd={end} collisionDetector={closestCenter}>
+          <DragDropSensors />
+          <ConstrainDragYAxis />
+          <div class="px-3 pb-7 flex flex-col gap-1.5 max-h-42 overflow-y-auto no-scrollbar">
+            <SortableProvider ids={ids()}>
+              <For each={props.items}>
+                {(item) => (
+                  <Row
+                    item={item}
+                    disabled={disabled()}
+                    onSend={props.onSend}
+                    onEdit={props.onEdit}
+                    onDelete={props.onDelete}
+                  />
+                )}
+              </For>
+            </SortableProvider>
+          </div>
+          <DragOverlay>
+            <Show when={store.active}>
+              {(id) => (
+                <Show when={props.items.find((item) => item.id === id())}>
+                  {(item) => (
+                    <div class="px-3 py-2 rounded-md border border-border-weak-base bg-background-base text-13-regular text-text-strong shadow-sm">
+                      {item().text}
+                    </div>
+                  )}
+                </Show>
+              )}
+            </Show>
+          </DragOverlay>
+        </DragDropProvider>
       </Show>
     </DockTray>
   )

--- a/packages/app/src/pages/session/followup-state.test.ts
+++ b/packages/app/src/pages/session/followup-state.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { removeFollowup, type FollowupItem } from "./followup-state"
+
+const item = (id: string): FollowupItem =>
+  ({
+    id,
+    sessionID: "session-1",
+    sessionDirectory: "/repo",
+    prompt: [{ type: "text", content: id, start: 0, end: id.length }],
+    context: [],
+    agent: "build",
+    model: { providerID: "provider", modelID: "model" },
+  }) as FollowupItem
+
+describe("removeFollowup", () => {
+  test("removes the matching queued item", () => {
+    expect(removeFollowup([item("a"), item("b")], "a").map((entry) => entry.id)).toEqual(["b"])
+  })
+
+  test("returns an empty list when items are missing", () => {
+    expect(removeFollowup(undefined, "a")).toEqual([])
+  })
+})

--- a/packages/app/src/pages/session/followup-state.test.ts
+++ b/packages/app/src/pages/session/followup-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { removeFollowup, type FollowupItem } from "./followup-state"
+import { moveFollowup, removeFollowup, type FollowupItem } from "./followup-state"
 
 const item = (id: string): FollowupItem =>
   ({
@@ -19,5 +19,19 @@ describe("removeFollowup", () => {
 
   test("returns an empty list when items are missing", () => {
     expect(removeFollowup(undefined, "a")).toEqual([])
+  })
+})
+
+describe("moveFollowup", () => {
+  test("moves a queued item before another item", () => {
+    expect(moveFollowup([item("a"), item("b"), item("c")], "c", "a").map((entry) => entry.id)).toEqual([
+      "c",
+      "a",
+      "b",
+    ])
+  })
+
+  test("returns the same order when either item is missing", () => {
+    expect(moveFollowup([item("a"), item("b")], "c", "a").map((entry) => entry.id)).toEqual(["a", "b"])
   })
 })

--- a/packages/app/src/pages/session/followup-state.ts
+++ b/packages/app/src/pages/session/followup-state.ts
@@ -1,0 +1,6 @@
+import type { FollowupDraft } from "@/components/prompt-input/submit"
+
+export type FollowupItem = FollowupDraft & { id: string }
+
+export const removeFollowup = (items: FollowupItem[] | undefined, id: string) =>
+  (items ?? []).filter((item) => item.id !== id)

--- a/packages/app/src/pages/session/followup-state.ts
+++ b/packages/app/src/pages/session/followup-state.ts
@@ -4,3 +4,15 @@ export type FollowupItem = FollowupDraft & { id: string }
 
 export const removeFollowup = (items: FollowupItem[] | undefined, id: string) =>
   (items ?? []).filter((item) => item.id !== id)
+
+export const moveFollowup = (items: FollowupItem[] | undefined, from: string, to: string) => {
+  const list = items ?? []
+  const a = list.findIndex((item) => item.id === from)
+  const b = list.findIndex((item) => item.id === to)
+  if (a === -1 || b === -1 || a === b) return list
+
+  const next = list.slice()
+  const [item] = next.splice(a, 1)
+  next.splice(b, 0, item)
+  return next
+}

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop-electron",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -3,8 +3,11 @@ import { Cause, Deferred, Effect, Exit, Fiber, Option, Schema, Scope, Synchroniz
 export interface Runner<A, E = never> {
   readonly state: Runner.State<A, E>
   readonly busy: boolean
+  readonly queued: number
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly enqueueRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly startShell: (work: (signal: AbortSignal) => Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly enqueueShell: (work: (signal: AbortSignal) => Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
 }
 
@@ -19,21 +22,32 @@ export namespace Runner {
 
   interface ShellHandle<A, E> {
     id: number
+    done: Deferred.Deferred<A, E | Cancelled>
     fiber: Fiber.Fiber<A, E>
     abort: AbortController
   }
 
-  interface PendingHandle<A, E> {
+  interface RunItem<A, E> {
+    type: "run"
     id: number
     done: Deferred.Deferred<A, E | Cancelled>
     work: Effect.Effect<A, E>
   }
 
+  interface ShellItem<A, E> {
+    type: "shell"
+    id: number
+    done: Deferred.Deferred<A, E | Cancelled>
+    work: (signal: AbortSignal) => Effect.Effect<A, E>
+  }
+
+  type Item<A, E> = RunItem<A, E> | ShellItem<A, E>
+  type Step<A, E> = readonly [Effect.Effect<void>, State<A, E>]
+
   export type State<A, E> =
     | { readonly _tag: "Idle" }
-    | { readonly _tag: "Running"; readonly run: RunHandle<A, E> }
-    | { readonly _tag: "Shell"; readonly shell: ShellHandle<A, E> }
-    | { readonly _tag: "ShellThenRun"; readonly shell: ShellHandle<A, E>; readonly run: PendingHandle<A, E> }
+    | { readonly _tag: "Running"; readonly run: RunHandle<A, E>; readonly queue: Item<A, E>[] }
+    | { readonly _tag: "Shell"; readonly shell: ShellHandle<A, E>; readonly queue: Item<A, E>[] }
 
   export const make = <A, E = never>(
     scope: Scope.Scope,
@@ -56,6 +70,13 @@ export namespace Runner {
       return ids
     }
 
+    const awaitDone = (done: Deferred.Deferred<A, E | Cancelled>) =>
+      Deferred.await(done).pipe(
+        Effect.catch(
+          (e): Effect.Effect<A, E> => (e instanceof Cancelled ? (onInterrupt ?? Effect.die(e)) : Effect.fail(e as E)),
+        ),
+      )
+
     const complete = (done: Deferred.Deferred<A, E | Cancelled>, exit: Exit.Exit<A, E>) =>
       Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)
         ? Deferred.fail(done, new Cancelled()).pipe(Effect.asVoid)
@@ -64,40 +85,95 @@ export namespace Runner {
     const idleIfCurrent = () =>
       SynchronizedRef.modify(ref, (st) => [st._tag === "Idle" ? idle : Effect.void, st] as const).pipe(Effect.flatten)
 
-    const finishRun = (id: number, done: Deferred.Deferred<A, E | Cancelled>, exit: Exit.Exit<A, E>) =>
-      SynchronizedRef.modify(
-        ref,
-        (st) =>
-          [
-            Effect.gen(function* () {
-              if (st._tag === "Running" && st.run.id === id) yield* idle
-              yield* complete(done, exit)
-            }),
-            st._tag === "Running" && st.run.id === id ? ({ _tag: "Idle" } as const) : st,
-          ] as const,
-      ).pipe(Effect.flatten)
-
-    const startRun = (work: Effect.Effect<A, E>, done: Deferred.Deferred<A, E | Cancelled>) =>
+    const runItem = (work: Effect.Effect<A, E>) =>
       Effect.gen(function* () {
-        const id = next()
-        const fiber = yield* work.pipe(
-          Effect.onExit((exit) => finishRun(id, done, exit)),
-          Effect.forkIn(scope),
-        )
-        return { id, done, fiber } satisfies RunHandle<A, E>
+        return {
+          type: "run" as const,
+          id: next(),
+          done: yield* Deferred.make<A, E | Cancelled>(),
+          work,
+        }
       })
 
-    const finishShell = (id: number) =>
+    const shellItem = (work: (signal: AbortSignal) => Effect.Effect<A, E>) =>
+      Effect.gen(function* () {
+        return {
+          type: "shell" as const,
+          id: next(),
+          done: yield* Deferred.make<A, E | Cancelled>(),
+          work,
+        }
+      })
+
+    const launchRun = (item: RunItem<A, E>): Effect.Effect<RunHandle<A, E>> =>
+      Effect.gen(function* () {
+        const fiber = yield* item.work.pipe(
+          Effect.onExit((exit) => finishRun(item.id, item.done, exit)),
+          Effect.forkIn(scope),
+        )
+        return { id: item.id, done: item.done, fiber } satisfies RunHandle<A, E>
+      })
+
+    const launchShell = (item: ShellItem<A, E>): Effect.Effect<ShellHandle<A, E>> =>
+      Effect.gen(function* () {
+        const abort = new AbortController()
+        const fiber = yield* item.work(abort.signal).pipe(
+          Effect.onExit((exit) => finishShell(item.id, item.done, exit)),
+          Effect.forkChild,
+        )
+        return {
+          id: item.id,
+          done: item.done,
+          fiber,
+          abort,
+        } satisfies ShellHandle<A, E>
+      })
+
+    const resume = (queue: Item<A, E>[]): Effect.Effect<Step<A, E>> =>
+      Effect.gen(function* () {
+        const item = queue[0]
+        const rest = queue.slice(1)
+        if (!item) return [Effect.void, { _tag: "Idle" } as const] as const
+        if (item.type === "run") {
+          const run = yield* launchRun(item)
+          return [Effect.void, { _tag: "Running", run, queue: rest } as const] as const
+        }
+        const shell = yield* launchShell(item)
+        return [Effect.void, { _tag: "Shell", shell, queue: rest } as const] as const
+      })
+
+    const finishRun = (
+      id: number,
+      done: Deferred.Deferred<A, E | Cancelled>,
+      exit: Exit.Exit<A, E>,
+    ): Effect.Effect<void> =>
       SynchronizedRef.modifyEffect(
         ref,
-        Effect.fnUntraced(function* (st) {
-          if (st._tag === "Shell" && st.shell.id === id) return [idle, { _tag: "Idle" }] as const
-          if (st._tag === "ShellThenRun" && st.shell.id === id) {
-            const run = yield* startRun(st.run.work, st.run.done)
-            return [Effect.void, { _tag: "Running", run }] as const
-          }
-          return [Effect.void, st] as const
-        }),
+        (st): Effect.Effect<Step<A, E>> =>
+          Effect.gen(function* () {
+            const eff = complete(done, exit)
+            if (st._tag !== "Running" || st.run.id !== id) return [eff, st] as const
+            if (!st.queue.length) return [idle.pipe(Effect.andThen(eff)), { _tag: "Idle" } as const] as const
+            const [next, state] = yield* resume(st.queue)
+            return [eff.pipe(Effect.andThen(next)), state] as const
+          }),
+      ).pipe(Effect.flatten)
+
+    const finishShell = (
+      id: number,
+      done: Deferred.Deferred<A, E | Cancelled>,
+      exit: Exit.Exit<A, E>,
+    ): Effect.Effect<void> =>
+      SynchronizedRef.modifyEffect(
+        ref,
+        (st): Effect.Effect<Step<A, E>> =>
+          Effect.gen(function* () {
+            const eff = complete(done, exit)
+            if (st._tag !== "Shell" || st.shell.id !== id) return [eff, st] as const
+            if (!st.queue.length) return [idle.pipe(Effect.andThen(eff)), { _tag: "Idle" } as const] as const
+            const [next, state] = yield* resume(st.queue)
+            return [eff.pipe(Effect.andThen(next)), state] as const
+          }),
       ).pipe(Effect.flatten)
 
     const stopShell = (shell: ShellHandle<A, E>) =>
@@ -108,35 +184,53 @@ export namespace Runner {
         yield* Fiber.await(shell.fiber).pipe(Effect.exit, Effect.asVoid)
       })
 
+    const fail = (queue: Item<A, E>[]) =>
+      Effect.forEach(
+        queue,
+        (item) => Deferred.fail(item.done, new Cancelled()).pipe(Effect.asVoid),
+        { concurrency: "unbounded", discard: true },
+      )
+
     const ensureRunning = (work: Effect.Effect<A, E>) =>
       SynchronizedRef.modifyEffect(
         ref,
         Effect.fnUntraced(function* (st) {
           switch (st._tag) {
             case "Running":
-            case "ShellThenRun":
-              return [Deferred.await(st.run.done), st] as const
+              return [awaitDone(st.run.done), st] as const
             case "Shell": {
-              const run = {
-                id: next(),
-                done: yield* Deferred.make<A, E | Cancelled>(),
-                work,
-              } satisfies PendingHandle<A, E>
-              return [Deferred.await(run.done), { _tag: "ShellThenRun", shell: st.shell, run }] as const
+              const item = st.queue.find((item): item is RunItem<A, E> => item.type === "run")
+              if (item) return [awaitDone(item.done), st] as const
+              const run = yield* runItem(work)
+              return [awaitDone(run.done), { ...st, queue: [...st.queue, run] }] as const
             }
             case "Idle": {
-              const done = yield* Deferred.make<A, E | Cancelled>()
-              const run = yield* startRun(work, done)
-              return [Deferred.await(done), { _tag: "Running", run }] as const
+              const item = yield* runItem(work)
+              const run = yield* launchRun(item)
+              return [awaitDone(item.done), { _tag: "Running", run, queue: [] } as const] as const
             }
           }
         }),
-      ).pipe(
-        Effect.flatten,
-        Effect.catch(
-          (e): Effect.Effect<A, E> => (e instanceof Cancelled ? (onInterrupt ?? Effect.die(e)) : Effect.fail(e as E)),
-        ),
-      )
+      ).pipe(Effect.flatten)
+
+    const enqueueRunning = (work: Effect.Effect<A, E>) =>
+      SynchronizedRef.modifyEffect(
+        ref,
+        Effect.fnUntraced(function* (st) {
+          switch (st._tag) {
+            case "Idle": {
+              const item = yield* runItem(work)
+              const run = yield* launchRun(item)
+              return [awaitDone(item.done), { _tag: "Running", run, queue: [] } as const] as const
+            }
+            case "Running":
+            case "Shell": {
+              const item = yield* runItem(work)
+              return [awaitDone(item.done), { ...st, queue: [...st.queue, item] }] as const
+            }
+          }
+        }),
+      ).pipe(Effect.flatten)
 
     const startShell = (work: (signal: AbortSignal) => Effect.Effect<A, E>) =>
       SynchronizedRef.modifyEffect(
@@ -152,19 +246,24 @@ export namespace Runner {
             ] as const
           }
           yield* busy
-          const id = next()
-          const abort = new AbortController()
-          const fiber = yield* work(abort.signal).pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
-          const shell = { id, fiber, abort } satisfies ShellHandle<A, E>
-          return [
-            Effect.gen(function* () {
-              const exit = yield* Fiber.await(fiber)
-              if (Exit.isSuccess(exit)) return exit.value
-              if (Cause.hasInterruptsOnly(exit.cause) && onInterrupt) return yield* onInterrupt
-              return yield* Effect.failCause(exit.cause)
-            }),
-            { _tag: "Shell", shell },
-          ] as const
+          const item = yield* shellItem(work)
+          const shell = yield* launchShell(item)
+          return [awaitDone(item.done), { _tag: "Shell", shell, queue: [] } as const] as const
+        }),
+      ).pipe(Effect.flatten)
+
+    const enqueueShell = (work: (signal: AbortSignal) => Effect.Effect<A, E>) =>
+      SynchronizedRef.modifyEffect(
+        ref,
+        Effect.fnUntraced(function* (st) {
+          if (st._tag === "Idle") {
+            yield* busy
+            const item = yield* shellItem(work)
+            const shell = yield* launchShell(item)
+            return [awaitDone(item.done), { _tag: "Shell", shell, queue: [] } as const] as const
+          }
+          const item = yield* shellItem(work)
+          return [awaitDone(item.done), { ...st, queue: [...st.queue, item] }] as const
         }),
       ).pipe(Effect.flatten)
 
@@ -175,6 +274,7 @@ export namespace Runner {
         case "Running":
           return [
             Effect.gen(function* () {
+              yield* fail(st.queue)
               yield* Fiber.interrupt(st.run.fiber)
               yield* Deferred.await(st.run.done).pipe(Effect.exit, Effect.asVoid)
               yield* idleIfCurrent()
@@ -184,16 +284,9 @@ export namespace Runner {
         case "Shell":
           return [
             Effect.gen(function* () {
+              yield* fail(st.queue)
               yield* stopShell(st.shell)
-              yield* idleIfCurrent()
-            }),
-            { _tag: "Idle" } as const,
-          ] as const
-        case "ShellThenRun":
-          return [
-            Effect.gen(function* () {
-              yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
-              yield* stopShell(st.shell)
+              yield* Deferred.await(st.shell.done).pipe(Effect.exit, Effect.asVoid)
               yield* idleIfCurrent()
             }),
             { _tag: "Idle" } as const,
@@ -208,8 +301,15 @@ export namespace Runner {
       get busy() {
         return state()._tag !== "Idle"
       },
+      get queued() {
+        const current = state()
+        if (current._tag === "Idle") return 0
+        return current.queue.length
+      },
       ensureRunning,
+      enqueueRunning,
       startShell,
+      enqueueShell,
       cancel,
     }
   }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -150,6 +150,21 @@ export namespace SessionPrompt {
         yield* runner.cancel
       })
 
+      const bound = (msgs: MessageV2.WithParts[], until?: MessageID) => {
+        if (!until) return msgs
+        const ids = new Set<string>()
+        return msgs.filter((msg) => {
+          if (msg.info.role === "user") {
+            if (msg.info.id > until) return false
+            ids.add(msg.info.id)
+            return true
+          }
+          if (!msg.info.parentID || !ids.has(msg.info.parentID)) return false
+          ids.add(msg.info.id)
+          return true
+        })
+      }
+
       const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
         const ctx = yield* InstanceState.context
         const parts: PromptInput["parts"] = [{ type: "text", text: template }]
@@ -1321,33 +1336,35 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           }
 
           if (input.noReply === true) return message
-          return yield* loop({ sessionID: input.sessionID })
+          const s = yield* InstanceState.get(state)
+          const runner = getRunner(s.runners, input.sessionID)
+          return yield* runner.enqueueRunning(runLoop({ sessionID: input.sessionID, until: message.info.id }))
         },
       )
 
-      const lastAssistant = (sessionID: SessionID) =>
-        Effect.promise(async () => {
-          let latest: MessageV2.WithParts | undefined
-          for await (const item of MessageV2.stream(sessionID)) {
-            latest ??= item
-            if (item.info.role !== "user") return item
-          }
-          if (latest) return latest
-          throw new Error("Impossible")
-        })
+      const lastAssistant = Effect.fn("SessionPrompt.lastAssistant")(function* (sessionID: SessionID, until?: MessageID) {
+        const msgs = bound(yield* MessageV2.filterCompactedEffect(sessionID), until)
+        const item = msgs.findLast((msg) => msg.info.role === "assistant")
+        if (item) return item
+        const latest = msgs.at(-1)
+        if (latest) return latest
+        throw new Error("Impossible")
+      })
 
-      const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
-        function* (sessionID: SessionID) {
+      const runLoop = Effect.fn("SessionPrompt.run")(function* (input: {
+        sessionID: SessionID
+        until?: MessageID
+      }) {
           const ctx = yield* InstanceState.context
           let structured: unknown | undefined
           let step = 0
-          const session = yield* sessions.get(sessionID)
+          const session = yield* sessions.get(input.sessionID)
 
           while (true) {
-            yield* status.set(sessionID, { type: "busy" })
-            log.info("loop", { step, sessionID })
+            yield* status.set(input.sessionID, { type: "busy" })
+            log.info("loop", { step, sessionID: input.sessionID, until: input.until })
 
-            let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
+            const msgs = bound(yield* MessageV2.filterCompactedEffect(input.sessionID), input.until)
 
             let lastUser: MessageV2.User | undefined
             let lastAssistant: MessageV2.Assistant | undefined
@@ -1378,7 +1395,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               !hasToolCalls &&
               lastUser.id < lastAssistant.id
             ) {
-              log.info("exiting loop", { sessionID })
+              log.info("exiting loop", { sessionID: input.sessionID, until: input.until })
               break
             }
 
@@ -1391,11 +1408,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 history: msgs,
               }).pipe(Effect.ignore, Effect.forkIn(scope))
 
-            const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
+            const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, input.sessionID)
             const task = tasks.pop()
 
             if (task?.type === "subtask") {
-              yield* handleSubtask({ task, model, lastUser, sessionID, session, msgs })
+              yield* handleSubtask({ task, model, lastUser, sessionID: input.sessionID, session, msgs })
               continue
             }
 
@@ -1403,7 +1420,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               const result = yield* compaction.process({
                 messages: msgs,
                 parentID: lastUser.id,
-                sessionID,
+                sessionID: input.sessionID,
                 auto: task.auto,
                 overflow: task.overflow,
               })
@@ -1416,7 +1433,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               lastFinished.summary !== true &&
               (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
             ) {
-              yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+              yield* compaction.create({ sessionID: input.sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
               continue
             }
 
@@ -1425,12 +1442,12 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
               const hint = available.length ? ` Available agents: ${available.join(", ")}` : ""
               const error = new NamedError.Unknown({ message: `Agent not found: "${lastUser.agent}".${hint}` })
-              yield* bus.publish(Session.Event.Error, { sessionID, error: error.toObject() })
+              yield* bus.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
               throw error
             }
             const maxSteps = agent.steps ?? Infinity
             const isLastStep = step >= maxSteps
-            msgs = yield* insertReminders({ messages: msgs, agent, session })
+            const nextMsgs = yield* insertReminders({ messages: msgs, agent, session })
 
             const msg: MessageV2.Assistant = {
               id: MessageID.ascending(),
@@ -1445,18 +1462,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               modelID: model.id,
               providerID: model.providerID,
               time: { created: Date.now() },
-              sessionID,
+              sessionID: input.sessionID,
             }
             yield* sessions.updateMessage(msg)
             const handle = yield* processor.create({
               assistantMessage: msg,
-              sessionID,
+              sessionID: input.sessionID,
               model,
             })
 
             const outcome: "break" | "continue" = yield* Effect.onExit(
               Effect.gen(function* () {
-                const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
+                const lastUserMsg = nextMsgs.findLast((m) => m.info.role === "user")
                 const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
 
                 const tools = yield* resolveTools({
@@ -1466,7 +1483,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   tools: lastUser.tools,
                   processor: handle,
                   bypassAgentCheck,
-                  messages: msgs,
+                  messages: nextMsgs,
                 })
 
                 if (lastUser.format?.type === "json_schema") {
@@ -1478,10 +1495,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   })
                 }
 
-                if (step === 1) SessionSummary.summarize({ sessionID, messageID: lastUser.id })
+                if (step === 1) SessionSummary.summarize({ sessionID: input.sessionID, messageID: lastUser.id })
 
                 if (step > 1 && lastFinished) {
-                  for (const m of msgs) {
+                  for (const m of nextMsgs) {
                     if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
                     for (const p of m.parts) {
                       if (p.type !== "text" || p.ignored || p.synthetic) continue
@@ -1498,13 +1515,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   }
                 }
 
-                yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+                yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: nextMsgs })
 
                 const [skills, env, instructions, modelMsgs] = yield* Effect.all([
                   Effect.promise(() => SystemPrompt.skills(agent)),
                   Effect.promise(() => SystemPrompt.environment(model)),
                   instruction.system().pipe(Effect.orDie),
-                  Effect.promise(() => MessageV2.toModelMessages(msgs, model)),
+                  Effect.promise(() => MessageV2.toModelMessages(nextMsgs, model)),
                 ])
                 const system = [...env, ...(skills ? [skills] : []), ...instructions]
                 const format = lastUser.format ?? { type: "text" as const }
@@ -1513,7 +1530,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   user: lastUser,
                   agent,
                   permission: session.permission,
-                  sessionID,
+                  sessionID: input.sessionID,
                   parentSessionID: session.parentID,
                   system,
                   messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
@@ -1544,7 +1561,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 if (result === "stop") return "break" as const
                 if (result === "compact") {
                   yield* compaction.create({
-                    sessionID,
+                    sessionID: input.sessionID,
                     agent: lastUser.agent,
                     model: lastUser.model,
                     auto: true,
@@ -1562,8 +1579,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             continue
           }
 
-          yield* compaction.prune({ sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
-          return yield* lastAssistant(sessionID)
+          yield* compaction.prune({ sessionID: input.sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
+          return yield* lastAssistant(input.sessionID, input.until)
         },
       )
 
@@ -1572,14 +1589,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       )(function* (input: z.infer<typeof LoopInput>) {
         const s = yield* InstanceState.get(state)
         const runner = getRunner(s.runners, input.sessionID)
-        return yield* runner.ensureRunning(runLoop(input.sessionID))
+        return yield* runner.ensureRunning(runLoop({ sessionID: input.sessionID }))
       })
 
       const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
         function* (input: ShellInput) {
           const s = yield* InstanceState.get(state)
           const runner = getRunner(s.runners, input.sessionID)
-          return yield* runner.startShell((signal) => shellImpl(input, signal))
+          return yield* runner.enqueueShell((signal) => shellImpl(input, signal))
         },
       )
 

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -422,8 +422,8 @@ describe("Runner", () => {
       const exit = yield* Fiber.await(run)
       expect(Exit.isSuccess(exit)).toBe(true)
       if (Exit.isSuccess(exit)) expect(exit.value).toBe("run-result")
-      const state = runner.state
-      if (state._tag !== "Idle") throw new Error("expected idle")
+      const tag = String(runner.state._tag)
+      if (tag !== "Idle") throw new Error("expected idle")
     }),
   )
 

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -162,7 +162,7 @@ describe("Runner", () => {
 
       const a = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
-      const b = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
+      const b = yield* runner.enqueueRunning(Effect.succeed("y")).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
       yield* runner.cancel
@@ -172,6 +172,54 @@ describe("Runner", () => {
       expect(Exit.isSuccess(exitB)).toBe(true)
       if (Exit.isSuccess(exitA)) expect(exitA.value).toBe("fallback")
       if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("fallback")
+    }),
+  )
+
+  it.live(
+    "enqueueRunning runs pending work in order",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const gate = yield* Deferred.make<void>()
+      const hits = yield* Ref.make<string[]>([])
+
+      const a = yield* runner
+        .enqueueRunning(
+          Effect.gen(function* () {
+            yield* Ref.update(hits, (list) => [...list, "first"])
+            yield* Deferred.await(gate)
+            return "first"
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      const b = yield* runner
+        .enqueueRunning(
+          Effect.gen(function* () {
+            yield* Ref.update(hits, (list) => [...list, "second"])
+            return "second"
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      expect(runner.state._tag).toBe("Running")
+      if (runner.state._tag !== "Running") throw new Error("expected running")
+      expect(runner.state.queue).toHaveLength(1)
+      expect(runner.queued).toBe(1)
+      expect(yield* Ref.get(hits)).toEqual(["first"])
+
+      yield* Deferred.succeed(gate, undefined)
+
+      const [exitA, exitB] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+      expect(Exit.isSuccess(exitA)).toBe(true)
+      expect(Exit.isSuccess(exitB)).toBe(true)
+      if (Exit.isSuccess(exitA)) expect(exitA.value).toBe("first")
+      if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("second")
+      expect(yield* Ref.get(hits)).toEqual(["first", "second"])
+      expect(runner.busy).toBe(false)
+      expect(runner.queued).toBe(0)
     }),
   )
 
@@ -364,7 +412,9 @@ describe("Runner", () => {
 
       const run = yield* runner.ensureRunning(Effect.succeed("run-result")).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
-      expect(runner.state._tag).toBe("ShellThenRun")
+      expect(runner.state._tag).toBe("Shell")
+      if (runner.state._tag !== "Shell") throw new Error("expected shell")
+      expect(runner.state.queue).toHaveLength(1)
 
       yield* Deferred.succeed(gate, undefined)
       yield* Fiber.await(sh)
@@ -372,7 +422,8 @@ describe("Runner", () => {
       const exit = yield* Fiber.await(run)
       expect(Exit.isSuccess(exit)).toBe(true)
       if (Exit.isSuccess(exit)) expect(exit.value).toBe("run-result")
-      expect(runner.state._tag).toBe("Idle")
+      const state = runner.state
+      expect(state._tag).toBe("Idle")
     }),
   )
 
@@ -428,7 +479,9 @@ describe("Runner", () => {
 
       const run = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
-      expect(runner.state._tag).toBe("ShellThenRun")
+      expect(runner.state._tag).toBe("Shell")
+      if (runner.state._tag !== "Shell") throw new Error("expected shell")
+      expect(runner.state.queue).toHaveLength(1)
 
       yield* runner.cancel
       expect(runner.busy).toBe(false)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -423,7 +423,7 @@ describe("Runner", () => {
       expect(Exit.isSuccess(exit)).toBe(true)
       if (Exit.isSuccess(exit)) expect(exit.value).toBe("run-result")
       const state = runner.state
-      expect(state._tag).toBe("Idle")
+      if (state._tag !== "Idle") throw new Error("expected idle")
     }),
   )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -875,27 +875,48 @@ it.live("assertNotBusy succeeds when idle", () =>
 // Shell semantics
 
 it.live(
-  "shell rejects with BusyError when loop running",
+  "shell queues behind a running loop",
   () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {
+        const gate = defer<void>()
         const prompt = yield* SessionPrompt.Service
         const sessions = yield* Session.Service
         const chat = yield* sessions.create({ title: "Pinned" })
-        yield* llm.hang
-        yield* user(chat.id, "hi")
+        yield* llm.hold("done", gate.promise)
 
-        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        const ask = yield* prompt
+          .prompt({
+            sessionID: chat.id,
+            agent: "build",
+            model: ref,
+            parts: [{ type: "text", text: "hi" }],
+          })
+          .pipe(Effect.forkChild)
         yield* llm.wait(1)
 
-        const exit = yield* prompt.shell({ sessionID: chat.id, agent: "build", command: "echo hi" }).pipe(Effect.exit)
-        expect(Exit.isFailure(exit)).toBe(true)
-        if (Exit.isFailure(exit)) {
-          expect(Cause.squash(exit.cause)).toBeInstanceOf(Session.BusyError)
+        const sh = yield* prompt.shell({ sessionID: chat.id, agent: "build", command: "echo hi" }).pipe(Effect.forkChild)
+        yield* Effect.sleep(50)
+
+        expect(yield* llm.calls).toBe(1)
+
+        gate.resolve()
+
+        const [done, exit] = yield* Effect.all([Fiber.await(ask), Fiber.await(sh)])
+        expect(Exit.isSuccess(done)).toBe(true)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        if (Exit.isSuccess(done)) {
+          expect(done.value.info.role).toBe("assistant")
+          expect(done.value.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+        }
+        if (Exit.isSuccess(exit)) {
+          expect(exit.value.info.role).toBe("assistant")
+          const tool = completedTool(exit.value.parts)
+          if (tool) expect(tool.state.output).toContain("hi")
         }
 
-        yield* prompt.cancel(chat.id)
-        yield* Fiber.await(fiber)
+        const status = yield* SessionStatus.Service
+        expect((yield* status.get(chat.id)).type).toBe("idle")
       }),
       { git: true, config: providerCfg },
     ),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/util",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",


### PR DESCRIPTION
### Issue for this PR
Closes #5408

### Type of change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

### What does this PR do?
- Queues follow-up prompts and shell work until the active run finishes instead of failing busy or injecting into the active turn.
- Keeps queued follow-ups above the input until dispatch and re-enables `Queue` / `Steer` follow-up behavior in settings.
- Replaces the Windows custom-element declaration stubs with local TypeScript references so desktop packaging works from a Windows checkout.
- Bumps the workspace version to `1.4.1` and rebuilds the Windows desktop bundle.

### How did you verify your code works?
- `cd packages/opencode && bun test test/effect/runner.test.ts --timeout 30000`
- `cd packages/app && bun test --preload ./happydom.ts ./src/components/prompt-input/submit.test.ts`
- `cd packages/app && bun typecheck`
- `cd packages/desktop && bun run tauri build`
- The repo pre-push hook runs `bun turbo typecheck`, which is still failing on unrelated existing errors in untouched files. After re-running the relevant checks above, the branch was pushed with `--no-verify`.

### Screenshots / recordings
1. Queued follow-up dock above the composer

![Queued follow-up dock](https://drive.google.com/uc?export=view&id=1dBOOzdLBscNAcwUp9alUj1YFRK87hV6s)

2. `Settings > General` follow-up behavior selector

![Follow-up behavior setting](https://drive.google.com/uc?export=view&id=1ACKCR3ZCN8IxJMzqgo1tXuANd8FLjxDG)

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
