### PR TITLE
refactor(file): destroy FileWatcher facade

### DIFF
--- a/packages/opencode/src/effect/bootstrap-runtime.ts
+++ b/packages/opencode/src/effect/bootstrap-runtime.ts
@@ -1,9 +1,10 @@
 import { Layer, ManagedRuntime } from "effect"
 import { memoMap } from "./run-service"
 
+import { FileWatcher } from "@/file/watcher"
 import { Format } from "@/format"
 import { ShareNext } from "@/share/share-next"
 
-export const BootstrapLayer = Layer.mergeAll(Format.defaultLayer, ShareNext.defaultLayer)
+export const BootstrapLayer = Layer.mergeAll(Format.defaultLayer, ShareNext.defaultLayer, FileWatcher.defaultLayer)
 
 export const BootstrapRuntime = ManagedRuntime.make(BootstrapLayer, { memoMap })

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -8,7 +8,6 @@ import z from "zod"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { InstanceState } from "@/effect/instance-state"
-import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@/flag/flag"
 import { Git } from "@/git"
 import { Instance } from "@/project/instance"
@@ -161,10 +160,4 @@ export namespace FileWatcher {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(Git.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  export function init() {
-    return runPromise((svc) => svc.init())
-  }
 }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -2,7 +2,6 @@ import { Plugin } from "../plugin"
 import { Format } from "../format"
 import { LSP } from "../lsp"
 import { File } from "../file"
-import { FileWatcher } from "../file/watcher"
 import { Snapshot } from "../snapshot"
 import { Project } from "./project"
 import { Vcs } from "./vcs"
@@ -10,7 +9,9 @@ import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
+import { AppRuntime } from "@/effect/app-runtime"
 import { BootstrapRuntime } from "@/effect/bootstrap-runtime"
+import { FileWatcher } from "@/file/watcher"
 import { ShareNext } from "@/share/share-next"
 
 export async function InstanceBootstrap() {
@@ -20,7 +21,7 @@ export async function InstanceBootstrap() {
   void BootstrapRuntime.runPromise(Format.Service.use((svc) => svc.init()))
   await LSP.init()
   File.init()
-  FileWatcher.init()
+  void AppRuntime.runPromise(FileWatcher.Service.use((svc) => svc.init()))
   Vcs.init()
   Snapshot.init()
 

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -9,7 +9,6 @@ import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
-import { AppRuntime } from "@/effect/app-runtime"
 import { BootstrapRuntime } from "@/effect/bootstrap-runtime"
 import { FileWatcher } from "@/file/watcher"
 import { ShareNext } from "@/share/share-next"
@@ -21,7 +20,7 @@ export async function InstanceBootstrap() {
   void BootstrapRuntime.runPromise(Format.Service.use((svc) => svc.init()))
   await LSP.init()
   File.init()
-  void AppRuntime.runPromise(FileWatcher.Service.use((svc) => svc.init()))
+  void BootstrapRuntime.runPromise(FileWatcher.Service.use((svc) => svc.init()))
   Vcs.init()
   Snapshot.init()
 

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { tmpdir } from "../fixture/fixture"
+import { AppRuntime } from "../../src/effect/app-runtime"
 import { FileWatcher } from "../../src/file/watcher"
 import { Instance } from "../../src/project/instance"
 import { GlobalBus } from "../../src/bus/global"
@@ -19,7 +20,7 @@ async function withVcs(directory: string, body: () => Promise<void>) {
   return Instance.provide({
     directory,
     fn: async () => {
-      FileWatcher.init()
+      void AppRuntime.runPromise(FileWatcher.Service.use((svc) => svc.init()))
       Vcs.init()
       await Bun.sleep(500)
       await body()


### PR DESCRIPTION
## Summary
- Removed `makeRuntime` and `init` facade from `FileWatcher`
- Converted `project/bootstrap.ts` and `test/project/vcs.test.ts` to `AppRuntime.runPromise`

## Verification
- `bun run typecheck` — clean