### PR TITLE
fix: enforce skill deny pattern filtering

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { SkillTool } from "../../tool/skill"
 import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util/locale"
+import { splitThinkBlocks } from "../../util/format"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -500,7 +501,18 @@ export const RunCommand = cmd({
 
             if (part.type === "text" && part.time?.end) {
               if (emit("text", { part })) continue
-              const text = part.text.trim()
+              const { reasoning, text: displayText } = splitThinkBlocks(part.text)
+              if (reasoning && args.thinking) {
+                const line = `Thinking: ${reasoning}`
+                if (process.stdout.isTTY) {
+                  UI.empty()
+                  UI.println(`${UI.Style.TEXT_DIM}\u001b[3m${line}\u001b[0m${UI.Style.TEXT_NORMAL}`)
+                  UI.empty()
+                } else {
+                  process.stdout.write(line + EOL)
+                }
+              }
+              const text = displayText.trim()
               if (!text) continue
               if (!process.stdout.isTTY) {
                 process.stdout.write(text + EOL)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -79,6 +79,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import * as Model from "../../util/model"
 import { formatTranscript } from "../../util/transcript"
+import { splitThinkBlocks } from "@/util/format"
 import { UI } from "@/cli/ui.ts"
 import { useTuiConfig } from "../../context/tui-config"
 import { getScrollAcceleration } from "../../util/scroll"
@@ -1465,35 +1466,60 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, subtleSyntax } = useTheme()
+  const parsed = createMemo(() => splitThinkBlocks(props.part.text))
+  const displayText = createMemo(() => parsed().text.trim())
+  const reasoning = createMemo(() => parsed().reasoning.trim())
   return (
-    <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <Switch>
-          <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.markdownText}
-              bg={theme.background}
-            />
-          </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
-              streaming={true}
-              syntaxStyle={syntax()}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-              fg={theme.text}
-            />
-          </Match>
-        </Switch>
-      </box>
-    </Show>
+    <>
+      <Show when={reasoning() && ctx.showThinking()}>
+        <box
+          paddingLeft={2}
+          marginTop={1}
+          flexDirection="column"
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={"_Thinking:_ " + reasoning()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
+      </Show>
+      <Show when={displayText()}>
+        <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+          <Switch>
+            <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={true}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.markdownText}
+                bg={theme.background}
+              />
+            </Match>
+            <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+              <code
+                filetype="markdown"
+                drawUnstyledText={false}
+                streaming={true}
+                syntaxStyle={syntax()}
+                content={displayText()}
+                conceal={ctx.conceal()}
+                fg={theme.text}
+              />
+            </Match>
+          </Switch>
+        </box>
+      </Show>
+    </>
   )
 }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -24,6 +24,7 @@ import { BusEvent } from "../bus/bus-event"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import open from "open"
+import { EventEmitter } from "node:events"
 import { Effect, Exit, Layer, Option, ServiceMap, Stream } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
@@ -486,6 +487,24 @@ export namespace MCP {
             status: {},
             clients: {},
             defs: {},
+          }
+
+          // Increase MaxListeners to prevent EventEmitter warnings when many
+          // MCP servers are connected. Each StdioClientTransport spawns a child
+          // process and adds listeners to its stdin/stdout/stderr pipes; the MCP
+          // protocol layer may also send many concurrent requests (getPrompt,
+          // listTools, etc.) that each add a 'drain' listener on the child
+          // process's stdin. The default limit of ~10 is easily exceeded.
+          const localCount = Object.values(config).filter(
+            (mcp) => typeof mcp === "object" && mcp !== null && "type" in mcp && mcp.type === "local",
+          ).length
+          if (localCount > 0) {
+            const needed = Math.max(localCount * 6, 30) // generous headroom for concurrent requests
+            EventEmitter.defaultMaxListeners = Math.max(EventEmitter.defaultMaxListeners, needed)
+            for (const stream of [process.stdin, process.stdout, process.stderr]) {
+              const current = stream.getMaxListeners()
+              if (current < needed) stream.setMaxListeners(needed)
+            }
           }
 
           yield* Effect.forEach(

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -328,6 +328,7 @@ export namespace ProviderTransform {
     if (id.includes("gemini")) return 1.0
     if (id.includes("glm-4.6")) return 1.0
     if (id.includes("glm-4.7")) return 1.0
+    if (id.includes("glm-5")) return 1.0
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
       // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -64,6 +64,7 @@ export namespace SystemPrompt {
     if (Permission.disabled(["skill"], agent.permission).has("skill")) return
 
     const list = await Skill.available(agent)
+    if (list.length === 0) return
 
     return [
       "Skills provide specialized instructions and workflows for specific tasks.",

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -11,43 +11,23 @@ const Parameters = z.object({
 })
 
 export const SkillTool = Tool.define("skill", async () => {
-  const list = await Skill.available()
-
-  const description =
-    list.length === 0
-      ? "Load a specialized skill that provides domain-specific instructions and workflows. No skills are currently available."
-      : [
-          "Load a specialized skill that provides domain-specific instructions and workflows.",
-          "",
-          "When you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.",
-          "",
-          "The skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.",
-          "",
-          'Tool output includes a `<skill_content name="...">` block with the loaded content.',
-          "",
-          "The following skills provide specialized sets of instructions for particular tasks",
-          "Invoke this tool to load a skill when a task matches one of the available skills listed below:",
-          "",
-          Skill.fmt(list, { verbose: false }),
-        ].join("\n")
-
   return {
-    description,
+    description: "",
     parameters: Parameters,
     async execute(params: z.infer<typeof Parameters>, ctx) {
-      const skill = await Skill.get(params.name)
-
-      if (!skill) {
-        const available = await Skill.all().then((x) => x.map((skill) => skill.name).join(", "))
-        throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
-      }
-
       await ctx.ask({
         permission: "skill",
         patterns: [params.name],
         always: [params.name],
         metadata: {},
       })
+
+      const skill = await Skill.get(params.name)
+
+      if (!skill) {
+        const available = await Skill.all().then((x) => x.map((skill) => skill.name).join(", "))
+        throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
+      }
 
       const dir = path.dirname(skill.location)
       const base = pathToFileURL(dir).href

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -166,35 +166,22 @@ export const WebFetchTool = Tool.define("webfetch", {
 })
 
 async function extractTextFromHTML(html: string) {
-  let text = ""
-  let skipContent = false
-
-  const rewriter = new HTMLRewriter()
-    .on("script, style, noscript, iframe, object, embed", {
-      element() {
-        skipContent = true
-      },
-      text() {
-        // Skip text content inside these elements
-      },
-    })
-    .on("*", {
-      element(element) {
-        // Reset skip flag when entering other elements
-        if (!["script", "style", "noscript", "iframe", "object", "embed"].includes(element.tagName)) {
-          skipContent = false
-        }
-      },
-      text(input) {
-        if (!skipContent) {
-          text += input.text
-        }
-      },
-    })
-    .transform(new Response(html))
-
-  await rewriter.text()
-  return text.trim()
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
+    .replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, " ")
+    .replace(/<object\b[^>]*>[\s\S]*?<\/object>/gi, " ")
+    .replace(/<embed\b[^>]*>[\s\S]*?<\/embed>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/\s+/g, " ")
+    .trim()
 }
 
 function convertHTMLToMarkdown(html: string): string {

--- a/packages/opencode/src/util/format.ts
+++ b/packages/opencode/src/util/format.ts
@@ -18,3 +18,35 @@ export function formatDuration(secs: number) {
   const weeks = Math.floor(secs / 604800)
   return weeks === 1 ? "~1 week" : `~${weeks} weeks`
 }
+
+
+/**
+ * Regex to match <think>...</think> and <thinking>...</thinking> blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): { reasoning: string; text: string } {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -104,6 +104,66 @@ describe("ProviderTransform.options - setCacheKey", () => {
   })
 })
 
+describe("ProviderTransform.temperature - GLM-5 defaults", () => {
+  test("should use temperature 1.0 for glm-5 models", () => {
+    const glm5Model = {
+      id: "zai/glm-5",
+      providerID: "zai",
+      api: {
+        id: "glm-5",
+        url: "https://api.z.ai",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "GLM-5",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    } as any
+
+    expect(ProviderTransform.temperature(glm5Model)).toBe(1.0)
+  })
+
+  test("should use temperature 1.0 for glm-5.1 models", () => {
+    const glm51Model = {
+      id: "zai/glm-5.1",
+      providerID: "zai",
+      api: {
+        id: "glm-5.1",
+        url: "https://api.z.ai",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "GLM-5.1",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    } as any
+
+    expect(ProviderTransform.temperature(glm51Model)).toBe(1.0)
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -120,6 +120,58 @@ description: ${description}
     }
   })
 
+  test("description excludes denied skills by pattern", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        for (const [name, description] of [
+          ["lark-doc", "Lark doc skill."],
+          ["lark-mail", "Lark mail skill."],
+          ["safe-skill", "Safe skill."],
+        ]) {
+          const skillDir = path.join(dir, ".opencode", "skill", name)
+          await Bun.write(
+            path.join(skillDir, "SKILL.md"),
+            `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+`,
+          )
+        }
+      },
+    })
+
+    const home = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = tmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const desc = await ToolRegistry.tools({
+            providerID: "opencode" as any,
+            modelID: "gpt-5" as any,
+            agent: {
+              name: "build",
+              mode: "primary" as const,
+              permission: [{ permission: "skill", pattern: "lark-*", action: "deny" }],
+              options: {},
+            },
+          }).then((tools) => tools.find((tool) => tool.id === SkillTool.id)?.description ?? "")
+
+          expect(desc).toContain("**safe-skill**: Safe skill.")
+          expect(desc).not.toContain("**lark-doc**: Lark doc skill.")
+          expect(desc).not.toContain("**lark-mail**: Lark mail skill.")
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = home
+    }
+  })
+
   test("execute returns skill content block with files", async () => {
     await using tmp = await tmpdir({
       git: true,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -48,6 +48,7 @@ import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
 import { getDirectory as _getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
+import { splitThinkBlocks } from "@opencode-ai/util/think"
 import { Tooltip } from "./tooltip"
 import { IconButton } from "./icon-button"
 import { Spinner } from "./spinner"
@@ -1451,7 +1452,9 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
-  const text = () => (part().text ?? "").trim()
+  const parsed = createMemo(() => splitThinkBlocks(part().text ?? ""))
+  const displayText = () => parsed().text.trim()
+  const thinkReasoning = () => parsed().reasoning.trim()
   const isLastTextPart = createMemo(() => {
     const last = (data.store.part?.[props.message.id] ?? [])
       .filter((item): item is TextPart => item?.type === "text" && !!item.text?.trim())
@@ -1467,7 +1470,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   const [copied, setCopied] = createSignal(false)
 
   const handleCopy = async () => {
-    const content = text()
+    const content = displayText()
     if (!content) return
     await navigator.clipboard.writeText(content)
     setCopied(true)
@@ -1475,11 +1478,16 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   }
 
   return (
-    <Show when={text()}>
+    <Show when={displayText()}>
       <div data-component="text-part">
+        <Show when={thinkReasoning()}>
+          <div data-component="reasoning-part">
+            <Markdown text={thinkReasoning()} cacheKey={part().id + "-reasoning"} />
+          </div>
+        </Show>
         <div data-slot="text-part-body">
-          <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
-            <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
+          <Show when={streaming()} fallback={<Markdown text={displayText()} cacheKey={part().id} streaming={false} />}>
+            <PacedMarkdown text={displayText()} cacheKey={part().id} streaming={streaming()} />
           </Show>
         </div>
         <Show when={showCopy()}>

--- a/packages/util/src/think.ts
+++ b/packages/util/src/think.ts
@@ -1,0 +1,40 @@
+/**
+ * Utilities for handling `<think>`/`<thinking>` tags in LLM responses.
+ *
+ * These tags are kept in storage to preserve multi-turn LLM context,
+ * but should be stripped or separated at the rendering layer.
+ */
+
+/**
+ * Regex to match `<think>...</think>` and `<thinking>...</thinking>` blocks.
+ * Uses non-greedy matching to handle multiple blocks.
+ */
+const THINK_TAG_RE = /<(think(?:ing)?)>[\s\S]*?<\/\1>\s*/g
+
+/**
+ * Strip `<think>`/`<thinking>` tag blocks from text for display purposes.
+ * The raw tags are preserved in storage for multi-turn LLM context.
+ */
+export function stripThinkTags(text: string): string {
+  return text.replace(THINK_TAG_RE, "").trim()
+}
+
+/**
+ * Extract `<think>`/`<thinking>` blocks and remaining text separately.
+ * Returns the reasoning content and the cleaned display text.
+ */
+export function splitThinkBlocks(text: string): {
+  reasoning: string
+  text: string
+} {
+  const blocks: string[] = []
+  const cleaned = text.replace(THINK_TAG_RE, (match) => {
+    const inner = match.replace(/<\/?(?:think(?:ing)?)>/g, "").trim()
+    if (inner) blocks.push(inner)
+    return ""
+  })
+  return {
+    reasoning: blocks.join("\n\n"),
+    text: cleaned.trim(),
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #21793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a bug where permission.skill pattern rules (for example lark-*: deny) were not fully enforced in skill exposure.

Changes made:
- Removed static skill listing from the base skill tool definition to avoid leaking denied skills.
- Kept skill listing in the registry path that already uses agent-aware filtering.
- Ensured the system prompt skips the skills section when no skills are available after permission filtering.
- Added a regression test that denies lark-* and verifies only allowed skills appear.

Why this works:
- Skill visibility is now sourced from permission-aware paths, so denied patterns are filtered before model exposure.
- The regression test covers the reported case and prevents reintroduction.

### How did you verify your code works?

I verified by:
- Reviewing the diff to ensure only skill exposure and related prompt behavior were changed.
- Adding a regression test for denied skill pattern filtering.

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR