### PR TITLE
refactor(account): destroy Account facade

### DIFF
--- a/packages/opencode/src/account/index.ts
+++ b/packages/opencode/src/account/index.ts
@@ -7,7 +7,6 @@ import {
   HttpClientResponse,
 } from "effect/unstable/http"
 
-import { makeRuntime } from "@/effect/run-service"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { AccountRepo, type AccountRow } from "./repo"
 import { normalizeServerUrl } from "./url"
@@ -454,18 +453,4 @@ export namespace Account {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(AccountRepo.layer), Layer.provide(FetchHttpClient.layer))
-
-  export const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export async function active(): Promise<Info | undefined> {
-    return Option.getOrUndefined(await runPromise((service) => service.active()))
-  }
-
-  export async function orgsByAccount(): Promise<readonly AccountOrgs[]> {
-    return runPromise((service) => service.orgsByAccount())
-  }
-
-  export async function switchOrg(accountID: AccountID, orgID: OrgID) {
-    return runPromise((service) => service.use(accountID, Option.some(orgID)))
-  }
 }

--- a/packages/opencode/src/cli/cmd/account.ts
+++ b/packages/opencode/src/cli/cmd/account.ts
@@ -3,6 +3,7 @@ import { Duration, Effect, Match, Option } from "effect"
 import { UI } from "../ui"
 import { AccountID, Account, OrgID, PollExpired, type PollResult } from "@/account"
 import { type AccountError } from "@/account/schema"
+import { AppRuntime } from "@/effect/app-runtime"
 import * as Prompt from "../effect/prompt"
 import open from "open"
 
@@ -182,7 +183,7 @@ export const LoginCommand = cmd({
     }),
   async handler(args) {
     UI.empty()
-    await Account.runPromise((_svc) => loginEffect(args.url))
+    await AppRuntime.runPromise(loginEffect(args.url))
   },
 })
 
@@ -196,7 +197,7 @@ export const LogoutCommand = cmd({
     }),
   async handler(args) {
     UI.empty()
-    await Account.runPromise((_svc) => logoutEffect(args.email))
+    await AppRuntime.runPromise(logoutEffect(args.email))
   },
 })
 
@@ -205,7 +206,7 @@ export const SwitchCommand = cmd({
   describe: false,
   async handler() {
     UI.empty()
-    await Account.runPromise((_svc) => switchEffect())
+    await AppRuntime.runPromise(switchEffect())
   },
 })
 
@@ -214,7 +215,7 @@ export const OrgsCommand = cmd({
   describe: false,
   async handler() {
     UI.empty()
-    await Account.runPromise((_svc) => orgsEffect())
+    await AppRuntime.runPromise(orgsEffect())
   },
 })
 
@@ -223,7 +224,7 @@ export const OpenCommand = cmd({
   describe: false,
   async handler() {
     UI.empty()
-    await Account.runPromise((_svc) => openEffect())
+    await AppRuntime.runPromise(openEffect())
   },
 })
 

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -15,7 +15,7 @@ import { AppRuntime } from "../../effect/app-runtime"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
-import { Option } from "effect"
+import { Effect, Option } from "effect"
 import { WorkspaceRoutes } from "./workspace"
 import { Agent } from "@/agent/agent"
 
@@ -57,14 +57,18 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [consoleState, groups] = await Promise.all([
-          Config.getConsoleState(),
-          AppRuntime.runPromise(Account.Service.use((svc) => svc.orgsByAccount())),
-        ])
-        return c.json({
-          ...consoleState,
-          switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
-        })
+        const result = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const config = yield* Config.Service
+            const account = yield* Account.Service
+            const [state, groups] = yield* Effect.all([config.getConsoleState(), account.orgsByAccount()])
+            return {
+              ...state,
+              switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
+            }
+          }),
+        )
+        return c.json(result)
       },
     )
     .get(
@@ -85,21 +89,22 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [groups, active] = await Promise.all([
-          AppRuntime.runPromise(Account.Service.use((svc) => svc.orgsByAccount())),
-          AppRuntime.runPromise(Account.Service.use((svc) => svc.active())),
-        ])
-
-        const info = Option.getOrUndefined(active)
-        const orgs = groups.flatMap((group) =>
-          group.orgs.map((org) => ({
-            accountID: group.account.id,
-            accountEmail: group.account.email,
-            accountUrl: group.account.url,
-            orgID: org.id,
-            orgName: org.name,
-            active: !!info && info.id === group.account.id && info.active_org_id === org.id,
-          })),
+        const orgs = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const account = yield* Account.Service
+            const [groups, active] = yield* Effect.all([account.orgsByAccount(), account.active()])
+            const info = Option.getOrUndefined(active)
+            return groups.flatMap((group) =>
+              group.orgs.map((org) => ({
+                accountID: group.account.id,
+                accountEmail: group.account.email,
+                accountUrl: group.account.url,
+                orgID: org.id,
+                orgName: org.name,
+                active: !!info && info.id === group.account.id && info.active_org_id === org.id,
+              })),
+            )
+          }),
         )
         return c.json({ orgs })
       },
@@ -125,7 +130,10 @@ export const ExperimentalRoutes = lazy(() =>
       async (c) => {
         const body = c.req.valid("json")
         await AppRuntime.runPromise(
-          Account.Service.use((svc) => svc.use(AccountID.make(body.accountID), Option.some(OrgID.make(body.orgID)))),
+          Effect.gen(function* () {
+            const account = yield* Account.Service
+            yield* account.use(AccountID.make(body.accountID), Option.some(OrgID.make(body.orgID)))
+          }),
         )
         return c.json(true)
       },

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -61,7 +61,7 @@ export const ExperimentalRoutes = lazy(() =>
           Effect.gen(function* () {
             const config = yield* Config.Service
             const account = yield* Account.Service
-            const [state, groups] = yield* Effect.all([config.getConsoleState(), account.orgsByAccount()])
+            const [state, groups] = yield* Effect.all([config.getConsoleState(), account.orgsByAccount()], { concurrency: "unbounded" })
             return {
               ...state,
               switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
@@ -92,7 +92,7 @@ export const ExperimentalRoutes = lazy(() =>
         const orgs = await AppRuntime.runPromise(
           Effect.gen(function* () {
             const account = yield* Account.Service
-            const [groups, active] = yield* Effect.all([account.orgsByAccount(), account.active()])
+            const [groups, active] = yield* Effect.all([account.orgsByAccount(), account.active()], { concurrency: "unbounded" })
             const info = Option.getOrUndefined(active)
             return groups.flatMap((group) =>
               group.orgs.map((org) => ({

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -11,9 +11,11 @@ import { Session } from "../../session"
 import { Config } from "../../config/config"
 import { ConsoleState } from "../../config/console-state"
 import { Account, AccountID, OrgID } from "../../account"
+import { AppRuntime } from "../../effect/app-runtime"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Option } from "effect"
 import { WorkspaceRoutes } from "./workspace"
 import { Agent } from "@/agent/agent"
 
@@ -55,7 +57,10 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [consoleState, groups] = await Promise.all([Config.getConsoleState(), Account.orgsByAccount()])
+        const [consoleState, groups] = await Promise.all([
+          Config.getConsoleState(),
+          AppRuntime.runPromise(Account.Service.use((svc) => svc.orgsByAccount())),
+        ])
         return c.json({
           ...consoleState,
           switchableOrgCount: groups.reduce((count, group) => count + group.orgs.length, 0),
@@ -80,8 +85,12 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const [groups, active] = await Promise.all([Account.orgsByAccount(), Account.active()])
+        const [groups, active] = await Promise.all([
+          AppRuntime.runPromise(Account.Service.use((svc) => svc.orgsByAccount())),
+          AppRuntime.runPromise(Account.Service.use((svc) => svc.active())),
+        ])
 
+        const info = Option.getOrUndefined(active)
         const orgs = groups.flatMap((group) =>
           group.orgs.map((org) => ({
             accountID: group.account.id,
@@ -89,7 +98,7 @@ export const ExperimentalRoutes = lazy(() =>
             accountUrl: group.account.url,
             orgID: org.id,
             orgName: org.name,
-            active: !!active && active.id === group.account.id && active.active_org_id === org.id,
+            active: !!info && info.id === group.account.id && info.active_org_id === org.id,
           })),
         )
         return c.json({ orgs })
@@ -115,7 +124,9 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", ConsoleSwitchBody),
       async (c) => {
         const body = c.req.valid("json")
-        await Account.switchOrg(AccountID.make(body.accountID), OrgID.make(body.orgID))
+        await AppRuntime.runPromise(
+          Account.Service.use((svc) => svc.use(AccountID.make(body.accountID), Option.some(OrgID.make(body.orgID)))),
+        )
         return c.json(true)
       },
     )


### PR DESCRIPTION
## Summary
- Removed `makeRuntime` and facade functions (`active`, `orgsByAccount`, `switchOrg`) from `Account`
- Effectified experimental routes: console handlers now use single `Effect.gen` blocks with `Config.Service` and `Account.Service` yielded from context, `Effect.all` for concurrent calls
- Converted `cli/cmd/account.ts` to use `AppRuntime.runPromise`

## Verification
- `bun run typecheck` — clean
- `bun run test test/account` — 26/26