### PR TITLE
fix(session): sort messages by creation time instead of id

### DIFF
--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "solid-js"
 import { useSync } from "@/context/sync"
 import { checksum } from "@opencode-ai/shared/util/encode"
 import { findLast } from "@opencode-ai/shared/util/array"
+import { sortMessages } from "@opencode-ai/shared/util/message"
 import { same } from "@/utils/same"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Accordion } from "@opencode-ai/ui/accordion"
@@ -102,7 +103,7 @@ export function SessionContextTab() {
     () => {
       const id = params.id
       if (!id) return emptyMessages
-      return (sync.data.message[id] ?? []) as Message[]
+      return sortMessages((sync.data.message[id] ?? []) as Message[])
     },
     emptyMessages,
     { equals: same },

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -346,6 +346,8 @@ export default function Page() {
 
   const [ui, setUi] = createStore({
     pendingMessage: undefined as string | undefined,
+    restoring: undefined as string | undefined,
+    reverting: false,
     reviewSnap: false,
     scrollGesture: 0,
     scroll: {
@@ -448,7 +450,11 @@ export default function Page() {
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
   const revertMessageID = createMemo(() => info()?.revert?.messageID)
-  const messages = createMemo(() => (params.id ? (sync.data.message[params.id] ?? []) : []))
+  const messages = createMemo(() => {
+    const id = params.id
+    if (!id) return []
+    return sync.data.message[id] ?? []
+  })
   const messagesReady = createMemo(() => {
     const id = params.id
     if (!id) return true
@@ -473,7 +479,8 @@ export default function Page() {
     () => {
       const revert = revertMessageID()
       if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
+      const idx = userMessages().findIndex((m) => m.id === revert)
+      return idx >= 0 ? userMessages().slice(0, idx) : userMessages()
     },
     emptyUserMessages,
     {
@@ -757,7 +764,7 @@ export default function Page() {
       )
       return
     }
-    const at = list.findIndex((item) => item.id > next.id)
+    const at = list.findIndex((item) => item.id.localeCompare(next.id) > 0)
     if (at >= 0) {
       globalSync.set("project", [...list.slice(0, at), next, ...list.slice(at)])
       return
@@ -1785,16 +1792,58 @@ export default function Page() {
   }
 
   const restore = (id: string) => {
-    if (!params.id || reverting()) return
-    return restoreMutation.mutateAsync(id)
+    const sessionID = params.id
+    if (!sessionID || ui.restoring || ui.reverting) return
+
+    const idx = userMessages().findIndex((m) => m.id === id)
+    const next = idx >= 0 ? userMessages()[idx + 1] : undefined
+    const prev = prompt.current().slice()
+    const last = info()?.revert
+
+    batch(() => {
+      setUi("restoring", id)
+      setUi("reverting", true)
+      roll(sessionID, next ? { messageID: next.id } : undefined)
+      if (next) {
+        prompt.set(draft(next.id))
+        return
+      }
+      prompt.reset()
+    })
+
+    const task = !next
+      ? halt(sessionID).then(() => sdk.client.session.unrevert({ sessionID }))
+      : halt(sessionID).then(() =>
+          sdk.client.session.revert({
+            sessionID,
+            messageID: next.id,
+          }),
+        )
+
+    return task
+      .then((result) => {
+        if (result.data) merge(result.data)
+      })
+      .catch((err) => {
+        batch(() => {
+          roll(sessionID, last)
+          prompt.set(prev)
+        })
+        fail(err)
+      })
+      .finally(() => {
+        batch(() => {
+          setUi("restoring", (value) => (value === id ? undefined : value))
+          setUi("reverting", false)
+        })
+      })
   }
 
   const rolled = createMemo(() => {
     const id = revertMessageID()
     if (!id) return []
-    return userMessages()
-      .filter((item) => item.id >= id)
-      .map((item) => ({ id: item.id, text: line(item.id) }))
+    const idx = userMessages().findIndex((m) => m.id === id)
+    return (idx >= 0 ? userMessages().slice(idx) : []).map((item) => ({ id: item.id, text: line(item.id) }))
   })
 
   const actions = { revert }
@@ -1926,7 +1975,7 @@ export default function Page() {
           <div class="flex-1 min-h-0 overflow-hidden">
             <Switch>
               <Match when={params.id}>
-                <Show when={messagesReady()}>
+                <Show when={messagesReady()} fallback={<div class="h-full" />}>
                   <MessageTimeline
                     mobileChanges={mobileChanges()}
                     mobileFallback={reviewContent({

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -15,8 +15,8 @@ import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { TextField } from "@opencode-ai/ui/text-field"
 import type { AssistantMessage, Message as MessageType, Part, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { showToast } from "@opencode-ai/ui/toast"
-import { Binary } from "@opencode-ai/shared/util/binary"
 import { getFilename } from "@opencode-ai/shared/util/path"
+import { sortMessages } from "@opencode-ai/shared/util/message"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
@@ -247,7 +247,7 @@ export function MessageTimeline(props: {
   const sessionMessages = createMemo(() => {
     const id = sessionID()
     if (!id) return emptyMessages
-    return sync.data.message[id] ?? emptyMessages
+    return sortMessages(sync.data.message[id] ?? emptyMessages)
   })
   const pending = createMemo(() =>
     sessionMessages().findLast(
@@ -281,8 +281,7 @@ export function MessageTimeline(props: {
     const parentID = pending()?.parentID
     if (parentID) {
       const messages = sessionMessages()
-      const result = Binary.search(messages, parentID, (message) => message.id)
-      const message = result.found ? messages[result.index] : messages.find((item) => item.id === parentID)
+      const message = messages.find((item) => item.id === parentID)
       if (message && message.role === "user") return message.id
     }
 
@@ -1024,6 +1023,15 @@ export function MessageTimeline(props: {
               <For each={rendered()}>
                 {(messageID) => {
                   const active = createMemo(() => activeMessageID() === messageID)
+                  const queued = createMemo(() => {
+                    if (active()) return false
+                    const activeID = activeMessageID()
+                    if (!activeID) return false
+                    const ids = rendered()
+                    const activeIdx = ids.indexOf(activeID)
+                    if (activeIdx === -1) return false
+                    return ids.indexOf(messageID) > activeIdx
+                  })
                   const comments = createMemo(() => messageComments(sync.data.part[messageID] ?? []), [], {
                     equals: (a, b) =>
                       a.length === b.length &&

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@solidjs/router"
+import { createMemo } from "solid-js"
 import { useCommand, type CommandOption } from "@/context/command"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { previewSelectedLines } from "@opencode-ai/ui/pierre/selection-bridge"
@@ -14,6 +15,7 @@ import { useTerminal } from "@/context/terminal"
 import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/shared/util/array"
 import { createSessionTabs } from "@/pages/session/helpers"
+import { sortMessages } from "@opencode-ai/shared/util/message"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -68,18 +70,14 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const closableTab = tabState.closableTab
 
   const idle = { type: "idle" as const }
-  const status = () => sync.data.session_status[params.id ?? ""] ?? idle
-  const messages = () => {
-    const id = params.id
-    if (!id) return []
-    return sync.data.message[id] ?? []
-  }
-  const userMessages = () => messages().filter((m) => m.role === "user") as UserMessage[]
-  const visibleUserMessages = () => {
+  const status = createMemo(() => sync.data.session_status[params.id ?? ""] ?? idle)
+  const messages = createMemo(() => sortMessages(params.id ? (sync.data.message[params.id] ?? []) : []))
+  const userMessages = createMemo(() => messages().filter((m) => m.role === "user") as UserMessage[])
+  const visibleUserMessages = createMemo(() => {
     const revert = info()?.revert?.messageID
     if (!revert) return userMessages()
     return userMessages().filter((m) => m.id < revert)
-  }
+  })
 
   const showAllFiles = () => {
     if (layout.fileTree.tab() !== "changes") return

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -76,7 +76,8 @@ export namespace SessionRevert {
         if (session.revert?.snapshot) yield* snap.restore(session.revert.snapshot)
         yield* snap.revert(patches)
         if (rev.snapshot) rev.diff = yield* snap.diff(rev.snapshot as string)
-        const range = all.filter((msg) => msg.info.id >= rev!.messageID)
+        const idx = all.findIndex((msg) => msg.info.id === rev!.messageID)
+        const range = idx >= 0 ? all.slice(idx) : all
         const diffs = yield* summary.computeDiff({ messages: range })
         yield* storage.write(["session_diff", input.sessionID], diffs).pipe(Effect.ignore)
         yield* bus.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: diffs })
@@ -109,17 +110,21 @@ export namespace SessionRevert {
         const messageID = session.revert.messageID
         const remove = [] as MessageV2.WithParts[]
         let target: MessageV2.WithParts | undefined
-        for (const msg of msgs) {
-          if (msg.info.id < messageID) continue
-          if (msg.info.id > messageID) {
+        const idx = msgs.findIndex((msg) => msg.info.id === messageID)
+        if (idx >= 0) {
+          for (let i = 0; i < msgs.length; i++) {
+            const msg = msgs[i]!
+            if (i < idx) continue
+            if (i > idx) {
+              remove.push(msg)
+              continue
+            }
+            if (session.revert.partID) {
+              target = msg
+              continue
+            }
             remove.push(msg)
-            continue
           }
-          if (session.revert.partID) {
-            target = msg
-            continue
-          }
-          remove.push(msg)
         }
         for (const msg of remove) {
           SyncEvent.run(MessageV2.Event.Removed, {

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -178,3 +178,51 @@ describe("session.prompt_async error handling", () => {
     expect(route).toContain("Bus.publish(Session.Event.Error")
   })
 })
+
+describe("message ordering", () => {
+  test("returns messages in reverse chronological order", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await withoutWatcher(() =>
+      Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          // Insert with out-of-order timestamps
+          const times = [300, 100, 200]
+          const ids = [] as MessageID[]
+          for (const t of times) {
+            const id = MessageID.ascending()
+            ids.push(id)
+            await Session.updateMessage({
+              id,
+              sessionID: session.id,
+              role: "user",
+              time: { created: t },
+              agent: "test",
+              model: { providerID: "test", modelID: "test" },
+              tools: {},
+              mode: "",
+            } as unknown as MessageV2.Info)
+            await Session.updatePart({
+              id: PartID.ascending(),
+              sessionID: session.id,
+              messageID: id,
+              type: "text",
+              text: `t${t}`,
+            })
+          }
+
+          const app = Server.Default().app
+          const res = await app.request(`/session/${session.id}/message`)
+          expect(res.status).toBe(200)
+          const body = (await res.json()) as MessageV2.WithParts[]
+          const order = body.map((m) => m.info.time.created)
+          // API returns oldest-first (page internally queries desc for cursor, then returns items)
+          expect(order).toEqual([100, 200, 300])
+
+          await Session.remove(session.id)
+        },
+      }),
+    )
+  })
+})

--- a/packages/opencode/test/session/fixtures/skewed-messages.ts
+++ b/packages/opencode/test/session/fixtures/skewed-messages.ts
@@ -1,0 +1,81 @@
+import { Identifier } from "../../../src/id/id"
+import { MessageV2 } from "../../../src/session/message-v2"
+import { MessageID, SessionID } from "../../../src/session/schema"
+import { ModelID, ProviderID } from "../../../src/provider/schema"
+
+export function makeUser(id: MessageID, opts?: Partial<MessageV2.User>): MessageV2.User {
+  return {
+    id,
+    sessionID: SessionID.make("test-session"),
+    role: "user",
+    time: { created: Date.now() },
+    agent: "default",
+    model: {
+      providerID: ProviderID.openai,
+      modelID: ModelID.make("gpt-4"),
+    },
+    ...opts,
+  }
+}
+
+export function makeAssistant(
+  id: MessageID,
+  parentID: MessageID,
+  opts?: Partial<MessageV2.Assistant>,
+): MessageV2.Assistant {
+  return {
+    id,
+    sessionID: SessionID.make("test-session"),
+    role: "assistant",
+    parentID,
+    time: { created: Date.now() },
+    modelID: ModelID.make("gpt-4"),
+    providerID: ProviderID.openai,
+    mode: "default",
+    agent: "default",
+    path: {
+      cwd: "/tmp",
+      root: "/tmp",
+    },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: {
+        read: 0,
+        write: 0,
+      },
+    },
+    finish: "stop",
+    ...opts,
+  }
+}
+
+export function aheadPair(): {
+  user: MessageV2.User
+  assistant: MessageV2.Assistant
+} {
+  const now = Date.now()
+  const userID = MessageID.make(Identifier.create("message", "ascending", now + 60_000))
+  const assistantID = MessageID.make(Identifier.create("message", "ascending", now))
+
+  return {
+    user: makeUser(userID),
+    assistant: makeAssistant(assistantID, userID),
+  }
+}
+
+export function behindPair(): {
+  user: MessageV2.User
+  assistant: MessageV2.Assistant
+} {
+  const now = Date.now()
+  const userID = MessageID.make(Identifier.create("message", "ascending", now - 60_000))
+  const assistantID = MessageID.make(Identifier.create("message", "ascending", now))
+
+  return {
+    user: makeUser(userID),
+    assistant: makeAssistant(assistantID, userID),
+  }
+}

--- a/packages/shared/src/util/message.ts
+++ b/packages/shared/src/util/message.ts
@@ -1,0 +1,44 @@
+type Message = {
+  id: string
+  role?: string
+  parentID?: string
+  time?: {
+    created?: number
+  }
+}
+
+function rank(message: Message) {
+  if (message.role === "user") return 0
+  if (message.role === "assistant") return 1
+  return 2
+}
+
+export function compareMessages(a: Message, b: Message) {
+  const at = a.time?.created ?? 0
+  const bt = b.time?.created ?? 0
+  if (at !== bt) return at - bt
+
+  const ar = rank(a)
+  const br = rank(b)
+  if (ar !== br) return ar - br
+
+  if (a.id < b.id) return -1
+  if (a.id > b.id) return 1
+  return 0
+}
+
+export function sortMessages<T extends Message>(messages: readonly T[]) {
+  return messages.slice().sort(compareMessages)
+}
+
+export function selectAssistants<T extends Message>(messages: readonly T[], parentID: string) {
+  return sortMessages(messages.filter((message) => message.role === "assistant" && message.parentID === parentID))
+}
+
+export function splitMessages<T extends Message>(messages: readonly T[], markerID?: string) {
+  const sorted = sortMessages(messages)
+  if (!markerID) return { before: sorted, after: [] as T[] }
+  const index = sorted.findIndex((message) => message.id === markerID)
+  if (index === -1) return { before: sorted, after: [] as T[] }
+  return { before: sorted.slice(0, index), after: sorted.slice(index) }
+}

--- a/packages/shared/test/util/message.test.ts
+++ b/packages/shared/test/util/message.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { selectAssistants, sortMessages, splitMessages } from "@opencode-ai/shared/util/message"
+
+describe("message", () => {
+  test("sortMessages uses created time before id", () => {
+    const result = sortMessages([
+      { id: "msg_z", role: "assistant", time: { created: 20 } },
+      { id: "msg_a", role: "user", time: { created: 10 } },
+    ])
+    expect(result.map((item) => item.id)).toEqual(["msg_a", "msg_z"])
+  })
+
+  test("selectAssistants finds replies even when assistant id sorts before user id", () => {
+    const result = selectAssistants(
+      [
+        { id: "msg_user", role: "user", time: { created: 10 } },
+        { id: "msg_assistant", role: "assistant", parentID: "msg_user", time: { created: 11 } },
+      ],
+      "msg_user",
+    )
+    expect(result.map((item) => item.id)).toEqual(["msg_assistant"])
+  })
+
+  test("splitMessages uses chronological order instead of id order", () => {
+    const result = splitMessages(
+      [
+        { id: "msg_3", role: "user", time: { created: 30 } },
+        { id: "msg_1", role: "user", time: { created: 10 } },
+        { id: "msg_2", role: "user", time: { created: 20 } },
+      ],
+      "msg_2",
+    )
+    expect(result.before.map((item) => item.id)).toEqual(["msg_1"])
+    expect(result.after.map((item) => item.id)).toEqual(["msg_2", "msg_3"])
+  })
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
     "@kobalte/core": "catalog:",
     "@opencode-ai/sdk": "workspace:*",
     "@opencode-ai/shared": "workspace:*",
+    "@opencode-ai/util": "workspace:*",
     "@pierre/diffs": "catalog:",
     "@shikijs/transformers": "3.9.2",
     "@solid-primitives/bounds": "0.1.3",

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -8,8 +8,8 @@ import type { SessionStatus } from "@opencode-ai/sdk/v2"
 import { useData } from "../context"
 import { useFileComponent } from "../context/file"
 
-import { Binary } from "@opencode-ai/shared/util/binary"
 import { getDirectory, getFilename } from "@opencode-ai/shared/util/path"
+import { sortMessages, selectAssistants } from "@opencode-ai/shared/util/message"
 import { createEffect, createMemo, createSignal, For, on, ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
@@ -154,6 +154,7 @@ export function SessionTurn(
     editToolDefaultOpen?: boolean
     active?: boolean
     status?: SessionStatus
+    queued?: boolean
     onUserInteracted?: () => void
     classes?: {
       root?: string
@@ -172,13 +173,13 @@ export function SessionTurn(
   const emptyDiffs: SnapshotFileDiff[] = []
   const idle = { type: "idle" as const }
 
-  const allMessages = createMemo(() => props.messages ?? list(data.store.message?.[props.sessionID], emptyMessages))
+  const allMessages = createMemo(
+    () => props.messages ?? sortMessages(list(data.store.message?.[props.sessionID], emptyMessages)),
+  )
 
   const messageIndex = createMemo(() => {
-    const messages = allMessages() ?? emptyMessages
-    const result = Binary.search(messages, props.messageID, (m) => m.id)
-
-    const index = result.found ? result.index : messages.findIndex((m) => m.id === props.messageID)
+    const messages = allMessages()
+    const index = messages.findIndex((m) => m.id === props.messageID)
     if (index < 0) return -1
 
     const msg = messages[index]
@@ -209,9 +210,8 @@ export function SessionTurn(
   const pendingUser = createMemo(() => {
     const item = pending()
     if (!item?.parentID) return
-    const messages = allMessages() ?? emptyMessages
-    const result = Binary.search(messages, item.parentID, (m) => m.id)
-    const msg = result.found ? messages[result.index] : messages.find((m) => m.id === item.parentID)
+    const messages = allMessages()
+    const msg = messages.find((m) => m.id === item.parentID)
     if (!msg || msg.role !== "user") return
     return msg
   })
@@ -224,6 +224,17 @@ export function SessionTurn(
     return parent.id === msg.id
   })
 
+  const queued = createMemo(() => {
+    if (typeof props.queued === "boolean") return props.queued
+    const index = messageIndex()
+    if (index < 0) return false
+    if (!pendingUser()) return false
+    const item = pending()
+    if (!item) return false
+    const messages = allMessages()
+    const active = messages.findIndex((m) => m.id === item.parentID)
+    return active >= 0 && index > active
+  })
   const parts = createMemo(() => {
     const msg = message()
     if (!msg) return emptyParts
@@ -265,19 +276,7 @@ export function SessionTurn(
     () => {
       const msg = message()
       if (!msg) return emptyAssistant
-
-      const messages = allMessages() ?? emptyMessages
-      const index = messageIndex()
-      if (index < 0) return emptyAssistant
-
-      const result: AssistantMessage[] = []
-      for (let i = index + 1; i < messages.length; i++) {
-        const item = messages[i]
-        if (!item) continue
-        if (item.role === "user") break
-        if (item.role === "assistant" && item.parentID === msg.id) result.push(item as AssistantMessage)
-      }
-      return result
+      return selectAssistants(allMessages(), msg.id) as AssistantMessage[]
     },
     emptyAssistant,
     { equals: same },


### PR DESCRIPTION
### Issue for this PR

Closes #15657
Closes #17012
Closes #21569

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes session logic that assumed message IDs were chronologically ordered.

The branch sorts session messages by creation time instead of raw ID order, updates revert paths to use index-based selection instead of ID comparisons, and updates the web session page so deep-linked sessions do not crash during initial message loading.

### How did you verify your code works?

- `cd packages/util && bun test src/message.test.ts`
- `cd packages/util && bun typecheck`
- `cd packages/opencode && bun typecheck`
- `cd packages/app && bun typecheck`
- `cd packages/ui && bun typecheck`
- Built-binary smoke test from this branch:
  - deep-linked session page loaded instead of hitting the app error boundary
  - imported/live skewed-message session API returned messages in chronological order

### Screenshots / recordings

Built web session page smoke-tested locally with Playwright after the deep-link crash fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
