### PR TITLE
fix(acp): stop emitting user_message_chunk during session/prompt turn

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -452,19 +452,6 @@ export namespace ACP {
                 return
             }
           }
-          if (part.type !== "text" && part.type !== "file") return
-          const msg = await this.sdk.session
-            .message(
-              { sessionID: part.sessionID, messageID: part.messageID, directory: session.cwd },
-              { throwOnError: true },
-            )
-            .then((x) => x.data)
-            .catch((err) => {
-              log.error("failed to fetch message for user chunk", { error: err })
-              return undefined
-            })
-          if (!msg || msg.info.role !== "user") return
-          await this.processMessage({ info: msg.info, parts: [part] })
           return
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #21708 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the `user_message_chunk` emission from the live `message.part.updated` handler during `session/prompt` turns.

Per the ACP spec, `user_message_chunk` should only be sent during `session/load` or `session/fork` to replay conversation history. #18625 added this emission on the live prompt path to align output between live and replay paths, but ACP clients already know the message they sent — the echo causes duplicate display.

This change only affects the live prompt path. `session/load` and `session/fork` replay behavior is unchanged.

### How did you verify your code works?

- Connected to the patched build via Obsidian Agent Client and Zed Editor over ACP
- Confirmed user messages are no longer duplicated on prompt
- Confirmed session/load still correctly replays full conversation history including user messages
- typecheck passes, existing tests pass

### Screenshots / recordings

Before:
<img width="449" height="183" alt="image" src="https://github.com/user-attachments/assets/8c821dc0-2bda-438d-a0fa-3adca492fe21" />
<img width="451" height="188" alt="image" src="https://github.com/user-attachments/assets/af7c1bd4-8a0b-4b09-a71c-04a708cd4647" />

After:
<img width="449" height="161" alt="image" src="https://github.com/user-attachments/assets/b9c367f0-c900-4f14-8050-acd45ee236c2" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR