### PR TITLE
fix: handle outputSchema compilation errors in MCP tool discovery

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -4,6 +4,8 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import type { jsonSchemaValidator as JsonSchemaValidatorProvider, JsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/types.js"
 import {
   CallToolResultSchema,
   type Tool as MCPToolDef,
@@ -29,6 +31,29 @@ import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
+
+/**
+ * Wraps AjvJsonSchemaValidator to catch schema compilation errors.
+ * opencode doesn't validate tool output schemas, so compilation failures
+ * (e.g. from complex or unsupported schemas) should not prevent tool discovery.
+ */
+class TolerantJsonSchemaValidator implements JsonSchemaValidatorProvider {
+  private inner = new AjvJsonSchemaValidator()
+
+  getValidator<T>(schema: any): JsonSchemaValidator<T> {
+    try {
+      return this.inner.getValidator<T>(schema)
+    } catch {
+      return (input: unknown) => ({
+        valid: true as const,
+        data: input as T,
+        errorMessage: undefined,
+      })
+    }
+  }
+}
+
+const tolerantValidator = new TolerantJsonSchemaValidator()
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -260,7 +285,7 @@ export namespace MCP {
           (t) =>
             Effect.tryPromise({
               try: () => {
-                const client = new Client({ name: "opencode", version: Installation.VERSION })
+                const client = new Client({ name: "opencode", version: Installation.VERSION }, { jsonSchemaValidator: tolerantValidator })
                 return withTimeout(client.connect(t), timeout).then(() => client)
               },
               catch: (e) => (e instanceof Error ? e : new Error(String(e))),
@@ -743,7 +768,7 @@ export namespace MCP {
 
         return yield* Effect.tryPromise({
           try: () => {
-            const client = new Client({ name: "opencode", version: Installation.VERSION })
+            const client = new Client({ name: "opencode", version: Installation.VERSION }, { jsonSchemaValidator: tolerantValidator })
             return client.connect(transport).then(() => ({ authorizationUrl: "", oauthState }))
           },
           catch: (error) => error,


### PR DESCRIPTION
## Summary

When an MCP server returns `outputSchema` in its `tools/list` response, the SDK's default `AjvJsonSchemaValidator` can throw during schema compilation via `ajv.compile()`. This error propagates through `listTools()` → `cacheToolMetadata()`, causing opencode's `defs()` function to catch the error and return `undefined`, which results in the server being marked as "Failed to get tools".

opencode doesn't use output schemas at all — only `inputSchema` is read in `convertMcpTool()`. So validation failures on `outputSchema` should never prevent tool discovery.

**Fix:** Create a `TolerantJsonSchemaValidator` that wraps `AjvJsonSchemaValidator` with try/catch in `getValidator()`. On compilation failure, returns a permissive fallback validator. Pass it to both `new Client()` calls via the SDK's `jsonSchemaValidator` option.

- 1 file changed: `packages/opencode/src/mcp/index.ts`
- 27 insertions, 2 deletions

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Config tests pass (144/144, 0 failures)
- [x] Static code path trace confirms the fix intercepts the exact throw site
- [x] SDK `Client` constructor correctly receives custom validator (verified via SDK source)

Closes #21373