### PR TITLE
refactor(session): destroy SessionRunState facade

### DIFF
--- a/packages/opencode/specs/effect-migration.md
+++ b/packages/opencode/specs/effect-migration.md
@@ -217,6 +217,7 @@ Fully migrated (single namespace, InstanceState where needed, flattened facade):
 - [x] `SessionSummary` — `session/summary.ts`
 - [x] `SessionRevert` — `session/revert.ts`
 - [x] `Instruction` — `session/instruction.ts`
+- [x] `SystemPrompt` — `session/system.ts`
 - [x] `Provider` — `provider/provider.ts`
 - [x] `Storage` — `storage/storage.ts`
 - [x] `ShareNext` — `share/share-next.ts`
@@ -340,3 +341,47 @@ For each service, the migration is roughly:
 - `ShareNext` — migrated 2026-04-11. Swapped remaining async callers to `AppRuntime.runPromise(ShareNext.Service.use(...))`, removed the `makeRuntime(...)` facade, and kept instance bootstrap on the shared app runtime.
 - `SessionTodo` — migrated 2026-04-10. Already matched the target service shape in `session/todo.ts`: single namespace, traced Effect methods, and no `makeRuntime(...)` facade remained; checklist updated to reflect the completed migration.
 - `Storage` — migrated 2026-04-10. One production caller (`Session.diff`) and all storage.test.ts tests converted to effectful style. Facades and `makeRuntime` removed.
+- `SessionRunState` — migrated 2026-04-11. Single caller in `server/routes/session.ts` converted; facade removed.
+- `Account` — migrated 2026-04-11. Callers in `server/routes/experimental.ts` and `cli/cmd/account.ts` converted; facade removed.
+- `Instruction` — migrated 2026-04-11. Test-only callers converted; facade removed.
+- `FileTime` — migrated 2026-04-11. Test-only callers converted; facade removed.
+- `FileWatcher` — migrated 2026-04-11. Callers in `project/bootstrap.ts` and test converted; facade removed.
+- `Question` — migrated 2026-04-11. Callers in `server/routes/question.ts` and test converted; facade removed.
+- `Truncate` — migrated 2026-04-11. Caller in `tool/tool.ts` and test converted; facade removed.
+
+## Route handler effectification
+
+Route handlers should wrap their entire body in a single `AppRuntime.runPromise(Effect.gen(...))` call, yielding services from context rather than calling facades one-by-one. This eliminates multiple `runPromise` round-trips and lets handlers compose naturally.
+
+```ts
+// Before — one facade call per service
+async (c) => {
+  await SessionRunState.assertNotBusy(id)
+  await Session.removeMessage({ sessionID: id, messageID })
+  return c.json(true)
+}
+
+// After — one Effect.gen, yield services from context
+async (c) => {
+  await AppRuntime.runPromise(
+    Effect.gen(function* () {
+      const state = yield* SessionRunState.Service
+      const session = yield* Session.Service
+      yield* state.assertNotBusy(id)
+      yield* session.removeMessage({ sessionID: id, messageID })
+    }),
+  )
+  return c.json(true)
+}
+```
+
+When migrating, always use `{ concurrency: "unbounded" }` with `Effect.all` — route handlers should run independent service calls in parallel, not sequentially.
+
+Route files to convert (each handler that calls facades should be wrapped):
+
+- [ ] `server/routes/session.ts` — heaviest; uses Session, SessionPrompt, SessionRevert, SessionCompaction, SessionShare, SessionSummary, SessionRunState, Agent, Permission, Bus
+- [ ] `server/routes/global.ts` — uses Config, Project, Provider, Vcs, Snapshot, Agent
+- [ ] `server/routes/provider.ts` — uses Provider, Auth, Config
+- [ ] `server/routes/question.ts` — uses Question
+- [ ] `server/routes/pty.ts` — uses Pty
+- [ ] `server/routes/experimental.ts` — uses Account, ToolRegistry, Agent, MCP, Config

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -724,7 +724,7 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const params = c.req.valid("param")
-        await SessionRunState.assertNotBusy(params.sessionID)
+        await AppRuntime.runPromise(SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID)))
         await Session.removeMessage({
           sessionID: params.sessionID,
           messageID: params.messageID,

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -13,6 +13,7 @@ import { SessionShare } from "@/share/session"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "../../session/todo"
+import { Effect } from "effect"
 import { AppRuntime } from "../../effect/app-runtime"
 import { Agent } from "../../agent/agent"
 import { Snapshot } from "@/snapshot"
@@ -724,11 +725,17 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const params = c.req.valid("param")
-        await AppRuntime.runPromise(SessionRunState.Service.use((svc) => svc.assertNotBusy(params.sessionID)))
-        await Session.removeMessage({
-          sessionID: params.sessionID,
-          messageID: params.messageID,
-        })
+        await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const state = yield* SessionRunState.Service
+            const session = yield* Session.Service
+            yield* state.assertNotBusy(params.sessionID)
+            yield* session.removeMessage({
+              sessionID: params.sessionID,
+              messageID: params.messageID,
+            })
+          }),
+        )
         return c.json(true)
       },
     )

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,6 +1,5 @@
 import { InstanceState } from "@/effect/instance-state"
 import { Runner } from "@/effect/runner"
-import { makeRuntime } from "@/effect/run-service"
 import { Effect, Layer, Scope, Context } from "effect"
 import { Session } from "."
 import { MessageV2 } from "./message-v2"
@@ -106,9 +105,4 @@ export namespace SessionRunState {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(SessionStatus.defaultLayer))
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function assertNotBusy(sessionID: SessionID) {
-    return runPromise((svc) => svc.assertNotBusy(sessionID))
-  }
 }

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -7,6 +7,7 @@ import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRunState } from "../../src/session/run-state"
 import { AppRuntime } from "../../src/effect/app-runtime"
+import { SessionStatus } from "../../src/session/status"
 import { Effect } from "effect"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
@@ -67,12 +68,13 @@ describe("session action routes", () => {
       fn: async () => {
         const session = await Session.create({})
         const msg = await user(session.id, "hello")
-        // Make the session busy by forking a never-ending runner
-        AppRuntime.runFork(
+        // Make the session busy by forking a never-ending runner, then wait for status
+        void AppRuntime.runPromise(
           SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, Effect.never)),
         )
-        // Give the fiber time to start and mark the session busy
-        await new Promise((r) => setTimeout(r, 50))
+        while ((await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.get(session.id)))).type !== "busy") {
+          await new Promise((r) => setTimeout(r, 5))
+        }
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app
 

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -67,11 +67,12 @@ describe("session action routes", () => {
       fn: async () => {
         const session = await Session.create({})
         const msg = await user(session.id, "hello")
-        // Make the session busy by starting a runner via ensureRunning
-        const work = Effect.never as Effect.Effect<any>
-        await AppRuntime.runPromise(
-          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, work)),
+        // Make the session busy by forking a never-ending runner
+        AppRuntime.runFork(
+          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, Effect.never)),
         )
+        // Give the fiber time to start and mark the session busy
+        await new Promise((r) => setTimeout(r, 50))
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app
 

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -3,11 +3,7 @@ import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
-import { ModelID, ProviderID } from "../../src/provider/schema"
-import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
-import { SessionRunState } from "../../src/session/run-state"
-import { AppRuntime } from "../../src/effect/app-runtime"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -17,25 +13,6 @@ afterEach(async () => {
   mock.restore()
   await Instance.disposeAll()
 })
-
-async function user(sessionID: SessionID, text: string) {
-  const msg = await Session.updateMessage({
-    id: MessageID.ascending(),
-    role: "user",
-    sessionID,
-    agent: "build",
-    model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
-    time: { created: Date.now() },
-  })
-  await Session.updatePart({
-    id: PartID.ascending(),
-    sessionID,
-    messageID: msg.id,
-    type: "text",
-    text,
-  })
-  return msg
-}
 
 describe("session action routes", () => {
   test("abort route calls SessionPrompt.cancel", async () => {
@@ -53,35 +30,6 @@ describe("session action routes", () => {
         expect(await res.json()).toBe(true)
         expect(cancel).toHaveBeenCalledWith(session.id)
 
-        await Session.remove(session.id)
-      },
-    })
-  })
-
-  test("delete message route returns 400 when session is busy", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await Session.create({})
-        const msg = await user(session.id, "hello")
-
-        // Mock assertNotBusy on the resolved service instance to throw BusyError
-        const svc = await AppRuntime.runPromise(
-          SessionRunState.Service.use((s) => Effect.succeed(s)),
-        ) as Record<string, any>
-        const orig = svc.assertNotBusy
-        svc.assertNotBusy = () => Effect.die(new Session.BusyError(session.id))
-
-        const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
-        const app = Server.Default().app
-
-        const res = await app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" })
-
-        expect(res.status).toBe(400)
-        expect(remove).not.toHaveBeenCalled()
-
-        svc.assertNotBusy = orig
         await Session.remove(session.id)
       },
     })

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -67,17 +67,15 @@ describe("session action routes", () => {
         const session = await Session.create({})
         const msg = await user(session.id, "hello")
 
-        // Make session busy: fork a never-ending runner and wait for status
-        await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const state = yield* SessionRunState.Service
-            const status = yield* SessionStatus.Service
-            yield* Effect.forkDaemon(state.ensureRunning(session.id, Effect.never, Effect.never))
-            while ((yield* status.get(session.id)).type !== "busy") {
-              yield* Effect.sleep("5 millis")
-            }
-          }),
+        // Make session busy: fire off a never-ending runner and poll until busy
+        void AppRuntime.runPromise(
+          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, Effect.never)),
         )
+        while (true) {
+          const s = await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.get(session.id)))
+          if (s.type === "busy") break
+          await new Promise((r) => setTimeout(r, 10))
+        }
 
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, describe, expect, mock, spyOn } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
@@ -6,11 +7,11 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRunState } from "../../src/session/run-state"
-import { AppRuntime } from "../../src/effect/app-runtime"
 import { SessionStatus } from "../../src/session/status"
-import { Effect } from "effect"
+import { Bus } from "../../src/bus"
 import { Log } from "../../src/util/log"
-import { tmpdir } from "../fixture/fixture"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
 
 Log.init({ print: false })
 
@@ -18,6 +19,15 @@ afterEach(async () => {
   mock.restore()
   await Instance.disposeAll()
 })
+
+const it = testEffect(
+  Layer.mergeAll(
+    Session.defaultLayer,
+    SessionRunState.defaultLayer,
+    SessionStatus.defaultLayer,
+    Bus.layer,
+  ),
+)
 
 async function user(sessionID: SessionID, text: string) {
   const msg = await Session.updateMessage({
@@ -39,54 +49,54 @@ async function user(sessionID: SessionID, text: string) {
 }
 
 describe("session action routes", () => {
-  test("abort route calls SessionPrompt.cancel", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await Session.create({})
+  it.live("abort route calls SessionPrompt.cancel", () =>
+    provideTmpdirInstance({ git: true })(
+      Effect.gen(function* () {
+        const session = yield* Effect.promise(() => Session.create({}))
         const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
         const app = Server.Default().app
 
-        const res = await app.request(`/session/${session.id}/abort`, {
-          method: "POST",
-        })
+        const res = yield* Effect.promise(() =>
+          app.request(`/session/${session.id}/abort`, { method: "POST" }),
+        )
 
         expect(res.status).toBe(200)
         expect(await res.json()).toBe(true)
         expect(cancel).toHaveBeenCalledWith(session.id)
 
-        await Session.remove(session.id)
-      },
-    })
-  })
+        yield* Effect.promise(() => Session.remove(session.id))
+      }),
+    ),
+  )
 
-  test("delete message route returns 400 when session is busy", async () => {
-    await using tmp = await tmpdir({ git: true })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const session = await Session.create({})
-        const msg = await user(session.id, "hello")
-        // Make the session busy by forking a never-ending runner, then wait for status
-        void AppRuntime.runPromise(
-          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, Effect.never)),
-        )
-        while ((await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.get(session.id)))).type !== "busy") {
-          await new Promise((r) => setTimeout(r, 5))
-        }
+  it.live("delete message route returns 400 when session is busy", () =>
+    provideTmpdirInstance({ git: true })(
+      Effect.gen(function* () {
+        const session = yield* Effect.promise(() => Session.create({}))
+        const msg = yield* Effect.promise(() => user(session.id, "hello"))
+
+        // Make session busy: fork a never-ending runner and wait for status
+        const state = yield* SessionRunState.Service
+        const status = yield* SessionStatus.Service
+        yield* Effect.fork(state.ensureRunning(session.id, Effect.never, Effect.never))
+        yield* Effect.fn("waitBusy")(function* () {
+          while ((yield* status.get(session.id)).type !== "busy") {
+            yield* Effect.sleep("5 millis")
+          }
+        })()
+
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app
 
-        const res = await app.request(`/session/${session.id}/message/${msg.id}`, {
-          method: "DELETE",
-        })
+        const res = yield* Effect.promise(() =>
+          app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" }),
+        )
 
         expect(res.status).toBe(400)
         expect(remove).not.toHaveBeenCalled()
 
-        await Session.remove(session.id)
-      },
-    })
-  })
+        yield* Effect.promise(() => Session.remove(session.id))
+      }),
+    ),
+  )
 })

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -49,54 +49,62 @@ async function user(sessionID: SessionID, text: string) {
 }
 
 describe("session action routes", () => {
-  it.live("abort route calls SessionPrompt.cancel", () =>
-    provideTmpdirInstance({ git: true })(
-      Effect.gen(function* () {
-        const session = yield* Effect.promise(() => Session.create({}))
-        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
-        const app = Server.Default().app
+  it.live(
+    "abort route calls SessionPrompt.cancel",
+    () =>
+      provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const session = yield* Effect.promise(() => Session.create({}))
+            const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
+            const app = Server.Default().app
 
-        const res = yield* Effect.promise(() =>
-          app.request(`/session/${session.id}/abort`, { method: "POST" }),
-        )
+            const res = yield* Effect.promise(() =>
+              app.request(`/session/${session.id}/abort`, { method: "POST" }),
+            )
 
-        expect(res.status).toBe(200)
-        expect(yield* Effect.promise(() => res.json())).toBe(true)
-        expect(cancel).toHaveBeenCalledWith(session.id)
+            expect(res.status).toBe(200)
+            expect(yield* Effect.promise(() => res.json())).toBe(true)
+            expect(cancel).toHaveBeenCalledWith(session.id)
 
-        yield* Effect.promise(() => Session.remove(session.id))
-      }),
-    ),
+            yield* Effect.promise(() => Session.remove(session.id))
+          }),
+        { git: true },
+      ),
   )
 
-  it.live("delete message route returns 400 when session is busy", () =>
-    provideTmpdirInstance({ git: true })(
-      Effect.gen(function* () {
-        const session = yield* Effect.promise(() => Session.create({}))
-        const msg = yield* Effect.promise(() => user(session.id, "hello"))
+  it.live(
+    "delete message route returns 400 when session is busy",
+    () =>
+      provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const session = yield* Effect.promise(() => Session.create({}))
+            const msg = yield* Effect.promise(() => user(session.id, "hello"))
 
-        // Make session busy: fork a never-ending runner and wait for status
-        const state = yield* SessionRunState.Service
-        const status = yield* SessionStatus.Service
-        yield* Effect.fork(state.ensureRunning(session.id, Effect.never, Effect.never))
-        yield* Effect.fn("waitBusy")(function* () {
-          while ((yield* status.get(session.id)).type !== "busy") {
-            yield* Effect.sleep("5 millis")
-          }
-        })()
+            // Make session busy: fork a never-ending runner and wait for status
+            const state = yield* SessionRunState.Service
+            const status = yield* SessionStatus.Service
+            yield* Effect.fork(state.ensureRunning(session.id, Effect.never, Effect.never))
+            yield* Effect.fn("waitBusy")(function* () {
+              while ((yield* status.get(session.id)).type !== "busy") {
+                yield* Effect.sleep("5 millis")
+              }
+            })()
 
-        const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
-        const app = Server.Default().app
+            const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
+            const app = Server.Default().app
 
-        const res = yield* Effect.promise(() =>
-          app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" }),
-        )
+            const res = yield* Effect.promise(() =>
+              app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" }),
+            )
 
-        expect(res.status).toBe(400)
-        expect(remove).not.toHaveBeenCalled()
+            expect(res.status).toBe(400)
+            expect(remove).not.toHaveBeenCalled()
 
-        yield* Effect.promise(() => Session.remove(session.id))
-      }),
-    ),
+            yield* Effect.promise(() => Session.remove(session.id))
+          }),
+        { git: true },
+      ),
   )
 })

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -6,6 +6,8 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRunState } from "../../src/session/run-state"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { Effect } from "effect"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 
@@ -65,7 +67,11 @@ describe("session action routes", () => {
       fn: async () => {
         const session = await Session.create({})
         const msg = await user(session.id, "hello")
-        const busy = spyOn(SessionRunState, "assertNotBusy").mockRejectedValue(new Session.BusyError(session.id))
+        // Make the session busy by starting a runner via ensureRunning
+        const work = Effect.never as Effect.Effect<any>
+        await AppRuntime.runPromise(
+          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, work)),
+        )
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app
 
@@ -74,7 +80,6 @@ describe("session action routes", () => {
         })
 
         expect(res.status).toBe(400)
-        expect(busy).toHaveBeenCalledWith(session.id)
         expect(remove).not.toHaveBeenCalled()
 
         await Session.remove(session.id)

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -7,7 +7,6 @@ import { ModelID, ProviderID } from "../../src/provider/schema"
 import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRunState } from "../../src/session/run-state"
-import { SessionStatus } from "../../src/session/status"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
@@ -67,15 +66,12 @@ describe("session action routes", () => {
         const session = await Session.create({})
         const msg = await user(session.id, "hello")
 
-        // Make session busy: fire off a never-ending runner and poll until busy
-        void AppRuntime.runPromise(
-          SessionRunState.Service.use((svc) => svc.ensureRunning(session.id, Effect.never, Effect.never)),
-        )
-        while (true) {
-          const s = await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.get(session.id)))
-          if (s.type === "busy") break
-          await new Promise((r) => setTimeout(r, 10))
-        }
+        // Mock assertNotBusy on the resolved service instance to throw BusyError
+        const svc = await AppRuntime.runPromise(
+          SessionRunState.Service.use((s) => Effect.succeed(s)),
+        ) as Record<string, any>
+        const orig = svc.assertNotBusy
+        svc.assertNotBusy = () => Effect.die(new Session.BusyError(session.id))
 
         const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
         const app = Server.Default().app
@@ -85,6 +81,7 @@ describe("session action routes", () => {
         expect(res.status).toBe(400)
         expect(remove).not.toHaveBeenCalled()
 
+        svc.assertNotBusy = orig
         await Session.remove(session.id)
       },
     })

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, mock, spyOn } from "bun:test"
-import { Effect, Fiber, Layer } from "effect"
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { Effect } from "effect"
 import { Instance } from "../../src/project/instance"
 import { Server } from "../../src/server/server"
 import { Session } from "../../src/session"
@@ -8,10 +8,9 @@ import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRunState } from "../../src/session/run-state"
 import { SessionStatus } from "../../src/session/status"
-import { Bus } from "../../src/bus"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { Log } from "../../src/util/log"
-import { provideTmpdirInstance } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { tmpdir } from "../fixture/fixture"
 
 Log.init({ print: false })
 
@@ -19,15 +18,6 @@ afterEach(async () => {
   mock.restore()
   await Instance.disposeAll()
 })
-
-const it = testEffect(
-  Layer.mergeAll(
-    Session.defaultLayer,
-    SessionRunState.defaultLayer,
-    SessionStatus.defaultLayer,
-    Bus.layer,
-  ),
-)
 
 async function user(sessionID: SessionID, text: string) {
   const msg = await Session.updateMessage({
@@ -49,62 +39,56 @@ async function user(sessionID: SessionID, text: string) {
 }
 
 describe("session action routes", () => {
-  it.live(
-    "abort route calls SessionPrompt.cancel",
-    () =>
-      provideTmpdirInstance(
-        () =>
+  test("abort route calls SessionPrompt.cancel", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/abort`, { method: "POST" })
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toBe(true)
+        expect(cancel).toHaveBeenCalledWith(session.id)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("delete message route returns 400 when session is busy", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const msg = await user(session.id, "hello")
+
+        // Make session busy: fork a never-ending runner and wait for status
+        await AppRuntime.runPromise(
           Effect.gen(function* () {
-            const session = yield* Effect.promise(() => Session.create({}))
-            const cancel = spyOn(SessionPrompt, "cancel").mockResolvedValue()
-            const app = Server.Default().app
-
-            const res = yield* Effect.promise(() =>
-              app.request(`/session/${session.id}/abort`, { method: "POST" }),
-            )
-
-            expect(res.status).toBe(200)
-            expect(yield* Effect.promise(() => res.json())).toBe(true)
-            expect(cancel).toHaveBeenCalledWith(session.id)
-
-            yield* Effect.promise(() => Session.remove(session.id))
-          }),
-        { git: true },
-      ),
-  )
-
-  it.live(
-    "delete message route returns 400 when session is busy",
-    () =>
-      provideTmpdirInstance(
-        () =>
-          Effect.gen(function* () {
-            const session = yield* Effect.promise(() => Session.create({}))
-            const msg = yield* Effect.promise(() => user(session.id, "hello"))
-
-            // Make session busy: fork a never-ending runner and wait for status
             const state = yield* SessionRunState.Service
             const status = yield* SessionStatus.Service
-            yield* Effect.fork(state.ensureRunning(session.id, Effect.never, Effect.never))
-            yield* Effect.fn("waitBusy")(function* () {
-              while ((yield* status.get(session.id)).type !== "busy") {
-                yield* Effect.sleep("5 millis")
-              }
-            })()
-
-            const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
-            const app = Server.Default().app
-
-            const res = yield* Effect.promise(() =>
-              app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" }),
-            )
-
-            expect(res.status).toBe(400)
-            expect(remove).not.toHaveBeenCalled()
-
-            yield* Effect.promise(() => Session.remove(session.id))
+            yield* Effect.forkDaemon(state.ensureRunning(session.id, Effect.never, Effect.never))
+            while ((yield* status.get(session.id)).type !== "busy") {
+              yield* Effect.sleep("5 millis")
+            }
           }),
-        { git: true },
-      ),
-  )
+        )
+
+        const remove = spyOn(Session, "removeMessage").mockResolvedValue(msg.id)
+        const app = Server.Default().app
+
+        const res = await app.request(`/session/${session.id}/message/${msg.id}`, { method: "DELETE" })
+
+        expect(res.status).toBe(400)
+        expect(remove).not.toHaveBeenCalled()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
 })

--- a/packages/opencode/test/server/session-actions.test.ts
+++ b/packages/opencode/test/server/session-actions.test.ts
@@ -61,7 +61,7 @@ describe("session action routes", () => {
         )
 
         expect(res.status).toBe(200)
-        expect(await res.json()).toBe(true)
+        expect(yield* Effect.promise(() => res.json())).toBe(true)
         expect(cancel).toHaveBeenCalledWith(session.id)
 
         yield* Effect.promise(() => Session.remove(session.id))


### PR DESCRIPTION
## Summary
- Removed `makeRuntime` and `assertNotBusy` facade from `SessionRunState`
- Converted the delete-message handler in `server/routes/session.ts` to wrap the entire body in `Effect.gen`, yielding both `SessionRunState.Service` and `Session.Service` from context
- Updated `session-actions.test.ts` to make the session actually busy via `ensureRunning` instead of spying on the deleted facade

## Verification
- `bun run typecheck` — clean
- `bun run test test/server/session-actions.test.ts` — 2/2