### PR TITLE
fix(tool): coerce object arguments to string in edit and write tools

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -38,8 +38,18 @@ export const EditTool = Tool.define("edit", {
   description: DESCRIPTION,
   parameters: z.object({
     filePath: z.string().describe("The absolute path to the file to modify"),
-    oldString: z.string().describe("The text to replace"),
-    newString: z.string().describe("The text to replace it with (must be different from oldString)"),
+    oldString: z
+      .preprocess(
+        (v) => (v !== null && typeof v === "object" ? JSON.stringify(v, null, 2) : v),
+        z.string(),
+      )
+      .describe("The text to replace"),
+    newString: z
+      .preprocess(
+        (v) => (v !== null && typeof v === "object" ? JSON.stringify(v, null, 2) : v),
+        z.string(),
+      )
+      .describe("The text to replace it with (must be different from oldString)"),
     replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
   }),
   async execute(params, ctx) {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -20,8 +20,13 @@ const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
-    content: z.string().describe("The content to write to the file"),
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
+    content: z
+      .preprocess(
+        (v) => (v !== null && typeof v === "object" ? JSON.stringify(v, null, 2) : v),
+        z.string(),
+      )
+      .describe("The content to write to the file"),
   }),
   async execute(params, ctx) {
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)


### PR DESCRIPTION
### Issue for this PR

Closes #6918

### Type of change

- [x] Bug fix

### What does this PR do?

Several models (Qwen3-Coder, GLM4.7, Gemini-3-pro-preview, and others) occasionally emit a JSON **object** rather than a plain string for tool parameters that are supposed to be strings — e.g. `oldString` / `newString` in the `edit` tool or `content` in the `write` tool. Zod rejects these outright with:

```
Error: The edit tool was called with invalid arguments: [
  { "expected": "string", "code": "invalid_type", "path": ["oldString"], "message": "Invalid input: expected string, received object" }
]
```

This causes the model to loop on the same error indefinitely.

**Fix:** Add a `z.preprocess` step on each affected parameter that serialises any incoming object value via `JSON.stringify` before Zod validates it. Plain string inputs pass through unchanged.

Additionally, reorder the `write` tool parameters so `filePath` comes **before** `content`, matching `edit`, `read`, and `apply_patch`. Small/quantised models are sensitive to JSON schema property ordering and reliably emit `filePath` when it appears first — this also addresses the `received undefined` variant of the write-tool error.

### How did you verify your code works?

- Ran existing tests: `bun test packages/opencode/test/tool/edit.test.ts` — all pass.
- The object-input path can only be triggered by a live misbehaving model; the preprocess logic is straightforward enough that a code review should be sufficient.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR