### PR TITLE
fix(app): keep workspace session paging aligned with recency

### DIFF
--- a/packages/app/src/context/global-sync/session-trim.test.ts
+++ b/packages/app/src/context/global-sync/session-trim.test.ts
@@ -56,4 +56,17 @@ describe("trimSessions", () => {
       "root-2",
     ])
   })
+
+  test("selects base roots by last update instead of creation order", () => {
+    const now = 20_000_000
+    const list = [
+      session({ id: "ses_z_old", created: now - 19_000_000, updated: now - 19_000_000 }),
+      session({ id: "ses_a_new", created: now - 1_000, updated: now - 1_000 }),
+      session({ id: "ses_m_resurfaced", created: now - 18_000_000, updated: now - 100 }),
+    ]
+
+    const result = trimSessions(list, { limit: 2, permission: {}, now })
+
+    expect(result.map((x) => x.id)).toEqual(["ses_a_new", "ses_m_resurfaced"])
+  })
 })

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -41,9 +41,10 @@ export function trimSessions(
     .filter((s) => !s.time?.archived)
     .sort((a, b) => cmp(a.id, b.id))
   const roots = all.filter((s) => !s.parentID)
+  const orderedRoots = roots.slice().sort(compareSessionRecent)
   const children = all.filter((s) => !!s.parentID)
-  const base = roots.slice(0, limit)
-  const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
+  const base = orderedRoots.slice(0, limit)
+  const recent = takeRecentSessions(orderedRoots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
   const keepRoots = [...base, ...recent]
   const keepRootIds = new Set(keepRoots.map((s) => s.id))
   const keepChildren = children.filter((s) => {


### PR DESCRIPTION
## Summary
- make the workspace session trim logic choose base root sessions by last activity instead of session id order
- keep sidebar load-more results aligned with the existing updated-time display sort so stale sessions do not jump ahead of recently active ones
- add a regression test covering a resurfaced old session outranking a newer-created but less recently updated session

## Verification
- bun test src/context/global-sync/session-trim.test.ts src/context/global-sync.test.ts src/context/global-sync/event-reducer.test.ts
- bun typecheck