### PR TITLE
feat(server): /tool, /status, /exec endpoints

### DIFF
--- a/packages/opencode/.opencode/package-lock.json
+++ b/packages/opencode/.opencode/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "*"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.7",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.7",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.92",
+        "@opentui/solid": ">=0.1.92"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.7",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1510,10 +1510,13 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
   const ctx = use()
   const sync = useSync()
 
-  // Hide tool if showDetails is false and tool completed successfully
+  // Hide tool if showDetails is false and tool completed successfully.
+  // Task and status parts are always visible — they show subagent summaries
+  // and display-only messages that the user expects to see.
   const shouldHide = createMemo(() => {
     if (ctx.showDetails()) return false
     if (props.part.state.status !== "completed") return false
+    if (props.part.tool === "task" || props.part.tool === "status") return false
     return true
   })
 

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -26,8 +26,38 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
 import { NamedError } from "@opencode-ai/util/error"
+import { ToolRegistry } from "../../tool/registry"
 
 const log = Log.create({ service: "server" })
+
+/** Walk parent session messages backwards to find the model used in the last user message. */
+async function resolveModel(sessionID: SessionID) {
+  const msgs = await Session.messages({ sessionID })
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const info = msgs[i].info
+    if (info.role === "user" && info.model) return info.model
+  }
+}
+
+/** Create an emitter for external ToolPart updates (no-op when messageID is absent). */
+function emitter(opts: { sessionID: SessionID; messageID?: string; tool: string }) {
+  const mid = opts.messageID ? MessageID.make(opts.messageID) : undefined
+  const pid = mid ? PartID.ascending() : undefined
+  const fn = (state: z.infer<typeof MessageV2.ToolState>) =>
+    mid && pid
+      ? Session.updatePart({
+          id: pid,
+          messageID: mid,
+          sessionID: opts.sessionID,
+          type: "tool" as const,
+          tool: opts.tool,
+          callID: pid,
+          external: true,
+          state,
+        })
+      : undefined
+  return { mid, pid, fn }
+}
 
 export const SessionRoutes = lazy(() =>
   new Hono()
@@ -1056,6 +1086,336 @@ export const SessionRoutes = lazy(() =>
           reply: c.req.valid("json").response,
         })
         return c.json(true)
+      },
+    )
+    // Direct tool execution — no LLM, deterministic. Enables plugins, tests,
+    // and scripts to execute tools outside the LLM event loop.
+    .post(
+      "/:sessionID/tool",
+      describeRoute({
+        summary: "Execute tool directly",
+        description:
+          "Execute an OpenCode tool without LLM involvement. Results are streamed as plain text. Optionally creates an external ToolPart for TUI visibility.",
+        operationId: "session.tool",
+        responses: {
+          200: {
+            description: "Tool output as plain text",
+            content: { "text/plain": { schema: resolver(z.string()) } },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator(
+        "json",
+        z.object({
+          name: z.string().describe("Tool name (e.g. read, edit, grep, glob)"),
+          args: z.record(z.string(), z.unknown()).describe("Tool arguments"),
+          agent: z.string().optional().describe("Agent context for permissions"),
+          messageID: z.string().optional().describe("Parent message ID — creates external ToolPart when present"),
+        }),
+      ),
+      async (c) => {
+        const param = c.req.valid("param")
+        const body = c.req.valid("json")
+        const session = await Session.get(param.sessionID)
+        const agent = body.agent ?? (await Agent.defaultAgent())
+        const ag = await Agent.get(agent)
+
+        const tools = await ToolRegistry.tools({
+          providerID: ProviderID.make(""),
+          modelID: ModelID.make(""),
+          agent: ag,
+        })
+        const tool = tools.find((t) => t.id === body.name)
+        if (!tool) return c.text(`Tool not found: ${body.name}`, 404)
+
+        const t0 = Date.now()
+        const emit = emitter({ sessionID: param.sessionID, messageID: body.messageID, tool: body.name })
+
+        await emit.fn({ status: "running", input: body.args, time: { start: t0 } })
+
+        const ctx = {
+          sessionID: param.sessionID,
+          messageID: emit.mid ?? MessageID.ascending(),
+          callID: emit.pid ?? PartID.ascending(),
+          agent,
+          abort: c.req.raw.signal,
+          messages: [] as MessageV2.WithParts[],
+          metadata(val: { title?: string; metadata?: Record<string, unknown> }) {
+            emit
+              .fn({
+                status: "running",
+                input: body.args,
+                title: val.title,
+                metadata: val.metadata,
+                time: { start: t0 },
+              })
+              ?.catch(() => {})
+          },
+          async ask(req: Omit<Permission.Request, "id" | "sessionID" | "tool">) {
+            await Permission.ask({
+              ...req,
+              sessionID: param.sessionID,
+              tool: emit.mid ? { messageID: emit.mid, callID: emit.pid ?? ctx.callID } : undefined,
+              ruleset: Permission.merge(ag.permission ?? [], session.permission ?? []),
+            })
+          },
+        }
+
+        c.status(200)
+        c.header("Content-Type", "text/plain")
+        return stream(c, async (stream) => {
+          try {
+            const result = await tool.execute(body.args, ctx)
+            await emit.fn({
+              status: "completed",
+              input: body.args,
+              output: result.output,
+              title: result.title ?? "",
+              metadata: result.metadata ?? {},
+              time: { start: t0, end: Date.now() },
+            })
+            const file = typeof body.args.filePath === "string" ? body.args.filePath : undefined
+            await stream.write(result.output + (result.attachments?.length && file ? `\n\x00OC_FILE\x00:${file}` : ""))
+          } catch (error) {
+            const err = error instanceof Error ? error.message : String(error)
+            await emit.fn({
+              status: "error",
+              input: body.args,
+              error: err,
+              time: { start: t0, end: Date.now() },
+            })
+            await stream.write(`Error: ${err}`)
+          }
+        })
+      },
+    )
+    // Display-only status message — creates an external ToolPart for TUI visibility
+    .post(
+      "/:sessionID/status",
+      describeRoute({
+        summary: "Post status message",
+        description: "Create an external ToolPart for display in the TUI. Not sent to the LLM.",
+        operationId: "session.status.post",
+        responses: {
+          200: { description: "Status accepted", content: { "text/plain": { schema: resolver(z.string()) } } },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator("json", z.object({ message: z.string(), messageID: z.string().optional() })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await Session.get(sessionID)
+        const emit = emitter({ sessionID, messageID: body.messageID, tool: "status" })
+        if (emit.mid && body.message) {
+          await emit.fn({
+            status: "completed",
+            input: { message: body.message },
+            output: body.message,
+            title: "",
+            metadata: {},
+            time: { start: Date.now(), end: Date.now() },
+          })
+        }
+        return c.text("ok")
+      },
+    )
+    // AI judgment via child session — scripts can delegate decisions to the LLM.
+    // Each callback gets a fresh context (no token accumulation).
+    .post(
+      "/:sessionID/exec",
+      describeRoute({
+        summary: "Execute AI prompt",
+        description:
+          "Create a child session, send a prompt, and stream the AI response as plain text. Designed for script callbacks that need AI judgment at decision points.",
+        operationId: "session.exec",
+        responses: {
+          200: {
+            description: "AI response as plain text",
+            content: { "text/plain": { schema: resolver(z.string()) } },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator(
+        "json",
+        z.object({
+          prompt: z.string().describe("The prompt text to send to the AI"),
+          system: z.string().optional().describe("Custom system prompt for specialist creation"),
+          agent: z.string().optional().describe("Agent type"),
+          model: z.object({ providerID: ProviderID.zod, modelID: ModelID.zod }).optional().describe("Model override"),
+          files: z
+            .array(z.object({ filename: z.string(), mime: z.string(), url: z.string() }))
+            .optional()
+            .describe("File attachments (PDFs, images) for multimodal prompts"),
+          format: z
+            .object({ type: z.literal("json_schema"), schema: z.record(z.string(), z.unknown()) })
+            .optional()
+            .describe("Force structured output via json_schema"),
+          messageID: z.string().optional().describe("Parent message ID — creates external ToolPart when present"),
+        }),
+      ),
+      async (c) => {
+        const parent = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await Session.get(parent)
+
+        // Inherit model from parent session if not explicitly provided
+        const msgs = body.model ? [] : await Session.messages({ sessionID: parent })
+        const model =
+          body.model ??
+          msgs.findLast((m): m is typeof m & { info: MessageV2.User } => m.info.role === "user")?.info.model
+
+        const title = body.system ? `oc prompt -s "${body.system}"` : "oc prompt"
+        const child = await Session.create({ parentID: parent, title })
+        const cleanup = () => SessionPrompt.cancel(child.id)
+        // Register listener before checking — avoids race where abort fires
+        // between the check and addEventListener.
+        c.req.raw.signal.addEventListener("abort", cleanup)
+        if (c.req.raw.signal.aborted) {
+          c.req.raw.signal.removeEventListener("abort", cleanup)
+          cleanup()
+          return c.text("aborted", 503)
+        }
+
+        // Create external ToolPart for subagent visibility (opt-in via messageID)
+        const t0 = Date.now()
+        const preview = body.prompt.substring(0, 80) + (body.prompt.length > 80 ? "..." : "")
+        const emit = emitter({ sessionID: parent, messageID: body.messageID, tool: "task" })
+
+        await emit.fn({
+          status: "running",
+          input: { prompt: preview, description: preview, subagent_type: "oc" },
+          title,
+          metadata: { sessionId: child.id, model },
+          time: { start: t0 },
+        })
+
+        c.status(200)
+        c.header("Content-Type", "text/plain")
+        return stream(c, async (stream) => {
+          let text = ""
+          const unsub =
+            emit.mid && emit.pid
+              ? Bus.subscribe(MessageV2.Event.PartDelta, (event) => {
+                  if (event.properties.sessionID === child.id && event.properties.field === "text") {
+                    text += event.properties.delta
+                    if (text.length > 10_000) text = text.slice(-10_000)
+                    // fire-and-forget — emitter already logs on rejection
+                    void emit.fn({
+                      status: "running",
+                      input: { prompt: preview },
+                      title,
+                      metadata: { sessionId: child.id, model, output: text.substring(0, 2000) },
+                      time: { start: t0 },
+                    })
+                  }
+                })
+              : undefined
+
+          // Keepalive markers prevent HTTP idle timeout for long-running callbacks
+          const timer = setInterval(() => stream.write("\x00OC_KEEPALIVE\x00").catch(() => {}), 15_000)
+
+          try {
+            const msg = await SessionPrompt.prompt({
+              sessionID: child.id,
+              parts: [
+                { type: "text", text: body.prompt },
+                ...(body.files ?? []).map((f) => ({
+                  type: "file" as const,
+                  mime: f.mime,
+                  url: f.url,
+                  filename: f.filename,
+                })),
+              ],
+              system: body.system,
+              agent: body.agent,
+              model,
+              format: body.format ? { ...body.format, retryCount: 3 } : undefined,
+            })
+            const out =
+              body.format && msg.info.role === "assistant" && msg.info.structured !== undefined
+                ? JSON.stringify(msg.info.structured)
+                : (msg.parts.findLast((p): p is typeof p & { type: "text"; text: string } => p.type === "text")?.text ??
+                  "")
+
+            await emit.fn({
+              status: "completed",
+              input: { prompt: preview },
+              output: out.substring(0, 2000),
+              title,
+              metadata: { sessionId: child.id, model },
+              time: { start: t0, end: Date.now() },
+            })
+            await stream.write(out)
+          } catch (error) {
+            const err = error instanceof Error ? error.message : String(error)
+            await emit.fn({
+              status: "error",
+              input: { prompt: preview },
+              error: err,
+              time: { start: t0, end: Date.now() },
+            })
+            await stream.write(`Error: ${err}`)
+          } finally {
+            clearInterval(timer)
+            unsub?.()
+            c.req.raw.signal.removeEventListener("abort", cleanup)
+          }
+        })
+      },
+    )
+    // Todo CRUD — create and bulk update
+    .post(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Create session todo",
+        operationId: "session.todo.create",
+        responses: {
+          200: {
+            description: "Updated todo list",
+            content: { "application/json": { schema: resolver(Todo.Info.array()) } },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator("json", Todo.Info),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.get(sessionID)
+        const todo = c.req.valid("json")
+        const existing = await Todo.get(sessionID)
+        const todos = [...existing, todo]
+        await Todo.update({ sessionID, todos })
+        return c.json(todos)
+      },
+    )
+    .put(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Update session todos",
+        operationId: "session.todo.update",
+        responses: {
+          200: {
+            description: "Updated todo list",
+            content: { "application/json": { schema: resolver(Todo.Info.array()) } },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator("json", z.object({ todos: Todo.Info.array() })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        await Session.get(sessionID)
+        const body = c.req.valid("json")
+        await Todo.update({ sessionID, todos: body.todos })
+        return c.json(body.todos)
       },
     ),
 )

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -30,32 +30,28 @@ import { ToolRegistry } from "../../tool/registry"
 
 const log = Log.create({ service: "server" })
 
-/** Walk parent session messages backwards to find the model used in the last user message. */
-async function resolveModel(sessionID: SessionID) {
-  const msgs = await Session.messages({ sessionID })
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    const info = msgs[i].info
-    if (info.role === "user" && info.model) return info.model
-  }
-}
-
 /** Create an emitter for external ToolPart updates (no-op when messageID is absent). */
 function emitter(opts: { sessionID: SessionID; messageID?: string; tool: string }) {
   const mid = opts.messageID ? MessageID.make(opts.messageID) : undefined
   const pid = mid ? PartID.ascending() : undefined
-  const fn = (state: z.infer<typeof MessageV2.ToolState>) =>
-    mid && pid
-      ? Session.updatePart({
-          id: pid,
-          messageID: mid,
-          sessionID: opts.sessionID,
-          type: "tool" as const,
-          tool: opts.tool,
-          callID: pid,
-          external: true,
-          state,
-        })
-      : undefined
+  const fn = (state: z.infer<typeof MessageV2.ToolState>): Promise<void> => {
+    if (!(mid && pid)) return Promise.resolve()
+    return Session.updatePart({
+      id: pid,
+      messageID: mid,
+      sessionID: opts.sessionID,
+      type: "tool" as const,
+      tool: opts.tool,
+      callID: pid,
+      external: true,
+      state,
+    }).then(
+      () => {},
+      (err) => {
+        log.warn("external part update failed", { tool: opts.tool, error: err })
+      },
+    )
+  }
   return { mid, pid, fn }
 }
 
@@ -220,6 +216,7 @@ export const SessionRoutes = lazy(() =>
         const todos = await AppRuntime.runPromise(Todo.Service.use((svc) => svc.get(sessionID)))
         return c.json(todos)
       },
+    )
     )
     .post(
       "/",
@@ -1143,15 +1140,14 @@ export const SessionRoutes = lazy(() =>
           abort: c.req.raw.signal,
           messages: [] as MessageV2.WithParts[],
           metadata(val: { title?: string; metadata?: Record<string, unknown> }) {
-            emit
-              .fn({
-                status: "running",
-                input: body.args,
-                title: val.title,
-                metadata: val.metadata,
-                time: { start: t0 },
-              })
-              ?.catch(() => {})
+            // fire-and-forget — emitter already logs on rejection
+            void emit.fn({
+              status: "running",
+              input: body.args,
+              title: val.title,
+              metadata: val.metadata,
+              time: { start: t0 },
+            })
           },
           async ask(req: Omit<Permission.Request, "id" | "sessionID" | "tool">) {
             await Permission.ask({
@@ -1321,17 +1317,18 @@ export const SessionRoutes = lazy(() =>
           const timer = setInterval(() => stream.write("\x00OC_KEEPALIVE\x00").catch(() => {}), 15_000)
 
           try {
+            const parts: Parameters<typeof SessionPrompt.prompt>[0]["parts"] = [
+              { type: "text", text: body.prompt },
+              ...(body.files ?? []).map((f) => ({
+                type: "file" as const,
+                mime: f.mime,
+                url: f.url,
+                filename: f.filename,
+              })),
+            ]
             const msg = await SessionPrompt.prompt({
               sessionID: child.id,
-              parts: [
-                { type: "text", text: body.prompt },
-                ...(body.files ?? []).map((f) => ({
-                  type: "file" as const,
-                  mime: f.mime,
-                  url: f.url,
-                  filename: f.filename,
-                })),
-              ],
+              parts,
               system: body.system,
               agent: body.agent,
               model,

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -217,6 +217,51 @@ export const SessionRoutes = lazy(() =>
         return c.json(todos)
       },
     )
+    .post(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Create session todo",
+        description: "Create a new todo item for the session.",
+        operationId: "session.todo.create",
+        responses: {
+          200: { description: "Created todo", content: { "application/json": { schema: resolver(Todo.Info) } } },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator(
+        "json",
+        z.object({ content: z.string(), status: z.string().optional(), priority: z.string().optional() }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        const todo = Todo.add(sessionID, body)
+        return c.json(todo)
+      },
+    )
+    .put(
+      "/:sessionID/todo",
+      describeRoute({
+        summary: "Update session todos",
+        description: "Replace all todos for a session (bulk update).",
+        operationId: "session.todo.update",
+        responses: {
+          200: {
+            description: "Updated todos",
+            content: { "application/json": { schema: resolver(Todo.Info.array()) } },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator("param", z.object({ sessionID: SessionID.zod })),
+      validator("json", z.object({ todos: z.array(Todo.Info) })),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await Todo.update({ sessionID, todos: body.todos })
+        return c.json(body.todos)
+      },
     )
     .post(
       "/",
@@ -1364,55 +1409,6 @@ export const SessionRoutes = lazy(() =>
             c.req.raw.signal.removeEventListener("abort", cleanup)
           }
         })
-      },
-    )
-    // Todo CRUD — create and bulk update
-    .post(
-      "/:sessionID/todo",
-      describeRoute({
-        summary: "Create session todo",
-        operationId: "session.todo.create",
-        responses: {
-          200: {
-            description: "Updated todo list",
-            content: { "application/json": { schema: resolver(Todo.Info.array()) } },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator("param", z.object({ sessionID: SessionID.zod })),
-      validator("json", Todo.Info),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        await Session.get(sessionID)
-        const todo = c.req.valid("json")
-        const existing = await Todo.get(sessionID)
-        const todos = [...existing, todo]
-        await Todo.update({ sessionID, todos })
-        return c.json(todos)
-      },
-    )
-    .put(
-      "/:sessionID/todo",
-      describeRoute({
-        summary: "Update session todos",
-        operationId: "session.todo.update",
-        responses: {
-          200: {
-            description: "Updated todo list",
-            content: { "application/json": { schema: resolver(Todo.Info.array()) } },
-          },
-          ...errors(400, 404),
-        },
-      }),
-      validator("param", z.object({ sessionID: SessionID.zod })),
-      validator("json", z.object({ todos: Todo.Info.array() })),
-      async (c) => {
-        const sessionID = c.req.valid("param").sessionID
-        await Session.get(sessionID)
-        const body = c.req.valid("json")
-        await Todo.update({ sessionID, todos: body.todos })
-        return c.json(body.todos)
       },
     ),
 )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -347,6 +347,10 @@ export namespace MessageV2 {
     tool: z.string(),
     state: ToolState,
     metadata: z.record(z.string(), z.any()).optional(),
+    /** When true, this tool execution was initiated externally (not by the LLM).
+     *  External parts are displayed in the TUI and persisted, but excluded from
+     *  model messages to prevent orphaned tool_use/tool_result pairs. */
+    external: z.boolean().optional(),
   }).meta({
     ref: "ToolPart",
   })
@@ -722,6 +726,9 @@ export namespace MessageV2 {
               type: "step-start",
             })
           if (part.type === "tool") {
+            // External tool executions (from plugins/HTTP, not LLM) are display-only.
+            // Including them would create orphaned tool_use/tool_result pairs.
+            if (part.external) continue
             toolNames.add(part.tool)
             if (part.state.status === "completed") {
               const outputText = part.state.time.compacted ? "[Old tool result content cleared]" : part.state.output

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -2,6 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { SessionID } from "./schema"
 import { Effect, Layer, Context } from "effect"
+import { makeRuntime } from "@/effect/run-service"
 import z from "zod"
 import { Database, eq, asc } from "../storage/db"
 import { TodoTable } from "./session.sql"
@@ -82,4 +83,47 @@ export namespace Todo {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+
+  const { runPromise } = makeRuntime(Service, defaultLayer)
+
+  export async function get(sessionID: SessionID) {
+    return runPromise((svc) => svc.get(sessionID))
+  }
+
+  export async function update(input: { sessionID: SessionID; todos: Info[] }) {
+    return runPromise((svc) => svc.update(input))
+  }
+
+  /** O(1) add — direct INSERT instead of delete-all + insert-all */
+  export function add(sessionID: SessionID, todo: Partial<Info> & { content: string }) {
+    const current = Database.use((db) =>
+      db.select().from(TodoTable).where(eq(TodoTable.session_id, sessionID)).orderBy(asc(TodoTable.position)).all(),
+    )
+    const newTodo: Info = {
+      content: todo.content,
+      status: todo.status ?? "pending",
+      priority: todo.priority ?? "medium",
+    }
+    Database.use((db) => {
+      db.insert(TodoTable)
+        .values({
+          session_id: sessionID,
+          content: newTodo.content,
+          status: newTodo.status,
+          priority: newTodo.priority,
+          position: current.length,
+        })
+        .run()
+    })
+    const updated = [
+      ...current.map((row) => ({
+        content: row.content,
+        status: row.status,
+        priority: row.priority,
+      })),
+      newTodo,
+    ]
+    void Bus.publish(Event.Updated, { sessionID, todos: updated })
+    return newTodo
+  }
 }

--- a/packages/opencode/test/cli/tui/tool-part-visibility.test.ts
+++ b/packages/opencode/test/cli/tui/tool-part-visibility.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+const src = readFileSync(resolve(import.meta.dir, "../../../src/cli/cmd/tui/routes/session/index.tsx"), "utf-8")
+
+describe("ToolPart shouldHide visibility logic", () => {
+  // Regression: shouldHide hid ALL completed tool parts, including external
+  // task/status parts created by `oc check` / `oc status`. Because the
+  // running→completed transition can arrive within a single render batch,
+  // these parts were invisible before the user could see them.
+  // The fix exempts tool types "task" and "status" from auto-hiding.
+
+  test("shouldHide block exempts task and status tool types", () => {
+    // Find the shouldHide memo body
+    const match = src.match(/const shouldHide = createMemo\(\(\) => \{([\s\S]*?)\}\)/)
+    expect(match).not.toBeNull()
+    const body = match![1]
+    expect(body).toContain('"task"')
+    expect(body).toContain('"status"')
+    // The exemption must return false (not hidden) for those types
+    expect(body).toMatch(/props\.part\.tool === "task".*return false|return false.*props\.part\.tool === "task"/s)
+  })
+
+  test("shouldHide exemption covers both task and status in one guard", () => {
+    // Both types should appear together in a single conditional so neither
+    // can be removed without the other being noticed.
+    const match = src.match(
+      /props\.part\.tool === "task"[^;]*props\.part\.tool === "status"|props\.part\.tool === "status"[^;]*props\.part\.tool === "task"/,
+    )
+    expect(match).not.toBeNull()
+  })
+})

--- a/packages/opencode/test/server/emitter-type.test.ts
+++ b/packages/opencode/test/server/emitter-type.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+describe("session routes emitter type safety", () => {
+  const src = readFileSync(resolve(import.meta.dir, "../../src/server/routes/session.ts"), "utf-8")
+
+  // Regression: the emitter fn returned `Promise<T> | undefined` with
+  // `.catch(() => undefined as any)`. Callers had to use optional chaining
+  // (`?.catch`) and the `as any` cast disabled type checking on the return.
+  // The fix makes fn always return `Promise<void>` for consistent await.
+  test("emitter fn always returns Promise<void>", () => {
+    // Must not contain the old `as any` cast pattern
+    expect(src).not.toContain("undefined as any")
+
+    // The fn signature should declare Promise<void> return type
+    const sig = src.match(/const fn = \(state:[^)]*\):\s*Promise<void>/)
+    expect(sig).not.toBeNull()
+  })
+
+  test("emitter fn uses Promise.resolve for no-op path (not undefined)", () => {
+    // The no-op branch must return Promise.resolve() not undefined
+    expect(src).toContain("Promise.resolve()")
+  })
+
+  // Regression: emitter rejection handler was `() => {}` which silently
+  // swallowed errors. External ToolPart updates could fail without any
+  // indication. The fix logs the error via the route-level logger.
+  test("emitter fn logs errors instead of silently swallowing", () => {
+    // The rejection handler must reference log.warn (not be empty)
+    expect(src).toMatch(/\.then\(\s*\(\) => \{\},\s*\(err\)/)
+    expect(src).toContain('log.warn("external part update failed"')
+  })
+
+  // Regression: emit.fn() was called without `void` prefix in synchronous
+  // callbacks (Bus subscriber, metadata callback). The returned Promise was
+  // neither awaited nor voided, causing unhandled rejection if updatePart failed.
+  test("fire-and-forget emit.fn calls use void prefix", () => {
+    // The PartDelta subscriber must use `void emit.fn(`
+    const delta = src.match(/Bus\.subscribe\(MessageV2\.Event\.PartDelta[\s\S]*?void emit\.fn\(/)
+    expect(delta).not.toBeNull()
+
+    // The metadata callback must use `void emit.fn(`
+    const meta = src.match(/metadata\([^)]*\)\s*\{[^}]*void emit\.fn\(/)
+    expect(meta).not.toBeNull()
+  })
+})

--- a/packages/opencode/test/server/session-naming.test.ts
+++ b/packages/opencode/test/server/session-naming.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+
+describe("session routes naming conventions", () => {
+  // Regression: the /exec endpoint used `sessionID` (uppercase D) in metadata
+  // objects, but the TUI Task component and the built-in TaskTool both read
+  // `metadata.sessionId` (lowercase d). The mismatch silently broke child-session
+  // click navigation and sync. This test ensures the correct lowercase key is
+  // always used inside metadata literals.
+  test("exec metadata uses sessionId (lowercase d) not sessionID (uppercase D)", () => {
+    const src = readFileSync(resolve(import.meta.dir, "../../src/server/routes/session.ts"), "utf-8")
+
+    // Must not find uppercase-D form inside a metadata object literal
+    const upper = [...src.matchAll(/metadata:\s*\{[^}]*sessionID\b/g)]
+    expect(upper.length).toBe(0)
+
+    // Must find the correct lowercase-d form (currently 3 occurrences in /exec)
+    const lower = [...src.matchAll(/metadata:\s*\{[^}]*sessionId\b/g)]
+    expect(lower.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/opencode/test/server/session-status.test.ts
+++ b/packages/opencode/test/server/session-status.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+afterEach(async () => {
+  mock.restore()
+  await Instance.disposeAll()
+})
+
+describe("session status route", () => {
+  test("accepts status with messageID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/status`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: "working", messageID: "msg-123" }),
+        })
+
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe("ok")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  // Regression: messageID was required in the zod validator but oc status
+  // only sends it when OPENCODE_MESSAGE_ID is set. Without this fix,
+  // oc status calls without a messageID would 400.
+  test("accepts status without messageID", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/status`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: "working" }),
+        })
+
+        // Without messageID the emitter is a no-op, but the route must not 400
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe("ok")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("rejects status without message field", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/status`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        })
+
+        expect(res.status).toBe(400)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/server/session-tool.test.ts
+++ b/packages/opencode/test/server/session-tool.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { Permission } from "../../src/permission"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+
+Log.init({ print: false })
+
+afterEach(async () => {
+  mock.restore()
+  await Instance.disposeAll()
+})
+
+describe("session tool route", () => {
+  test(
+    "executes read tool and returns file content",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const file = path.join(tmp.path, "hello.txt")
+          await fs.writeFile(file, "world")
+          const session = await Session.create({})
+          spyOn(Permission, "ask").mockResolvedValue(undefined as any)
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/tool`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: "read",
+              args: { filePath: file },
+            }),
+          })
+
+          expect(res.status).toBe(200)
+          const text = await res.text()
+          expect(text).toContain("world")
+
+          await Session.remove(session.id)
+        },
+      })
+    },
+    { timeout: 15000 },
+  )
+
+  test("returns 404 for unknown tool", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/tool`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "nonexistent_tool_xyz",
+            args: {},
+          }),
+        })
+
+        expect(res.status).toBe(404)
+        const text = await res.text()
+        expect(text).toContain("Tool not found")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("returns 400 for missing required fields", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/tool`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        })
+
+        expect(res.status).toBe(400)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test(
+    "reports tool execution error in output",
+    async () => {
+      await using tmp = await tmpdir({ git: true })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const session = await Session.create({})
+          spyOn(Permission, "ask").mockResolvedValue(undefined as any)
+          const app = Server.Default().app
+
+          const res = await app.request(`/session/${session.id}/tool`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              name: "read",
+              args: { filePath: "/nonexistent/path/that/does/not/exist.txt" },
+            }),
+          })
+
+          expect(res.status).toBe(200)
+          const text = await res.text()
+          expect(text).toContain("Error:")
+
+          await Session.remove(session.id)
+        },
+      })
+    },
+    { timeout: 15000 },
+  )
+})

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -774,6 +774,585 @@ describe("session.message-v2.toModelMessage", () => {
     expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([])
   })
 
+  test("excludes external tool parts from model messages", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-llm",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-external",
+            tool: "read",
+            external: true,
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/file" },
+              output: "file content",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // The LLM tool call should be present; the external one should be excluded
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-llm",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-llm",
+            toolName: "bash",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("excludes messages with only external tool parts", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "hello",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-ext",
+            tool: "status",
+            external: true,
+            state: {
+              status: "completed",
+              input: { message: "status update" },
+              output: "status update",
+              title: "",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // The assistant message has only external parts, so it should produce
+    // an empty assistant content. The toModelMessages function drops messages
+    // with no meaningful content.
+    expect(result.length).toBe(1)
+    expect(result[0]).toStrictEqual({
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    })
+  })
+
+  test("excludes external tool parts in error/pending/running states", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "hello",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "text",
+            text: "reply",
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-ext-err",
+            tool: "bash",
+            external: true,
+            state: {
+              status: "error",
+              input: { cmd: "fail" },
+              error: "boom",
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "a3"),
+            type: "tool",
+            callID: "call-ext-pending",
+            tool: "read",
+            external: true,
+            state: {
+              status: "pending",
+              input: { path: "/tmp" },
+              raw: "",
+            },
+          },
+          {
+            ...basePart(assistantID, "a4"),
+            type: "tool",
+            callID: "call-ext-running",
+            tool: "grep",
+            external: true,
+            state: {
+              status: "running",
+              input: { pattern: "test" },
+              time: { start: 0 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // All external tool parts should be excluded regardless of status
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
+    ])
+  })
+
+  test("includes tool parts with explicit external: false as normal", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-normal",
+            tool: "bash",
+            external: false,
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // explicit false should be treated as normal LLM tool call
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-normal",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-normal",
+            toolName: "bash",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("preserves ordering when external parts are interleaved with LLM parts", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "do tasks",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-llm-1",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/a" },
+              output: "content a",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-ext-1",
+            tool: "status",
+            external: true,
+            state: {
+              status: "completed",
+              input: { message: "status" },
+              output: "status",
+              title: "",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "a3"),
+            type: "tool",
+            callID: "call-llm-2",
+            tool: "edit",
+            state: {
+              status: "completed",
+              input: { filePath: "/b" },
+              output: "edited",
+              title: "Edit",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // Both LLM tool calls should be present; the external one in between should be skipped
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "do tasks" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-llm-1",
+            toolName: "read",
+            input: { filePath: "/a" },
+            providerExecuted: undefined,
+          },
+          {
+            type: "tool-call",
+            toolCallId: "call-llm-2",
+            toolName: "edit",
+            input: { filePath: "/b" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-llm-1",
+            toolName: "read",
+            output: { type: "text", value: "content a" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-llm-2",
+            toolName: "edit",
+            output: { type: "text", value: "edited" },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("treats tool parts with external: undefined as normal LLM tool calls", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-default",
+            tool: "bash",
+            // external is omitted (undefined) — should be treated as non-external
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // undefined external should be treated the same as false (normal LLM tool call)
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-default",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-default",
+            toolName: "bash",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("does not register external tool names for model output conversion", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    // When external tools are the ONLY tool parts, no tool names should be
+    // registered internally, preventing stale tool-name leaks into the
+    // convertToModelMessages call.
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "hello",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "text",
+            text: "I ran a tool externally",
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-ext",
+            tool: "some_plugin_tool",
+            external: true,
+            state: {
+              status: "completed",
+              input: { arg: "val" },
+              output: "result",
+              title: "Plugin",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // Only the text content should remain; no tool-call/tool-result from the external tool
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I ran a tool externally" }],
+      },
+    ])
+  })
+
+  test("drops assistant message with only step-start and external tool parts", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "hello",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "step-start",
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-ext",
+            tool: "status",
+            external: true,
+            state: {
+              status: "completed",
+              input: { message: "working" },
+              output: "working",
+              title: "",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+
+    // step-start + external-only = no meaningful content → message dropped
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+    ])
+  })
+
   test("converts pending/running tool calls to error results to prevent dangling tool_use", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
@@ -862,6 +1441,49 @@ describe("session.message-v2.toModelMessage", () => {
         ],
       },
     ])
+  })
+})
+
+describe("session.message-v2.ToolPart.external", () => {
+  const pid = PartID.ascending()
+  const mid = MessageID.ascending()
+
+  function toolPart(ext?: boolean) {
+    return {
+      id: pid,
+      sessionID,
+      messageID: mid,
+      type: "tool" as const,
+      callID: "call-1",
+      tool: "bash",
+      ...(ext !== undefined && { external: ext }),
+      state: {
+        status: "completed" as const,
+        input: { cmd: "ls" },
+        output: "ok",
+        title: "Bash",
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    }
+  }
+
+  test("schema accepts external: true", () => {
+    const result = MessageV2.ToolPart.safeParse(toolPart(true))
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.external).toBe(true)
+  })
+
+  test("schema accepts external: false", () => {
+    const result = MessageV2.ToolPart.safeParse(toolPart(false))
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.external).toBe(false)
+  })
+
+  test("schema accepts missing external field (undefined)", () => {
+    const result = MessageV2.ToolPart.safeParse(toolPart())
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.external).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1448,7 +1448,7 @@ describe("session.message-v2.ToolPart.external", () => {
   const pid = PartID.ascending()
   const mid = MessageID.ascending()
 
-  function toolPart(ext?: boolean) {
+  function make(ext?: boolean) {
     return {
       id: pid,
       sessionID,
@@ -1469,19 +1469,19 @@ describe("session.message-v2.ToolPart.external", () => {
   }
 
   test("schema accepts external: true", () => {
-    const result = MessageV2.ToolPart.safeParse(toolPart(true))
+    const result = MessageV2.ToolPart.safeParse(make(true))
     expect(result.success).toBe(true)
     if (result.success) expect(result.data.external).toBe(true)
   })
 
   test("schema accepts external: false", () => {
-    const result = MessageV2.ToolPart.safeParse(toolPart(false))
+    const result = MessageV2.ToolPart.safeParse(make(false))
     expect(result.success).toBe(true)
     if (result.success) expect(result.data.external).toBe(false)
   })
 
   test("schema accepts missing external field (undefined)", () => {
-    const result = MessageV2.ToolPart.safeParse(toolPart())
+    const result = MessageV2.ToolPart.safeParse(make())
     expect(result.success).toBe(true)
     if (result.success) expect(result.data.external).toBeUndefined()
   })


### PR DESCRIPTION
### Issue for this PR

Closes #21771
Depends on #21772 (`external` flag on ToolPart)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds three server endpoints for plugin interaction with sessions:

- **POST /session/:id/tool** — injects an external tool call + result into a session, marked with `external: true` so the model context builder skips it.
- **POST /session/:id/status** — appends a display-only status message to a session (for TUI progress reporting).
- **POST /session/:id/exec** — executes a named tool with given args via a child session and returns the result.

This PR includes the `external` flag commit as a base. Once #21772 lands, this branch will be rebased to drop the duplicate.

### How did you verify your code works?

- Unit tests: `session-tool.test.ts`, `session-status.test.ts`, `session-naming.test.ts`, `session-todo.test.ts`, `emitter-type.test.ts`
- TUI visibility test: `tool-part-visibility.test.ts`
- `bun turbo typecheck` passes

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Part of the plugin primitives work split from #21687 (tracking issue #20018).