### PR TITLE
feat(bash): add env parameter for setting environment variables

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -64,6 +64,7 @@ const Parameters = z.object({
     .describe(
       "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
     ),
+  env: z.record(z.string(), z.string()).optional().describe("Environment variables to set for the command"),
 })
 
 type Part = {
@@ -487,7 +488,7 @@ export const BashTool = Tool.define("bash", async () => {
           name,
           command: params.command,
           cwd,
-          env: await shellEnv(ctx, cwd),
+          env: { ...(await shellEnv(ctx, cwd)), ...params.env },
           timeout,
           description: params.description,
         },

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -25,6 +25,7 @@ Before executing the command, please follow these steps:
 Usage notes:
   - The command argument is required.
   - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
+  - You can specify an optional env parameter to set environment variables for the command (e.g., `env: { "MY_VAR": "value" }`). These are merged with the existing environment.
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use `head`, `tail`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -1097,3 +1097,43 @@ describe("tool.bash truncation", () => {
     })
   })
 })
+
+describe("tool.bash env", () => {
+  test("sets environment variables", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "echo $TEST_VAR",
+            description: "Echo environment variable",
+            env: { TEST_VAR: "hello_world" },
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("hello_world")
+      },
+    })
+  })
+
+  test("sets multiple environment variables", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "echo $VAR1 $VAR2",
+            description: "Echo multiple environment variables",
+            env: { VAR1: "foo", VAR2: "bar" },
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("foo bar")
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Replacement for #11068

This PR replaces #11068, which was automatically closed.

## The need persists

We're seeing more cases of things handling the workaround situation poorly (needing to use `env` variables to pass through parent environment, or having issues with how the existing workaround handles `BUN_ENV` vs `NODE_ENV` vs user-set environment).

## Summary

Add an `env` parameter to the `bash` command for setting environment variables, similar to how other commands handle this.

This allows users to explicitly set environment variables when running bash commands, which is useful when you need to:
- Pass specific environment variables to a bash script
- Override or add to the existing environment
- Provide a cleaner API than the workaround approach

## Related

Original issue: #11065
Original PR: #11068