### PR TITLE
fix(opencode): delete-to-line-start getting stuck at line boundary

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -935,6 +935,13 @@ export function Prompt(props: PromptProps) {
                   }
                   // If no image, let the default paste behavior continue
                 }
+                if (keybind.match("input_delete_to_line_start", e)) {
+                  const cursor = input.editorView.getCursor()
+                  if (cursor.col === 0 && cursor.row > 0) {
+                    input.deleteCharBackward()
+                    e.preventDefault()
+                  }
+                }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()
                   input.extmarks.clear()


### PR DESCRIPTION
### Issue for this PR

Closes #21663

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`deleteToLineStart()` in `@opentui/core` only deletes when `cursor.col > 0`. After clearing a line's content, the cursor is at col 0 and further presses do nothing — it never removes the newline to join with the previous line.

This adds an `onKeyDown` intercept in the prompt: when `delete-to-line-start` fires and the cursor is at col 0 with row > 0, it calls `deleteCharBackward()` to remove the newline, joining with the previous line. Repeated presses then continue clearing upward as expected.

### How did you verify your code works?

- Typecheck passes (`bun typecheck` in `packages/opencode`)
- Manual testing: typed 3+ lines, pressed Ctrl+U repeatedly — each press now clears a line or joins with the previous one

### Screenshots / recordings

_N/A — keyboard behavior fix, no UI change._

### Checklist

- [x] I have tested my changes locally, see screen recording

https://github.com/user-attachments/assets/e3aba8dd-ad70-42d1-adf0-a448c7a630af

- [x] I have not included unrelated changes in this PR