### PR TITLE
fix: normalize WSL desktop session paths

### DIFF
--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -7,7 +7,11 @@ type SessionStore = {
 }
 
 export const workspaceKey = (directory: string) => {
-  const value = directory.replaceAll("\\", "/")
+  let value = directory.replaceAll("\\", "/")
+  const wslMatch = value.match(/(?:^|\/+)(?:wsl(?:\.localhost|\$))\/[^/]+(\/.*)$/i)
+  if (wslMatch?.[1]) {
+    value = wslMatch[1]
+  }
   const drive = value.match(/^([A-Za-z]:)\/+$/)
   if (drive) return `${drive[1]}/`
   if (/^\/+$/i.test(value)) return "/"

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -38,6 +38,18 @@ export namespace Session {
   const parentTitlePrefix = "New session - "
   const childTitlePrefix = "Child session - "
 
+  function normalizeSessionDirectory(directory: string) {
+    let value = directory.replaceAll("\\", "/")
+    const wslMatch = value.match(/(?:^|\/+)(?:wsl(?:\.localhost|\$))\/[^/]+(\/.*)$/i)
+    if (wslMatch?.[1]) {
+      value = wslMatch[1]
+    }
+    const drive = value.match(/^([A-Za-z]:)\/+$/)
+    if (drive) return `${drive[1]}/`
+    if (/^\/+$/i.test(value)) return "/"
+    return value.replace(/\/+$/, "")
+  }
+
   function createDefaultTitle(isChild = false) {
     return (isChild ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString()
   }
@@ -381,12 +393,13 @@ export namespace Session {
         permission?: Permission.Ruleset
       }) {
         const ctx = yield* InstanceState.context
+        const directory = normalizeSessionDirectory(input.directory)
         const result: Info = {
           id: SessionID.descending(input.id),
           slug: Slug.create(),
           version: Installation.VERSION,
           projectID: ctx.project.id,
-          directory: input.directory,
+          directory,
           workspaceID: input.workspaceID,
           parentID: input.parentID,
           title: input.title ?? createDefaultTitle(!!input.parentID),


### PR DESCRIPTION
### Issue for this PR

Closes #17765

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This normalizes WSL UNC-style desktop paths before comparing sidebar workspace keys and before saving new session directories.

That fixes the Windows Desktop + WSL case where sessions were written to the database but disappeared from the sidebar because the same repo could be identified as both `/home/...` and `\\wsl.localhost\...`.

### How did you verify your code works?

- Ran `bun turbo typecheck --filter=@opencode-ai/app --filter=opencode`
- Reproduced the bug locally with Windows Desktop connected to a WSL-backed server
- Confirmed new sessions were saved with `/home/...` directories in the database
- Confirmed the patched UI showed the saved sessions in the sidebar again

### Screenshots / recordings

Not attached. I verified the visible change locally by reproducing the blank-sidebar case and then confirming the saved sessions reappeared in the patched UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
