### PR TITLE
feat(mcp): forward session ID and plugin _meta to MCP tool calls

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -144,11 +144,13 @@ export namespace MCP {
     return dynamicTool({
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
-      execute: async (args: unknown) => {
+      execute: async (args: unknown, opts?) => {
+        const meta = (opts as any)?._meta as Record<string, unknown> | undefined
         return client.callTool(
           {
             name: mcpTool.name,
             arguments: (args || {}) as Record<string, unknown>,
+            ...(meta ? { _meta: meta } : {}),
           },
           CallToolResultSchema,
           {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -483,14 +483,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             Effect.runPromise(
               Effect.gen(function* () {
                 const ctx = context(args, opts)
+                const hook: { args: unknown; _meta?: Record<string, unknown> } = {
+                  args,
+                  _meta: { sessionID: ctx.sessionID },
+                }
                 yield* plugin.trigger(
                   "tool.execute.before",
                   { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
-                  { args },
+                  hook,
                 )
                 yield* Effect.promise(() => ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] }))
                 const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.promise(() =>
-                  execute(args, opts),
+                  execute(hook.args, { ...opts, _meta: hook._meta } as typeof opts),
                 )
                 yield* plugin.trigger(
                   "tool.execute.after",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -231,7 +231,7 @@ export interface Hooks {
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },
-    output: { args: any },
+    output: { args: any; _meta?: Record<string, unknown> },
   ) => Promise<void>
   "shell.env"?: (
     input: { cwd: string; sessionID?: string; callID?: string },


### PR DESCRIPTION
### Issue for this PR

Closes #6279
Closes #17084

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP servers currently have no way to know which opencode session called them. This adds two things:

1. **Built-in session context**: opencode now always includes `_meta: { sessionID }` in every `callTool()` request. MCP servers receive the caller's session ID automatically via the standard MCP `_meta` field.

2. **Plugin-extensible `_meta`**: the `tool.execute.before` hook output now includes an optional `_meta` field. Plugins can add custom metadata (correlation IDs, trace context, etc.) that gets forwarded to downstream MCP servers alongside the built-in sessionID.

When no plugin sets `_meta`, MCP servers still receive `{ sessionID }`. When a plugin adds fields, they merge with the built-in ones.

**Files changed (3):**
- `packages/opencode/src/mcp/index.ts` — read `_meta` from execute opts, forward to `client.callTool()`
- `packages/opencode/src/session/prompt.ts` — seed `_meta` with `{ sessionID }`, pass through hook and into execute
- `packages/plugin/src/index.ts` — add `_meta` to `tool.execute.before` hook output type

### How did you verify your code works?

- All 236 session tests pass (0 fail, 624 assertions)
- Typecheck: zero new errors (existing `llm.ts` errors are from upstream #19955, present on bare `dev`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR