### PR TITLE
fix: preserve input when permission prompt appears

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -220,12 +220,26 @@ export function Session() {
 
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef | undefined
-  const bind = (r: PromptRef | undefined) => {
-    prompt = r
-    promptRef.set(r)
-    if (seeded || !route.initialPrompt || !r) return
+  let savedPrompt: PromptInfo | undefined
+  const bind = (promptRefParam: PromptRef | undefined) => {
+    if (!promptRefParam) {
+      if (prompt?.current) {
+        savedPrompt = prompt.current
+      }
+      prompt = undefined
+      promptRef.set(undefined)
+      return
+    }
+    prompt = promptRefParam
+    promptRef.set(promptRefParam)
+    if (savedPrompt) {
+      promptRefParam.set(savedPrompt)
+      savedPrompt = undefined
+      return
+    }
+    if (seeded || !route.initialPrompt) return
     seeded = true
-    r.set(route.initialPrompt)
+    promptRefParam.set(route.initialPrompt)
   }
   const keybind = useKeybind()
   const dialog = useDialog()


### PR DESCRIPTION
### Issue for this PR
Closes #21614

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When typing in the input box and a permission prompt appears, the input text is cleared. This is because the Prompt component is conditionally rendered with `<Show when={visible()}>`. When a permission prompt appears, `visible()` becomes `false` and the Prompt component unmounts. When the permission is dismissed, Prompt remounts with empty state.

This fix preserves the input by saving the prompt's current state (input text and parts) before unmounting in the `bind` callback, and restoring it after remounting.

### How did you verify your code works?
Tested the permission prompt flow in TUI - typed in the input, triggered a permission prompt, and verified the input was preserved after dismissing the permission.

### Screenshots / recordings
Video demonstrating the fix: https://discord.com/channels/1391832426048651334/1394667004979445931/1492537747322175628

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR