### PR TITLE
fix(ui): render MCP tool output in GenericTool fallback

### DIFF
--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -1,10 +1,13 @@
-import { createEffect, For, Match, on, onCleanup, Show, Switch, type JSX } from "solid-js"
+import { createEffect, createSignal, For, Match, on, onCleanup, Show, Switch, type JSX } from "solid-js"
 import { animate, type AnimationPlaybackControls } from "motion"
 import { useI18n } from "../context/i18n"
 import { createStore } from "solid-js/store"
 import { Collapsible } from "./collapsible"
 import type { IconProps } from "./icon"
+import { IconButton } from "./icon-button"
 import { TextShimmer } from "./text-shimmer"
+import { Tooltip } from "./tooltip"
+import { Markdown } from "./markdown"
 
 export type TriggerTitle = {
   title: string
@@ -265,8 +268,17 @@ export function GenericTool(props: {
   status?: string
   hideDetails?: boolean
   input?: Record<string, unknown>
+  output?: string
 }) {
   const i18n = useI18n()
+  const [copied, setCopied] = createSignal(false)
+
+  const handleCopy = async () => {
+    if (!props.output) return
+    await navigator.clipboard.writeText(props.output)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
 
   return (
     <BasicTool
@@ -278,6 +290,32 @@ export function GenericTool(props: {
         args: args(props.input),
       }}
       hideDetails={props.hideDetails}
-    />
+    >
+      <Show when={props.output}>
+        <div data-component="bash-output">
+          <div data-slot="bash-copy">
+            <Tooltip
+              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              placement="top"
+              gutter={4}
+            >
+              <IconButton
+                icon={copied() ? "check" : "copy"}
+                size="small"
+                variant="secondary"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleCopy}
+                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+              />
+            </Tooltip>
+          </div>
+          <div data-slot="bash-scroll" data-scrollable>
+            <pre data-slot="bash-pre">
+              <code>{props.output}</code>
+            </pre>
+          </div>
+        </div>
+      </Show>
+    </BasicTool>
   )
 }


### PR DESCRIPTION
GenericTool now accepts and renders the output prop using the same data-scrollable pattern as built-in tools, making MCP tool results visible in the web/desktop UI.

### Issue for this PR

Closes #15825

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `GenericTool`(the fallback renderer for MCP tools) was a self-closing `<BasicTool />` — No output was rendered to the user whatsoever.

That way no user could see what actually was returned from the MCP tools - they had to rely on the LLM to interprete it correctly. 

To fix this, I added the `output` prop. Render it inside BasicTool using the same output as the bash-tool - this wraps the output in a copyable box. 

I also tested it using only the `Markdown` component, which also worked fine, but I found that the bash-output gives it a more polished and consistent look to other tools. If you would like to have the Markdown component instead, let me know and I'll change it. 

Using only the Markdown component would make this only a few lines of change, if you prefer to keep the change smaller.

### How did you verify your code works?

I started the UI locally using `bun dev` and let the agent execute a custom MCP tool (`kindly-web-search`)

### Screenshots / recordings

Before:
<img width="507" height="57" alt="grafik" src="https://github.com/user-attachments/assets/3bc1e166-c3c8-4a56-9d5b-00bfeaae0ad2" />

After (Collapsed):
<img width="619" height="53" alt="grafik" src="https://github.com/user-attachments/assets/c969a9e8-caf9-4d39-a36d-9aa07858c037" />

After (Expanded):
<img width="690" height="295" alt="grafik" src="https://github.com/user-attachments/assets/0828ee84-b1c8-4038-ac83-177b5d5cc60c" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
