### PR TITLE
refactor: extract LSP diagnostic report formatter

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -540,6 +540,8 @@ export namespace LSP {
   export const outgoingCalls = async (input: LocInput) => runPromise((svc) => svc.outgoingCalls(input))
 
   export namespace Diagnostic {
+    const MAX_PER_FILE = 20
+
     export function pretty(diagnostic: LSPClient.Diagnostic) {
       const severityMap = {
         1: "ERROR",
@@ -553,6 +555,15 @@ export namespace LSP {
       const col = diagnostic.range.start.character + 1
 
       return `${severity} [${line}:${col}] ${diagnostic.message}`
+    }
+
+    export function report(file: string, issues: LSPClient.Diagnostic[]) {
+      const errors = issues.filter((item) => item.severity === 1)
+      if (errors.length === 0) return ""
+      const limited = errors.slice(0, MAX_PER_FILE)
+      const more = errors.length - MAX_PER_FILE
+      const suffix = more > 0 ? `\n... and ${more} more` : ""
+      return `<diagnostics file="${file}">\n${limited.map(pretty).join("\n")}${suffix}\n</diagnostics>`
     }
   }
 }

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -258,20 +258,13 @@ export const ApplyPatchTool = Tool.defineEffect(
       })
       let output = `Success. Updated the following files:\n${summaryLines.join("\n")}`
 
-      // Report LSP errors for changed files
-      const MAX_DIAGNOSTICS_PER_FILE = 20
       for (const change of fileChanges) {
         if (change.type === "delete") continue
         const target = change.movePath ?? change.filePath
-        const normalized = AppFileSystem.normalizePath(target)
-        const issues = diagnostics[normalized] ?? []
-        const errors = issues.filter((item) => item.severity === 1)
-        if (errors.length > 0) {
-          const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-          const suffix =
-            errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
-          output += `\n\nLSP errors detected in ${path.relative(Instance.worktree, target).replaceAll("\\", "/")}, please fix:\n<diagnostics file="${target}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-        }
+        const block = LSP.Diagnostic.report(target, diagnostics[AppFileSystem.normalizePath(target)] ?? [])
+        if (!block) continue
+        const rel = path.relative(Instance.worktree, target).replaceAll("\\", "/")
+        output += `\n\nLSP errors detected in ${rel}, please fix:\n${block}`
       }
 
       return {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -20,8 +20,6 @@ import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 
-const MAX_DIAGNOSTICS_PER_FILE = 20
-
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
 }
@@ -166,16 +164,8 @@ export const EditTool = Tool.defineEffect(
           yield* lsp.touchFile(filePath, true)
           const diagnostics = yield* lsp.diagnostics()
           const normalizedFilePath = Filesystem.normalizePath(filePath)
-          const issues = diagnostics[normalizedFilePath] ?? []
-          const errors = issues.filter((item) => item.severity === 1)
-          if (errors.length > 0) {
-            const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-            const suffix =
-              errors.length > MAX_DIAGNOSTICS_PER_FILE
-                ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more`
-                : ""
-            output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-          }
+          const block = LSP.Diagnostic.report(filePath, diagnostics[normalizedFilePath] ?? [])
+          if (block) output += `\n\nLSP errors detected in this file, please fix:\n${block}`
 
           return {
             metadata: {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -15,7 +15,6 @@ import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 
-const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
 export const WriteTool = Tool.defineEffect(
@@ -72,20 +71,16 @@ export const WriteTool = Tool.defineEffect(
           const normalizedFilepath = AppFileSystem.normalizePath(filepath)
           let projectDiagnosticsCount = 0
           for (const [file, issues] of Object.entries(diagnostics)) {
-            const errors = issues.filter((item) => item.severity === 1)
-            if (errors.length === 0) continue
-            const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-            const suffix =
-              errors.length > MAX_DIAGNOSTICS_PER_FILE
-                ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more`
-                : ""
-            if (file === normalizedFilepath) {
-              output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filepath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+            const current = file === normalizedFilepath
+            if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
+            const block = LSP.Diagnostic.report(current ? filepath : file, issues)
+            if (!block) continue
+            if (current) {
+              output += `\n\nLSP errors detected in this file, please fix:\n${block}`
               continue
             }
-            if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
             projectDiagnosticsCount++
-            output += `\n\nLSP errors detected in other files:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+            output += `\n\nLSP errors detected in other files:\n${block}`
           }
 
           return {


### PR DESCRIPTION
## Summary

Adds `LSP.Diagnostic.report(file, issues)` next to the existing `LSP.Diagnostic.pretty` to centralize the filter / cap / `<diagnostics>`-block formatting that was duplicated across `write`, `edit`, and `apply_patch`.

Call sites keep control over their surrounding header text ("in this file", "in other files", "in {rel}") since that's the only real variation.

Net **−11 lines**, no new files.

## Test plan
- [x] `bun run typecheck` in `packages/opencode`