### PR TITLE
refactor(tool): Tool.Context.metadata returns Effect

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -158,7 +158,7 @@ async function createToolContext(agent: Agent.Info) {
     agent: agent.name,
     abort: new AbortController().signal,
     messages: [],
-    metadata: () => {},
+    metadata: () => Effect.void,
     ask(req: Omit<Permission.Request, "id" | "sessionID" | "tool">) {
       return Effect.sync(() => {
         for (const pattern of req.patterns) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -364,21 +364,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           agent: input.agent.name,
           messages: input.messages,
           metadata: (val) =>
-            run.promise(
-              input.processor.updateToolCall(options.toolCallId, (match) => {
-                if (!["running", "pending"].includes(match.state.status)) return match
-                return {
-                  ...match,
-                  state: {
-                    title: val.title,
-                    metadata: val.metadata,
-                    status: "running",
-                    input: args,
-                    time: { start: Date.now() },
-                  },
-                }
-              }),
-            ),
+            input.processor.updateToolCall(options.toolCallId, (match) => {
+              if (!["running", "pending"].includes(match.state.status)) return match
+              return {
+                ...match,
+                state: {
+                  title: val.title,
+                  metadata: val.metadata,
+                  status: "running",
+                  input: args,
+                  time: { start: Date.now() },
+                },
+              }
+            }),
           ask: (req) =>
             permission
               .ask({
@@ -592,17 +590,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             callID: part.callID,
             extra: { bypassAgentCheck: true, promptOps },
             messages: msgs,
-            metadata(val: { title?: string; metadata?: Record<string, any> }) {
-              return run.promise(
-                Effect.gen(function* () {
-                  part = yield* sessions.updatePart({
-                    ...part,
-                    type: "tool",
-                    state: { ...part.state, ...val },
-                  } satisfies MessageV2.ToolPart)
-                }),
-              )
-            },
+            metadata: (val: { title?: string; metadata?: Record<string, any> }) =>
+              Effect.gen(function* () {
+                part = yield* sessions.updatePart({
+                  ...part,
+                  type: "tool",
+                  state: { ...part.state, ...val },
+                } satisfies MessageV2.ToolPart)
+              }),
             ask: (req: any) =>
               permission
                 .ask({
@@ -1054,7 +1049,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                       messageID: info.id,
                       extra: { bypassCwdCheck: true, ...extra },
                       messages: [],
-                      metadata: () => {},
+                      metadata: () => Effect.void,
                       ask: () => Effect.void,
                     })
                     .pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort())))

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -385,7 +385,7 @@ export const BashTool = Tool.define(
       let expired = false
       let aborted = false
 
-      ctx.metadata({
+      yield* ctx.metadata({
         metadata: {
           output: "",
           description: input.description,
@@ -397,16 +397,15 @@ export const BashTool = Tool.define(
           const handle = yield* spawner.spawn(cmd(input.shell, input.name, input.command, input.cwd, input.env))
 
           yield* Effect.forkScoped(
-            Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
-              Effect.sync(() => {
-                output += chunk
-                ctx.metadata({
-                  metadata: {
-                    output: preview(output),
-                    description: input.description,
-                  },
-                })
-              }),
+            Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
+              output += chunk
+              return ctx.metadata({
+                metadata: {
+                  output: preview(output),
+                  description: input.description,
+                },
+              })
+            },
             ),
           )
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -158,7 +158,7 @@ export const EditTool = Tool.define(
             if (change.removed) filediff.deletions += change.count || 0
           }
 
-          ctx.metadata({
+          yield* ctx.metadata({
             metadata: {
               diff,
               filediff,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -109,7 +109,7 @@ export const TaskTool = Tool.define(
         providerID: msg.info.providerID,
       }
 
-      ctx.metadata({
+      yield* ctx.metadata({
         title: params.description,
         metadata: {
           sessionId: nextSession.id,

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -22,7 +22,7 @@ export namespace Tool {
     callID?: string
     extra?: { [key: string]: any }
     messages: MessageV2.WithParts[]
-    metadata(input: { title?: string; metadata?: M }): void
+    metadata(input: { title?: string; metadata?: M }): Effect.Effect<void>
     ask(input: Omit<Permission.Request, "id" | "sessionID" | "tool">): Effect.Effect<void>
   }
 

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -22,7 +22,7 @@ const baseCtx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
 }
 
 type AskInput = {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -29,7 +29,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 
@@ -982,13 +982,14 @@ describe("tool.bash abort", () => {
             {
               ...ctx,
               abort: controller.signal,
-              metadata: (input) => {
-                const output = (input.metadata as { output?: string })?.output
-                if (output && output.includes("before") && !controller.signal.aborted) {
-                  collected.push(output)
-                  controller.abort()
-                }
-              },
+              metadata: (input) =>
+                Effect.sync(() => {
+                  const output = (input.metadata as { output?: string })?.output
+                  if (output && output.includes("before") && !controller.signal.aborted) {
+                    collected.push(output)
+                    controller.abort()
+                  }
+                }),
             },
           ),
         )
@@ -1074,10 +1075,11 @@ describe("tool.bash abort", () => {
             },
             {
               ...ctx,
-              metadata: (input) => {
-                const output = (input.metadata as { output?: string })?.output
-                if (output) updates.push(output)
-              },
+              metadata: (input) =>
+                Effect.sync(() => {
+                  const output = (input.metadata as { output?: string })?.output
+                  if (output) updates.push(output)
+                }),
             },
           ),
         )

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -20,7 +20,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -16,7 +16,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
 }
 
 const glob = (p: string) =>

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -20,7 +20,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -15,7 +15,7 @@ const ctx = {
   agent: "test-agent",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -29,7 +29,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -19,7 +19,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
 }
 
 afterEach(async () => {

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -208,7 +208,7 @@ describe("tool.task", () => {
             abort: new AbortController().signal,
             extra: { promptOps },
             messages: [],
-            metadata() {},
+            metadata: () => Effect.void,
             ask: () => Effect.void,
           },
         )
@@ -246,7 +246,7 @@ describe("tool.task", () => {
               abort: new AbortController().signal,
               extra: { promptOps, ...extra },
               messages: [],
-              metadata() {},
+              metadata: () => Effect.void,
               ask: (input) =>
                 Effect.sync(() => {
                   calls.push(input)
@@ -295,7 +295,7 @@ describe("tool.task", () => {
             abort: new AbortController().signal,
             extra: { promptOps },
             messages: [],
-            metadata() {},
+            metadata: () => Effect.void,
             ask: () => Effect.void,
           },
         )
@@ -334,7 +334,7 @@ describe("tool.task", () => {
               abort: new AbortController().signal,
               extra: { promptOps },
               messages: [],
-              metadata() {},
+              metadata: () => Effect.void,
               ask: () => Effect.void,
             },
           )

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -15,7 +15,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -22,7 +22,7 @@ const ctx = {
   agent: "build",
   abort: AbortSignal.any([]),
   messages: [],
-  metadata: () => {},
+  metadata: () => Effect.void,
   ask: () => Effect.void,
 }
 


### PR DESCRIPTION
## Summary
- Change `Tool.Context.metadata` from `() => void` to `() => Effect.Effect<void>`, matching the pattern already used by `Tool.Context.ask`
- Remove `run.promise` wrappers in `prompt.ts` metadata callbacks since the Effect is now yielded in the fiber
- Update all tool callsites (`bash.ts`, `edit.ts`, `task.ts`) to `yield*` the metadata Effect
- Update all test mocks to return `Effect.void`

## Test plan
- [x] `bun run typecheck` passes (no new errors)
- [x] `bun run test test/tool/` — 167 tests pass
- [x] `bun run test test/session/prompt-effect.test.ts` — 34 tests pass