### PR TITLE
fix: guarantee function_call_output.output is always a string

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
@@ -146,13 +146,24 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
             case "error-json":
               contentValue = JSON.stringify(output.value)
               break
+            default: {
+              // Safety net: guarantee contentValue is always a string.
+              // Some providers reject non-string tool output content.
+              // Cast through unknown because TypeScript narrows switch to never on exhaustive matches,
+              // but runtime may encounter unexpected output types (e.g. from stored conversation history).
+              const fallback = (output as { type: string; value?: unknown }).value
+              contentValue = typeof fallback === "string" ? fallback : JSON.stringify(fallback ?? "")
+              break
+            }
           }
 
           const toolResponseMetadata = getOpenAIMetadata(toolResponse)
           messages.push({
             role: "tool",
             tool_call_id: toolResponse.toolCallId,
-            content: contentValue,
+            // Guarantee content is always a string — the Responses API
+            // rejects arrays/objects in function_call_output.output.
+            content: typeof contentValue === "string" ? contentValue : JSON.stringify(contentValue),
             ...toolResponseMetadata,
           })
         }

--- a/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/convert-to-openai-responses-input.ts
@@ -305,12 +305,25 @@ export async function convertToOpenAIResponsesInput({
             case "error-json":
               contentValue = JSON.stringify(output.value)
               break
+            default: {
+              // Safety net: ensure output is always a string for the Responses API
+              // which requires function_call_output.output to be type string.
+              // Cast through unknown because TypeScript narrows switch to never on exhaustive matches,
+              // but runtime may encounter unexpected output types (e.g. from stored conversation history).
+              const fallback = (output as { type: string; value?: unknown }).value
+              contentValue = typeof fallback === "string" ? fallback : JSON.stringify(fallback ?? "")
+              break
+            }
           }
 
           input.push({
             type: "function_call_output",
             call_id: part.toolCallId,
-            output: contentValue,
+            // The Responses API rejects non-string output values with:
+            //   json: cannot unmarshal array into Go struct field
+            //   ResponsesFunctionCallOutput.output of type string
+            // Guarantee it's always a string.
+            output: typeof contentValue === "string" ? contentValue : JSON.stringify(contentValue),
           })
         }
 


### PR DESCRIPTION
Fixes #17201

## Root Cause

The Responses API rejects non-string output values with:
\json: cannot unmarshal array into Go struct field ResponsesFunctionCallOutput.output of type string\

Two code paths serialize tool results for the API:
1. Responses API (convert-to-openai-responses-input.ts) - no default case in switch
2. Chat Completions (convert-to-openai-compatible-chat-messages.ts) - same issue

When a tool returns binary/structured data that doesn't match expected output types, or when stored conversation history is replayed with unexpected types, the raw array/object gets passed directly to the API.

## Fix
- Added default case to both switch statements that stringifies unknown output types
- Added runtime typeof safety net on the final output/content value to guarantee it's always a string