### PR TITLE
perf(opencode): reduce redundant summary and queue overhead

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -396,9 +396,8 @@ export namespace SessionProcessor {
           }
           ctx.reasoningMap = {}
 
-          const parts = MessageV2.parts(ctx.assistantMessage.id)
-          for (const part of parts) {
-            if (part.type !== "tool" || part.state.status === "completed" || part.state.status === "error") continue
+          for (const part of Object.values(ctx.toolcalls)) {
+            if (part.state.status === "completed" || part.state.status === "error") continue
             yield* session.updatePart({
               ...part,
               state: {
@@ -409,6 +408,7 @@ export namespace SessionProcessor {
               },
             })
           }
+          ctx.toolcalls = {}
           ctx.assistantMessage.time.completed = Date.now()
           yield* session.updateMessage(ctx.assistantMessage)
         })

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -1,5 +1,5 @@
 import z from "zod"
-import { Effect, Layer, ServiceMap } from "effect"
+import { Cache, Duration, Effect, Layer, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import { Bus } from "@/bus"
 import { Snapshot } from "@/snapshot"
@@ -7,6 +7,7 @@ import { Storage } from "@/storage/storage"
 import { Session } from "."
 import { MessageV2 } from "./message-v2"
 import { SessionID, MessageID } from "./schema"
+import { InstanceState } from "@/effect/instance-state"
 
 export namespace SessionSummary {
   function unquoteGitPath(input: string) {
@@ -80,6 +81,20 @@ export namespace SessionSummary {
       const snapshot = yield* Snapshot.Service
       const storage = yield* Storage.Service
       const bus = yield* Bus.Service
+      const state = yield* InstanceState.make(
+        Effect.fn("SessionSummary.state")(function* () {
+          return {
+            pending: yield* Cache.make<string, void>({
+              capacity: 1024,
+              timeToLive: Duration.infinity,
+              lookup: (key) => {
+                const [sessionID, messageID] = JSON.parse(key) as [SessionID, MessageID]
+                return run({ sessionID, messageID })
+              },
+            }),
+          }
+        }),
+      )
 
       const computeDiff = Effect.fn("SessionSummary.computeDiff")(function* (input: {
         messages: MessageV2.WithParts[]
@@ -103,10 +118,7 @@ export namespace SessionSummary {
         return []
       })
 
-      const summarize = Effect.fn("SessionSummary.summarize")(function* (input: {
-        sessionID: SessionID
-        messageID: MessageID
-      }) {
+      const run = Effect.fn("SessionSummary.run")(function* (input: { sessionID: SessionID; messageID: MessageID }) {
         const all = yield* sessions.messages({ sessionID: input.sessionID })
         if (!all.length) return
 
@@ -130,6 +142,15 @@ export namespace SessionSummary {
         const msgDiffs = yield* computeDiff({ messages })
         target.info.summary = { ...target.info.summary, diffs: msgDiffs }
         yield* sessions.updateMessage(target.info)
+      })
+
+      const summarize = Effect.fn("SessionSummary.summarize")(function* (input: {
+        sessionID: SessionID
+        messageID: MessageID
+      }) {
+        const s = yield* InstanceState.get(state)
+        const key = JSON.stringify([input.sessionID, input.messageID])
+        yield* Cache.get(s.pending, key).pipe(Effect.ensuring(Cache.invalidate(s.pending, key)))
       })
 
       const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {

--- a/packages/opencode/src/util/queue.ts
+++ b/packages/opencode/src/util/queue.ts
@@ -1,5 +1,6 @@
 export class AsyncQueue<T> implements AsyncIterable<T> {
   private queue: T[] = []
+  private idx = 0
   private resolvers: ((value: T) => void)[] = []
 
   push(item: T) {
@@ -9,7 +10,17 @@ export class AsyncQueue<T> implements AsyncIterable<T> {
   }
 
   async next(): Promise<T> {
-    if (this.queue.length > 0) return this.queue.shift()!
+    if (this.idx < this.queue.length) {
+      const item = this.queue[this.idx++]!
+      if (this.idx === this.queue.length) {
+        this.queue = []
+        this.idx = 0
+      } else if (this.idx > 1024 && this.idx * 2 >= this.queue.length) {
+        this.queue = this.queue.slice(this.idx)
+        this.idx = 0
+      }
+      return item
+    }
     return new Promise((resolve) => this.resolvers.push(resolve))
   }
 

--- a/packages/opencode/test/session/summary.test.ts
+++ b/packages/opencode/test/session/summary.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import { Bus } from "../../src/bus"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { SessionSummary } from "../../src/session/summary"
+import { Snapshot } from "../../src/snapshot"
+import { Storage } from "../../src/storage/storage"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+function defer<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe("SessionSummary", () => {
+  test("deduplicates identical in-flight summarize calls", async () => {
+    await using tmp = await tmpdir()
+
+    const gate = defer<void>()
+    let diffCalls = 0
+    let messageCalls = 0
+    let summaryCalls = 0
+    let updateCalls = 0
+    const sessionID = SessionID.make("ses_summary_test")
+    const userID = MessageID.ascending()
+    const assistantID = MessageID.ascending()
+    const providerID = ProviderID.make("test")
+    const modelID = ModelID.make("test-model")
+    const msgs = [
+      {
+        info: {
+          id: userID,
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID, modelID },
+        },
+        parts: [
+          {
+            id: PartID.ascending(),
+            messageID: userID,
+            sessionID,
+            type: "text",
+            text: "hi",
+          },
+        ],
+      },
+      {
+        info: {
+          id: assistantID,
+          sessionID,
+          role: "assistant",
+          parentID: userID,
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          modelID,
+          providerID,
+          time: { created: Date.now() },
+          finish: "stop",
+        },
+        parts: [
+          {
+            id: PartID.ascending(),
+            messageID: assistantID,
+            sessionID,
+            type: "step-start",
+            snapshot: "from",
+          },
+          {
+            id: PartID.ascending(),
+            messageID: assistantID,
+            sessionID,
+            type: "step-finish",
+            reason: "stop",
+            snapshot: "to",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          },
+        ],
+      },
+    ] satisfies MessageV2.WithParts[]
+
+    const layer = Layer.mergeAll(
+      Layer.succeed(
+        Session.Service,
+        Session.Service.of({
+          messages: () => {
+            messageCalls++
+            return Effect.succeed(msgs)
+          },
+          setSummary: () => {
+            summaryCalls++
+            return Effect.void
+          },
+          updateMessage: <T extends MessageV2.Info>(msg: T) => {
+            updateCalls++
+            return Effect.succeed(msg)
+          },
+        } as any),
+      ),
+      Layer.succeed(
+        Snapshot.Service,
+        Snapshot.Service.of({
+          diffFull: () =>
+            Effect.gen(function* () {
+              diffCalls++
+              yield* Effect.promise(() => gate.promise)
+              return [{ file: "a.ts", before: "", after: "x", additions: 1, deletions: 0 }]
+            }),
+        } as any),
+      ),
+      Layer.succeed(
+        Storage.Service,
+        Storage.Service.of({
+          write: () => Effect.void,
+        } as any),
+      ),
+      Layer.succeed(
+        Bus.Service,
+        Bus.Service.of({
+          publish: () => Effect.void,
+        } as any),
+      ),
+    )
+
+    const rt = ManagedRuntime.make(SessionSummary.layer.pipe(Layer.provide(layer)))
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const body = SessionSummary.Service.use((svc) => svc.summarize({ sessionID, messageID: userID }))
+          const a = rt.runPromise(body)
+          const b = rt.runPromise(body)
+          await Bun.sleep(10)
+          expect(messageCalls).toBe(1)
+          expect(diffCalls).toBe(1)
+          gate.resolve()
+          await Promise.all([a, b])
+        },
+      })
+    } finally {
+      await rt.dispose()
+    }
+
+    expect(summaryCalls).toBe(1)
+    expect(updateCalls).toBe(1)
+  })
+})

--- a/packages/opencode/test/util/queue.test.ts
+++ b/packages/opencode/test/util/queue.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { AsyncQueue } from "../../src/util/queue"
+
+describe("AsyncQueue", () => {
+  test("preserves order across many dequeues", async () => {
+    const q = new AsyncQueue<number>()
+
+    for (let i = 0; i < 5000; i++) q.push(i)
+
+    for (let i = 0; i < 5000; i++) {
+      expect(await q.next()).toBe(i)
+    }
+  })
+
+  test("delivers pushed values to waiting readers", async () => {
+    const q = new AsyncQueue<string>()
+    const next = q.next()
+
+    q.push("ok")
+
+    expect(await next).toBe("ok")
+  })
+})


### PR DESCRIPTION
## Summary
- dedupe identical in-flight `SessionSummary.summarize()` calls so concurrent summary work shares one computation instead of re-reading messages and re-running snapshot diffs in parallel
- replace `AsyncQueue`'s `Array.shift()` dequeue path with a head-index queue to remove O(n) copies from hot SSE / event / TUI delivery paths
- avoid rereading persisted tool parts during `SessionProcessor` cleanup by using the in-memory `ctx.toolcalls` map that already tracks active tool calls

## Why
The current opencode hot path still pays for a few avoidable costs in high-frequency paths:
- summary generation can be triggered concurrently for the same `{sessionID, messageID}` pair, which duplicates message hydration and diff work
- queue consumers pay repeated `shift()` costs during sustained event delivery
- processor cleanup rereads message parts that are already available in memory

None of these change the user-visible model behavior. The goal here is to shave redundant work from core loop infrastructure while preserving fault tolerance and existing tool-loop semantics.

## What changed
### 1. Single-flight session summary work
`packages/opencode/src/session/summary.ts`
- adds per-instance summary state through `InstanceState`
- uses `Effect` `Cache.make()` to share one in-flight summarize operation per `[sessionID, messageID]`
- invalidates the cache entry after completion so this remains single-flight work sharing rather than long-lived result caching
- keeps the rest of the summary pipeline unchanged: session summary aggregation, stored diff write, diff event publish, and user-message summary update

`packages/opencode/test/session/summary.test.ts`
- adds a regression test that fires two concurrent summarize calls
- verifies only one message load and one diff computation happen

### 2. O(1) queue dequeue path
`packages/opencode/src/util/queue.ts`
- adds a queue head index instead of removing from the front of the array with `shift()`
- compacts the backing array only when enough items have been consumed to make compaction worthwhile
- keeps ordering semantics and waiter handoff behavior unchanged

`packages/opencode/test/util/queue.test.ts`
- verifies long ordered dequeue behavior
- verifies waiting readers still receive pushed values correctly

### 3. Processor cleanup avoids redundant reads
`packages/opencode/src/session/processor.ts`
- cleanup now iterates the in-memory `ctx.toolcalls` map rather than rereading all parts for the assistant message
- only unfinished in-memory tool calls are converted to terminal error state during abort / cleanup
- explicitly leaves the existing doom-loop detection semantics intact

## Scope
This PR is intentionally limited to `packages/opencode/**` hot-path infrastructure.
It does **not** include the unrelated local `packages/console/**` changes currently present in my working tree.

## Validation
### Typecheck
Run from `packages/opencode`:
- `bun typecheck`

### Targeted tests
Run from `packages/opencode`:
- `bun test test/session/summary.test.ts test/util/queue.test.ts test/session/processor-effect.test.ts`

Result:
- all targeted tests passed

### Manual QA
Run from `packages/opencode`:
- `bun -e 'import { AsyncQueue } from "./src/util/queue"; const q = new AsyncQueue(); q.push("a"); q.push("b"); console.log([await q.next(), await q.next()].join(","))'`
  - output: `a,b`
- summary single-flight probe against `SessionSummary.layer`
  - output: `summary_messages:1`
  - output: `summary_calls:1`

### Microbench checks
Run from `packages/opencode`:
- queue comparison over 200000 push+pop operations
  - `shift:18.13ms`
  - `idx:12.73ms`
- warmed tool-registry benchmark used during validation of the broader hot-path investigation
  - `warm_same:24.12ms`
  - `vary_agent:32.38ms`

## Trade-offs / things to watch
- summary single-flight state is bounded to 1024 keys and invalidated after completion, so it should not become a persistent result cache
- queue compaction trades occasional slice work for much cheaper steady-state dequeue behavior
- processor cleanup now trusts the authoritative in-memory in-flight tool map during teardown, which is the same state the stream handler mutates during execution

## Follow-up measurement plan
After merge, the next useful measurement is an end-to-end agent-loop benchmark on a fixed fixture repo that captures:
- wall-clock latency per loop iteration
- CPU time
- RSS / heap growth under repeated runs
- count of summary invocations and tool-cleanup reads

That follow-up would quantify how much these micro-optimizations move real session throughput under realistic load.