### PR TITLE
fix(provider): normalize missing array items in tool schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -967,32 +967,58 @@ export namespace ProviderTransform {
     }
     */
 
+    const isPlainObject = (node: unknown): node is Record<string, any> =>
+      typeof node === "object" && node !== null && !Array.isArray(node)
+    const hasCombiner = (node: unknown) =>
+      isPlainObject(node) && (Array.isArray(node.anyOf) || Array.isArray(node.oneOf) || Array.isArray(node.allOf))
+    const hasSchemaIntent = (node: unknown) => {
+      if (!isPlainObject(node)) return false
+      if (hasCombiner(node)) return true
+      return [
+        "type",
+        "properties",
+        "items",
+        "prefixItems",
+        "enum",
+        "const",
+        "$ref",
+        "additionalProperties",
+        "patternProperties",
+        "required",
+        "not",
+        "if",
+        "then",
+        "else",
+      ].some((key) => key in node)
+    }
+
+    const sanitizeMissingArrayItems = (obj: any): any => {
+      if (obj === null || typeof obj !== "object") {
+        return obj
+      }
+
+      if (Array.isArray(obj)) {
+        return obj.map(sanitizeMissingArrayItems)
+      }
+
+      const result: any = {}
+      for (const [key, value] of Object.entries(obj)) {
+        result[key] = typeof value === "object" && value !== null ? sanitizeMissingArrayItems(value) : value
+      }
+
+      // OpenAI-compatible tool validators reject array nodes without an explicit items schema.
+      // Adding an empty schema preserves the original "any item shape is allowed" meaning.
+      if (result.type === "array" && result.items == null && !hasCombiner(result)) {
+        result.items = {}
+      }
+
+      return result
+    }
+
+    schema = sanitizeMissingArrayItems(schema)
+
     // Convert integer enums to string enums for Google/Gemini
     if (model.providerID === "google" || model.api.id.includes("gemini")) {
-      const isPlainObject = (node: unknown): node is Record<string, any> =>
-        typeof node === "object" && node !== null && !Array.isArray(node)
-      const hasCombiner = (node: unknown) =>
-        isPlainObject(node) && (Array.isArray(node.anyOf) || Array.isArray(node.oneOf) || Array.isArray(node.allOf))
-      const hasSchemaIntent = (node: unknown) => {
-        if (!isPlainObject(node)) return false
-        if (hasCombiner(node)) return true
-        return [
-          "type",
-          "properties",
-          "items",
-          "prefixItems",
-          "enum",
-          "const",
-          "$ref",
-          "additionalProperties",
-          "patternProperties",
-          "required",
-          "not",
-          "if",
-          "then",
-          "else",
-        ].some((key) => key in node)
-      }
 
       const sanitizeGemini = (obj: any): any => {
         if (obj === null || typeof obj !== "object") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -440,6 +440,38 @@ describe("ProviderTransform.providerOptions", () => {
   })
 })
 
+describe("ProviderTransform.schema - missing array items", () => {
+  test("adds missing items for openai nested array branches", () => {
+    const openaiModel = {
+      providerID: "openai",
+      api: {
+        id: "gpt-5",
+      },
+    } as any
+
+    const schema = {
+      type: "object",
+      properties: {
+        ports: {
+          anyOf: [
+            {
+              type: "object",
+              additionalProperties: {
+                anyOf: [{ type: "string" }, { type: "number" }, { type: "array" }],
+              },
+            },
+            { type: "null" },
+          ],
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(openaiModel, schema) as any
+
+    expect(result.properties.ports.anyOf[0].additionalProperties.anyOf[2].items).toEqual({})
+  })
+})
+
 describe("ProviderTransform.schema - gemini array items", () => {
   test("adds missing items for array properties", () => {
     const geminiModel = {


### PR DESCRIPTION
## Summary
- normalize tool schemas so array nodes missing `items` are converted to `items: {}` before they are sent to model providers
- preserve the original permissive schema semantics while avoiding OpenAI/OpenAI-compatible validation failures on MCP tools such as `docker_create_container`
- add a regression test for the nested `ports -> additionalProperties -> anyOf -> array` schema shape that triggered the bug

## Testing
- `bun test test/provider/transform.test.ts --timeout 30000`
- push hook: `bun turbo typecheck`