### PR TITLE
fix(plugin): import solid runtime plugin support in plugin loader

### DIFF
--- a/packages/opencode/src/plugin/loader.ts
+++ b/packages/opencode/src/plugin/loader.ts
@@ -1,3 +1,4 @@
+import "@opentui/solid/runtime-plugin-support"
 import { Config } from "@/config/config"
 import { Installation } from "@/installation"
 import {


### PR DESCRIPTION
### Issue for this PR

Closes #22045

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI plugin runtime imports `@opentui/solid/runtime-plugin-support` at the top of `packages/opencode/src/cli/cmd/tui/plugin/runtime.ts:1`, which lets Solid plugins register themselves inside a compiled binary. The plugin loader used by the server process at `packages/opencode/src/plugin/loader.ts` does not have the same import, so a server plugin that ships compiled `.tsx` components cannot find its Solid runtime when loaded from a compiled binary.

The fix is a single import at the top of `plugin/loader.ts`, matching the existing TUI pattern.

### How did you verify your code works?

I hit this while working on a local server plugin that ships a compiled `.tsx` component: without the import the plugin silently failed to mount, with the import it renders correctly. I did not add a unit test — the change is a single import that mirrors the TUI pattern, and there's no existing test coverage for plugin loader imports to extend.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
