### PR TITLE
fix: tolerate outputSchema compilation failures in MCP tool discovery

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -4,6 +4,8 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+import type { jsonSchemaValidator as JsonSchemaValidatorProvider, JsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/types.js"
 import {
   CallToolResultSchema,
   type Tool as MCPToolDef,
@@ -29,6 +31,29 @@ import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
+
+/**
+ * Wraps AjvJsonSchemaValidator to catch schema compilation errors.
+ * opencode doesn't validate tool output schemas, so compilation failures
+ * (e.g. from complex or unsupported schemas) should not prevent tool discovery.
+ */
+class TolerantJsonSchemaValidator implements JsonSchemaValidatorProvider {
+  private inner = new AjvJsonSchemaValidator()
+
+  getValidator<T>(schema: any): JsonSchemaValidator<T> {
+    try {
+      return this.inner.getValidator<T>(schema)
+    } catch {
+      return (input: unknown) => ({
+        valid: true as const,
+        data: input as T,
+        errorMessage: undefined,
+      })
+    }
+  }
+}
+
+const tolerantValidator = new TolerantJsonSchemaValidator()
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
@@ -260,7 +285,7 @@ export namespace MCP {
           (t) =>
             Effect.tryPromise({
               try: () => {
-                const client = new Client({ name: "opencode", version: Installation.VERSION })
+                const client = new Client({ name: "opencode", version: Installation.VERSION }, { jsonSchemaValidator: tolerantValidator })
                 return withTimeout(client.connect(t), timeout).then(() => client)
               },
               catch: (e) => (e instanceof Error ? e : new Error(String(e))),
@@ -743,7 +768,7 @@ export namespace MCP {
 
         return yield* Effect.tryPromise({
           try: () => {
-            const client = new Client({ name: "opencode", version: Installation.VERSION })
+            const client = new Client({ name: "opencode", version: Installation.VERSION }, { jsonSchemaValidator: tolerantValidator })
             return client.connect(transport).then(() => ({ authorizationUrl: "", oauthState }))
           },
           catch: (error) => error,


### PR DESCRIPTION
### Issue for this PR

Closes #21591

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an MCP server returns `outputSchema` in its `tools/list` response, the SDK's `AjvJsonSchemaValidator.getValidator()` calls `ajv.compile(schema)` with no try/catch. If the schema uses unsupported keywords, it throws and the entire `listTools()` call fails, making the server show "Failed to get tools."

opencode never uses `outputSchema` (only `inputSchema` in `convertMcpTool()`), so these compilation failures shouldn't block tool discovery.

The fix wraps `AjvJsonSchemaValidator` in a `TolerantJsonSchemaValidator` that catches `getValidator()` failures and returns a permissive fallback. Uses the SDK's `jsonSchemaValidator` extension point, no monkey-patching. One file changed, ~20 lines added.

### How did you verify your code works?

- Traced the code path: `listTools()` → `cacheToolMetadata()` → `getValidator(outputSchema)` — confirmed the wrapper intercepts the throw
- typecheck passes
- All existing tests pass
- Working servers still use the real AJV validator (fallback only triggers on compilation errors)

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR