### PR TITLE
fix(tui): surface nested subagent prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -87,6 +87,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { TuiPluginRuntime } from "../../plugin"
 import { DialogGoUpsell } from "../../component/dialog-go-upsell"
 import { SessionRetry } from "@/session/retry"
+import { sessionChildren, sessionPermissionRequest, sessionQuestionRequest } from "./request-tree"
 
 addDefaultParsers(parsers.parsers)
 
@@ -125,20 +126,19 @@ export function Session() {
   const { theme } = useTheme()
   const promptRef = usePromptRef()
   const session = createMemo(() => sync.session.get(route.sessionID))
-  const children = createMemo(() => {
-    const parentID = session()?.parentID ?? session()?.id
-    return sync.data.session
-      .filter((x) => x.parentID === parentID || x.id === parentID)
-      .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
-  })
+  const children = createMemo(() => sessionChildren(sync.data.session, session()))
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+    const request = sessionPermissionRequest(sync.data.session, sync.data.permission, session())
+    if (!request) return []
+    return [request]
   })
   const questions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
+    const request = sessionQuestionRequest(sync.data.session, sync.data.question, session())
+    if (!request) return []
+    return [request]
   })
   const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/request-tree.ts
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/request-tree.ts
@@ -1,0 +1,62 @@
+import type { PermissionRequest, QuestionRequest, Session } from "@opencode-ai/sdk/v2"
+
+export function sessionChildren(list: Session[], current?: Session) {
+  const id = current?.parentID ?? current?.id
+  if (!id) return []
+  return list
+    .filter((item) => item.parentID === id || item.id === id)
+    .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+}
+
+function sessionTreeRequest<T>(
+  sessions: Session[],
+  requests: Record<string, T[] | undefined>,
+  current?: Session,
+  include: (item: T) => boolean = () => true,
+) {
+  const id = current?.parentID ?? current?.id
+  if (!id) return
+
+  const map = sessions.reduce((acc, item) => {
+    if (!item.parentID) return acc
+    const list = acc.get(item.parentID)
+    if (list) list.push(item.id)
+    if (!list) acc.set(item.parentID, [item.id])
+    return acc
+  }, new Map<string, string[]>())
+
+  // Breadth-first traversal so root requests are preferred over descendants.
+  const seen = new Set([id])
+  const ids = [id]
+  for (const item of ids) {
+    const list = map.get(item)
+    if (!list) continue
+    for (const child of list) {
+      if (seen.has(child)) continue
+      seen.add(child)
+      ids.push(child)
+    }
+  }
+
+  const hit = ids.find((item) => requests[item]?.some(include))
+  if (!hit) return
+  return requests[hit]?.find(include)
+}
+
+export function sessionPermissionRequest(
+  session: Session[],
+  request: Record<string, PermissionRequest[] | undefined>,
+  current?: Session,
+  include?: (item: PermissionRequest) => boolean,
+) {
+  return sessionTreeRequest(session, request, current, include)
+}
+
+export function sessionQuestionRequest(
+  session: Session[],
+  request: Record<string, QuestionRequest[] | undefined>,
+  current?: Session,
+  include?: (item: QuestionRequest) => boolean,
+) {
+  return sessionTreeRequest(session, request, current, include)
+}

--- a/packages/opencode/test/cli/tui/session-request-tree.test.ts
+++ b/packages/opencode/test/cli/tui/session-request-tree.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import type { PermissionRequest, QuestionRequest, Session } from "@opencode-ai/sdk/v2"
+import { sessionPermissionRequest, sessionQuestionRequest } from "../../../src/cli/cmd/tui/routes/session/request-tree"
+
+const session = (id: string, parentID?: string) => ({
+  id,
+  parentID,
+}) as Session
+
+const permission = (id: string, sessionID: string) => ({
+  id,
+  sessionID,
+}) as PermissionRequest
+
+const question = (id: string, sessionID: string) => ({
+  id,
+  sessionID,
+}) as QuestionRequest
+
+describe("session request tree", () => {
+  test("finds nested grandchild permission request from root session", () => {
+    const root = session("root")
+    const all = [root, session("child", "root"), session("grand", "child")]
+    const result = sessionPermissionRequest(all, { grand: [permission("perm-grand", "grand")] }, root)
+
+    expect(result?.id).toBe("perm-grand")
+  })
+
+  test("finds nested grandchild question request from root session", () => {
+    const root = session("root")
+    const all = [root, session("child", "root"), session("grand", "child")]
+    const result = sessionQuestionRequest(all, { grand: [question("q-grand", "grand")] }, root)
+
+    expect(result?.id).toBe("q-grand")
+  })
+})

--- a/packages/opencode/test/cli/tui/sync-provider.test.tsx
+++ b/packages/opencode/test/cli/tui/sync-provider.test.tsx
@@ -2,11 +2,13 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
+import type { Event, GlobalEvent } from "@opencode-ai/sdk/v2"
 import { ArgsProvider } from "../../../src/cli/cmd/tui/context/args"
 import { ExitProvider } from "../../../src/cli/cmd/tui/context/exit"
 import { ProjectProvider, useProject } from "../../../src/cli/cmd/tui/context/project"
 import { SDKProvider } from "../../../src/cli/cmd/tui/context/sdk"
 import { SyncProvider, useSync } from "../../../src/cli/cmd/tui/context/sync"
+import { sessionPermissionRequest, sessionQuestionRequest } from "../../../src/cli/cmd/tui/routes/session/request-tree"
 
 const sighup = new Set(process.listeners("SIGHUP"))
 
@@ -85,6 +87,94 @@ function data(workspace?: string | null) {
 type Hit = {
   path: string
   workspace?: string
+}
+
+function event(payload: Event, input: { directory: string; workspace?: string }): GlobalEvent {
+  return {
+    directory: input.directory,
+    workspace: input.workspace,
+    payload,
+  }
+}
+
+function createSource() {
+  let fn: ((event: GlobalEvent) => void) | undefined
+
+  return {
+    source: {
+      subscribe: async (handler: (event: GlobalEvent) => void) => {
+        fn = handler
+        return () => {
+          if (fn === handler) fn = undefined
+        }
+      },
+    },
+    emit(evt: GlobalEvent) {
+      if (!fn) throw new Error("event source not ready")
+      fn(evt)
+    },
+  }
+}
+
+function ses(id: string, updated: number, parentID?: string) {
+  return event(
+    {
+      type: "session.updated",
+      properties: {
+        info: {
+          id,
+          parentID,
+          title: id,
+          time: { updated },
+        },
+      },
+    } as Event,
+    { directory: "/tmp/root" },
+  )
+}
+
+function perm(id: string, sessionID: string) {
+  return event(
+    {
+      type: "permission.asked",
+      properties: {
+        id,
+        sessionID,
+        permission: "bash",
+        patterns: ["*"],
+        metadata: {},
+        always: [],
+      },
+    } as Event,
+    { directory: "/tmp/root" },
+  )
+}
+
+function ask(id: string, sessionID: string) {
+  return event(
+    {
+      type: "question.asked",
+      properties: {
+        id,
+        sessionID,
+        questions: [
+          {
+            question: "Pick one",
+            header: "pick",
+            options: [{ label: "one", description: "first" }],
+            multiple: false,
+          },
+        ],
+      },
+    } as Event,
+    { directory: "/tmp/root" },
+  )
+}
+
+function tree(source: ReturnType<typeof createSource>) {
+  source.emit(ses("root", 1))
+  source.emit(ses("child", 2, "root"))
+  source.emit(ses("grand", 3, "child"))
 }
 
 function createFetch(log: Hit[]) {
@@ -173,7 +263,7 @@ function createFetch(log: Hit[]) {
   ) satisfies typeof fetch
 }
 
-async function mount(log: Hit[]) {
+async function mount(log: Hit[], events?: { subscribe: (handler: (event: GlobalEvent) => void) => Promise<() => void> }) {
   let project!: ReturnType<typeof useProject>
   let sync!: ReturnType<typeof useSync>
   let done!: () => void
@@ -186,7 +276,7 @@ async function mount(log: Hit[]) {
       url="http://test"
       directory="/tmp/root"
       fetch={createFetch(log)}
-      events={{ subscribe: async () => () => {} }}
+      events={events ?? { subscribe: async () => () => {} }}
     >
       <ArgsProvider continue={false}>
         <ExitProvider>
@@ -285,6 +375,67 @@ describe("SyncProvider", () => {
       expect(sync.data.message.ses_1[0]?.id).toBe("msg_1")
       expect(sync.data.part.msg_1[0]).toMatchObject({ type: "text", text: "part-ws_b" })
       expect(sync.data.session_diff.ses_1[0]?.file).toBe("ws_b.ts")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("surfaces nested grandchild permission request from sync events", async () => {
+    const log: Hit[] = []
+    const source = createSource()
+    const { app, sync } = await mount(log, source.source)
+
+    try {
+      await waitBoot(log)
+
+      tree(source)
+      source.emit(perm("perm-grand", "grand"))
+
+      await wait(() => (sync.data.permission.grand?.length ?? 0) === 1)
+
+      const req = sessionPermissionRequest(sync.data.session, sync.data.permission, sync.session.get("root"))
+      expect(req?.id).toBe("perm-grand")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("surfaces nested grandchild question request from sync events", async () => {
+    const log: Hit[] = []
+    const source = createSource()
+    const { app, sync } = await mount(log, source.source)
+
+    try {
+      await waitBoot(log)
+
+      tree(source)
+      source.emit(ask("q-grand", "grand"))
+
+      await wait(() => (sync.data.question.grand?.length ?? 0) === 1)
+
+      const req = sessionQuestionRequest(sync.data.session, sync.data.question, sync.session.get("root"))
+      expect(req?.id).toBe("q-grand")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("prefers root permission request over descendant", async () => {
+    const log: Hit[] = []
+    const source = createSource()
+    const { app, sync } = await mount(log, source.source)
+
+    try {
+      await waitBoot(log)
+
+      tree(source)
+      source.emit(perm("perm-root", "root"))
+      source.emit(perm("perm-grand", "grand"))
+
+      await wait(() => (sync.data.permission.root?.length ?? 0) === 1 && (sync.data.permission.grand?.length ?? 0) === 1)
+
+      const req = sessionPermissionRequest(sync.data.session, sync.data.permission, sync.session.get("root"))
+      expect(req?.id).toBe("perm-root")
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
### Issue for this PR

Closes #13715

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The root TUI session only surfaced permission/question requests from direct child sessions, so prompts from deeper nested subagent sessions could hang without being shown.

This PR adds descendant-aware request selection (root-first traversal) and wires it into the TUI session route. It also adds regression tests at selector level and sync-provider integration level to cover nested prompt surfacing.

### How did you verify your code works?

- Reproduced with red/green flow:
  - temporarily reverted traversal logic and confirmed nested-grandchild tests fail
  - restored fix and confirmed tests pass
- Ran locally:
  - `bun test test/cli/tui/session-request-tree.test.ts`
  - `bun test test/cli/tui/sync-provider.test.tsx`
- Compiled and tested locally with the built binary; nested prompt surfacing works in live usage.

### Screenshots / recordings

N/A (logic + tests change; no UI layout/styling change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR