### PR TITLE
fix(app): limit file tree concurrent requests to prevent ERR_INSUFFICIENT_RESOURCES

### DIFF
--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -16,6 +16,35 @@ type TreeStoreOptions = {
   onError: (message: string) => void
 }
 
+// ── Concurrency limiter ──────────────────────────────────────────────
+// Prevents the file tree from exhausting the browser's connection pool
+// when many directories are expanded simultaneously.
+const MAX_CONCURRENT = 6
+
+function createSemaphore(limit: number) {
+  let active = 0
+  const queue: Array<() => void> = []
+
+  function release() {
+    active--
+    const next = queue.shift()
+    if (next) {
+      active++
+      next()
+    }
+  }
+
+  function acquire(): Promise<void> {
+    if (active < limit) {
+      active++
+      return Promise.resolve()
+    }
+    return new Promise<void>((resolve) => queue.push(resolve))
+  }
+
+  return { acquire, release }
+}
+
 export function createFileTreeStore(options: TreeStoreOptions) {
   const [tree, setTree] = createStore<{
     node: Record<string, FileNode>
@@ -26,6 +55,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
   })
 
   const inflight = new Map<string, Promise<void>>()
+  const semaphore = createSemaphore(MAX_CONCURRENT)
 
   const reset = () => {
     inflight.clear()
@@ -60,8 +90,9 @@ export function createFileTreeStore(options: TreeStoreOptions) {
 
     const directory = options.scope()
 
-    const promise = options
-      .list(dir)
+    const promise = semaphore
+      .acquire()
+      .then(() => options.list(dir))
       .then((nodes) => {
         if (options.scope() !== directory) return
         const prevChildren = tree.dir[dir]?.children ?? []
@@ -120,6 +151,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
         options.onError(e.message)
       })
       .finally(() => {
+        semaphore.release()
         inflight.delete(dir)
       })
 

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -45,6 +45,8 @@ function createSemaphore(limit: number) {
   return { acquire, release }
 }
 
+const semaphore = createSemaphore(MAX_CONCURRENT)
+
 export function createFileTreeStore(options: TreeStoreOptions) {
   const [tree, setTree] = createStore<{
     node: Record<string, FileNode>
@@ -55,7 +57,6 @@ export function createFileTreeStore(options: TreeStoreOptions) {
   })
 
   const inflight = new Map<string, Promise<void>>()
-  const semaphore = createSemaphore(MAX_CONCURRENT)
 
   const reset = () => {
     inflight.clear()


### PR DESCRIPTION
### Issue for this PR

Closes #21853

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a concurrency limiter (semaphore, max 6) to the file tree's directory listing requests. Without it, expanding a project with many directories fires one HTTP request per directory simultaneously, exhausting the browser's per-host connection pool and causing `ERR_INSUFFICIENT_RESOURCES`.

The semaphore is module-scoped so it's shared across project switches — prevents the pool from being drained when switching between large projects.

### How did you verify your code works?

- Opened a project with 80+ directories — tree loads without errors, Network tab shows max 6 concurrent requests at a time.
- Switched between projects rapidly — no connection pool exhaustion.
- `bun typecheck` passes from `packages/opencode`.

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR