### PR TITLE
fix(stats): filter messages by creation time when --days is set

### DIFF
--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -167,7 +167,10 @@ export async function aggregateSessionStats(days?: number, projectFilter?: strin
     const batch = filteredSessions.slice(i, i + BATCH_SIZE)
 
     const batchPromises = batch.map(async (session) => {
-      const messages = await Session.messages({ sessionID: session.id })
+      const allMessages = await Session.messages({ sessionID: session.id })
+      const messages = cutoffTime > 0
+        ? allMessages.filter((m) => m.info.time.created >= cutoffTime)
+        : allMessages
 
       let sessionCost = 0
       let sessionTokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }


### PR DESCRIPTION
### Issue for this PR

Closes #21920

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode stats --days=N` filters sessions by their `time.updated` timestamp, but when computing costs and token counts it considers **all messages** in those sessions — including messages created weeks or months before the window.

Root cause: in `aggregateSessionStats`, the cutoff is applied to sessions but not to their messages. Every message in the session is accumulated unconditionally.

Fix: after fetching messages for a session, filter them to only include messages whose `time.created >= cutoffTime` before accumulating stats. One extra filter step per session batch, no change to the session-level filter or the no-`--days` path (`cutoffTime === 0`).

### How did you verify your code works?

Verified that `Message.Info` has a `time.created: number` field. The change is confined to a single file and does not affect the no-`--days` path.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR