### PR TITLE
fix(plugin): write server plugin load errors to stderr

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -169,8 +169,10 @@ export namespace Plugin {
 
                   if (stage === "install") {
                     const parsed = parsePluginSpecifier(spec)
+                    const installMsg = `Failed to install plugin ${parsed.pkg}@${parsed.version}: ${message}`
                     log.error("failed to install plugin", { pkg: parsed.pkg, version: parsed.version, error: message })
-                    publishPluginError(bus, `Failed to install plugin ${parsed.pkg}@${parsed.version}: ${message}`)
+                    process.stderr.write(`[plugin] ${installMsg}\n`)
+                    publishPluginError(bus, installMsg)
                     return
                   }
 
@@ -181,13 +183,17 @@ export namespace Plugin {
                   }
 
                   if (stage === "entry") {
+                    const entryMsg = `Failed to load plugin ${spec}: ${message}`
                     log.error("failed to resolve plugin server entry", { path: spec, error: message })
-                    publishPluginError(bus, `Failed to load plugin ${spec}: ${message}`)
+                    process.stderr.write(`[plugin] ${entryMsg}\n`)
+                    publishPluginError(bus, entryMsg)
                     return
                   }
 
+                  const loadMsg = `Failed to load plugin ${spec}: ${message}`
                   log.error("failed to load plugin", { path: spec, target: resolved?.entry, error: message })
-                  publishPluginError(bus, `Failed to load plugin ${spec}: ${message}`)
+                  process.stderr.write(`[plugin] ${loadMsg}\n`)
+                  publishPluginError(bus, loadMsg)
                 },
               },
             }),
@@ -201,15 +207,15 @@ export namespace Plugin {
               try: () => applyPlugin(load, input, hooks),
               catch: (err) => {
                 const message = errorMessage(err)
+                const applyMsg = `Failed to load plugin ${load.spec}: ${message}`
                 log.error("failed to load plugin", { path: load.spec, error: message })
-                return message
+                process.stderr.write(`[plugin] ${applyMsg}\n`)
+                return applyMsg
               },
             }).pipe(
               Effect.catch((message) =>
                 bus.publish(Session.Event.Error, {
-                  error: new NamedError.Unknown({
-                    message: `Failed to load plugin ${load.spec}: ${message}`,
-                  }).toObject(),
+                  error: new NamedError.Unknown({ message }).toObject(),
                 }),
               ),
             )


### PR DESCRIPTION
### Issue for this PR

Closes #21638

### Type of change

- [x] Bug fix

### What does this PR do?

When a local plugin (e.g. `.opencode/plugins/my-plugin.ts`) fails to load, the error was silently dropped. Two things work against visibility:

1. `log.error()` writes to the log file, which most users never check during development.
2. `publishPluginError()` fires a `Session.Event.Error` bus event — but plugins load at startup before any session is created, so there are no subscribers and the event is dropped.

The TUI plugin runtime already handles this correctly by calling `console.error` alongside `log.error` so errors appear in the terminal immediately. This PR applies the same pattern to the server plugin loader: add `process.stderr.write` for install, entry resolution, and load failures. The existing `log.error` and `publishPluginError` calls are kept so in-session errors still appear in the UI.

### How did you verify your code works?

Ran `bun test test/plugin/loader-shared.test.ts` — all 27 tests pass. The stderr output from error paths is visible in the test output, confirming each error case now surfaces correctly.

### Screenshots / recordings

_No UI screenshot — the fix makes terminal output appear where there was none before._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR