### PR TITLE
feat: compression improvements

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -7,6 +7,7 @@ import z from "zod"
 import { ModelsDev } from "../provider/models"
 import { mergeDeep, pipe, unique } from "remeda"
 import { Global } from "../global"
+import { EventEmitter } from "events"
 import fsNode from "fs/promises"
 import { NamedError } from "@opencode-ai/util/error"
 import { Flag } from "../flag/flag"
@@ -1543,6 +1544,28 @@ export namespace Config {
         const state = yield* InstanceState.make<State>(
           Effect.fn("Config.state")(function* (ctx) {
             return yield* loadInstanceState(ctx)
+          }),
+        )
+
+        // Hot-reload: listen for config file changes via GlobalBus
+        const CONFIG_FILENAMES = ["opencode.json", "opencode.jsonc", "config.json"]
+        let reloadTimer: ReturnType<typeof setTimeout> | undefined
+        const listener = (evt: any) => {
+          if (evt?.payload?.type !== "file.watcher.updated") return
+          if (evt?.payload?.properties?.event === "unlink") return
+          const file = evt?.payload?.properties?.file as string | undefined
+          if (!file) return
+          if (!CONFIG_FILENAMES.some((name) => file.endsWith(name) && !file.includes("node_modules"))) return
+          if (reloadTimer) clearTimeout(reloadTimer)
+          reloadTimer = setTimeout(() => {
+            log.info("config file changed, reloading", { file })
+            void Instance.disposeAll().catch(() => {})
+          }, 500)
+        }
+        EventEmitter.prototype.on.call(GlobalBus, "event", listener)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            EventEmitter.prototype.off.call(GlobalBus, "event", listener)
           }),
         )
 

--- a/packages/opencode/src/filesystem/index.ts
+++ b/packages/opencode/src/filesystem/index.ts
@@ -6,6 +6,7 @@ import { lookup } from "mime-types"
 import { Effect, FileSystem, Layer, Schema, Context } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { Glob } from "../util/glob"
+import { Platform } from "../util/platform"
 
 export namespace AppFileSystem {
   export class FileSystemError extends Schema.TaggedErrorClass<FileSystemError>()("FileSystemError", {
@@ -188,6 +189,8 @@ export namespace AppFileSystem {
 
   export function normalizePath(p: string): string {
     if (process.platform !== "win32") return p
+    // WSL UNC paths are already valid Windows paths — skip realpathSync
+    if (Platform.isWslUncPath(p)) return p
     const resolved = pathResolve(windowsPath(p))
     try {
       return realpathSync.native(resolved)

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -1,6 +1,7 @@
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { Effect, Layer, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Platform } from "@/util/platform"
 
 export namespace Git {
   const cfg = [
@@ -88,14 +89,27 @@ export namespace Git {
 
       const run = Effect.fn("Git.run")(
         function* (args: string[], opts: Options) {
-          const proc = ChildProcess.make("git", [...cfg, ...args], {
-            cwd: opts.cwd,
-            env: opts.env,
-            extendEnv: true,
-            stdin: "ignore",
-            stdout: "pipe",
-            stderr: "pipe",
-          })
+          // When cwd is a WSL UNC path, run git inside WSL
+          const wslInfo = Platform.isWslUncPath(opts.cwd) ? Platform.parseWslUncPath(opts.cwd) : undefined
+
+          const proc =
+            wslInfo && process.platform === "win32"
+              ? ChildProcess.make("wsl.exe", ["-d", wslInfo.distro, "-e", "git", ...cfg, ...args], {
+                  cwd: process.env.SYSTEMROOT || "C:\\Windows",
+                  env: opts.env,
+                  extendEnv: true,
+                  stdin: "ignore",
+                  stdout: "pipe",
+                  stderr: "pipe",
+                })
+              : ChildProcess.make("git", [...cfg, ...args], {
+                  cwd: opts.cwd,
+                  env: opts.env,
+                  extendEnv: true,
+                  stdin: "ignore",
+                  stdout: "pipe",
+                  stderr: "pipe",
+                })
           const handle = yield* spawner.spawn(proc)
           const [stdout, stderr] = yield* Effect.all(
             [Stream.mkString(Stream.decodeText(handle.stdout)), Stream.mkString(Stream.decodeText(handle.stderr))],

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -7,6 +7,7 @@ import { Flag } from "@/flag/flag"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
 import { which } from "../util/which"
+import { Platform } from "../util/platform"
 import { ProjectID } from "./schema"
 import { Effect, Layer, Path, Scope, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
@@ -149,6 +150,11 @@ export namespace Project {
         if (!name) return cwd
         name = name.replace(/[\r\n]+$/, "")
         if (!name) return cwd
+        // Don't convert WSL UNC paths through windowsPath — they're already valid
+        if (Platform.isWslUncPath(cwd)) {
+          if (pathSvc.isAbsolute(name)) return pathSvc.normalize(name)
+          return pathSvc.resolve(cwd, name)
+        }
         name = AppFileSystem.windowsPath(name)
         if (pathSvc.isAbsolute(name)) return pathSvc.normalize(name)
         return pathSvc.resolve(cwd, name)

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -28,6 +28,21 @@ export namespace ProviderError {
     /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
   ]
 
+  const CONNECTION_PATTERNS = /ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|fetch failed/i
+  const LOCALHOST_PATTERN = /(?:localhost|127\.0\.0\.1|\[::1\]):\d+/
+
+  function localProviderHint(url: string | undefined, providerID: string): string | undefined {
+    if (!url || !LOCALHOST_PATTERN.test(url)) return undefined
+
+    if (providerID === "ollama" || url.includes(":11434")) return "Is Ollama running? Start it with: ollama serve"
+    if (providerID === "litellm" || url.includes(":4000"))
+      return "Is LiteLLM proxy running? Check your base URL and API key"
+    if (providerID === "lm-studio" || url.includes(":1234"))
+      return "Is LM Studio server running? Open LM Studio and start the local server"
+    if (providerID === "localai") return "Is LocalAI server running? Check your configuration"
+    return "Cannot connect to local provider. Is the server running?"
+  }
+
   function isOpenAiErrorRetryable(e: APICallError) {
     const status = e.statusCode
     if (!status) return e.isRetryable
@@ -178,6 +193,23 @@ export namespace ProviderError {
         type: "context_overflow",
         message: m,
         responseBody: input.error.responseBody,
+      }
+    }
+
+    // Detect connection errors to local providers and add helpful hints
+    if (CONNECTION_PATTERNS.test(m)) {
+      const hint = localProviderHint(input.error.url, input.providerID)
+      if (hint) {
+        const metadata = input.error.url ? { url: input.error.url } : undefined
+        return {
+          type: "api_error",
+          message: `${m}. ${hint}`,
+          statusCode: input.error.statusCode,
+          isRetryable: false,
+          responseHeaders: input.error.responseHeaders,
+          responseBody: input.error.responseBody,
+          metadata,
+        }
       }
     }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -815,6 +815,27 @@ export namespace Provider {
             },
           },
         }),
+      litellm: Effect.fnUntraced(function* (input: Info) {
+        const providerConfig = (yield* dep.config()).provider?.["litellm"]
+        const apiKey = Env.get("LITELLM_API_KEY")
+        const baseURL = providerConfig?.options?.baseURL ?? providerConfig?.api
+
+        if (!baseURL) {
+          return { autoload: false }
+        }
+
+        const options: Record<string, any> = { baseURL }
+        if (apiKey) options.apiKey = apiKey
+        else if (providerConfig?.options?.apiKey) options.apiKey = providerConfig.options.apiKey
+
+        return {
+          autoload: true,
+          options,
+          async getModel(sdk: any, modelID: string) {
+            return sdk.languageModel(modelID)
+          },
+        }
+      }),
     }
   }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1091,6 +1091,13 @@ export namespace Provider {
           // extend database from config
           for (const [providerID, provider] of configProviders) {
             const existing = database[providerID]
+
+            // Validate custom providers that have no database entry
+            if (!existing && !provider.api && !provider.npm && !provider.models) {
+              log.warn("custom provider has no api, npm, or models — skipping", { providerID })
+              continue
+            }
+
             const parsed: Info = {
               id: ProviderID.make(providerID),
               name: provider.name ?? existing?.name ?? providerID,
@@ -1175,6 +1182,12 @@ export namespace Provider {
               )
               parsed.models[modelID] = parsedModel
             }
+
+            // Warn if custom provider has models with no context limit
+            if (!existing && Object.values(parsed.models).some((m) => m.limit.context === 0)) {
+              log.warn("custom provider models have no context limit — set limit.context in config", { providerID })
+            }
+
             database[providerID] = parsed
           }
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -4,6 +4,7 @@ import { Session } from "."
 import { SessionID, MessageID, PartID } from "./schema"
 import { Instance } from "../project/instance"
 import { Provider } from "../provider/provider"
+import { ProviderTransform } from "../provider/transform"
 import { MessageV2 } from "./message-v2"
 import z from "zod"
 import { Token } from "../util/token"
@@ -33,8 +34,17 @@ export namespace SessionCompaction {
   }
 
   export const PRUNE_MINIMUM = 20_000
-  export const PRUNE_PROTECT = 40_000
-  const PRUNE_PROTECTED_TOOLS = ["skill"]
+  export const PRUNE_PROTECT_MIN = 20_000
+  export const PRUNE_PROTECT_RATIO = 0.15
+  export const PRUNE_PROACTIVE_RATIO = 0.5
+  const PRUNE_PROTECTED_TOOLS = [
+    "skill",
+    "compress",
+    "todowrite",
+    "background_output",
+    "lsp_diagnostics",
+    "lsp_symbols",
+  ]
 
   export interface Interface {
     readonly isOverflow: (input: {
@@ -42,6 +52,11 @@ export namespace SessionCompaction {
       model: Provider.Model
     }) => Effect.Effect<boolean>
     readonly prune: (input: { sessionID: SessionID }) => Effect.Effect<void>
+    readonly pruneIfNeeded: (input: {
+      sessionID: SessionID
+      tokens: MessageV2.Assistant["tokens"]
+      model: Provider.Model
+    }) => Effect.Effect<void>
     readonly process: (input: {
       parentID: MessageID
       messages: MessageV2.WithParts[]
@@ -100,6 +115,16 @@ export namespace SessionCompaction {
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed(undefined)))
         if (!msgs) return
 
+        let contextLimit = 128_000
+        const lastAssistant = msgs.findLast((m) => m.info.role === "assistant")
+        if (lastAssistant && lastAssistant.info.role === "assistant") {
+          try {
+            const model = yield* provider.getModel(lastAssistant.info.providerID, lastAssistant.info.modelID)
+            contextLimit = model.limit.context || 128_000
+          } catch {}
+        }
+        const protect = Math.max(PRUNE_PROTECT_MIN, Math.round(contextLimit * PRUNE_PROTECT_RATIO))
+
         let total = 0
         let pruned = 0
         const toPrune: MessageV2.ToolPart[] = []
@@ -115,10 +140,10 @@ export namespace SessionCompaction {
             if (part.type === "tool")
               if (part.state.status === "completed") {
                 if (PRUNE_PROTECTED_TOOLS.includes(part.tool)) continue
-                if (part.state.time.compacted) break loop
+                if (part.state.time.compacted) continue
                 const estimate = Token.estimate(part.state.output)
                 total += estimate
-                if (total > PRUNE_PROTECT) {
+                if (total > protect) {
                   pruned += estimate
                   toPrune.push(part)
                 }
@@ -368,9 +393,30 @@ When constructing the summary, try to stick to this template:
         })
       })
 
+      const pruneIfNeeded = Effect.fn("SessionCompaction.pruneIfNeeded")(function* (input: {
+        sessionID: SessionID
+        tokens: MessageV2.Assistant["tokens"]
+        model: Provider.Model
+      }) {
+        const cfg = yield* config.get()
+        if (cfg.compaction?.prune === false) return
+        const context = input.model.limit.context
+        if (context === 0) return
+        const maxOutput = ProviderTransform.maxOutputTokens(input.model)
+        const reserved = cfg.compaction?.reserved ?? Math.min(20_000, maxOutput)
+        const usable = input.model.limit.input ? input.model.limit.input - reserved : context - maxOutput
+        const count =
+          input.tokens.total ||
+          input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
+        if (count < usable * PRUNE_PROACTIVE_RATIO) return
+        log.info("proactive prune triggered", { count, usable, ratio: count / usable })
+        yield* prune({ sessionID: input.sessionID })
+      })
+
       return Service.of({
         isOverflow,
         prune,
+        pruneIfNeeded,
         process: processCompaction,
         create,
       })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -11,7 +11,9 @@ import { Session } from "."
 import { LLM } from "./llm"
 import { MessageV2 } from "./message-v2"
 import { isOverflow } from "./overflow"
+import { SessionCompaction } from "./compaction"
 import { Token } from "@/util/token"
+import { ProviderTransform } from "@/provider/transform"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
@@ -398,6 +400,20 @@ export namespace SessionProcessor {
                 isOverflow({ cfg: yield* config.get(), tokens: usage.tokens, model: ctx.model })
               ) {
                 ctx.needsCompaction = true
+              }
+              if (!ctx.assistantMessage.summary) {
+                const context = ctx.model.limit.context
+                if (context > 0) {
+                  const maxOutput = ProviderTransform.maxOutputTokens(ctx.model)
+                  const reserved = (yield* config.get()).compaction?.reserved ?? Math.min(20_000, maxOutput)
+                  const usable = ctx.model.limit.input ? ctx.model.limit.input - reserved : context - maxOutput
+                  const count =
+                    usage.tokens.total ||
+                    usage.tokens.input + usage.tokens.output + usage.tokens.cache.read + usage.tokens.cache.write
+                  if (count >= usable * 0.5) {
+                    SessionCompaction.prune({ sessionID: ctx.sessionID })
+                  }
+                }
               }
               return
             }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -11,6 +11,7 @@ import { Session } from "."
 import { LLM } from "./llm"
 import { MessageV2 } from "./message-v2"
 import { isOverflow } from "./overflow"
+import { Token } from "@/util/token"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
@@ -72,6 +73,7 @@ export namespace SessionProcessor {
     needsCompaction: boolean
     currentText: MessageV2.TextPart | undefined
     reasoningMap: Record<string, MessageV2.ReasoningPart>
+    sentChars: number
   }
 
   type StreamEvent = Event
@@ -119,6 +121,7 @@ export namespace SessionProcessor {
           needsCompaction: false,
           currentText: undefined,
           reasoningMap: {},
+          sentChars: 0,
         }
         let aborted = false
         const slog = log.with({ sessionID: input.sessionID, messageID: input.assistantMessage.id })
@@ -360,6 +363,7 @@ export namespace SessionProcessor {
               ctx.assistantMessage.finish = value.finishReason
               ctx.assistantMessage.cost += usage.cost
               ctx.assistantMessage.tokens = usage.tokens
+              Token.updateRatio({ chars: ctx.sentChars, tokens: usage.tokens.input })
               yield* session.updatePart({
                 id: PartID.ascending(),
                 reason: value.finishReason,
@@ -539,6 +543,7 @@ export namespace SessionProcessor {
             yield* Effect.gen(function* () {
               ctx.currentText = undefined
               ctx.reasoningMap = {}
+              ctx.sentChars = JSON.stringify(streamInput.messages).length
               const stream = llm.stream(streamInput)
 
               yield* stream.pipe(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1362,6 +1362,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             }
 
             if (task?.type === "compaction") {
+              yield* compaction.prune({ sessionID })
               const result = yield* compaction.process({
                 messages: msgs,
                 parentID: lastUser.id,

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -2,6 +2,7 @@ import { Flag } from "@/flag/flag"
 import { lazy } from "@/util/lazy"
 import { Filesystem } from "@/util/filesystem"
 import { which } from "@/util/which"
+import { Platform } from "@/util/platform"
 import path from "path"
 import { spawn, type ChildProcess } from "child_process"
 import { setTimeout as sleep } from "node:timers/promises"
@@ -61,9 +62,14 @@ export namespace Shell {
     if (powershell) return powershell
   }
 
-  function select(file: string | undefined, opts?: { acceptable?: boolean }) {
+  function select(file: string | undefined, opts?: { acceptable?: boolean; directory?: string }) {
     if (file && (!opts?.acceptable || !BLACKLIST.has(name(file)))) return full(file)
     if (process.platform === "win32") {
+      // If the project is inside WSL filesystem, use wsl.exe as shell wrapper
+      if (opts?.directory && Platform.isWslUncPath(opts.directory)) {
+        const wsl = which("wsl.exe")
+        if (wsl) return wsl
+      }
       const shell = pick()
       if (shell) return shell
     }
@@ -107,4 +113,8 @@ export namespace Shell {
   export const preferred = lazy(() => select(process.env.SHELL))
 
   export const acceptable = lazy(() => select(process.env.SHELL, { acceptable: true }))
+
+  export function forDirectory(directory: string): string {
+    return select(process.env.SHELL, { acceptable: true, directory })
+  }
 }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -12,6 +12,7 @@ import { AppFileSystem } from "@/filesystem"
 import { fileURLToPath } from "url"
 import { Flag } from "@/flag/flag"
 import { Shell } from "@/shell/shell"
+import { Platform } from "@/util/platform"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncate"
@@ -23,6 +24,7 @@ import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 const PS = new Set(["powershell", "pwsh"])
+const WSL = new Set(["wsl.exe", "wsl"])
 const CWD = new Set(["cd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -243,8 +245,19 @@ const ask = Effect.fn("BashTool.ask")(function* (ctx: Tool.Context, scan: Scan) 
   })
 })
 
-function cmd(shell: string, name: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
-  if (process.platform === "win32" && PS.has(name)) {
+function cmd(shell: string, shName: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
+  if (process.platform === "win32" && WSL.has(shName)) {
+    const info = Platform.parseWslUncPath(cwd)
+    const args = info ? ["-d", info.distro, "-e", "bash", "-lc", command] : ["-e", "bash", "-lc", command]
+    return ChildProcess.make(shell, args, {
+      cwd: process.env.SYSTEMROOT || "C:\\Windows",
+      env,
+      stdin: "ignore",
+      detached: false,
+    })
+  }
+
+  if (process.platform === "win32" && PS.has(shName)) {
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
       cwd,
       env,
@@ -455,10 +468,11 @@ export const BashTool = Tool.define(
     })
 
     return async () => {
-      const shell = Shell.acceptable()
-      const name = Shell.name(shell)
-      const chain =
-        name === "powershell"
+      const shell = Shell.forDirectory(Instance.directory)
+      const shName = Shell.name(shell)
+      const chain = WSL.has(shName)
+        ? "Commands run inside WSL via bash. Use '&&' to chain dependent commands (e.g., `git add . && git commit -m \"message\"`)."
+        : shName === "powershell"
           ? "If the commands depend on each other and must run sequentially, avoid '&&' in this shell because Windows PowerShell 5.1 does not support it. Use PowerShell conditionals such as `cmd1; if ($?) { cmd2 }` when later commands must depend on earlier success."
           : "If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m \"message\" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead."
       log.info("bash tool using shell", { shell })
@@ -466,7 +480,7 @@ export const BashTool = Tool.define(
       return {
         description: DESCRIPTION.replaceAll("${directory}", Instance.directory)
           .replaceAll("${os}", process.platform)
-          .replaceAll("${shell}", name)
+          .replaceAll("${shell}", shName)
           .replaceAll("${chaining}", chain)
           .replaceAll("${maxLines}", String(Truncate.MAX_LINES))
           .replaceAll("${maxBytes}", String(Truncate.MAX_BYTES)),
@@ -480,7 +494,7 @@ export const BashTool = Tool.define(
               throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
             }
             const timeout = params.timeout ?? DEFAULT_TIMEOUT
-            const ps = PS.has(name)
+            const ps = PS.has(shName)
             const root = yield* parse(params.command, ps)
             const scan = yield* collect(root, cwd, ps, shell)
             if (!Instance.containsPath(cwd)) scan.dirs.add(cwd)
@@ -489,7 +503,7 @@ export const BashTool = Tool.define(
             return yield* run(
               {
                 shell,
-                name,
+                name: shName,
                 command: params.command,
                 cwd,
                 env: yield* shellEnv(ctx, cwd),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -17,6 +17,10 @@ import { Format } from "../format"
 import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
+
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
@@ -79,7 +83,7 @@ export const EditTool = Tool.define(
                 diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
                 yield* ctx.ask({
                   permission: "edit",
-                  patterns: [path.relative(Instance.worktree, filePath)],
+                  patterns: [toPosix(path.relative(Instance.worktree, filePath))],
                   always: ["*"],
                   metadata: {
                     filepath: filePath,
@@ -119,7 +123,7 @@ export const EditTool = Tool.define(
               )
               yield* ctx.ask({
                 permission: "edit",
-                patterns: [path.relative(Instance.worktree, filePath)],
+                patterns: [toPosix(path.relative(Instance.worktree, filePath))],
                 always: ["*"],
                 metadata: {
                   filepath: filePath,
@@ -179,7 +183,7 @@ export const EditTool = Tool.define(
               diff,
               filediff,
             },
-            title: `${path.relative(Instance.worktree, filePath)}`,
+            title: toPosix(path.relative(Instance.worktree, filePath)),
             output,
           }
         }),

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -9,6 +9,10 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const GlobTool = Tool.define(
   "glob",
   Effect.gen(function* () {
@@ -81,7 +85,7 @@ export const GlobTool = Tool.define(
           }
 
           return {
-            title: path.relative(Instance.worktree, search),
+            title: toPosix(path.relative(Instance.worktree, search)),
             metadata: {
               count: files.length,
               truncated,

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -8,6 +8,10 @@ import { Instance } from "../project/instance"
 import { Ripgrep } from "../file/ripgrep"
 import { assertExternalDirectoryEffect } from "./external-directory"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const IGNORE_PATTERNS = [
   "node_modules/",
   "__pycache__/",
@@ -121,7 +125,7 @@ export const ListTool = Tool.define(
           const output = `${searchPath}/\n` + renderDir(".", 0)
 
           return {
-            title: path.relative(Instance.worktree, searchPath),
+            title: toPosix(path.relative(Instance.worktree, searchPath)),
             metadata: {
               count: files.length,
               truncated: files.length >= LIMIT,

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -9,6 +9,10 @@ import { pathToFileURL } from "url"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 const operations = [
   "goToDefinition",
   "findReferences",
@@ -46,7 +50,7 @@ export const LspTool = Tool.define(
 
           const uri = pathToFileURL(file).href
           const position = { file, line: args.line - 1, character: args.character - 1 }
-          const relPath = path.relative(Instance.worktree, file)
+          const relPath = toPosix(path.relative(Instance.worktree, file))
           const title = `${args.operation} ${relPath}:${args.line}:${args.character}`
 
           const exists = yield* fs.existsSafe(file)

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -6,6 +6,10 @@ import DESCRIPTION from "./multiedit.txt"
 import path from "path"
 import { Instance } from "../project/instance"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const MultiEditTool = Tool.define(
   "multiedit",
   Effect.gen(function* () {
@@ -49,7 +53,7 @@ export const MultiEditTool = Tool.define(
             results.push(result)
           }
           return {
-            title: path.relative(Instance.worktree, params.filePath),
+            title: toPosix(path.relative(Instance.worktree, params.filePath)),
             metadata: {
               results: results.map((r) => r.metadata),
             },

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -10,6 +10,10 @@ import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 function getLastModel(sessionID: SessionID) {
   for (const item of MessageV2.stream(sessionID)) {
     if (item.info.role === "user" && item.info.model) return item.info.model
@@ -30,7 +34,7 @@ export const PlanExitTool = Tool.define(
       execute: (_params: {}, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const info = yield* session.get(ctx.sessionID)
-          const plan = path.relative(Instance.worktree, Session.plan(info))
+          const plan = toPosix(path.relative(Instance.worktree, Session.plan(info)))
           const answers = yield* question.ask({
             sessionID: ctx.sessionID,
             questions: [

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -13,6 +13,10 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
@@ -92,7 +96,7 @@ export const ReadTool = Tool.define(
       if (process.platform === "win32") {
         filepath = AppFileSystem.normalizePath(filepath)
       }
-      const title = path.relative(Instance.worktree, filepath)
+      const title = toPosix(path.relative(Instance.worktree, filepath))
 
       const stat = yield* fs.stat(filepath).pipe(
         Effect.catchIf(

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -17,6 +17,10 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const WriteTool = Tool.define(
   "write",
   Effect.gen(function* () {
@@ -46,7 +50,7 @@ export const WriteTool = Tool.define(
           const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
           yield* ctx.ask({
             permission: "edit",
-            patterns: [path.relative(Instance.worktree, filepath)],
+            patterns: [toPosix(path.relative(Instance.worktree, filepath))],
             always: ["*"],
             metadata: {
               filepath,
@@ -82,7 +86,7 @@ export const WriteTool = Tool.define(
           }
 
           return {
-            title: path.relative(Instance.worktree, filepath),
+            title: toPosix(path.relative(Instance.worktree, filepath)),
             metadata: {
               diagnostics,
               filepath,

--- a/packages/opencode/src/util/platform.ts
+++ b/packages/opencode/src/util/platform.ts
@@ -1,0 +1,76 @@
+import { execSync } from "child_process"
+import fs from "fs"
+import { lazy } from "./lazy"
+
+export namespace Platform {
+  export type Environment = "win32" | "wsl1" | "wsl2" | "linux" | "darwin"
+
+  const detect = lazy((): Environment => {
+    if (process.platform !== "linux") return process.platform === "win32" ? "win32" : "darwin"
+
+    try {
+      const version = fs.readFileSync("/proc/version", "utf8").toLowerCase()
+      if (version.includes("microsoft") || version.includes("wsl")) {
+        if (version.includes("microsoft-standard-wsl2")) return "wsl2"
+        if (fs.existsSync("/sys/module/vsock")) return "wsl2"
+        return "wsl1"
+      }
+    } catch {}
+
+    return "linux"
+  })
+
+  export const env = (): Environment => detect()
+
+  export const isWsl = (): boolean => {
+    const e = env()
+    return e === "wsl1" || e === "wsl2"
+  }
+
+  export const isWindows = (): boolean => process.platform === "win32" || isWsl()
+
+  export const wslVersion = (): 1 | 2 | undefined => {
+    const e = env()
+    if (e === "wsl1") return 1
+    if (e === "wsl2") return 2
+    return undefined
+  }
+
+  export const wslDistro = (): string | undefined => process.env.WSL_DISTRO_NAME
+
+  export function isWslUncPath(p: string): boolean {
+    if (process.platform !== "win32") return false
+    const lower = p.toLowerCase().replace(/\\/g, "/")
+    return lower.startsWith("//wsl$/") || lower.startsWith("//wsl.localhost/")
+  }
+
+  export function parseWslUncPath(p: string): { distro: string; linuxPath: string } | undefined {
+    if (!isWslUncPath(p)) return undefined
+    const normalized = p.replace(/\\/g, "/")
+    const match = normalized.match(/^\/\/wsl(?:\$|\.localhost)\/([^/]+)(\/.*)?$/i)
+    if (!match) return undefined
+    return { distro: match[1], linuxPath: match[2] || "/" }
+  }
+
+  export function toWslUncPath(linuxPath: string, distro: string): string {
+    const posix = linuxPath.replace(/\\/g, "/")
+    return `\\\\wsl$\\${distro}\\${posix.replace(/^\//, "")}`
+  }
+
+  export function wslDistros(): string[] {
+    if (process.platform !== "win32") return []
+    try {
+      const result = execSync("wsl.exe --list --quiet", {
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 5000,
+      })
+      return result
+        .split("\n")
+        .map((line) => line.trim().replace(/\0/g, ""))
+        .filter(Boolean)
+    } catch {
+      return []
+    }
+  }
+}

--- a/packages/opencode/src/util/token.ts
+++ b/packages/opencode/src/util/token.ts
@@ -1,7 +1,16 @@
 export namespace Token {
-  const CHARS_PER_TOKEN = 4
+  let charsPerToken = 4
 
   export function estimate(input: string) {
-    return Math.max(0, Math.round((input || "").length / CHARS_PER_TOKEN))
+    return Math.max(0, Math.round((input || "").length / charsPerToken))
+  }
+
+  export function updateRatio({ chars, tokens }: { chars: number; tokens: number }) {
+    if (tokens <= 0 || chars <= 0) return
+    charsPerToken = charsPerToken * 0.7 + (chars / tokens) * 0.3
+  }
+
+  export function resetRatio() {
+    charsPerToken = 4
   }
 }


### PR DESCRIPTION
## Summary

- **Model-aware token estimation**: Replace crude `char/4` heuristic with EMA ratio (0.7/0.3 blend) derived from actual API `tokens.input` vs serialized message length. Adapts per-session to the model's actual tokenization.

- **Prune before compaction**: Run `prune()` synchronously before `compaction.process()` so old tool outputs are cleared before sending to the summarization LLM, reducing compaction cost and overflow risk.

- **Smarter prune algorithm**:
  - Context-relative protect budget (15% of model context, min 20k tokens) instead of flat 40k
  - Skip already-compacted parts instead of breaking (reaches older prunable content)
  - Expanded protected tools: `compress`, `todowrite`, `background_output`, `lsp_diagnostics`, `lsp_symbols`

- **Proactive pruning**: Fire-and-forget prune after each step when context usage exceeds 50% of usable context, keeping context leaner throughout long sessions.

## Files changed

- `src/util/token.ts` — EMA ratio tracking (`updateRatio`, `resetRatio`)
- `src/session/compaction.ts` — Smarter prune with context-relative budget, expanded protection, `pruneIfNeeded` API
- `src/session/processor.ts` — Feed token ratio on finish-step, proactive prune trigger
- `src/session/prompt.ts` — Prune before compaction call
