### PR TITLE
fix(mcp): add onprogress callback so resetTimeoutOnProgress actually works

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -154,6 +154,7 @@ export namespace MCP {
           {
             resetTimeoutOnProgress: true,
             timeout,
+            onprogress: () => {}, // inject progressToken so resetTimeoutOnProgress works
           },
         )
       },


### PR DESCRIPTION
## Problem

`convertMcpTool` passes `resetTimeoutOnProgress: true` to `client.callTool()`, but the TypeScript MCP SDK (`@modelcontextprotocol/sdk@1.27.1`) only injects `_meta.progressToken` into the outgoing JSON-RPC request when an **`onprogress` callback** is provided — not when `resetTimeoutOnProgress` alone is set:

```typescript
// sdk/src/shared/protocol.ts
if (options?.onprogress) {          // ← ONLY path that injects progressToken
  this._progressHandlers.set(messageId, options.onprogress);
  jsonrpcRequest.params = { ..., _meta: { progressToken: messageId } };
}
this._setupTimeout(messageId, timeout, ..., options?.resetTimeoutOnProgress);
```

Without `progressToken` in the request, MCP servers cannot match their `notifications/progress` responses to the pending call. The SDK's `_onprogress` handler matches by `params.progressToken → messageId` — no token means no match, means `_resetTimeout` is never called, and the 60-second `DEFAULT_REQUEST_TIMEOUT_MSEC` fires regardless of how often the server sends progress pings.

**Symptom**: long-running HITL tools (tools that open a browser window and wait for a human) time out with `-32001` after exactly 60 seconds even though the server is actively sending progress notifications.

Related SDK issue: https://github.com/modelcontextprotocol/typescript-sdk/issues/245

## Fix

Pass a no-op `onprogress: () => {}` callback. This forces the SDK to inject `progressToken` into the request `_meta`, which allows incoming `notifications/progress` to be matched and `_resetTimeout` to fire — making `resetTimeoutOnProgress: true` actually do what it says.

```typescript
return client.callTool(
  { name: mcpTool.name, arguments: ... },
  CallToolResultSchema,
  {
    resetTimeoutOnProgress: true,
    timeout,
    onprogress: () => {}, // inject progressToken so resetTimeoutOnProgress works
  },
)
```

## Impact

- Long-running MCP tool calls (anything that waits for human input or external events) will no longer timeout at 60s when the server sends progress pings.
- Zero behavior change for tools that complete quickly — `onprogress: () => {}` is a no-op callback that doesn't affect anything else.

## Longer-term

A proper fix in the SDK itself would be to inject `progressToken` whenever `resetTimeoutOnProgress: true` is set, not only when `onprogress` is provided. A PR for that is open at https://github.com/modelcontextprotocol/typescript-sdk — but this 1-line fix works today without waiting on upstream.