### PR TITLE
fix: disable default Effect console logger

### DIFF
--- a/packages/opencode/src/effect/logger.ts
+++ b/packages/opencode/src/effect/logger.ts
@@ -55,7 +55,7 @@ export namespace EffectLogger {
     }
   })
 
-  export const layer = Logger.layer([logger], { mergeWithExisting: true })
+  export const layer = Logger.layer([logger], { mergeWithExisting: false })
 
   export const create = (base: Fields = {}): Handle => ({
     debug: (msg, extra) => call((item) => Effect.logDebug(item), base, msg, extra),

--- a/packages/opencode/src/effect/oltp.ts
+++ b/packages/opencode/src/effect/oltp.ts
@@ -31,12 +31,14 @@ export namespace Observability {
 
   export const layer = !base
     ? EffectLogger.layer
-    : Otlp.layerJson({
-        baseUrl: base,
-        loggerExportInterval: Duration.seconds(1),
-        // Disable console logger - only export to OTLP
-        loggerMergeWithExisting: false,
-        resource,
-        headers,
-      }).pipe(Layer.provide(FetchHttpClient.layer))
+    : Layer.mergeAll(
+        EffectLogger.layer,
+        Otlp.layerJson({
+          baseUrl: base,
+          loggerExportInterval: Duration.seconds(1),
+          loggerMergeWithExisting: true,
+          resource,
+          headers,
+        }),
+      ).pipe(Layer.provide(FetchHttpClient.layer))
 }

--- a/packages/opencode/src/effect/oltp.ts
+++ b/packages/opencode/src/effect/oltp.ts
@@ -6,9 +6,8 @@ import { Flag } from "@/flag/flag"
 import { CHANNEL, VERSION } from "@/installation/meta"
 
 export namespace Observability {
-  export const enabled = !!Flag.OTEL_EXPORTER_OTLP_ENDPOINT
-
   const base = Flag.OTEL_EXPORTER_OTLP_ENDPOINT
+  export const enabled = !!base
 
   const resource = {
     serviceName: "opencode",
@@ -32,14 +31,12 @@ export namespace Observability {
 
   export const layer = !base
     ? EffectLogger.layer
-    : Layer.mergeAll(
-        EffectLogger.layer,
-        Otlp.layerJson({
-          baseUrl: base,
-          loggerExportInterval: Duration.seconds(5),
-          loggerMergeWithExisting: true,
-          resource,
-          headers,
-        }),
-      ).pipe(Layer.provide(FetchHttpClient.layer))
+    : Otlp.layerJson({
+        baseUrl: base,
+        loggerExportInterval: Duration.seconds(1),
+        // Disable console logger - only export to OTLP
+        loggerMergeWithExisting: false,
+        resource,
+        headers,
+      }).pipe(Layer.provide(FetchHttpClient.layer))
 }


### PR DESCRIPTION
## Summary
- replace the default Effect logger with the app logger so logs stop printing to stdout
- keep OTLP logging as the only logger sink when `OTEL_EXPORTER_OTLP_ENDPOINT` is configured
- simplify observability setup to avoid merging the custom logger into the OTLP logger layer