### PR TITLE
fix(effect): suspend agent default layer construction

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -393,11 +393,13 @@ export namespace Agent {
     }),
   )
 
-  export const defaultLayer = layer.pipe(
-    Layer.provide(Provider.defaultLayer),
-    Layer.provide(Auth.defaultLayer),
-    Layer.provide(Config.defaultLayer),
-    Layer.provide(Skill.defaultLayer),
+  export const defaultLayer = Layer.suspend(() =>
+    layer.pipe(
+      Layer.provide(Provider.defaultLayer),
+      Layer.provide(Auth.defaultLayer),
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(Skill.defaultLayer),
+    ),
   )
 
   const { runPromise } = makeRuntime(Service, defaultLayer)


### PR DESCRIPTION
## Summary
- wrap `Agent.defaultLayer` in `Layer.suspend` so its dependency graph is constructed lazily
- avoid eager layer construction at runtime setup boundaries where dependent default layers may still be initializing
- isolate the change to the agent service used by the runtime-backed facade path

## Testing
- `bun run build` in `packages/sdk/js`
- `bun typecheck` in `packages/opencode`