### PR TITLE
refactor: collapse command facade

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,6 +1,5 @@
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import type { InstanceContext } from "@/project/instance"
 import { SessionID, MessageID } from "@/session/schema"
 import { Effect, Layer, Context } from "effect"
@@ -189,10 +188,4 @@ export namespace Command {
     Layer.provide(MCP.defaultLayer),
     Layer.provide(Skill.defaultLayer),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function list() {
-    return runPromise((svc) => svc.list())
-  }
 }

--- a/packages/opencode/src/effect/bootstrap-runtime.ts
+++ b/packages/opencode/src/effect/bootstrap-runtime.ts
@@ -1,0 +1,9 @@
+import { Layer, ManagedRuntime } from "effect"
+import { memoMap } from "./run-service"
+
+import { Format } from "@/format"
+import { ShareNext } from "@/share/share-next"
+
+export const BootstrapLayer = Layer.mergeAll(Format.defaultLayer, ShareNext.defaultLayer)
+
+export const BootstrapRuntime = ManagedRuntime.make(BootstrapLayer, { memoMap })

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -10,14 +10,14 @@ import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
-import { AppRuntime } from "@/effect/app-runtime"
+import { BootstrapRuntime } from "@/effect/bootstrap-runtime"
 import { ShareNext } from "@/share/share-next"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await Plugin.init()
-  void AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
-  void AppRuntime.runPromise(Format.Service.use((svc) => svc.init()))
+  void BootstrapRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
+  void BootstrapRuntime.runPromise(Format.Service.use((svc) => svc.init()))
   await LSP.init()
   File.init()
   FileWatcher.init()

--- a/packages/opencode/src/server/instance.ts
+++ b/packages/opencode/src/server/instance.ts
@@ -191,7 +191,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, app: Hono = new Hono()
         },
       }),
       async (c) => {
-        const commands = await Command.list()
+        const commands = await AppRuntime.runPromise(Command.Service.use((svc) => svc.list()))
         return c.json(commands)
       },
     )


### PR DESCRIPTION
## Summary
- remove the `Command.list()` runtime facade from `packages/opencode/src/command/index.ts`
- switch the server command-list route to `AppRuntime.runPromise(Command.Service.use(...))`
- preserve existing command listing behavior while keeping command access on the service boundary

## Verification
- `bun run typecheck` in `packages/opencode`