### PR TITLE
refactor: remove unused runtime facade exports

### DIFF
--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -461,28 +461,11 @@ export namespace Account {
     return Option.getOrUndefined(await runPromise((service) => service.active()))
   }
 
-  export async function list(): Promise<Info[]> {
-    return runPromise((service) => service.list())
-  }
-
-  export async function activeOrg(): Promise<ActiveOrg | undefined> {
-    return Option.getOrUndefined(await runPromise((service) => service.activeOrg()))
-  }
-
   export async function orgsByAccount(): Promise<readonly AccountOrgs[]> {
     return runPromise((service) => service.orgsByAccount())
   }
 
-  export async function orgs(accountID: AccountID): Promise<readonly Org[]> {
-    return runPromise((service) => service.orgs(accountID))
-  }
-
   export async function switchOrg(accountID: AccountID, orgID: OrgID) {
     return runPromise((service) => service.use(accountID, Option.some(orgID)))
-  }
-
-  export async function token(accountID: AccountID): Promise<AccessToken | undefined> {
-    const t = await runPromise((service) => service.token(accountID))
-    return Option.getOrUndefined(t)
   }
 }

--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -499,4 +499,3 @@ const rt = lazy(async () => {
 
 type RT = Awaited<ReturnType<typeof rt>>
 export const runPromiseExit: RT["runPromiseExit"] = async (...args) => (await rt()).runPromiseExit(...(args as [any]))
-export const runPromise: RT["runPromise"] = async (...args) => (await rt()).runPromise(...(args as [any]))

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -265,39 +265,7 @@ export namespace Git {
     return runPromise((git) => git.run(args, opts))
   }
 
-  export async function branch(cwd: string) {
-    return runPromise((git) => git.branch(cwd))
-  }
-
-  export async function prefix(cwd: string) {
-    return runPromise((git) => git.prefix(cwd))
-  }
-
   export async function defaultBranch(cwd: string) {
     return runPromise((git) => git.defaultBranch(cwd))
-  }
-
-  export async function hasHead(cwd: string) {
-    return runPromise((git) => git.hasHead(cwd))
-  }
-
-  export async function mergeBase(cwd: string, base: string, head?: string) {
-    return runPromise((git) => git.mergeBase(cwd, base, head))
-  }
-
-  export async function show(cwd: string, ref: string, file: string, prefix?: string) {
-    return runPromise((git) => git.show(cwd, ref, file, prefix))
-  }
-
-  export async function status(cwd: string) {
-    return runPromise((git) => git.status(cwd))
-  }
-
-  export async function diff(cwd: string, ref: string) {
-    return runPromise((git) => git.diff(cwd, ref))
-  }
-
-  export async function stats(cwd: string, ref: string) {
-    return runPromise((git) => git.stats(cwd, ref))
   }
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -906,9 +906,6 @@ export namespace MCP {
 
   export const disconnect = async (name: string) => runPromise((svc) => svc.disconnect(name))
 
-  export const getPrompt = async (clientName: string, name: string, args?: Record<string, string>) =>
-    runPromise((svc) => svc.getPrompt(clientName, name, args))
-
   export const startAuth = async (mcpName: string) => runPromise((svc) => svc.startAuth(mcpName))
 
   export const authenticate = async (mcpName: string) => runPromise((svc) => svc.authenticate(mcpName))

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -371,10 +371,6 @@ export namespace Pty {
     return runPromise((svc) => svc.get(id))
   }
 
-  export async function resize(id: PtyID, cols: number, rows: number) {
-    return runPromise((svc) => svc.resize(id, cols, rows))
-  }
-
   export async function write(id: PtyID, data: string) {
     return runPromise((svc) => svc.write(id, data))
   }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -401,17 +401,6 @@ When constructing the summary, try to stick to this template:
     return runPromise((svc) => svc.prune(input))
   }
 
-  export const process = fn(
-    z.object({
-      parentID: MessageID.zod,
-      messages: z.custom<MessageV2.WithParts[]>(),
-      sessionID: SessionID.zod,
-      auto: z.boolean(),
-      overflow: z.boolean().optional(),
-    }),
-    (input) => runPromise((svc) => svc.process(input)),
-  )
-
   export const create = fn(
     z.object({
       sessionID: SessionID.zod,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -730,7 +730,6 @@ export namespace Session {
     runPromise((svc) => svc.fork(input)),
   )
 
-  export const touch = fn(SessionID.zod, (id) => runPromise((svc) => svc.touch(id)))
   export const get = fn(SessionID.zod, (id) => runPromise((svc) => svc.get(id)))
   export const share = fn(SessionID.zod, (id) => runPromise((svc) => svc.share(id)))
   export const unshare = fn(SessionID.zod, (id) => runPromise((svc) => svc.unshare(id)))
@@ -743,23 +742,11 @@ export namespace Session {
     runPromise((svc) => svc.setArchived(input)),
   )
 
-  export const setPermission = fn(z.object({ sessionID: SessionID.zod, permission: Permission.Ruleset }), (input) =>
-    runPromise((svc) => svc.setPermission(input)),
-  )
-
   export const setRevert = fn(
     z.object({ sessionID: SessionID.zod, revert: Info.shape.revert, summary: Info.shape.summary }),
     (input) =>
       runPromise((svc) => svc.setRevert({ sessionID: input.sessionID, revert: input.revert, summary: input.summary })),
   )
-
-  export const clearRevert = fn(SessionID.zod, (id) => runPromise((svc) => svc.clearRevert(id)))
-
-  export const setSummary = fn(z.object({ sessionID: SessionID.zod, summary: Info.shape.summary }), (input) =>
-    runPromise((svc) => svc.setSummary({ sessionID: input.sessionID, summary: input.summary })),
-  )
-
-  export const diff = fn(SessionID.zod, (id) => runPromise((svc) => svc.diff(id)))
 
   export const messages = fn(z.object({ sessionID: SessionID.zod, limit: z.number().optional() }), (input) =>
     runPromise((svc) => svc.messages(input)),

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -85,10 +85,6 @@ export namespace Todo {
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
   const { runPromise } = makeRuntime(Service, defaultLayer)
 
-  export async function update(input: { sessionID: SessionID; todos: Info[] }) {
-    return runPromise((svc) => svc.update(input))
-  }
-
   export async function get(sessionID: SessionID) {
     return runPromise((svc) => svc.get(sessionID))
   }


### PR DESCRIPTION
## Summary
- remove repo-wide unused runtime facade exports from account, git, session, storage, MCP, pty, and cross-spawn-spawner modules
- shrink the Promise facade surface without changing any effectful service implementations or boundary behavior
- make the eventual move to a single shared managed runtime easier by deleting dead entry points first

## Testing
- `git diff --check`
- `bun typecheck` currently fails in the fresh worktree because `@tsconfig/bun` is not installed there