### PR TITLE
fix(session): omit unsupported pdf tool-result attachments

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -619,7 +619,9 @@ export namespace MessageV2 {
           attachments?: Array<{ mime: string; url: string }>
         }
         const attachments = (outputObject.attachments ?? []).filter((attachment) => {
-          return attachment.url.startsWith("data:") && attachment.url.includes(",")
+          if (!attachment.url.startsWith("data:") || !attachment.url.includes(",")) return false
+          if (attachment.mime === "application/pdf" && !model.capabilities.input.pdf) return false
+          return true
         })
 
         return {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -428,7 +428,10 @@ describe("session.message-v2.toModelMessage", () => {
             type: "tool-result",
             toolCallId: "call-1",
             toolName: "read",
-            output: { type: "text", value: "PDF read successfully" },
+            output: {
+              type: "content",
+              value: [{ type: "text", text: "PDF read successfully" }],
+            },
           },
         ],
       },

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -359,6 +359,82 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("omits pdf tool-result attachments for models without pdf input support", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "read pdf",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "debug/cv-print-test.pdf" },
+              output: "PDF read successfully",
+              title: "Read PDF",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-1"),
+                  type: "file",
+                  mime: "application/pdf",
+                  filename: "cv-print-test.pdf",
+                  url: "data:application/pdf;base64,Zm9v",
+                },
+              ],
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "read pdf" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "read",
+            input: { filePath: "debug/cv-print-test.pdf" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "read",
+            output: { type: "text", value: "PDF read successfully" },
+          },
+        ],
+      },
+    ])
+  })
+
   test("omits provider metadata when assistant model differs", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"


### PR DESCRIPTION
### Issue for this PR

Closes #21908

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR stops completed tool results from forwarding PDF attachments back into model context when the selected model does not support `input.pdf`.

`read.ts` currently treats PDFs as attachments and returns `PDF read successfully`, which is fine. The problem is later in `MessageV2.toModelMessagesEffect()`: completed tool-result attachments are passed through for OpenAI-compatible SDKs without checking whether the actual model can accept PDFs. That means a healthy PDF can be reintroduced into model context for a model that cannot consume PDFs, and the downstream provider/model can respond as if the file were malformed.

Important context: the investigated session used the **Oh My OpenAgent plugin**. The repeated continuation / todo spam observed in that session should be treated as plugin-influenced behavior, not as the primary OpenCode-core bug this PR is fixing. This PR is intentionally limited to the PDF capability mismatch in core message assembly.

The change is intentionally narrow:
- keep the existing behavior for models that support PDF input
- drop only `application/pdf` tool-result attachments when `model.capabilities.input.pdf` is false
- add a regression for the `read` tool-result case

### How did you verify your code works?

- confirmed the failing PDF from the investigated session is healthy (`%PDF-1.4`, SHA-256 `5ba26ba22bca394c29ab50d8ac1ba4097332a1100d76d9b1e2aae4195cc6216b`)
- traced the upstream code path from `tool/read.ts` into `session/message-v2.ts`
- added a targeted regression in `packages/opencode/test/session/message-v2.test.ts`
- reviewed the exact CI failure for the first PR revision and corrected the test expectation to match the actual serialized tool-result shape

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
