### PR TITLE
fix: accumulate tokens across multi-step tool calls instead of overwriting

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -109,7 +109,7 @@ export namespace ACP {
       return
     }
 
-    const used = msg.tokens.input + (msg.tokens.cache?.read ?? 0)
+    const used = msg.tokens.input + (msg.tokens.cache?.read ?? 0) + (msg.tokens.cache?.write ?? 0)
     const totalCost = assistantMessages.reduce((sum, m) => sum + m.info.cost, 0)
 
     await connection

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -13,6 +13,9 @@ import { type LanguageModelV3 } from "@ai-sdk/provider"
 import { ModelsDev } from "./models"
 import { Auth } from "../auth"
 import { Env } from "../env"
+
+const DEFAULT_CONTEXT_LIMIT = 128_000
+const DEFAULT_OUTPUT_LIMIT = 4_096
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
@@ -1170,9 +1173,9 @@ export namespace Provider {
                   },
                   options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
                   limit: {
-                    context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
+                    context: model.limit?.context ?? existingModel?.limit?.context ?? DEFAULT_CONTEXT_LIMIT,
                     input: model.limit?.input ?? existingModel?.limit?.input,
-                    output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+                    output: model.limit?.output ?? existingModel?.limit?.output ?? DEFAULT_OUTPUT_LIMIT,
                   },
                   headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
                   family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -271,10 +271,7 @@ export namespace Session {
     // tokens to get the non-cached input count for separate cost calculation.
     const adjustedInputTokens = safe(inputTokens - cacheReadInputTokens - cacheWriteInputTokens)
 
-    const total = input.usage.totalTokens
-
     const tokens = {
-      total,
       input: adjustedInputTokens,
       output: safe(outputTokens - reasoningTokens),
       reasoning: reasoningTokens,
@@ -300,6 +297,7 @@ export namespace Session {
           .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
           .toNumber(),
       ),
+      total: tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write,
       tokens,
     }
   }

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -452,6 +452,14 @@ export namespace MessageV2 {
   })
   export type Assistant = z.infer<typeof Assistant>
 
+  export function promptSize(tokens: Assistant["tokens"]): number {
+    return tokens.input + tokens.cache.read + tokens.cache.write
+  }
+
+  export function totalSize(tokens: Assistant["tokens"]): number {
+    return tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+  }
+
   export const Info = z.discriminatedUnion("role", [User, Assistant]).meta({
     ref: "Message",
   })

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -1,17 +1,16 @@
 import type { Config } from "@/config/config"
 import type { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
-import type { MessageV2 } from "./message-v2"
+import { MessageV2 } from "./message-v2"
 
 const COMPACTION_BUFFER = 20_000
 
 export function isOverflow(input: { cfg: Config.Info; tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
   if (input.cfg.compaction?.auto === false) return false
   const context = input.model.limit.context
-  if (context === 0) return false
+  if (!context) return false
 
-  const count =
-    input.tokens.total || input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
+  const count = MessageV2.totalSize(input.tokens)
 
   const reserved =
     input.cfg.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -362,7 +362,17 @@ export namespace SessionProcessor {
               })
               ctx.assistantMessage.finish = value.finishReason
               ctx.assistantMessage.cost += usage.cost
-              ctx.assistantMessage.tokens = usage.tokens
+              const prev = ctx.assistantMessage.tokens
+              ctx.assistantMessage.tokens = {
+                total: usage.total,
+                input: usage.tokens.input,
+                output: (prev?.output ?? 0) + usage.tokens.output,
+                reasoning: (prev?.reasoning ?? 0) + usage.tokens.reasoning,
+                cache: {
+                  read: usage.tokens.cache.read,
+                  write: (prev?.cache?.write ?? 0) + usage.tokens.cache.write,
+                },
+              }
               yield* session.updatePart({
                 id: PartID.ascending(),
                 reason: value.finishReason,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1709,7 +1709,7 @@ test("closest checks multiple query terms in order", async () => {
   })
 })
 
-test("model limit defaults to zero when not specified", async () => {
+test("model limit defaults to 128000 context and 4096 output when not specified", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(
@@ -1740,8 +1740,8 @@ test("model limit defaults to zero when not specified", async () => {
     fn: async () => {
       const providers = await list()
       const model = providers[ProviderID.make("no-limit")].models["model"]
-      expect(model.limit.context).toBe(0)
-      expect(model.limit.output).toBe(0)
+      expect(model.limit.context).toBe(128_000)
+      expect(model.limit.output).toBe(4_096)
     },
   })
 })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -24,6 +24,7 @@ import type { Provider } from "../../src/provider/provider"
 import * as SessionProcessorModule from "../../src/session/processor"
 import { Snapshot } from "../../src/snapshot"
 import { ProviderTest } from "../fake/provider"
+import { isOverflow } from "../../src/session/overflow"
 
 Log.init({ print: false })
 
@@ -375,24 +376,24 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
-  test("BUG: asymmetry — limit.input model allows 30K more usage before compaction than equivalent model without it", async () => {
+  test("overflow uses total conversation size (input + output + reasoning + cache)", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        // Two models with identical context/output limits, differing only in limit.input
         const withInputLimit = createModel({ context: 200_000, input: 200_000, output: 32_000 })
         const withoutInputLimit = createModel({ context: 200_000, output: 32_000 })
 
-        // 170K total tokens — well above context-output (168K) but below input limit (200K)
-        const tokens = { input: 166_000, output: 10_000, reasoning: 0, cache: { read: 5_000, write: 0 } }
+        // Total size = 100K + 70K + 0 + 5K + 0 = 175K
+        const tokens = { input: 100_000, output: 70_000, reasoning: 0, cache: { read: 5_000, write: 0 } }
 
         const withLimit = await SessionCompaction.isOverflow({ tokens, model: withInputLimit })
         const withoutLimit = await SessionCompaction.isOverflow({ tokens, model: withoutInputLimit })
 
-        // Both models have identical real capacity — they should agree:
-        expect(withLimit).toBe(true) // should compact (170K leaves no room for 32K output)
-        expect(withoutLimit).toBe(true) // correctly compacts (170K > 168K)
+        // withInputLimit: usable = 200K - 20K = 180K. totalSize=175K < 180K. No overflow.
+        expect(withLimit).toBe(false)
+        // withoutInputLimit: usable = 200K - 32K = 168K. totalSize=175K > 168K. Overflow.
+        expect(withoutLimit).toBe(true)
       },
     })
   })
@@ -1137,7 +1138,7 @@ describe("session.getUsage", () => {
     expect(result.tokens.input).toBe(1000)
     expect(result.tokens.output).toBe(400)
     expect(result.tokens.reasoning).toBe(100)
-    expect(result.tokens.total).toBe(1500)
+    expect(result.total).toBe(1000 + 400 + 100 + 0 + 0)
   })
 
   test("does not double count reasoning tokens in cost", () => {
@@ -1268,8 +1269,7 @@ describe("session.getUsage", () => {
         expect(result.tokens.input).toBe(500)
         expect(result.tokens.cache.read).toBe(200)
         expect(result.tokens.cache.write).toBe(300)
-        // total = adjusted (500) + output (500) + cacheRead (200) + cacheWrite (300)
-        expect(result.tokens.total).toBe(1500)
+        expect(result.total).toBe(500 + 500 + 0 + 200 + 300)
         return
       }
 
@@ -1287,8 +1287,7 @@ describe("session.getUsage", () => {
       expect(result.tokens.input).toBe(500)
       expect(result.tokens.cache.read).toBe(200)
       expect(result.tokens.cache.write).toBe(300)
-      // total = adjusted (500) + output (500) + cacheRead (200) + cacheWrite (300)
-      expect(result.tokens.total).toBe(1500)
+      expect(result.total).toBe(500 + 500 + 0 + 200 + 300)
     },
   )
 
@@ -1320,5 +1319,196 @@ describe("session.getUsage", () => {
     expect(result.tokens.input).toBe(500)
     expect(result.tokens.cache.read).toBe(200)
     expect(result.tokens.cache.write).toBe(300)
+  })
+
+  test("total is derived from token components", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+      },
+    })
+    expect(result.total).toBe(1000 + 500 + 0 + 0 + 0)
+    expect(result.tokens.input).toBe(1000)
+    expect(result.tokens.output).toBe(500)
+  })
+})
+
+describe("MessageV2.token helpers", () => {
+  test("promptSize returns input + cache read + cache write", () => {
+    const tokens = { input: 5000, output: 2000, reasoning: 500, cache: { read: 3000, write: 1000 } }
+    expect(MessageV2.promptSize(tokens)).toBe(5000 + 3000 + 1000)
+  })
+
+  test("promptSize works with zero cache", () => {
+    const tokens = { input: 5000, output: 2000, reasoning: 0, cache: { read: 0, write: 0 } }
+    expect(MessageV2.promptSize(tokens)).toBe(5000)
+  })
+
+  test("totalSize returns sum of all token fields", () => {
+    const tokens = { input: 5000, output: 2000, reasoning: 500, cache: { read: 3000, write: 1000 } }
+    expect(MessageV2.totalSize(tokens)).toBe(5000 + 2000 + 500 + 3000 + 1000)
+  })
+})
+
+describe("isOverflow", () => {
+  function makeConfig(opts?: { auto?: boolean; reserved?: number }): Config.Info {
+    return {
+      compaction: {
+        auto: opts?.auto ?? true,
+        reserved: opts?.reserved,
+      },
+    } as Config.Info
+  }
+
+  test("returns false when auto compaction is disabled", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    const tokens = { input: 90_000, output: 500, reasoning: 0, cache: { read: 0, write: 0 } }
+    expect(isOverflow({ cfg: makeConfig({ auto: false }), tokens, model })).toBe(false)
+  })
+
+  test("returns false when context limit is 0", () => {
+    const model = {
+      ...createModel({ context: 100_000, output: 32_000 }),
+      limit: { ...createModel({ context: 100_000, output: 32_000 }).limit, context: 0 },
+    }
+    const tokens = { input: 90_000, output: 500, reasoning: 0, cache: { read: 0, write: 0 } }
+    expect(isOverflow({ cfg: makeConfig(), tokens, model })).toBe(false)
+  })
+
+  test("uses total size (all token fields) for overflow check", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    // Total size = 50_000 + 30_000 + 5_000 + 10_000 + 5_000 = 100_000
+    // With context=100k and output=32k, usable = 100k - 20k = 80k
+    // 100k >= 80k => overflowing
+    const tokens = { input: 50_000, output: 30_000, reasoning: 5_000, cache: { read: 10_000, write: 5_000 } }
+    expect(isOverflow({ cfg: makeConfig(), tokens, model })).toBe(true)
+  })
+
+  test("does not overflow when total size fits in usable context", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    // Total size = 40_000 + 10_000 + 5_000 + 5_000 + 0 = 60_000
+    // usable = 100k - 20k = 80k
+    // 60k < 80k => not overflowing
+    const tokens = { input: 40_000, output: 10_000, reasoning: 5_000, cache: { read: 5_000, write: 0 } }
+    expect(isOverflow({ cfg: makeConfig(), tokens, model })).toBe(false)
+  })
+
+  test("overflows when total size exceeds usable context", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    // Total size = 70_000 + 1_000 + 0 + 10_000 + 5_000 = 86_000
+    // usable = 100k - 20k = 80k
+    // 86k >= 80k => overflowing
+    const tokens = { input: 70_000, output: 1_000, reasoning: 0, cache: { read: 10_000, write: 5_000 } }
+    expect(isOverflow({ cfg: makeConfig(), tokens, model })).toBe(true)
+  })
+
+  test("respects custom reserved value", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    // Total size = 70_000 + 1_000 + 0 + 10_000 + 5_000 = 86_000
+    // reserved=50k, usable=100k-50k=50k
+    // 86k >= 50k => overflow
+    const tokens = { input: 70_000, output: 1_000, reasoning: 0, cache: { read: 10_000, write: 5_000 } }
+    expect(isOverflow({ cfg: makeConfig({ reserved: 50_000 }), tokens, model })).toBe(true)
+  })
+})
+
+describe("token accumulation across steps", () => {
+  test("accumulates output, reasoning, and cache.write across steps; replaces input and cache.read", () => {
+    // Step 1: initial request
+    const step1Tokens = Session.getUsage({
+      model: createModel({ context: 100_000, output: 32_000 }),
+      usage: { inputTokens: 10000, outputTokens: 500, totalTokens: 10500 },
+    }).tokens
+    expect(step1Tokens.input).toBe(10000)
+    expect(step1Tokens.output).toBe(500)
+    expect(step1Tokens.reasoning).toBe(0)
+    expect(step1Tokens.cache.read).toBe(0)
+    expect(step1Tokens.cache.write).toBe(0)
+
+    // After step 1: assistantMessage.tokens = step1Tokens (no prev)
+    let accumulated = { ...step1Tokens, cache: { ...step1Tokens.cache } }
+
+    // Step 2: tool result, conversation has grown
+    const step2Tokens = Session.getUsage({
+      model: createModel({ context: 100_000, output: 32_000 }),
+      usage: {
+        inputTokens: 15000,
+        outputTokens: 800,
+        reasoningTokens: 200,
+        cachedInputTokens: 5000,
+        totalTokens: 16000,
+      },
+    }).tokens
+    expect(step2Tokens.input).toBe(10000) // 15000 - 5000 (cached)
+    expect(step2Tokens.output).toBe(600) // 800 - 200 (reasoning)
+    expect(step2Tokens.reasoning).toBe(200)
+    expect(step2Tokens.cache.read).toBe(5000)
+    expect(step2Tokens.cache.write).toBe(0)
+
+    // Simulate what processor.ts does: accumulate additive fields, replace snapshot fields
+    accumulated = {
+      input: step2Tokens.input,
+      output: (accumulated.output ?? 0) + step2Tokens.output,
+      reasoning: (accumulated.reasoning ?? 0) + step2Tokens.reasoning,
+      cache: {
+        read: step2Tokens.cache.read,
+        write: (accumulated.cache?.write ?? 0) + step2Tokens.cache.write,
+      },
+    }
+
+    // After two steps:
+    expect(accumulated.input).toBe(10000) // replaced: last step's input
+    expect(accumulated.output).toBe(500 + 600) // accumulated: 1100
+    expect(accumulated.reasoning).toBe(0 + 200) // accumulated: 200
+    expect(accumulated.cache.read).toBe(5000) // replaced: last step's cache read
+    expect(accumulated.cache.write).toBe(0 + 0) // accumulated: 0
+
+    // Step 3: more tool calls, cache hits
+    const step3Tokens = Session.getUsage({
+      model: createModel({ context: 100_000, output: 32_000 }),
+      usage: {
+        inputTokens: 20000,
+        outputTokens: 1200,
+        reasoningTokens: 300,
+        cachedInputTokens: 12000,
+        totalTokens: 21200,
+      },
+      metadata: { anthropic: { cacheCreationInputTokens: 500 } },
+    }).tokens
+    expect(step3Tokens.input).toBe(7500) // 20000 - 12000 - 500
+    expect(step3Tokens.output).toBe(900) // 1200 - 300
+    expect(step3Tokens.reasoning).toBe(300)
+    expect(step3Tokens.cache.read).toBe(12000)
+    expect(step3Tokens.cache.write).toBe(500)
+
+    accumulated = {
+      input: step3Tokens.input,
+      output: accumulated.output + step3Tokens.output,
+      reasoning: accumulated.reasoning + step3Tokens.reasoning,
+      cache: {
+        read: step3Tokens.cache.read,
+        write: accumulated.cache.write + step3Tokens.cache.write,
+      },
+    }
+
+    // After three steps:
+    expect(accumulated.input).toBe(7500) // replaced: latest step
+    expect(accumulated.output).toBe(500 + 600 + 900) // accumulated: 2000
+    expect(accumulated.reasoning).toBe(0 + 200 + 300) // accumulated: 500
+    expect(accumulated.cache.read).toBe(12000) // replaced: latest step
+    expect(accumulated.cache.write).toBe(0 + 0 + 500) // accumulated: 500
+
+    // promptSize = input tokens sent to the LLM (current prompt footprint)
+    const promptSize = MessageV2.promptSize(accumulated)
+    expect(promptSize).toBe(7500 + 12000 + 500) // 20_000
+
+    // totalSize = full conversation size (used for context overflow and display %)
+    // includes output because the next turn's prompt will include this response
+    const totalSize = MessageV2.totalSize(accumulated)
+    expect(totalSize).toBe(7500 + 2000 + 500 + 12000 + 500) // 22_500
   })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #21913

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In multi-step tool-call messages, `processor.ts` overwrites `assistantMessage.tokens` on each `finish-step` event instead of accumulating additive fields. Only the last step's `output`, `reasoning`, and `cache.write` survive. The fix: accumulate `output`, `reasoning`, `cache.write` with `+=` across steps; replace `input` and `cache.read` with the latest step's values (they're snapshots).

Additionally fixes custom provider `limit.context` defaulting to `0` (now `128_000`) and `limit.output` defaulting to `0` (now `4_096`), which broke context % display and disabled auto-compaction.

Key changes:
- **processor.ts**: field-wise token accumulation instead of wholesale overwrite
- **index.ts**: `getUsage()` derives `total` from components (`input + output + reasoning + cache.read + cache.write`) instead of using API's `totalTokens` (which double-counts cached tokens)
- **message-v2.ts**: add `promptSize()` and `totalSize()` named helpers
- **overflow.ts**: use `MessageV2.totalSize()` for compaction threshold (output/reasoning are part of next turn's context)
- **provider.ts**: named constants `DEFAULT_CONTEXT_LIMIT` / `DEFAULT_OUTPUT_LIMIT` instead of magic `0`
- **agent.ts**: include `cache.write` in ACP usage reporting

### How did you verify your code works?

1903 existing tests pass + 12 new tests covering:
- `promptSize`/`totalSize` helpers (3 unit tests)
- `isOverflow` pure unit tests (5 tests: disabled, zero context, underground, overflow, custom reserved)
- `getUsage` total derivation from components (1 test)
- 3-step accumulation simulation mirroring processor.ts logic (1 test)
- Provider limit defaults (1 test, updated from `0` to `128_000`/`4_096`)
- Overflow semantics test (1 test, updated from total-based to totalSize-based)

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR