### PR TITLE
fix(perf): optimize levenshtein distance algorithm

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -175,21 +175,38 @@ const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.3
  * Levenshtein distance algorithm implementation
  */
 function levenshtein(a: string, b: string): number {
-  // Handle empty strings
   if (a === "" || b === "") {
     return Math.max(a.length, b.length)
   }
-  const matrix = Array.from({ length: a.length + 1 }, (_, i) =>
-    Array.from({ length: b.length + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
-  )
 
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
-    }
+  if (a.length > b.length) {
+    const tmp = a
+    a = b
+    b = tmp
   }
-  return matrix[a.length][b.length]
+
+  let prevRow = new Int32Array(a.length + 1)
+  let currRow = new Int32Array(a.length + 1)
+
+  for (let i = 0; i <= a.length; i++) {
+    prevRow[i] = i
+  }
+
+  for (let j = 1; j <= b.length; j++) {
+    currRow[0] = j
+    for (let i = 1; i <= a.length; i++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      currRow[i] = Math.min(
+        currRow[i - 1] + 1,
+        prevRow[i] + 1,
+        prevRow[i - 1] + cost
+      )
+    }
+    const tempRow = prevRow
+    prevRow = currRow
+    currRow = tempRow
+  }
+  return prevRow[a.length]
 }
 
 export const SimpleReplacer: Replacer = function* (_content, find) {


### PR DESCRIPTION
This fixes an issue where the edit tool was extremely CPU-bound when dealing with large block sizes, often observed with Gemini 3.1 which tends to output larger replacement blocks.

The previous implementation used O(N*M) space by allocating an array of arrays, causing massive garbage collection overhead. The new implementation uses typed arrays and O(min(N,M)) space.

### Issue for this PR

Closes #21470 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reduces the dime and space of `levenshtein` distance calculation. Before I was seeing constant 100% CPU, now, I see ~20% on average

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I re-installed from my tree and gave it a challenging task using gemini-3.1 and it made progress

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
