### PR TITLE
fix: show command as description for shell escape (!) tool calls

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -769,7 +769,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           state: {
             status: "running",
             time: { start: Date.now() },
-            input: { command: input.command },
+            input: { command: input.command, description: input.command },
           },
         }
         yield* sessions.updatePart(part)


### PR DESCRIPTION
### Issue for this PR

Closes #22112

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When using `!` shell escape, the tool part is created with `input: { command }` but no `description`. The agent-invoked bash tool always provides a `description` (a required parameter in the schema) which shows as the subtitle in the Shell tool header. Shell escape commands show nothing.

One-line fix in `packages/opencode/src/session/prompt.ts` -- sets `description` to the command text itself so the user can see what command was run in the tool header.

### How did you verify your code works?

Ran `bun run dev web`, used `!sleep 1s` shell escape, confirmed the command text now appears as the subtitle in the Shell tool header after completion.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR