### PR TITLE
fix(tui): lazy-load attach bootstrap state

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -61,6 +61,7 @@ export function DialogSessionList() {
 
   onMount(() => {
     dialog.setSize("large")
+    void sync.session.list()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-workspace-list.tsx
@@ -267,7 +267,7 @@ export function DialogWorkspaceList() {
 
   onMount(() => {
     dialog.setSize("large")
-    void sync.workspace.sync()
+    void Promise.all([sync.session.list(), sync.workspace.sync()])
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -480,6 +480,8 @@ export function Autocomplete(props: {
 
   function show(mode: "@" | "/") {
     command.keybinds(false)
+    if (mode === "/") void sync.command.sync()
+    if (mode === "@") void sync.resource.sync()
     setStore({
       visible: mode,
       index: props.input().cursorOffset,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -24,7 +24,6 @@ import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
 import type { AssistantMessage, FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
-import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
 import { formatDuration } from "@/util/format"
 import { createColors, createFrames } from "../../ui/spinner.ts"
@@ -656,6 +655,17 @@ export function Prompt(props: PromptProps) {
     const currentMode = store.mode
     const variant = local.model.variant.current()
 
+    const slash = inputText.startsWith("/")
+      ? await sync.command
+          .sync()
+          .then(() => {
+            const firstLine = inputText.split("\n")[0]
+            const command = firstLine.split(" ")[0].slice(1)
+            return sync.data.command.some((x) => x.name === command)
+          })
+          .catch(() => false)
+      : false
+
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
@@ -667,14 +677,7 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
-    } else if (
-      inputText.startsWith("/") &&
-      iife(() => {
-        const firstLine = inputText.split("\n")[0]
-        const command = firstLine.split(" ")[0].slice(1)
-        return sync.data.command.some((x) => x.name === command)
-      })
-    ) {
+    } else if (slash) {
       // Parse command from first line, preserve multi-line content in arguments
       const firstLineEnd = inputText.indexOf("\n")
       const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)

--- a/packages/opencode/src/cli/cmd/tui/component/workspace/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/workspace/dialog-session-list.tsx
@@ -86,6 +86,7 @@ export function DialogSessionList(props: { workspaceID?: string; localOnly?: boo
 
   onMount(() => {
     dialog.setSize("large")
+    if (!props.workspaceID) void sync.session.list()
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -7,6 +7,8 @@ export interface Args {
   continue?: boolean
   sessionID?: string
   fork?: boolean
+  transport?: "local" | "attach"
+  url?: string
 }
 
 export const { use: useArgs, provider: ArgsProvider } = createSimpleContext({

--- a/packages/opencode/src/cli/cmd/tui/context/directory.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/directory.ts
@@ -1,11 +1,13 @@
 import { createMemo } from "solid-js"
 import { useSync } from "./sync"
+import { useSDK } from "./sdk"
 import { Global } from "@/global"
 
 export function useDirectory() {
   const sync = useSync()
+  const sdk = useSDK()
   return createMemo(() => {
-    const directory = sync.data.path.directory || process.cwd()
+    const directory = sync.data.path.directory || sdk.directory || process.cwd()
     const result = directory.replace(Global.Path.home, "~")
     if (sync.data.vcs?.branch) return result + ":" + sync.data.vcs.branch
     return result

--- a/packages/opencode/src/cli/cmd/tui/context/sync-eager.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/sync-eager.ts
@@ -1,0 +1,9 @@
+export function eager(args: { continue?: boolean; transport?: "local" | "attach" }) {
+  const extra = args.transport !== "attach"
+  return {
+    session: Boolean(args.continue || extra),
+    command: extra,
+    resource: extra,
+    workspace: extra,
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -25,6 +25,7 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
+import { eager } from "./sync-eager"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
@@ -106,6 +107,72 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const sdk = useSDK()
+    const args = useArgs()
+    const load = eager(args)
+    let listed = false
+    let commanded = false
+    let resourced = false
+    let listedRun: Promise<Session[]> | undefined
+    let commandRun: Promise<Command[]> | undefined
+    let resourceRun: Promise<Record<string, McpResource>> | undefined
+
+    function sort(list: Session[]) {
+      return list.toSorted((a, b) => a.id.localeCompare(b.id))
+    }
+
+    function syncSessions() {
+      if (listed) return Promise.resolve(store.session)
+      if (listedRun) return listedRun
+      const next = sdk.client.session
+        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000 })
+        .then((x) => sort(x.data ?? []))
+        .then((x) => {
+          setStore("session", reconcile(x))
+          listed = true
+          return x
+        })
+        .finally(() => {
+          if (listedRun === next) listedRun = undefined
+        })
+      listedRun = next
+      return next
+    }
+
+    function syncCommands() {
+      if (commanded) return Promise.resolve(store.command)
+      if (commandRun) return commandRun
+      const next = sdk.client.command
+        .list()
+        .then((x) => x.data ?? [])
+        .then((x) => {
+          setStore("command", reconcile(x))
+          commanded = true
+          return x
+        })
+        .finally(() => {
+          if (commandRun === next) commandRun = undefined
+        })
+      commandRun = next
+      return next
+    }
+
+    function syncResources() {
+      if (resourced) return Promise.resolve(store.mcp_resource)
+      if (resourceRun) return resourceRun
+      const next = sdk.client.experimental.resource
+        .list()
+        .then((x) => x.data ?? {})
+        .then((x) => {
+          setStore("mcp_resource", reconcile(x))
+          resourced = true
+          return x
+        })
+        .finally(() => {
+          if (resourceRun === next) resourceRun = undefined
+        })
+      resourceRun = next
+      return next
+    }
 
     async function syncWorkspaces() {
       const result = await sdk.client.experimental.workspace.list().catch(() => undefined)
@@ -353,14 +420,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const exit = useExit()
-    const args = useArgs()
 
     async function bootstrap() {
       console.log("bootstrapping")
-      const start = Date.now() - 30 * 24 * 60 * 60 * 1000
-      const sessionListPromise = sdk.client.session
-        .list({ start: start })
-        .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
+      listed = false
+      commanded = false
+      resourced = false
+      const sessionListPromise = load.session ? syncSessions() : undefined
 
       // blocking - include session.list when continuing a session
       const providersPromise = sdk.client.config.providers({}, { throwOnError: true })
@@ -372,7 +438,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         providerListPromise,
         agentsPromise,
         configPromise,
-        ...(args.continue ? [sessionListPromise] : []),
+        ...(args.continue && sessionListPromise ? [sessionListPromise] : []),
       ]
 
       await Promise.all(blockingRequests)
@@ -402,7 +468,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               setStore("provider_next", reconcile(providerList))
               setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
-              if (sessions !== undefined) setStore("session", reconcile(sessions))
+              if (sessions !== undefined) {
+                setStore("session", reconcile(sessions))
+                listed = true
+              }
             })
           })
         })
@@ -410,11 +479,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
-            sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
+            ...(args.continue || !sessionListPromise ? [] : [sessionListPromise]),
+            ...(load.command ? [syncCommands()] : []),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
-            sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
+            ...(load.resource ? [syncResources()] : []),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),
             sdk.client.session.status().then((x) => {
               setStore("session_status", reconcile(x.data!))
@@ -422,7 +491,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.provider.auth().then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get().then((x) => setStore("vcs", reconcile(x.data))),
             sdk.client.path.get().then((x) => setStore("path", reconcile(x.data!))),
-            syncWorkspaces(),
+            ...(load.workspace ? [syncWorkspaces()] : []),
           ]).then(() => {
             setStore("status", "complete")
           })
@@ -452,6 +521,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         return store.status !== "loading"
       },
       session: {
+        list: syncSessions,
         get(sessionID: string) {
           const match = Binary.search(store.session, sessionID, (s) => s.id)
           if (match.found) return store.session[match.index]
@@ -490,6 +560,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           )
           fullSyncedSessions.add(sessionID)
         },
+      },
+      command: {
+        sync: syncCommands,
+      },
+      resource: {
+        sync: syncResources,
       },
       workspace: {
         get(workspaceID: string) {

--- a/packages/opencode/test/cli/tui/sync-eager.test.ts
+++ b/packages/opencode/test/cli/tui/sync-eager.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { eager } from "../../../src/cli/cmd/tui/context/sync-eager"
+
+describe("sync eager attach bootstrap", () => {
+  test("skips nonessential attach bootstrap loads", () => {
+    expect(eager({ transport: "attach" })).toEqual({
+      session: false,
+      command: false,
+      resource: false,
+      workspace: false,
+    })
+  })
+
+  test("still preloads sessions when attach continues", () => {
+    expect(eager({ transport: "attach", continue: true })).toEqual({
+      session: true,
+      command: false,
+      resource: false,
+      workspace: false,
+    })
+  })
+
+  test("keeps full bootstrap for local tui", () => {
+    expect(eager({ transport: "local" })).toEqual({
+      session: true,
+      command: true,
+      resource: true,
+      workspace: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- stop eager-loading session lists, server commands, MCP resources, and workspace lists during opencode attach bootstrap
- lazy-load those datasets only when attach UI paths actually need them, while still preloading sessions for attach --continue
- keep attached directory display stable with an SDK directory fallback and cover the eager-load policy with a focused helper test

## Testing
- local smoke: sync-eager helper assertions passed
- container smoke: sync-eager helper assertions passed in oven/bun:1.3.10
- bun typecheck in this worktree still reports pre-existing branch/runtime issues outside this change set; touched attach files no longer introduce new type errors