### PR TITLE
fix(app): harden self-hosted web startup and session path handling

### DIFF
--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -214,8 +214,9 @@ export default function FileTree(props: {
   const draggable = () => props.draggable ?? true
 
   const key = (p: string) =>
-    file
+    (file
       .normalize(p)
+      ?? "")
       .replace(/[\\/]+$/, "")
       .replaceAll("\\", "/")
   const chain = props._chain ? [...props._chain, key(props.path)] : [key(props.path)]

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -115,7 +115,7 @@ const isLocalCurrentUrl = (url: string) => {
 
 const getDefaultUrl = () => {
   const current = getCurrentUrl()
-  if (isLocalCurrentUrl(current)) return current
+  if (!import.meta.env.DEV && isLocalCurrentUrl(current)) return current
   const lsDefault = readDefaultServerUrl()
   if (lsDefault) return lsDefault
   return current
@@ -129,7 +129,13 @@ const platform: Platform = {
   forward,
   restart,
   notify,
-  getDefaultServer: async () => ServerConnection.Key.make(getDefaultUrl()),
+  getDefaultServer: async () => {
+    if (import.meta.env.DEV) {
+      const stored = readDefaultServerUrl()
+      return stored ? ServerConnection.Key.make(stored) : null
+    }
+    return ServerConnection.Key.make(getDefaultUrl())
+  },
   setDefaultServer: writeDefaultServerUrl,
 }
 

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -104,10 +104,21 @@ const getCurrentUrl = () => {
   return location.origin
 }
 
+const isLocalCurrentUrl = (url: string) => {
+  try {
+    const next = new URL(url)
+    return next.hostname === "localhost" || next.hostname === "127.0.0.1" || next.hostname === "::1"
+  } catch {
+    return false
+  }
+}
+
 const getDefaultUrl = () => {
+  const current = getCurrentUrl()
+  if (isLocalCurrentUrl(current)) return current
   const lsDefault = readDefaultServerUrl()
   if (lsDefault) return lsDefault
-  return getCurrentUrl()
+  return current
 }
 
 const platform: Platform = {
@@ -118,10 +129,7 @@ const platform: Platform = {
   forward,
   restart,
   notify,
-  getDefaultServer: async () => {
-    const stored = readDefaultServerUrl()
-    return stored ? ServerConnection.Key.make(stored) : null
-  },
+  getDefaultServer: async () => ServerConnection.Key.make(getDefaultUrl()),
   setDefaultServer: writeDefaultServerUrl,
 }
 

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -6,8 +6,8 @@ type SessionStore = {
   path: { directory: string }
 }
 
-export const workspaceKey = (directory: string) => {
-  const value = directory.replaceAll("\\", "/")
+export const workspaceKey = (directory?: string) => {
+  const value = (directory ?? "").replaceAll("\\", "/")
   const drive = value.match(/^([A-Za-z]:)\/+$/)
   if (drive) return `${drive[1]}/`
   if (/^\/+$/i.test(value)) return "/"

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -58,7 +58,9 @@ export function SessionSidePanel(props: {
   })
   const treeWidth = createMemo(() => (fileOpen() ? `${layout.fileTree.width()}px` : "0px"))
 
-  const diffFiles = createMemo(() => props.diffs().map((d) => d.file))
+  const diffFiles = createMemo(() =>
+    props.diffs().flatMap((d) => (typeof d.file === "string" && d.file ? [d.file] : [])),
+  )
   const kinds = createMemo(() => {
     const merge = (a: "add" | "del" | "mix" | undefined, b: "add" | "del" | "mix") => {
       if (!a) return b
@@ -66,11 +68,13 @@ export function SessionSidePanel(props: {
       return "mix" as const
     }
 
-    const normalize = (p: string) => p.replaceAll("\\\\", "/").replace(/\/+$/, "")
+    const normalize = (p?: string) =>
+      typeof p === "string" ? p.replaceAll("\\\\", "/").replace(/\/+$/, "") : ""
 
     const out = new Map<string, "add" | "del" | "mix">()
     for (const diff of props.diffs()) {
       const file = normalize(diff.file)
+      if (!file) continue
       const kind = diff.status === "added" ? "add" : diff.status === "deleted" ? "del" : "mix"
 
       out.set(file, kind)

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />


### PR DESCRIPTION
### Issue for this PR

Closes #21849

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two self-hosted web regressions in the app package.

- It guards missing `directory` and `diff.file` values so the workspace/session UI does not crash while normalizing paths.
- It makes the web app prefer the current local self-hosted server instead of a stale saved server URL when booting in the browser.
- It also fixes the `custom-elements.d.ts` reference files so the repo typecheck hook passes again.

### How did you verify your code works?

- Built the Windows binary from source and ran the self-hosted server locally.
- Verified with `node + playwright` that `http://127.0.0.1:4099/` reaches `READY=complete` and renders the home page.
- Verified `/project` and `/session` load again from the existing main database.
- Verified `packages/desktop-electron` and `packages/enterprise` typecheck after the declaration reference fix.

### Screenshots / recordings

_No recording attached._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
