### PR TITLE
test(app): stabilize windows theme select e2e

### DIFF
--- a/packages/app/e2e/settings/settings.spec.ts
+++ b/packages/app/e2e/settings/settings.spec.ts
@@ -110,7 +110,9 @@ test("changing theme persists in localStorage", async ({ page, gotoSession }) =>
     .find((x) => x && x !== currentTheme)
   expect(nextTheme).toBeTruthy()
 
-  await items.filter({ hasText: nextTheme! }).first().click()
+  const option = items.filter({ hasText: nextTheme! }).first()
+  await expect(option).toBeVisible()
+  await option.click({ force: true })
 
   await page.keyboard.press("Escape")
 


### PR DESCRIPTION
### Issue for this PR

Closes #21915

Related: #17093
Blocked by / helping unblock: #21233, #21559

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This stabilizes the flaky Windows Playwright interaction in `packages/app/e2e/settings/settings.spec.ts` for `changing theme persists in localStorage`.

The test now targets the resolved theme option, waits for it to be visible, and uses a forced click for that specific popup interaction instead of relying on a normal click against an element that Windows CI reports as unstable.

### Why does this need a focused PR?

`#17093` is the broad flaky-CI umbrella, but this timeout is specific enough to isolate: one Windows Playwright failure in one settings selector path.

That matters because the same flaky Windows e2e is blocking unrelated work, including `#21233`, and it has also been blocking confidence on `#21559`. Keeping this PR narrowly scoped makes it easier to land as an unblocker without dragging other changes along.

### How did you verify your code works?

- `PLAYWRIGHT_BROWSERS_PATH="/home/ravi/code/opencode/wrap-links/.playwright-browsers" PLAYWRIGHT_WORKERS=2 bun test:e2e:local -- e2e/settings/settings.spec.ts -g "changing theme persists in localStorage" --repeat-each=5`
- Result: `5 passed`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
