### PR TITLE
fix: guard gpt-5 reasoningSummary for azure

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -823,7 +823,7 @@ export namespace ProviderTransform {
     }
 
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-      if (!input.model.api.id.includes("gpt-5-pro")) {
+      if (!input.model.api.id.includes("gpt-5-pro") && input.model.providerID !== "azure") {
         result["reasoningEffort"] = "medium"
         result["reasoningSummary"] = "auto"
       }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -173,14 +173,14 @@ describe("ProviderTransform.options - google thinkingConfig gating", () => {
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 
-  const createGpt5Model = (apiId: string) =>
+  const createGpt5Model = (apiId: string, providerID = "openai", npm = "@ai-sdk/openai") =>
     ({
-      id: `openai/${apiId}`,
-      providerID: "openai",
+      id: `${providerID}/${apiId}`,
+      providerID,
       api: {
         id: apiId,
         url: "https://api.openai.com",
-        npm: "@ai-sdk/openai",
+        npm,
       },
       name: apiId,
       capabilities: {
@@ -202,7 +202,15 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   test("gpt-5.2 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.2")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningSummary).toBe("auto")
     expect(result.textVerbosity).toBe("low")
+  })
+
+  test("azure gpt-5.2 should NOT have reasoningSummary or textVerbosity set", () => {
+    const model = createGpt5Model("gpt-5.2", "azure", "@ai-sdk/azure")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
   })
 
   test("gpt-5.1 should have textVerbosity set to low", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #21237

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes an inconsistency in `ProviderTransform.options` for `gpt-5` models.

`textVerbosity` was already guarded for Azure, but `reasoningSummary` was still being injected for Azure `gpt-5` models. That made the transform logic inconsistent and could send unsupported options to Azure.

This change applies the same Azure guard to `reasoningSummary` and adds coverage for both the OpenAI and Azure paths in `transform.test.ts`.

### How did you verify your code works?

- Added provider transform coverage for OpenAI and Azure `gpt-5.2`
- Ran `bun test test/provider/transform.test.ts`
- Ran `bun typecheck`

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR