### PR TITLE
feat(opencode): add threshold-based compaction via maxTurns config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1015,6 +1015,12 @@ export namespace Config {
             .min(0)
             .optional()
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
+          maxTurns: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Trigger compaction every N agent turns regardless of context size (default: disabled)"),
         })
         .optional(),
       experimental: z

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -18,7 +18,7 @@ import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect, Layer, ServiceMap } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import { InstanceState } from "@/effect/instance-state"
-import { isOverflow as overflow } from "./overflow"
+import { isOverflow as overflow, isThresholdReached as thresholdReached } from "./overflow"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -41,6 +41,7 @@ export namespace SessionCompaction {
       tokens: MessageV2.Assistant["tokens"]
       model: Provider.Model
     }) => Effect.Effect<boolean>
+    readonly isThresholdReached: (input: { turnsSinceCompaction: number }) => Effect.Effect<boolean>
     readonly prune: (input: { sessionID: SessionID }) => Effect.Effect<void>
     readonly process: (input: {
       parentID: MessageID
@@ -86,6 +87,12 @@ export namespace SessionCompaction {
         model: Provider.Model
       }) {
         return overflow({ cfg: yield* config.get(), tokens: input.tokens, model: input.model })
+      })
+
+      const isThresholdReached = Effect.fn("SessionCompaction.isThresholdReached")(function* (input: {
+        turnsSinceCompaction: number
+      }) {
+        return thresholdReached({ cfg: yield* config.get(), turnsSinceCompaction: input.turnsSinceCompaction })
       })
 
       // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
@@ -372,6 +379,7 @@ When constructing the summary, try to stick to this template:
 
       return Service.of({
         isOverflow,
+        isThresholdReached,
         prune,
         process: processCompaction,
         create,
@@ -397,6 +405,10 @@ When constructing the summary, try to stick to this template:
 
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     return runPromise((svc) => svc.isOverflow(input))
+  }
+
+  export async function isThresholdReached(input: { turnsSinceCompaction: number }) {
+    return runPromise((svc) => svc.isThresholdReached(input))
   }
 
   export async function prune(input: { sessionID: SessionID }) {

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -20,3 +20,8 @@ export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistan
     : context - ProviderTransform.maxOutputTokens(input.model)
   return count >= usable
 }
+
+export function isThresholdReached(input: { cfg: Config.Info; turnsSinceCompaction: number }) {
+  const maxTurns = input.cfg.compaction?.maxTurns
+  return maxTurns !== undefined && input.turnsSinceCompaction >= maxTurns
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1341,6 +1341,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const ctx = yield* InstanceState.context
           let structured: unknown | undefined
           let step = 0
+          let turnsSinceCompaction = 0
           const session = yield* sessions.get(sessionID)
 
           while (true) {
@@ -1417,6 +1418,17 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
             ) {
               yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+              turnsSinceCompaction = 0
+              continue
+            }
+
+            if (
+              lastFinished &&
+              lastFinished.summary !== true &&
+              (yield* compaction.isThresholdReached({ turnsSinceCompaction }))
+            ) {
+              yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+              turnsSinceCompaction = 0
               continue
             }
 
@@ -1550,6 +1562,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     auto: true,
                     overflow: !handle.message.finish,
                   })
+                  turnsSinceCompaction = 0
                 }
                 return "continue" as const
               }),
@@ -1558,6 +1571,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 yield* InstanceState.withALS(() => instruction.clear(handle.message.id)).pipe(Effect.flatMap((x) => x))
               }),
             )
+            turnsSinceCompaction++
             if (outcome === "break") break
             continue
           }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -431,6 +431,53 @@ describe("session.compaction.isOverflow", () => {
   })
 })
 
+describe("session.compaction.isThresholdReached", () => {
+  test("returns false when maxTurns is not configured", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 5 })).toBe(false)
+      },
+    })
+  })
+
+  test("returns true when turnsSinceCompaction reaches maxTurns", async () => {
+    await using tmp = await tmpdir({ config: { compaction: { maxTurns: 3 } } })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 3 })).toBe(true)
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 4 })).toBe(true)
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 10 })).toBe(true)
+      },
+    })
+  })
+
+  test("returns false when turnsSinceCompaction is below maxTurns", async () => {
+    await using tmp = await tmpdir({ config: { compaction: { maxTurns: 3 } } })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 0 })).toBe(false)
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 1 })).toBe(false)
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 2 })).toBe(false)
+      },
+    })
+  })
+
+  test("returns false for turnsSinceCompaction 0 even with maxTurns 1", async () => {
+    await using tmp = await tmpdir({ config: { compaction: { maxTurns: 1 } } })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 0 })).toBe(false)
+        expect(await SessionCompaction.isThresholdReached({ turnsSinceCompaction: 1 })).toBe(true)
+      },
+    })
+  })
+})
+
 describe("session.compaction.create", () => {
   test("creates a compaction user message and part", async () => {
     await using tmp = await tmpdir()


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `compaction.maxTurns` config option that triggers proactive context compaction every N agent turns, regardless of how full the context window is.

The existing compaction strategy is purely reactive — it fires only when token usage approaches the model's context limit. This works for overflow prevention but leaves sessions that accumulate irrelevant context over many turns untouched until they hit the limit. `maxTurns` fills that gap by letting users set a fixed compaction cadence.

**Implementation details:**

- `overflow.ts`: new `isThresholdReached()` pure function, symmetric with the existing `isOverflow()` — reads `cfg.compaction.maxTurns` and returns true when `turnsSinceCompaction >= maxTurns`
- `compaction.ts`: exposes `isThresholdReached` on the `SessionCompaction` service interface and as a standalone async export
- `config.ts`: adds `maxTurns` (optional positive integer) to the compaction config schema
- `prompt.ts`: introduces a dedicated `turnsSinceCompaction` counter in the run loop — increments only after real LLM turns complete, resets whenever any compaction is triggered. The threshold check sits after the overflow check and is guarded by `lastFinished.summary !== true` to avoid triggering immediately after a compaction message.

### How did you verify your code works?

- Added 4 unit tests in `test/session/compaction.test.ts` covering: disabled (no config), exact boundary (`turnsSinceCompaction === maxTurns`), below threshold, and edge case (`maxTurns: 1`)
- `bun test test/session/compaction.test.ts` — 42/42 pass
- `bun turbo typecheck` — 0 errors across all packages
- Manually traced the loop execution to verify the counter semantics (increments only on LLM turns, not on compaction-processing iterations)

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR