### PR TITLE
refactor: destroy ShareNext facade

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -219,11 +219,11 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 - [x] `Instruction` — `session/instruction.ts`
 - [x] `Provider` — `provider/provider.ts`
 - [x] `Storage` — `storage/storage.ts`
+- [x] `ShareNext` — `share/share-next.ts`
 
 Still open:
 
 - [ ] `SessionTodo` — `session/todo.ts`
-- [ ] `ShareNext` — `share/share-next.ts`
 - [ ] `SyncEvent` — `sync/index.ts`
 - [ ] `Workspace` — `control-plane/workspace.ts`
 
@@ -336,4 +336,5 @@ For each service, the migration is roughly:
 
 ### Migration log
 
+- `ShareNext` — migrated 2026-04-11. Swapped remaining async callers to `AppRuntime.runPromise(ShareNext.Service.use(...))`, removed the `makeRuntime(...)` facade, and kept instance bootstrap on the shared app runtime.
 - `Storage` — migrated 2026-04-10. One production caller (`Session.diff`) and all storage.test.ts tests converted to effectful style. Facades and `makeRuntime` removed.

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -10,6 +10,7 @@ import { Instance } from "../../project/instance"
 import { ShareNext } from "../../share/share-next"
 import { EOL } from "os"
 import { Filesystem } from "../../util/filesystem"
+import { AppRuntime } from "@/effect/app-runtime"
 
 /** Discriminated union returned by the ShareNext API (GET /api/shares/:id/data) */
 export type ShareData =
@@ -100,7 +101,7 @@ export const ImportCommand = cmd({
       if (isUrl) {
         const slug = parseShareUrl(args.file)
         if (!slug) {
-          const baseUrl = await ShareNext.url()
+          const baseUrl = await AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.url()))
           process.stdout.write(`Invalid URL format. Expected: ${baseUrl}/share/<slug>`)
           process.stdout.write(EOL)
           return
@@ -108,7 +109,7 @@ export const ImportCommand = cmd({
 
         const parsed = new URL(args.file)
         const baseUrl = parsed.origin
-        const req = await ShareNext.request()
+        const req = await AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.request()))
         const headers = shouldAttachShareAuthHeaders(args.file, req.baseUrl) ? req.headers : {}
 
         const dataPath = req.api.data(slug)

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -10,12 +10,13 @@ import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
+import { AppRuntime } from "@/effect/app-runtime"
 import { ShareNext } from "@/share/share-next"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await Plugin.init()
-  ShareNext.init()
+  void AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
   Format.init()
   await LSP.init()
   File.init()

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -4,7 +4,6 @@ import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } fr
 import { Account } from "@/account"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Session } from "@/session"
@@ -348,26 +347,4 @@ export namespace ShareNext {
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Session.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function init() {
-    return runPromise((svc) => svc.init())
-  }
-
-  export async function url() {
-    return runPromise((svc) => svc.url())
-  }
-
-  export async function request(): Promise<Req> {
-    return runPromise((svc) => svc.request())
-  }
-
-  export async function create(sessionID: SessionID) {
-    return runPromise((svc) => svc.create(sessionID))
-  }
-
-  export async function remove(sessionID: SessionID) {
-    return runPromise((svc) => svc.remove(sessionID))
-  }
 }


### PR DESCRIPTION
## Summary
- remove the `ShareNext` async facade and call the service directly through `AppRuntime`
- keep bootstrap and import flows on the shared runtime instead of a per-service runtime wrapper
- update the Effect migration spec to mark `ShareNext` as completed

## Verification
- bun typecheck
- bun run test test/share/share-next.test.ts test/cli/import.test.ts