### PR TITLE
refactor(session): inline init route orchestration

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -14,6 +14,7 @@ import { SessionSummary } from "@/session/summary"
 import { Todo } from "../../session/todo"
 import { Agent } from "../../agent/agent"
 import { Snapshot } from "@/snapshot"
+import { Command } from "../../command"
 import { Log } from "../../util/log"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
@@ -292,6 +293,7 @@ export const SessionRoutes = lazy(() =>
         return c.json(session)
       },
     )
+    // TODO(v2): remove this dedicated route and rely on the normal `/init` command flow.
     .post(
       "/:sessionID/init",
       describeRoute({
@@ -317,11 +319,24 @@ export const SessionRoutes = lazy(() =>
           sessionID: SessionID.zod,
         }),
       ),
-      validator("json", Session.initialize.schema.omit({ sessionID: true })),
+      validator(
+        "json",
+        z.object({
+          modelID: ModelID.zod,
+          providerID: ProviderID.zod,
+          messageID: MessageID.zod,
+        }),
+      ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         const body = c.req.valid("json")
-        await Session.initialize({ ...body, sessionID })
+        await SessionPrompt.command({
+          sessionID,
+          messageID: body.messageID,
+          model: body.providerID + "/" + body.modelID,
+          command: Command.Default.INIT,
+          arguments: "",
+        })
         return c.json(true)
       },
     )

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -20,16 +20,13 @@ import { updateSchema } from "../util/update-schema"
 import { MessageV2 } from "./message-v2"
 import { Instance } from "../project/instance"
 import { InstanceState } from "@/effect/instance-state"
-import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
-import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, MessageID, PartID } from "./schema"
 
 import type { Provider } from "@/provider/provider"
-import { ModelID, ProviderID } from "@/provider/schema"
 import { Permission } from "@/permission"
 import { Global } from "@/global"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
@@ -358,12 +355,6 @@ export namespace Session {
       field: string
       delta: string
     }) => Effect.Effect<void>
-    readonly initialize: (input: {
-      sessionID: SessionID
-      modelID: ModelID
-      providerID: ProviderID
-      messageID: MessageID
-    }) => Effect.Effect<void>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Session") {}
@@ -512,12 +503,12 @@ export namespace Session {
             .get(),
         )
         if (!row) return
-        return {
+        return MessageV2.Part.parse({
           ...row.data,
           id: row.id,
           sessionID: row.session_id,
           messageID: row.message_id,
-        } as MessageV2.Part
+        })
       })
 
       const create = Effect.fn("Session.create")(function* (input?: {
@@ -616,7 +607,7 @@ export namespace Session {
 
       const diff = Effect.fn("Session.diff")(function* (sessionID: SessionID) {
         return yield* Effect.tryPromise(() => Storage.read<Snapshot.FileDiff[]>(["session_diff", sessionID])).pipe(
-          Effect.orElseSucceed(() => [] as Snapshot.FileDiff[]),
+          Effect.orElseSucceed((): Snapshot.FileDiff[] => []),
         )
       })
 
@@ -665,23 +656,6 @@ export namespace Session {
         yield* bus.publish(MessageV2.Event.PartDelta, input)
       })
 
-      const initialize = Effect.fn("Session.initialize")(function* (input: {
-        sessionID: SessionID
-        modelID: ModelID
-        providerID: ProviderID
-        messageID: MessageID
-      }) {
-        yield* Effect.promise(() =>
-          SessionPrompt.command({
-            sessionID: input.sessionID,
-            messageID: input.messageID,
-            model: input.providerID + "/" + input.modelID,
-            command: Command.Default.INIT,
-            arguments: "",
-          }),
-        )
-      })
-
       return Service.of({
         create,
         fork,
@@ -705,7 +679,6 @@ export namespace Session {
         updatePart,
         getPart,
         updatePartDelta,
-        initialize,
       })
     }),
   )
@@ -894,10 +867,5 @@ export namespace Session {
       delta: z.string(),
     }),
     (input) => runPromise((svc) => svc.updatePartDelta(input)),
-  )
-
-  export const initialize = fn(
-    z.object({ sessionID: SessionID.zod, modelID: ModelID.zod, providerID: ProviderID.zod, messageID: MessageID.zod }),
-    (input) => runPromise((svc) => svc.initialize(input)),
   )
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -503,12 +503,12 @@ export namespace Session {
             .get(),
         )
         if (!row) return
-        return MessageV2.Part.parse({
+        return {
           ...row.data,
           id: row.id,
           sessionID: row.session_id,
           messageID: row.message_id,
-        })
+        } as MessageV2.Part
       })
 
       const create = Effect.fn("Session.create")(function* (input?: {


### PR DESCRIPTION
## Summary
- remove the special-case `Session.initialize` method and inline the existing init command flow directly in the `session.init` route
- keep the dedicated route for API compatibility for now, with a TODO to remove it in v2
- replace two local casts in `Session` with typed alternatives (`MessageV2.Part.parse(...)` and a typed empty-array fallback)

## Testing
- `bun typecheck`
- `bun turbo typecheck`