### PR TITLE
feat(mcp): forward plugin-set _meta to downstream MCP tool calls

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -144,11 +144,13 @@ export namespace MCP {
     return dynamicTool({
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
-      execute: async (args: unknown) => {
+      execute: async (args: unknown, opts?) => {
+        const meta = (opts as any)?._meta as Record<string, unknown> | undefined
         return client.callTool(
           {
             name: mcpTool.name,
             arguments: (args || {}) as Record<string, unknown>,
+            ...(meta ? { _meta: meta } : {}),
           },
           CallToolResultSchema,
           {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -483,14 +483,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             Effect.runPromise(
               Effect.gen(function* () {
                 const ctx = context(args, opts)
+                const hookOutput: { args: unknown; _meta?: Record<string, unknown> } = { args }
                 yield* plugin.trigger(
                   "tool.execute.before",
                   { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
-                  { args },
+                  hookOutput,
                 )
                 yield* Effect.promise(() => ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] }))
                 const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
-                  execute(args, opts),
+                  execute(hookOutput.args, { ...opts, _meta: hookOutput._meta } as typeof opts),
                 )
                 yield* plugin.trigger(
                   "tool.execute.after",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -231,7 +231,7 @@ export interface Hooks {
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },
-    output: { args: any },
+    output: { args: any; _meta?: Record<string, unknown> },
   ) => Promise<void>
   "shell.env"?: (
     input: { cwd: string; sessionID?: string; callID?: string },


### PR DESCRIPTION
### Issue for this PR

Closes #17084

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins can mutate `args` in `tool.execute.before` but there's no way to set `_meta` on downstream MCP `tools/call` requests. I need this to forward correlation IDs to my MCP servers without stuffing them into tool arguments.

This adds `_meta` as an optional field on the `tool.execute.before` hook output. If a plugin sets it, it gets forwarded in `client.callTool()`. When no plugin sets it, nothing changes.

### How did you verify your code works?

Built with `bun run build -- --single`, called MCP tools through a proxy server, confirmed `_meta` shows up in the JSON-RPC request when set by a plugin and is absent when not.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR