### PR TITLE
fix: handle stream interruption for OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -645,6 +645,18 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           },
 
           flush(controller) {
+            // If the stream ended without receiving a finish_reason from the
+            // provider and we still have active output (incomplete text,
+            // reasoning, or tool calls), the stream was truncated. Emit an
+            // error event so downstream consumers can distinguish this from a
+            // normal completion and trigger retry logic.
+            const hasActiveOutput = isActiveReasoning || isActiveText || toolCalls.some((tc) => !tc.hasFinished)
+            if (finishReason.unified === "other" && finishReason.raw === undefined && hasActiveOutput) {
+              controller.enqueue({
+                type: "error",
+                error: new Error("Stream ended unexpectedly — no finish reason received while output was still active"),
+              })
+            }
             if (isActiveReasoning) {
               controller.enqueue({
                 type: "reasoning-end",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1021,6 +1021,15 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case e instanceof Error && e.message === "SSE read timed out":
+        return new MessageV2.APIError(
+          {
+            message: "Stream read timed out — no data received within the chunk timeout window",
+            isRetryable: true,
+            metadata: { code: "SSE_TIMEOUT", message: e.message },
+          },
+          { cause: e },
+        ).toObject()
       case e instanceof Error:
         return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
       default:

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -61,14 +61,18 @@ export namespace SessionRetry {
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
     }
 
-    // Check for rate limit patterns in plain text error messages
+    // Check for stream interruption patterns that should be retried
     const msg = error.data?.message
     if (typeof msg === "string") {
       const lower = msg.toLowerCase()
       if (
         lower.includes("rate increased too quickly") ||
         lower.includes("rate limit") ||
-        lower.includes("too many requests")
+        lower.includes("too many requests") ||
+        lower.includes("sse read timed out") ||
+        lower.includes("connection reset") ||
+        lower.includes("aborted") ||
+        lower.includes("stream ended unexpectedly")
       ) {
         return msg
       }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1029,4 +1029,15 @@ describe("session.message-v2.fromError", () => {
 
     expect(result.name).toBe("MessageAbortedError")
   })
+
+  test("classifies SSE read timed out as retryable APIError", () => {
+    const sseTimeout = new Error("SSE read timed out")
+
+    const result = MessageV2.fromError(sseTimeout, { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+    expect((result as MessageV2.APIError).data.message).toInclude("timed out")
+    expect((result as MessageV2.APIError).data.metadata?.code).toBe("SSE_TIMEOUT")
+  })
 })

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -184,6 +184,30 @@ describe("session.retry.retryable", () => {
     expect(retryable).toBeDefined()
     expect(retryable).toBe("Response decompression failed")
   })
+
+  test("retries SSE read timed out errors", () => {
+    const msg = "SSE read timed out"
+    const error = wrap(msg)
+    expect(SessionRetry.retryable(error)).toBe(msg)
+  })
+
+  test("retries connection reset errors", () => {
+    const msg = "Connection reset by peer"
+    const error = wrap(msg)
+    expect(SessionRetry.retryable(error)).toBe(msg)
+  })
+
+  test("retries aborted errors", () => {
+    const msg = "The operation was aborted"
+    const error = wrap(msg)
+    expect(SessionRetry.retryable(error)).toBe(msg)
+  })
+
+  test("retries stream ended unexpectedly errors", () => {
+    const msg = "Stream ended unexpectedly — no finish reason received while output was still active"
+    const error = wrap(msg)
+    expect(SessionRetry.retryable(error)).toBe(msg)
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #20466
Related #15393, #17680, #17574, #17307

### Type of change

- [x] Bug fix

### What does this PR do?

OpenAI-compatible providers (Ollama, cloud models) can interrupt SSE streams mid-response. Previously, opencode silently accepted the truncated output as a complete response — no retry, no error, just a cut-off answer.

Three fixes:

1. **`retry.ts`** — Added SSE timeout, connection reset, abort, and stream truncation patterns to `retryable()` matching so interrupted streams are automatically retried.

2. **`message-v2.ts`** — Classified `SSE read timed out` errors as `APIError(isRetryable: true)` instead of `Unknown`, so the retry mechanism recognizes and retries chunk timeouts.

3. **`openai-compatible-chat-language-model.ts`** — When `flush()` is called without a `finish_reason` from the provider while output is still active (text/reasoning/tool-call), emit an `error` event. This triggers the error handling path which retries, rather than silently accepting a truncated response.

### How did you verify your code works?

- 5 new `retryable()` test cases: SSE timeout, connection reset, aborted, stream ended unexpectedly, existing rate-limit still passes
- 1 new `fromError()` test case: `SSE read timed out` → `APIError(isRetryable: true, code: SSE_TIMEOUT)`
- All 51 tests across `retry.test.ts` and `message-v2.test.ts` pass

### Screenshots / recordings

N/A — backend fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR