### PR TITLE
fix: catch exception from fetch call when download Ripgrep binary

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -145,7 +145,10 @@ export namespace Ripgrep {
       const filename = `ripgrep-${version}-${config.platform}.${config.extension}`
       const url = `https://github.com/BurntSushi/ripgrep/releases/download/${version}/${filename}`
 
-      const response = await fetch(url)
+      const response = await fetch(url).catch((error:any) => {
+        log.error(`Failed to download ripgrep from URL:${url}, error:${error?.message ?? String(error)}`)
+        throw new DownloadFailedError({ url, status: -1 })
+      })
       if (!response.ok) throw new DownloadFailedError({ url, status: response.status })
 
       const arrayBuffer = await response.arrayBuffer()


### PR DESCRIPTION
### Issue for this PR
Fixes #21646 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adding a proper .catch() handler around the fetch call responsible for downloading the `Ripgrep ` binary to capture the network exception.
Log the specific target URL that failed to download for debugging purposes.
Throw the existing error RipgrepDownloadFailedError to replace the confusing `Unable to connect` message.


### How did you verify your code works?
bun dev
### Screenshots / recordings
Only error message changed, no UI change.
**Before**
```
✱ Glob "xxxx.ts" 
Unable to connect. Is the computer able to access the url?
```


**After**
```
✱ Glob "xxxx.ts" 
RipgrepDownloadFailedError
```

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
