### PR TITLE
refactor: make TaskPromptOps effectful

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1665,8 +1665,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
       const promptOps: TaskPromptOps = {
         cancel: (sessionID) => run.fork(cancel(sessionID)),
-        resolvePromptParts: (template) => run.promise(resolvePromptParts(template)),
-        prompt: (input) => run.promise(prompt(input)),
+        resolvePromptParts: (template) => resolvePromptParts(template),
+        prompt: (input) => prompt(input),
       }
 
       return Service.of({

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -12,8 +12,8 @@ import { Log } from "@/util/log"
 
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): void
-  resolvePromptParts(template: string): Promise<SessionPrompt.PromptInput["parts"]>
-  prompt(input: SessionPrompt.PromptInput): Promise<MessageV2.WithParts>
+  resolvePromptParts(template: string): Effect.Effect<SessionPrompt.PromptInput["parts"]>
+  prompt(input: SessionPrompt.PromptInput): Effect.Effect<MessageV2.WithParts>
 }
 
 const id = "task"
@@ -132,24 +132,22 @@ export const TaskTool = Tool.define(
         }),
         () =>
           Effect.gen(function* () {
-            const parts = yield* Effect.promise(() => ops.resolvePromptParts(params.prompt))
-            const result = yield* Effect.promise(() =>
-              ops.prompt({
-                messageID,
-                sessionID: nextSession.id,
-                model: {
-                  modelID: model.modelID,
-                  providerID: model.providerID,
-                },
-                agent: next.name,
-                tools: {
-                  ...(canTodo ? {} : { todowrite: false }),
-                  ...(canTask ? {} : { task: false }),
-                  ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),
-                },
-                parts,
-              }),
-            )
+            const parts = yield* ops.resolvePromptParts(params.prompt)
+            const result = yield* ops.prompt({
+              messageID,
+              sessionID: nextSession.id,
+              model: {
+                modelID: model.modelID,
+                providerID: model.providerID,
+              },
+              agent: next.name,
+              tools: {
+                ...(canTodo ? {} : { todowrite: false }),
+                ...(canTask ? {} : { task: false }),
+                ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),
+              },
+              parts,
+            })
 
             return {
               title: params.description,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -65,11 +65,12 @@ const seed = Effect.fn("TaskToolTest.seed")(function* (title = "Pinned") {
 function stubOps(opts?: { onPrompt?: (input: SessionPrompt.PromptInput) => void; text?: string }): TaskPromptOps {
   return {
     cancel() {},
-    resolvePromptParts: async (template) => [{ type: "text", text: template }],
-    prompt: async (input) => {
-      opts?.onPrompt?.(input)
-      return reply(input, opts?.text ?? "done")
-    },
+    resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+    prompt: (input) =>
+      Effect.sync(() => {
+        opts?.onPrompt?.(input)
+        return reply(input, opts?.text ?? "done")
+      }),
   }
 }
 


### PR DESCRIPTION
## Summary
- `TaskPromptOps.resolvePromptParts` and `TaskPromptOps.prompt` now return `Effect` instead of `Promise`
- Task tool `yield*`s the ops directly instead of wrapping in `Effect.promise`
- prompt.ts passes the Effect functions directly instead of wrapping with `run.promise`

## Test plan
- [x] `test/tool/task.test.ts` — all 6 pass
- [x] `test/session/prompt-effect.test.ts` — all 34 pass