### PR TITLE
fix(sdk): ensure opencode server closes cleanly via process groups

### DIFF
--- a/packages/sdk/js/src/process.ts
+++ b/packages/sdk/js/src/process.ts
@@ -9,7 +9,11 @@ export function stop(proc: ChildProcess) {
     if (!out.error && out.status === 0) return
   }
   // Kill the entire process group (negative PID) to prevent orphaned processes
-  process.kill(-proc.pid, "SIGTERM");
+  if (proc.pid) {
+    process.kill(-proc.pid, "SIGTERM");
+  } else {
+    proc.kill()
+  }
 }
 
 export function bindAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {

--- a/packages/sdk/js/src/process.ts
+++ b/packages/sdk/js/src/process.ts
@@ -8,7 +8,8 @@ export function stop(proc: ChildProcess) {
     const out = spawnSync("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { windowsHide: true })
     if (!out.error && out.status === 0) return
   }
-  proc.kill()
+  // Kill the entire process group (negative PID) to prevent orphaned processes
+  process.kill(-proc.pid, "SIGTERM");
 }
 
 export function bindAbort(proc: ChildProcess, signal?: AbortSignal, onAbort?: () => void) {

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -37,6 +37,8 @@ export async function createOpencodeServer(options?: ServerOptions) {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
     },
+    // Start in a new process group so we can kill the entire tree
+    detached: true
   })
   let clear = () => {}
 

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -37,6 +37,8 @@ export async function createOpencodeServer(options?: ServerOptions) {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
     },
+    // Start in a new process group so we can kill the entire tree
+    detached: true
   })
   let clear = () => {}
 


### PR DESCRIPTION
### Issue for this PR

Closes #21628

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes an issue where calling server.close() would only terminate the immediate process wrapper, leaving the underlying opencode server orphaned and the network port occupied.
I updated the SDK to spawn the process in a new process group (detached: true). This change uses a negative PID (-proc.pid) on POSIX systems to signal the entire process group. In windows this seems already handled via taskkill /T /F .


The use case I have opencode installed with deno, when I use the close api it kills the deno wrapper but not the actual opencode binary, this fixes it.
**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

With this change close kills deno wraooer and opencode 

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR