### PR TITLE
refactor: extract LSP diagnostics reporting utility

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -14,6 +14,7 @@ import { Filesystem } from "../util/filesystem"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
+import * as DiagnosticsReporter from "./diagnostics-reporter"
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -251,18 +252,18 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
     let output = `Success. Updated the following files:\n${summaryLines.join("\n")}`
 
     // Report LSP errors for changed files
-    const MAX_DIAGNOSTICS_PER_FILE = 20
     for (const change of fileChanges) {
       if (change.type === "delete") continue
       const target = change.movePath ?? change.filePath
       const normalized = Filesystem.normalizePath(target)
       const issues = diagnostics[normalized] ?? []
-      const errors = issues.filter((item) => item.severity === 1)
-      if (errors.length > 0) {
-        const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-        const suffix =
-          errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
-        output += `\n\nLSP errors detected in ${path.relative(Instance.worktree, target).replaceAll("\\", "/")}, please fix:\n<diagnostics file="${target}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+      const report = DiagnosticsReporter.formatDiagnostics(target, issues)
+      if (report.output) {
+        const relPath = path.relative(Instance.worktree, target).replaceAll("\\", "/")
+        output += report.output.replace(
+          "LSP errors detected in this file, please fix:",
+          `LSP errors detected in ${relPath}, please fix:`,
+        )
       }
     }
 

--- a/packages/opencode/src/tool/diagnostics-reporter.ts
+++ b/packages/opencode/src/tool/diagnostics-reporter.ts
@@ -1,0 +1,83 @@
+import { LSP } from "../lsp"
+import { LSPClient } from "../lsp/client"
+
+const MAX_DIAGNOSTICS_PER_FILE = 20
+
+export interface DiagnosticResult {
+  output: string
+  wasTruncated: boolean
+}
+
+export function formatDiagnostics(filePath: string, issues: LSPClient.Diagnostic[]): DiagnosticResult {
+  const errors = issues.filter((item) => item.severity === 1)
+  if (errors.length === 0) {
+    return { output: "", wasTruncated: false }
+  }
+
+  const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+  const suffix =
+    errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+
+  const output = `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+
+  return {
+    output,
+    wasTruncated: errors.length > MAX_DIAGNOSTICS_PER_FILE,
+  }
+}
+
+export function formatDiagnosticsForOtherFile(filePath: string, issues: LSPClient.Diagnostic[]): DiagnosticResult {
+  const errors = issues.filter((item) => item.severity === 1)
+  if (errors.length === 0) {
+    return { output: "", wasTruncated: false }
+  }
+
+  const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+  const suffix =
+    errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+
+  const output = `\n\nLSP errors detected in other files:\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+
+  return {
+    output,
+    wasTruncated: errors.length > MAX_DIAGNOSTICS_PER_FILE,
+  }
+}
+
+export interface ProjectDiagnosticsResult {
+  output: string
+  currentFileOutput: string
+  otherFilesCount: number
+}
+
+export function formatProjectDiagnostics(
+  currentFile: string,
+  diagnostics: Record<string, LSPClient.Diagnostic[]>,
+  maxOtherFiles = 5,
+): ProjectDiagnosticsResult {
+  let currentFileOutput = ""
+  let otherFilesOutput = ""
+  let otherFilesCount = 0
+
+  for (const [file, issues] of Object.entries(diagnostics)) {
+    const errors = issues.filter((item) => item.severity === 1)
+    if (errors.length === 0) continue
+
+    const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+    const suffix =
+      errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+
+    if (file === currentFile) {
+      currentFileOutput = `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+    } else if (otherFilesCount < maxOtherFiles) {
+      otherFilesCount++
+      otherFilesOutput += `\n\nLSP errors detected in other files:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+    }
+  }
+
+  return {
+    output: currentFileOutput + otherFilesOutput,
+    currentFileOutput,
+    otherFilesCount,
+  }
+}

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -19,8 +19,7 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
-
-const MAX_DIAGNOSTICS_PER_FILE = 20
+import * as DiagnosticsReporter from "./diagnostics-reporter"
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -167,15 +166,8 @@ export const EditTool = Tool.defineEffect(
           const diagnostics = yield* lsp.diagnostics()
           const normalizedFilePath = Filesystem.normalizePath(filePath)
           const issues = diagnostics[normalizedFilePath] ?? []
-          const errors = issues.filter((item) => item.severity === 1)
-          if (errors.length > 0) {
-            const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-            const suffix =
-              errors.length > MAX_DIAGNOSTICS_PER_FILE
-                ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more`
-                : ""
-            output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-          }
+          const report = DiagnosticsReporter.formatDiagnostics(filePath, issues)
+          output += report.output
 
           return {
             metadata: {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -14,9 +14,7 @@ import { AppFileSystem } from "../filesystem"
 import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
-
-const MAX_DIAGNOSTICS_PER_FILE = 20
-const MAX_PROJECT_DIAGNOSTICS_FILES = 5
+import * as DiagnosticsReporter from "./diagnostics-reporter"
 
 export const WriteTool = Tool.defineEffect(
   "write",
@@ -70,23 +68,8 @@ export const WriteTool = Tool.defineEffect(
           yield* lsp.touchFile(filepath, true)
           const diagnostics = yield* lsp.diagnostics()
           const normalizedFilepath = AppFileSystem.normalizePath(filepath)
-          let projectDiagnosticsCount = 0
-          for (const [file, issues] of Object.entries(diagnostics)) {
-            const errors = issues.filter((item) => item.severity === 1)
-            if (errors.length === 0) continue
-            const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-            const suffix =
-              errors.length > MAX_DIAGNOSTICS_PER_FILE
-                ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more`
-                : ""
-            if (file === normalizedFilepath) {
-              output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filepath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-              continue
-            }
-            if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
-            projectDiagnosticsCount++
-            output += `\n\nLSP errors detected in other files:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-          }
+          const report = DiagnosticsReporter.formatProjectDiagnostics(normalizedFilepath, diagnostics)
+          output += report.output
 
           return {
             title: path.relative(Instance.worktree, filepath),


### PR DESCRIPTION
## Summary

Adds `LSP.Diagnostic.report(file, issues)` next to the existing `LSP.Diagnostic.pretty` to centralize the filter / cap / `<diagnostics>`-block formatting that was duplicated across `write`, `edit`, and `apply_patch`.

Call sites keep control over their surrounding header text ("in this file", "in other files", "in {rel}") since that's the only real variation.

## Stats
- `lsp/index.ts` +11
- `write.ts` −6 net
- `edit.ts` −10 net
- `apply_patch.ts` −7 net
- **Net −11 lines**, no new files.

## Test plan
- [x] `bun run typecheck` in `packages/opencode`