### PR TITLE
refactor(session): remove dead updatePartDelta facade

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -851,14 +851,4 @@ export namespace Session {
     return runPromise((svc) => svc.updatePart(part))
   }
 
-  export const updatePartDelta = fn(
-    z.object({
-      sessionID: SessionID.zod,
-      messageID: MessageID.zod,
-      partID: PartID.zod,
-      field: z.string(),
-      delta: z.string(),
-    }),
-    (input) => runPromise((svc) => svc.updatePartDelta(input)),
-  )
 }


### PR DESCRIPTION
## Summary
- Remove the `Session.updatePartDelta` facade function which had zero callers anywhere in the codebase (src or tests)
- The underlying service method is still used directly via Effect in `processor.ts`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test test/session/` — 242 tests pass
- [x] `bun test test/bus/ test/file/` — 118 tests pass