### PR TITLE
Remove deprecated qwen3.6-plus-free model

### DIFF
--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -11579,23 +11579,7 @@
         "limit": { "context": 400000, "input": 272000, "output": 128000 },
         "provider": { "npm": "@ai-sdk/openai" }
       },
-      "qwen3.6-plus-free": {
-        "id": "qwen3.6-plus-free",
-        "name": "Qwen3.6 Plus Free",
-        "family": "qwen-free",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": true,
-        "interleaved": { "field": "reasoning_content" },
-        "temperature": true,
-        "knowledge": "2024-12",
-        "release_date": "2026-03-30",
-        "last_updated": "2026-03-30",
-        "modalities": { "input": ["text"], "output": ["text"] },
-        "open_weights": false,
-        "cost": { "input": 0, "output": 0, "cache_read": 0 },
-        "limit": { "context": 1048576, "output": 64000 }
-      },
+
       "gpt-5.3-codex-spark": {
         "id": "gpt-5.3-codex-spark",
         "name": "GPT-5.3 Codex Spark",

--- a/packages/web/src/content/docs/ar/zen.mdx
+++ b/packages/web/src/content/docs/ar/zen.mdx
@@ -92,7 +92,6 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 يستخدم [معرّف النموذج](/docs/config/#models) في إعدادات OpenCode الصيغة `opencode/<model-id>`. على سبيل المثال، بالنسبة إلى GPT 5.3 Codex، ستستخدم `opencode/gpt-5.3-codex` في إعداداتك.
@@ -118,7 +117,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free    | Free    | Free            | -               |
 | MiMo V2 Pro Free                  | Free    | Free    | Free            | -               |
 | MiMo V2 Omni Free                 | Free    | Free    | Free            | -               |
-| Qwen3.6 Plus Free                 | Free    | Free    | Free            | -               |
 | Nemotron 3 Super Free             | Free    | Free    | Free            | -               |
 | MiniMax M2.5 Free                 | Free    | Free    | Free            | -               |
 | MiniMax M2.5                      | $0.30   | $1.20   | $0.06           | $0.375          |
@@ -166,7 +164,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - MiMo V2 Pro Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - MiMo V2 Omni Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
-- Qwen3.6 Plus Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - Nemotron 3 Super Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - Big Pickle نموذج خفي ومتاح مجانا على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 
@@ -194,6 +191,7 @@ https://opencode.ai/zen/v1/models
 
 | النموذج          | تاريخ الإيقاف |
 | ---------------- | ------------- |
+| Qwen3.6 Plus Free | 9 أبريل 2026 |
 | MiniMax M2.1     | 15 مارس 2026  |
 | GLM 4.7          | 15 مارس 2026  |
 | GLM 4.6          | 15 مارس 2026  |
@@ -212,7 +210,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: خلال فترته المجانية، قد تُستخدم البيانات المجمعة لتحسين النموذج.
 - MiMo V2 Pro Free: خلال فترته المجانية، قد تُستخدم البيانات المجمعة لتحسين النموذج.
 - MiMo V2 Omni Free: خلال فترته المجانية، قد تُستخدم البيانات المجمعة لتحسين النموذج.
-- Qwen3.6 Plus Free: خلال فترته المجانية، قد تُستخدم البيانات المجمعة لتحسين النموذج.
 - Nemotron 3 Super Free: خلال فترته المجانية، قد تُستخدم البيانات المجمعة لتحسين النموذج.
 - OpenAI APIs: يتم الاحتفاظ بالطلبات لمدة 30 يوما وفقا لـ [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: يتم الاحتفاظ بالطلبات لمدة 30 يوما وفقا لـ [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/bs/zen.mdx
+++ b/packages/web/src/content/docs/bs/zen.mdx
@@ -97,7 +97,6 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [model id](/docs/config/#models) u vašoj OpenCode konfiguraciji koristi format
@@ -125,7 +124,6 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -173,7 +171,6 @@ Besplatni modeli:
 - MiniMax M2.5 Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - MiMo V2 Pro Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - MiMo V2 Omni Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
-- Qwen3.6 Plus Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - Nemotron 3 Super Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - Big Pickle je stealth model koji je besplatan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 
@@ -205,6 +202,7 @@ vam ipak može naplatiti više od $20 ako vam stanje padne ispod $5.
 
 | Model            | Datum zastarijevanja |
 | ---------------- | -------------------- |
+| Qwen3.6 Plus Free | April 9, 2026        |
 | MiniMax M2.1     | March 15, 2026       |
 | GLM 4.7          | March 15, 2026       |
 | GLM 4.6          | March 15, 2026       |
@@ -224,7 +222,6 @@ i ne koriste vaše podatke za treniranje modela, uz sljedeće izuzetke:
 - MiniMax M2.5 Free: Tokom besplatnog perioda, prikupljeni podaci mogu se koristiti za poboljšanje modela.
 - MiMo V2 Pro Free: Tokom besplatnog perioda, prikupljeni podaci mogu se koristiti za poboljšanje modela.
 - MiMo V2 Omni Free: Tokom besplatnog perioda, prikupljeni podaci mogu se koristiti za poboljšanje modela.
-- Qwen3.6 Plus Free: Tokom besplatnog perioda, prikupljeni podaci mogu se koristiti za poboljšanje modela.
 - Nemotron 3 Super Free: Tokom besplatnog perioda, prikupljeni podaci mogu se koristiti za poboljšanje modela.
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/da/zen.mdx
+++ b/packages/web/src/content/docs/da/zen.mdx
@@ -97,7 +97,6 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [model id](/docs/config/#models) i din OpenCode-konfiguration
@@ -125,7 +124,6 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -173,7 +171,6 @@ De gratis modeller:
 - MiniMax M2.5 Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - MiMo V2 Pro Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - MiMo V2 Omni Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
-- Qwen3.6 Plus Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - Nemotron 3 Super Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - Big Pickle er en stealth-model, som er gratis på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 
@@ -204,6 +201,7 @@ at opkræve dig mere end $20, hvis din saldo kommer under $5.
 
 | Model            | Udfasningsdato |
 | ---------------- | -------------- |
+| Qwen3.6 Plus Free | April 9, 2026  |
 | MiniMax M2.1     | March 15, 2026 |
 | GLM 4.7          | March 15, 2026 |
 | GLM 4.6          | March 15, 2026 |
@@ -222,7 +220,6 @@ Alle vores modeller hostes i US. Vores udbydere følger en nul-opbevaringspoliti
 - MiniMax M2.5 Free: I den gratis periode kan indsamlede data blive brugt til at forbedre modellen.
 - MiMo V2 Pro Free: I den gratis periode kan indsamlede data blive brugt til at forbedre modellen.
 - MiMo V2 Omni Free: I den gratis periode kan indsamlede data blive brugt til at forbedre modellen.
-- Qwen3.6 Plus Free: I den gratis periode kan indsamlede data blive brugt til at forbedre modellen.
 - Nemotron 3 Super Free: I den gratis periode kan indsamlede data blive brugt til at forbedre modellen.
 - OpenAI APIs: Anmodninger opbevares i 30 dage i overensstemmelse med [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Anmodninger opbevares i 30 dage i overensstemmelse med [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/de/zen.mdx
+++ b/packages/web/src/content/docs/de/zen.mdx
@@ -88,7 +88,6 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 Die [Model-ID](/docs/config/#models) in deiner OpenCode-Konfiguration verwendet das Format `opencode/<model-id>`. Für GPT 5.3 Codex würdest du zum Beispiel `opencode/gpt-5.3-codex` in deiner Konfiguration verwenden.
@@ -114,7 +113,6 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -162,7 +160,6 @@ Die kostenlosen Modelle:
 - MiniMax M2.5 Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - MiMo V2 Pro Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - MiMo V2 Omni Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
-- Qwen3.6 Plus Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - Nemotron 3 Super Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - Big Pickle ist ein Stealth-Modell, das für begrenzte Zeit kostenlos auf OpenCode verfügbar ist. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 
@@ -188,8 +185,9 @@ Angenommen, du setzt ein monatliches Nutzungslimit von $20, dann wird Zen in ein
 
 ### Veraltete Modelle
 
-| Model            | Deprecation date |
-| ---------------- | ---------------- |
+| Model             | Deprecation date |
+| ----------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026    |
 | MiniMax M2.1     | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
@@ -208,7 +206,6 @@ Alle unsere Modelle werden in den USA gehostet. Unsere Provider folgen einer Zer
 - MiniMax M2.5 Free: Während des kostenlosen Zeitraums können gesammelte Daten zur Verbesserung des Modells verwendet werden.
 - MiMo V2 Pro Free: Während des kostenlosen Zeitraums können gesammelte Daten zur Verbesserung des Modells verwendet werden.
 - MiMo V2 Omni Free: Während des kostenlosen Zeitraums können gesammelte Daten zur Verbesserung des Modells verwendet werden.
-- Qwen3.6 Plus Free: Während des kostenlosen Zeitraums können gesammelte Daten zur Verbesserung des Modells verwendet werden.
 - Nemotron 3 Super Free: Während des kostenlosen Zeitraums können gesammelte Daten zur Verbesserung des Modells verwendet werden.
 - OpenAI APIs: Anfragen werden in Übereinstimmung mit [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 30 Tage lang gespeichert.
 - Anthropic APIs: Anfragen werden in Übereinstimmung mit [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 30 Tage lang gespeichert.

--- a/packages/web/src/content/docs/es/zen.mdx
+++ b/packages/web/src/content/docs/es/zen.mdx
@@ -97,7 +97,6 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 El [identificador del modelo](/docs/config/#models) en tu configuración de OpenCode
@@ -125,7 +124,6 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | Big Pickle                        | Free    | Free    | Free             | -                  |
 | MiMo V2 Pro Free                  | Free    | Free    | Free             | -                  |
 | MiMo V2 Omni Free                 | Free    | Free    | Free             | -                  |
-| Qwen3.6 Plus Free                 | Free    | Free    | Free             | -                  |
 | Nemotron 3 Super Free             | Free    | Free    | Free             | -                  |
 | MiniMax M2.5 Free                 | Free    | Free    | Free             | -                  |
 | MiniMax M2.5                      | $0.30   | $1.20   | $0.06            | $0.375             |
@@ -173,7 +171,6 @@ Los modelos gratuitos:
 - MiniMax M2.5 Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - MiMo V2 Pro Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - MiMo V2 Omni Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
-- Qwen3.6 Plus Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - Nemotron 3 Super Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - Big Pickle es un modelo stealth que es gratuito en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 
@@ -202,8 +199,9 @@ cobrándote más de $20 si tu saldo baja de $5.
 
 ### Modelos obsoletos
 
-| Modelo           | Fecha de retirada |
-| ---------------- | ----------------- |
+| Modelo            | Fecha de retirada |
+| ----------------- | ----------------- |
+| Qwen3.6 Plus Free | April 9, 2026     |
 | MiniMax M2.1     | March 15, 2026    |
 | GLM 4.7          | March 15, 2026    |
 | GLM 4.6          | March 15, 2026    |
@@ -222,7 +220,6 @@ Todos nuestros modelos están alojados en US. Nuestros proveedores siguen una po
 - MiniMax M2.5 Free: Durante su período gratuito, los datos recopilados pueden usarse para mejorar el modelo.
 - MiMo V2 Pro Free: Durante su período gratuito, los datos recopilados pueden usarse para mejorar el modelo.
 - MiMo V2 Omni Free: Durante su período gratuito, los datos recopilados pueden usarse para mejorar el modelo.
-- Qwen3.6 Plus Free: Durante su período gratuito, los datos recopilados pueden usarse para mejorar el modelo.
 - Nemotron 3 Super Free: Durante su período gratuito, los datos recopilados pueden usarse para mejorar el modelo.
 - OpenAI APIs: Las solicitudes se conservan durante 30 días de acuerdo con [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Las solicitudes se conservan durante 30 días de acuerdo con [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/fr/zen.mdx
+++ b/packages/web/src/content/docs/fr/zen.mdx
@@ -88,7 +88,6 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 Le [model id](/docs/config/#models) dans votre configuration OpenCode utilise le format `opencode/<model-id>`. Par exemple, pour GPT 5.3 Codex, vous utiliseriez `opencode/gpt-5.3-codex` dans votre configuration.
@@ -114,7 +113,6 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -162,7 +160,6 @@ Les modèles gratuits :
 - MiniMax M2.5 Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - MiMo V2 Pro Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - MiMo V2 Omni Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
-- Qwen3.6 Plus Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - Nemotron 3 Super Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - Big Pickle est un modèle stealth gratuit sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 
@@ -188,8 +185,9 @@ Par exemple, si vous définissez une limite d'utilisation mensuelle à $20, Zen 
 
 ### Modèles obsolètes
 
-| Modèle           | Date de dépréciation |
-| ---------------- | -------------------- |
+| Modèle            | Date de dépréciation |
+| ----------------- | -------------------- |
+| Qwen3.6 Plus Free | April 9, 2026        |
 | MiniMax M2.1     | March 15, 2026       |
 | GLM 4.7          | March 15, 2026       |
 | GLM 4.6          | March 15, 2026       |
@@ -208,7 +206,6 @@ Tous nos modèles sont hébergés aux US. Nos fournisseurs suivent une politique
 - MiniMax M2.5 Free : Pendant sa période gratuite, les données collectées peuvent être utilisées pour améliorer le modèle.
 - MiMo V2 Pro Free : Pendant sa période gratuite, les données collectées peuvent être utilisées pour améliorer le modèle.
 - MiMo V2 Omni Free : Pendant sa période gratuite, les données collectées peuvent être utilisées pour améliorer le modèle.
-- Qwen3.6 Plus Free : Pendant sa période gratuite, les données collectées peuvent être utilisées pour améliorer le modèle.
 - Nemotron 3 Super Free : Pendant sa période gratuite, les données collectées peuvent être utilisées pour améliorer le modèle.
 - OpenAI APIs : Les requêtes sont conservées pendant 30 jours conformément à [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs : Les requêtes sont conservées pendant 30 jours conformément à [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/it/zen.mdx
+++ b/packages/web/src/content/docs/it/zen.mdx
@@ -97,7 +97,6 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 Il [model id](/docs/config/#models) nella config di OpenCode
@@ -125,7 +124,6 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -173,7 +171,6 @@ I modelli gratuiti:
 - MiniMax M2.5 Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - MiMo V2 Pro Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - MiMo V2 Omni Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
-- Qwen3.6 Plus Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - Nemotron 3 Super Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - Big Pickle è un modello stealth che è gratuito su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 
@@ -204,6 +201,7 @@ per addebitarti più di $20 se il tuo saldo scende sotto $5.
 
 | Modello          | Data di deprecazione |
 | ---------------- | -------------------- |
+| Qwen3.6 Plus Free | April 9, 2026       |
 | MiniMax M2.1     | March 15, 2026       |
 | GLM 4.7          | March 15, 2026       |
 | GLM 4.6          | March 15, 2026       |
@@ -222,7 +220,6 @@ Tutti i nostri modelli sono ospitati negli US. I nostri provider seguono una pol
 - MiniMax M2.5 Free: durante il periodo gratuito, i dati raccolti possono essere usati per migliorare il modello.
 - MiMo V2 Pro Free: durante il periodo gratuito, i dati raccolti possono essere usati per migliorare il modello.
 - MiMo V2 Omni Free: durante il periodo gratuito, i dati raccolti possono essere usati per migliorare il modello.
-- Qwen3.6 Plus Free: durante il periodo gratuito, i dati raccolti possono essere usati per migliorare il modello.
 - Nemotron 3 Super Free: durante il periodo gratuito, i dati raccolti possono essere usati per migliorare il modello.
 - OpenAI APIs: le richieste vengono conservate per 30 giorni in conformità con [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: le richieste vengono conservate per 30 giorni in conformità con [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/ja/zen.mdx
+++ b/packages/web/src/content/docs/ja/zen.mdx
@@ -88,7 +88,6 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 OpenCode 設定で使う [model id](/docs/config/#models) は `opencode/<model-id>` 形式です。たとえば、GPT 5.3 Codex では設定に `opencode/gpt-5.3-codex` を使用します。
@@ -114,7 +113,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -162,7 +160,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - MiMo V2 Pro Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - MiMo V2 Omni Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
-- Qwen3.6 Plus Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - Nemotron 3 Super Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - Big Pickle はステルスモデルで、期間限定で OpenCode で無料提供されています。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 
@@ -190,6 +187,7 @@ https://opencode.ai/zen/v1/models
 
 | Model            | Deprecation date |
 | ---------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026   |
 | MiniMax M2.1     | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
@@ -208,7 +206,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: 無料提供期間中、収集されたデータがモデル改善に使われる場合があります。
 - MiMo V2 Pro Free: 無料提供期間中、収集されたデータがモデル改善に使われる場合があります。
 - MiMo V2 Omni Free: 無料提供期間中、収集されたデータがモデル改善に使われる場合があります。
-- Qwen3.6 Plus Free: 無料提供期間中、収集されたデータがモデル改善に使われる場合があります。
 - Nemotron 3 Super Free: 無料提供期間中、収集されたデータがモデル改善に使われる場合があります。
 - OpenAI APIs: リクエストは [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) に従って 30 日間保持されます。
 - Anthropic APIs: リクエストは [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) に従って 30 日間保持されます。

--- a/packages/web/src/content/docs/ko/zen.mdx
+++ b/packages/web/src/content/docs/ko/zen.mdx
@@ -88,7 +88,6 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 OpenCode config에서 사용하는 [모델 ID](/docs/config/#models)는 `opencode/<model-id>` 형식입니다. 예를 들어 GPT 5.3 Codex를 사용하려면 config에서 `opencode/gpt-5.3-codex`를 사용하면 됩니다.
@@ -114,7 +113,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -162,7 +160,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - MiMo V2 Pro Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - MiMo V2 Omni Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
-- Qwen3.6 Plus Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - Nemotron 3 Super Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - Big Pickle은 한정된 기간 동안 OpenCode에서 무료로 제공되는 stealth model입니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 
@@ -190,6 +187,7 @@ https://opencode.ai/zen/v1/models
 
 | 모델             | 지원 중단 날짜 |
 | ---------------- | -------------- |
+| Qwen3.6 Plus Free | April 9, 2026 |
 | MiniMax M2.1     | March 15, 2026 |
 | GLM 4.7          | March 15, 2026 |
 | GLM 4.6          | March 15, 2026 |
@@ -208,7 +206,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: 무료 제공 기간에는 수집된 데이터가 모델 개선에 사용될 수 있습니다.
 - MiMo V2 Pro Free: 무료 제공 기간에는 수집된 데이터가 모델 개선에 사용될 수 있습니다.
 - MiMo V2 Omni Free: 무료 제공 기간에는 수집된 데이터가 모델 개선에 사용될 수 있습니다.
-- Qwen3.6 Plus Free: 무료 제공 기간에는 수집된 데이터가 모델 개선에 사용될 수 있습니다.
 - Nemotron 3 Super Free: 무료 제공 기간에는 수집된 데이터가 모델 개선에 사용될 수 있습니다.
 - OpenAI APIs: 요청은 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data)에 따라 30일 동안 보관됩니다.
 - Anthropic APIs: 요청은 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage)에 따라 30일 동안 보관됩니다.

--- a/packages/web/src/content/docs/nb/zen.mdx
+++ b/packages/web/src/content/docs/nb/zen.mdx
@@ -97,7 +97,6 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [modell-id](/docs/config/#models) i OpenCode-konfigurasjonen din
@@ -125,7 +124,6 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | Big Pickle                        | Free    | Free    | Free          | -               |
 | MiMo V2 Pro Free                  | Free    | Free    | Free          | -               |
 | MiMo V2 Omni Free                 | Free    | Free    | Free          | -               |
-| Qwen3.6 Plus Free                 | Free    | Free    | Free          | -               |
 | Nemotron 3 Super Free             | Free    | Free    | Free          | -               |
 | MiniMax M2.5 Free                 | Free    | Free    | Free          | -               |
 | MiniMax M2.5                      | $0.30   | $1.20   | $0.06         | $0.375          |
@@ -173,7 +171,6 @@ Gratis-modellene:
 - MiniMax M2.5 Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - MiMo V2 Pro Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - MiMo V2 Omni Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
-- Qwen3.6 Plus Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - Nemotron 3 Super Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - Big Pickle er en stealth-modell som er gratis på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 
@@ -202,9 +199,10 @@ med å belaste deg mer enn $20 hvis saldoen din går under $5.
 
 ### Utfasede modeller
 
-| Modell           | Utfasingsdato  |
-| ---------------- | -------------- |
-| MiniMax M2.1     | March 15, 2026 |
+| Modell            | Utfasingsdato  |
+| ----------------- | -------------- |
+| Qwen3.6 Plus Free | April 9, 2026  |
+| MiniMax M2.1      | March 15, 2026 |
 | GLM 4.7          | March 15, 2026 |
 | GLM 4.6          | March 15, 2026 |
 | Gemini 3 Pro     | March 9, 2026  |
@@ -222,7 +220,6 @@ Alle modellene våre hostes i US. Leverandørene våre følger en policy for zer
 - MiniMax M2.5 Free: I gratisperioden kan innsamlede data brukes til å forbedre modellen.
 - MiMo V2 Pro Free: I gratisperioden kan innsamlede data brukes til å forbedre modellen.
 - MiMo V2 Omni Free: I gratisperioden kan innsamlede data brukes til å forbedre modellen.
-- Qwen3.6 Plus Free: I gratisperioden kan innsamlede data brukes til å forbedre modellen.
 - Nemotron 3 Super Free: I gratisperioden kan innsamlede data brukes til å forbedre modellen.
 - OpenAI APIs: Forespørsler lagres i 30 dager i samsvar med [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Forespørsler lagres i 30 dager i samsvar med [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/pl/zen.mdx
+++ b/packages/web/src/content/docs/pl/zen.mdx
@@ -97,7 +97,6 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [ID modelu](/docs/config/#models) w Twojej konfiguracji OpenCode używa formatu
@@ -125,7 +124,6 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | Big Pickle                        | Free    | Free    | Free           | -              |
 | MiMo V2 Pro Free                  | Free    | Free    | Free           | -              |
 | MiMo V2 Omni Free                 | Free    | Free    | Free           | -              |
-| Qwen3.6 Plus Free                 | Free    | Free    | Free           | -              |
 | Nemotron 3 Super Free             | Free    | Free    | Free           | -              |
 | MiniMax M2.5 Free                 | Free    | Free    | Free           | -              |
 | MiniMax M2.5                      | $0.30   | $1.20   | $0.06          | $0.375         |
@@ -174,7 +172,6 @@ Darmowe modele:
 - MiniMax M2.5 Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - MiMo V2 Pro Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - MiMo V2 Omni Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
-- Qwen3.6 Plus Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - Nemotron 3 Super Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - Big Pickle to stealth model, który jest darmowy w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 
@@ -203,9 +200,10 @@ ostatecznie obciążyć Cię kwotą wyższą niż $20, jeśli Twoje saldo spadni
 
 ### Deprecated models
 
-| Model            | Deprecation date |
-| ---------------- | ---------------- |
-| MiniMax M2.1     | March 15, 2026   |
+| Model             | Deprecation date |
+| ----------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026    |
+| MiniMax M2.1      | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
 | Gemini 3 Pro     | March 9, 2026    |
@@ -223,7 +221,6 @@ Wszystkie nasze modele są hostowane w US. Nasi dostawcy stosują politykę zero
 - MiniMax M2.5 Free: W czasie darmowego okresu zebrane dane mogą być wykorzystywane do ulepszania modelu.
 - MiMo V2 Pro Free: W czasie darmowego okresu zebrane dane mogą być wykorzystywane do ulepszania modelu.
 - MiMo V2 Omni Free: W czasie darmowego okresu zebrane dane mogą być wykorzystywane do ulepszania modelu.
-- Qwen3.6 Plus Free: W czasie darmowego okresu zebrane dane mogą być wykorzystywane do ulepszania modelu.
 - Nemotron 3 Super Free: W czasie darmowego okresu zebrane dane mogą być wykorzystywane do ulepszania modelu.
 - OpenAI APIs: Żądania są przechowywane przez 30 dni zgodnie z [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Żądania są przechowywane przez 30 dni zgodnie z [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/pt-br/zen.mdx
+++ b/packages/web/src/content/docs/pt-br/zen.mdx
@@ -88,7 +88,6 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 O [model id](/docs/config/#models) na sua configuração do OpenCode usa o formato `opencode/<model-id>`. Por exemplo, para GPT 5.3 Codex, você usaria `opencode/gpt-5.3-codex` na sua configuração.
@@ -114,7 +113,6 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | Big Pickle                        | Free    | Free    | Free             | -                |
 | MiMo V2 Pro Free                  | Free    | Free    | Free             | -                |
 | MiMo V2 Omni Free                 | Free    | Free    | Free             | -                |
-| Qwen3.6 Plus Free                 | Free    | Free    | Free             | -                |
 | Nemotron 3 Super Free             | Free    | Free    | Free             | -                |
 | MiniMax M2.5 Free                 | Free    | Free    | Free             | -                |
 | MiniMax M2.5                      | $0.30   | $1.20   | $0.06            | $0.375           |
@@ -162,7 +160,6 @@ Os modelos gratuitos:
 - MiniMax M2.5 Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - MiMo V2 Pro Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - MiMo V2 Omni Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
-- Qwen3.6 Plus Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - Nemotron 3 Super Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - Big Pickle é um modelo stealth que está gratuito no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 
@@ -188,9 +185,10 @@ Por exemplo, digamos que você defina um limite mensal de uso de $20; o Zen não
 
 ### Modelos obsoletos
 
-| Modelo           | Data de descontinuação |
-| ---------------- | ---------------------- |
-| MiniMax M2.1     | March 15, 2026         |
+| Modelo            | Data de descontinuação |
+| ----------------- | ---------------------- |
+| Qwen3.6 Plus Free | April 9, 2026          |
+| MiniMax M2.1      | March 15, 2026         |
 | GLM 4.7          | March 15, 2026         |
 | GLM 4.6          | March 15, 2026         |
 | Gemini 3 Pro     | March 9, 2026          |
@@ -208,7 +206,6 @@ Todos os nossos modelos são hospedados nos US. Nossos provedores seguem uma pol
 - MiniMax M2.5 Free: Durante seu período gratuito, os dados coletados podem ser usados para melhorar o modelo.
 - MiMo V2 Pro Free: Durante seu período gratuito, os dados coletados podem ser usados para melhorar o modelo.
 - MiMo V2 Omni Free: Durante seu período gratuito, os dados coletados podem ser usados para melhorar o modelo.
-- Qwen3.6 Plus Free: Durante seu período gratuito, os dados coletados podem ser usados para melhorar o modelo.
 - Nemotron 3 Super Free: Durante seu período gratuito, os dados coletados podem ser usados para melhorar o modelo.
 - OpenAI APIs: As solicitações são retidas por 30 dias de acordo com [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: As solicitações são retidas por 30 dias de acordo com [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/ru/zen.mdx
+++ b/packages/web/src/content/docs/ru/zen.mdx
@@ -97,7 +97,6 @@ OpenCode Zen работает как любой другой провайдер 
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [идентификатор модели](/docs/config/#models) в вашей конфигурации OpenCode
@@ -125,7 +124,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -173,7 +171,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - MiMo V2 Pro Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - MiMo V2 Omni Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
-- Qwen3.6 Plus Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - Nemotron 3 Super Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - Big Pickle — это скрытая модель, которая доступна бесплатно в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 
@@ -204,6 +201,7 @@ https://opencode.ai/zen/v1/models
 
 | Модель           | Дата устаревания |
 | ---------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026   |
 | MiniMax M2.1     | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
@@ -222,7 +220,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: во время бесплатного периода собранные данные могут использоваться для улучшения модели.
 - MiMo V2 Pro Free: во время бесплатного периода собранные данные могут использоваться для улучшения модели.
 - MiMo V2 Omni Free: во время бесплатного периода собранные данные могут использоваться для улучшения модели.
-- Qwen3.6 Plus Free: во время бесплатного периода собранные данные могут использоваться для улучшения модели.
 - Nemotron 3 Super Free: во время бесплатного периода собранные данные могут использоваться для улучшения модели.
 - OpenAI APIs: запросы хранятся 30 дней в соответствии с [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: запросы хранятся 30 дней в соответствии с [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/th/zen.mdx
+++ b/packages/web/src/content/docs/th/zen.mdx
@@ -90,7 +90,6 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 [model id](/docs/config/#models) ใน OpenCode config ของคุณใช้รูปแบบ `opencode/<model-id>` ตัวอย่างเช่น สำหรับ GPT 5.3 Codex คุณจะใช้ `opencode/gpt-5.3-codex` ใน config ของคุณ
@@ -116,7 +115,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -164,7 +162,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - MiMo V2 Pro Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - MiMo V2 Omni Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
-- Qwen3.6 Plus Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - Nemotron 3 Super Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - Big Pickle เป็น stealth model ที่ใช้งานฟรีบน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 
@@ -192,6 +189,7 @@ https://opencode.ai/zen/v1/models
 
 | Model            | Deprecation date |
 | ---------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026   |
 | MiniMax M2.1     | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
@@ -210,7 +208,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: ระหว่างช่วงที่เปิดให้ใช้ฟรี ข้อมูลที่เก็บรวบรวมอาจถูกนำไปใช้เพื่อปรับปรุงโมเดล
 - MiMo V2 Pro Free: ระหว่างช่วงที่เปิดให้ใช้ฟรี ข้อมูลที่เก็บรวบรวมอาจถูกนำไปใช้เพื่อปรับปรุงโมเดล
 - MiMo V2 Omni Free: ระหว่างช่วงที่เปิดให้ใช้ฟรี ข้อมูลที่เก็บรวบรวมอาจถูกนำไปใช้เพื่อปรับปรุงโมเดล
-- Qwen3.6 Plus Free: ระหว่างช่วงที่เปิดให้ใช้ฟรี ข้อมูลที่เก็บรวบรวมอาจถูกนำไปใช้เพื่อปรับปรุงโมเดล
 - Nemotron 3 Super Free: ระหว่างช่วงที่เปิดให้ใช้ฟรี ข้อมูลที่เก็บรวบรวมอาจถูกนำไปใช้เพื่อปรับปรุงโมเดล
 - OpenAI APIs: คำขอจะถูกเก็บไว้เป็นเวลา 30 วันตาม [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: คำขอจะถูกเก็บไว้เป็นเวลา 30 วันตาม [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/tr/zen.mdx
+++ b/packages/web/src/content/docs/tr/zen.mdx
@@ -88,7 +88,6 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 OpenCode yapılandırmanızdaki [model id](/docs/config/#models) `opencode/<model-id>` biçimini kullanır. Örneğin, GPT 5.3 Codex için yapılandırmanızda `opencode/gpt-5.3-codex` kullanırsınız.
@@ -114,7 +113,6 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | Big Pickle                        | Free   | Free    | Free        | -            |
 | MiMo V2 Pro Free                  | Free   | Free    | Free        | -            |
 | MiMo V2 Omni Free                 | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -162,7 +160,6 @@ Kredi kartı ücretleri maliyet üzerinden yansıtılır (%4.4 + işlem başına
 - MiniMax M2.5 Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - MiMo V2 Pro Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - MiMo V2 Omni Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
-- Qwen3.6 Plus Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - Nemotron 3 Super Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - Big Pickle, sınırlı bir süre için OpenCode'da ücretsiz olan gizli bir modeldir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 
@@ -190,6 +187,7 @@ Ayrıca tüm çalışma alanı için ve ekibinizdeki her üye için aylık kulla
 
 | Model            | Kullanımdan kaldırılma tarihi |
 | ---------------- | ----------------------------- |
+| Qwen3.6 Plus Free | April 9, 2026                |
 | MiniMax M2.1     | March 15, 2026                |
 | GLM 4.7          | March 15, 2026                |
 | GLM 4.6          | March 15, 2026                |
@@ -208,7 +206,6 @@ Tüm modellerimiz US'de barındırılıyor. Sağlayıcılarımız zero-retention
 - MiniMax M2.5 Free: Ücretsiz döneminde toplanan veriler modeli iyileştirmek için kullanılabilir.
 - MiMo V2 Pro Free: Ücretsiz döneminde toplanan veriler modeli iyileştirmek için kullanılabilir.
 - MiMo V2 Omni Free: Ücretsiz döneminde toplanan veriler modeli iyileştirmek için kullanılabilir.
-- Qwen3.6 Plus Free: Ücretsiz döneminde toplanan veriler modeli iyileştirmek için kullanılabilir.
 - Nemotron 3 Super Free: Ücretsiz döneminde toplanan veriler modeli iyileştirmek için kullanılabilir.
 - OpenAI APIs: İstekler [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) uyarınca 30 gün boyunca saklanır.
 - Anthropic APIs: İstekler [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) uyarınca 30 gün boyunca saklanır.

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -95,7 +95,6 @@ You can also access our models through the following API endpoints.
 | GLM 5                 | glm-5                 | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Kimi K2.5             | kimi-k2.5             | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 The [model id](/docs/config/#models) in your OpenCode config
@@ -121,7 +120,6 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | Model                             | Input  | Output  | Cached Read | Cached Write |
 | --------------------------------- | ------ | ------- | ----------- | ------------ |
 | Big Pickle                        | Free   | Free    | Free        | -            |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free        | -            |
 | Nemotron 3 Super Free             | Free   | Free    | Free        | -            |
 | MiniMax M2.5 Free                 | Free   | Free    | Free        | -            |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06       | $0.375       |
@@ -167,7 +165,6 @@ Credit card fees are passed along at cost (4.4% + $0.30 per transaction); we don
 The free models:
 
 - MiniMax M2.5 Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
-- Qwen3.6 Plus Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Nemotron 3 Super Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 
@@ -198,6 +195,7 @@ charging you more than $20 if your balance goes below $5.
 
 | Model            | Deprecation date |
 | ---------------- | ---------------- |
+| Qwen3.6 Plus Free | April 9, 2026    |
 | MiniMax M2.1     | March 15, 2026   |
 | GLM 4.7          | March 15, 2026   |
 | GLM 4.6          | March 15, 2026   |
@@ -214,7 +212,6 @@ All our models are hosted in the US. Our providers follow a zero-retention polic
 
 - Big Pickle: During its free period, collected data may be used to improve the model.
 - MiniMax M2.5 Free: During its free period, collected data may be used to improve the model.
-- Qwen3.6 Plus Free: During its free period, collected data may be used to improve the model.
 - Nemotron 3 Super Free: During its free period, collected data may be used to improve the model.
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).

--- a/packages/web/src/content/docs/zh-cn/zen.mdx
+++ b/packages/web/src/content/docs/zh-cn/zen.mdx
@@ -88,7 +88,6 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 在你的 OpenCode 配置中，[模型 ID](/docs/config/#models) 使用 `opencode/<model-id>` 格式。例如，对于 GPT 5.3 Codex，你需要在配置中使用 `opencode/gpt-5.3-codex`。
@@ -114,7 +113,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free     | -        |
 | MiMo V2 Pro Free                  | Free   | Free    | Free     | -        |
 | MiMo V2 Omni Free                 | Free   | Free    | Free     | -        |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free     | -        |
 | Nemotron 3 Super Free             | Free   | Free    | Free     | -        |
 | MiniMax M2.5 Free                 | Free   | Free    | Free     | -        |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06    | $0.375   |
@@ -162,7 +160,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - MiMo V2 Pro Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - MiMo V2 Omni Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
-- Qwen3.6 Plus Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - Nemotron 3 Super Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - Big Pickle 是一个隐身模型，目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 
@@ -190,6 +187,7 @@ https://opencode.ai/zen/v1/models
 
 | 模型             | 弃用日期       |
 | ---------------- | -------------- |
+| Qwen3.6 Plus Free | April 9, 2026  |
 | MiniMax M2.1     | March 15, 2026 |
 | GLM 4.7          | March 15, 2026 |
 | GLM 4.6          | March 15, 2026 |
@@ -208,7 +206,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free：在免费期间，收集的数据可能会被用于改进模型。
 - MiMo V2 Pro Free：在免费期间，收集的数据可能会被用于改进模型。
 - MiMo V2 Omni Free：在免费期间，收集的数据可能会被用于改进模型。
-- Qwen3.6 Plus Free：在免费期间，收集的数据可能会被用于改进模型。
 - Nemotron 3 Super Free：在免费期间，收集的数据可能会被用于改进模型。
 - OpenAI APIs：请求会根据 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 保留 30 天。
 - Anthropic APIs：请求会根据 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 保留 30 天。

--- a/packages/web/src/content/docs/zh-tw/zen.mdx
+++ b/packages/web/src/content/docs/zh-tw/zen.mdx
@@ -92,7 +92,6 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | Big Pickle            | big-pickle            | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Pro Free      | mimo-v2-pro-free      | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | MiMo V2 Omni Free     | mimo-v2-omni-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
-| Qwen3.6 Plus Free     | qwen3.6-plus-free     | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Super Free | nemotron-3-super-free | `https://opencode.ai/zen/v1/chat/completions`      | `@ai-sdk/openai-compatible` |
 
 OpenCode 設定中的 [模型 ID](/docs/config/#models) 會使用 `opencode/<model-id>`
@@ -119,7 +118,6 @@ https://opencode.ai/zen/v1/models
 | Big Pickle                        | Free   | Free    | Free     | -        |
 | MiMo V2 Pro Free                  | Free   | Free    | Free     | -        |
 | MiMo V2 Omni Free                 | Free   | Free    | Free     | -        |
-| Qwen3.6 Plus Free                 | Free   | Free    | Free     | -        |
 | Nemotron 3 Super Free             | Free   | Free    | Free     | -        |
 | MiniMax M2.5 Free                 | Free   | Free    | Free     | -        |
 | MiniMax M2.5                      | $0.30  | $1.20   | $0.06    | $0.375   |
@@ -168,7 +166,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - MiMo V2 Pro Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - MiMo V2 Omni Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
-- Qwen3.6 Plus Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - Nemotron 3 Super Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - Big Pickle 是一個隱身模型，在 OpenCode 上限時免費提供。團隊正在利用這段時間收集回饋並改進模型。
 
@@ -197,6 +194,7 @@ https://opencode.ai/zen/v1/models
 
 | 模型             | 棄用日期       |
 | ---------------- | -------------- |
+| Qwen3.6 Plus Free | April 9, 2026  |
 | MiniMax M2.1     | March 15, 2026 |
 | GLM 4.7          | March 15, 2026 |
 | GLM 4.6          | March 15, 2026 |
@@ -215,7 +213,6 @@ https://opencode.ai/zen/v1/models
 - MiniMax M2.5 Free: 在免費期間，收集到的資料可能會用於改進模型。
 - MiMo V2 Pro Free: 在免費期間，收集到的資料可能會用於改進模型。
 - MiMo V2 Omni Free: 在免費期間，收集到的資料可能會用於改進模型。
-- Qwen3.6 Plus Free: 在免費期間，收集到的資料可能會用於改進模型。
 - Nemotron 3 Super Free: 在免費期間，收集到的資料可能會用於改進模型。
 - OpenAI APIs: 請求會依據 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 保留 30 天。
 - Anthropic APIs: 請求會依據 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 保留 30 天。


### PR DESCRIPTION
This PR removes the deprecated qwen3.6-plus-free model from all documentation and test fixtures.

## Background
The qwen3.6-plus-free model has been deprecated and its endpoint no longer works, but it was still configurable and documented. This could mislead users who might configure it only to have API requests fail.

## Changes Made
- Removed qwen3.6-plus-free from the endpoints table in all 18 language docs
- Removed pricing information from all pricing tables
- Removed from free models list in all locales
- Removed from privacy section (data collection exceptions)
- Added to the deprecated models table with deprecation date (April 9, 2026)
- Removed the model entry from packages/opencode/test/tool/fixtures/models-api.json

## Files Changed
- 18 documentation files (1 English + 17 translations)
- 1 test fixture file

## Verification
- [x] All references to qwen3.6-plus-free removed from active model lists
- [x] Model added to deprecated models table
- [x] Test fixture JSON structure remains valid