### PR TITLE
refactor: collapse Format facade

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -2,7 +2,6 @@ import { Effect, Layer, Context } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import path from "path"
 import { mergeDeep } from "remeda"
 import z from "zod"
@@ -193,18 +192,4 @@ export namespace Format {
     Layer.provide(Config.defaultLayer),
     Layer.provide(CrossSpawnSpawner.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function init() {
-    return runPromise((s) => s.init())
-  }
-
-  export async function status() {
-    return runPromise((s) => s.status())
-  }
-
-  export async function file(filepath: string) {
-    return runPromise((s) => s.file(filepath))
-  }
 }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -17,7 +17,7 @@ export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await Plugin.init()
   void AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
-  Format.init()
+  void AppRuntime.runPromise(Format.Service.use((svc) => svc.init()))
   await LSP.init()
   File.init()
   FileWatcher.init()

--- a/packages/opencode/src/server/instance.ts
+++ b/packages/opencode/src/server/instance.ts
@@ -30,6 +30,7 @@ import { ProviderRoutes } from "./routes/provider"
 import { EventRoutes } from "./routes/event"
 import { errorHandler } from "./middleware"
 import { getMimeType } from "hono/utils/mime"
+import { AppRuntime } from "@/effect/app-runtime"
 
 const log = Log.create({ service: "server" })
 
@@ -277,7 +278,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()
         },
       }),
       async (c) => {
-        return c.json(await Format.status())
+        return c.json(await AppRuntime.runPromise(Format.Service.use((svc) => svc.status())))
       },
     )
     .all("/*", async (c) => {


### PR DESCRIPTION
## Summary
- remove the `Format` async facade wrappers and keep `packages/opencode/src/format/index.ts` service-only
- migrate the bootstrap and server formatter status edge to `AppRuntime.runPromise(Format.Service.use(...))`
- preserve existing formatter behavior while aligning callers with direct service usage

## Verification
- `bun run typecheck`
- `bun run test test/format/format.test.ts`