### PR TITLE
fix: pass explicit id through Session.create to createNext

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -493,6 +493,7 @@ export namespace Session {
         }).pipe(Effect.withSpan("Session.updatePart"))
 
       const create = Effect.fn("Session.create")(function* (input?: {
+        id?: SessionID
         parentID?: SessionID
         title?: string
         permission?: Permission.Ruleset
@@ -500,6 +501,7 @@ export namespace Session {
       }) {
         const directory = yield* InstanceState.directory
         return yield* createNext({
+          id: input?.id,
           parentID: input?.parentID,
           directory,
           title: input?.title,
@@ -688,6 +690,7 @@ export namespace Session {
   export const create = fn(
     z
       .object({
+        id: SessionID.zod.optional(),
         parentID: SessionID.zod.optional(),
         title: z.string().optional(),
         permission: Info.shape.permission,


### PR DESCRIPTION
### Issue for this PR

Closes #21568

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Session.create` accepted `parentID`, `title`, `permission`, `workspaceID` but not `id`. The underlying `createNext` helper already supports an optional `id` parameter and uses it via `SessionID.descending(input.id)`, but the public `create` function never passed it through.

This adds `id?: SessionID` to both the internal `create` function signature and the public Zod schema, then threads `input?.id` into the `createNext` call. When no `id` is provided, behavior is unchanged (auto-generated descending ID).

### How did you verify your code works?

- Typecheck passes: `bun x turbo typecheck --filter=opencode`
- Traced the code path: `Session.create` → `createNext` → `SessionID.descending(input.id)` → `generateID()` which returns the given ID when provided, or generates a new one when not

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR