### PR TITLE
fix: detect tool calls as agent-initiated in Copilot plugin

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -83,30 +83,45 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                 // Completions API
                 if (body?.messages && url.includes("completions")) {
                   const last = body.messages[body.messages.length - 1]
+                  const hasToolCalls = body.messages.some(
+                    (msg: any) =>
+                      Array.isArray(msg.content) && msg.content.some((part: any) => part?.type === "tool_result") ||
+                      msg.role === "tool",
+                  )
                   return {
                     isVision: body.messages.some(
                       (msg: any) =>
                         Array.isArray(msg.content) && msg.content.some((part: any) => part.type === "image_url"),
                     ),
-                    isAgent: last?.role !== "user",
+                    isAgent: hasToolCalls || last?.role !== "user",
                   }
                 }
 
                 // Responses API
                 if (body?.input) {
                   const last = body.input[body.input.length - 1]
+                  const hasToolCalls = body.input.some(
+                    (item: any) =>
+                      Array.isArray(item?.content) && item.content.some((part: any) => part?.type === "tool_result") ||
+                      item.role === "tool",
+                  )
                   return {
                     isVision: body.input.some(
                       (item: any) =>
                         Array.isArray(item?.content) && item.content.some((part: any) => part.type === "input_image"),
                     ),
-                    isAgent: last?.role !== "user",
+                    isAgent: hasToolCalls || last?.role !== "user",
                   }
                 }
 
                 // Messages API
                 if (body?.messages) {
                   const last = body.messages[body.messages.length - 1]
+                  const hasToolCalls = body.messages.some(
+                    (msg: any) =>
+                      Array.isArray(msg.content) && msg.content.some((part: any) => part?.type === "tool_result") ||
+                      msg.role === "tool",
+                  )
                   const hasNonToolCalls =
                     Array.isArray(last?.content) && last.content.some((part: any) => part?.type !== "tool_result")
                   return {
@@ -122,7 +137,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
                               part.content.some((nested: any) => nested?.type === "image")),
                         ),
                     ),
-                    isAgent: !(last?.role === "user" && hasNonToolCalls),
+                    isAgent: hasToolCalls || !(last?.role === "user" && hasNonToolCalls),
                   }
                 }
               } catch {}


### PR DESCRIPTION
### Issue for this PR

Closes #8030

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Copilot was charging premium requests for tool calls because `isAgent` only checked the last message role. Tool results often have `role: "user"`, so they got flagged as user-initiated.

Fixed by checking the full message context for `tool_result` parts or `role: "tool"`. If any exist, the request is marked as agent-initiated.

Changed 3 API paths in `packages/opencode/src/plugin/github-copilot/copilot.ts`: Completions, Responses, and Messages.

### How did you verify your code works?

Ran `bun turbo typecheck` — all 13 packages passed. The logic follows the existing compaction detection pattern already in the same file's `chat.headers` hook.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR