### PR TITLE
chore: bump Bun to 1.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop tauri dev",

--- a/packages/containers/bun-node/Dockerfile
+++ b/packages/containers/bun-node/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REGISTRY}/build/base:24.04
 SHELL ["/bin/bash", "-lc"]
 
 ARG NODE_VERSION=24.4.0
-ARG BUN_VERSION=1.3.11
+ARG BUN_VERSION=1.3.12
 
 ENV BUN_INSTALL=/opt/bun
 ENV PATH=/opt/bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Bumps Bun from 1.3.11 to 1.3.12.

- `packageManager` in root `package.json`
- `BUN_VERSION` in `packages/containers/bun-node/Dockerfile`

Note: `@types/bun@1.3.12` is not yet published on npm, so `@types/bun` remains at 1.3.11.