### PR TITLE
refactor(tool): convert question tool internals to Effect

### DIFF
--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -20,27 +20,26 @@ export const QuestionTool = Tool.defineEffect<typeof parameters, Metadata, Quest
     return {
       description: DESCRIPTION,
       parameters,
-      async execute(params: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) {
-        const answers = await question
-          .ask({
+      execute: (params: z.infer<typeof parameters>, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          const answers = yield* question.ask({
             sessionID: ctx.sessionID,
             questions: params.questions,
             tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
           })
-          .pipe(Effect.runPromise)
 
-        const formatted = params.questions
-          .map((q, i) => `"${q.question}"="${answers[i]?.length ? answers[i].join(", ") : "Unanswered"}"`)
-          .join(", ")
+          const formatted = params.questions
+            .map((q, i) => `"${q.question}"="${answers[i]?.length ? answers[i].join(", ") : "Unanswered"}"`)
+            .join(", ")
 
-        return {
-          title: `Asked ${params.questions.length} question${params.questions.length > 1 ? "s" : ""}`,
-          output: `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`,
-          metadata: {
-            answers,
-          },
-        }
-      },
+          return {
+            title: `Asked ${params.questions.length} question${params.questions.length > 1 ? "s" : ""}`,
+            output: `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`,
+            metadata: {
+              answers,
+            },
+          }
+        }).pipe(Effect.runPromise),
     }
   }),
 )


### PR DESCRIPTION
Mechanical conversion of the `question` tool's execute method from async/await to `Effect.gen` + `Effect.promise`, with `Effect.runPromise` at the boundary. No behavioral change — precursor to eventually making tool execute return Effect natively.