### PR TITLE
fix(provider): enable image support for custom OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1139,7 +1139,7 @@ export namespace Provider {
                     audio:
                       model.modalities?.input?.includes("audio") ?? existingModel?.capabilities.input.audio ?? false,
                     image:
-                      model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? false,
+                      model.modalities?.input?.includes("image") ?? existingModel?.capabilities.input.image ?? (provider?.npm === "@ai-sdk/openai-compatible" ? true : false),
                     video:
                       model.modalities?.input?.includes("video") ?? existingModel?.capabilities.input.video ?? false,
                     pdf: model.modalities?.input?.includes("pdf") ?? existingModel?.capabilities.input.pdf ?? false,


### PR DESCRIPTION
### Issue for this PR
Closes #20802

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom OpenAI-compatible providers (e.g., longent, Ollama with vision models) were unable to process image attachments. Users received the error: "I can't read \`image.png\` here because this model does not support image input" even when the provider actually supported vision capabilities.

**Root cause**: In `packages/opencode/src/provider/provider.ts:1110`, the default value for `capabilities.input.image` was `false` for custom providers without explicit `modalities` declaration. This caused `transform.ts:265` to filter out image parts before they could reach the existing conversion logic in `convert-to-openai-compatible-chat-messages.ts`.

**Fix**: Changed the default to `true` specifically for providers using `@ai-sdk/openai-compatible`:
```typescript
image: model.modalities?.input?.includes("image") ??
       existingModel?.capabilities.input.image ??
       (provider?.npm === "@ai-sdk/openai-compatible" ? true : false)
```

This is a one-line change that:
1. Checks if user explicitly declared `modalities.input.image` (highest priority)
2. Falls back to existing model definition from models.dev (if available)
3. For custom OpenAI-compatible providers, defaults to `true` instead of `false`

**Why this works**: The existing conversion logic in `convert-to-openai-compatible-chat-messages.ts:45-64` already correctly transforms `file` parts to `image_url` format. The issue was that custom providers were being flagged as "not supporting image input" before the conversion could happen.

### How did you verify your code works?

1. Created worktree to test the change
2. Configured a custom OpenAI-compatible provider without `modalities` declaration
3. Sent image attachments through the OpenCode session API
4. Verified that images now correctly reach the provider (previously were filtered out)
5. Confirmed the change is backward compatible:
   - Providers with explicit `modalities` still use their declaration
   - Official providers from models.dev keep their capabilities
   - Typecheck passes for all 19 packages

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR