### PR TITLE
refactor(tool): use Session.Service directly in TaskTool

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -36,6 +36,7 @@ export const TaskTool = Tool.define(
   Effect.gen(function* () {
     const agent = yield* Agent.Service
     const config = yield* Config.Service
+    const sessions = yield* Session.Service
 
     const run = Effect.fn("TaskTool.execute")(function* (params: z.infer<typeof parameters>, ctx: Tool.Context) {
       const cfg = yield* config.get()
@@ -62,44 +63,41 @@ export const TaskTool = Tool.define(
 
       const taskID = params.task_id
       const session = taskID
-        ? yield* Effect.promise(() => {
-            const id = SessionID.make(taskID)
-            return Session.get(id).catch(() => undefined)
-          })
+        ? yield* sessions.get(SessionID.make(taskID)).pipe(
+            Effect.catchCause(() => Effect.succeed(undefined)),
+          )
         : undefined
       const nextSession =
         session ??
-        (yield* Effect.promise(() =>
-          Session.create({
-            parentID: ctx.sessionID,
-            title: params.description + ` (@${next.name} subagent)`,
-            permission: [
-              ...(canTodo
-                ? []
-                : [
-                    {
-                      permission: "todowrite" as const,
-                      pattern: "*" as const,
-                      action: "deny" as const,
-                    },
-                  ]),
-              ...(canTask
-                ? []
-                : [
-                    {
-                      permission: id,
-                      pattern: "*" as const,
-                      action: "deny" as const,
-                    },
-                  ]),
-              ...(cfg.experimental?.primary_tools?.map((item) => ({
-                pattern: "*",
-                action: "allow" as const,
-                permission: item,
-              })) ?? []),
-            ],
-          }),
-        ))
+        (yield* sessions.create({
+          parentID: ctx.sessionID,
+          title: params.description + ` (@${next.name} subagent)`,
+          permission: [
+            ...(canTodo
+              ? []
+              : [
+                  {
+                    permission: "todowrite" as const,
+                    pattern: "*" as const,
+                    action: "deny" as const,
+                  },
+                ]),
+            ...(canTask
+              ? []
+              : [
+                  {
+                    permission: id,
+                    pattern: "*" as const,
+                    action: "deny" as const,
+                  },
+                ]),
+            ...(cfg.experimental?.primary_tools?.map((item) => ({
+              pattern: "*",
+              action: "allow" as const,
+              permission: item,
+            })) ?? []),
+          ],
+        }))
 
       const msg = yield* Effect.sync(() => MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }))
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))


### PR DESCRIPTION
## Summary
- Convert TaskTool to use `yield* Session.Service` instead of calling `Session.get`/`Session.create` facades through `Effect.promise`, eliminating unnecessary runtime roundtrips
- The `sessions.get` call uses `Effect.catchCause` to handle `NotFoundError` (a thrown exception) gracefully, matching the original `.catch(() => undefined)` behavior

## Test plan
- [x] `bun test test/tool/task.test.ts` — all 6 tests pass
- [x] `bun test test/session/` — all 242 tests pass
- [x] `bun run typecheck` — no new errors in src/