### PR TITLE
feat(provider): add native Eden AI support

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1255,20 +1255,22 @@ export namespace Provider {
             mergeProvider(providerID, partial)
           }
 
-          const gitlab = ProviderID.make("gitlab")
-          if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
-            yield* Effect.promise(async () => {
-              try {
-                const discovered = await discoveryLoaders[gitlab]()
-                for (const [modelID, model] of Object.entries(discovered)) {
-                  if (!providers[gitlab].models[modelID]) {
-                    providers[gitlab].models[modelID] = model
+          for (const [id, discover] of Object.entries(discoveryLoaders)) {
+            const providerID = ProviderID.make(id)
+            if (providers[providerID] && isProviderAllowed(providerID)) {
+              yield* Effect.promise(async () => {
+                try {
+                  const discovered = await discover()
+                  for (const [modelID, model] of Object.entries(discovered)) {
+                    if (!providers[providerID].models[modelID]) {
+                      providers[providerID].models[modelID] = model
+                    }
                   }
+                } catch (e) {
+                  log.warn("state discovery error", { id, error: e })
                 }
-              } catch (e) {
-                log.warn("state discovery error", { id: "gitlab", error: e })
-              }
-            })
+              })
+            }
           }
 
           for (const hook of plugins) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -525,6 +525,105 @@ export namespace Provider {
           },
         }
       }),
+      edenai: Effect.fnUntraced(function* (input: Info) {
+        const auth = yield* dep.auth(input.id)
+        const apiKey = yield* Effect.sync(() => {
+          if (auth?.type === "api") return auth.key
+          return Env.get("EDENAI_API_KEY")
+        })
+
+        if (!apiKey) {
+          return { autoload: false }
+        }
+
+        const options = {
+          baseURL: "https://api.edenai.run/v3/llm",
+          apiKey,
+        }
+
+        return {
+          autoload: true,
+          options,
+          async discoverModels(): Promise<Record<string, Model>> {
+            log.info("edenai model discovery starting")
+            try {
+              const res = await fetch("https://api.edenai.run/v3/llm/models", {
+                headers: { Authorization: `Bearer ${apiKey}` },
+                signal: AbortSignal.timeout(10000),
+              })
+              if (!res.ok) throw new Error(`HTTP ${res.status}`)
+              const json = await res.json()
+              const models: Record<string, Model> = {}
+
+              for (const m of json.data || []) {
+                const caps = m.capabilities || {}
+                if (!caps.supports_function_calling) continue
+
+                const p = m.pricing || {}
+                const cost = {
+                  input: (p.input_cost_per_token || 0) * 1000000,
+                  output: (p.output_cost_per_token || 0) * 1000000,
+                  cache: {
+                    read: (p.cache_read_input_token_cost || 0) * 1000000,
+                    write: (p.cache_creation_input_token_cost || 0) * 1000000,
+                  },
+                }
+
+                models[m.id] = {
+                  id: ModelID.make(m.id),
+                  providerID: ProviderID.make("edenai"),
+                  name: m.model_name || m.id,
+                  family: "",
+                  api: {
+                    id: m.id,
+                    url: "https://api.edenai.run/v3/llm",
+                    npm: "@ai-sdk/openai-compatible",
+                  },
+                  status: "active",
+                  headers: {},
+                  options: {},
+                  cost,
+                  limit: {
+                    context: m.context_length || 128000,
+                    output: 4096,
+                  },
+                  capabilities: {
+                    temperature: true,
+                    reasoning: !!caps.supports_reasoning,
+                    attachment: false,
+                    toolcall: true,
+                    input: {
+                      text: (caps.input_modalities || []).includes("text"),
+                      audio: (caps.input_modalities || []).includes("audio"),
+                      image: (caps.input_modalities || []).includes("image"),
+                      video: (caps.input_modalities || []).includes("video"),
+                      pdf: false,
+                    },
+                    output: {
+                      text: (caps.output_modalities || []).includes("text"),
+                      audio: (caps.output_modalities || []).includes("audio"),
+                      image: (caps.output_modalities || []).includes("image"),
+                      video: (caps.output_modalities || []).includes("video"),
+                      pdf: false,
+                    },
+                    interleaved: false,
+                  },
+                  release_date: m.created ? new Date(m.created * 1000).toISOString() : "",
+                  variants: {},
+                }
+              }
+
+              log.info("edenai model discovery complete", {
+                count: Object.keys(models).length,
+              })
+              return models
+            } catch (e) {
+              log.warn("edenai model discovery failed", { error: e })
+              return {}
+            }
+          },
+        }
+      }),
       zenmux: () =>
         Effect.succeed({
           autoload: false,
@@ -1040,6 +1139,17 @@ export namespace Provider {
           const cfg = yield* config.get()
           const modelsDev = yield* Effect.promise(() => ModelsDev.get())
           const database = mapValues(modelsDev, fromModelsDevProvider)
+
+          if (!database["edenai"]) {
+            database["edenai"] = {
+              id: ProviderID.make("edenai"),
+              name: "Eden AI",
+              source: "custom",
+              env: ["EDENAI_API_KEY"],
+              options: { baseURL: "https://api.edenai.run/v3/llm" },
+              models: {},
+            }
+          }
 
           const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
           const languages = new Map<string, LanguageModelV3>()

--- a/packages/opencode/test/provider/edenai.test.ts
+++ b/packages/opencode/test/provider/edenai.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe, afterEach, beforeEach } from "bun:test"
+import { ProviderID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+
+describe("Eden AI Provider", () => {
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    // @ts-expect-error
+    global.fetch = async (url, options) => {
+      if (url === "https://api.edenai.run/v3/llm/models") {
+        return new Response(JSON.stringify({
+          data: [
+            {
+              id: "fake-provider/awesome-model",
+              model_name: "Awesome Model",
+              capabilities: { supports_function_calling: true },
+              pricing: { input_cost_per_token: 0.00003, output_cost_per_token: 0.00006 }
+            }
+          ]
+        }))
+      }
+      return originalFetch(url, options)
+    }
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.EDENAI_API_KEY
+  })
+
+  test("loads automatically when EDENAI_API_KEY is present", async () => {
+    process.env.EDENAI_API_KEY = "test_key"
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const edenai = providers[ProviderID.make("edenai")]
+        expect(edenai).toBeDefined()
+        expect(edenai.source).toBe("env")
+        expect(edenai.key).toBe("test_key")
+        expect(edenai.options.baseURL).toBe("https://api.edenai.run/v3/llm")
+        expect(Object.keys(edenai.models).length).toBe(1)
+        expect(edenai.models["fake-provider/awesome-model"].name).toBe("Awesome Model")
+      },
+    })
+  })
+
+  test("does not load automatically without EDENAI_API_KEY", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const edenai = providers[ProviderID.make("edenai")]
+        expect(edenai).toBeUndefined()
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
* Integrates Eden AI as a native provider
* Dynamically fetches Eden AI models via its `/v3/llm/models` endpoint
* Maps Eden AI capabilities and standardizes API configuration