### PR TITLE
feat(app): add markdown preview/source toggle for file tabs

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -458,6 +458,8 @@ export const dict = {
   "session.files.all": "كل الملفات",
   "session.files.empty": "لا توجد ملفات",
   "session.files.binaryContent": "ملف ثنائي (لا يمكن عرض المحتوى)",
+  "session.files.viewPreview": "معاينة",
+  "session.files.viewSource": "مصدر",
   "session.messages.renderEarlier": "عرض الرسائل السابقة",
   "session.messages.loadingEarlier": "جارٍ تحميل الرسائل السابقة...",
   "session.messages.loadEarlier": "تحميل الرسائل السابقة",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -462,6 +462,8 @@ export const dict = {
   "session.files.all": "Todos os arquivos",
   "session.files.empty": "Nenhum arquivo",
   "session.files.binaryContent": "Arquivo binário (conteúdo não pode ser exibido)",
+  "session.files.viewPreview": "Pré-visualização",
+  "session.files.viewSource": "Código-fonte",
   "session.messages.renderEarlier": "Renderizar mensagens anteriores",
   "session.messages.loadingEarlier": "Carregando mensagens anteriores...",
   "session.messages.loadEarlier": "Carregar mensagens anteriores",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -515,6 +515,8 @@ export const dict = {
   "session.files.all": "Sve datoteke",
   "session.files.empty": "Nema datoteka",
   "session.files.binaryContent": "Binarna datoteka (sadržaj se ne može prikazati)",
+  "session.files.viewPreview": "Pregled",
+  "session.files.viewSource": "Izvor",
 
   "session.messages.renderEarlier": "Prikaži ranije poruke",
   "session.messages.loadingEarlier": "Učitavanje ranijih poruka...",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -511,6 +511,8 @@ export const dict = {
   "session.files.all": "Alle filer",
   "session.files.empty": "Ingen filer",
   "session.files.binaryContent": "Binær fil (indhold kan ikke vises)",
+  "session.files.viewPreview": "Forhåndsvisning",
+  "session.files.viewSource": "Kilde",
   "session.messages.renderEarlier": "Vis tidligere beskeder",
   "session.messages.loadingEarlier": "Indlæser tidligere beskeder...",
   "session.messages.loadEarlier": "Indlæs tidligere beskeder",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -470,6 +470,8 @@ export const dict = {
   "session.files.all": "Alle Dateien",
   "session.files.empty": "Keine Dateien",
   "session.files.binaryContent": "Binärdatei (Inhalt kann nicht angezeigt werden)",
+  "session.files.viewPreview": "Vorschau",
+  "session.files.viewSource": "Quelle",
   "session.messages.renderEarlier": "Frühere Nachrichten rendern",
   "session.messages.loadingEarlier": "Lade frühere Nachrichten...",
   "session.messages.loadEarlier": "Frühere Nachrichten laden",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -544,6 +544,8 @@ export const dict = {
   "session.files.all": "All files",
   "session.files.empty": "No files",
   "session.files.binaryContent": "Binary file (content cannot be displayed)",
+  "session.files.viewPreview": "Preview",
+  "session.files.viewSource": "Source",
 
   "session.messages.renderEarlier": "Render earlier messages",
   "session.messages.loadingEarlier": "Loading earlier messages...",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -516,6 +516,8 @@ export const dict = {
   "session.files.all": "Todos los archivos",
   "session.files.empty": "Sin archivos",
   "session.files.binaryContent": "Archivo binario (el contenido no puede ser mostrado)",
+  "session.files.viewPreview": "Vista previa",
+  "session.files.viewSource": "Fuente",
 
   "session.messages.renderEarlier": "Renderizar mensajes anteriores",
   "session.messages.loadingEarlier": "Cargando mensajes anteriores...",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -467,6 +467,8 @@ export const dict = {
   "session.files.all": "Tous les fichiers",
   "session.files.empty": "Aucun fichier",
   "session.files.binaryContent": "Fichier binaire (le contenu ne peut pas être affiché)",
+  "session.files.viewPreview": "Aperçu",
+  "session.files.viewSource": "Source",
   "session.messages.renderEarlier": "Afficher les messages précédents",
   "session.messages.loadingEarlier": "Chargement des messages précédents...",
   "session.messages.loadEarlier": "Charger les messages précédents",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -459,6 +459,8 @@ export const dict = {
   "session.files.all": "すべてのファイル",
   "session.files.empty": "ファイルなし",
   "session.files.binaryContent": "バイナリファイル（内容を表示できません）",
+  "session.files.viewPreview": "プレビュー",
+  "session.files.viewSource": "ソース",
   "session.messages.renderEarlier": "以前のメッセージを表示",
   "session.messages.loadingEarlier": "以前のメッセージを読み込み中...",
   "session.messages.loadEarlier": "以前のメッセージを読み込む",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -461,6 +461,8 @@ export const dict = {
   "session.files.all": "모든 파일",
   "session.files.empty": "파일 없음",
   "session.files.binaryContent": "바이너리 파일 (내용을 표시할 수 없음)",
+  "session.files.viewPreview": "미리보기",
+  "session.files.viewSource": "소스",
   "session.messages.renderEarlier": "이전 메시지 렌더링",
   "session.messages.loadingEarlier": "이전 메시지 로드 중...",
   "session.messages.loadEarlier": "이전 메시지 로드",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -516,6 +516,8 @@ export const dict = {
   "session.files.all": "Alle filer",
   "session.files.empty": "Ingen filer",
   "session.files.binaryContent": "Binær fil (innhold kan ikke vises)",
+  "session.files.viewPreview": "Forhåndsvisning",
+  "session.files.viewSource": "Kilde",
 
   "session.messages.renderEarlier": "Vis tidligere meldinger",
   "session.messages.loadingEarlier": "Laster inn tidligere meldinger...",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -460,6 +460,8 @@ export const dict = {
   "session.files.all": "Wszystkie pliki",
   "session.files.empty": "Brak plików",
   "session.files.binaryContent": "Plik binarny (zawartość nie może być wyświetlona)",
+  "session.files.viewPreview": "Podgląd",
+  "session.files.viewSource": "Źródło",
   "session.messages.renderEarlier": "Renderuj wcześniejsze wiadomości",
   "session.messages.loadingEarlier": "Ładowanie wcześniejszych wiadomości...",
   "session.messages.loadEarlier": "Załaduj wcześniejsze wiadomości",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -514,6 +514,8 @@ export const dict = {
   "session.files.all": "Все файлы",
   "session.files.empty": "Нет файлов",
   "session.files.binaryContent": "Двоичный файл (содержимое не может быть отображено)",
+  "session.files.viewPreview": "Предпросмотр",
+  "session.files.viewSource": "Исходный код",
   "session.messages.renderEarlier": "Показать предыдущие сообщения",
   "session.messages.loadingEarlier": "Загрузка предыдущих сообщений...",
   "session.messages.loadEarlier": "Загрузить предыдущие сообщения",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -510,6 +510,8 @@ export const dict = {
   "session.files.empty": "ไม่มีไฟล์",
   "session.files.all": "ไฟล์ทั้งหมด",
   "session.files.binaryContent": "ไฟล์ไบนารี (ไม่สามารถแสดงเนื้อหาได้)",
+  "session.files.viewPreview": "ดูตัวอย่าง",
+  "session.files.viewSource": "ซอร์สโค้ด",
 
   "session.messages.renderEarlier": "แสดงข้อความก่อนหน้า",
   "session.messages.loadingEarlier": "กำลังโหลดข้อความก่อนหน้า...",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -520,6 +520,8 @@ export const dict = {
   "session.files.all": "Tüm dosyalar",
   "session.files.empty": "Dosya yok",
   "session.files.binaryContent": "İkili dosya (içerik görüntülenemiyor)",
+  "session.files.viewPreview": "Önizleme",
+  "session.files.viewSource": "Kaynak",
 
   "session.messages.renderEarlier": "Önceki mesajları göster",
   "session.messages.loadingEarlier": "Önceki mesajlar yükleniyor...",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -512,6 +512,8 @@ export const dict = {
   "session.files.all": "所有文件",
   "session.files.empty": "无文件",
   "session.files.binaryContent": "二进制文件（无法显示内容）",
+  "session.files.viewPreview": "预览",
+  "session.files.viewSource": "源代码",
   "session.messages.renderEarlier": "显示更早的消息",
   "session.messages.loadingEarlier": "正在加载更早的消息...",
   "session.messages.loadEarlier": "加载更早的消息",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -507,6 +507,8 @@ export const dict = {
   "session.files.all": "所有檔案",
   "session.files.empty": "沒有檔案",
   "session.files.binaryContent": "二進位檔案（無法顯示內容）",
+  "session.files.viewPreview": "預覽",
+  "session.files.viewSource": "原始碼",
   "session.messages.renderEarlier": "顯示更早的訊息",
   "session.messages.loadingEarlier": "正在載入更早的訊息...",
   "session.messages.loadEarlier": "載入更早的訊息",

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, Match, on, onCleanup, Switch } from "solid-js"
+import { createEffect, createMemo, createSignal, Match, on, onCleanup, Show, Switch } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
 import { makeEventListener } from "@solid-primitives/event-listener"
@@ -12,6 +12,7 @@ import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { showToast } from "@opencode-ai/ui/toast"
+import { Markdown } from "@opencode-ai/ui/markdown"
 import { selectionFromLines, useFile, type FileSelection, type SelectedLineRange } from "@/context/file"
 import { useComments } from "@/context/comments"
 import { useLanguage } from "@/context/language"
@@ -211,6 +212,12 @@ export function FileTabContent(props: { tab: string }) {
     view,
   })
 
+  const isMarkdown = createMemo(() => {
+    const p = path()
+    return p ? /\.(?:md|markdown)$/i.test(p) : false
+  })
+  const [preview, setPreview] = createSignal(true)
+
   const selectionPreview = (source: string, selection: FileSelection) => {
     return previewSelectedLines(source, {
       start: selection.startLine,
@@ -359,10 +366,20 @@ export function FileTabContent(props: { tab: string }) {
       path,
       () => {
         commentsUi.note.reset()
+        setPreview(true)
       },
       { defer: true },
     ),
   )
+
+  createEffect(() => {
+    const focus = comments.focus()
+    const p = path()
+    if (!focus || !p) return
+    if (focus.file !== p) return
+    if (activeFileTab() !== props.tab) return
+    if (preview()) setPreview(false)
+  })
 
   createEffect(() => {
     const focus = comments.focus()
@@ -449,7 +466,28 @@ export function FileTabContent(props: { tab: string }) {
   return (
     <Tabs.Content value={props.tab} class="mt-3 relative h-full">
       <ScrollView class="h-full" viewportRef={scrollSync.setViewport} onScroll={scrollSync.handleScroll as any}>
+        <Show when={state()?.loaded && isMarkdown() && state()?.content?.type !== "binary"}>
+          <div class="sticky top-0 z-10 flex items-center gap-1 bg-surface px-4 py-1.5 border-b border-border">
+            <button
+              class={"px-2 py-0.5 rounded text-sm " + (preview() ? "bg-surface-active text-text" : "text-text-weak hover:text-text")}
+              onClick={() => setPreview(true)}
+            >
+              {language.t("session.files.viewPreview")}
+            </button>
+            <button
+              class={"px-2 py-0.5 rounded text-sm " + (!preview() ? "bg-surface-active text-text" : "text-text-weak hover:text-text")}
+              onClick={() => setPreview(false)}
+            >
+              {language.t("session.files.viewSource")}
+            </button>
+          </div>
+        </Show>
         <Switch>
+          <Match when={state()?.loaded && isMarkdown() && preview()}>
+            <div class="px-6 py-4 pb-40">
+              <Markdown text={contents()} cacheKey={cacheKey()} />
+            </div>
+          </Match>
           <Match when={state()?.loaded}>{renderFile(contents())}</Match>
           <Match when={state()?.loading}>
             <div class="px-6 py-4 text-text-weak">{language.t("common.loading")}...</div>


### PR DESCRIPTION
## Summary

Adds a **Preview / Source toggle** for Markdown files in the file viewer tab. When a `.md` or `.markdown` file is opened, a sticky toolbar appears with Preview and Source buttons, defaulting to the rendered preview. Clicking a comment automatically switches to Source view for inline annotation.

Continues the work from #13704 by @kimi-chen, reimplemented from scratch against the current `dev` branch after significant codebase refactoring.

## Changes

- **`file-tabs.tsx`** — Added `isMarkdown` memo, `preview` signal, comment-focus effect (auto-switches to Source when a comment is focused), sticky toggle toolbar, and `<Markdown>` rendered preview using the existing `@opencode-ai/ui/markdown` component
- **i18n** — Added `session.files.viewPreview` and `session.files.viewSource` keys across all 17 locale files (en, de, es, fr, ja, zh, zht, ar, br, bs, da, ko, no, pl, ru, th, tr)

## Design Decisions

- **Binary file guard**: The toggle only renders when content type is not binary (`state()?.content?.type !== "binary"`)
- **Comment focus**: When a comment is focused on the current file, preview mode auto-switches to Source so the user can see the inline annotation
- **Path change reset**: Switching files resets to Preview mode
- **No new dependencies**: Reuses the existing `<Markdown>` component from `@opencode-ai/ui/markdown`

## Credit

This feature was originally proposed and prototyped in #13704 by @kimi-chen. This PR is a clean reimplementation addressing the review feedback from that PR (binary guard, comment focus, i18n coverage).

Co-authored-by: kimi-chen <kimi-chen@users.noreply.github.com>