### PR TITLE
fix(ui): show "Running commands" instead of "Thinking" while bash tool executes

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -346,6 +346,7 @@ export function SessionTurn(
   const assistantDerived = createMemo(() => {
     let visible = 0
     let reason: string | undefined
+    let bash = false
     const show = showReasoningSummaries()
     for (const message of assistantMessages()) {
       for (const part of list(data.store.part?.[message.id], emptyParts)) {
@@ -356,12 +357,20 @@ export function SessionTurn(
           const h = heading(part.text)
           if (h) reason = h
         }
+        if (
+          part.type === "tool" &&
+          part.tool === "bash" &&
+          (part.state.status === "running" || part.state.status === "pending")
+        ) {
+          bash = true
+        }
       }
     }
-    return { visible, reason }
+    return { visible, reason, bash }
   })
   const assistantVisible = createMemo(() => assistantDerived().visible)
   const reasoningHeading = createMemo(() => assistantDerived().reason)
+  const bashRunning = createMemo(() => assistantDerived().bash)
   const showThinking = createMemo(() => {
     if (!working() || !!error()) return false
     if (status().type === "retry") return false
@@ -414,7 +423,11 @@ export function SessionTurn(
               </Show>
               <Show when={showThinking()}>
                 <div data-slot="session-turn-thinking">
-                  <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} />
+                  <TextShimmer
+                    text={i18n.t(
+                      bashRunning() ? "ui.sessionTurn.status.runningCommands" : "ui.sessionTurn.status.thinking",
+                    )}
+                  />
                   <Show when={!showReasoningSummaries()}>
                     <TextReveal
                       text={reasoningHeading()}


### PR DESCRIPTION
### Issue for this PR

Closes #22108

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web UI shows "Thinking" while the session is busy, even when a bash tool is actively running and the model is just waiting for shell output. This happens because `showThinking` in `session-turn.tsx` returns `true` unconditionally when `showReasoningSummaries` is `false` (the default).

The fix tracks whether any bash tool part has `running` or `pending` status inside the existing `assistantDerived` memo. When a bash tool is active, the shimmer text switches from "Thinking" to "Running commands" using the existing i18n key `ui.sessionTurn.status.runningCommands` (already translated in all 17 locales).

### How did you verify your code works?

manually tested. see below.

### Screenshots / recordings

before:
<img width="233" height="128" alt="image" src="https://github.com/user-attachments/assets/7406e7c2-67c8-42b7-9f9d-a8b241696a8f" />


after:
<img width="333" height="142" alt="image" src="https://github.com/user-attachments/assets/502eb8b3-aa01-40a5-9b3a-0cc0db6d47f2" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
