### PR TITLE
fix(lsp): fix oxlint LSP race condition on --help stdout read

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -223,7 +223,6 @@ export namespace LSPServer {
     async spawn(root) {
       const ext = process.platform === "win32" ? ".cmd" : ""
 
-      const serverTarget = path.join("node_modules", ".bin", "oxc_language_server" + ext)
       const lintTarget = path.join("node_modules", ".bin", "oxlint" + ext)
 
       const resolveBin = async (target: string) => {
@@ -249,10 +248,9 @@ export namespace LSPServer {
       }
 
       if (lintBin) {
-        const proc = spawn(lintBin, ["--help"])
-        await proc.exited
+        const proc = Process.spawn([lintBin, "--help"], { stdout: "pipe" })
         if (proc.stdout) {
-          const help = await text(proc.stdout)
+          const [, help] = await Promise.all([proc.exited, text(proc.stdout)])
           if (help.includes("--lsp")) {
             return {
               process: spawn(lintBin, ["--lsp"], {
@@ -260,19 +258,8 @@ export namespace LSPServer {
               }),
             }
           }
-        }
-      }
-
-      let serverBin = await resolveBin(serverTarget)
-      if (!serverBin) {
-        const found = which("oxc_language_server")
-        if (found) serverBin = found
-      }
-      if (serverBin) {
-        return {
-          process: spawn(serverBin, [], {
-            cwd: root,
-          }),
+        } else {
+          await proc.exited
         }
       }
 


### PR DESCRIPTION
### Issue for this PR

Closes #17597
Closes #16309

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The oxlint LSP never starts because the detection code awaits `proc.exited` before reading `proc.stdout`. By the time `text(proc.stdout)` runs, the stream is already drained, yielding an empty string — so `help.includes("--lsp")` is always false.

Fix: read stdout concurrently with `proc.exited` via `Promise.all`. Also switched to `Process.spawn` with `{ stdout: "pipe" }` instead of the LSP `spawn` wrapper (which forces stdin/stdout/stderr pipes and is meant for running the actual LSP server, not a one-off `--help` check). Removed the `oxc_language_server` fallback since it's not a bin entry in the oxlint npm package.

### How did you verify your code works?

1. Standalone Node.js reproduction confirming the sequential read yields 0 bytes while `Promise.all` yields 6142 bytes with `--lsp` present.
2. Ran `opencode run` via `bun dev` against a test project with `.oxlintrc.json` and a `.ts` file. Logs confirm the LSP starts:
```
INFO service=lsp serverID=oxlint spawned lsp server
INFO service=lsp.client serverID=oxlint starting client
INFO service=lsp.client serverID=oxlint sending initialize
INFO service=lsp.client serverID=oxlint initialized
```

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR