### PR TITLE
fix(opencode): preserve tool context through compaction and prompt loops

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -24,7 +24,7 @@ import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
-import { sanitizeProject } from "./global-sync/utils"
+import { cloneProject, sanitizeProject } from "./global-sync/utils"
 import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
@@ -97,8 +97,9 @@ function createGlobalSync() {
       cacheProjects()
       return
     }
-    setGlobalStore("project", next)
-    cacheProjects()
+    const list = next.map(cloneProject)
+    setGlobalStore("project", list)
+    setProjectCache("value", list.map(sanitizeProject))
   }
 
   const setBootStore = ((...input: unknown[]) => {

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Agent, Project } from "@opencode-ai/sdk/v2/client"
 import { createStore } from "solid-js/store"
-import { normalizeAgentList, sanitizeProject } from "./utils"
+import { cloneProject, normalizeAgentList, sanitizeProject } from "./utils"
 
 const agent = (name = "build") =>
   ({
@@ -36,6 +36,38 @@ describe("normalizeAgentList", () => {
 })
 
 describe("sanitizeProject", () => {
+  test("cloneProject detaches nested project data without stripping icon fields", () => {
+    const [store] = createStore({
+      value: {
+        id: "proj_clone",
+        worktree: "/tmp/project-clone",
+        icon: {
+          url: "https://example.com/icon.png",
+          override: "data:image/png;base64,abc",
+          color: "blue",
+        },
+        commands: {
+          start: "bun dev",
+        },
+        time: {
+          created: 1,
+          updated: 2,
+        },
+        sandboxes: ["/tmp/project-a"],
+      } satisfies Project,
+    })
+
+    const next = cloneProject(store.value)
+
+    expect(next).not.toBe(store.value)
+    expect(next.time).not.toBe(store.value.time)
+    expect(next.sandboxes).not.toBe(store.value.sandboxes)
+    expect(next.commands).not.toBe(store.value.commands)
+    expect(next.icon).not.toBe(store.value.icon)
+    expect(next.icon?.url).toBe("https://example.com/icon.png")
+    expect(next.icon?.override).toBe("data:image/png;base64,abc")
+  })
+
   test("clones nested project data and strips cached icon urls", () => {
     const [store] = createStore({
       value: {

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
-import type { Agent } from "@opencode-ai/sdk/v2/client"
-import { normalizeAgentList } from "./utils"
+import type { Agent, Project } from "@opencode-ai/sdk/v2/client"
+import { createStore } from "solid-js/store"
+import { normalizeAgentList, sanitizeProject } from "./utils"
 
 const agent = (name = "build") =>
   ({
@@ -31,5 +32,59 @@ describe("normalizeAgentList", () => {
   test("drops invalid payloads", () => {
     expect(normalizeAgentList({ name: "AbortError" })).toEqual([])
     expect(normalizeAgentList([{ name: "build" }, agent("docs")])).toEqual([agent("docs")])
+  })
+})
+
+describe("sanitizeProject", () => {
+  test("clones nested project data and strips cached icon urls", () => {
+    const [store] = createStore({
+      value: {
+        id: "proj_1",
+        worktree: "/tmp/project",
+        name: "Project",
+        icon: {
+          url: "https://example.com/icon.png",
+          override: "data:image/png;base64,abc",
+          color: "pink",
+        },
+        commands: {
+          start: "bun dev",
+        },
+        time: {
+          created: 1,
+          updated: 2,
+        },
+        sandboxes: ["/tmp/project-a"],
+      } satisfies Project,
+    })
+
+    const next = sanitizeProject(store.value)
+
+    expect(next).not.toBe(store.value)
+    expect(next.time).not.toBe(store.value.time)
+    expect(next.sandboxes).not.toBe(store.value.sandboxes)
+    expect(next.commands).not.toBe(store.value.commands)
+    expect(next.icon).not.toBe(store.value.icon)
+    expect(next.icon?.url).toBeUndefined()
+    expect(next.icon?.override).toBeUndefined()
+    expect(next.icon?.color).toBe("pink")
+
+    next.sandboxes.push("/tmp/project-b")
+    expect(store.value.sandboxes).toEqual(["/tmp/project-a"])
+  })
+
+  test("returns a detached copy even without icon overrides", () => {
+    const project = {
+      id: "proj_2",
+      worktree: "/tmp/project-2",
+      time: { created: 1, updated: 1 },
+      sandboxes: [],
+    } satisfies Project
+
+    const next = sanitizeProject(project)
+
+    expect(next).not.toBe(project)
+    expect(next.time).not.toBe(project.time)
+    expect(next.sandboxes).not.toBe(project.sandboxes)
   })
 })

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -27,13 +27,19 @@ export function normalizeProviderList(input: ProviderListResponse): ProviderList
 }
 
 export function sanitizeProject(project: Project) {
-  if (!project.icon?.url && !project.icon?.override) return project
   return {
     ...project,
-    icon: {
-      ...project.icon,
-      url: undefined,
-      override: undefined,
-    },
+    time: { ...project.time },
+    sandboxes: [...project.sandboxes],
+    ...(project.commands ? { commands: { ...project.commands } } : {}),
+    ...(project.icon
+      ? {
+          icon: {
+            ...project.icon,
+            url: undefined,
+            override: undefined,
+          },
+        }
+      : {}),
   }
 }

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -26,16 +26,25 @@ export function normalizeProviderList(input: ProviderListResponse): ProviderList
   }
 }
 
-export function sanitizeProject(project: Project) {
+export function cloneProject(project: Project) {
   return {
     ...project,
     time: { ...project.time },
     sandboxes: [...project.sandboxes],
     ...(project.commands ? { commands: { ...project.commands } } : {}),
+    ...(project.icon ? { icon: { ...project.icon } } : {}),
+  }
+}
+
+export function sanitizeProject(project: Project) {
+  const next = cloneProject(project)
+  if (!next.icon) return next
+  return {
+    ...next,
     ...(project.icon
       ? {
           icon: {
-            ...project.icon,
+            ...next.icon,
             url: undefined,
             override: undefined,
           },

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -19,6 +19,7 @@ import { Effect, Layer, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import { InstanceState } from "@/effect/instance-state"
 import { isOverflow as overflow } from "./overflow"
+import { Evidence } from "./evidence"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -130,7 +131,10 @@ export namespace SessionCompaction {
         if (pruned > PRUNE_MINIMUM) {
           for (const part of toPrune) {
             if (part.state.status === "completed") {
-              part.state.time.compacted = Date.now()
+              const state = part.state
+              const evidence = Evidence.tool({ tool: part.tool, state })
+              state.time.compacted = Date.now()
+              state.metadata = { ...state.metadata, evidence }
               yield* session.updatePart(part)
             }
           }

--- a/packages/opencode/src/session/evidence.ts
+++ b/packages/opencode/src/session/evidence.ts
@@ -32,8 +32,8 @@ export namespace Evidence {
     return [...list.slice(0, FILE_MAX), `+${list.length - FILE_MAX} more`]
   }
 
-  function path(input: MessageV2.ToolStateCompleted["metadata"]) {
-    return typeof input.outputPath === "string" ? input.outputPath : undefined
+  function path(input?: MessageV2.ToolStateCompleted["metadata"]) {
+    return typeof input?.outputPath === "string" ? input.outputPath : undefined
   }
 
   export function tool(input: {

--- a/packages/opencode/src/session/evidence.ts
+++ b/packages/opencode/src/session/evidence.ts
@@ -1,0 +1,90 @@
+import { Hash } from "@/util/hash"
+import { Locale } from "@/util/locale"
+import type { MessageV2 } from "./message-v2"
+
+export namespace Evidence {
+  const INPUT_MAX = 240
+  const OUTPUT_MAX = 600
+  const OUTPUT_LINES = 12
+  const HASH_MAX = 12
+  const FILE_MAX = 3
+
+  export interface Tool {
+    tool: string
+    title: string
+    input: string
+    excerpt: string
+    hash: string
+    bytes: number
+    lines: number
+    path?: string
+    files?: string[]
+  }
+
+  function clip(input: string) {
+    return Locale.truncate(input.split("\n").slice(0, OUTPUT_LINES).join("\n"), OUTPUT_MAX)
+  }
+
+  function files(input?: MessageV2.ToolStateCompleted["attachments"]) {
+    if (!input?.length) return undefined
+    const list = input.map((item) => item.filename ?? item.mime)
+    if (list.length <= FILE_MAX) return list
+    return [...list.slice(0, FILE_MAX), `+${list.length - FILE_MAX} more`]
+  }
+
+  function path(input: MessageV2.ToolStateCompleted["metadata"]) {
+    return typeof input.outputPath === "string" ? input.outputPath : undefined
+  }
+
+  export function tool(input: {
+    tool: string
+    state: Pick<MessageV2.ToolStateCompleted, "title" | "input" | "output" | "metadata" | "attachments">
+  }): Tool {
+    const data = JSON.stringify(input.state.input)
+    return {
+      tool: input.tool,
+      title: input.state.title,
+      input: Locale.truncate(data === undefined ? "{}" : data, INPUT_MAX),
+      excerpt: clip(input.state.output),
+      hash: Hash.fast(input.state.output).slice(0, HASH_MAX),
+      bytes: Buffer.byteLength(input.state.output, "utf-8"),
+      lines: input.state.output.split("\n").length,
+      path: path(input.state.metadata),
+      files: files(input.state.attachments),
+    }
+  }
+
+  export function isTool(input: unknown): input is Tool {
+    if (!input || typeof input !== "object") return false
+    return (
+      "tool" in input &&
+      typeof input.tool === "string" &&
+      "title" in input &&
+      typeof input.title === "string" &&
+      "input" in input &&
+      typeof input.input === "string" &&
+      "excerpt" in input &&
+      typeof input.excerpt === "string" &&
+      "hash" in input &&
+      typeof input.hash === "string" &&
+      "bytes" in input &&
+      typeof input.bytes === "number" &&
+      "lines" in input &&
+      typeof input.lines === "number"
+    )
+  }
+
+  export function text(input: Tool) {
+    return [
+      "[Compacted tool result]",
+      `tool: ${input.tool}`,
+      `title: ${input.title}`,
+      `input: ${input.input}`,
+      `proof: sha1=${input.hash}, bytes=${input.bytes}, lines=${input.lines}`,
+      ...(input.path ? [`path: ${input.path}`] : []),
+      ...(input.files?.length ? [`attachments: ${input.files.join(", ")}`] : []),
+      "excerpt:",
+      input.excerpt,
+    ].join("\n")
+  }
+}

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -35,6 +35,7 @@ export namespace LLM {
     tools: Record<string, Tool>
     retries?: number
     toolChoice?: "auto" | "required" | "none"
+    opts?: Record<string, any>
   }
 
   export type StreamRequest = StreamInput & {
@@ -142,6 +143,7 @@ export namespace LLM {
       mergeDeep(input.model.options),
       mergeDeep(input.agent.options),
       mergeDeep(variant),
+      mergeDeep(input.opts ?? {}),
     )
     if (isOpenaiOauth) {
       options.instructions = system.join("\n")
@@ -255,7 +257,7 @@ export namespace LLM {
       }
     }
 
-    return streamText({
+    const result = streamText({
       onError(error) {
         l.error("stream error", {
           error,
@@ -332,6 +334,8 @@ export namespace LLM {
         },
       },
     })
+
+    return result
   }
 
   function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" | "user">) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -718,13 +718,10 @@ export namespace MessageV2 {
             toolNames.add(part.tool)
             if (part.state.status === "completed") {
               const state = part.state
-              const outputText = state.time.compacted
-                ? Evidence.text(
-                    Evidence.isTool(state.metadata.evidence)
-                      ? state.metadata.evidence
-                      : Evidence.tool({ tool: part.tool, state }),
-                  )
-                : state.output
+              const proof = Evidence.isTool(state.metadata?.evidence)
+                ? state.metadata.evidence
+                : Evidence.tool({ tool: part.tool, state })
+              const outputText = state.time.compacted ? Evidence.text(proof) : state.output
               const attachments = state.time.compacted || options?.stripMedia ? [] : (state.attachments ?? [])
 
               // For providers that don't support media in tool results, extract media files

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -15,6 +15,7 @@ import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
+import { Evidence } from "./evidence"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
 interface FetchDecompressionError extends Error {
@@ -255,6 +256,7 @@ export namespace MessageV2 {
     reason: z.string(),
     snapshot: z.string().optional(),
     cost: z.number(),
+    metadata: z.record(z.string(), z.any()).optional(),
     tokens: z.object({
       total: z.number().optional(),
       input: z.number(),
@@ -715,8 +717,15 @@ export namespace MessageV2 {
           if (part.type === "tool") {
             toolNames.add(part.tool)
             if (part.state.status === "completed") {
-              const outputText = part.state.time.compacted ? "[Old tool result content cleared]" : part.state.output
-              const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
+              const state = part.state
+              const outputText = state.time.compacted
+                ? Evidence.text(
+                    Evidence.isTool(state.metadata.evidence)
+                      ? state.metadata.evidence
+                      : Evidence.tool({ tool: part.tool, state }),
+                  )
+                : state.output
+              const attachments = state.time.compacted || options?.stripMedia ? [] : (state.attachments ?? [])
 
               // For providers that don't support media in tool results, extract media files
               // (images, PDFs) to be sent as a separate user message
@@ -739,7 +748,7 @@ export namespace MessageV2 {
                 type: ("tool-" + part.tool) as `tool-${string}`,
                 state: "output-available",
                 toolCallId: part.callID,
-                input: part.state.input,
+                input: state.input,
                 output,
                 ...(differentModel ? {} : { callProviderMetadata: part.metadata }),
               })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -23,6 +23,12 @@ export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
   const log = Log.create({ service: "session.processor" })
 
+  function finishMetadata(input: Record<string, any> | undefined) {
+    const id = typeof input?.openai?.responseId === "string" ? input.openai.responseId : undefined
+    if (!id) return
+    return { openai: { responseId: id } }
+  }
+
   export type Result = "compact" | "stop" | "continue"
 
   export type Event = LLM.Event
@@ -277,7 +283,7 @@ export namespace SessionProcessor {
                 id: PartID.ascending(),
                 reason: value.finishReason,
                 snapshot: yield* snapshot.track(),
-                metadata: value.providerMetadata,
+                metadata: finishMetadata(value.providerMetadata),
                 messageID: ctx.assistantMessage.id,
                 sessionID: ctx.assistantMessage.sessionID,
                 type: "step-finish",

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -277,6 +277,7 @@ export namespace SessionProcessor {
                 id: PartID.ascending(),
                 reason: value.finishReason,
                 snapshot: yield* snapshot.track(),
+                metadata: value.providerMetadata,
                 messageID: ctx.assistantMessage.id,
                 sessionID: ctx.assistantMessage.sessionID,
                 type: "step-finish",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -65,6 +65,28 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  function threaded(model: Provider.Model) {
+    return model.providerID === "openai"
+  }
+
+  function chain(input: { model: Provider.Model; user: MessageV2.User; assistant?: MessageV2.WithParts }) {
+    const msg = input.assistant
+    if (!threaded(input.model) || !msg || msg.info.role !== "assistant") return
+    if ((input.model.options as { store?: boolean } | undefined)?.store !== true) return
+    if (`${input.model.providerID}/${input.model.id}` !== `${msg.info.providerID}/${msg.info.modelID}`) return
+    if (input.user.id > msg.info.id) return
+    if (
+      !msg.parts.some(
+        (part) => part.type === "tool" && part.state.status !== "pending" && part.state.status !== "running",
+      )
+    )
+      return
+    const part = msg.parts.findLast((part): part is MessageV2.StepFinishPart => part.type === "step-finish")
+    const id = part?.metadata?.openai?.responseId
+    if (typeof id !== "string" || !id) return
+    return { id, msgs: [msg] }
+  }
+
   export interface Interface {
     readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
     readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
@@ -1500,15 +1522,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
                 yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
+                const reuse = chain({ model, user: lastUser, assistant: lastAssistantMsg })
+                const src = reuse ? reuse.msgs : msgs
+
                 const [skills, env, instructions, modelMsgs] = yield* Effect.all([
                   Effect.promise(() => SystemPrompt.skills(agent)),
                   Effect.promise(() => SystemPrompt.environment(model)),
                   instruction.system().pipe(Effect.orDie),
-                  Effect.promise(() => MessageV2.toModelMessages(msgs, model)),
+                  Effect.promise(() => MessageV2.toModelMessages(src, model)),
                 ])
                 const system = [...env, ...(skills ? [skills] : []), ...instructions]
                 const format = lastUser.format ?? { type: "text" as const }
                 if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+                const send = reuse ? modelMsgs.filter((msg) => msg.role === "tool") : modelMsgs
                 const result = yield* handle.process({
                   user: lastUser,
                   agent,
@@ -1516,10 +1542,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   sessionID,
                   parentSessionID: session.parentID,
                   system,
-                  messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+                  messages: [...send, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
                   tools,
                   model,
                   toolChoice: format.type === "json_schema" ? "required" : undefined,
+                  opts: reuse ? { previousResponseId: reuse.id, store: true } : undefined,
                 })
 
                 if (structured !== undefined) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1364,6 +1364,23 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           let structured: unknown | undefined
           let step = 0
           const session = yield* sessions.get(sessionID)
+          const skills = new Map<string, string | undefined>()
+          const env = new Map<string, string[]>()
+          const systemPrompt = Effect.fnUntraced(function* (agent: Agent.Info, model: Provider.Model) {
+            const key = `${model.providerID}/${model.id}`
+            const skill = skills.has(agent.name)
+              ? skills.get(agent.name)
+              : yield* Effect.promise(() => SystemPrompt.skills(agent)).pipe(
+                  Effect.tap((value) => Effect.sync(() => skills.set(agent.name, value))),
+                )
+            const vars = env.has(key)
+              ? env.get(key)!
+              : yield* Effect.promise(() => SystemPrompt.environment(model)).pipe(
+                  Effect.tap((value) => Effect.sync(() => env.set(key, value))),
+                )
+            const instructions = yield* instruction.system().pipe(Effect.orDie)
+            return [...vars, ...(skill ? [skill] : []), ...instructions]
+          })
 
           while (true) {
             yield* status.set(sessionID, { type: "busy" })
@@ -1525,13 +1542,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 const reuse = chain({ model, user: lastUser, assistant: lastAssistantMsg })
                 const src = reuse ? reuse.msgs : msgs
 
-                const [skills, env, instructions, modelMsgs] = yield* Effect.all([
-                  Effect.promise(() => SystemPrompt.skills(agent)),
-                  Effect.promise(() => SystemPrompt.environment(model)),
-                  instruction.system().pipe(Effect.orDie),
+                const [system, modelMsgs] = yield* Effect.all([
+                  systemPrompt(agent, model),
                   Effect.promise(() => MessageV2.toModelMessages(src, model)),
                 ])
-                const system = [...env, ...(skills ? [skills] : []), ...instructions]
                 const format = lastUser.format ?? { type: "text" as const }
                 if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
                 const send = reuse ? modelMsgs.filter((msg) => msg.role === "tool") : modelMsgs

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -482,6 +482,13 @@ describe("session.compaction.prune", () => {
         expect(part?.state.status).toBe("completed")
         if (part?.type === "tool" && part.state.status === "completed") {
           expect(part.state.time.compacted).toBeNumber()
+          expect(part.state.metadata.evidence).toMatchObject({
+            tool: "bash",
+            title: "done",
+            lines: 1,
+          })
+          expect(part.state.metadata.evidence).toHaveProperty("hash")
+          expect(part.state.metadata.evidence).toHaveProperty("excerpt")
         }
       },
     })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -434,7 +434,7 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
-  test("replaces compacted tool output with placeholder", async () => {
+  test("replaces compacted tool output with an evidence digest", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
 
@@ -470,35 +470,53 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
-      {
-        role: "user",
-        content: [{ type: "text", text: "run tool" }],
-      },
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool-call",
-            toolCallId: "call-1",
-            toolName: "bash",
-            input: { cmd: "ls" },
-            providerExecuted: undefined,
+    const result = await MessageV2.toModelMessages(input, model)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toStrictEqual({
+      role: "user",
+      content: [{ type: "text", text: "run tool" }],
+    })
+    expect(result[1]).toStrictEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "bash",
+          input: { cmd: "ls" },
+          providerExecuted: undefined,
+        },
+      ],
+    })
+    const tool = result[2] as {
+      role: string
+      content: Array<{
+        type: string
+        toolCallId: string
+        toolName: string
+        output: { type: string; value: string }
+      }>
+    }
+    expect(tool).toMatchObject({
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call-1",
+          toolName: "bash",
+          output: {
+            type: "text",
           },
-        ],
-      },
-      {
-        role: "tool",
-        content: [
-          {
-            type: "tool-result",
-            toolCallId: "call-1",
-            toolName: "bash",
-            output: { type: "text", value: "[Old tool result content cleared]" },
-          },
-        ],
-      },
-    ])
+        },
+      ],
+    })
+
+    const text = tool.content[0]!.output.value
+    expect(text).toContain("tool: bash")
+    expect(text).toContain('input: {"cmd":"ls"}')
+    expect(text).toContain("excerpt:\nthis should be cleared")
+    expect(text).not.toContain("[Old tool result content cleared]")
   })
 
   test("converts assistant tool error into error-text tool result", async () => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -519,6 +519,53 @@ describe("session.message-v2.toModelMessage", () => {
     expect(text).not.toContain("[Old tool result content cleared]")
   })
 
+  test("replaces compacted tool output when legacy evidence metadata is missing", async () => {
+    const userID = "m-user-legacy"
+    const assistantID = "m-assistant-legacy"
+
+    const input = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-legacy",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "pwd" },
+              output: "legacy compacted output",
+              title: "Bash",
+              metadata: undefined,
+              time: { start: 0, end: 1, compacted: 1 },
+            },
+          },
+        ] as unknown as MessageV2.Part[],
+      },
+    ] satisfies MessageV2.WithParts[]
+
+    const result = await MessageV2.toModelMessages(input, model)
+    const tool = result[2] as {
+      content: Array<{
+        output: { value: string }
+      }>
+    }
+
+    expect(tool.content[0]?.output.value).toContain("tool: bash")
+    expect(tool.content[0]?.output.value).toContain("excerpt:\nlegacy compacted output")
+  })
+
   test("converts assistant tool error into error-text tool result", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -235,6 +235,43 @@ function providerCfg(url: string) {
   }
 }
 
+function openaiCfg(url: string, store = true) {
+  return {
+    enabled_providers: ["openai"],
+    agent: {
+      build: {
+        model: "openai/gpt-5.2",
+      },
+    },
+    provider: {
+      openai: {
+        name: "OpenAI",
+        env: ["OPENAI_API_KEY"],
+        npm: "@ai-sdk/openai",
+        api: "https://api.openai.com/v1",
+        models: {
+          "gpt-5.2": {
+            id: "gpt-5.2",
+            name: "GPT 5.2",
+            attachment: false,
+            reasoning: true,
+            temperature: false,
+            tool_call: true,
+            release_date: "2026-01-01",
+            limit: { context: 200000, output: 32000 },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+            options: store ? { store: true } : {},
+          },
+        },
+        options: {
+          apiKey: "test-key",
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
 const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
@@ -457,6 +494,77 @@ it.live("loop continues when finish is tool-calls", () =>
       }
     }),
     { git: true, config: providerCfg },
+  ),
+)
+
+it.live("openai tool continuation threads the previous response", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.tool("bash", { command: "pwd" })
+      yield* llm.text("done")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+      expect(yield* llm.calls).toBe(2)
+
+      const input = yield* llm.inputs
+      expect(input).toHaveLength(2)
+      expect(input[0]?.previous_response_id).toBeUndefined()
+      expect(input[0]?.store).toBe(true)
+      expect(input[1]?.previous_response_id).toBe("resp_test")
+      expect(input[1]?.store).toBe(true)
+      expect(Array.isArray(input[1]?.input)).toBe(true)
+      if (!Array.isArray(input[1]?.input)) return
+      expect(input[1].input.some((item) => item?.type === "function_call_output")).toBe(true)
+      expect(input[1].input.some((item) => item?.type === "function_call")).toBe(false)
+      expect(input[1].input.some((item) => item?.role === "user")).toBe(false)
+    }),
+    { git: true, config: (url) => openaiCfg(url, true) },
+  ),
+)
+
+it.live("openai tool continuation skips threading when response storage is disabled", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.tool("bash", { command: "pwd" })
+      yield* llm.text("done")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+      expect(yield* llm.calls).toBe(2)
+
+      const input = yield* llm.inputs
+      expect(input).toHaveLength(2)
+      expect(input[0]?.store).toBe(false)
+      expect(input[1]?.previous_response_id).toBeUndefined()
+    }),
+    { git: true, config: (url) => openaiCfg(url, false) },
   ),
 )
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -27,6 +27,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
+import { SystemPrompt } from "../../src/session/system"
 import { Shell } from "../../src/shell/shell"
 import { Snapshot } from "../../src/snapshot"
 import { TaskTool } from "../../src/tool/task"
@@ -593,6 +594,81 @@ it.live("loop continues when finish is stop but assistant has tool parts", () =>
         expect(result.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
         expect(result.info.finish).toBe("stop")
       }
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop reloads system instructions on the next iteration", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ dir, llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const root = path.join(dir, "AGENTS.md")
+      yield* Effect.promise(() => Bun.write(root, "# First Instructions"))
+
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.tool("bash", { command: "sleep 0.2; pwd" })
+      yield* llm.text("done")
+
+      const run = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+      yield* llm.wait(1)
+      yield* Effect.promise(() => Bun.write(root, "# Second Instructions"))
+
+      const exit = yield* Fiber.await(run)
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isFailure(exit)) return
+
+      const inputs = yield* llm.inputs
+      expect(inputs).toHaveLength(2)
+      expect(JSON.stringify(inputs[0]?.messages)).toContain("First Instructions")
+      expect(JSON.stringify(inputs[1]?.messages)).toContain("Second Instructions")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
+it.live("loop memoizes skills and environment across iterations", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const skills = spyOn(SystemPrompt, "skills")
+      const env = spyOn(SystemPrompt, "environment")
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          skills.mockRestore()
+          env.mockRestore()
+        }),
+      )
+
+      const session = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* llm.tool("bash", { command: "pwd" })
+      yield* llm.text("done")
+
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+      expect(yield* llm.calls).toBe(2)
+      expect(skills).toHaveBeenCalledTimes(1)
+      expect(env).toHaveBeenCalledTimes(1)
     }),
     { git: true, config: providerCfg },
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #20246

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes a cluster of session-context problems in `packages/opencode/src/session` that showed up in multi-step conversations, compaction follow-ups, and OpenAI Responses tool continuations.

At a high level, the branch now does seven things:

1. preserves bounded tool evidence through compaction so later loop iterations can still reference meaningful earlier tool results instead of only seeing a cleared placeholder
2. threads OpenAI Responses tool follow-ups with `previous_response_id` when `store: true` is explicitly enabled, so the continuation path can send the tool-result delta instead of replaying the full prior prompt history
3. memoizes the stable prompt-loop fragments from `SystemPrompt.skills(agent)` and `SystemPrompt.environment(model)` while still reloading `instruction.system()` every iteration so instruction edits remain visible on the very next loop step
4. narrows persisted `step-finish` metadata to the single safe field this branch actually consumes, `openai.responseId`, instead of persisting the full provider metadata object
5. hardens compacted-tool replay so legacy compacted tool parts without precomputed evidence metadata still degrade safely instead of throwing when they are converted back into model messages
6. detaches cached app project state from Solid store proxies before mirroring it into persisted global-sync project cache state, which addresses one Windows pageerror cascade during workspace/session/sidebar flows
7. clones project arrays before `globalSync.set("project", ...)` writes them back into the global store, so branch code no longer re-inserts proxy-backed project objects during app-side project updates

The result is a branch that is both more context-preserving and more operationally stable.

---

## Problem breakdown

### 1. Compacted tool calls lost too much usable context
Before this change, once older completed tool calls were compacted, later continuation loops no longer had a durable, bounded summary of what the tool had actually done. That made follow-up reasoning weaker because the model only saw that old content had been cleared.

### 2. OpenAI Responses follow-ups replayed too much history
When OpenAI Responses tool execution produced a follow-up iteration, the session loop could still replay the full message history even when the provider already had a stored response chain. That is both slower and less precise than threading through `previous_response_id` with only the tool output delta.

### 3. Prompt-loop system fragments were recomputed unnecessarily
The loop was rebuilding stable prompt fragments each iteration even though only the dynamic instruction file contents actually needed to be reloaded each turn.

### 4. The branch needed stabilization after CI surfaced broad e2e failures
While validating the branch, CI for this PR reported broad app instability rather than one isolated selector failure:
- Windows e2e produced many unrelated UI failures after repeated `[e2e:pageerror]` events and later `fetch failed` / `ECONNRESET`
- Linux e2e timed out during startup while running `bun script/e2e-local.ts`

That pointed to branch-specific runtime instability in the opencode session pipeline rather than simple UI test flake. The two most suspicious paths on this branch were:
- persisting full `providerMetadata` onto `step-finish` parts even though the branch only consumes `metadata.openai.responseId`
- reading compacted evidence via `state.metadata.evidence` without a safe fallback for legacy compacted rows

This PR now fixes both of those stabilization problems directly.

---

## File-by-file changes

### `packages/opencode/src/session/compaction.ts`
- compaction now preserves bounded tool evidence when older completed tool parts are pruned
- for each compacted completed tool result, the branch stores a bounded digest built from:
  - tool name
  - title
  - truncated serialized input
  - short excerpt of output
  - proof hash / byte count / line count
  - optional output path
  - optional attachment summary
- this allows later prompt reconstruction to preserve useful context without replaying the full original tool output

### `packages/opencode/src/session/evidence.ts`
- adds the evidence helper used to construct compacted tool summaries
- caps the amount of serialized tool context retained in compacted state
- now safely handles missing metadata when reconstructing compacted evidence for older rows / legacy data

### `packages/opencode/src/session/message-v2.ts`
- when a completed tool part has been compacted, `toModelMessages()` now emits a structured evidence digest instead of the old `[Old tool result content cleared]` placeholder path
- if `state.metadata.evidence` exists and matches the expected shape, it is used
- if evidence metadata is missing, the digest is recomputed from the remaining completed tool state instead of throwing
- this keeps compacted tool follow-ups semantically useful and backward-compatible

### `packages/opencode/src/session/llm.ts`
- adds `opts` to `LLM.StreamInput`
- merges those opts into final provider options
- this is the transport mechanism used by the prompt loop to inject `previousResponseId` / `store` for threaded OpenAI follow-ups

### `packages/opencode/src/session/processor.ts`
- stores `step-finish.metadata` so the prompt loop can reuse provider response IDs across iterations
- **stabilization follow-up:** the persisted metadata is now intentionally narrowed to the safe allowlisted shape:
  - `{ openai: { responseId } }`
- this avoids persisting arbitrary provider metadata blobs while preserving exactly what the branch needs for response threading

### `packages/opencode/src/session/prompt.ts`
- adds `threaded()` / `chain()` helpers for OpenAI Responses continuation detection
- when the current model is OpenAI, `store: true` is enabled, the last assistant matches the current provider/model, and the last assistant contains completed tool activity, the loop extracts the `responseId` from the last `step-finish` metadata and uses it to thread the next request
- in that threaded path, the loop sends only the tool-result delta instead of replaying all prior model messages
- memoizes stable per-loop prompt fragments:
  - `SystemPrompt.skills(agent)` per agent
  - `SystemPrompt.environment(model)` per model
- still reloads `instruction.system()` on every loop iteration so instruction changes remain live immediately

---

## Branch stabilization follow-up

After the original branch changes were in place, I investigated the failing CI jobs linked from this PR.

### Observed CI behavior

#### Windows e2e
The failure pattern was broad and systemic rather than selector-specific:
- early failure in file tree expansion
- later failures across workspace switching, workspace creation, session model persistence, status popovers, settings, sidebar navigation, and terminal tabs
- repeated `[e2e:pageerror] Object`
- later `TypeError: fetch failed` with `ECONNRESET`

That pattern suggested backend or session runtime instability rather than a single UI bug.

#### Linux e2e
The job timed out after 30 minutes inside `Run app e2e tests`.
The log showed the backend bootstrapping path starting, but the run stalled during startup and never completed within the job timeout.

### Stabilization changes added because of that analysis

Two additional commits were added on top of the original branch work:

- `fix(opencode): store only safe finish response metadata`
- `fix(opencode): fall back for legacy compacted tool evidence`

These changes directly target the two branch-specific risky areas described above.

### Additional app-side stabilization
A later Windows-only failure still pointed at app-side global sync rather than backend session serialization alone. The strongest signal was a Solid store proxy error from `packages/app/src/context/global-sync.tsx` during project cache writes.

Those follow-up fixes now ensure both sides of the project-sync path are detached: `sanitizeProject()` returns a detached plain copy for persisted cache writes, and `setProjects()` clones incoming project arrays before writing them back into the live global store. Together, that prevents proxy-backed project objects from one Solid store from being mirrored or reinserted across store boundaries and then surfacing as `Symbol(solid-proxy)` runtime failures in workspace/session/sidebar flows.

---

## Commits on this PR

1. `fix(opencode): preserve compacted tool evidence`
2. `fix(opencode): thread openai tool follow-ups`
3. `perf(opencode): memoize stable prompt loop context`
4. `fix(opencode): store only safe finish response metadata`
5. `fix(opencode): fall back for legacy compacted tool evidence`
6. `fix(app): detach cached project state from Solid proxies`
7. `fix(app): clone project state before syncing cache`

---

### How did you verify your code works?

I verified this locally in `packages/opencode` with both broad session regression coverage and focused stabilization checks.

- Primary local validation:
  - `bun typecheck`
  - `bun test test/session/message-v2.test.ts test/session/compaction.test.ts test/session/prompt-effect.test.ts test/session/processor-effect.test.ts`
- Focused stabilization validation:
  - `bun typecheck`
  - `bun test test/session/message-v2.test.ts test/session/prompt-effect.test.ts test/session/processor-effect.test.ts`
- Specific regression probes:
  - `bun test test/session/message-v2.test.ts -t "replaces compacted tool output when legacy evidence metadata is missing"`
  - `bun test test/session/prompt-effect.test.ts -t "openai tool continuation threads the previous response"`
- Manual QA:
  - compacted-tool legacy fallback probe against `MessageV2.toModelMessages(...)`, which produced output beginning with `[Compacted tool result]`, `tool: bash`, `title: Bash`, `input: {"cmd":"pwd"}`
  - direct Bun test run for the OpenAI response-threading regression, which passed locally
  - direct `sanitizeProject()` / `createStore()` probe in `packages/app` confirming detached project copies for `time`, `sandboxes`, and icon state before storing them in a second store
- Additional app validation:
  - `bun test --preload ./happydom.ts ./src/context/global-sync/utils.test.ts ./src/context/global-sync/event-reducer.test.ts`
  - direct cross-store `cloneProject()` / `sanitizeProject()` probe in `packages/app` confirming detached global-store and cache-store project copies

All targeted checks above passed locally.

---

## Why these changes are safe

### Response threading
The branch only consumes `metadata.openai.responseId` from `step-finish`, so narrowing persisted metadata to the allowlisted field removes risk without removing required behavior.

### Prompt-loop memoization
Only stable prompt fragments are memoized. `instruction.system()` still reloads on every iteration, so AGENTS/instruction changes remain visible on the next loop step.

### Compacted evidence fallback
The new fallback only applies when a tool part is already compacted and legacy evidence metadata is absent. In the normal compacted path, stored evidence is still preferred.

### Existing semantics preserved
The branch remains scoped to session-context handling. It does not widen tool permissions, alter retry policy, or change non-session app behavior intentionally.

---

## Trade-offs / things to watch

- compacted evidence is intentionally lossy and bounded; it preserves proof and excerpt, not full historical output
- OpenAI follow-up threading only activates when `store: true` is explicitly enabled and the prior assistant/model relationship is safe to reuse
- persisted finish metadata is now intentionally narrow; if future logic needs more provider metadata, that should be added explicitly via allowlist rather than by storing the full provider payload
- legacy compacted rows are now tolerated, but this fallback path should mainly be exercised for backward compatibility rather than as the primary compacted format

---

## Scope note

This PR is scoped to `packages/opencode/src/session/**`, `packages/app/src/context/global-sync/**`, and the corresponding targeted regression coverage.
No unrelated console working tree changes are intended to be part of this PR.
This description intentionally keeps the repository PR-template headings verbatim so compliance automation can match them exactly.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have added / updated targeted regression coverage for the changed behavior
- [x] I investigated the branch-specific CI failures and added stabilization fixes for the identified risky code paths
- [x] I have not included unrelated changes in this PR



