### PR TITLE
perf(app): debounce file watcher invalidations

### DIFF
--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test"
 import { invalidateFromWatcher } from "./watcher"
+
+beforeEach(() => {
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  // Flush any pending timers so module-level state is clean between tests
+  jest.runAllTimers()
+  jest.useRealTimers()
+})
 
 describe("file watcher invalidation", () => {
   test("reloads open files and refreshes loaded parent on add", () => {
@@ -23,6 +33,7 @@ describe("file watcher invalidation", () => {
       },
     )
 
+    jest.advanceTimersByTime(200)
     expect(loads).toEqual(["src/new.ts"])
     expect(refresh).toEqual(["src"])
   })
@@ -55,6 +66,7 @@ describe("file watcher invalidation", () => {
       },
     )
 
+    jest.advanceTimersByTime(200)
     expect(loads).toEqual(["src/open.ts"])
   })
 
@@ -79,6 +91,9 @@ describe("file watcher invalidation", () => {
       },
     )
 
+    // Flush first event before the second, since the second uses different ops
+    jest.advanceTimersByTime(200)
+
     invalidateFromWatcher(
       {
         type: "file.watcher.updated",
@@ -102,6 +117,11 @@ describe("file watcher invalidation", () => {
         refreshDir: (path) => refresh.push(path),
       },
     )
+
+    // The second event targets a file (not a directory), so "change" on a file
+    // means node.type !== "directory" → dir is undefined → early return.
+    // No refreshDir should be called for the second event.
+    jest.advanceTimersByTime(200)
 
     expect(refresh).toEqual(["src"])
   })
@@ -144,6 +164,7 @@ describe("file watcher invalidation", () => {
       },
     )
 
+    jest.advanceTimersByTime(200)
     expect(refresh).toEqual([])
   })
 })

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -15,6 +15,42 @@ type WatcherOps = {
   refreshDir: (path: string) => void
 }
 
+// ── Debounced watcher ────────────────────────────────────────────────
+// Collect invalidation targets over a short window and flush them in a
+// single batch.  This avoids firing N parallel HTTP requests when an
+// agent writes N files in quick succession.
+
+const DEBOUNCE_MS = 150
+
+let pendingFiles = new Set<string>()
+let pendingDirs = new Set<string>()
+let timer: ReturnType<typeof setTimeout> | undefined
+let lastOps: WatcherOps | undefined
+
+function flush() {
+  timer = undefined
+  const ops = lastOps
+  if (!ops) return
+
+  const files = pendingFiles
+  const dirs = pendingDirs
+  pendingFiles = new Set()
+  pendingDirs = new Set()
+
+  for (const file of files) {
+    ops.loadFile(file)
+  }
+  for (const dir of dirs) {
+    ops.refreshDir(dir)
+  }
+}
+
+function schedule(ops: WatcherOps) {
+  lastOps = ops
+  if (timer !== undefined) return
+  timer = setTimeout(flush, DEBOUNCE_MS)
+}
+
 export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (event.type !== "file.watcher.updated") return
   const props =
@@ -29,7 +65,8 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (path.startsWith(".git/")) return
 
   if (ops.hasFile(path) || ops.isOpen?.(path)) {
-    ops.loadFile(path)
+    pendingFiles.add(path)
+    schedule(ops)
   }
 
   if (kind === "change") {
@@ -41,13 +78,14 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
     })()
     if (dir === undefined) return
     if (!ops.isDirLoaded(dir)) return
-    ops.refreshDir(dir)
+    pendingDirs.add(dir)
+    schedule(ops)
     return
   }
   if (kind !== "add" && kind !== "unlink") return
 
   const parent = path.split("/").slice(0, -1).join("/")
   if (!ops.isDirLoaded(parent)) return
-
-  ops.refreshDir(parent)
+  pendingDirs.add(parent)
+  schedule(ops)
 }


### PR DESCRIPTION
### Issue for this PR

Closes #21854

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Batches file watcher invalidations over a 150ms window before flushing. When an agent writes N files in quick succession, the watcher was calling `loadFile`/`refreshDir` synchronously for each event, firing N parallel HTTP requests within milliseconds. Now it collects targets in a `Set` and flushes once per window.

### How did you verify your code works?

- Asked an agent to create 15 files at once — Network tab shows a single batch of requests after a short pause instead of 15 simultaneous ones.
- Watcher tests updated with fake timers — all 4 pass.
- `bun typecheck` passes from `packages/opencode`.

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR