### PR TITLE
fix: free model token usage percentage and overflow detection

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -88,7 +88,7 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
               <span class="text-text-invert-base">{language.t("context.usage.tokens")}</span>
             </div>
             <div class="flex items-center gap-2">
-              <span class="text-text-invert-strong">{ctx().usage ?? 0}%</span>
+              <span class="text-text-invert-strong">{ctx().usage !== null ? `${ctx().usage}%` : "\u2014"}</span>
               <span class="text-text-invert-base">{language.t("context.usage.usage")}</span>
             </div>
           </>

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -385,7 +385,7 @@ export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit
     for (const [tool, count] of toolsToDisplay) {
       const barLength = Math.max(1, Math.floor((count / maxCount) * 20))
       const bar = "█".repeat(barLength)
-      const percentage = ((count / totalToolUsage) * 100).toFixed(1)
+      const percentage = totalToolUsage > 0 ? ((count / totalToolUsage) * 100).toFixed(1) : "0.0"
 
       const maxToolLength = 18
       const truncatedTool = tool.length > maxToolLength ? tool.substring(0, maxToolLength - 2) + ".." : tool

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -38,7 +38,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
         <b>Context</b>
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
-      <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
+      <text fg={theme().textMuted}>{state().percent !== null ? `${state().percent}% used` : "limit unknown"}</text>
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
     </box>
   )

--- a/packages/opencode/src/provider/constants.ts
+++ b/packages/opencode/src/provider/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Default limits used when a model has no explicit limit configuration
+ * and no data is available from the models.dev database.
+ */
+
+/** When limit.context is not configured and no models.dev data exists, use this default context window size */
+export const DEFAULT_CONTEXT_LIMIT = 128_000
+
+/** When limit.output is not configured and no models.dev data exists, use this default output token limit */
+export const DEFAULT_OUTPUT_LIMIT = 8192

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -20,6 +20,7 @@ import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
 import { Effect, Layer, ServiceMap } from "effect"
+import { DEFAULT_CONTEXT_LIMIT, DEFAULT_OUTPUT_LIMIT } from "./constants"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 
@@ -1158,9 +1159,20 @@ export namespace Provider {
                 },
                 options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
                 limit: {
-                  context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
+                  context: (() => {
+                    const resolved = model.limit?.context ?? existingModel?.limit?.context
+                    if (resolved === undefined) {
+                      log.info("model has no context limit configured, using default", {
+                        provider: providerID,
+                        model: modelID,
+                        default: DEFAULT_CONTEXT_LIMIT,
+                      })
+                      return DEFAULT_CONTEXT_LIMIT
+                    }
+                    return resolved
+                  })(),
                   input: model.limit?.input ?? existingModel?.limit?.input,
-                  output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+                  output: model.limit?.output ?? existingModel?.limit?.output ?? DEFAULT_OUTPUT_LIMIT,
                 },
                 headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
                 family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@/config/config"
 import type { Provider } from "@/provider/provider"
+import { DEFAULT_CONTEXT_LIMIT } from "@/provider/constants"
 import { ProviderTransform } from "@/provider/transform"
 import type { MessageV2 } from "./message-v2"
 
@@ -7,8 +8,7 @@ const COMPACTION_BUFFER = 20_000
 
 export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
   if (input.cfg.compaction?.auto === false) return false
-  const context = input.model.limit.context
-  if (context === 0) return false
+  const context = input.model.limit.context || DEFAULT_CONTEXT_LIMIT
 
   const count =
     input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write

--- a/packages/opencode/test/provider/constants.test.ts
+++ b/packages/opencode/test/provider/constants.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { DEFAULT_CONTEXT_LIMIT, DEFAULT_OUTPUT_LIMIT } from "../../src/provider/constants"
+
+describe("provider constants", () => {
+  test("DEFAULT_CONTEXT_LIMIT should be a positive number", () => {
+    expect(DEFAULT_CONTEXT_LIMIT).toBeGreaterThan(0)
+    expect(Number.isFinite(DEFAULT_CONTEXT_LIMIT)).toBe(true)
+  })
+
+  test("DEFAULT_OUTPUT_LIMIT should be a positive number", () => {
+    expect(DEFAULT_OUTPUT_LIMIT).toBeGreaterThan(0)
+    expect(Number.isFinite(DEFAULT_OUTPUT_LIMIT)).toBe(true)
+  })
+
+  test("DEFAULT_CONTEXT_LIMIT should be greater than DEFAULT_OUTPUT_LIMIT", () => {
+    expect(DEFAULT_CONTEXT_LIMIT).toBeGreaterThan(DEFAULT_OUTPUT_LIMIT)
+  })
+
+  test("DEFAULT_CONTEXT_LIMIT should be 128000", () => {
+    expect(DEFAULT_CONTEXT_LIMIT).toBe(128_000)
+  })
+
+  test("DEFAULT_OUTPUT_LIMIT should be 8192", () => {
+    expect(DEFAULT_OUTPUT_LIMIT).toBe(8192)
+  })
+})

--- a/packages/opencode/test/provider/limit-defaults.test.ts
+++ b/packages/opencode/test/provider/limit-defaults.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID } from "../../src/provider/schema"
+import { DEFAULT_CONTEXT_LIMIT, DEFAULT_OUTPUT_LIMIT } from "../../src/provider/constants"
+
+describe("custom model limit defaults", () => {
+  test("model without limit.context uses DEFAULT_CONTEXT_LIMIT", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              "no-limit": {
+                name: "No Limit Provider",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  model: {
+                    name: "Model",
+                    tool_call: true,
+                    // no limit specified
+                  },
+                },
+                options: { apiKey: "test" },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const model = providers[ProviderID.make("no-limit")].models["model"]
+        expect(model.limit.context).toBe(DEFAULT_CONTEXT_LIMIT)
+      },
+    })
+  })
+
+  test("model without limit.output uses DEFAULT_OUTPUT_LIMIT", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              "no-limit": {
+                name: "No Limit Provider",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  model: {
+                    name: "Model",
+                    tool_call: true,
+                    // no limit specified
+                  },
+                },
+                options: { apiKey: "test" },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const model = providers[ProviderID.make("no-limit")].models["model"]
+        expect(model.limit.output).toBe(DEFAULT_OUTPUT_LIMIT)
+      },
+    })
+  })
+
+  test("model with explicit limit.context overrides default", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              "with-limit": {
+                name: "With Limit Provider",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                models: {
+                  model: {
+                    name: "Model",
+                    tool_call: true,
+                    limit: { context: 64000, output: 4096 },
+                  },
+                },
+                options: { apiKey: "test" },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const providers = await Provider.list()
+        const model = providers[ProviderID.make("with-limit")].models["model"]
+        expect(model.limit.context).toBe(64000)
+        expect(model.limit.output).toBe(4096)
+      },
+    })
+  })
+
+  test("model inheriting limit from existing database model does not use default", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            provider: {
+              anthropic: {
+                models: {
+                  "claude-sonnet-4-20250514": {
+                    name: "Custom Name",
+                    // no limit - should inherit from database
+                  },
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        process.env.ANTHROPIC_API_KEY = "test-api-key"
+      },
+      fn: async () => {
+        const providers = await Provider.list()
+        const model = providers[ProviderID.anthropic].models["claude-sonnet-4-20250514"]
+        // Should inherit from database, not use default
+        expect(model.limit.context).toBeGreaterThan(0)
+        expect(model.limit.context).not.toBe(DEFAULT_CONTEXT_LIMIT)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1670,7 +1670,7 @@ test("closest checks multiple query terms in order", async () => {
   })
 })
 
-test("model limit defaults to zero when not specified", async () => {
+test("model limit defaults to DEFAULT_CONTEXT_LIMIT/DEFAULT_OUTPUT_LIMIT when not specified", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -1701,8 +1701,8 @@ test("model limit defaults to zero when not specified", async () => {
     fn: async () => {
       const providers = await Provider.list()
       const model = providers[ProviderID.make("no-limit")].models["model"]
-      expect(model.limit.context).toBe(0)
-      expect(model.limit.output).toBe(0)
+      expect(model.limit.context).toBe(128_000)
+      expect(model.limit.output).toBe(8192)
     },
   })
 })

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { isOverflow } from "../../src/session/overflow"
+import { DEFAULT_CONTEXT_LIMIT } from "../../src/provider/constants"
+import type { Provider } from "../../src/provider/provider"
+import type { MessageV2 } from "../../src/session/message-v2"
+import type { Config } from "../../src/config/config"
+
+// mock model has limit.output=8192, so maxOutputTokens=8192
+// usable = context - maxOutputTokens = context - 8192
+// overflow when count >= usable
+
+function makeInput(overrides: {
+  contextLimit?: number
+  inputLimit?: number
+  tokens?: Partial<MessageV2.Assistant["tokens"]>
+  autoCompaction?: boolean
+}) {
+  const context = overrides.contextLimit ?? 0
+  return {
+    cfg: {
+      compaction: {
+        auto: overrides.autoCompaction ?? true,
+      },
+    } as Config.Info,
+    tokens: {
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+      ...overrides.tokens,
+    } as MessageV2.Assistant["tokens"],
+    model: {
+      limit: {
+        context,
+        input: overrides.inputLimit,
+        output: 8192,
+      },
+    } as Provider.Model,
+  }
+}
+
+describe("isOverflow", () => {
+  test("returns false when auto compaction is disabled", () => {
+    const input = makeInput({ contextLimit: 128000, autoCompaction: false, tokens: { input: 200000 } })
+    expect(isOverflow(input)).toBe(false)
+  })
+
+  test("returns false when token usage is below limit", () => {
+    const input = makeInput({ contextLimit: 128000, tokens: { input: 50000 } })
+    expect(isOverflow(input)).toBe(false)
+  })
+
+  test("returns true when token usage exceeds limit", () => {
+    // usable = 128000 - 8192 = 119808, count = 120000
+    const input = makeInput({ contextLimit: 128000, tokens: { input: 120000 } })
+    expect(isOverflow(input)).toBe(true)
+  })
+
+  test("uses DEFAULT_CONTEXT_LIMIT when model limit.context is 0 instead of skipping detection", () => {
+    // Before the fix: context=0 → return false (skip detection entirely)
+    // After the fix: context=0 → use DEFAULT_CONTEXT_LIMIT (128000)
+    // usable = 128000 - 8192 = 119808
+
+    // Below default limit: count = 100000 < 119808
+    const inputBelow = makeInput({ contextLimit: 0, tokens: { input: 100000 } })
+    expect(isOverflow(inputBelow)).toBe(false)
+
+    // Exceed default limit: count = 120000 >= 119808
+    const inputAbove = makeInput({ contextLimit: 0, tokens: { input: 120000 } })
+    expect(isOverflow(inputAbove)).toBe(true)
+  })
+
+  test("uses DEFAULT_CONTEXT_LIMIT when model limit.context is 0 with input limit", () => {
+    // With inputLimit, usable = inputLimit - reserved
+    // reserved = min(20000, 8192) = 8192
+    // usable = 60000 - 8192 = 51808
+    const input = makeInput({ contextLimit: 0, inputLimit: 60000, tokens: { input: 55000 } })
+    expect(isOverflow(input)).toBe(true)
+  })
+
+  test("respects explicit limit.context over default", () => {
+    // usable = 64000 - 8192 = 55808
+    const inputAbove = makeInput({ contextLimit: 64000, tokens: { input: 60000 } })
+    expect(isOverflow(inputAbove)).toBe(true)
+
+    const inputBelow = makeInput({ contextLimit: 64000, tokens: { input: 30000 } })
+    expect(isOverflow(inputBelow)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes token usage percentage display and overflow detection when using custom provider free models that have no explicit `limit.context` configuration.

- **Root cause**: When a custom provider model has no `limit.context` configured and no data in models.dev, the default was `0`, causing division-by-zero in percentage calculations and skipping overflow detection entirely.
- **Fix**: Use `DEFAULT_CONTEXT_LIMIT` (128,000) and `DEFAULT_OUTPUT_LIMIT` (8,192) as fallback defaults instead of `0`, with a log warning guiding users to configure explicitly.

## Changes

### Core fix (P0)
- **`src/provider/constants.ts`** (new): Define `DEFAULT_CONTEXT_LIMIT = 128_000` and `DEFAULT_OUTPUT_LIMIT = 8192` as shared constants
- **`src/provider/provider.ts`**: Use defaults when `limit.context`/`limit.output` is not configured; log info warning when default is applied (approach A + C)
- **`src/session/overflow.ts`**: Use `DEFAULT_CONTEXT_LIMIT` instead of skipping detection when `limit.context === 0`

### UI fallback consistency (P2)
- **`context.tsx`**: Show "limit unknown" instead of misleading "0% used"
- **`session-context-usage.tsx`**: Show "—" instead of misleading "0%"

### Defensive hardening (P3)
- **`stats.ts`**: Add `totalToolUsage > 0` zero-division check

## Tests added
- `test/provider/constants.test.ts` — 5 tests
- `test/provider/limit-defaults.test.ts` — 4 tests
- `test/session/overflow.test.ts` — 6 tests
- Updated existing `test/provider/provider.test.ts` assertions

## Test plan
- [x] All 90 provider + session tests pass
- [x] No new TypeScript type errors introduced
- [ ] Manual: Configure custom provider free model without `limit.context`, verify percentage displays correctly
- [ ] Manual: Long conversation with custom free model triggers auto-compaction
- [ ] Manual: User-configured `limit.context` overrides default and no warning is logged