### PR TITLE
docs(web): add opencode-preview to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -27,6 +27,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                          |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.        |
+| [opencode-preview](https://github.com/Edison-A-N/opencode-preview)                              | Instant file preview (Markdown, DrawIO, HTML, CSV, code) with live reload and dark mode      |
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                             |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                      |


### PR DESCRIPTION
### Issue for this PR

N/A — This is a community plugin submission to the ecosystem page, as invited by the page itself: "Want to add your OpenCode related project to this list? Submit a PR."

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-preview](https://github.com/Edison-A-N/opencode-preview) to the Plugins table in `ecosystem.mdx`.

opencode-preview is an OpenCode plugin that auto-starts a file preview server. It supports Markdown (GFM + syntax highlighting), DrawIO diagrams, sandboxed HTML, CSV tables, and 40+ code languages. Features include WebSocket live reload, dark mode, multi-project URL isolation, and a TUI sidebar widget. Install is one line of JSON: `"plugin": ["Edison-A-N/opencode-preview"]`.

I built this plugin because switching out of the terminal to preview files breaks flow. This keeps everything in one place.

### How did you verify your code works?

This is a documentation-only change (one table row added to ecosystem.mdx). Verified the Markdown table syntax is correct and the entry is in alphabetical order among existing plugins.

### Screenshots / recordings

_N/A — documentation change only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR