### PR TITLE
fix(tui): save clipboard-pasted images to temp files for MCP tool access

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -2,7 +2,8 @@ import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, decodePasteB
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
+import { tmpdir } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { useLocal } from "@tui/context/local"
 import { useTheme } from "@tui/context/theme"
@@ -789,14 +790,28 @@ export function Prompt(props: PromptProps) {
       typeId: promptPartTypeId,
     })
 
+    let url = `data:${file.mime};base64,${file.content}`
+    let filepath = file.filepath
+
+    if (!filepath && file.mime.startsWith("image/")) {
+      const ext = file.mime.split("/")[1] ?? "png"
+      filepath = path.join(tmpdir(), `opencode-paste-${Date.now()}.${ext}`)
+      try {
+        await Bun.write(filepath, Buffer.from(file.content, "base64"))
+        url = pathToFileURL(filepath).href
+      } catch {
+        // fall back to data URL
+      }
+    }
+
     const part: Omit<FilePart, "id" | "messageID" | "sessionID"> = {
       type: "file" as const,
       mime: file.mime,
       filename: file.filename,
-      url: `data:${file.mime};base64,${file.content}`,
+      url,
       source: {
         type: "file",
-        path: file.filepath ?? file.filename ?? "",
+        path: filepath ?? file.filename ?? "",
         text: {
           start: extmarkStart,
           end: extmarkEnd,


### PR DESCRIPTION
### Issue for this PR

Closes #14673

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an image is pasted from the clipboard (Cmd+V / Ctrl+V), OpenCode stores it as an inline `data:image/...;base64,...` URL. This works for multimodal models, but non-vision models that rely on MCP tools to analyze images break because MCP tools expect a file path on disk, not a raw base64 string.

This PR saves clipboard-pasted images to a temp file in `os.tmpdir()` and sets the attachment URL to `file://...`, so MCP tools can read them. The `data:` URL is kept as fallback if writing fails.

Single file change, ~15 lines added.

### How did you verify your code works?

1. `bun run typecheck` passes across all 13 packages
2. Built a local binary (`bun run script/build.ts`) and verified:
   - Pasting an image from clipboard creates a file at `/tmp/opencode-paste-<timestamp>.png`
   - The attachment URL is now a `file://` URL instead of `data:...`
   - An MCP tool (custom zai-vision server reading from the temp path) successfully analyzed the pasted screenshot
3. Verified that non-image attachments are unaffected (no change in behavior)

### Screenshots / recordings

_No UI changes — purely internal data handling._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR