### PR TITLE
fix: save pasted clipboard images to temp files to support MCP tools (#14673)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -2,7 +2,9 @@ import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, decodePasteB
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
+import fs from "fs/promises"
+import { tmpdir } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { useLocal } from "@tui/context/local"
 import { useTheme } from "@tui/context/theme"
@@ -789,14 +791,28 @@ export function Prompt(props: PromptProps) {
       typeId: promptPartTypeId,
     })
 
+    let url = `data:${file.mime};base64,${file.content}`
+    let filepath = file.filepath
+
+    if (!filepath && file.mime.startsWith("image/")) {
+      const ext = file.mime.split("/")[1] ?? "png"
+      filepath = path.join(tmpdir(), `opencode-paste-${Date.now()}.${ext}`)
+      try {
+        await fs.writeFile(filepath, Buffer.from(file.content, "base64"))
+        url = pathToFileURL(filepath).href
+      } catch (err) {
+        console.error("Failed to save pasted image:", err)
+      }
+    }
+
     const part: Omit<FilePart, "id" | "messageID" | "sessionID"> = {
       type: "file" as const,
       mime: file.mime,
       filename: file.filename,
-      url: `data:${file.mime};base64,${file.content}`,
+      url,
       source: {
         type: "file",
-        path: file.filepath ?? file.filename ?? "",
+        path: filepath ?? file.filename ?? "",
         text: {
           start: extmarkStart,
           end: extmarkEnd,


### PR DESCRIPTION
### Issue for this PR

Closes #14673

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently, when an image is pasted from the clipboard into the prompt, it gets converted to a Base64 data URL and sent directly to the language model. While this works for multimodal models, it breaks workflows where non-vision models (like GLM-5.1) rely on external MCP tools (like `zai-vision`) because these tools typically expect a valid file path on disk, not a raw Base64 string.

This PR modifies the `pasteAttachment` function in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`. 
When an image is pasted from the clipboard (i.e. no `filepath` exists), it:
1. Writes the base64 content to a temporary file in `os.tmpdir()`.
2. Uses the newly created temporary file path (`file://...`) as the attachment URL.

### How did you verify your code works?

Compiled `opencode` locally (`bun run build`), confirmed that pasting images from clipboard now creates a temporary image file under `/tmp`, and verified that MCP servers can now read these files properly without throwing Base64 parsing errors.

### Screenshots / recordings



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._