### PR TITLE
feat(session): harden per-session SQLite sharding

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -184,8 +184,8 @@ export namespace Runner {
         case "ShellThenRun":
           return [
             Effect.gen(function* () {
-              yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
               yield* stopShell(st.shell)
+              yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
               yield* idleIfCurrent()
             }),
             { _tag: "Idle" } as const,

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -133,6 +133,12 @@ export namespace Project {
       const db = <T>(fn: (d: Parameters<typeof Database.use>[0] extends (trx: infer D) => any ? D : never) => T) =>
         Effect.sync(() => Database.use(fn))
 
+      type Sync<T> = T extends Promise<any> ? never : T
+
+      const tx = <T>(
+        fn: (d: Parameters<typeof Database.transaction>[0] extends (trx: infer D) => any ? D : never) => Sync<T>,
+      ) => Effect.sync(() => Database.transaction(fn, { behavior: "immediate" }))
+
       const emitUpdated = (data: Info) =>
         Effect.sync(() =>
           GlobalBus.emit("event", {
@@ -246,7 +252,7 @@ export namespace Project {
         })
 
         // Phase 2: upsert
-        const row = yield* db((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, data.id)).get())
+        const row = yield* tx((d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, data.id)).get())
         const existing = row
           ? fromRow(row)
           : {
@@ -278,9 +284,8 @@ export namespace Project {
           { concurrency: "unbounded" },
         ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
 
-        yield* db((d) =>
-          d
-            .insert(ProjectTable)
+        yield* tx((d) => {
+          d.insert(ProjectTable)
             .values({
               id: result.id,
               worktree: result.worktree,
@@ -308,18 +313,15 @@ export namespace Project {
                 commands: result.commands,
               },
             })
-            .run(),
-        )
+            .run()
 
-        if (data.id !== ProjectID.global) {
-          yield* db((d) =>
-            d
-              .update(SessionTable)
-              .set({ project_id: data.id })
-              .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
-              .run(),
-          )
-        }
+          if (data.id === ProjectID.global) return
+
+          d.update(SessionTable)
+            .set({ project_id: data.id })
+            .where(and(eq(SessionTable.project_id, ProjectID.global), eq(SessionTable.directory, data.worktree)))
+            .run()
+        })
 
         yield* emitUpdated(result)
         return { project: result, sandbox: data.sandbox }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -23,6 +23,7 @@ import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
+import { makeRuntime } from "@/effect/run-service"
 
 import type { Provider } from "@/provider/provider"
 import { Permission } from "@/permission"
@@ -424,6 +425,14 @@ export namespace Session {
 
         yield* Effect.sync(() => SyncEvent.run(Event.Created, { sessionID: result.id, info: result }))
 
+        if (!input.parentID) {
+          try {
+            Database.session(result.id)
+          } catch (e) {
+            log.error("failed to create per-tree db", { error: e })
+          }
+        }
+
         if (!Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
           // This only exist for backwards compatibility. We should not be
           // manually publishing this event; it is a sync event now
@@ -498,19 +507,17 @@ export namespace Session {
         }).pipe(Effect.withSpan("Session.updatePart"))
 
       const getPart: Interface["getPart"] = Effect.fn("Session.getPart")(function* (input) {
-        const row = Database.use((db) =>
-          db
-            .select()
-            .from(PartTable)
-            .where(
-              and(
-                eq(PartTable.session_id, input.sessionID),
-                eq(PartTable.message_id, input.messageID),
-                eq(PartTable.id, input.partID),
-              ),
-            )
-            .get(),
-        )
+        const row = Database.resolveSession(input.sessionID)
+          .select()
+          .from(PartTable)
+          .where(
+            and(
+              eq(PartTable.session_id, input.sessionID),
+              eq(PartTable.message_id, input.messageID),
+              eq(PartTable.id, input.partID),
+            ),
+          )
+          .get()
         if (!row) return
         return {
           ...row.data,
@@ -703,6 +710,24 @@ export namespace Session {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Storage.defaultLayer))
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function create(input?: CreateInput) {
+    return runPromise((svc) => svc.create(input))
+  }
+
+  export async function remove(sessionID: SessionID) {
+    return runPromise((svc) => svc.remove(sessionID))
+  }
+
+  export async function updateMessage<T extends MessageV2.Info>(msg: T) {
+    return runPromise((svc) => svc.updateMessage(msg))
+  }
+
+  export async function updatePart<T extends MessageV2.Part>(part: T) {
+    return runPromise((svc) => svc.updatePart(part))
+  }
 
   export function* list(input?: {
     directory?: string

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -550,18 +550,20 @@ export namespace MessageV2 {
       and(eq(MessageTable.time_created, row.time), lt(MessageTable.id, row.id)),
     )
 
-  function hydrate(rows: (typeof MessageTable.$inferSelect)[]) {
+  function resolve(sid: SessionID) {
+    return Database.resolveSession(sid)
+  }
+
+  function hydrate(db: Database.TxOrDb, rows: (typeof MessageTable.$inferSelect)[]) {
     const ids = rows.map((row) => row.id)
     const partByMessage = new Map<string, MessageV2.Part[]>()
     if (ids.length > 0) {
-      const partRows = Database.use((db) =>
-        db
-          .select()
-          .from(PartTable)
-          .where(inArray(PartTable.message_id, ids))
-          .orderBy(PartTable.message_id, PartTable.id)
-          .all(),
-      )
+      const partRows = db
+        .select()
+        .from(PartTable)
+        .where(inArray(PartTable.message_id, ids))
+        .orderBy(PartTable.message_id, PartTable.id)
+        .all()
       for (const row of partRows) {
         const next = part(row)
         const list = partByMessage.get(row.message_id)
@@ -850,15 +852,14 @@ export namespace MessageV2 {
     const where = before
       ? and(eq(MessageTable.session_id, input.sessionID), older(before))
       : eq(MessageTable.session_id, input.sessionID)
-    const rows = Database.use((db) =>
-      db
-        .select()
-        .from(MessageTable)
-        .where(where)
-        .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
-        .limit(input.limit + 1)
-        .all(),
-    )
+    const db = resolve(input.sessionID)
+    const rows = db
+      .select()
+      .from(MessageTable)
+      .where(where)
+      .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
+      .limit(input.limit + 1)
+      .all()
     if (rows.length === 0) {
       const row = Database.use((db) =>
         db.select({ id: SessionTable.id }).from(SessionTable).where(eq(SessionTable.id, input.sessionID)).get(),
@@ -872,7 +873,7 @@ export namespace MessageV2 {
 
     const more = rows.length > input.limit
     const slice = more ? rows.slice(0, input.limit) : rows
-    const items = hydrate(slice)
+    const items = hydrate(db, slice)
     items.reverse()
     const tail = slice.at(-1)
     return {
@@ -896,33 +897,28 @@ export namespace MessageV2 {
     }
   }
 
-  export function parts(message_id: MessageID) {
-    const rows = Database.use((db) =>
-      db.select().from(PartTable).where(eq(PartTable.message_id, message_id)).orderBy(PartTable.id).all(),
-    )
-    return rows.map(
-      (row) =>
-        ({
-          ...row.data,
-          id: row.id,
-          sessionID: row.session_id,
-          messageID: row.message_id,
-        }) as MessageV2.Part,
-    )
+  export function parts(mid: MessageID, sid?: SessionID) {
+    const db = sid ? resolve(sid) : Database.Client()
+    return db.select().from(PartTable).where(eq(PartTable.message_id, mid)).orderBy(PartTable.id).all().map(part)
   }
 
   export function get(input: { sessionID: SessionID; messageID: MessageID }): WithParts {
-    const row = Database.use((db) =>
-      db
-        .select()
-        .from(MessageTable)
-        .where(and(eq(MessageTable.id, input.messageID), eq(MessageTable.session_id, input.sessionID)))
-        .get(),
-    )
+    const db = resolve(input.sessionID)
+    const row = db
+      .select()
+      .from(MessageTable)
+      .where(and(eq(MessageTable.id, input.messageID), eq(MessageTable.session_id, input.sessionID)))
+      .get()
     if (!row) throw new NotFoundError({ message: `Message not found: ${input.messageID}` })
     return {
       info: info(row),
-      parts: parts(input.messageID),
+      parts: db
+        .select()
+        .from(PartTable)
+        .where(eq(PartTable.message_id, input.messageID))
+        .orderBy(PartTable.id)
+        .all()
+        .map(part),
     }
   }
 
@@ -944,9 +940,7 @@ export namespace MessageV2 {
     return result
   }
 
-  export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: SessionID) {
-    return filterCompacted(stream(sessionID))
-  })
+  export const filterCompactedEffect = (sessionID: SessionID) => Effect.succeed(filterCompacted(stream(sessionID)))
 
   export function fromError(
     e: unknown,
@@ -998,7 +992,7 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
-      case APICallError.isInstance(e):
+      case APICallError.isInstance(e): {
         const parsed = ProviderError.parseAPICallError({
           providerID: ctx.providerID,
           error: e,
@@ -1024,6 +1018,7 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      }
       case e instanceof Error:
         return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
       default:

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -4,6 +4,7 @@ import { SessionID } from "./schema"
 import { Effect, Layer, Context } from "effect"
 import z from "zod"
 import { Database, eq, asc } from "../storage/db"
+import { makeRuntime } from "@/effect/run-service"
 import { TodoTable } from "./session.sql"
 
 export namespace Todo {
@@ -39,11 +40,12 @@ export namespace Todo {
       const bus = yield* Bus.Service
 
       const update = Effect.fn("Todo.update")(function* (input: { sessionID: SessionID; todos: Info[] }) {
-        yield* Effect.sync(() =>
-          Database.transaction((db) => {
-            db.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
+        yield* Effect.sync(() => {
+          const db = Database.resolveSession(input.sessionID)
+          db.transaction((tx) => {
+            tx.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
             if (input.todos.length === 0) return
-            db.insert(TodoTable)
+            tx.insert(TodoTable)
               .values(
                 input.todos.map((todo, position) => ({
                   session_id: input.sessionID,
@@ -54,22 +56,21 @@ export namespace Todo {
                 })),
               )
               .run()
-          }),
-        )
+          })
+        })
         yield* bus.publish(Event.Updated, input)
       })
 
       const get = Effect.fn("Todo.get")(function* (sessionID: SessionID) {
-        const rows = yield* Effect.sync(() =>
-          Database.use((db) =>
-            db
-              .select()
-              .from(TodoTable)
-              .where(eq(TodoTable.session_id, sessionID))
-              .orderBy(asc(TodoTable.position))
-              .all(),
-          ),
-        )
+        const rows = yield* Effect.sync(() => {
+          const db = Database.resolveSession(sessionID)
+          return db
+            .select()
+            .from(TodoTable)
+            .where(eq(TodoTable.session_id, sessionID))
+            .orderBy(asc(TodoTable.position))
+            .all()
+        })
         return rows.map((row) => ({
           content: row.content,
           status: row.status,
@@ -82,4 +83,14 @@ export namespace Todo {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function get(sessionID: SessionID) {
+    return runPromise((svc) => svc.get(sessionID))
+  }
+
+  export async function update(input: { sessionID: SessionID; todos: Info[] }) {
+    return runPromise((svc) => svc.update(input))
+  }
 }

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -1,7 +1,7 @@
-import { type SQLiteBunDatabase } from "drizzle-orm/bun-sqlite"
 import { migrate } from "drizzle-orm/bun-sqlite/migrator"
 import { type SQLiteTransaction } from "drizzle-orm/sqlite-core"
 export * from "drizzle-orm"
+import { Database as SQLite } from "bun:sqlite"
 import { LocalContext } from "../util/local-context"
 import { lazy } from "../util/lazy"
 import { Global } from "../global"
@@ -9,7 +9,7 @@ import { Log } from "../util/log"
 import { NamedError } from "@opencode-ai/shared/util/error"
 import z from "zod"
 import path from "path"
-import { readFileSync, readdirSync, existsSync } from "fs"
+import { readFileSync, readdirSync, existsSync, mkdirSync } from "fs"
 import { Flag } from "../flag/flag"
 import { CHANNEL } from "../installation/meta"
 import { InstanceState } from "@/effect/instance-state"
@@ -45,9 +45,78 @@ export namespace Database {
 
   export type Transaction = SQLiteTransaction<"sync", void>
 
-  type Client = SQLiteBunDatabase
+  type Client = ReturnType<typeof init> & {
+    $client: {
+      close(): void
+    }
+  }
+
+  type Entry = {
+    db: Client
+    at: number
+  }
 
   type Journal = { sql: string; timestamp: number; name: string }[]
+
+  const limit = 50
+  const retry = [50, 200, 800]
+  const count = {
+    write: 0,
+    retry: 0,
+    exhausted: 0,
+  }
+  const buf = new Int32Array(new SharedArrayBuffer(4))
+
+  const cache = new Map<string, Entry>()
+  const migrating = new Set<string>()
+  const swept = new Set<string>()
+
+  const schema = [
+    `CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER,
+      time_updated INTEGER,
+      data TEXT NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS message_session_time_created_id_idx ON message (session_id, time_created, id)`,
+    `CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES message(id) ON DELETE CASCADE,
+      session_id TEXT NOT NULL,
+      time_created INTEGER,
+      time_updated INTEGER,
+      data TEXT NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS part_message_id_id_idx ON part (message_id, id)`,
+    `CREATE INDEX IF NOT EXISTS part_session_idx ON part (session_id)`,
+    `CREATE TABLE IF NOT EXISTS todo (
+      session_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      status TEXT NOT NULL,
+      priority TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      time_created INTEGER,
+      time_updated INTEGER,
+      PRIMARY KEY (session_id, position)
+    )`,
+    `CREATE INDEX IF NOT EXISTS todo_session_idx ON todo (session_id)`,
+    `CREATE TABLE IF NOT EXISTS event_sequence (
+      aggregate_id TEXT NOT NULL PRIMARY KEY,
+      seq INTEGER NOT NULL
+    )`,
+    `CREATE TABLE IF NOT EXISTS event (
+      id TEXT PRIMARY KEY,
+      aggregate_id TEXT NOT NULL REFERENCES event_sequence(aggregate_id) ON DELETE CASCADE,
+      seq INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      data TEXT NOT NULL,
+      origin TEXT
+    )`,
+  ]
+  const meta = `CREATE TABLE IF NOT EXISTS _meta (key TEXT PRIMARY KEY, value TEXT)`
+
+  const tables = ["message", "part", "todo", "event_sequence", "event"]
 
   function time(tag: string) {
     const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(tag)
@@ -67,32 +136,151 @@ export namespace Database {
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name)
 
-    const sql = dirs
-      .map((name) => {
-        const file = path.join(dir, name, "migration.sql")
-        if (!existsSync(file)) return
-        return {
+    const sql = dirs.flatMap((name) => {
+      const file = path.join(dir, name, "migration.sql")
+      if (!existsSync(file)) return []
+      return [
+        {
           sql: readFileSync(file, "utf-8"),
           timestamp: time(name),
           name,
-        }
-      })
-      .filter(Boolean) as Journal
+        },
+      ]
+    })
 
     return sql.sort((a, b) => a.timestamp - b.timestamp)
   }
+
+  function pragma(db: Client, isGlobal: boolean = false) {
+    db.run("PRAGMA journal_mode = WAL")
+    db.run("PRAGMA synchronous = NORMAL")
+    const timeout = isGlobal ? 10000 : 5000
+    db.run(`PRAGMA busy_timeout = ${timeout}`)
+    db.run("PRAGMA cache_size = -64000")
+    db.run("PRAGMA foreign_keys = ON")
+    db.run("PRAGMA mmap_size = 134217728")
+    db.run("PRAGMA temp_store = MEMORY")
+    db.run("PRAGMA wal_checkpoint(PASSIVE)")
+  }
+
+  function wait(ms: number) {
+    if (ms <= 0) return
+    Atomics.wait(buf, 0, 0, ms)
+  }
+
+  function backoff(ms: number) {
+    return Math.round(ms * (0.75 + Math.random() * 0.5))
+  }
+
+  function busy(err: unknown) {
+    if (!(err instanceof Error)) return
+    const code = "code" in err && typeof err.code === "string" ? err.code : undefined
+    if (code?.startsWith("SQLITE_BUSY")) return code
+    if (err.message.includes("SQLITE_BUSY_SNAPSHOT")) return "SQLITE_BUSY_SNAPSHOT"
+    if (err.message.includes("SQLITE_BUSY_RECOVERY")) return "SQLITE_BUSY_RECOVERY"
+    if (err.message.includes("SQLITE_BUSY") || err.message.includes("database is locked")) return "SQLITE_BUSY"
+  }
+
+  function evict() {
+    if (cache.size <= limit) return
+    const sorted = [...cache.entries()].sort((a, b) => a[1].at - b[1].at)
+    while (cache.size > limit && sorted.length) {
+      const item = sorted.shift()!
+      item[1].db.$client.close()
+      cache.delete(item[0])
+    }
+  }
+
+  const idle = 5 * 60_000
+  function metrics() {
+    return {
+      "db.global.writes": count.write,
+      "db.global.retries": count.retry,
+      "db.global.busy_errors": count.exhausted,
+    }
+  }
+
+  export function monitor() {
+    try {
+      const result = {
+        wal_bytes: 0,
+        checkpoint: undefined as
+          | {
+              blocked: number
+              wal_pages: number
+              checkpointed_pages: number
+            }
+          | undefined,
+        metrics: metrics(),
+      }
+      if (!Path.endsWith(":memory:")) {
+        const db = Client()
+        const file = `${Path}-wal`
+        if (existsSync(file)) {
+          const bytes = Bun.file(file).size
+          const mb = (bytes / (1024 * 1024)).toFixed(2)
+          result.wal_bytes = bytes
+          if (bytes > 50 * 1024 * 1024) {
+            log.warn("wal.size.large", { bytes, mb })
+          } else {
+            log.info("wal.size", { bytes, mb })
+          }
+        }
+        const checkpoint = db.$client.query("PRAGMA wal_checkpoint(PASSIVE)").get() as {
+          busy: number
+          log: number
+          checkpointed: number
+        } | null
+        if (checkpoint) {
+          result.checkpoint = {
+            blocked: checkpoint.busy,
+            wal_pages: checkpoint.log,
+            checkpointed_pages: checkpoint.checkpointed,
+          }
+          if (checkpoint.log > checkpoint.checkpointed) {
+            log.warn("wal.checkpoint.incomplete", result.checkpoint)
+          } else {
+            log.info("wal.checkpoint.complete", result.checkpoint)
+          }
+        }
+      }
+      log.info("db.metrics", result.metrics)
+      return result
+    } catch (err) {
+      log.warn("wal.monitoring.error", { error: err })
+      return {
+        wal_bytes: 0,
+        checkpoint: undefined,
+        metrics: metrics(),
+      }
+    }
+  }
+
+  const sweep = setInterval(() => {
+    const cutoff = Date.now() - idle
+    for (const [id, item] of cache) {
+      if (item.at < cutoff) {
+        item.db.$client.close()
+        cache.delete(id)
+      }
+    }
+    monitor()
+  }, 60_000)
+  if (typeof sweep === "object" && "unref" in sweep) sweep.unref()
 
   export const Client = lazy(() => {
     log.info("opening database", { path: Path })
 
     const db = init(Path)
+    const versionRow = db.$client.query("SELECT sqlite_version()").get() as Record<string, string>
+    const version = versionRow ? Object.values(versionRow)[0] : "unknown"
+    log.info("sqlite version", { version })
+    const [major, minor, patch] = version.split(".").map(Number)
+    if (major < 3 || (major === 3 && minor < 51) || (major === 3 && minor === 51 && patch < 3)) {
+      log.warn("SQLite < 3.51.3 — WAL-reset race possible", { version })
+    }
 
-    db.run("PRAGMA journal_mode = WAL")
-    db.run("PRAGMA synchronous = NORMAL")
-    db.run("PRAGMA busy_timeout = 5000")
-    db.run("PRAGMA cache_size = -64000")
-    db.run("PRAGMA foreign_keys = ON")
-    db.run("PRAGMA wal_checkpoint(PASSIVE)")
+    pragma(db, true)
 
     // Apply schema migrations
     const entries =
@@ -112,12 +300,286 @@ export namespace Database {
       migrate(db, entries)
     }
 
+    try {
+      db.run("UPDATE session SET origin_machine = 'unknown' WHERE origin_machine IS NULL")
+    } catch (err) {
+      log.warn("origin_machine backfill failed", { error: err })
+    }
+
     return db
   })
 
+  export const sessionDir = iife(() => path.join(Global.Path.data, "sessions"))
+
+  export function session(id: string) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(id)) throw new Error(`invalid session id: ${id}`)
+    const item = cache.get(id)
+    if (item) {
+      item.at = Date.now()
+      return item.db
+    }
+
+    mkdirSync(sessionDir, { recursive: true })
+    const file = path.join(sessionDir, id + ".db")
+    const fresh = !existsSync(file)
+    const db = init(file)
+    pragma(db, false)
+
+    if (fresh) {
+      for (const sql of schema) db.run(sql)
+      db.run(meta)
+    }
+
+    cache.set(id, { db, at: Date.now() })
+    evict()
+    return db
+  }
+
+  export function hasSession(id: string) {
+    if (cache.has(id)) return true
+    const file = path.join(sessionDir, id + ".db")
+    if (!existsSync(file)) return false
+    let db: SQLite | undefined
+    try {
+      db = new SQLite(file, { readonly: true, create: false })
+      const rows = db
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?, ?, ?)")
+        .all(...tables) as Array<{ name: string }>
+      return rows.length === tables.length
+    } catch {
+      return false
+    } finally {
+      db?.close()
+    }
+  }
+
+  export function sessionRoot(id: string) {
+    if (hasSession(id)) return id
+
+    const seen = new Set<string>()
+    let next: string | undefined = id
+
+    for (let hop = 0; hop < 100 && next; hop++) {
+      if (seen.has(next)) {
+        log.warn("parent chain cycle detected", { id })
+        return
+      }
+
+      seen.add(next)
+
+      const row = Client().$client.query("SELECT parent_id FROM session WHERE id = ?").get(next) as {
+        parent_id: string | null
+      } | null
+      const parent = row?.parent_id ?? undefined
+      if (!parent) return
+      if (hasSession(parent)) return parent
+      next = parent
+    }
+
+    if (next) log.warn("parent chain cycle detected", { id })
+  }
+
+  function findRoot(id: string): string | undefined {
+    const seen = new Set<string>()
+    let curr: string | undefined = id
+    for (let hop = 0; hop < 100 && curr; hop++) {
+      if (seen.has(curr)) return undefined
+      seen.add(curr)
+      const row = Client().$client.query("SELECT parent_id FROM session WHERE id = ?").get(curr) as {
+        parent_id: string | null
+      } | null
+      if (!row) return undefined
+      if (!row.parent_id) return curr
+      curr = row.parent_id
+    }
+    return undefined
+  }
+
+  function seed(root: string) {
+    if (migrating.has(root)) return
+    migrating.add(root)
+    try {
+      const shard = session(root)
+      const src = Client().$client
+      const dst = shard.$client
+
+      const tree = src
+        .query(
+          `WITH RECURSIVE t(id) AS (
+            SELECT id FROM session WHERE id = ?
+            UNION ALL
+            SELECT s.id FROM session s JOIN t ON s.parent_id = t.id
+          ) SELECT id FROM t`,
+        )
+        .all(root) as { id: string }[]
+      const ids = tree.map((r) => r.id)
+      if (ids.length === 0) return
+
+      log.info("migrate.start", { root, sessions: ids.length })
+
+      const ph = ids.map(() => "?").join(",")
+      const mem = Path.endsWith(":memory:")
+      if (!mem) dst.exec(`ATTACH DATABASE '${Path}' AS global`)
+      try {
+        dst.exec("BEGIN IMMEDIATE")
+        try {
+          if (mem) {
+            const msg = dst.prepare(
+              "INSERT OR IGNORE INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+            )
+            for (const r of src.query(`SELECT * FROM message WHERE session_id IN (${ph})`).all(...ids) as any[])
+              msg.run(r.id, r.session_id, r.time_created, r.time_updated, r.data)
+            const part = dst.prepare(
+              "INSERT OR IGNORE INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            for (const r of src.query(`SELECT * FROM part WHERE session_id IN (${ph})`).all(...ids) as any[])
+              part.run(r.id, r.message_id, r.session_id, r.time_created, r.time_updated, r.data)
+            const todo = dst.prepare(
+              "INSERT OR IGNORE INTO todo (session_id, content, status, priority, position, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            )
+            for (const r of src.query(`SELECT * FROM todo WHERE session_id IN (${ph})`).all(...ids) as any[])
+              todo.run(r.session_id, r.content, r.status, r.priority, r.position, r.time_created, r.time_updated)
+            const seq = dst.prepare("INSERT OR IGNORE INTO event_sequence (aggregate_id, seq) VALUES (?, ?)")
+            for (const r of src
+              .query(`SELECT * FROM event_sequence WHERE aggregate_id IN (${ph})`)
+              .all(...ids) as any[])
+              seq.run(r.aggregate_id, r.seq)
+            const evt = dst.prepare(
+              "INSERT OR IGNORE INTO event (id, aggregate_id, seq, type, data, origin) VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            for (const r of src.query(`SELECT * FROM event WHERE aggregate_id IN (${ph})`).all(...ids) as any[])
+              evt.run(r.id, r.aggregate_id, r.seq, r.type, r.data, r.origin)
+          } else {
+            dst
+              .query(
+                `INSERT OR IGNORE INTO message (id, session_id, time_created, time_updated, data) SELECT id, session_id, time_created, time_updated, data FROM global.message WHERE session_id IN (${ph})`,
+              )
+              .run(...ids)
+            dst
+              .query(
+                `INSERT OR IGNORE INTO part (id, message_id, session_id, time_created, time_updated, data) SELECT id, message_id, session_id, time_created, time_updated, data FROM global.part WHERE session_id IN (${ph})`,
+              )
+              .run(...ids)
+            dst
+              .query(
+                `INSERT OR IGNORE INTO todo (session_id, content, status, priority, position, time_created, time_updated) SELECT session_id, content, status, priority, position, time_created, time_updated FROM global.todo WHERE session_id IN (${ph})`,
+              )
+              .run(...ids)
+            dst
+              .query(
+                `INSERT OR IGNORE INTO event_sequence (aggregate_id, seq) SELECT aggregate_id, seq FROM global.event_sequence WHERE aggregate_id IN (${ph})`,
+              )
+              .run(...ids)
+            dst
+              .query(
+                `INSERT OR IGNORE INTO event (id, aggregate_id, seq, type, data, origin) SELECT id, aggregate_id, seq, type, data, origin FROM global.event WHERE aggregate_id IN (${ph})`,
+              )
+              .run(...ids)
+          }
+          dst.exec("COMMIT")
+          dst.run(meta)
+          for (const sid of ids) {
+            const msg = src.query("SELECT MAX(time_created) as t FROM message WHERE session_id = ?").get(sid) as {
+              t: number | null
+            } | null
+            const part = src.query("SELECT MAX(time_created) as t FROM part WHERE session_id = ?").get(sid) as {
+              t: number | null
+            } | null
+            const todo = src.query("SELECT MAX(time_created) as t FROM todo WHERE session_id = ?").get(sid) as {
+              t: number | null
+            } | null
+            dst
+              .query("INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)")
+              .run(`swept:msg:${sid}`, String(msg?.t ?? 0))
+            dst
+              .query("INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)")
+              .run(`swept:part:${sid}`, String(part?.t ?? 0))
+            dst
+              .query("INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)")
+              .run(`swept:todo:${sid}`, String(todo?.t ?? 0))
+          }
+          log.info("migrate.done", { root, sessions: ids.length })
+        } catch (err) {
+          dst.exec("ROLLBACK")
+          throw err
+        }
+      } finally {
+        if (!mem) dst.exec("DETACH DATABASE global")
+      }
+    } finally {
+      migrating.delete(root)
+    }
+  }
+
+  export function ensureShard(id: string): string | undefined {
+    const root = sessionRoot(id)
+    if (root) {
+      if (!swept.has(id)) {
+        swept.add(id)
+        const db = session(root).$client
+        db.run(meta)
+        const msg = db.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${id}`) as { value: string } | null
+        const part = db.query("SELECT value FROM _meta WHERE key = ?").get(`swept:part:${id}`) as {
+          value: string
+        } | null
+        const todo = db.query("SELECT value FROM _meta WHERE key = ?").get(`swept:todo:${id}`) as {
+          value: string
+        } | null
+        const gmsg = Client()
+          .$client.query("SELECT MAX(time_created) as t FROM message WHERE session_id = ?")
+          .get(id) as { t: number | null } | null
+        const gpart = Client()
+          .$client.query("SELECT MAX(time_created) as t FROM part WHERE session_id = ?")
+          .get(id) as { t: number | null } | null
+        const gtodo = Client()
+          .$client.query("SELECT MAX(time_created) as t FROM todo WHERE session_id = ?")
+          .get(id) as { t: number | null } | null
+        const stale =
+          !msg ||
+          String(gmsg?.t ?? 0) !== msg.value ||
+          !part ||
+          String(gpart?.t ?? 0) !== part.value ||
+          !todo ||
+          String(gtodo?.t ?? 0) !== todo.value
+        if (stale) seed(root)
+      }
+      return root
+    }
+
+    const target = findRoot(id)
+    if (!target) return undefined
+
+    seed(target)
+    return target
+  }
+
+  export function resolveSession(id: string) {
+    const root = ensureShard(id)
+    if (root) return session(root)
+    return Client()
+  }
+
+  export function closeSession(id: string) {
+    const item = cache.get(id)
+    if (!item) return
+    item.db.$client.close()
+    cache.delete(id)
+  }
+
+  export function resetSwept() {
+    swept.clear()
+  }
+
   export function close() {
+    for (const item of cache.values()) item.db.$client.close()
+    cache.clear()
+    swept.clear()
     Client().$client.close()
     Client.reset()
+  }
+
+  export function stats() {
+    return { ...count }
   }
 
   export type TxOrDb = Transaction | Client
@@ -162,11 +624,31 @@ export namespace Database {
       return callback(ctx.use().tx)
     } catch (err) {
       if (err instanceof LocalContext.NotFound) {
-        const effects: (() => void | Promise<void>)[] = []
-        const txCallback = InstanceState.bind((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
-        const result = Client().transaction(txCallback, { behavior: options?.behavior })
-        for (const effect of effects) effect()
-        return result as NotPromise<T>
+        count.write += 1
+        let first: unknown
+        for (let i = 0; i <= retry.length; i++) {
+          const effects: (() => void | Promise<void>)[] = []
+          const txCallback = InstanceState.bind((tx: TxOrDb) => ctx.provide({ tx, effects }, () => callback(tx)))
+          try {
+            const result = Client().transaction(txCallback, { behavior: options?.behavior })
+            for (const effect of effects) effect()
+            return result as NotPromise<T>
+          } catch (err) {
+            const type = busy(err)
+            if (!type) throw err
+            first ??= err
+            const base = retry[i]
+            if (base === undefined) {
+              count.exhausted += 1
+              log.warn("sqlite.busy.exhausted", { attempt: i + 1, type, aggregate: stats() })
+              throw first
+            }
+            const delay = backoff(base)
+            count.retry += 1
+            log.warn("sqlite.busy.retry", { attempt: i + 1, delay, type, aggregate: stats() })
+            wait(delay)
+          }
+        }
       }
       throw err
     }

--- a/packages/opencode/src/sync/index.ts
+++ b/packages/opencode/src/sync/index.ts
@@ -1,6 +1,5 @@
 import z from "zod"
 import type { ZodObject } from "zod"
-import { EventEmitter } from "events"
 import { Database, eq } from "@/storage/db"
 import { GlobalBus } from "@/bus/global"
 import { Bus as ProjectBus } from "@/bus"
@@ -33,6 +32,8 @@ export namespace SyncEvent {
   export type SerializedEvent<Def extends Definition = Definition> = Event<Def> & { type: string }
 
   type ProjectorFunc = (db: Database.TxOrDb, data: unknown) => void
+  type Sync<T> = T extends Promise<any> ? never : T
+  const sessionTypes = new Set(["session.created", "session.updated", "session.deleted"])
 
   export const registry = new Map<string, Definition>()
   let projectors: Map<Definition, ProjectorFunc> | undefined
@@ -66,7 +67,7 @@ export namespace SyncEvent {
   }
 
   export function versionedType<A extends string>(type: A): A
-  export function versionedType<A extends string, B extends number>(type: A, version: B): `${A}/${B}`
+  export function versionedType<A extends string, B extends number>(type: A, version: B): `${A}.${B}`
   export function versionedType(type: string, version?: number) {
     return version ? `${type}.${version}` : type
   }
@@ -103,6 +104,99 @@ export namespace SyncEvent {
     return [def, func as ProjectorFunc]
   }
 
+  function root(type: string, agg: string): string | undefined {
+    if (sessionTypes.has(type)) return
+    const version = versions.get(type)
+    if (!version) return
+    const def = registry.get(versionedType(type, version))
+    if (!def) return
+    if (def.aggregate !== "sessionID") return
+    return Database.sessionRoot(agg)
+  }
+
+  function seq(type: string, agg: string) {
+    const id = root(type, agg)
+    if (id) {
+      return Database.session(id)
+        .select({ seq: EventSequenceTable.seq })
+        .from(EventSequenceTable)
+        .where(eq(EventSequenceTable.aggregate_id, agg))
+        .get()
+    }
+    return Database.use((db) =>
+      db
+        .select({ seq: EventSequenceTable.seq })
+        .from(EventSequenceTable)
+        .where(eq(EventSequenceTable.aggregate_id, agg))
+        .get(),
+    )
+  }
+
+  function transact<T>(
+    type: string,
+    agg: string,
+    cb: (tx: Database.TxOrDb) => Sync<T>,
+    options?: { behavior?: "deferred" | "immediate" | "exclusive" },
+  ): Sync<T> {
+    const id = root(type, agg)
+    if (id) {
+      return Database.session(id).transaction((tx) => cb(tx), { behavior: options?.behavior }) as Sync<T>
+    }
+    return Database.transaction(cb, options)
+  }
+
+  function apply<Def extends Definition>(tx: Database.TxOrDb, projector: ProjectorFunc, def: Def, event: Event<Def>) {
+    projector(tx, event.data)
+
+    if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
+      tx.insert(EventSequenceTable)
+        .values({
+          aggregate_id: event.aggregateID,
+          seq: event.seq,
+        })
+        .onConflictDoUpdate({
+          target: EventSequenceTable.aggregate_id,
+          set: { seq: event.seq },
+        })
+        .run()
+      tx.insert(EventTable)
+        .values({
+          id: event.id,
+          seq: event.seq,
+          aggregate_id: event.aggregateID,
+          type: versionedType(def.type, def.version),
+          data: event.data as Record<string, unknown>,
+        })
+        .run()
+    }
+  }
+
+  function emit<Def extends Definition>(def: Def, event: Event<Def>, options: { publish: boolean }) {
+    return () => {
+      if (options?.publish) {
+        const result = convertEvent(def.type, event.data)
+        if (result instanceof Promise) {
+          result.then((data) => {
+            ProjectBus.publish({ type: def.type, properties: def.schema }, data)
+          })
+        } else {
+          ProjectBus.publish({ type: def.type, properties: def.schema }, result)
+        }
+
+        GlobalBus.emit("event", {
+          directory: Instance.directory,
+          project: Instance.project.id,
+          workspace: WorkspaceContext.workspaceID,
+          payload: {
+            type: "sync",
+            name: versionedType(def.type, def.version),
+            ...event,
+          },
+        })
+      }
+    }
+  }
+
   function process<Def extends Definition>(def: Def, event: Event<Def>, options: { publish: boolean }) {
     if (projectors == null) {
       throw new Error("No projectors available. Call `SyncEvent.init` to install projectors")
@@ -115,55 +209,8 @@ export namespace SyncEvent {
 
     // idempotent: need to ignore any events already logged
 
-    Database.transaction((tx) => {
-      projector(tx, event.data)
-
-      if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
-        tx.insert(EventSequenceTable)
-          .values({
-            aggregate_id: event.aggregateID,
-            seq: event.seq,
-          })
-          .onConflictDoUpdate({
-            target: EventSequenceTable.aggregate_id,
-            set: { seq: event.seq },
-          })
-          .run()
-        tx.insert(EventTable)
-          .values({
-            id: event.id,
-            seq: event.seq,
-            aggregate_id: event.aggregateID,
-            type: versionedType(def.type, def.version),
-            data: event.data as Record<string, unknown>,
-          })
-          .run()
-      }
-
-      Database.effect(() => {
-        if (options?.publish) {
-          const result = convertEvent(def.type, event.data)
-          if (result instanceof Promise) {
-            result.then((data) => {
-              ProjectBus.publish({ type: def.type, properties: def.schema }, data)
-            })
-          } else {
-            ProjectBus.publish({ type: def.type, properties: def.schema }, result)
-          }
-
-          GlobalBus.emit("event", {
-            directory: Instance.directory,
-            project: Instance.project.id,
-            workspace: WorkspaceContext.workspaceID,
-            payload: {
-              type: "sync",
-              name: versionedType(def.type, def.version),
-              ...event,
-            },
-          })
-        }
-      })
-    })
+    transact(def.type, event.aggregateID, (tx) => apply(tx, projector, def, event))
+    Database.effect(emit(def, event, options))
   }
 
   // TODO:
@@ -172,19 +219,13 @@ export namespace SyncEvent {
   //   and it validets all the sequence ids
   // * when loading events from db, apply zod validation to ensure shape
 
-  export function replay(event: SerializedEvent, options?: { publish: boolean }) {
+  export function replay(event: SerializedEvent, options?: { republish: boolean }) {
     const def = registry.get(event.type)
     if (!def) {
       throw new Error(`Unknown event type: ${event.type}`)
     }
 
-    const row = Database.use((db) =>
-      db
-        .select({ seq: EventSequenceTable.seq })
-        .from(EventSequenceTable)
-        .where(eq(EventSequenceTable.aggregate_id, event.aggregateID))
-        .get(),
-    )
+    const row = seq(def.type, event.aggregateID)
 
     const latest = row?.seq ?? -1
     if (event.seq <= latest) {
@@ -196,7 +237,7 @@ export namespace SyncEvent {
       throw new Error(`Sequence mismatch for aggregate "${event.aggregateID}": expected ${expected}, got ${event.seq}`)
     }
 
-    process(def, event, { publish: !!options?.publish })
+    process(def, event, { publish: !!options?.republish })
   }
 
   export function replayAll(events: SerializedEvent[], options?: { publish: boolean }) {
@@ -213,13 +254,14 @@ export namespace SyncEvent {
       }
     }
     for (const item of events) {
-      replay(item, options)
+      replay(item, options ? { republish: options.publish } : undefined)
     }
     return source
   }
 
   export function run<Def extends Definition>(def: Def, data: Event<Def>["data"], options?: { publish?: boolean }) {
     const agg = (data as Record<string, string>)[def.aggregate]
+    const publish = options?.publish ?? true
     // This should never happen: we've enforced it via typescript in
     // the definition
     if (agg == null) {
@@ -230,12 +272,13 @@ export namespace SyncEvent {
       throw new Error(`SyncEvent.run: running old versions of events is not allowed: ${def.type}`)
     }
 
-    const { publish = true } = options || {}
-
     // Note that this is an "immediate" transaction which is critical.
     // We need to make sure we can safely read and write with nothing
     // else changing the data from under us
-    Database.transaction(
+    let fn = () => {}
+    transact(
+      def.type,
+      agg,
       (tx) => {
         const id = EventID.ascending()
         const row = tx
@@ -246,12 +289,18 @@ export namespace SyncEvent {
         const seq = row?.seq != null ? row.seq + 1 : 0
 
         const event = { id, seq, aggregateID: agg, data }
-        process(def, event, { publish })
+        const projector = projectors?.get(def)
+        if (!projector) {
+          throw new Error(`Projector not found for event: ${def.type}`)
+        }
+        apply(tx, projector, def, event)
+        fn = emit(def, event, { publish })
       },
       {
         behavior: "immediate",
       },
     )
+    Database.effect(fn)
   }
 
   export function remove(aggregateID: string) {

--- a/packages/opencode/test/fixture/session-load-worker.ts
+++ b/packages/opencode/test/fixture/session-load-worker.ts
@@ -1,0 +1,195 @@
+import "../../src/server/projectors"
+import { Database } from "../../src/storage/db"
+import { Log } from "../../src/util/log"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Session } from "../../src/session"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { ProjectID } from "../../src/project/schema"
+import { ProjectTable } from "../../src/project/project.sql"
+import { Installation } from "../../src/installation"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { SyncEvent } from "../../src/sync"
+import { Instance } from "../../src/project/instance"
+import path from "path"
+
+type Msg = {
+  mode: "sharded" | "global"
+  idx: number
+  dir: string
+  file: string
+  msgs: number
+  updates: number
+}
+
+type Out = {
+  idx: number
+  mode: "sharded" | "global"
+  session: SessionID
+  started: number
+  ended: number
+  global: number[]
+  shard: number[]
+  errors: string[]
+  counts: {
+    created: number
+    updated: number
+    messages: number
+    parts: number
+  }
+}
+
+await Log.init({ print: false })
+
+const input = JSON.parse(process.argv[2] ?? "{}") as Msg
+const out: Out = {
+  idx: input.idx,
+  mode: input.mode,
+  session: SessionID.descending(),
+  started: Date.now(),
+  ended: 0,
+  global: [],
+  shard: [],
+  errors: [],
+  counts: {
+    created: 0,
+    updated: 0,
+    messages: 0,
+    parts: 0,
+  },
+}
+
+function fail(err: unknown) {
+  if (err instanceof Error) {
+    const code = "code" in err && typeof err.code === "string" ? ` ${err.code}` : ""
+    return `${err.name}${code}: ${err.message}`
+  }
+  return String(err)
+}
+
+function time<T>(list: number[], fn: () => T) {
+  const at = performance.now()
+  const result = fn()
+  list.push(Number((performance.now() - at).toFixed(3)))
+  return result
+}
+
+function info(id: SessionID, pid: ProjectID) {
+  const now = Date.now()
+  return {
+    id,
+    slug: `load-${input.idx}`,
+    projectID: pid,
+    directory: path.join(input.dir, `session-${input.idx}`),
+    title: `load-${input.idx}`,
+    version: Installation.VERSION,
+    time: {
+      created: now,
+      updated: now,
+    },
+  } satisfies Session.Info
+}
+
+function msg(id: SessionID, n: number) {
+  const mid = MessageID.ascending()
+  const now = Date.now()
+  const info: MessageV2.User = {
+    id: mid,
+    sessionID: id,
+    role: "user",
+    time: { created: now },
+    agent: `worker-${input.idx}`,
+    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    tools: {},
+  }
+  const part: MessageV2.TextPart = {
+    id: PartID.ascending(),
+    sessionID: id,
+    messageID: mid,
+    type: "text",
+    text: `load-${input.idx}-${n}`,
+  }
+  return { info, part, now }
+}
+
+function patch(n: number) {
+  return {
+    title: `load-${input.idx}-${n}`,
+    time: {
+      updated: Date.now(),
+    },
+  }
+}
+
+try {
+  await Instance.provide({
+    directory: input.dir,
+    fn: async () => {
+      const pid = ProjectID.make(`project-load-${input.idx}`)
+      const session = SessionID.make(out.session)
+      const row = info(session, pid)
+
+      const now = Date.now()
+      Database.transaction((tx) => {
+        tx.insert(ProjectTable)
+          .values({
+            id: pid,
+            worktree: row.directory,
+            time_created: now,
+            time_updated: now,
+            sandboxes: [],
+          })
+          .onConflictDoNothing()
+          .run()
+      })
+
+      time(out.global, () => {
+        SyncEvent.run(Session.Event.Created, {
+          sessionID: session,
+          info: row,
+        })
+      })
+      out.counts.created += 1
+
+      if (input.mode === "sharded") {
+        Database.session(session)
+        for (let i = 0; i < input.msgs; i++) {
+          const item = msg(session, i)
+          time(out.shard, () => {
+            SyncEvent.run(MessageV2.Event.Updated, {
+              sessionID: session,
+              info: item.info,
+            })
+            SyncEvent.run(MessageV2.Event.PartUpdated, {
+              sessionID: session,
+              part: item.part,
+              time: item.now,
+            })
+          })
+          out.counts.messages += 1
+          out.counts.parts += 1
+        }
+      }
+
+      for (let i = 0; i < input.updates; i++) {
+        time(out.global, () => {
+          SyncEvent.run(Session.Event.Updated, {
+            sessionID: session,
+            info: patch(i),
+          })
+        })
+        out.counts.updated += 1
+      }
+    },
+  })
+} catch (err) {
+  out.errors.push(fail(err))
+} finally {
+  out.ended = Date.now()
+  try {
+    Database.close()
+  } catch {}
+}
+
+await Bun.write(Bun.stdout, JSON.stringify(out))
+
+process.exit(out.errors.length ? 1 : 0)

--- a/packages/opencode/test/server/session-sharding.test.ts
+++ b/packages/opencode/test/server/session-sharding.test.ts
@@ -1,0 +1,631 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync } from "fs"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { NodeFileSystem } from "@effect/platform-node"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { Database, eq } from "../../src/storage/db"
+import { MessageTable, PartTable, TodoTable } from "../../src/session/session.sql"
+import { Log } from "../../src/util/log"
+import { initProjectors } from "../../src/server/projectors"
+import { tmpdir, provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { Agent as AgentSvc } from "../../src/agent/agent"
+import { Bus } from "../../src/bus"
+import { Command } from "../../src/command"
+import { Config } from "../../src/config/config"
+import { FileTime } from "../../src/file/time"
+import { LSP } from "../../src/lsp"
+import { MCP } from "../../src/mcp"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider as ProviderSvc } from "../../src/provider/provider"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Question } from "../../src/question"
+import { Todo } from "../../src/session/todo"
+import { LLM } from "../../src/session/llm"
+import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { SessionCompaction } from "../../src/session/compaction"
+import { Instruction } from "../../src/session/instruction"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionSummary } from "../../src/session/summary"
+import { SessionRevert } from "../../src/session/revert"
+import { SessionRunState } from "../../src/session/run-state"
+import { SessionStatus } from "../../src/session/status"
+import { SystemPrompt } from "../../src/session/system"
+import { Skill } from "../../src/skill"
+import { Snapshot } from "../../src/snapshot"
+import { Format } from "../../src/format"
+import { ToolRegistry } from "../../src/tool/registry"
+import { Truncate } from "../../src/tool/truncate"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { Ripgrep } from "../../src/file/ripgrep"
+
+Log.init({ print: false })
+initProjectors()
+
+afterEach(async () => {
+  await Instance.disposeAll()
+  Database.close()
+})
+
+async function msg(sid: SessionID, text: string) {
+  const id = MessageID.ascending()
+  await Session.updateMessage({
+    id,
+    sessionID: sid,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    tools: {},
+  } satisfies MessageV2.User)
+  await Session.updatePart({
+    id: PartID.ascending(),
+    sessionID: sid,
+    messageID: id,
+    type: "text",
+    text,
+  })
+  return id
+}
+
+describe("sharding via serve API", () => {
+  test("new session creates shard file", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const app = Server.Default().app
+        const res = await app.request("/session", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        })
+        expect(res.status).toBe(200)
+        const session = (await res.json()) as { id: string }
+        expect(session.id).toMatch(/^ses_/)
+
+        const file = path.join(Database.sessionDir, session.id + ".db")
+        expect(existsSync(file)).toBe(true)
+
+        await Session.remove(session.id as SessionID)
+      },
+    })
+  })
+
+  test("messages written to shard are readable via API", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const id = await msg(session.id, "shard-routed")
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/message`)
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as MessageV2.WithParts[]
+        expect(body).toHaveLength(1)
+        expect(body[0]!.info.id).toBe(id)
+
+        const shard = Database.session(session.id)
+        const global = Database.Client()
+        const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+        const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+        expect(in_shard?.id).toBe(id)
+        expect(in_global).toBeUndefined()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("child session has no shard file", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const parent = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request("/session", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ parentID: parent.id }),
+        })
+        expect(res.status).toBe(200)
+        const child = (await res.json()) as { id: string }
+
+        const file = path.join(Database.sessionDir, child.id + ".db")
+        expect(existsSync(file)).toBe(false)
+
+        await Session.remove(child.id as SessionID)
+        await Session.remove(parent.id)
+      },
+    })
+  })
+
+  test("child messages route through parent shard", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const parent = await Session.create({})
+        const child = await Session.create({ parentID: parent.id })
+        const id = await msg(child.id, "child-msg")
+
+        const shard = Database.session(parent.id)
+        const row = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+        expect(row?.id).toBe(id)
+
+        const app = Server.Default().app
+        const res = await app.request(`/session/${child.id}/message`)
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as MessageV2.WithParts[]
+        expect(body).toHaveLength(1)
+
+        await Session.remove(child.id)
+        await Session.remove(parent.id)
+      },
+    })
+  })
+
+  test("session list includes sharded sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const s1 = await Session.create({})
+        const s2 = await Session.create({})
+
+        const sessions = [...Session.list({ directory: tmp.path })]
+        const ids = sessions.map((s) => s.id)
+        expect(ids).toContain(s1.id)
+        expect(ids).toContain(s2.id)
+        expect(existsSync(path.join(Database.sessionDir, s1.id + ".db"))).toBe(true)
+        expect(existsSync(path.join(Database.sessionDir, s2.id + ".db"))).toBe(true)
+
+        await Session.remove(s1.id)
+        await Session.remove(s2.id)
+      },
+    })
+  })
+})
+
+describe("getPart shard routing", () => {
+  test("resolveSession routes to shard for tool parts", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const mid = MessageID.ascending()
+        const pid = PartID.ascending()
+
+        await Session.updateMessage({
+          id: mid,
+          sessionID: session.id,
+          role: "assistant",
+          parentID: MessageID.ascending(),
+          providerID: ProviderID.make("test"),
+          modelID: ModelID.make("test"),
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now() },
+          agent: "test",
+          mode: "",
+        } satisfies MessageV2.Assistant)
+
+        await Session.updatePart({
+          id: pid,
+          sessionID: session.id,
+          messageID: mid,
+          type: "tool",
+          tool: "bash",
+          callID: "call_test",
+          state: { status: "pending", input: {}, raw: "" },
+        } as unknown as MessageV2.Part)
+
+        const shard = Database.session(session.id)
+        const in_shard = shard.select().from(PartTable).where(eq(PartTable.id, pid)).get()
+        expect(in_shard).toBeDefined()
+
+        const global = Database.Client()
+        const in_global = global.select().from(PartTable).where(eq(PartTable.id, pid)).get()
+        expect(in_global).toBeUndefined()
+
+        const resolved = Database.resolveSession(session.id)
+        const via_resolve = resolved.select().from(PartTable).where(eq(PartTable.id, pid)).get()
+        expect(via_resolve).toBeDefined()
+        expect(via_resolve?.id).toBe(pid)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})
+
+describe("sweep marker via serve API", () => {
+  test("orphan messages in global are swept into shard on first access", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        await msg(session.id, "normal")
+
+        const src = Database.Client().$client
+        const now = Date.now()
+        src
+          .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+          .run(MessageID.ascending(), session.id, now, now, JSON.stringify({ role: "user", text: "orphan" }))
+
+        Database.closeSession(session.id)
+        Database.resetSwept()
+
+        const app = Server.Default().app
+        const res = await app.request(`/session/${session.id}/message`)
+        expect(res.status).toBe(200)
+        const body = (await res.json()) as MessageV2.WithParts[]
+        expect(body).toHaveLength(2)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("marker prevents redundant sweep on second access", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const src = Database.Client().$client
+        src
+          .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+          .run(
+            MessageID.ascending(),
+            session.id,
+            Date.now(),
+            Date.now(),
+            JSON.stringify({ role: "user", text: "orphan" }),
+          )
+
+        Database.closeSession(session.id)
+        Database.resetSwept()
+        Database.ensureShard(session.id)
+
+        Database.closeSession(session.id)
+        Database.resetSwept()
+        const before = performance.now()
+        Database.ensureShard(session.id)
+        const elapsed = performance.now() - before
+        expect(elapsed).toBeLessThan(50)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})
+
+function toolPart(parts: MessageV2.Part[]) {
+  return parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
+}
+
+type CompletedToolPart = MessageV2.ToolPart & { state: MessageV2.ToolStateCompleted }
+
+function completedTool(parts: MessageV2.Part[]) {
+  const part = toolPart(parts)
+  expect(part?.state.status).toBe("completed")
+  return part?.state.status === "completed" ? (part as CompletedToolPart) : undefined
+}
+
+const mcpStub = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in shard tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in shard tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in shard tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lspStub = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const filetime = Layer.succeed(
+  FileTime.Service,
+  FileTime.Service.of({
+    read: () => Effect.void,
+    get: () => Effect.succeed(undefined),
+    assert: () => Effect.void,
+    withLock: (_filepath, fn) => fn(),
+  }),
+)
+
+const status = SessionStatus.layer.pipe(Layer.provideMerge(Bus.layer))
+const run = SessionRunState.layer.pipe(Layer.provide(status))
+const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
+
+function makeHttp() {
+  const deps = Layer.mergeAll(
+    Session.defaultLayer,
+    Snapshot.defaultLayer,
+    LLM.defaultLayer,
+    AgentSvc.defaultLayer,
+    Command.defaultLayer,
+    Permission.defaultLayer,
+    Plugin.defaultLayer,
+    Config.defaultLayer,
+    ProviderSvc.defaultLayer,
+    Format.defaultLayer,
+    filetime,
+    lspStub,
+    mcpStub,
+    AppFileSystem.defaultLayer,
+    status,
+    SessionSummary.defaultLayer,
+    SystemPrompt.defaultLayer,
+  ).pipe(Layer.provideMerge(infra))
+  const question = Question.layer.pipe(Layer.provideMerge(deps))
+  const todo = Todo.layer.pipe(Layer.provideMerge(deps))
+  const registry = ToolRegistry.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(CrossSpawnSpawner.defaultLayer),
+    Layer.provide(Ripgrep.defaultLayer),
+    Layer.provideMerge(todo),
+    Layer.provideMerge(question),
+    Layer.provideMerge(deps),
+  )
+  const trunc = Truncate.layer.pipe(Layer.provideMerge(deps))
+  const proc = SessionProcessor.layer.pipe(Layer.provideMerge(deps))
+  const compact = SessionCompaction.layer.pipe(Layer.provideMerge(proc), Layer.provideMerge(deps))
+  return Layer.mergeAll(
+    TestLLMServer.layer,
+    SessionPrompt.layer.pipe(
+      Layer.provide(SessionRevert.defaultLayer),
+      Layer.provideMerge(run),
+      Layer.provideMerge(compact),
+      Layer.provideMerge(proc),
+      Layer.provideMerge(registry),
+      Layer.provideMerge(trunc),
+      Layer.provide(Instruction.defaultLayer),
+      Layer.provideMerge(deps),
+    ),
+  )
+}
+
+const it = testEffect(makeHttp())
+
+const cfg = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string) {
+  return {
+    ...cfg,
+    provider: {
+      ...cfg.provider,
+      test: {
+        ...cfg.provider.test,
+        options: {
+          ...cfg.provider.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+const boot = Effect.fn("test.boot")(function* () {
+  const prompt = yield* SessionPrompt.Service
+  const sessions = yield* Session.Service
+  const chat = yield* sessions.create({
+    title: "Shard Test",
+    permission: [{ permission: "*", pattern: "*", action: "allow" }],
+  })
+  return { prompt, sessions, chat }
+})
+
+describe("shard isolation via Effect integration", () => {
+  it.live(
+    "tool execution via shell writes to shard not global",
+    () =>
+      provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const { prompt, chat } = yield* boot()
+            const result = yield* prompt.shell({
+              sessionID: chat.id,
+              agent: "build",
+              command: "echo SHARD_TOOL_TEST",
+            })
+
+            const tool = completedTool(result.parts)
+            expect(tool).toBeDefined()
+            if (!tool) return
+
+            expect(tool.state.output).toContain("SHARD_TOOL_TEST")
+
+            const shard = Database.session(chat.id)
+            const in_shard = shard.select({ id: PartTable.id }).from(PartTable).where(eq(PartTable.id, tool.id)).get()
+            expect(in_shard?.id).toBe(tool.id)
+
+            const global = Database.Client()
+            const in_global = global.select({ id: PartTable.id }).from(PartTable).where(eq(PartTable.id, tool.id)).get()
+            expect(in_global).toBeUndefined()
+          }),
+        { git: true, config: cfg },
+      ),
+    30_000,
+  )
+
+  it.live(
+    "tool state transitions show completed status with input and output",
+    () =>
+      provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const { prompt, chat } = yield* boot()
+            const result = yield* prompt.shell({
+              sessionID: chat.id,
+              agent: "build",
+              command: "echo STATE_OK",
+            })
+
+            const tool = completedTool(result.parts)
+            expect(tool).toBeDefined()
+            if (!tool) return
+
+            expect(tool.state.status).toBe("completed")
+            expect(tool.state.input.command).toContain("echo STATE_OK")
+            expect(tool.state.output).toContain("STATE_OK")
+          }),
+        { git: true, config: cfg },
+      ),
+    30_000,
+  )
+
+  it.live(
+    "full prompt flow writes messages to shard not global",
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const chat = yield* sessions.create({
+            title: "Shard Prompt",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            noReply: true,
+            parts: [{ type: "text", text: "shard prompt test" }],
+          })
+          yield* llm.text("shard response")
+
+          const result = yield* prompt.loop({ sessionID: chat.id })
+          expect(result.info.role).toBe("assistant")
+
+          const shard = Database.session(chat.id)
+          const msgs = shard.select({ id: MessageTable.id }).from(MessageTable).all()
+          expect(msgs.length).toBeGreaterThanOrEqual(2)
+
+          const global = Database.Client()
+          const in_global = global
+            .select({ id: MessageTable.id })
+            .from(MessageTable)
+            .where(eq(MessageTable.session_id, chat.id))
+            .all()
+          expect(in_global).toHaveLength(0)
+        }),
+        { git: true, config: providerCfg },
+      ),
+    30_000,
+  )
+
+  it.live(
+    "todo writes go to shard not global",
+    () =>
+      provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const sessions = yield* Session.Service
+            const todo = yield* Todo.Service
+            const chat = yield* sessions.create({ title: "Todo Shard" })
+
+            yield* todo.update({
+              sessionID: chat.id,
+              todos: [
+                { content: "first task", status: "pending", priority: "high" },
+                { content: "second task", status: "in_progress", priority: "medium" },
+              ],
+            })
+
+            const shard = Database.session(chat.id)
+            const in_shard = shard.select().from(TodoTable).where(eq(TodoTable.session_id, chat.id)).all()
+            expect(in_shard).toHaveLength(2)
+            expect(in_shard[0]!.content).toBe("first task")
+            expect(in_shard[1]!.content).toBe("second task")
+
+            const global = Database.Client()
+            const in_global = global.select().from(TodoTable).where(eq(TodoTable.session_id, chat.id)).all()
+            expect(in_global).toHaveLength(0)
+
+            const fetched = yield* todo.get(chat.id)
+            expect(fetched).toHaveLength(2)
+            expect(fetched[0]!.content).toBe("first task")
+            expect(fetched[1]!.content).toBe("second task")
+          }),
+        { git: true, config: cfg },
+      ),
+    30_000,
+  )
+})

--- a/packages/opencode/test/session/concurrency-load.test.ts
+++ b/packages/opencode/test/session/concurrency-load.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dir, "../..")
+const repo = path.join(root, "../..")
+const worker = path.join(import.meta.dir, "../fixture/session-load-worker.ts")
+const count = 20
+const msgs = 50
+const shardUpdates = 10
+const globalUpdates = 100
+const walLimit = 100 * 1024 * 1024
+const soakMs = Number(process.env.OPENCODE_LOAD_SOAK_MS ?? "0")
+const soak = soakMs > 0 ? test : test.skip
+
+type Msg = {
+  mode: "sharded" | "global"
+  idx: number
+  dir: string
+  file: string
+  msgs: number
+  updates: number
+}
+
+type Out = {
+  idx: number
+  mode: "sharded" | "global"
+  session: string
+  started: number
+  ended: number
+  global: number[]
+  shard: number[]
+  errors: string[]
+  counts: {
+    created: number
+    updated: number
+    messages: number
+    parts: number
+  }
+}
+
+type Run = {
+  code: number
+  stdout: string
+  stderr: string
+  out: Out | null
+}
+
+function env(dir: string, file: string, idx: number | string) {
+  return {
+    ...process.env,
+    OPENCODE_DB: file,
+    OPENCODE_TEST_HOME: dir,
+    XDG_DATA_HOME: path.join(dir, "data"),
+    XDG_CACHE_HOME: path.join(dir, `cache-${idx}`),
+    XDG_CONFIG_HOME: path.join(dir, `config-${idx}`),
+    XDG_STATE_HOME: path.join(dir, `state-${idx}`),
+  }
+}
+
+function proc(msg: Msg) {
+  return Bun.spawn({
+    cmd: [process.execPath, worker, JSON.stringify(msg)],
+    cwd: root,
+    env: env(msg.dir, msg.file, msg.idx),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+function warm(dir: string, file: string) {
+  return Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import "./src/server/projectors"',
+        'import { Database } from "./src/storage/db"',
+        'import { Log } from "./src/util/log"',
+        "await Log.init({ print: false })",
+        "Database.Client()",
+        "Database.close()",
+        "process.exit(0)",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: env(dir, file, "warm"),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+async function text(stream: ReadableStream<Uint8Array> | number | null) {
+  if (!stream || typeof stream === "number") return ""
+  return new Response(stream).text()
+}
+
+async function run(msg: Msg): Promise<Run> {
+  const child = proc(msg)
+  const [code, stdout, stderr] = await Promise.all([child.exited, text(child.stdout), text(child.stderr)])
+  const json = stdout.trim()
+  return {
+    code,
+    stdout,
+    stderr,
+    out: json ? (JSON.parse(json) as Out) : null,
+  }
+}
+
+function pct(list: number[], q: number) {
+  if (!list.length) return 0
+  const idx = Math.max(0, Math.ceil(list.length * q) - 1)
+  return list[Math.min(idx, list.length - 1)]
+}
+
+function stats(list: number[]) {
+  const sorted = [...list].sort((a, b) => a - b)
+  return {
+    count: sorted.length,
+    min: sorted[0] ?? 0,
+    p50: pct(sorted, 0.5),
+    p95: pct(sorted, 0.95),
+    p99: pct(sorted, 0.99),
+    max: sorted.at(-1) ?? 0,
+  }
+}
+
+async function save(name: string, lines: string[]) {
+  const dir = path.join(repo, ".sisyphus/evidence")
+  await fs.mkdir(dir, { recursive: true })
+  await Bun.write(path.join(dir, name), lines.join("\n") + "\n")
+}
+
+async function walk(dir: string): Promise<string[]> {
+  const list = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+  const next = await Promise.all(
+    list.map((item) => {
+      const file = path.join(dir, item.name)
+      if (item.isDirectory()) return walk(file)
+      return [file]
+    }),
+  )
+  return next.flat()
+}
+
+async function wals(dir: string) {
+  const files = (await walk(dir)).filter((file) => file.endsWith(".db-wal"))
+  const list = await Promise.all(
+    files.map(async (file) => ({
+      file,
+      size: (await fs.stat(file)).size,
+    })),
+  )
+  return list.sort((a, b) => b.size - a.size)
+}
+
+function lines(name: string, list: Run[], wal: Awaited<ReturnType<typeof wals>>, global: number[], shard: number[]) {
+  const start = Math.min(...list.flatMap((item) => (item.out ? [item.out.started] : [])))
+  const end = Math.max(...list.flatMap((item) => (item.out ? [item.out.ended] : [])))
+  const span = Number.isFinite(start) && Number.isFinite(end) && end >= start ? end - start : 0
+  const total = global.length + shard.length
+  const rate = span > 0 ? Number(((total * 1000) / span).toFixed(2)) : 0
+  return [
+    `scenario: ${name}`,
+    `workers: ${list.length}`,
+    `writes: ${total}`,
+    `duration_ms: ${span}`,
+    `throughput_per_s: ${rate}`,
+    `global_stats: ${JSON.stringify(stats(global))}`,
+    `shard_stats: ${JSON.stringify(stats(shard))}`,
+    `wal_max_bytes: ${wal[0]?.size ?? 0}`,
+    `wal_files: ${JSON.stringify(wal.slice(0, 10))}`,
+    ...list.flatMap((item, i) => [
+      `worker_${i}_exit: ${item.code}`,
+      `worker_${i}_stdout: ${item.stdout.trim()}`,
+      `worker_${i}_stderr: ${item.stderr.trim()}`,
+    ]),
+  ]
+}
+
+async function scenario(tmp: string, mode: Msg["mode"], updates: number) {
+  const file = path.join(tmp, `${mode}.db`)
+  const init = warm(tmp, file)
+  if (init.exitCode !== 0) throw new Error(init.stderr.toString() || init.stdout.toString())
+  const list = await Promise.all(
+    Array.from({ length: count }, (_, idx) =>
+      run({
+        mode,
+        idx,
+        dir: tmp,
+        file,
+        msgs,
+        updates,
+      }),
+    ),
+  )
+  const out = list.flatMap((item) => (item.out ? [item.out] : []))
+  const global = out.flatMap((item) => item.global)
+  const shard = out.flatMap((item) => item.shard)
+  const wal = await wals(tmp)
+  return { list, out, global, shard, wal }
+}
+
+function check(result: Awaited<ReturnType<typeof scenario>>) {
+  const bad = result.list
+    .map((item, idx) => ({
+      idx,
+      code: item.code,
+      stdout: item.stdout.trim(),
+      stderr: item.stderr.trim(),
+    }))
+    .filter((item) => item.code !== 0)
+  expect(bad).toEqual([])
+  expect(result.out).toHaveLength(count)
+  expect(result.out.flatMap((item) => item.errors)).toEqual([])
+  expect(result.list.map((item) => item.stderr).join("\n")).not.toContain("SQLITE_BUSY")
+  expect(result.list.map((item) => item.stderr).join("\n")).not.toContain("SQLITE_BUSY_SNAPSHOT")
+  expect(result.wal[0]?.size ?? 0).toBeLessThan(walLimit)
+}
+
+describe("session concurrency load", () => {
+  test("runs 20 sharded workers without SQLITE_BUSY and keeps WAL under 100MB", async () => {
+    await using tmp = await tmpdir()
+    const result = await scenario(tmp.path, "sharded", shardUpdates)
+
+    await save("task-5-load-test-sharded.txt", lines("sharded", result.list, result.wal, result.global, result.shard))
+
+    check(result)
+    expect(result.global).toHaveLength(count * (1 + shardUpdates))
+    expect(result.shard).toHaveLength(count * msgs)
+    expect(stats(result.shard).p99).toBeLessThan(5_000)
+  }, 120_000)
+
+  test("runs 20 global stress workers without SQLITE_BUSY and keeps WAL under 100MB", async () => {
+    await using tmp = await tmpdir()
+    const result = await scenario(tmp.path, "global", globalUpdates)
+
+    await save("task-5-load-test-global.txt", lines("global", result.list, result.wal, result.global, result.shard))
+
+    check(result)
+    expect(result.global).toHaveLength(count * (1 + globalUpdates))
+    expect(result.shard).toEqual([])
+    expect(stats(result.global).p99).toBeLessThan(10_000)
+  }, 120_000)
+
+  soak(
+    "soaks multi-process contention for the configured duration",
+    async () => {
+      const start = Date.now()
+      let round = 0
+      let max = 0
+      const global: number[] = []
+      const shard: number[] = []
+
+      while (Date.now() - start < soakMs) {
+        {
+          await using tmp = await tmpdir()
+          const result = await scenario(tmp.path, "sharded", shardUpdates)
+          check(result)
+          global.push(...result.global)
+          shard.push(...result.shard)
+          max = Math.max(max, result.wal[0]?.size ?? 0)
+        }
+
+        {
+          await using tmp = await tmpdir()
+          const result = await scenario(tmp.path, "global", globalUpdates)
+          check(result)
+          global.push(...result.global)
+          max = Math.max(max, result.wal[0]?.size ?? 0)
+        }
+
+        round += 1
+      }
+
+      await save("task-5-load-test-soak.txt", [
+        "scenario: soak",
+        `target_ms: ${soakMs}`,
+        `elapsed_ms: ${Date.now() - start}`,
+        `rounds: ${round}`,
+        `global_stats: ${JSON.stringify(stats(global))}`,
+        `shard_stats: ${JSON.stringify(stats(shard))}`,
+        `wal_max_bytes: ${max}`,
+      ])
+
+      expect(Date.now() - start).toBeGreaterThanOrEqual(soakMs)
+      expect(stats(global).p99).toBeLessThan(10_000)
+      expect(stats(shard).p99).toBeLessThan(5_000)
+      expect(max).toBeLessThan(walLimit)
+    },
+    soakMs + 180_000,
+  )
+})

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -449,7 +449,7 @@ describe("MessageV2.parts", () => {
         const session = await svc.create({})
         const [id] = await fill(session.id, 1)
 
-        const result = MessageV2.parts(id)
+        const result = MessageV2.parts(id, session.id)
         expect(result).toHaveLength(1)
         expect(result[0].type).toBe("text")
         expect((result[0] as MessageV2.TextPart).text).toBe("m0")
@@ -466,7 +466,7 @@ describe("MessageV2.parts", () => {
         const session = await svc.create({})
         const id = await addUser(session.id)
 
-        const result = MessageV2.parts(id)
+        const result = MessageV2.parts(id, session.id)
         expect(result).toEqual([])
 
         await svc.remove(session.id)
@@ -496,7 +496,7 @@ describe("MessageV2.parts", () => {
           text: "third",
         })
 
-        const result = MessageV2.parts(id)
+        const result = MessageV2.parts(id, session.id)
         expect(result).toHaveLength(3)
         expect((result[0] as MessageV2.TextPart).text).toBe("m0")
         expect((result[1] as MessageV2.TextPart).text).toBe("second")
@@ -525,7 +525,7 @@ describe("MessageV2.parts", () => {
         const session = await svc.create({})
         const [id] = await fill(session.id, 1)
 
-        const result = MessageV2.parts(id)
+        const result = MessageV2.parts(id, session.id)
         expect(result[0].sessionID).toBe(session.id)
         expect(result[0].messageID).toBe(id)
 
@@ -852,7 +852,7 @@ describe("MessageV2 consistency", () => {
         const [id] = await fill(session.id, 1)
 
         const got = MessageV2.get({ sessionID: session.id, messageID: id })
-        const standalone = MessageV2.parts(id)
+        const standalone = MessageV2.parts(id, session.id)
         expect(got.parts).toEqual(standalone)
 
         await svc.remove(session.id)

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -220,7 +220,7 @@ it.live("session.processor effect tests capture llm input cleanly", () =>
         } satisfies LLM.StreamInput
 
         const value = yield* handle.process(input)
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
         const calls = yield* llm.calls
 
         expect(value).toBe("continue")
@@ -354,7 +354,7 @@ it.live("session.processor effect tests stop after token overflow requests compa
           tools: {},
         })
 
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
 
         expect(value).toBe("compact")
         expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
@@ -399,7 +399,7 @@ it.live("session.processor effect tests capture reasoning from http mock", () =>
           tools: {},
         })
 
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
         const reasoning = parts.find((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
         const text = parts.find((part): part is MessageV2.TextPart => part.type === "text")
 
@@ -447,7 +447,7 @@ it.live("session.processor effect tests reset reasoning state across retries", (
           tools: {},
         })
 
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
         const reasoning = parts.filter((part): part is MessageV2.ReasoningPart => part.type === "reasoning")
 
         expect(value).toBe("continue")
@@ -538,7 +538,7 @@ it.live("session.processor effect tests retry recognized structured json errors"
           tools: {},
         })
 
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
 
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(2)
@@ -685,7 +685,7 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
         yield* Effect.promise(async () => {
           const end = Date.now() + 500
           while (Date.now() < end) {
-            const parts = await MessageV2.parts(msg.id)
+            const parts = await MessageV2.parts(msg.id, chat.id)
             if (parts.some((part) => part.type === "tool")) return
             await Bun.sleep(10)
           }
@@ -693,7 +693,7 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
         yield* Fiber.interrupt(run)
 
         const exit = yield* Fiber.await(run)
-        const parts = MessageV2.parts(msg.id)
+        const parts = MessageV2.parts(msg.id, chat.id)
         const call = parts.find((part): part is MessageV2.ToolPart => part.type === "tool")
 
         expect(Exit.isFailure(exit)).toBe(true)

--- a/packages/opencode/test/session/resolve-routing.test.ts
+++ b/packages/opencode/test/session/resolve-routing.test.ts
@@ -1,0 +1,648 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { existsSync, mkdirSync, unlinkSync, statSync } from "fs"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Todo } from "../../src/session/todo"
+import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { Database, eq } from "../../src/storage/db"
+import { MessageTable, PartTable, SessionTable, TodoTable } from "../../src/session/session.sql"
+import { SyncEvent } from "../../src/sync"
+import { initProjectors } from "../../src/server/projectors"
+import { Log } from "../../src/util/log"
+
+Log.init({ print: false })
+initProjectors()
+
+async function scope(fn: () => Promise<void>) {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        await fn()
+      } finally {
+        await Instance.disposeAll()
+        Database.close()
+      }
+    },
+  })
+}
+
+function shardfile(id: SessionID) {
+  return path.join(Database.sessionDir, id + ".db")
+}
+
+async function unlink(file: string) {
+  for (let i = 0; i < 100; i++) {
+    if (!existsSync(file)) return
+    try {
+      unlinkSync(file)
+      return
+    } catch (err) {
+      const code = err && typeof err === "object" && "code" in err ? err.code : undefined
+      if ((code !== "EBUSY" && code !== "EPERM") || i === 19) throw err
+      await Bun.sleep(50)
+    }
+  }
+}
+
+async function drop(id: SessionID) {
+  Database.closeSession(id)
+  for (const ext of [".db", ".db-shm", ".db-wal"]) {
+    await unlink(path.join(Database.sessionDir, id + ext))
+  }
+}
+
+async function msg(sid: SessionID, text: string) {
+  const id = MessageID.ascending()
+  const info: MessageV2.User = {
+    id,
+    sessionID: sid,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+    tools: {},
+  }
+  const part: MessageV2.TextPart = {
+    id: PartID.ascending(),
+    sessionID: info.sessionID,
+    messageID: id,
+    type: "text",
+    text,
+  }
+  SyncEvent.run(MessageV2.Event.Updated, { sessionID: sid, info })
+  SyncEvent.run(MessageV2.Event.PartUpdated, { sessionID: sid, part, time: Date.now() })
+  return id
+}
+
+describe("resolve() routing", () => {
+  test("message updates stay readable from a sharded session", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const id = await msg(session.id, "route to shard")
+
+      expect(Database.hasSession(session.id)).toBe(true)
+
+      const item = MessageV2.get({ sessionID: session.id, messageID: id })
+      expect(item.info.id).toBe(id)
+
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+      const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+
+      expect(in_shard?.id).toBe(id)
+      expect(in_global).toBeUndefined()
+    })
+  })
+
+  test("message updates re-resolve from the shard after Database.close()", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const file = shardfile(session.id)
+      const id = await msg(session.id, "cold cache")
+
+      expect(existsSync(file)).toBe(true)
+
+      await Instance.disposeAll()
+      Database.close()
+      expect(Database.hasSession(session.id)).toBe(true)
+
+      const item = MessageV2.get({ sessionID: session.id, messageID: id })
+      expect(item.info.id).toBe(id)
+      expect(item.parts).toMatchObject([
+        { id: item.parts[0]?.id, messageID: id, sessionID: session.id, type: "text", text: "cold cache" },
+      ])
+
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+      const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+
+      expect(in_shard?.id).toBe(id)
+      expect(in_global).toBeUndefined()
+    })
+  })
+
+  test("hasSession returns true when session is in cache", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const file = shardfile(session.id)
+      expect(existsSync(file)).toBe(true)
+
+      // Session.create() calls Database.session() which adds to cache
+      // hasSession returns true from cache hit
+      expect(Database.hasSession(session.id)).toBe(true)
+
+      // Database.session() returns the shard, not the global DB
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      expect(shard).not.toBe(global)
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("hasSession accepts a schema-only shard after cold cache", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const file = shardfile(session.id)
+
+      // Close the session to clear it from cache
+      Database.closeSession(session.id)
+
+      expect(statSync(file).size).toBeGreaterThan(0)
+      expect(Database.hasSession(session.id)).toBe(true)
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("child sessions without a dedicated shard route through the root shard", async () => {
+    await scope(async () => {
+      const parent = await Session.create({})
+      const child = await Session.create({ parentID: parent.id })
+      Database.closeSession(parent.id)
+      Database.closeSession(child.id)
+
+      expect(Database.hasSession(parent.id)).toBe(true)
+      expect(Database.hasSession(child.id)).toBe(false)
+      expect(Database.sessionRoot(parent.id)).toBe(parent.id)
+      expect(Database.sessionRoot(child.id)).toBe(parent.id)
+      expect(Database.sessionRoot("ses_missing_root")).toBeUndefined()
+
+      const id = await msg(child.id, "child routes to root shard")
+      const item = MessageV2.get({ sessionID: child.id, messageID: id })
+      expect(item.info.id).toBe(id)
+
+      const shard = Database.session(parent.id)
+      const global = Database.Client()
+      const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+      const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+
+      expect(in_shard?.id).toBe(id)
+      expect(in_global).toBeUndefined()
+
+      await Session.remove(parent.id)
+      Database.closeSession(parent.id)
+      Database.closeSession(child.id)
+    })
+  })
+
+  test("sessionRoot returns undefined when a parent row is missing", async () => {
+    await scope(async () => {
+      const parent = await Session.create({})
+      const child = await Session.create({ parentID: parent.id })
+      const db = Database.Client().$client
+      const file = shardfile(parent.id)
+
+      await drop(parent.id)
+      await drop(child.id)
+      db.query("DELETE FROM session WHERE id = ?").run(parent.id)
+
+      expect(Database.sessionRoot(child.id)).toBeUndefined()
+
+      await Session.remove(child.id)
+    })
+  })
+
+  test("sessionRoot returns undefined for cyclic parent chains", async () => {
+    await scope(async () => {
+      const parent = await Session.create({})
+      const child = await Session.create({ parentID: parent.id })
+      const db = Database.Client().$client
+      const file = shardfile(parent.id)
+
+      await drop(parent.id)
+      await drop(child.id)
+      db.query("UPDATE session SET parent_id = ? WHERE id = ?").run(child.id, parent.id)
+
+      expect(Database.sessionRoot(child.id)).toBeUndefined()
+
+      db.query("UPDATE session SET parent_id = NULL WHERE id = ?").run(parent.id)
+      await Session.remove(parent.id)
+    })
+  })
+
+  test("session list comes from the global DB regardless of shards", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+
+      // Write a message to grow the shard
+      await msg(session.id, "list test")
+      expect(Database.hasSession(session.id)).toBe(true)
+
+      // Session should appear in the list (queried from global DB metadata)
+      const sessions: Session.Info[] = []
+      for await (const s of Session.list({})) {
+        if (s.id === session.id) sessions.push(s)
+      }
+      expect(sessions.length).toBe(1)
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("hasSession returns false for empty/malformed shard files", async () => {
+    await scope(async () => {
+      const id = "test-malformed-shard"
+      mkdirSync(Database.sessionDir, { recursive: true })
+      const file = shardfile(id as SessionID)
+
+      // Create an empty file (simulates the bug that created 4KB empty shards)
+      await Bun.write(file, "")
+      expect(existsSync(file)).toBe(true)
+      expect(Database.hasSession(id)).toBe(false)
+
+      await unlink(file)
+    })
+  })
+
+  test("message writes roundtrip immediately through the shard", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const id = await msg(session.id, "immediate shard read")
+      const item = MessageV2.get({ sessionID: session.id, messageID: id })
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+      const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+
+      expect(item.info.id).toBe(id)
+      expect(item.parts).toMatchObject([
+        { id: item.parts[0]?.id, messageID: id, sessionID: session.id, type: "text", text: "immediate shard read" },
+      ])
+      expect(in_shard?.id).toBe(id)
+      expect(in_global).toBeUndefined()
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("todo updates roundtrip through the shard", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const todos = [
+        { content: "one", status: "pending", priority: "high" },
+        { content: "two", status: "completed", priority: "low" },
+      ] satisfies Todo.Info[]
+
+      await Todo.update({ sessionID: session.id, todos })
+      const item = await Todo.get(session.id)
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const in_shard = shard
+        .select()
+        .from(TodoTable)
+        .where(eq(TodoTable.session_id, session.id))
+        .orderBy(TodoTable.position)
+        .all()
+      const in_global = global
+        .select()
+        .from(TodoTable)
+        .where(eq(TodoTable.session_id, session.id))
+        .orderBy(TodoTable.position)
+        .all()
+
+      expect(item).toEqual(todos)
+      expect(in_shard.map((row) => ({ content: row.content, status: row.status, priority: row.priority }))).toEqual(
+        todos,
+      )
+      expect(in_global).toEqual([])
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("first write to a shard-less session triggers lazy migration on read", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const file = shardfile(session.id)
+
+      await drop(session.id)
+
+      expect(existsSync(file)).toBe(false)
+      expect(Database.hasSession(session.id)).toBe(false)
+
+      // Write via SyncEvent goes to global (sync layer uses sessionRoot, not ensureShard)
+      const id = await msg(session.id, "lazy shard")
+
+      // Read triggers resolveSession → ensureShard → migration
+      const item = MessageV2.get({ sessionID: session.id, messageID: id })
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const in_shard = shard.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+      const in_global = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, id)).get()
+
+      expect(item.info.id).toBe(id)
+      expect(item.parts).toMatchObject([
+        { id: item.parts[0]?.id, messageID: id, sessionID: session.id, type: "text", text: "lazy shard" },
+      ])
+      expect(existsSync(file)).toBe(true)
+      expect(in_shard?.id).toBe(id)
+      // Global retains the copy (not deleted during migration)
+      expect(in_global?.id).toBe(id)
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+
+  test("lazy migration copies existing global data into the new shard", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const file = shardfile(session.id)
+
+      // Write a message to the shard via normal path
+      const old = await msg(session.id, "before migration")
+
+      // Copy shard data into global DB to simulate pre-shard state
+      const shard = Database.session(session.id)
+      const global = Database.Client()
+      const rows = shard.select().from(MessageTable).where(eq(MessageTable.session_id, session.id)).all()
+      for (const row of rows) {
+        global
+          .insert(MessageTable)
+          .values({ id: row.id, session_id: row.session_id, time_created: row.time_created, data: row.data })
+          .run()
+      }
+      const parts = shard.select().from(PartTable).where(eq(PartTable.session_id, session.id)).all()
+      for (const row of parts) {
+        global
+          .insert(PartTable)
+          .values({
+            id: row.id,
+            message_id: row.message_id,
+            session_id: row.session_id,
+            time_created: row.time_created,
+            data: row.data,
+          })
+          .run()
+      }
+
+      // Drop the shard so resolveSession falls through
+      await drop(session.id)
+      expect(existsSync(file)).toBe(false)
+
+      // Confirm the old message is readable from the global fallback
+      const before = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, old)).get()
+      expect(before?.id).toBe(old)
+
+      // Write a new todo — this triggers lazy migration
+      await Todo.update({ sessionID: session.id, todos: [{ content: "post", status: "pending", priority: "high" }] })
+
+      // Shard should now exist
+      expect(existsSync(file)).toBe(true)
+
+      // Old message should have been migrated into the shard
+      const fresh = Database.session(session.id)
+      const migrated = fresh.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, old)).get()
+      expect(migrated?.id).toBe(old)
+
+      // New todo should be in the shard
+      const todos = fresh.select().from(TodoTable).where(eq(TodoTable.session_id, session.id)).all()
+      expect(todos.length).toBe(1)
+      expect(todos[0]?.content).toBe("post")
+
+      // Global still has the old copy (not deleted during migration)
+      const still = global.select({ id: MessageTable.id }).from(MessageTable).where(eq(MessageTable.id, old)).get()
+      expect(still?.id).toBe(old)
+
+      await Session.remove(session.id)
+      Database.closeSession(session.id)
+    })
+  })
+})
+
+describe("sweep marker", () => {
+  test("seed writes marker, second ensureShard skips seed", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const sid = session.id
+
+      // Write a message via Sync → goes to shard
+      await msg(sid, "shard-msg")
+
+      // Simulate orphan: insert directly into global
+      const src = Database.Client().$client
+      const now = Date.now()
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, now, now, JSON.stringify({ role: "user", text: "orphan" }))
+
+      // First ensureShard: no marker → should seed
+      Database.closeSession(sid)
+      const db1 = Database.ensureShard(sid)
+      expect(db1).toBe(sid)
+
+      // Verify marker was written
+      const shard = Database.session(sid).$client
+      const mark = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${sid}`) as {
+        value: string
+      } | null
+      const part = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:part:${sid}`) as {
+        value: string
+      } | null
+      const todo = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:todo:${sid}`) as {
+        value: string
+      } | null
+      expect(mark).not.toBeNull()
+      expect(part).not.toBeNull()
+      expect(todo).not.toBeNull()
+      expect(Number(mark!.value)).toBeGreaterThan(0)
+      expect(Number(part!.value)).toBe(0)
+      expect(Number(todo!.value)).toBe(0)
+
+      // Close and reopen to reset in-memory swept set
+      Database.closeSession(sid)
+      Database.resetSwept()
+
+      // Second ensureShard: marker matches global MAX → should skip seed
+      const before = performance.now()
+      const db2 = Database.ensureShard(sid)
+      const elapsed = performance.now() - before
+      expect(db2).toBe(sid)
+      // Should avoid an expensive re-seed on the same markers
+      expect(elapsed).toBeLessThan(2_000)
+    })
+  })
+
+  test("new orphan after sweep triggers re-seed", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const sid = session.id
+
+      // Write initial message and trigger first sweep
+      await msg(sid, "initial")
+      const src = Database.Client().$client
+      const now = Date.now()
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, now, now, JSON.stringify({ role: "user", text: "orphan-1" }))
+
+      Database.closeSession(sid)
+      Database.ensureShard(sid)
+
+      // Verify orphan was copied to shard
+      const shard1 = Database.session(sid)
+      const count1 = shard1.select().from(MessageTable).where(eq(MessageTable.session_id, sid)).all().length
+      expect(count1).toBe(2) // shard-msg + orphan-1
+
+      // Now add ANOTHER orphan with a newer timestamp
+      const later = now + 10000
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, later, later, JSON.stringify({ role: "user", text: "orphan-2" }))
+
+      // Reset swept set to simulate process restart
+      Database.closeSession(sid)
+      Database.resetSwept()
+
+      // ensureShard should detect stale marker and re-seed
+      Database.ensureShard(sid)
+
+      const shard2 = Database.session(sid)
+      const count2 = shard2.select().from(MessageTable).where(eq(MessageTable.session_id, sid)).all().length
+      expect(count2).toBe(3) // shard-msg + orphan-1 + orphan-2
+    })
+  })
+
+  test("marker survives shard cache eviction", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const sid = session.id
+
+      // Plant orphan and sweep
+      const src = Database.Client().$client
+      const now = Date.now()
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, now, now, JSON.stringify({ role: "user", text: "orphan" }))
+
+      Database.ensureShard(sid)
+
+      // Close the shard (simulates cache eviction)
+      Database.closeSession(sid)
+      Database.resetSwept()
+
+      // Reopen — marker should still be in the sqlite file
+      const shard = Database.session(sid).$client
+      const mark = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${sid}`) as {
+        value: string
+      } | null
+      const part = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:part:${sid}`) as {
+        value: string
+      } | null
+      const todo = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:todo:${sid}`) as {
+        value: string
+      } | null
+      expect(mark).not.toBeNull()
+      expect(part).not.toBeNull()
+      expect(todo).not.toBeNull()
+      expect(Number(mark!.value)).toBe(now)
+      expect(Number(part!.value)).toBe(0)
+      expect(Number(todo!.value)).toBe(0)
+    })
+  })
+
+  test("child session marker is independent of parent marker", async () => {
+    await scope(async () => {
+      const parent = await Session.create({})
+      const child = await Session.create({ parentID: parent.id })
+      const src = Database.Client().$client
+      const now = Date.now()
+      const later = now + 10000
+
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), parent.id, now, now, JSON.stringify({ role: "user", text: "parent-orphan-1" }))
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), child.id, now, now, JSON.stringify({ role: "user", text: "child-orphan-1" }))
+
+      Database.closeSession(parent.id)
+      Database.resetSwept()
+      Database.ensureShard(child.id)
+
+      let shard = Database.session(parent.id).$client
+      const parent_before = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${parent.id}`) as {
+        value: string
+      } | null
+      const child_before = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${child.id}`) as {
+        value: string
+      } | null
+
+      expect(parent_before?.value).toBe(String(now))
+      expect(child_before?.value).toBe(String(now))
+
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), parent.id, later, later, JSON.stringify({ role: "user", text: "parent-orphan-2" }))
+
+      Database.closeSession(parent.id)
+      Database.ensureShard(parent.id)
+      shard = Database.session(parent.id).$client
+
+      const parent_after = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${parent.id}`) as {
+        value: string
+      } | null
+      const child_after = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${child.id}`) as {
+        value: string
+      } | null
+
+      expect(parent_after?.value).toBe(String(later))
+      expect(child_after?.value).toBe(String(now))
+    })
+  })
+
+  test("close clears swept gate so a reopened shard rechecks markers", async () => {
+    await scope(async () => {
+      const session = await Session.create({})
+      const sid = session.id
+      const now = Date.now()
+      const later = now + 10000
+      const row = Database.Client().select().from(SessionTable).where(eq(SessionTable.id, sid)).get()
+
+      expect(row?.id).toBe(sid)
+
+      Database.Client()
+        .$client.query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, now, now, JSON.stringify({ role: "user", text: "orphan-1" }))
+
+      Database.closeSession(sid)
+      Database.resetSwept()
+      Database.ensureShard(sid)
+
+      Database.close()
+
+      const src = Database.Client().$client
+      src.exec("PRAGMA foreign_keys = OFF")
+      Database.Client().insert(SessionTable).values(row!).onConflictDoNothing().run()
+      src
+        .query("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)")
+        .run(MessageID.ascending(), sid, later, later, JSON.stringify({ role: "user", text: "orphan-2" }))
+      src.exec("PRAGMA foreign_keys = ON")
+
+      Database.ensureShard(sid)
+
+      const shard = Database.session(sid).$client
+      const mark = shard.query("SELECT value FROM _meta WHERE key = ?").get(`swept:msg:${sid}`) as {
+        value: string
+      } | null
+      const rows = Database.session(sid).select().from(MessageTable).where(eq(MessageTable.session_id, sid)).all()
+
+      expect(mark?.value).toBe(String(later))
+      expect(rows).toHaveLength(2)
+    })
+  })
+})

--- a/packages/opencode/test/storage/checkpoint-monitoring.test.ts
+++ b/packages/opencode/test/storage/checkpoint-monitoring.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dirname, "../..")
+
+async function probe(file: string, body: string[]) {
+  const run = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { Database } from "./src/storage/db"',
+        'import { Log } from "./src/util/log"',
+        "await Log.init({ print: true })",
+        "const db = Database.Client()",
+        ...body,
+        "await Bun.write(Bun.stdout, JSON.stringify(Database.monitor()))",
+        "process.exit(0)",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENCODE_DB: file,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (run.exitCode !== 0) {
+    throw new Error(run.stderr.toString() || run.stdout.toString())
+  }
+  return {
+    out: JSON.parse(run.stdout.toString()) as {
+      checkpoint?: {
+        blocked: number
+        wal_pages: number
+        checkpointed_pages: number
+      }
+    },
+    err: run.stderr.toString(),
+  }
+}
+
+describe("checkpoint monitoring", () => {
+  test("Database.monitor reports checkpoint payload and logs checkpoint status", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "checkpoint.db")
+    const result = await probe(file, [
+      'db.$client.run("CREATE TABLE IF NOT EXISTS test (id TEXT PRIMARY KEY, data TEXT)")',
+      'for (let i = 0; i < 50; i++) db.$client.run("INSERT OR REPLACE INTO test VALUES (?, ?)", [`id-${i}`, `data-${i}`])',
+    ])
+
+    expect(result.out.checkpoint).toBeDefined()
+    expect(typeof result.out.checkpoint?.blocked).toBe("number")
+    expect(typeof result.out.checkpoint?.wal_pages).toBe("number")
+    expect(typeof result.out.checkpoint?.checkpointed_pages).toBe("number")
+    expect(result.err).toMatch(/wal\.checkpoint\.(complete|incomplete)/)
+  })
+})

--- a/packages/opencode/test/storage/pragma.test.ts
+++ b/packages/opencode/test/storage/pragma.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { Database } from "../../src/storage/db"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dirname, "../..")
+
+async function pragma(kind: "global" | "shard", sql: string) {
+  await using tmp = await tmpdir()
+  const file = path.join(tmp.path, "pragma.db")
+  const run = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { Database } from "./src/storage/db"',
+        "const kind = process.env.OPENCODE_PRAGMA_KIND",
+        "const sql = process.env.OPENCODE_PRAGMA_SQL",
+        'const db = kind === "global" ? Database.Client() : Database.session("test-session")',
+        "const row = db.$client.query(`PRAGMA ${sql}`).get()",
+        "process.stdout.write(JSON.stringify(row))",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENCODE_DB: file,
+      OPENCODE_PRAGMA_KIND: kind,
+      OPENCODE_PRAGMA_SQL: sql,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (run.exitCode !== 0) {
+    throw new Error(run.stderr.toString())
+  }
+  return JSON.parse(run.stdout.toString()) as Record<string, number | string>
+}
+
+describe("Database Pragmas", () => {
+  afterEach(() => {
+    Database.close()
+  })
+
+  test("global DB has busy_timeout = 10000", async () => {
+    const result = await pragma("global", "busy_timeout")
+    expect(Object.values(result)[0]).toBe(10000)
+  })
+
+  test("shard DB has busy_timeout = 5000", async () => {
+    const result = await pragma("shard", "busy_timeout")
+    expect(Object.values(result)[0]).toBe(5000)
+  })
+
+  test("global DB has mmap_size = 134217728", async () => {
+    const result = await pragma("global", "mmap_size")
+    expect(Object.values(result)[0]).toBe(134217728)
+  })
+
+  test("shard DB has mmap_size = 134217728", async () => {
+    const result = await pragma("shard", "mmap_size")
+    expect(Object.values(result)[0]).toBe(134217728)
+  })
+
+  test("global DB has temp_store = MEMORY", async () => {
+    const result = await pragma("global", "temp_store")
+    // MEMORY = 2
+    expect(Object.values(result)[0]).toBe(2)
+  })
+
+  test("shard DB has temp_store = MEMORY", async () => {
+    const result = await pragma("shard", "temp_store")
+    // MEMORY = 2
+    expect(Object.values(result)[0]).toBe(2)
+  })
+
+  test("global DB has journal_mode = WAL", async () => {
+    const result = await pragma("global", "journal_mode")
+    expect(Object.values(result)[0]).toBe("wal")
+  })
+
+  test("global DB has synchronous = NORMAL", async () => {
+    const result = await pragma("global", "synchronous")
+    // NORMAL = 1
+    expect(Object.values(result)[0]).toBe(1)
+  })
+
+  test("global DB has foreign_keys = ON", async () => {
+    const result = await pragma("global", "foreign_keys")
+    expect(Object.values(result)[0]).toBe(1)
+  })
+})

--- a/packages/opencode/test/storage/retry.test.ts
+++ b/packages/opencode/test/storage/retry.test.ts
@@ -1,0 +1,212 @@
+import { existsSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dirname, "../..")
+const sid = "retry-session"
+
+function env(tmp: string, file?: string) {
+  return {
+    ...process.env,
+    OPENCODE_DB: file,
+    OPENCODE_BUSY_TIMEOUT: "1",
+    OPENCODE_GO: path.join(tmp, "go"),
+    OPENCODE_READY: path.join(tmp, "ready"),
+    OPENCODE_SESSION_ID: sid,
+    XDG_CACHE_HOME: tmp,
+    XDG_CONFIG_HOME: tmp,
+    XDG_DATA_HOME: tmp,
+    XDG_STATE_HOME: tmp,
+  }
+}
+
+function call(kind: "global" | "shard", tmp: string, file?: string) {
+  return Bun.spawn({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { existsSync } from "fs"',
+        'import { Database } from "./src/storage/db"',
+        'import { EventSequenceTable } from "./src/sync/event.sql"',
+        'const id = process.env.OPENCODE_SESSION_ID || "retry-session"',
+        'const go = process.env.OPENCODE_GO || "go"',
+        'const ready = process.env.OPENCODE_READY || "ready"',
+        'const db = process.env.OPENCODE_KIND === "global" ? Database.Client() : Database.session(id)',
+        'db.$client.run(`PRAGMA busy_timeout = ${process.env.OPENCODE_BUSY_TIMEOUT || "1"}`)',
+        'await Bun.write(ready, "ready")',
+        "while (!existsSync(go)) await Bun.sleep(10)",
+        'const stats = () => typeof Database.stats === "function" ? Database.stats() : null',
+        "try {",
+        '  const write = (tx) => { tx.insert(EventSequenceTable).values({ aggregate_id: id, seq: 1 }).run(); return "ok" }',
+        '  const result = process.env.OPENCODE_KIND === "global" ? Database.transaction(write, { behavior: "immediate" }) : Database.session(id).transaction(write, { behavior: "immediate" })',
+        "  await Bun.write(Bun.stdout, JSON.stringify({ ok: true, result, stats: stats() }))",
+        "} catch (err) {",
+        "  await Bun.write(Bun.stdout, JSON.stringify({ ok: false, name: err?.name, message: err?.message, code: err?.code, errno: err?.errno, stats: stats() }))",
+        "  process.exit(1)",
+        "}",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...env(tmp, file),
+      OPENCODE_KIND: kind,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+function hold(file: string, tmp: string, ms: number) {
+  return Bun.spawn({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { Database } from "bun:sqlite"',
+        'const db = new Database(process.env.OPENCODE_LOCK_DB || "")',
+        'db.run("BEGIN IMMEDIATE")',
+        "db.run(\"INSERT INTO event_sequence (aggregate_id, seq) VALUES ('hold', 1)\")",
+        'await Bun.write(process.env.OPENCODE_LOCK || "lock", "lock")',
+        'await Bun.sleep(Number(process.env.OPENCODE_HOLD || "0"))',
+        'db.run("ROLLBACK")',
+        "db.close()",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENCODE_HOLD: String(ms),
+      OPENCODE_LOCK: path.join(tmp, "lock"),
+      OPENCODE_LOCK_DB: file,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+}
+
+function delays(text: string) {
+  return [...text.matchAll(/delay=(\d+)/g)].map((item) => Number(item[1]))
+}
+
+async function wait(file: string, proc?: Bun.Subprocess, timeout: number = 5_000) {
+  for (let i = 0; i < timeout / 10; i++) {
+    if (existsSync(file)) return
+    await Bun.sleep(10)
+  }
+  const stream = proc?.stderr
+  const err = stream && typeof stream !== "number" ? await new Response(stream).text() : ""
+  throw new Error(`timed out waiting for ${file}\n${err}`)
+}
+
+describe("Database.transaction busy retry", () => {
+  test("retries global transactions with backoff and jitter", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "global.db")
+    const proc = call("global", tmp.path, file)
+    await wait(path.join(tmp.path, "ready"), proc, 15_000)
+
+    const lock = hold(file, tmp.path, 120)
+    await wait(path.join(tmp.path, "lock"), lock)
+    await Bun.write(path.join(tmp.path, "go"), "go")
+
+    const code = await proc.exited
+    await lock.exited
+    const text = await new Response(proc.stdout).text()
+    const err = await new Response(proc.stderr).text()
+    const out = JSON.parse(text) as {
+      ok: boolean
+      result?: string
+      stats: Record<string, number> | null
+    }
+
+    expect(code).toBe(0)
+    expect(out.ok).toBe(true)
+    expect(out.result).toBe("ok")
+    expect(out.stats).toBeDefined()
+    expect(out.stats?.write).toBe(1)
+    expect(out.stats?.retry).toBe(2)
+    expect(out.stats?.exhausted).toBe(0)
+    expect(err).toContain("sqlite.busy.retry")
+    expect(err).not.toContain("sqlite.busy.exhausted")
+
+    const list = delays(err)
+    expect(list).toHaveLength(2)
+    expect(list[0]).toBeGreaterThanOrEqual(38)
+    expect(list[0]).toBeLessThanOrEqual(63)
+    expect(list[1]).toBeGreaterThanOrEqual(150)
+    expect(list[1]).toBeLessThanOrEqual(250)
+  }, 15_000)
+
+  test("rethrows the original busy error after retries exhaust", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "global.db")
+    const proc = call("global", tmp.path, file)
+    await wait(path.join(tmp.path, "ready"), proc, 15_000)
+
+    const lock = hold(file, tmp.path, 2000)
+    await wait(path.join(tmp.path, "lock"), lock)
+    await Bun.write(path.join(tmp.path, "go"), "go")
+
+    const code = await proc.exited
+    await lock.exited
+
+    const text = await new Response(proc.stdout).text()
+    const err = await new Response(proc.stderr).text()
+    const out = JSON.parse(text) as {
+      ok: boolean
+      name: string
+      message: string
+      code: string
+      errno: number
+      stats: Record<string, number> | null
+    }
+
+    expect(code).toBe(1)
+    expect(out.ok).toBe(false)
+    expect(out.name).toBe("SQLiteError")
+    expect(out.message).toBe("database is locked")
+    expect(out.code).toBe("SQLITE_BUSY")
+    expect(out.errno).toBe(5)
+    expect(out.stats).toBeDefined()
+    expect(out.stats?.write).toBe(1)
+    expect(out.stats?.retry).toBe(3)
+    expect(out.stats?.exhausted).toBe(1)
+    expect(err).toContain("sqlite.busy.retry")
+    expect(err).toContain("sqlite.busy.exhausted")
+    expect(delays(err)).toHaveLength(3)
+  }, 15_000)
+
+  test("shard transactions skip global retry overhead", async () => {
+    await using tmp = await tmpdir()
+    const proc = call("shard", tmp.path)
+
+    const file = path.join(tmp.path, "opencode", "sessions", `${sid}.db`)
+    await wait(path.join(tmp.path, "ready"), proc, 15_000)
+    const lock = hold(file, tmp.path, 2000)
+    await wait(path.join(tmp.path, "lock"), lock)
+    await Bun.write(path.join(tmp.path, "go"), "go")
+
+    const code = await proc.exited
+    await lock.exited
+
+    const text = await new Response(proc.stdout).text()
+    const err = await new Response(proc.stderr).text()
+    const out = JSON.parse(text) as {
+      ok: boolean
+      code: string
+      stats: Record<string, number> | null
+    }
+
+    expect(code).toBe(1)
+    expect(out.ok).toBe(false)
+    expect(out.code).toBe("SQLITE_BUSY")
+    expect(out.stats).toBeDefined()
+    expect(out.stats?.write).toBe(0)
+    expect(out.stats?.retry).toBe(0)
+    expect(out.stats?.exhausted).toBe(0)
+    expect(err).not.toContain("sqlite.busy.retry")
+    expect(err).not.toContain("sqlite.busy.exhausted")
+  }, 15_000)
+})

--- a/packages/opencode/test/storage/wal-monitoring.test.ts
+++ b/packages/opencode/test/storage/wal-monitoring.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dirname, "../..")
+
+async function probe(file: string, body: string[]) {
+  const run = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { Database } from "./src/storage/db"',
+        'import { Log } from "./src/util/log"',
+        "await Log.init({ print: true })",
+        "const db = Database.Client()",
+        ...body,
+        "await Bun.write(Bun.stdout, JSON.stringify(Database.monitor()))",
+        "process.exit(0)",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENCODE_DB: file,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (run.exitCode !== 0) {
+    throw new Error(run.stderr.toString() || run.stdout.toString())
+  }
+  return {
+    out: JSON.parse(run.stdout.toString()) as {
+      wal_bytes: number
+      metrics: Record<string, number>
+    },
+    err: run.stderr.toString(),
+  }
+}
+
+describe("WAL health monitoring", () => {
+  test("Database.monitor logs wal size for file-backed databases", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "wal.db")
+    const result = await probe(file, [
+      'db.$client.run("CREATE TABLE IF NOT EXISTS test (id TEXT PRIMARY KEY, data TEXT)")',
+      'for (let i = 0; i < 200; i++) db.$client.run("INSERT OR REPLACE INTO test VALUES (?, ?)", [`id-${i}`, `data-${i}`])',
+    ])
+
+    expect(result.out.wal_bytes).toBeGreaterThan(0)
+    expect(result.err).toContain("wal.size")
+    expect(result.err).toContain("db.metrics")
+  })
+})

--- a/packages/opencode/test/storage/write-metrics.test.ts
+++ b/packages/opencode/test/storage/write-metrics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+
+const root = path.join(import.meta.dirname, "../..")
+
+async function probe(file: string, body: string[]) {
+  const run = Bun.spawnSync({
+    cmd: [
+      "bun",
+      "-e",
+      [
+        'import { Database } from "./src/storage/db"',
+        'import { Log } from "./src/util/log"',
+        "await Log.init({ print: true })",
+        "const db = Database.Client()",
+        ...body,
+        "await Bun.write(Bun.stdout, JSON.stringify({ stats: Database.stats(), monitor: Database.monitor() }))",
+        "process.exit(0)",
+      ].join(";"),
+    ],
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENCODE_DB: file,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (run.exitCode !== 0) {
+    throw new Error(run.stderr.toString() || run.stdout.toString())
+  }
+  return {
+    out: JSON.parse(run.stdout.toString()) as {
+      stats: Record<string, number>
+      monitor: {
+        metrics: Record<string, number>
+      }
+    },
+    err: run.stderr.toString(),
+  }
+}
+
+describe("write metrics", () => {
+  test("Database.monitor logs the planned metric keys", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "metrics.db")
+    const result = await probe(file, [
+      'db.$client.run("CREATE TABLE IF NOT EXISTS test (id TEXT PRIMARY KEY, data TEXT)")',
+      'for (let i = 0; i < 5; i++) Database.transaction(() => db.$client.run("INSERT OR REPLACE INTO test VALUES (?, ?)", [`id-${i}`, `data-${i}`]))',
+      'const shard = Database.session("metrics-session")',
+      'shard.$client.run("CREATE TABLE IF NOT EXISTS local (id TEXT PRIMARY KEY, data TEXT)")',
+      'shard.$client.run("INSERT OR REPLACE INTO local VALUES (?, ?)", ["id", "data"])',
+    ])
+
+    expect(result.out.stats.write).toBeGreaterThanOrEqual(5)
+    expect(result.out.monitor.metrics["db.global.writes"]).toBe(result.out.stats.write)
+    expect(result.out.monitor.metrics["db.global.retries"]).toBe(result.out.stats.retry)
+    expect(result.out.monitor.metrics["db.global.busy_errors"]).toBe(result.out.stats.exhausted)
+    expect(result.err).toContain("db.metrics")
+    expect(result.err).toContain("db.global.writes")
+    expect(result.err).toContain("db.global.retries")
+    expect(result.err).toContain("db.global.busy_errors")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20935

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds per-session-tree SQLite sharding for message, part, todo, and event storage while keeping session and project metadata in the global database. Old sessions still fall back to the global database when no shard exists yet, so the new path can coexist with pre-sharding data.

It also hardens the global write path with `SQLITE_BUSY*` retry/backoff, WAL/checkpoint monitoring, and targeted routing plus load coverage. During soak verification on current `dev`, project bootstrap writes also needed the same immediate transaction wrapper so worker startup would not surface rare `SQLITE_BUSY_RECOVERY` failures before shard activity began.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test test/storage/retry.test.ts test/storage/pragma.test.ts test/storage/db.test.ts test/storage/wal-monitoring.test.ts test/storage/checkpoint-monitoring.test.ts test/storage/write-metrics.test.ts test/session/concurrency-load.test.ts`
- `cd packages/opencode && OPENCODE_LOAD_SOAK_MS=300000 bun test test/session/concurrency-load.test.ts -t "soaks multi-process contention for the configured duration"`

### Screenshots / recordings

N/A (storage/runtime change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR