### PR TITLE
fix(tui): increase diff line number contrast in opencode theme

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
@@ -138,7 +138,7 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "darkStep3",
+      "dark": "darkStep12",
       "light": "lightStep3"
     },
     "diffAddedLineNumberBg": {


### PR DESCRIPTION
### Issue for this PR

Fixes #21618

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It changes the color of the dark `diffLineNumber` from the `opencode` theme from `darkStep3` to `darkStep12` to improve the contrast and readability of the code diffs shown when the `opencode` theme is being used.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I modified the base theme, and tried it out in opencode with the updated colors, then asked an AI agent to do a small change on my codebase to compare the readability of the lines in the diffs between the old `darkStep3` color and the `darkStep12` color

### Screenshots / recordings

Here's how it looked like before, with it using `darkStep3`:
<img width="1079" height="413" alt="image" src="https://github.com/user-attachments/assets/9f60ae6d-d9fc-453b-bded-fdbd67e48ff0" />


And here's how it looks like now, with it using `darkStep12`:

<img width="1091" height="625" alt="image" src="https://github.com/user-attachments/assets/3ecfdd27-4b4b-476b-a3df-5ef25aca45c8" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
