### PR TITLE
feat(app): restore queued follow-up mode

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -136,8 +136,8 @@ beforeAll(async () => {
 
   mock.module("@/context/followup-queue", () => ({
     useFollowupQueue: () => ({
-      enqueue: (input: { messageID: string }) => {
-        queuedMessages.push(input.messageID)
+      enqueue: (input: { optimisticMessage: { id: string } }) => {
+        queuedMessages.push(input.optimisticMessage.id)
       },
     }),
   }))

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -5,10 +5,14 @@ let createPromptSubmit: typeof import("./submit").createPromptSubmit
 
 const createdClients: string[] = []
 const createdSessions: string[] = []
+const promptAsyncCalls: string[] = []
+const queuedMessages: string[] = []
 const sentShell: string[] = []
 const syncedDirectories: string[] = []
 
 let selected = "/repo/worktree-a"
+let currentParams = {} as { id?: string }
+let followupMode: "queue" | "steer" = "steer"
 
 const promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
 
@@ -22,6 +26,10 @@ const clientFor = (directory: string) => {
       },
       shell: async () => {
         sentShell.push(directory)
+        return { data: undefined }
+      },
+      promptAsync: async () => {
+        promptAsyncCalls.push(directory)
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
@@ -39,7 +47,7 @@ beforeAll(async () => {
 
   mock.module("@solidjs/router", () => ({
     useNavigate: () => () => undefined,
-    useParams: () => ({}),
+    useParams: () => currentParams,
   }))
 
   mock.module("@opencode-ai/sdk/v2/client", () => ({
@@ -126,6 +134,22 @@ beforeAll(async () => {
     }),
   }))
 
+  mock.module("@/context/followup-queue", () => ({
+    useFollowupQueue: () => ({
+      enqueue: (input: { messageID: string }) => {
+        queuedMessages.push(input.messageID)
+      },
+    }),
+  }))
+
+  mock.module("@/context/settings", () => ({
+    useSettings: () => ({
+      general: {
+        followup: () => followupMode,
+      },
+    }),
+  }))
+
   mock.module("@/context/platform", () => ({
     usePlatform: () => ({
       fetch: fetch,
@@ -145,9 +169,13 @@ beforeAll(async () => {
 beforeEach(() => {
   createdClients.length = 0
   createdSessions.length = 0
+  promptAsyncCalls.length = 0
+  queuedMessages.length = 0
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
+  currentParams = {}
+  followupMode = "steer"
 })
 
 describe("prompt submit worktree selection", () => {
@@ -180,5 +208,33 @@ describe("prompt submit worktree selection", () => {
     expect(createdSessions).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
     expect(sentShell).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
     expect(syncedDirectories).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
+  })
+
+  test("queues follow-up prompts when queue mode is enabled", async () => {
+    currentParams = { id: "session-existing" }
+    followupMode = "queue"
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-existing" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      mode: () => "normal",
+      working: () => true,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+
+    await submit.handleSubmit(event)
+
+    expect(queuedMessages).toHaveLength(1)
+    expect(promptAsyncCalls).toHaveLength(0)
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -338,8 +338,9 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     if (params.id && input.working() && settings.general.followup() === "queue") {
       followupQueue.enqueue({
         sessionID: session.id,
-        messageID,
-        parts: requestParts,
+        optimisticMessage,
+        optimisticParts,
+        requestParts,
         agent,
         model,
         variant,

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -4,12 +4,14 @@ import { base64Encode } from "@opencode-ai/util/encode"
 import { useNavigate, useParams } from "@solidjs/router"
 import type { Accessor } from "solid-js"
 import type { FileSelection } from "@/context/file"
+import { useFollowupQueue } from "@/context/followup-queue"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { useLocal } from "@/context/local"
 import { type ImageAttachmentPart, type Prompt, usePrompt } from "@/context/prompt"
 import { useSDK } from "@/context/sdk"
+import { useSettings } from "@/context/settings"
 import { useSync } from "@/context/sync"
 import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
@@ -57,9 +59,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const globalSync = useGlobalSync()
   const local = useLocal()
   const prompt = usePrompt()
+  const followupQueue = useFollowupQueue()
   const layout = useLayout()
   const language = useLanguage()
   const params = useParams()
+  const settings = useSettings()
 
   const errorMessage = (err: unknown) => {
     if (err && typeof err === "object" && "data" in err) {
@@ -330,6 +334,18 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     removeCommentItems(commentItems)
     clearInput()
     addOptimisticMessage()
+
+    if (params.id && input.working() && settings.general.followup() === "queue") {
+      followupQueue.enqueue({
+        sessionID: session.id,
+        messageID,
+        parts: requestParts,
+        agent,
+        model,
+        variant,
+      })
+      return
+    }
 
     const waitForWorktree = async () => {
       const worktree = WorktreeState.get(sessionDirectory)

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -48,6 +48,10 @@ export const SettingsGeneral: Component = () => {
   })
 
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
+  const followupOptions = createMemo((): { value: "queue" | "steer"; label: string }[] => [
+    { value: "queue", label: language.t("settings.general.row.followup.option.queue") },
+    { value: "steer", label: language.t("settings.general.row.followup.option.steer") },
+  ])
 
   const check = () => {
     if (!platform.checkUpdate) return
@@ -276,6 +280,24 @@ export const SettingsGeneral: Component = () => {
       <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.feed")}</h3>
 
       <div class="bg-surface-raised-base px-4 rounded-lg">
+        <SettingsRow
+          title={language.t("settings.general.row.followup.title")}
+          description={language.t("settings.general.row.followup.description")}
+        >
+          <Select
+            data-action="settings-feed-followup"
+            options={followupOptions()}
+            current={followupOptions().find((o) => o.value === settings.general.followup())}
+            value={(o) => o.value}
+            label={(o) => o.label}
+            onSelect={(option) => option && settings.general.setFollowup(option.value)}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
+            triggerStyle={{ "min-width": "180px" }}
+          />
+        </SettingsRow>
+
         <SettingsRow
           title={language.t("settings.general.row.reasoningSummaries.title")}
           description={language.t("settings.general.row.reasoningSummaries.description")}

--- a/packages/app/src/context/followup-queue.tsx
+++ b/packages/app/src/context/followup-queue.tsx
@@ -1,0 +1,116 @@
+import { createEffect } from "solid-js"
+import { createStore } from "solid-js/store"
+import { createSimpleContext } from "@opencode-ai/ui/context"
+import { showToast } from "@opencode-ai/ui/toast"
+import type { AgentPartInput, FilePartInput, SubtaskPartInput, TextPartInput } from "@opencode-ai/sdk/v2/client"
+import { useLanguage } from "@/context/language"
+import { useSDK } from "./sdk"
+import { useSync } from "./sync"
+
+type PromptPartInput = (TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput) & { id?: string }
+
+export type FollowupQueueItem = {
+  sessionID: string
+  messageID: string
+  parts: PromptPartInput[]
+  agent: string
+  model: {
+    providerID: string
+    modelID: string
+  }
+  variant?: string
+}
+
+export const { use: useFollowupQueue, provider: FollowupQueueProvider } = createSimpleContext({
+  name: "FollowupQueue",
+  init: () => {
+    const sdk = useSDK()
+    const sync = useSync()
+    const language = useLanguage()
+    const [store, setStore] = createStore<{
+      items: Record<string, FollowupQueueItem[] | undefined>
+    }>({
+      items: {},
+    })
+
+    const dispatching = new Set<string>()
+
+    const errorMessage = (err: unknown) => {
+      if (err && typeof err === "object" && "data" in err) {
+        const data = (err as { data?: { message?: string } }).data
+        if (data?.message) return data.message
+      }
+      if (err instanceof Error) return err.message
+      return language.t("common.requestFailed")
+    }
+
+    const queueFor = (sessionID: string) => store.items[sessionID] ?? []
+
+    const removeQueuedItem = (sessionID: string, messageID: string) => {
+      setStore("items", sessionID, (items) => {
+        if (!items?.length) return undefined
+        const next = items.filter((item) => item.messageID !== messageID)
+        return next.length > 0 ? next : undefined
+      })
+    }
+
+    const dispatchNext = (sessionID: string) => {
+      if (dispatching.has(sessionID)) return
+
+      const status = sync.data.session_status[sessionID] ?? { type: "idle" as const }
+      if (status.type !== "idle") return
+
+      const next = queueFor(sessionID)[0]
+      if (!next) return
+
+      dispatching.add(sessionID)
+      sync.set("session_status", sessionID, { type: "busy" })
+
+      void sdk.client.session
+        .promptAsync({
+          sessionID: next.sessionID,
+          messageID: next.messageID,
+          agent: next.agent,
+          model: next.model,
+          parts: next.parts,
+          variant: next.variant,
+        })
+        .then(() => {
+          removeQueuedItem(sessionID, next.messageID)
+        })
+        .catch((err) => {
+          removeQueuedItem(sessionID, next.messageID)
+          sync.session.optimistic.remove({
+            sessionID: next.sessionID,
+            messageID: next.messageID,
+          })
+          sync.set("session_status", sessionID, { type: "idle" })
+          showToast({
+            title: language.t("prompt.toast.promptSendFailed.title"),
+            description: errorMessage(err),
+          })
+        })
+        .finally(() => {
+          dispatching.delete(sessionID)
+        })
+    }
+
+    createEffect(() => {
+      for (const sessionID of Object.keys(store.items)) {
+        dispatchNext(sessionID)
+      }
+    })
+
+    return {
+      enqueue(item: FollowupQueueItem) {
+        setStore("items", item.sessionID, (items) => [...(items ?? []), item])
+      },
+      count(sessionID: string) {
+        return queueFor(sessionID).length
+      },
+      isQueued(sessionID: string, messageID: string) {
+        return queueFor(sessionID).some((item) => item.messageID === messageID)
+      },
+    }
+  },
+})

--- a/packages/app/src/context/followup-queue.tsx
+++ b/packages/app/src/context/followup-queue.tsx
@@ -1,9 +1,17 @@
-import { createEffect } from "solid-js"
+import { batch, createEffect } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { showToast } from "@opencode-ai/ui/toast"
-import type { AgentPartInput, FilePartInput, SubtaskPartInput, TextPartInput } from "@opencode-ai/sdk/v2/client"
+import type {
+  AgentPartInput,
+  FilePartInput,
+  Message,
+  Part,
+  SubtaskPartInput,
+  TextPartInput,
+} from "@opencode-ai/sdk/v2/client"
 import { useLanguage } from "@/context/language"
+import { Identifier } from "@/utils/id"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 
@@ -11,8 +19,9 @@ type PromptPartInput = (TextPartInput | FilePartInput | AgentPartInput | Subtask
 
 export type FollowupQueueItem = {
   sessionID: string
-  messageID: string
-  parts: PromptPartInput[]
+  optimisticMessage: Message
+  optimisticParts: Part[]
+  requestParts: PromptPartInput[]
   agent: string
   model: {
     providerID: string
@@ -29,11 +38,19 @@ export const { use: useFollowupQueue, provider: FollowupQueueProvider } = create
     const language = useLanguage()
     const [store, setStore] = createStore<{
       items: Record<string, FollowupQueueItem[] | undefined>
+      active: Record<
+        string,
+        | {
+            messageID: string
+          }
+        | undefined
+      >
     }>({
       items: {},
+      active: {},
     })
 
-    const dispatching = new Set<string>()
+    const starting = new Set<string>()
 
     const errorMessage = (err: unknown) => {
       if (err && typeof err === "object" && "data" in err) {
@@ -45,59 +62,154 @@ export const { use: useFollowupQueue, provider: FollowupQueueProvider } = create
     }
 
     const queueFor = (sessionID: string) => store.items[sessionID] ?? []
+    const activeFor = (sessionID: string) => store.active[sessionID]
 
-    const removeQueuedItem = (sessionID: string, messageID: string) => {
+    const dropQueuedHead = (sessionID: string) => {
       setStore("items", sessionID, (items) => {
         if (!items?.length) return undefined
-        const next = items.filter((item) => item.messageID !== messageID)
+        const next = items.slice(1)
         return next.length > 0 ? next : undefined
       })
     }
 
-    const dispatchNext = (sessionID: string) => {
-      if (dispatching.has(sessionID)) return
+    const setActive = (sessionID: string, messageID: string) => {
+      setStore("active", sessionID, { messageID })
+    }
 
-      const status = sync.data.session_status[sessionID] ?? { type: "idle" as const }
-      if (status.type !== "idle") return
+    const clearActive = (sessionID: string) => {
+      setStore("active", sessionID, undefined)
+    }
+
+    const rekeyOptimisticFollowup = (input: FollowupQueueItem) => {
+      const messageID = Identifier.ascending("message")
+      return {
+        messageID,
+        message: {
+          ...input.optimisticMessage,
+          id: messageID,
+          time: {
+            ...input.optimisticMessage.time,
+            created: Date.now(),
+          },
+        } satisfies Message,
+        parts: input.optimisticParts.map((part) => ({
+          ...part,
+          sessionID: input.sessionID,
+          messageID,
+        })) satisfies Part[],
+      }
+    }
+
+    const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+    const waitForQueuedTurn = async (sessionID: string, messageID: string) => {
+      const timeoutAt = Date.now() + 5 * 60 * 1000
+      let sawAssistant = false
+
+      while (Date.now() < timeoutAt) {
+        const [statusResult, messagesResult] = await Promise.all([
+          sdk.client.session.status(),
+          sdk.client.session.messages({ sessionID, limit: 200 }),
+        ])
+
+        const status = statusResult.data?.[sessionID] ?? { type: "idle" as const }
+        const messages = messagesResult.data ?? []
+
+        if (!sawAssistant) {
+          sawAssistant = messages.some(
+            (message) => message.info.role === "assistant" && message.info.parentID === messageID,
+          )
+        }
+
+        if (sawAssistant && status.type === "idle") {
+          return true
+        }
+
+        await wait(500)
+      }
+
+      return false
+    }
+
+    const dispatchNext = async (sessionID: string) => {
+      if (activeFor(sessionID) || starting.has(sessionID)) return
 
       const next = queueFor(sessionID)[0]
       if (!next) return
 
-      dispatching.add(sessionID)
-      sync.set("session_status", sessionID, { type: "busy" })
+      starting.add(sessionID)
 
-      void sdk.client.session
-        .promptAsync({
-          sessionID: next.sessionID,
-          messageID: next.messageID,
-          agent: next.agent,
-          model: next.model,
-          parts: next.parts,
-          variant: next.variant,
-        })
-        .then(() => {
-          removeQueuedItem(sessionID, next.messageID)
-        })
-        .catch((err) => {
-          removeQueuedItem(sessionID, next.messageID)
+      try {
+        const status = await sdk.client.session
+          .status()
+          .then((result) => result.data?.[sessionID] ?? { type: "idle" as const })
+        if (status.type !== "idle") return
+
+        const optimistic = rekeyOptimisticFollowup(next)
+
+        batch(() => {
+          setActive(sessionID, optimistic.messageID)
+          dropQueuedHead(sessionID)
           sync.session.optimistic.remove({
             sessionID: next.sessionID,
-            messageID: next.messageID,
+            messageID: next.optimisticMessage.id,
           })
-          sync.set("session_status", sessionID, { type: "idle" })
+          sync.session.optimistic.add({
+            sessionID: next.sessionID,
+            message: optimistic.message,
+            parts: optimistic.parts,
+          })
+        })
+
+        starting.delete(sessionID)
+
+        await sdk.client.session.promptAsync({
+          sessionID: next.sessionID,
+          messageID: optimistic.messageID,
+          agent: next.agent,
+          model: next.model,
+          parts: next.requestParts,
+          variant: next.variant,
+        })
+
+        const completed = await waitForQueuedTurn(sessionID, optimistic.messageID)
+        if (!completed) {
+          batch(() => {
+            showToast({
+              title: language.t("prompt.toast.promptSendFailed.title"),
+              description: "Timed out waiting for queued follow-up to finish",
+            })
+          })
+        }
+      } catch (err) {
+        const active = activeFor(sessionID)
+        batch(() => {
+          if (active?.messageID) {
+            sync.session.optimistic.remove({
+              sessionID: next.sessionID,
+              messageID: active.messageID,
+            })
+          }
           showToast({
             title: language.t("prompt.toast.promptSendFailed.title"),
             description: errorMessage(err),
           })
         })
-        .finally(() => {
-          dispatching.delete(sessionID)
-        })
+      } finally {
+        starting.delete(sessionID)
+        clearActive(sessionID)
+      }
     }
 
     createEffect(() => {
-      for (const sessionID of Object.keys(store.items)) {
-        dispatchNext(sessionID)
+      const sessionIDs = new Set([...Object.keys(store.items), ...Object.keys(store.active)])
+
+      for (const sessionID of sessionIDs) {
+        const active = activeFor(sessionID)
+        const status = sync.data.session_status[sessionID] ?? { type: "idle" as const }
+
+        if (active || status.type !== "idle") continue
+        void dispatchNext(sessionID)
       }
     })
 
@@ -109,7 +221,7 @@ export const { use: useFollowupQueue, provider: FollowupQueueProvider } = create
         return queueFor(sessionID).length
       },
       isQueued(sessionID: string, messageID: string) {
-        return queueFor(sessionID).some((item) => item.messageID === messageID)
+        return queueFor(sessionID).some((item) => item.optimisticMessage.id === messageID)
       },
     }
   },

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -22,6 +22,7 @@ export interface Settings {
   general: {
     autoSave: boolean
     releaseNotes: boolean
+    followup: "queue" | "steer"
     showReasoningSummaries: boolean
     shellToolPartsExpanded: boolean
     editToolPartsExpanded: boolean
@@ -45,6 +46,7 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
+    followup: "steer",
     showReasoningSummaries: false,
     shellToolPartsExpanded: true,
     editToolPartsExpanded: false,
@@ -125,6 +127,10 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         releaseNotes: withFallback(() => store.general?.releaseNotes, defaultSettings.general.releaseNotes),
         setReleaseNotes(value: boolean) {
           setStore("general", "releaseNotes", value)
+        },
+        followup: withFallback(() => store.general?.followup, defaultSettings.general.followup),
+        setFollowup(value: "queue" | "steer") {
+          setStore("general", "followup", value)
         },
         showReasoningSummaries: withFallback(
           () => store.general?.showReasoningSummaries,

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -523,6 +523,7 @@ export const dict = {
   "session.messages.loadEarlier": "Load earlier messages",
   "session.messages.loading": "Loading messages...",
   "session.messages.jumpToLatest": "Jump to latest",
+  "session.messages.queued": "Queued",
 
   "session.context.addToContext": "Add {{selection}} to context",
   "session.todo.title": "Todos",
@@ -634,6 +635,11 @@ export const dict = {
   "settings.general.row.theme.description": "Customise how OpenCode is themed.",
   "settings.general.row.font.title": "Font",
   "settings.general.row.font.description": "Customise the mono font used in code blocks",
+  "settings.general.row.followup.title": "Follow-up behavior",
+  "settings.general.row.followup.description":
+    "Choose whether follow-up prompts steer immediately or wait in a queue until the current response finishes",
+  "settings.general.row.followup.option.queue": "Queue",
+  "settings.general.row.followup.option.steer": "Steer",
   "settings.general.row.reasoningSummaries.title": "Show reasoning summaries",
   "settings.general.row.reasoningSummaries.description": "Display model reasoning summaries in the timeline",
   "settings.general.row.shellToolPartsExpanded.title": "Expand shell tool parts",

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "@solidjs/router"
 import { SDKProvider } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
 import { LocalProvider } from "@/context/local"
+import { FollowupQueueProvider } from "@/context/followup-queue"
 
 import { DataProvider } from "@opencode-ai/ui/context"
 import { decode64 } from "@/utils/base64"
@@ -52,7 +53,9 @@ export default function Layout(props: ParentProps) {
     <Show when={directory()}>
       <SDKProvider directory={directory}>
         <SyncProvider>
-          <DirectoryDataProvider directory={directory()}>{props.children}</DirectoryDataProvider>
+          <FollowupQueueProvider>
+            <DirectoryDataProvider directory={directory()}>{props.children}</DirectoryDataProvider>
+          </FollowupQueueProvider>
         </SyncProvider>
       </SDKProvider>
     </Show>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -16,6 +16,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useFollowupQueue } from "@/context/followup-queue"
 import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
@@ -115,6 +116,7 @@ export function MessageTimeline(props: {
   const settings = useSettings()
   const dialog = useDialog()
   const language = useLanguage()
+  const followupQueue = useFollowupQueue()
 
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
   const sessionID = createMemo(() => params.id)
@@ -554,6 +556,7 @@ export function MessageTimeline(props: {
             <For each={props.renderedUserMessages}>
               {(message) => {
                 const comments = createMemo(() => messageComments(sync.data.part[message.id] ?? []))
+                const queued = createMemo(() => followupQueue.isQueued(message.sessionID, message.id))
                 return (
                   <div
                     id={props.anchor(message.id)}
@@ -594,6 +597,15 @@ export function MessageTimeline(props: {
                               )}
                             </For>
                           </div>
+                        </div>
+                      </div>
+                    </Show>
+                    <Show when={queued()}>
+                      <div class="w-full px-4 md:px-5 pb-2">
+                        <div class="ml-auto flex max-w-[82%] justify-end">
+                          <span class="inline-flex items-center rounded-full border border-border-weak-base bg-background-stronger px-2 py-0.5 text-11-medium uppercase tracking-wide text-text-weak">
+                            {language.t("session.messages.queued")}
+                          </span>
                         </div>
                       </div>
                     </Show>


### PR DESCRIPTION
## Summary
- restore the Queue/Steer follow-up setting in the app UI and settings store
- implement client-side tail queuing so queued follow-ups wait for `session.idle` before calling `promptAsync`
- show a queued badge for locally delayed follow-up messages so they stay visible in the timeline

## Why
The previous Queue option was removed because follow-up prompts were being dequeued at the wrong time. This keeps the existing Steer behavior as the default, but restores a real delayed queue mode for users who want follow-ups to start only after the current turn fully finishes.

## Testing
- `bun test --preload ./happydom.ts ./src/components/prompt-input/submit.test.ts` (run from `packages/app`)
- `bun run typecheck` (run from `packages/app`)
- `bun run build` (run from `packages/app`)