### PR TITLE
fix(i18n): detect zh-TW/zh-HK/zh-MO as Traditional Chinese

### DIFF
--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -135,7 +135,15 @@ export function loadLocaleDict(locale: Locale) {
 
 const localeMatchers: Array<{ locale: Locale; match: (language: string) => boolean }> = [
   { locale: "en", match: (language) => language.startsWith("en") },
-  { locale: "zht", match: (language) => language.startsWith("zh") && language.includes("hant") },
+  {
+    locale: "zht",
+    match: (language) =>
+      language.startsWith("zh") &&
+      (language.includes("hant") ||
+        language.includes("-tw") ||
+        language.includes("-hk") ||
+        language.includes("-mo")),
+  },
   { locale: "zh", match: (language) => language.startsWith("zh") },
   { locale: "ko", match: (language) => language.startsWith("ko") },
   { locale: "de", match: (language) => language.startsWith("de") },

--- a/packages/desktop-electron/src/renderer/i18n/index.ts
+++ b/packages/desktop-electron/src/renderer/i18n/index.ts
@@ -78,7 +78,8 @@ function detectLocale(): Locale {
     if (!language) continue
     if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
-      if (language.toLowerCase().includes("hant")) return "zht"
+      const value = language.toLowerCase()
+      if (value.includes("hant") || value.includes("-tw") || value.includes("-hk") || value.includes("-mo")) return "zht"
       return "zh"
     }
     if (language.toLowerCase().startsWith("ko")) return "ko"

--- a/packages/desktop/src/i18n/index.ts
+++ b/packages/desktop/src/i18n/index.ts
@@ -79,7 +79,8 @@ function detectLocale(): Locale {
     if (!language) continue
     if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
-      if (language.toLowerCase().includes("hant")) return "zht"
+      const value = language.toLowerCase()
+      if (value.includes("hant") || value.includes("-tw") || value.includes("-hk") || value.includes("-mo")) return "zht"
       return "zh"
     }
     if (language.toLowerCase().startsWith("ko")) return "ko"


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Traditional Chinese (`zht`) locale matcher in `packages/app`, `packages/desktop`, and `packages/desktop-electron` only checks whether the browser-reported language tag contains `hant`:

```ts
// packages/app/src/context/language.tsx
{ locale: "zht", match: (language) => language.startsWith("zh") && language.includes("hant") },
```

In practice almost no system actually reports `zh-Hant`. What browsers and operating systems send for Traditional Chinese users is `zh-TW`, `zh-HK`, or `zh-MO`. Those fall through the `zht` matcher and hit the next one (`zh`), so Traditional Chinese users get Simplified Chinese on first load — even though the `zht` dictionary is already shipped and the locale picker lists it.

`packages/console/app/src/lib/language.ts` already has the correct check, so this PR just brings the three app/desktop entry points into line with it:

```ts
language.startsWith("zh") &&
(language.includes("hant") ||
  language.includes("-tw") ||
  language.includes("-hk") ||
  language.includes("-mo"))
```

No other behaviour changes. Users who previously had `zh` auto-selected and then manually switched to `zht` are unaffected because that choice is persisted in `localStorage` / the `oc_locale` cookie and takes precedence over auto-detection.

### How did you verify your code works?

Traced the three matchers against the sample `navigator.languages` values that Chrome/Firefox/Safari actually emit on Traditional Chinese systems (`zh-TW`, `zh-TW,zh;q=0.9,en;q=0.8`, `zh-Hant-TW`, `zh-HK`) and confirmed they now map to `zht` while `zh-CN` / `zh-SG` still map to `zh`. Also diffed against `packages/console/app/src/lib/language.ts` to confirm the logic is consistent with the existing console implementation.

### Screenshots / recordings

N/A — no UI changes, only locale auto-detection logic.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR