### PR TITLE
fix(opencode): restore abort-aware shell cancellation in Runner and SessionPrompt

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -4,7 +4,7 @@ export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
-  readonly startShell: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly startShell: (work: (signal: AbortSignal) => Effect.Effect<A, E>) => Effect.Effect<A, E>
   readonly cancel: Effect.Effect<void>
 }
 
@@ -19,6 +19,7 @@ interface RunHandle<A, E> {
 interface ShellHandle<A, E> {
   id: number
   fiber: Fiber.Fiber<A, E>
+  abort: AbortController
 }
 
 interface PendingHandle<A, E> {
@@ -98,7 +99,12 @@ export const make = <A, E = never>(
       }),
     ).pipe(Effect.flatten)
 
-  const stopShell = (shell: ShellHandle<A, E>) => Fiber.interrupt(shell.fiber)
+  const stopShell = (shell: ShellHandle<A, E>) =>
+    Effect.gen(function* () {
+      shell.abort.abort()
+      yield* Effect.sleep("100 millis")
+      yield* Fiber.interrupt(shell.fiber)
+    })
 
   const ensureRunning = (work: Effect.Effect<A, E>) =>
     SynchronizedRef.modifyEffect(
@@ -130,7 +136,7 @@ export const make = <A, E = never>(
       ),
     )
 
-  const startShell = (work: Effect.Effect<A, E>) =>
+  const startShell = (work: (signal: AbortSignal) => Effect.Effect<A, E>) =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
@@ -145,8 +151,9 @@ export const make = <A, E = never>(
         }
         yield* busy
         const id = next()
-        const fiber = yield* work.pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
-        const shell = { id, fiber } satisfies ShellHandle<A, E>
+        const abort = new AbortController()
+        const fiber = yield* work(abort.signal).pipe(Effect.ensuring(finishShell(id)), Effect.forkChild)
+        const shell = { id, fiber, abort } satisfies ShellHandle<A, E>
         return [
           Effect.gen(function* () {
             const exit = yield* Fiber.await(fiber)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -718,7 +718,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       } satisfies MessageV2.TextPart)
     })
 
-    const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput) {
+    const shellImpl = Effect.fn("SessionPrompt.shellImpl")(function* (input: ShellInput, signal: AbortSignal) {
       const ctx = yield* InstanceState.context
       const run = yield* runner()
       const session = yield* sessions.get(input.sessionID)
@@ -840,6 +840,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       let output = ""
       let aborted = false
+
+      if (signal.aborted) {
+        aborted = true
+      } else {
+        signal.addEventListener("abort", () => {
+          aborted = true
+        }, { once: true })
+      }
 
       const finish = Effect.uninterruptible(
         Effect.gen(function* () {
@@ -1543,7 +1551,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const shell: (input: ShellInput) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.shell")(
       function* (input: ShellInput) {
-        return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), shellImpl(input))
+        return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), (signal) => shellImpl(input, signal))
       },
     )
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -17,7 +17,7 @@ export interface Interface {
   readonly startShell: (
     sessionID: SessionID,
     onInterrupt: Effect.Effect<MessageV2.WithParts>,
-    work: Effect.Effect<MessageV2.WithParts>,
+    work: (signal: AbortSignal) => Effect.Effect<MessageV2.WithParts>,
   ) => Effect.Effect<MessageV2.WithParts>
 }
 
@@ -94,7 +94,7 @@ export const layer = Layer.effect(
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
       sessionID: SessionID,
       onInterrupt: Effect.Effect<MessageV2.WithParts>,
-      work: Effect.Effect<MessageV2.WithParts>,
+      work: (signal: AbortSignal) => Effect.Effect<MessageV2.WithParts>,
     ) {
       return yield* (yield* runner(sessionID, onInterrupt)).startShell(work)
     })

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -250,7 +250,7 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const result = yield* runner.startShell(Effect.succeed("shell-done"))
+      const result = yield* runner.startShell(() => Effect.succeed("shell-done"))
       expect(result).toBe("shell-done")
       expect(runner.busy).toBe(false)
     }),
@@ -264,7 +264,7 @@ describe("Runner", () => {
       const fiber = yield* runner.ensureRunning(Effect.never.pipe(Effect.as("x"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
-      const exit = yield* runner.startShell(Effect.succeed("nope")).pipe(Effect.exit)
+      const exit = yield* runner.startShell(() => Effect.succeed("nope")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
 
       yield* runner.cancel
@@ -282,7 +282,7 @@ describe("Runner", () => {
       const sh = yield* runner.startShell((_signal) => Deferred.await(gate).pipe(Effect.as("first"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
-      const exit = yield* runner.startShell(Effect.succeed("second")).pipe(Effect.exit)
+      const exit = yield* runner.startShell(() => Effect.succeed("second")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
 
       yield* Deferred.succeed(gate, undefined)
@@ -300,10 +300,10 @@ describe("Runner", () => {
         },
       })
 
-      const sh = yield* runner.startShell(Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell(() => Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
-      const exit = yield* runner.startShell(Effect.succeed("second")).pipe(Effect.exit)
+      const exit = yield* runner.startShell(() => Effect.succeed("second")).pipe(Effect.exit)
       expect(Exit.isFailure(exit)).toBe(true)
 
       yield* runner.cancel
@@ -319,7 +319,7 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s)
       const gate = yield* Deferred.make<void>()
 
-      const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("ignored"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell(() => Deferred.await(gate).pipe(Effect.as("ignored"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
       const stop = yield* runner.cancel.pipe(Effect.forkChild)
@@ -343,7 +343,7 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s)
       const gate = yield* Deferred.make<void>()
 
-      const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("shell-result"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell(() => Deferred.await(gate).pipe(Effect.as("shell-result"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
       expect(runner.state._tag).toBe("Shell")
 
@@ -369,7 +369,7 @@ describe("Runner", () => {
       const calls = yield* Ref.make(0)
       const gate = yield* Deferred.make<void>()
 
-      const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("shell"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell(() => Deferred.await(gate).pipe(Effect.as("shell"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
       const work = Effect.gen(function* () {
@@ -396,7 +396,7 @@ describe("Runner", () => {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
 
-      const sh = yield* runner.startShell(Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell(() => Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
       const run = yield* runner.ensureRunning(Effect.succeed("y")).pipe(Effect.forkChild)
@@ -409,6 +409,58 @@ describe("Runner", () => {
       yield* Fiber.await(sh)
       const exit = yield* Fiber.await(run)
       expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.live(
+    "cancel triggers abort signal before fiber interrupt",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const abortTriggered = yield* Ref.make(false)
+
+      const work = (signal: AbortSignal) =>
+        Effect.gen(function* () {
+          signal.addEventListener(
+            "abort",
+            () => {
+              Effect.runFork(Ref.set(abortTriggered, true))
+            },
+            { once: true },
+          )
+          yield* Effect.never
+        })
+
+      const sh = yield* runner.startShell(work).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancel
+      yield* Effect.sleep("10 millis")
+
+      expect(yield* Ref.get(abortTriggered)).toBe(true)
+      expect(runner.busy).toBe(false)
+
+      yield* Fiber.await(sh)
+    }),
+  )
+
+  it.live(
+    "can start new work immediately after canceling shell",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+
+      const work = (_signal: AbortSignal) => Effect.never.pipe(Effect.as("aborted"))
+      const sh = yield* runner.startShell(work).pipe(Effect.forkChild)
+      yield* Effect.sleep("10 millis")
+
+      yield* runner.cancel
+      yield* Fiber.await(sh)
+      expect(runner.busy).toBe(false)
+
+      const result = yield* runner.startShell(() => Effect.succeed("new-shell"))
+      expect(result).toBe("new-shell")
+      expect(runner.busy).toBe(false)
     }),
   )
 
@@ -451,7 +503,7 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s, {
         onBusy: Ref.update(count, (n) => n + 1),
       })
-      yield* runner.startShell(Effect.succeed("done"))
+      yield* runner.startShell(() => Effect.succeed("done"))
       expect(yield* Ref.get(count)).toBe(1)
     }),
   )
@@ -482,7 +534,7 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s)
       const gate = yield* Deferred.make<void>()
 
-      const fiber = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("ok"))).pipe(Effect.forkChild)
+      const fiber = yield* runner.startShell(() => Deferred.await(gate).pipe(Effect.as("ok"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
       expect(runner.busy).toBe(true)
 

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -279,7 +279,7 @@ describe("Runner", () => {
       const runner = Runner.make<string>(s)
       const gate = yield* Deferred.make<void>()
 
-      const sh = yield* runner.startShell(Deferred.await(gate).pipe(Effect.as("first"))).pipe(Effect.forkChild)
+      const sh = yield* runner.startShell((_signal) => Deferred.await(gate).pipe(Effect.as("first"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")
 
       const exit = yield* runner.startShell(Effect.succeed("second")).pipe(Effect.exit)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -428,7 +428,7 @@ describe("Runner", () => {
             },
             { once: true },
           )
-          yield* Effect.never
+          return yield* Effect.never.pipe(Effect.as("aborted"))
         })
 
       const sh = yield* runner.startShell(work).pipe(Effect.forkChild)


### PR DESCRIPTION
### Issue for this PR

Closes #21743

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This restores abort-aware shell cancellation semantics that existed before 1.4.x.

In 1.3.17, shell execution used an explicit abort signal and a graceful-first stop path. In 1.4.x, `Runner.startShell(...)` was simplified to a plain `Effect`, the shell abort controller was removed, and `SessionPrompt.shellImpl(...)` stopped receiving an abort signal.

This PR restores that behavior by:
- changing `Runner.startShell(...)` back to an abort-aware contract
- storing an `AbortController` in shell state
- aborting cooperatively before falling back to fiber interrupt
- plumbing `AbortSignal` back into `SessionPrompt.shellImpl(...)`
- adding regression tests for shell cancellation

### How did you verify your code works?

I verified it by:
- reproducing the regression on 1.4.2
- confirming that 1.3.17 works
- adding regression tests for shell cancellation
- manually testing interrupt behavior in TUI with a long-running shell action

### Screenshots / recordings

N/A (non-UI bug fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR