### PR TITLE
refactor(plugin): return Effect from ToolContext.ask

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -450,6 +450,7 @@
       "version": "1.4.3",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
+        "effect": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -30,7 +30,6 @@ import { Glob } from "../util/glob"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Effect, Layer, Context } from "effect"
-import { EffectLogger } from "@/effect/logger"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
@@ -137,7 +136,7 @@ export namespace ToolRegistry {
                 Effect.gen(function* () {
                   const pluginCtx: PluginToolContext = {
                     ...toolCtx,
-                    ask: (req) => Effect.runPromise(toolCtx.ask(req).pipe(Effect.provide(EffectLogger.layer))),
+                    ask: (req) => toolCtx.ask(req),
                     directory: ctx.directory,
                     worktree: ctx.worktree,
                   }

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "@opencode-ai/sdk": "workspace:*",
+    "effect": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { Effect } from "effect"
 
 export type ToolContext = {
   sessionID: string
@@ -16,7 +17,7 @@ export type ToolContext = {
   worktree: string
   abort: AbortSignal
   metadata(input: { title?: string; metadata?: { [key: string]: any } }): void
-  ask(input: AskInput): Promise<void>
+  ask(input: AskInput): Effect.Effect<void>
 }
 
 type AskInput = {


### PR DESCRIPTION
## Summary
- Change `ToolContext.ask` return type from `Promise<void>` to `Effect.Effect<void>` in `@opencode-ai/plugin`
- Remove the `Effect.runPromise` bridge in `registry.ts` that was converting between the two
- Add `effect` as a dependency of the plugin package

## Test plan
- [x] `bun run typecheck` passes for both `packages/plugin` and `packages/opencode`
- [x] `bun run test test/tool/` — all 167 tests pass