### PR TITLE
fix(opencode): guard reasoningSummary for azure in options()

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -825,7 +825,9 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
+        if (input.model.providerID !== "azure") {
+          result["reasoningSummary"] = "auto"
+        }
       }
 
       // Only set textVerbosity for non-chat gpt-5.x models

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -170,6 +170,48 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
   })
 })
 
+describe("ProviderTransform.options - gpt-5 reasoningSummary azure guard", () => {
+  const sessionID = "test-session-123"
+
+  const createGpt5Model = (apiId: string, providerID = "openai", npm = "@ai-sdk/openai") =>
+    ({
+      id: `${providerID}/${apiId}`,
+      providerID,
+      api: {
+        id: apiId,
+        url: "https://api.openai.com",
+        npm,
+      },
+      name: apiId,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.03, output: 0.06, cache: { read: 0.001, write: 0.002 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("openai gpt-5 should have reasoningSummary", () => {
+    const model = createGpt5Model("gpt-5")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningSummary).toBe("auto")
+  })
+
+  test("azure gpt-5 should NOT have reasoningSummary", () => {
+    const model = createGpt5Model("gpt-5", "azure", "@ai-sdk/azure")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningSummary).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 


### PR DESCRIPTION
### Issue for this PR

Closes #21237

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ProviderTransform.options()` sets `reasoningSummary = "auto"` for all gpt-5 models unconditionally. The `textVerbosity` parameter in the same block already has `&& input.model.providerID !== "azure"`, but `reasoningSummary` does not. This adds the same guard.

**Scope note:** `ProviderTransform.variants()` also sets `reasoningSummary` for Azure variants — that's left intentional. The existing test at line 2372 ("standard azure models return custom efforts with reasoningSummary") explicitly expects it, and the default Azure path uses `sdk.responses()` which tolerates the parameter. This PR only fixes the asymmetric default in `options()`, which fires unconditionally regardless of API path.

### How did you verify your code works?

1. Wrote a verification script that imports the real `ProviderTransform` module (not mocks) and exercises `options()`, `variants()`, and `providerOptions()` with Azure model configs matching the repo's `models-api.json` fixtures. Confirmed:
   - `options()` no longer sets `reasoningSummary` for Azure gpt-5 models
   - `variants()` still does (intentional, tested by maintainers)
   - `providerOptions()` wrapping correctly reflects the change

2. Unit tests added and all 123 existing `transform.test.ts` tests pass:
   ```
   cd packages/opencode && bun test -- test/provider/transform.test.ts
   ```

3. Could not run the full repo-wide `bun typecheck` locally — it fails on pre-existing `Buffer` type errors in unrelated files (`clipboard.ts`, `cross-spawn-spawner.ts`, `db.node.ts`, `filesystem.ts`). These same errors exist on a clean checkout of `upstream/dev` with `bun@1.3.11`. CI should pass as it uses a different environment.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>