### PR TITLE
fix: Sub-Agent permissions override

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1311,13 +1311,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const message = yield* createUserMessage(input)
           yield* sessions.touch(input.sessionID)
 
+          const sessionPerms = session.permission ?? []
           const permissions: Permission.Ruleset = []
           for (const [t, enabled] of Object.entries(input.tools ?? {})) {
             permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
           }
-          if (permissions.length > 0) {
-            session.permission = permissions
-            yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+          const merged = Permission.merge(sessionPerms, permissions)
+          if (merged.length > 0) {
+            session.permission = merged
+            yield* sessions.setPermission({ sessionID: session.id, permission: merged })
           }
 
           if (input.noReply === true) return message

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -56,6 +56,9 @@ export const TaskTool = Tool.define("task", async () => {
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
       const hasTodoWritePermission = agent.permission.some((rule) => rule.permission === "todowrite")
 
+      const parent = await Session.get(ctx.sessionID).catch(() => {})
+      const parentPerms = parent?.permission ?? []
+
       const session = await iife(async () => {
         if (params.task_id) {
           const found = await Session.get(SessionID.make(params.task_id)).catch(() => {})
@@ -66,6 +69,7 @@ export const TaskTool = Tool.define("task", async () => {
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
           permission: [
+            ...parentPerms,
             ...(hasTodoWritePermission
               ? []
               : [


### PR DESCRIPTION
### fix: Sub-Agents permissions override
[Plan mode restrictions bypassed when spawning sub-agents](https://github.com/anomalyco/opencode/compare/dev...nightguarder:opencode:fix/6527-subagent-permissions?expand=1#top)

Fixes #6527 

Closes #6527

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes sub-agent permission bypass: when spawning sub-agents from Plan mode, they now inherit the parent session's permissions (including `edit: deny`). Previously, sub-agents ran with full permissions and could edit files despite Plan mode being active.

Changes:
1. **task.ts**: Inherit parent session permissions when creating child session
2. In task.ts, we get parent permissions and pass them to child session creation
3. **prompt.ts**: Merge existing session permissions with tools flags instead of replacing
4. In prompt.ts we ensure the permissions get merged - not replaced with input.tools flag



### How did you verify your code works?

- [x] Code compiles and follows existing patterns
- [x] Follows the same permission merge logic used elsewhere in the codebase