### PR TITLE
feat(app): add release tag link in update toast

### DIFF
--- a/packages/app/src/constants/urls.ts
+++ b/packages/app/src/constants/urls.ts
@@ -1,0 +1,1 @@
+export const projectGitHubUrl: string = "https://github.com/anomalyco/opencode"

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -87,6 +87,7 @@ import {
 } from "./layout/sidebar-workspace"
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { projectGitHubUrl } from "@/constants/urls"
 
 export default function Layout(props: ParentProps) {
   const [store, setStore, , ready] = persisted(
@@ -372,11 +373,27 @@ export default function Layout(props: ParentProps) {
         platform.checkUpdate!().then(({ updateAvailable, version }) => {
           if (!updateAvailable) return
           if (toastId !== undefined) return
+          const ver = version ?? ""
+          const url = `${projectGitHubUrl}/releases/tag/v${ver}`
+          const text = language.t("toast.update.description", { version: ver })
+          const parts = text.split(ver)
+          const desc =
+            parts.length === 2 ? (
+              <>
+                {parts[0]}
+                <button class="underline cursor-pointer" onClick={() => platform.openLink(url)}>
+                  {ver}
+                </button>
+                {parts[1]}
+              </>
+            ) : (
+              text
+            )
           toastId = showToast({
             persistent: true,
             icon: "download",
             title: language.t("toast.update.title"),
-            description: language.t("toast.update.description", { version: version ?? "" }),
+            description: desc,
             actions: [
               {
                 label: language.t("toast.update.action.installRestart"),

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -107,7 +107,7 @@ export interface ToastAction {
 
 export interface ToastOptions {
   title?: string
-  description?: string
+  description?: string | JSX.Element
   icon?: IconProps["name"]
   variant?: ToastVariant
   duration?: number


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/21847

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every time when I see "Update available" toast, I want to know what's new in the release. But I have to go to the browser enter GitHub project url to check.
So in this PR, I make the version number be a clickable url, open the tag web page, easier for users to check the release note. 

### How did you verify your code works?

Add below codes in `packages/app/src/pages/layout.tsx` line 372, to trigger the toast in desktop app.
```tsx
      // DEV: force show update toast for testing
      if (import.meta.env.DEV) {
        platform.checkUpdate = async () => ({ updateAvailable: true, version: "8.8.8" })
      }
```

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

<img width="858" height="332" alt="image" src="https://github.com/user-attachments/assets/b0372444-0959-457e-8fa8-6d08cb7263bf" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
