### PR TITLE
fix(app): guard message memos against undefined on deep-link render

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -465,15 +465,21 @@ export default function Page() {
     return sync.session.history.loading(id)
   })
   const userMessages = createMemo(
-    () => messages().filter((m) => m.role === "user") as UserMessage[],
+    () => {
+      const msgs = messages()
+      if (!msgs || !messagesReady()) return emptyUserMessages
+      return msgs.filter((m) => m.role === "user") as UserMessage[]
+    },
     emptyUserMessages,
     { equals: same },
   )
   const visibleUserMessages = createMemo(
     () => {
+      const msgs = userMessages()
+      if (!msgs) return emptyUserMessages
       const revert = revertMessageID()
-      if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
+      if (!revert) return msgs
+      return msgs.filter((m) => m.id < revert)
     },
     emptyUserMessages,
     {
@@ -1497,7 +1503,7 @@ export default function Page() {
   const historyWindow = createSessionHistoryWindow({
     sessionID: () => params.id,
     messagesReady,
-    loaded: () => messages().length,
+    loaded: () => (messages() ?? []).length,
     visibleUserMessages,
     historyMore,
     historyLoading,


### PR DESCRIPTION
### Issue for this PR

Closes #21569

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opening a deep-linked session URL (`/<directory>/session/<id>`), the `sync.data.message[id]` store entry may not be populated yet. The `userMessages` memo calls `messages().filter(...)` without checking readiness, which can throw `TypeError: Cannot read properties of undefined (reading 'filter')`.

This adds two guards:
- `userMessages` now checks `messagesReady()` and returns `emptyUserMessages` when the store isn't ready
- `visibleUserMessages` and the `loaded` callback get null-safe access to avoid the same class of error

### How did you verify your code works?

- Typecheck passes: `bun x turbo typecheck --filter=@opencode-ai/app`
- Traced the render flow: on deep-link navigation, `SyncProvider` gates on `ready`, but within the first reactive pass `messages()` can still yield undefined before the store is hydrated. The `messagesReady()` guard short-circuits to the seed value.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR