### PR TITLE
fix(app): prevent IME Enter from committing custom answers in SessionQuestionDock

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -543,6 +543,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                 rows={1}
                 disabled={sending()}
                 onKeyDown={(e) => {
+                  if (e.isComposing || e.keyCode === 229) return
                   if (e.key === "Escape") {
                     e.preventDefault()
                     setStore("editing", false)


### PR DESCRIPTION
### Issue for this PR

Closes #21889

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `SessionQuestionDock`, the custom answer textarea was missing an IME composition guard in its `keydown` handler. Pressing Enter to confirm a CJK candidate (Japanese, Chinese, Korean) would trigger `commitCustom()` and exit editing mode instead of just committing the character. Added the standard `isComposing || keyCode === 229` early return so key handling is skipped during composition.

### How did you verify your code works?

Tested in Safari and Chrome using Japanese IME. Enter now confirms the candidate without committing the custom answer or closing the textarea.

### Screenshots / recordings

#### After fix

https://github.com/user-attachments/assets/5115ba5a-faaf-4603-bd1e-d8a584316fa2

#### Before fix

https://github.com/user-attachments/assets/7db8c266-2798-4cc2-be03-9a8e4e42c949

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR