### PR TITLE
fix: use navigate for Electron session links

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -5,7 +5,7 @@ import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/util/path"
-import { A, useParams } from "@solidjs/router"
+import { A, useNavigate, useParams } from "@solidjs/router"
 import { type Accessor, createMemo, For, type JSX, Match, Show, Switch } from "solid-js"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -94,16 +94,20 @@ const SessionRow = (props: {
   sidebarOpened: Accessor<boolean>
   warmPress: () => void
   warmFocus: () => void
+  onSelect: () => void
 }): JSX.Element => {
   const title = () => sessionTitle(props.session.title)
+  const href = () => `/${props.slug}/session/${props.session.id}`
 
   return (
     <A
-      href={`/${props.slug}/session/${props.session.id}`}
+      href={href()}
       class={`flex items-center gap-2 min-w-0 w-full text-left focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
       onPointerDown={props.warmPress}
       onFocus={props.warmFocus}
-      onClick={() => {
+      onClick={(event) => {
+        event.preventDefault()
+        props.onSelect()
         if (props.sidebarOpened()) return
         props.clearHoverProjectSoon()
       }}
@@ -135,6 +139,7 @@ const SessionRow = (props: {
 }
 
 export const SessionItem = (props: SessionItemProps): JSX.Element => {
+  const navigate = useNavigate()
   const params = useParams()
   const layout = useLayout()
   const language = useLanguage()
@@ -207,6 +212,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       sidebarOpened={layout.sidebar.opened}
       warmPress={() => warm(2, "high")}
       warmFocus={() => warm(2, "high")}
+      onSelect={() => navigate(`/${props.slug}/session/${props.session.id}`)}
     />
   )
 


### PR DESCRIPTION
### Issue for this PR 22024

Closes #22024

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an Electron issue where clicking a session from the sidebar could leave the session view empty, even though selecting the workspace loaded the last session correctly.

The change updates session sidebar navigation to call the router's `navigate()` API explicitly instead of relying only on link navigation. This matches the working workspace navigation path and fixes the empty session view when switching sessions in Electron.

### How did you verify your code works?

Tested locally in the Electron app by switching between sessions from the sidebar and confirming the selected session now loads correctly.

I also ran `bun typecheck` in `packages/app`, but it is currently blocked by a pre-existing unrelated error in `packages/app/src/custom-elements.d.ts`.

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR