### PR TITLE
refactor(tool): convert invalid tool internals to Effect

### DIFF
--- a/packages/opencode/src/tool/invalid.ts
+++ b/packages/opencode/src/tool/invalid.ts
@@ -1,17 +1,19 @@
 import z from "zod"
+import { Effect } from "effect"
 import { Tool } from "./tool"
+
+const parameters = z.object({
+  tool: z.string(),
+  error: z.string(),
+})
 
 export const InvalidTool = Tool.define("invalid", {
   description: "Do not use",
-  parameters: z.object({
-    tool: z.string(),
-    error: z.string(),
-  }),
-  async execute(params) {
-    return {
+  parameters,
+  execute: (params: z.infer<typeof parameters>) =>
+    Effect.succeed({
       title: "Invalid Tool",
       output: `The arguments provided to the tool are invalid: ${params.error}`,
       metadata: {},
-    }
-  },
+    }).pipe(Effect.runPromise),
 })


### PR DESCRIPTION
Mechanical conversion of the `invalid` tool's execute method from async/await to `Effect.gen` + `Effect.promise`, with `Effect.runPromise` at the boundary. No behavioral change — precursor to eventually making tool execute return Effect natively.