### PR TITLE
fix(opencode): recover from truncated tool calls instead of failing silently

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -329,6 +329,28 @@ export namespace LLM {
             toolName: lower,
           }
         }
+        // When the tool name is valid but args failed to parse, the output
+        // was likely truncated by the token limit.  Give the model a clear
+        // signal so it can retry with smaller input instead of looping.
+        if (tools[failed.toolCall.toolName] || tools[lower]) {
+          l.warn("truncated tool call detected", {
+            tool: failed.toolCall.toolName,
+            error: failed.error.message,
+          })
+          return {
+            ...failed.toolCall,
+            input: JSON.stringify({
+              tool: failed.toolCall.toolName,
+              error:
+                "Your output was truncated because it exceeded the token limit. " +
+                "The tool arguments were cut off and could not be parsed. " +
+                "Split your operation into smaller pieces and try again. " +
+                "For file writes, use the Edit tool for targeted changes or write smaller sections. " +
+                "For bash commands, break long heredocs into multiple shorter commands.",
+            }),
+            toolName: "invalid",
+          }
+        }
         return {
           ...failed.toolCall,
           input: JSON.stringify({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1376,6 +1376,35 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             const hasToolCalls =
               lastAssistantMsg?.parts.some((part) => part.type === "tool" && !part.metadata?.providerExecuted) ?? false
 
+            // When the model hit the output token limit (finishReason: "length"),
+            // its response was truncated.  Instead of silently exiting, inject a
+            // continuation message so the model can finish its work.
+            if (lastAssistant?.finish === "length" && lastUser.id < lastAssistant.id) {
+              log.warn("output truncated by token limit, auto-continuing", { sessionID })
+              const continuationMsg: MessageV2.User = {
+                id: MessageID.ascending(),
+                sessionID,
+                role: "user",
+                time: { created: Date.now() },
+                agent: lastUser.agent,
+                model: lastUser.model,
+              }
+              yield* sessions.updateMessage(continuationMsg)
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: continuationMsg.id,
+                sessionID,
+                type: "text",
+                text:
+                  "Your previous response was truncated because it exceeded the output token limit. " +
+                  "If you were writing a file, split it into smaller pieces. " +
+                  "If you were using a tool, use smaller arguments. " +
+                  "Continue where you left off.",
+                synthetic: true,
+              })
+              continue
+            }
+
             if (
               lastAssistant?.finish &&
               !["tool-calls"].includes(lastAssistant.finish) &&


### PR DESCRIPTION
### Issue for this PR

Closes #18108
Closes #17471
Refs #14519, #13102, #18151, #18131

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a model's output hits `max_tokens` mid-tool-call, the streamed JSON arguments get truncated. The tool parser receives `undefined` for required fields, producing:

```
The bash tool was called with invalid arguments: [
  {"expected": "string", "code": "invalid_type", "path": ["command"],
   "message": "Invalid input: expected string, received undefined"}
]
```

Two fixes:

**1. Truncation detection in `experimental_repairToolCall`** (`llm.ts`)

`repairToolCall` currently only handles tool name case-sensitivity. All other parse failures route to the generic `invalid` tool. But when `toolName` is a valid registered tool and the args failed to parse, the cause is truncation, not an invalid tool. This check distinguishes the two cases and returns an actionable error telling the model to split its operation into smaller pieces.

**2. Auto-continue on `finishReason: "length"`** (`prompt.ts`)

The session loop exits when `finishReason` is anything other than `"tool-calls"`. This means `"length"` (token limit hit) causes the session to stop silently. Now the loop detects `"length"`, injects a synthetic continuation message, and keeps going so the model can resume.

### How did you verify your code works?

- `bun run --cwd packages/opencode tsc --noEmit` passes with no new type errors
- Changes are additive only: 51 lines added, 0 removed, no changes to tests or public API
- Manually tested by triggering large file writes that exceed `OUTPUT_TOKEN_MAX` and verifying the model receives the truncation error message and retries with smaller operations

### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR