### PR TITLE
fix(tui): guard enabledFormatters against undefined to prevent crash

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -12,7 +12,7 @@ export function DialogStatus() {
   const { theme } = useTheme()
   const dialog = useDialog()
 
-  const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
+  const enabledFormatters = createMemo(() => (sync.data.formatter ?? []).filter((f) => f.enabled))
 
   const plugins = createMemo(() => {
     const list = sync.data.config.plugin ?? []

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -424,7 +424,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.experimental.resource
               .list({ workspace })
               .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
-            sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data!))),
+            sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
             sdk.client.session.status({ workspace }).then((x) => {
               setStore("session_status", reconcile(x.data!))
             }),


### PR DESCRIPTION
### Issue for this PR

Closes #22050
Closes #22021

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI crashes with `TypeError: undefined is not an object (evaluating 'enabledFormatters().length')` when the `enabledFormatters()` SolidJS signal returns `undefined` instead of an array.

**Root cause**: In `sync.tsx`, the formatter status SDK call uses `x.data!` (non-null assertion). When `x.data` is `undefined`, `reconcile(undefined)` overwrites the initial `[]` store value with `undefined`. The `createMemo` in `dialog-status.tsx` then calls `.filter()` on `undefined`, and downstream `.length` access crashes.

**Fix** (two changes):
1. **Source fix** (`sync.tsx`): Changed `reconcile(x.data!)` to `reconcile(x.data ?? [])` so the store always holds an array.
2. **Consumer guard** (`dialog-status.tsx`): Added `?? []` fallback in the `createMemo` — `(sync.data.formatter ?? []).filter(...)` — as defense-in-depth against any other path that could set formatter to undefined.

### How did you verify your code works?

- `tsgo --noEmit` (typecheck) passes with no errors
- Reviewed all usages of `enabledFormatters()` in `dialog-status.tsx` — the `.length` and `<For each={...}>` accesses are now safe
- The fix matches the existing pattern used by other fields (e.g. `x.data ?? []` on line 421 for commands, `x.data ?? {}` on line 426/431)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR