### PR TITLE
refactor(git): remove runtime facade wrappers

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -29,6 +29,7 @@ import { Provider } from "../../provider/provider"
 import { Bus } from "../../bus"
 import { MessageV2 } from "../../session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
+import { AppRuntime } from "@/effect/app-runtime"
 import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
@@ -258,7 +259,9 @@ export const GithubInstallCommand = cmd({
             }
 
             // Get repo info
-            const info = (await Git.run(["remote", "get-url", "origin"], { cwd: Instance.worktree })).text().trim()
+            const info = await AppRuntime.runPromise(
+              Git.Service.use((git) => git.run(["remote", "get-url", "origin"], { cwd: Instance.worktree })),
+            ).then((x) => x.text().trim())
             const parsed = parseGitHubRemote(info)
             if (!parsed) {
               prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
@@ -497,20 +500,21 @@ export const GithubRunCommand = cmd({
           : "issue"
         : undefined
       const gitText = async (args: string[]) => {
-        const result = await Git.run(args, { cwd: Instance.worktree })
+        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result.text().trim()
       }
       const gitRun = async (args: string[]) => {
-        const result = await Git.run(args, { cwd: Instance.worktree })
+        const result = await AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
         if (result.exitCode !== 0) {
           throw new Process.RunFailedError(["git", ...args], result.exitCode, result.stdout, result.stderr)
         }
         return result
       }
-      const gitStatus = (args: string[]) => Git.run(args, { cwd: Instance.worktree })
+      const gitStatus = (args: string[]) =>
+        AppRuntime.runPromise(Git.Service.use((git) => git.run(args, { cwd: Instance.worktree })))
       const commitChanges = async (summary: string, actor?: string) => {
         const args = ["commit", "-m", summary]
         if (actor) args.push("-m", `Co-authored-by: ${actor} <${actor}@users.noreply.github.com>`)

--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -1,5 +1,6 @@
 import { UI } from "../ui"
 import { cmd } from "./cmd"
+import { AppRuntime } from "@/effect/app-runtime"
 import { Git } from "@/git"
 import { Instance } from "@/project/instance"
 import { Process } from "@/util/process"
@@ -67,19 +68,29 @@ export const PrCommand = cmd({
               const remoteName = forkOwner
 
               // Check if remote already exists
-              const remotes = (await Git.run(["remote"], { cwd: Instance.worktree })).text().trim()
+              const remotes = await AppRuntime.runPromise(
+                Git.Service.use((git) => git.run(["remote"], { cwd: Instance.worktree })),
+              ).then((x) => x.text().trim())
               if (!remotes.split("\n").includes(remoteName)) {
-                await Git.run(["remote", "add", remoteName, `https://github.com/${forkOwner}/${forkName}.git`], {
-                  cwd: Instance.worktree,
-                })
+                await AppRuntime.runPromise(
+                  Git.Service.use((git) =>
+                    git.run(["remote", "add", remoteName, `https://github.com/${forkOwner}/${forkName}.git`], {
+                      cwd: Instance.worktree,
+                    }),
+                  ),
+                )
                 UI.println(`Added fork remote: ${remoteName}`)
               }
 
               // Set upstream to the fork so pushes go there
               const headRefName = prInfo.headRefName
-              await Git.run(["branch", `--set-upstream-to=${remoteName}/${headRefName}`, localBranchName], {
-                cwd: Instance.worktree,
-              })
+              await AppRuntime.runPromise(
+                Git.Service.use((git) =>
+                  git.run(["branch", `--set-upstream-to=${remoteName}/${headRefName}`, localBranchName], {
+                    cwd: Instance.worktree,
+                  }),
+                ),
+              )
             }
 
             // Check for opencode session link in PR body

--- a/packages/opencode/src/effect/bootstrap-runtime.ts
+++ b/packages/opencode/src/effect/bootstrap-runtime.ts
@@ -1,0 +1,9 @@
+import { Layer, ManagedRuntime } from "effect"
+import { memoMap } from "./run-service"
+
+import { Format } from "@/format"
+import { ShareNext } from "@/share/share-next"
+
+export const BootstrapLayer = Layer.mergeAll(Format.defaultLayer, ShareNext.defaultLayer)
+
+export const BootstrapRuntime = ManagedRuntime.make(BootstrapLayer, { memoMap })

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -1,7 +1,6 @@
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { Effect, Layer, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { makeRuntime } from "@/effect/run-service"
 
 export namespace Git {
   const cfg = [
@@ -258,14 +257,4 @@ export namespace Git {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(CrossSpawnSpawner.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function run(args: string[], opts: Options) {
-    return runPromise((git) => git.run(args, opts))
-  }
-
-  export async function defaultBranch(cwd: string) {
-    return runPromise((git) => git.defaultBranch(cwd))
-  }
 }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -10,14 +10,14 @@ import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
-import { AppRuntime } from "@/effect/app-runtime"
+import { BootstrapRuntime } from "@/effect/bootstrap-runtime"
 import { ShareNext } from "@/share/share-next"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await Plugin.init()
-  void AppRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
-  void AppRuntime.runPromise(Format.Service.use((svc) => svc.init()))
+  void BootstrapRuntime.runPromise(ShareNext.Service.use((svc) => svc.init()))
+  void BootstrapRuntime.runPromise(Format.Service.use((svc) => svc.init()))
   await LSP.init()
   File.init()
   FileWatcher.init()


### PR DESCRIPTION
## Summary
- remove the async `Git.run()` and `Git.defaultBranch()` facade wrappers from `packages/opencode/src/git/index.ts`
- migrate the remaining CLI edge callers to `AppRuntime.runPromise(Git.Service.use(...))`
- keep the existing Git service behavior unchanged while narrowing access to the Effect service surface

## Verification
- `bun run typecheck`
- `bun run test test/git/git.test.ts`