### PR TITLE
fix(opencode): classify OpenAI responses missing-scope failures as auth errors

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -161,6 +161,10 @@ export namespace ProviderError {
         responseBody?: string
       }
     | {
+        type: "auth_error"
+        message: string
+      }
+    | {
         type: "api_error"
         message: string
         statusCode?: number
@@ -178,6 +182,21 @@ export namespace ProviderError {
         type: "context_overflow",
         message: m,
         responseBody: input.error.responseBody,
+      }
+    }
+
+    if (input.error.statusCode === 401 && /missing scopes?:/i.test(m)) {
+      if (input.providerID === "openai" && m.includes("api.responses.write")) {
+        return {
+          type: "auth_error",
+          message:
+            "This OpenAI credential cannot create Responses API runs. Enable 'Responses API → Write' for the key, verify your org/project role, or use a key with broader access.",
+        }
+      }
+
+      return {
+        type: "auth_error",
+        message: m,
       }
     }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -1000,6 +1000,15 @@ export namespace MessageV2 {
           providerID: ctx.providerID,
           error: e,
         })
+        if (parsed.type === "auth_error") {
+          return new MessageV2.AuthError(
+            {
+              providerID: ctx.providerID,
+              message: parsed.message,
+            },
+            { cause: e },
+          ).toObject()
+        }
         if (parsed.type === "context_overflow") {
           return new MessageV2.ContextOverflowError(
             {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -981,6 +981,37 @@ describe("session.message-v2.fromError", () => {
     expect(MessageV2.APIError.isInstance(result)).toBe(true)
   })
 
+  test("classifies OpenAI responses missing_scope as ProviderAuthError", () => {
+    const result = MessageV2.fromError(
+      new APICallError({
+        message:
+          "You have insufficient permissions for this operation. Missing scopes: api.responses.write. Check that you have the correct role in your organization and project.",
+        url: "https://api.openai.com/v1/responses",
+        requestBodyValues: {},
+        statusCode: 401,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: JSON.stringify({
+          error: {
+            code: "missing_scope",
+            message:
+              "You have insufficient permissions for this operation. Missing scopes: api.responses.write. Check that you have the correct role in your organization and project.",
+          },
+        }),
+        isRetryable: false,
+      }),
+      { providerID: ProviderID.make("openai") },
+    )
+
+    expect(result).toStrictEqual({
+      name: "ProviderAuthError",
+      data: {
+        providerID: "openai",
+        message:
+          "This OpenAI credential cannot create Responses API runs. Enable 'Responses API → Write' for the key, verify your org/project role, or use a key with broader access.",
+      },
+    })
+  })
+
   test("serializes unknown inputs", () => {
     const result = MessageV2.fromError(123, { providerID })
 


### PR DESCRIPTION
### Issue for this PR

Closes #21928

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When OpenAI returns `401 Missing scopes: api.responses.write`, OpenCode was storing that failure as a generic `APIError`.

This change classifies that path as an auth/configuration failure instead:
- `packages/opencode/src/provider/error.ts` now parses missing-scope 401s as `auth_error`
- `packages/opencode/src/session/message-v2.ts` maps that case to `ProviderAuthError`
- `packages/opencode/test/session/message-v2.test.ts` adds a regression test for the exact OpenAI Responses API scope error

That gives users a direct remediation message instead of making the failure look like a normal provider/runtime error.

### How did you verify your code works?

- Ran `bun test test/session/message-v2.test.ts` from `packages/opencode`
- Ran `bun typecheck` from `packages/opencode`
- Ran `bun turbo typecheck` from the repo root while pushing the branch (the pre-push hook passed)

### Screenshots / recordings

No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR