### PR TITLE
refactor: remove ProviderAuth facade

### DIFF
--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -2,7 +2,6 @@ import type { AuthOAuthResult, Hooks } from "@opencode-ai/plugin"
 import { NamedError } from "@opencode-ai/util/error"
 import { Auth } from "@/auth"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Plugin } from "../plugin"
 import { ProviderID } from "./schema"
 import { Array as Arr, Effect, Layer, Record, Result, Context } from "effect"
@@ -232,22 +231,4 @@ export namespace ProviderAuth {
   export const defaultLayer = Layer.suspend(() =>
     layer.pipe(Layer.provide(Auth.defaultLayer), Layer.provide(Plugin.defaultLayer)),
   )
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function methods() {
-    return runPromise((svc) => svc.methods())
-  }
-
-  export async function authorize(input: {
-    providerID: ProviderID
-    method: number
-    inputs?: Record<string, string>
-  }): Promise<Authorization | undefined> {
-    return runPromise((svc) => svc.authorize(input))
-  }
-
-  export async function callback(input: { providerID: ProviderID; method: number; code?: string }) {
-    return runPromise((svc) => svc.callback(input))
-  }
 }

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -6,6 +6,7 @@ import { Provider } from "../../provider/provider"
 import { ModelsDev } from "../../provider/models"
 import { ProviderAuth } from "../../provider/auth"
 import { ProviderID } from "../../provider/schema"
+import { AppRuntime } from "../../effect/app-runtime"
 import { mapValues } from "remeda"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
@@ -81,7 +82,7 @@ export const ProviderRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json(await ProviderAuth.methods())
+        return c.json(await AppRuntime.runPromise(ProviderAuth.Service.use((svc) => svc.methods())))
       },
     )
     .post(
@@ -118,11 +119,15 @@ export const ProviderRoutes = lazy(() =>
       async (c) => {
         const providerID = c.req.valid("param").providerID
         const { method, inputs } = c.req.valid("json")
-        const result = await ProviderAuth.authorize({
-          providerID,
-          method,
-          inputs,
-        })
+        const result = await AppRuntime.runPromise(
+          ProviderAuth.Service.use((svc) =>
+            svc.authorize({
+              providerID,
+              method,
+              inputs,
+            }),
+          ),
+        )
         return c.json(result)
       },
     )
@@ -160,11 +165,15 @@ export const ProviderRoutes = lazy(() =>
       async (c) => {
         const providerID = c.req.valid("param").providerID
         const { method, code } = c.req.valid("json")
-        await ProviderAuth.callback({
-          providerID,
-          method,
-          code,
-        })
+        await AppRuntime.runPromise(
+          ProviderAuth.Service.use((svc) =>
+            svc.callback({
+              providerID,
+              method,
+              code,
+            }),
+          ),
+        )
         return c.json(true)
       },
     ),

--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
 import fs from "fs/promises"
+import { Effect } from "effect"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { ProviderAuth } from "../../src/provider/auth"
@@ -39,14 +40,18 @@ describe("plugin.auth-override", () => {
     const methods = await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        return ProviderAuth.methods()
+        return Effect.runPromise(
+          ProviderAuth.Service.use((svc) => svc.methods()).pipe(Effect.provide(ProviderAuth.defaultLayer)),
+        )
       },
     })
 
     const plainMethods = await Instance.provide({
       directory: plain.path,
       fn: async () => {
-        return ProviderAuth.methods()
+        return Effect.runPromise(
+          ProviderAuth.Service.use((svc) => svc.methods()).pipe(Effect.provide(ProviderAuth.defaultLayer)),
+        )
       },
     })
 


### PR DESCRIPTION
## Summary
- remove the `ProviderAuth` async facade wrappers and `makeRuntime` usage from the service module
- call `ProviderAuth.Service` directly from the provider route handlers via `AppRuntime.runPromise`
- update the auth override test to exercise the service directly with `ProviderAuth.defaultLayer`

## Verification
- `bun run typecheck`
- `bun run test test/plugin/auth-override.test.ts`