### PR TITLE
fix: harden kimi structured output and replay

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
@@ -10,6 +10,10 @@ function getOpenAIMetadata(message: { providerOptions?: SharedV3ProviderOptions 
   return message?.providerOptions?.copilot ?? {}
 }
 
+function getOpenAICompatibleMetadata(message: { providerOptions?: SharedV3ProviderOptions }) {
+  return message?.providerOptions?.openaiCompatible ?? {}
+}
+
 export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Prompt): OpenAICompatibleChatPrompt {
   const messages: OpenAICompatibleChatPrompt = []
   for (const { role, content, ...message } of prompt) {
@@ -74,6 +78,10 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
         let text = ""
         let reasoningText: string | undefined
         let reasoningOpaque: string | undefined
+        const openAICompatibleMetadata = getOpenAICompatibleMetadata({ ...message }) as {
+          reasoning_content?: string
+          reasoning_details?: string
+        }
         const toolCalls: Array<{
           id: string
           type: "function"
@@ -117,6 +125,14 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
           role: "assistant",
           content: text || null,
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+          reasoning_content:
+            typeof openAICompatibleMetadata.reasoning_content === "string"
+              ? openAICompatibleMetadata.reasoning_content
+              : undefined,
+          reasoning_details:
+            typeof openAICompatibleMetadata.reasoning_details === "string"
+              ? openAICompatibleMetadata.reasoning_details
+              : undefined,
           reasoning_text: reasoningOpaque ? reasoningText : undefined,
           reasoning_opaque: reasoningOpaque,
           ...metadata,

--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-api-types.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-api-types.ts
@@ -43,6 +43,9 @@ export interface OpenAICompatibleAssistantMessage extends JsonRecord<OpenAICompa
   role: "assistant"
   content?: string | null
   tool_calls?: Array<OpenAICompatibleMessageToolCall>
+  // Generic interleaved reasoning fields used by OpenAI-compatible providers.
+  reasoning_content?: string
+  reasoning_details?: string
   // Copilot-specific reasoning fields
   reasoning_text?: string
   reasoning_opaque?: string

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -20,6 +20,15 @@ function mimeToModality(mime: string): Modality | undefined {
 export namespace ProviderTransform {
   export const OUTPUT_TOKEN_MAX = Flag.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX || 32_000
 
+  export function toolChoice(
+    model: Provider.Model,
+    format: { type: "text" | "json_schema" },
+  ): "auto" | "required" | undefined {
+    if (format.type !== "json_schema") return undefined
+    if (model.family?.startsWith("kimi")) return "auto"
+    return "required"
+  }
+
   // Maps npm package to the key the AI SDK expects for providerOptions
   function sdkKey(npm: string): string | undefined {
     switch (npm) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -65,6 +65,15 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  export function getToolChoice(
+    model: Provider.Model,
+    format: { type: "text" | "json_schema" },
+  ): "auto" | "required" | undefined {
+    if (format.type !== "json_schema") return undefined
+    if (model.api.id.toLowerCase().includes("kimi")) return "auto"
+    return "required"
+  }
+
   export interface Interface {
     readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
     readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
@@ -1484,7 +1493,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
                 tools,
                 model,
-                toolChoice: format.type === "json_schema" ? "required" : undefined,
+                toolChoice: getToolChoice(model, format),
               })
 
               if (structured !== undefined) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -65,15 +65,6 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
-  export function getToolChoice(
-    model: Provider.Model,
-    format: { type: "text" | "json_schema" },
-  ): "auto" | "required" | undefined {
-    if (format.type !== "json_schema") return undefined
-    if (model.api.id.toLowerCase().includes("kimi")) return "auto"
-    return "required"
-  }
-
   export interface Interface {
     readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
     readonly prompt: (input: PromptInput) => Effect.Effect<MessageV2.WithParts>
@@ -1493,7 +1484,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
                 tools,
                 model,
-                toolChoice: getToolChoice(model, format),
+                toolChoice: ProviderTransform.toolChoice(model, format),
               })
 
               if (structured !== undefined) {

--- a/packages/opencode/test/provider/copilot/convert-to-copilot-messages.test.ts
+++ b/packages/opencode/test/provider/copilot/convert-to-copilot-messages.test.ts
@@ -475,6 +475,74 @@ describe("reasoning (copilot-specific)", () => {
       },
     ])
   })
+
+  test("should include generic reasoning_content from openaiCompatible providerOptions", () => {
+    const result = convertToCopilotMessages([
+      {
+        role: "assistant",
+        providerOptions: {
+          openaiCompatible: {
+            reasoning_content: "Let me think before I call the tool.",
+          },
+        },
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call1",
+            toolName: "calculator",
+            input: { a: 1, b: 2 },
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call1",
+            type: "function",
+            function: {
+              name: "calculator",
+              arguments: JSON.stringify({ a: 1, b: 2 }),
+            },
+          },
+        ],
+        reasoning_content: "Let me think before I call the tool.",
+        reasoning_details: undefined,
+        reasoning_text: undefined,
+        reasoning_opaque: undefined,
+      },
+    ])
+  })
+
+  test("should include generic reasoning_details from openaiCompatible providerOptions", () => {
+    const result = convertToCopilotMessages([
+      {
+        role: "assistant",
+        providerOptions: {
+          openaiCompatible: {
+            reasoning_details: "Step-by-step replay payload",
+          },
+        },
+        content: [{ type: "text", text: "Done!" }],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: "Done!",
+        tool_calls: undefined,
+        reasoning_content: undefined,
+        reasoning_details: "Step-by-step replay payload",
+        reasoning_text: undefined,
+        reasoning_opaque: undefined,
+      },
+    ])
+  })
 })
 
 describe("full conversation", () => {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -9,6 +9,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
+import type { Provider } from "../../src/provider/provider"
 
 Log.init({ print: false })
 
@@ -519,4 +520,87 @@ describe("session.agent-resolution", () => {
       },
     })
   }, 30000)
+})
+
+describe("session.prompt structured output tool choice", () => {
+  test("uses auto for Kimi json_schema requests", () => {
+    const model: Provider.Model = {
+      id: ModelID.make("kimi-k2.5"),
+      providerID: ProviderID.make("opencode"),
+      api: {
+        id: "kimi-k2.5",
+        url: "https://example.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "Kimi K2.5",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: {
+          text: true,
+          audio: false,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        output: {
+          text: true,
+          audio: false,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        interleaved: { field: "reasoning_content" },
+      },
+      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      limit: { context: 100000, output: 10000 },
+      release_date: "2026-01-01",
+      options: {},
+    }
+
+    expect(SessionPrompt.getToolChoice(model, { type: "json_schema" })).toBe("auto")
+  })
+
+  test("keeps required for non-Kimi json_schema requests", () => {
+    const model: Provider.Model = {
+      id: ModelID.make("gpt-5.2"),
+      providerID: ProviderID.make("openai"),
+      api: {
+        id: "gpt-5.2",
+        url: "https://example.com",
+        npm: "@ai-sdk/openai",
+      },
+      name: "GPT-5.2",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: {
+          text: true,
+          audio: false,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        output: {
+          text: true,
+          audio: false,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      limit: { context: 100000, output: 10000 },
+      release_date: "2026-01-01",
+      options: {},
+    }
+
+    expect(SessionPrompt.getToolChoice(model, { type: "json_schema" })).toBe("required")
+    expect(SessionPrompt.getToolChoice(model, { type: "text" })).toBeUndefined()
+  })
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -556,8 +556,10 @@ describe("session.prompt structured output tool choice", () => {
         },
         interleaved: { field: "reasoning_content" },
       },
-      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
       limit: { context: 100000, output: 10000 },
+      status: "active",
+      headers: {},
       release_date: "2026-01-01",
       options: {},
     }
@@ -596,8 +598,10 @@ describe("session.prompt structured output tool choice", () => {
         },
         interleaved: false,
       },
-      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
       limit: { context: 100000, output: 10000 },
+      status: "active",
+      headers: {},
       release_date: "2026-01-01",
       options: {},
     }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -7,6 +7,7 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { Session } from "../../src/session"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
+import { ProviderTransform } from "../../src/provider/transform"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 import type { Provider } from "../../src/provider/provider"
@@ -533,6 +534,7 @@ describe("session.prompt structured output tool choice", () => {
         npm: "@ai-sdk/openai-compatible",
       },
       name: "Kimi K2.5",
+      family: "kimi",
       capabilities: {
         temperature: true,
         reasoning: true,
@@ -560,7 +562,7 @@ describe("session.prompt structured output tool choice", () => {
       options: {},
     }
 
-    expect(SessionPrompt.getToolChoice(model, { type: "json_schema" })).toBe("auto")
+    expect(ProviderTransform.toolChoice(model, { type: "json_schema" })).toBe("auto")
   })
 
   test("keeps required for non-Kimi json_schema requests", () => {
@@ -600,7 +602,7 @@ describe("session.prompt structured output tool choice", () => {
       options: {},
     }
 
-    expect(SessionPrompt.getToolChoice(model, { type: "json_schema" })).toBe("required")
-    expect(SessionPrompt.getToolChoice(model, { type: "text" })).toBeUndefined()
+    expect(ProviderTransform.toolChoice(model, { type: "json_schema" })).toBe("required")
+    expect(ProviderTransform.toolChoice(model, { type: "text" })).toBeUndefined()
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15197
Closes #15226

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two Kimi-specific protocol mismatches in opencode's current `dev` branch.

First, it preserves `reasoning_content` / `reasoning_details` when prior assistant turns are replayed through the OpenAI-compatible chat path. That addresses the replay failure reported in #15197 and also helps with the broader replay-stripping problem discussed in #19081.

Second, it stops forcing `tool_choice: "required"` for Kimi structured-output requests. Kimi thinking mode rejects that combination, so structured output now uses `auto` for Kimi-family models instead. That addresses #15226.

The fix is intentionally narrow:
- it adds the replay serialization on the OpenAI-compatible chat transport
- it moves the structured-output tool-choice decision into `ProviderTransform`
- it keeps the Kimi exception keyed off `model.family`
- it adds regression coverage for both behaviors

Related upstream work:
- #14637 and #14641 fix the same general replay problem for the Anthropic SDK path; this PR covers the OpenAI-compatible chat path instead, so it complements rather than duplicates those PRs
- #18054 improves provider routing for OpenAI-compatible models like Kimi, but it does not address these two protocol mismatches directly
- #20650 appears to be a broader provider/model malformed-tool-calling issue; this PR does not try to solve that class of failure, but it should reduce false Kimi failures caused by opencode's own request formatting

In practice, this should make Kimi sessions more stable in two places that currently fail immediately: multi-turn replay after tool use, and JSON-schema/structured-output requests.

### How did you verify your code works?

I tested the touched paths locally with:
- `bun test test/provider/copilot/convert-to-copilot-messages.test.ts`
- `bun test test/session/prompt.test.ts`
- `bun test test/provider/transform.test.ts`
- `bun test test/session/structured-output.test.ts`

I also ran diagnostics on the changed files before committing.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
