### PR TITLE
acp: replay resumed sessions and derive fallback titles

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -41,6 +41,7 @@ import { Provider } from "../provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
 import { Agent as AgentModule } from "../agent/agent"
 import { Installation } from "@/installation"
+import { Session } from "@/session"
 import { MessageV2 } from "@/session/message-v2"
 import { Config } from "@/config/config"
 import { Todo } from "@/session/todo"
@@ -126,6 +127,36 @@ export namespace ACP {
       })
   }
 
+  async function getMessages(sdk: OpencodeClient, sessionID: string, directory: string) {
+    return sdk.session
+      .messages({ sessionID, directory }, { throwOnError: true })
+      .then((x) => x.data)
+      .catch((error) => {
+        log.error("failed to fetch session messages", { error, sessionID })
+        return undefined
+      })
+  }
+
+  function getTitle(messages?: SessionMessageResponse[]) {
+    if (!messages) return
+    for (const msg of messages) {
+      if (msg.info.role !== "user") continue
+      const text = msg.parts
+        .flatMap((part) => {
+          if (part.type === "text" && !part.synthetic && !part.ignored) return [part.text]
+          if (part.type === "subtask") return [part.description || part.prompt]
+          return []
+        })
+        .map((part) => part.trim())
+        .find((part) => part.length > 0)
+      if (!text) continue
+      const line = text.replace(/\s+/g, " ").trim()
+      if (!line) continue
+      if (line.length <= 100) return line
+      return line.slice(0, 97) + "..."
+    }
+  }
+
   export async function init({ sdk: _sdk }: { sdk: OpencodeClient }) {
     return {
       create: (connection: AgentSideConnection, fullConfig: ACPConfig) => {
@@ -156,6 +187,35 @@ export namespace ACP {
       this.sdk = config.sdk
       this.sessionManager = new ACPSessionManager(this.sdk)
       this.startEventSubscription()
+    }
+
+    private async replay(sessionID: string, directory: string) {
+      const messages = await getMessages(this.sdk, sessionID, directory)
+      for (const msg of messages ?? []) {
+        log.debug("replay message", msg)
+        await this.processMessage(msg)
+      }
+      return messages
+    }
+
+    private hydrate(result: Awaited<ReturnType<Agent["loadSessionMode"]>>, sessionID: string, messages?: SessionMessageResponse[]) {
+      const last = messages?.findLast((msg) => msg.info.role === "user")?.info
+      if (last?.role !== "user") return result
+      result.models.currentModelId = `${last.model.providerID}/${last.model.modelID}`
+      this.sessionManager.setModel(sessionID, {
+        providerID: ProviderID.make(last.model.providerID),
+        modelID: ModelID.make(last.model.modelID),
+      })
+      if (result.modes?.availableModes.some((mode) => mode.id === last.agent)) {
+        result.modes.currentModeId = last.agent
+        this.sessionManager.setMode(sessionID, last.agent)
+      }
+      result.configOptions = buildConfigOptions({
+        currentModelId: result.models.currentModelId,
+        availableModels: result.models.availableModels,
+        modes: result.modes,
+      })
+      return result
     }
 
     private startEventSubscription() {
@@ -638,43 +698,8 @@ export namespace ACP {
           sessionId,
         })
 
-        // Replay session history
-        const messages = await this.sdk.session
-          .messages(
-            {
-              sessionID: sessionId,
-              directory,
-            },
-            { throwOnError: true },
-          )
-          .then((x) => x.data)
-          .catch((err) => {
-            log.error("unexpected error when fetching message", { error: err })
-            return undefined
-          })
-
-        const lastUser = messages?.findLast((m) => m.info.role === "user")?.info
-        if (lastUser?.role === "user") {
-          result.models.currentModelId = `${lastUser.model.providerID}/${lastUser.model.modelID}`
-          this.sessionManager.setModel(sessionId, {
-            providerID: ProviderID.make(lastUser.model.providerID),
-            modelID: ModelID.make(lastUser.model.modelID),
-          })
-          if (result.modes?.availableModes.some((m) => m.id === lastUser.agent)) {
-            result.modes.currentModeId = lastUser.agent
-            this.sessionManager.setMode(sessionId, lastUser.agent)
-          }
-          result.configOptions = buildConfigOptions({
-            currentModelId: result.models.currentModelId,
-            availableModels: result.models.availableModels,
-            modes: result.modes,
-          })
-        }
-
-        for (const msg of messages ?? []) {
-          log.debug("replay message", msg)
-          await this.processMessage(msg)
-        }
+        const messages = await this.replay(sessionId, directory)
+        this.hydrate(result, sessionId, messages)
 
         await sendUsageUpdate(this.connection, this.sdk, sessionId, directory)
 
@@ -709,12 +734,16 @@ export namespace ACP {
         const filtered = cursor ? sorted.filter((s) => s.time.updated < cursor) : sorted
         const page = filtered.slice(0, limit)
 
-        const entries: SessionInfo[] = page.map((session) => ({
-          sessionId: session.id,
-          cwd: session.directory,
-          title: session.title,
-          updatedAt: new Date(session.time.updated).toISOString(),
-        }))
+        const entries: SessionInfo[] = await Promise.all(
+          page.map(async (session) => ({
+            sessionId: session.id,
+            cwd: session.directory,
+            title: Session.isDefaultTitle(session.title)
+              ? getTitle(await getMessages(this.sdk, session.id, session.directory)) ?? session.title
+              : session.title,
+            updatedAt: new Date(session.time.updated).toISOString(),
+          })),
+        )
 
         const last = page[page.length - 1]
         const next = filtered.length > limit && last ? String(last.time.updated) : undefined
@@ -767,24 +796,7 @@ export namespace ACP {
           sessionId,
         })
 
-        const messages = await this.sdk.session
-          .messages(
-            {
-              sessionID: sessionId,
-              directory,
-            },
-            { throwOnError: true },
-          )
-          .then((x) => x.data)
-          .catch((err) => {
-            log.error("unexpected error when fetching message", { error: err })
-            return undefined
-          })
-
-        for (const msg of messages ?? []) {
-          log.debug("replay message", msg)
-          await this.processMessage(msg)
-        }
+        await this.replay(sessionId, directory)
 
         await sendUsageUpdate(this.connection, this.sdk, sessionId, directory)
 
@@ -816,6 +828,9 @@ export namespace ACP {
           mcpServers,
           sessionId,
         })
+
+        const messages = await this.replay(sessionId, directory)
+        this.hydrate(result, sessionId, messages)
 
         await sendUsageUpdate(this.connection, this.sdk, sessionId, directory)
 

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -369,6 +369,117 @@ describe("acp.agent event subscription", () => {
     })
   })
 
+  test("derives session titles for default titled sessions in listSessions()", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, stop, sdk } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+
+        sdk.session.list = async () => ({
+          data: [
+            {
+              id: "ses_1",
+              directory: cwd,
+              title: "New session - 2026-04-09T15:24:00.000Z",
+              time: { updated: Date.now() },
+            },
+            {
+              id: "ses_2",
+              directory: cwd,
+              title: "Keep custom title",
+              time: { updated: Date.now() - 1 },
+            },
+          ],
+        })
+        sdk.session.messages = async (input?: any) => ({
+          data:
+            input?.sessionID === "ses_1"
+              ? [
+                  {
+                    info: { role: "user", sessionID: "ses_1" },
+                    parts: [
+                      {
+                        id: "part_1",
+                        sessionID: "ses_1",
+                        messageID: "msg_1",
+                        type: "text",
+                        text: "Pressing win + e not opening my doom emacs, why?",
+                      },
+                    ],
+                  },
+                ]
+              : [],
+        })
+
+        const result = await agent.listSessions({ cwd } as any)
+
+        expect(result.sessions[0]?.title).toBe("Pressing win + e not opening my doom emacs, why?")
+        expect(result.sessions[1]?.title).toBe("Keep custom title")
+        stop()
+      },
+    })
+  })
+
+  test("replays history on resumeSession()", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, sessionUpdates, stop, sdk } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        sdk.session.messages = async () => ({
+          data: [
+            {
+              info: {
+                id: "msg_user",
+                role: "user",
+                sessionID: sessionId,
+                model: { providerID: "opencode", modelID: "big-pickle" },
+                agent: "build",
+              },
+              parts: [
+                {
+                  id: "part_user",
+                  sessionID: sessionId,
+                  messageID: "msg_user",
+                  type: "text",
+                  text: "hello from history",
+                },
+              ],
+            },
+            {
+              info: {
+                id: "msg_assistant",
+                role: "assistant",
+                sessionID: sessionId,
+              },
+              parts: [
+                {
+                  id: "part_assistant",
+                  sessionID: sessionId,
+                  messageID: "msg_assistant",
+                  type: "text",
+                  text: "hi back",
+                },
+              ],
+            },
+          ],
+        })
+
+        await agent.unstable_resumeSession({ sessionId, cwd, mcpServers: [] } as any)
+
+        const updates = sessionUpdates.filter((item) => item.sessionId === sessionId).map((item) => item.update.sessionUpdate)
+        expect(updates).toContain("user_message_chunk")
+        expect(updates).toContain("agent_message_chunk")
+        stop()
+      },
+    })
+  })
+
   test("permission.asked events are handled and replied", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode's ACP resume path wasn't replaying prior session messages, so agent-shell could reopen a session without showing the previous conversation. ACP session lists could also show generic \`New session - ...\` titles because ACP exposed the stored default title before a better title had been generated.

This change makes ACP resume replay stored messages and reuse the same model/mode hydration as ACP load. It also derives a fallback title from the first real user prompt when ACP lists a session whose persisted title is still the default placeholder. I added regressions for both behaviors in the existing ACP event subscription test file.

### How did you verify your code works?

- `bun test test/acp/event-subscription.test.ts --timeout 30000`
- `bun typecheck`
- pre-push hook also ran `bun turbo typecheck`

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR