### PR TITLE
ci use node 24 in test workflow fixing random ECONNRESET

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   checks: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   unit:
     name: unit (${{ matrix.settings.name }})
@@ -37,6 +40,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
@@ -101,6 +109,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
- opt GitHub Actions JavaScript actions into Node 24 ahead of the runner default change
- set up Node 24 in the unit and e2e jobs so shell `node` commands also use the newer runtime

fixes stale socket reuse e.g. these random issues
<img width="826" height="423" alt="image" src="https://github.com/user-attachments/assets/00e97d12-9e25-48af-9d19-ec75069b03cf" />

likely related to https://github.com/nodejs/undici/issues/3492
