### PR TITLE
refactor(opencode): lazily compose default layers

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -398,11 +398,13 @@ export namespace Agent {
     }),
   )
 
-  export const defaultLayer = layer.pipe(
-    Layer.provide(Provider.defaultLayer),
-    Layer.provide(Auth.defaultLayer),
-    Layer.provide(Config.defaultLayer),
-    Layer.provide(Skill.defaultLayer),
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(
+      Layer.provide(Provider.defaultLayer),
+      Layer.provide(Auth.defaultLayer),
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(Skill.defaultLayer),
+    ),
   )
 
   const { runPromise } = makeRuntime(Service, defaultLayer)

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -183,9 +183,7 @@ export namespace Command {
     }),
   )
 
-  export const defaultLayer = layer.pipe(
-    Layer.provide(Config.defaultLayer),
-    Layer.provide(MCP.defaultLayer),
-    Layer.provide(Skill.defaultLayer),
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(MCP.defaultLayer), Layer.provide(Skill.defaultLayer)),
   )
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -678,7 +678,9 @@ export namespace Session {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Storage.defaultLayer))
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(Layer.provide(Bus.layer), Layer.provide(Storage.defaultLayer)),
+  )
 
   const { runPromise } = makeRuntime(Service, defaultLayer)
 

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -339,12 +339,14 @@ export namespace ShareNext {
     }),
   )
 
-  export const defaultLayer = layer.pipe(
-    Layer.provide(Bus.layer),
-    Layer.provide(Account.defaultLayer),
-    Layer.provide(Config.defaultLayer),
-    Layer.provide(FetchHttpClient.layer),
-    Layer.provide(Provider.defaultLayer),
-    Layer.provide(Session.defaultLayer),
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(
+      Layer.provide(Bus.layer),
+      Layer.provide(Account.defaultLayer),
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(FetchHttpClient.layer),
+      Layer.provide(Provider.defaultLayer),
+      Layer.provide(Session.defaultLayer),
+    ),
   )
 }

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -230,11 +230,13 @@ export namespace Skill {
     }),
   )
 
-  export const defaultLayer = layer.pipe(
-    Layer.provide(Discovery.defaultLayer),
-    Layer.provide(Config.defaultLayer),
-    Layer.provide(Bus.layer),
-    Layer.provide(AppFileSystem.defaultLayer),
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(
+      Layer.provide(Discovery.defaultLayer),
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(Bus.layer),
+      Layer.provide(AppFileSystem.defaultLayer),
+    ),
   )
 
   export function fmt(list: Info[], opts: { verbose: boolean }) {


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

defaultLayer is currently composed at import time. This makes module evaluation sensitive to transitive import order, even though the layer graph itself is unchanged.

Wrap these compositions in Layer.suspend() so the same graph is built on demand instead of during module load. This reduces init-order coupling and makes import reordering for startup work safer.

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

