### PR TITLE
fix: render think tags as reasoning blocks + fix MCP MaxListeners overflow

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { splitThinkBlocks } from "../../util/format"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -500,7 +501,18 @@ export const RunCommand = cmd({
 
             if (part.type === "text" && part.time?.end) {
               if (emit("text", { part })) continue
-              const text = part.text.trim()
+              const { reasoning, text: displayText } = splitThinkBlocks(part.text)
+              if (reasoning && args.thinking) {
+                const line = `Thinking: ${reasoning}`
+                if (process.stdout.isTTY) {
+                  UI.empty()
+                  UI.println(`${UI.Style.TEXT_DIM}\u001b[3m${line}\u001b[0m${UI.Style.TEXT_NORMAL}`)
+                  UI.empty()
+                } else {
+                  process.stdout.write(line + EOL)
+                }
+              }
+              const text = displayText.trim()
               if (!text) continue
               if (!process.stdout.isTTY) {
                 process.stdout.write(text + EOL)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -79,6 +79,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import * as Model from "../../util/model"
 import { formatTranscript } from "../../util/transcript"
+import { splitThinkBlocks } from "@/util/format"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
@@ -1465,35 +1466,60 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, subtleSyntax } = useTheme()
+  const parsed = createMemo(() => splitThinkBlocks(props.part.text))
+  const displayText = createMemo(() => parsed().text.trim())
+  const reasoning = createMemo(() => parsed().reasoning.trim())
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <Switch>
-          <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.markdownText}
-              bg={theme.background}
-            />
-          </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
-              syntaxStyle={syntax()}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.text}
-            />
-          </Match>
-        </Switch>
-      </box>
-    </Show>
+    <>
+      <Show when={reasoning() && ctx.showThinking()}>
+        <box
+          paddingLeft={2}
+          marginTop={1}
+          flexDirection="column"
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={"_Thinking:_ " + reasoning()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
+      </Show>
+      <Show when={displayText()}>
+        <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+          <Switch>
+            <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={true}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.markdownText}
+                bg={theme.background}
+              />
+            </Match>
+            <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <code
+                filetype="markdown"
+                drawUnstyledText={false}
+                streaming={true}
+                syntaxStyle={syntax()}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.text}
+              />
+            </Match>
+          </Switch>
+        </box>
+      </Show>
+    </>
   )
 }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -24,6 +24,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import { EventEmitter } from "node:events"
 import { Effect, Exit, Layer, Option, ServiceMap, Stream } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
@@ -486,6 +487,24 @@ export namespace MCP {
             status: {},
             clients: {},
             defs: {},
+          }
+
+          // Increase MaxListeners to prevent EventEmitter warnings when many
+          // MCP servers are connected. Each StdioClientTransport spawns a child
+          // process and adds listeners to its stdin/stdout/stderr pipes; the MCP
+          // protocol layer may also send many concurrent requests (getPrompt,
+          // listTools, etc.) that each add a 'drain' listener on the child
+          // process's stdin. The default limit of ~10 is easily exceeded.
+          const localCount = Object.values(config).filter(
+            (mcp) => typeof mcp === "object" && mcp !== null && "type" in mcp && mcp.type === "local",
+          ).length
+          if (localCount > 0) {
+            const needed = Math.max(localCount * 6, 30) // generous headroom for concurrent requests
+            EventEmitter.defaultMaxListeners = Math.max(EventEmitter.defaultMaxListeners, needed)
+            for (const stream of [process.stdin, process.stdout, process.stderr]) {
+              const current = stream.getMaxListeners()
+              if (current < needed) stream.setMaxListeners(needed)
+            }
           }
 
           yield* Effect.forEach(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -328,6 +328,7 @@ export namespace ProviderTransform {
     if (id.includes("gemini")) return 1.0
     if (id.includes("glm-4.6")) return 1.0
     if (id.includes("glm-4.7")) return 1.0
+    if (id.includes("glm-5")) return 1.0
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
       // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -18,3 +18,35 @@ export function formatDuration(secs: number) {
   const weeks = Math.floor(secs / 604800)
   return weeks === 1 ? "~1 week" : `~${weeks} weeks`
 }
+
+
+/**
+ * Regex to match <think>...</think> and <thinking>...</thinking> blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): { reasoning: string; text: string } {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -104,6 +104,66 @@ describe("ProviderTransform.options - setCacheKey", () => {
   })
 })
 
+describe("ProviderTransform.temperature - GLM-5 defaults", () => {
+  test("should use temperature 1.0 for glm-5 models", () => {
+    const glm5Model = {
+      id: "zai/glm-5",
+      providerID: "zai",
+      api: {
+        id: "glm-5",
+        url: "https://api.z.ai",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "GLM-5",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    } as any
+
+    expect(ProviderTransform.temperature(glm5Model)).toBe(1.0)
+  })
+
+  test("should use temperature 1.0 for glm-5.1 models", () => {
+    const glm51Model = {
+      id: "zai/glm-5.1",
+      providerID: "zai",
+      api: {
+        id: "glm-5.1",
+        url: "https://api.z.ai",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "GLM-5.1",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    } as any
+
+    expect(ProviderTransform.temperature(glm51Model)).toBe(1.0)
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -48,6 +48,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
+import { splitThinkBlocks } from "@opencode-ai/util/think"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { Spinner } from "./spinner"
@@ -1451,7 +1452,9 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
-  const text = () => (part().text ?? "").trim()
+  const parsed = createMemo(() => splitThinkBlocks(part().text ?? ""))
+  const displayText = () => parsed().text.trim()
+  const thinkReasoning = () => parsed().reasoning.trim()
   const isLastTextPart = createMemo(() => {
     const last = (data.store.part?.[props.message.id] ?? [])
       .filter((item): item is TextPart => item?.type === "text" && !!item.text?.trim())
@@ -1467,7 +1470,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const [copied, setCopied] = createSignal(false)
 
   const handleCopy = async () => {
-    const content = text()
+    const content = displayText()
     if (!content) return
     await navigator.clipboard.writeText(content)
     setCopied(true)
@@ -1475,11 +1478,16 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   }
 
   return (
-    <Show when={text()}>
+    <Show when={displayText()}>
       <div data-component="text-part">
+        <Show when={thinkReasoning()}>
+          <div data-component="reasoning-part">
+            <Markdown text={thinkReasoning()} cacheKey={part().id + "-reasoning"} />
+          </div>
+        </Show>
         <div data-slot="text-part-body">
-          <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
-            <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
+          <Show when={streaming()} fallback={<Markdown text={displayText()} cacheKey={part().id} streaming={false} />}>
+            <PacedMarkdown text={displayText()} cacheKey={part().id} streaming={streaming()} />
           </Show>
         </div>
         <Show when={showCopy()}>

--- a/packages/util/src/think.ts
+++ b/packages/util/src/think.ts
@@ -1,0 +1,40 @@
+/**
+ * Utilities for handling `<think>`/`<thinking>` tags in LLM responses.
+ *
+ * These tags are kept in storage to preserve multi-turn LLM context,
+ * but should be stripped or separated at the rendering layer.
+ */
+
+/**
+ * Regex to match `<think>...</think>` and `<thinking>...</thinking>` blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): {
+  reasoning: string
+  text: string
+} {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #16903

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GLM-5 model pollutes context window with broken thinking output. Raw `<think>` tags leak into the UI as garbled `?` characters, breaking TUI layout and status indicators.

**Think-tag fix:**
- Added `splitThinkBlocks()` / `stripThinkTags()` utilities in `packages/util/src/think.ts` and `packages/opencode/src/util/format.ts`
- TUI `TextPart` now extracts reasoning and renders it as a dimmed/bordered block (only when thinking display is enabled)
- Web UI `TextPartDisplay` renders extracted reasoning in a `reasoning-part` div
- CLI `run.ts` strips think tags from output; shows reasoning with `--thinking` flag
- GLM-5 temperature set to 1.0 for stability

**MCP MaxListeners fix (related):**
- With 7+ local MCP servers, the default `EventEmitter` limit of 10 is easily exceeded
- Dynamically calculates the needed limit from the local MCP server count and raises `EventEmitter.defaultMaxListeners` + per-stream limits before connecting

### How did you verify your code works?

Tested locally with GLM-5 model. Verified `<think>` tags no longer leak into TUI/web rendered output and reasoning blocks display correctly. MCP fix verified with multiple local MCP servers — no more MaxListeners warnings.

### Screenshots / recordings

_N/A — TUI text rendering change; reasoning blocks render with dim/italic styling behind a left border._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR