### PR TITLE
fix: nested error message extraction and text part timing

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -65,7 +65,7 @@ export namespace ProviderError {
       try {
         const body = JSON.parse(e.responseBody)
         // try to extract common error message fields
-        const errMsg = body.message || body.error || body.error?.message
+        const errMsg = body.message || (typeof body.error === "string" ? body.error : body.error?.message)
         if (errMsg && typeof errMsg === "string") {
           return `${msg}: ${errMsg}`
         }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -349,7 +349,7 @@ export namespace SessionProcessor {
                 },
                 { text: ctx.currentText.text },
               )).text
-              ctx.currentText.time = { start: Date.now(), end: Date.now() }
+              ctx.currentText.time = { start: ctx.currentText.time?.start ?? Date.now(), end: Date.now() }
               if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
               yield* session.updatePart(ctx.currentText)
               ctx.currentText = undefined


### PR DESCRIPTION
## Summary

Fixes two related bugs that degrade error reporting quality and timing accuracy:

- **Error message extraction** (`provider/error.ts`): When `body.error` is an object (standard OpenAI/Anthropic API format), `||` short-circuits and selects the truthy object, causing `typeof errMsg === "string"` to fail. Now checks `typeof body.error` before selecting the value.
- **Text part timing** (`session/processor.ts`): The `text-end` handler overwrites the real start time from `text-start` with `Date.now()`, making start and end identical. Now preserves the original start time, consistent with the cleanup handler at line 385.

Fixes #21544

## Test plan

- [ ] Trigger an API error with a provider that returns `{ error: { message: "...", type: "..." } }` format (e.g., OpenAI with invalid key) -- verify the error message is clean, not a raw JSON dump
- [ ] Trigger an API error with a provider that returns `{ error: "string message" }` format -- verify the string error message is still extracted correctly
- [ ] Send a message and check that text parts have distinct start/end times reflecting actual generation duration