### PR TITLE
refactor: destroy Todo facade

### DIFF
--- a/packages/opencode/src/effect/oltp.ts
+++ b/packages/opencode/src/effect/oltp.ts
@@ -31,14 +31,11 @@ export namespace Observability {
 
   export const layer = !base
     ? EffectLogger.layer
-    : Layer.mergeAll(
-        EffectLogger.layer,
-        Otlp.layerJson({
-          baseUrl: base,
-          loggerExportInterval: Duration.seconds(1),
-          loggerMergeWithExisting: true,
-          resource,
-          headers,
-        }),
-      ).pipe(Layer.provide(FetchHttpClient.layer))
+    : Otlp.layerJson({
+        baseUrl: base,
+        loggerExportInterval: Duration.seconds(1),
+        loggerMergeWithExisting: true,
+        resource,
+        headers,
+      }).pipe(Layer.provide(EffectLogger.layer), Layer.provide(FetchHttpClient.layer))
 }

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -13,6 +13,7 @@ import { SessionShare } from "@/share/session"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "../../session/todo"
+import { AppRuntime } from "../../effect/app-runtime"
 import { Agent } from "../../agent/agent"
 import { Snapshot } from "@/snapshot"
 import { Command } from "../../command"
@@ -185,7 +186,7 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const todos = await Todo.get(sessionID)
+        const todos = await AppRuntime.runPromise(Todo.Service.use((svc) => svc.get(sessionID)))
         return c.json(todos)
       },
     )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -102,6 +102,9 @@ export namespace SessionPrompt {
       const instruction = yield* Instruction.Service
       const state = yield* SessionRunState.Service
       const revert = yield* SessionRevert.Service
+      const svc = yield* Effect.services<never>()
+      const runFork = Effect.runForkWith(svc)
+      const runPromise = Effect.runPromiseWith(svc)
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
         yield* elog.info("cancel", { sessionID })
@@ -358,7 +361,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           agent: input.agent.name,
           messages: input.messages,
           metadata: (val) =>
-            Effect.runPromise(
+            runPromise(
               input.processor.updateToolCall(options.toolCallId, (match) => {
                 if (!["running", "pending"].includes(match.state.status)) return match
                 return {
@@ -374,7 +377,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }),
             ),
           ask: (req) =>
-            Effect.runPromise(
+            runPromise(
               permission.ask({
                 ...req,
                 sessionID: input.session.id,
@@ -395,7 +398,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             description: item.description,
             inputSchema: jsonSchema(schema as any),
             execute(args, options) {
-              return Effect.runPromise(
+              return runPromise(
                 Effect.gen(function* () {
                   const ctx = context(args, options)
                   yield* plugin.trigger(
@@ -436,7 +439,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const transformed = ProviderTransform.schema(input.model, schema)
           item.inputSchema = jsonSchema(transformed)
           item.execute = (args, opts) =>
-            Effect.runPromise(
+            runPromise(
               Effect.gen(function* () {
                 const ctx = context(args, opts)
                 yield* plugin.trigger(
@@ -587,7 +590,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               extra: { bypassAgentCheck: true, promptOps },
               messages: msgs,
               metadata(val: { title?: string; metadata?: Record<string, any> }) {
-                return Effect.runPromise(
+                return runPromise(
                   Effect.gen(function* () {
                     part = yield* sessions.updatePart({
                       ...part,
@@ -598,7 +601,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 )
               },
               ask(req: any) {
-                return Effect.runPromise(
+                return runPromise(
                   permission.ask({
                     ...req,
                     sessionID,
@@ -855,7 +858,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               output += chunk
               if (part.state.status === "running") {
                 part.state.metadata = { output, description: "" }
-                void Effect.runFork(sessions.updatePart(part))
+                void runFork(sessions.updatePart(part))
               }
             }),
           )
@@ -1655,9 +1658,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
 
       const promptOps: TaskPromptOps = {
-        cancel: (sessionID) => Effect.runFork(cancel(sessionID)),
-        resolvePromptParts: (template) => Effect.runPromise(resolvePromptParts(template)),
-        prompt: (input) => Effect.runPromise(prompt(input)),
+        cancel: (sessionID) => runFork(cancel(sessionID)),
+        resolvePromptParts: (template) => runPromise(resolvePromptParts(template)),
+        prompt: (input) => runPromise(prompt(input)),
       }
 
       return Service.of({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -102,9 +102,6 @@ export namespace SessionPrompt {
       const instruction = yield* Instruction.Service
       const state = yield* SessionRunState.Service
       const revert = yield* SessionRevert.Service
-      const svc = yield* Effect.services<never>()
-      const runFork = Effect.runForkWith(svc)
-      const runPromise = Effect.runPromiseWith(svc)
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
         yield* elog.info("cancel", { sessionID })
@@ -361,7 +358,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           agent: input.agent.name,
           messages: input.messages,
           metadata: (val) =>
-            runPromise(
+            Effect.runPromise(
               input.processor.updateToolCall(options.toolCallId, (match) => {
                 if (!["running", "pending"].includes(match.state.status)) return match
                 return {
@@ -377,7 +374,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               }),
             ),
           ask: (req) =>
-            runPromise(
+            Effect.runPromise(
               permission.ask({
                 ...req,
                 sessionID: input.session.id,
@@ -398,7 +395,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             description: item.description,
             inputSchema: jsonSchema(schema as any),
             execute(args, options) {
-              return runPromise(
+              return Effect.runPromise(
                 Effect.gen(function* () {
                   const ctx = context(args, options)
                   yield* plugin.trigger(
@@ -439,7 +436,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           const transformed = ProviderTransform.schema(input.model, schema)
           item.inputSchema = jsonSchema(transformed)
           item.execute = (args, opts) =>
-            runPromise(
+            Effect.runPromise(
               Effect.gen(function* () {
                 const ctx = context(args, opts)
                 yield* plugin.trigger(
@@ -590,7 +587,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               extra: { bypassAgentCheck: true, promptOps },
               messages: msgs,
               metadata(val: { title?: string; metadata?: Record<string, any> }) {
-                return runPromise(
+                return Effect.runPromise(
                   Effect.gen(function* () {
                     part = yield* sessions.updatePart({
                       ...part,
@@ -601,7 +598,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 )
               },
               ask(req: any) {
-                return runPromise(
+                return Effect.runPromise(
                   permission.ask({
                     ...req,
                     sessionID,
@@ -858,7 +855,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               output += chunk
               if (part.state.status === "running") {
                 part.state.metadata = { output, description: "" }
-                void runFork(sessions.updatePart(part))
+                void Effect.runFork(sessions.updatePart(part))
               }
             }),
           )
@@ -1658,9 +1655,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
 
       const promptOps: TaskPromptOps = {
-        cancel: (sessionID) => runFork(cancel(sessionID)),
-        resolvePromptParts: (template) => runPromise(resolvePromptParts(template)),
-        prompt: (input) => runPromise(prompt(input)),
+        cancel: (sessionID) => Effect.runFork(cancel(sessionID)),
+        resolvePromptParts: (template) => Effect.runPromise(resolvePromptParts(template)),
+        prompt: (input) => Effect.runPromise(prompt(input)),
       }
 
       return Service.of({

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,6 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
-import { makeRuntime } from "@/effect/run-service"
 import { SessionID } from "./schema"
 import { Effect, Layer, ServiceMap } from "effect"
 import z from "zod"
@@ -83,9 +82,4 @@ export namespace Todo {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function get(sessionID: SessionID) {
-    return runPromise((svc) => svc.get(sessionID))
-  }
 }


### PR DESCRIPTION
## Summary

Second facade destruction. Tiny diff — proves the second migration pattern (non-effectful caller → AppRuntime).

## Changes

- **`server/routes/session.ts`** — the GET `/session/:id/todo` handler now does `AppRuntime.runPromise(Todo.Service.use((svc) => svc.get(sessionID)))` instead of calling the `Todo.get` promise facade
- **`session/todo.ts`** — deleted the `export async function get` facade, the `makeRuntime(...)` line, and the unused `makeRuntime` import

## Test plan

- [x] Typecheck clean
- [x] Full suite: 1883 pass, 0 fail
- [ ] CI green