### PR TITLE
fix(tui): guard sync.data.mcp against undefined

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -50,10 +50,10 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={Object.keys(sync.data.mcp ?? {}).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
-          <For each={Object.entries(sync.data.mcp)}>
+          <text fg={theme.text}>{Object.keys(sync.data.mcp ?? {}).length} MCP Servers</text>
+          <For each={Object.entries(sync.data.mcp ?? {})}>
             {([key, item]) => (
               <box flexDirection="row" gap={1}>
                 <text

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -420,7 +420,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data!))),
-            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data!))),
+            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
             sdk.client.experimental.resource
               .list({ workspace })
               .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -176,7 +176,7 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       return sync.data.lsp.map((item) => ({ id: item.id, root: item.root, status: item.status }))
     },
     mcp() {
-      return Object.entries(sync.data.mcp)
+      return Object.entries(sync.data.mcp ?? {})
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([name, item]) => ({
           name,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -10,8 +10,8 @@ export function Footer() {
   const { theme } = useTheme()
   const sync = useSync()
   const route = useRoute()
-  const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
-  const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
+  const mcp = createMemo(() => Object.values(sync.data.mcp ?? {}).filter((x) => x.status === "connected").length)
+  const mcpError = createMemo(() => Object.values(sync.data.mcp ?? {}).some((x) => x.status === "failed"))
   const lsp = createMemo(() => Object.keys(sync.data.lsp))
   const permissions = createMemo(() => {
     if (route.data.type !== "session") return []


### PR DESCRIPTION
### Issue for this PR

Closes #22102

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a TUI crash where `Object.entries(sync.data.mcp)` throws `TypeError: Object.entries requires that input parameter not be null or undefined` when MCP status data has not loaded yet.

The root cause is in `sync.tsx` where `x.data!` uses a non-null assertion on MCP status response data. When the response data is null/undefined, this propagates to all consumers that call `Object.entries()`, `Object.keys()`, or `Object.values()` on `sync.data.mcp`.

The fix adds `?? {}` fallbacks at the source (sync store setter) and at each consumer site, matching the existing pattern used for `mcp_resource` and `command` data on adjacent lines.

### How did you verify your code works?

- Ran `bun typecheck` in packages/opencode — passes
- Verified the fix matches the pattern already used for `mcp_resource` on the adjacent line in sync.tsx
- Same fix pattern as PR #22099 which fixed the identical issue for `sync.data.formatter`

### Screenshots / recordings

N/A — crash fix, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR