### PR TITLE
fix(opencode): skip eager import for disabled local tools

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -159,9 +159,22 @@ export namespace ToolRegistry {
           const matches = dirs.flatMap((dir) =>
             Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }),
           )
+          const cfg = yield* config.get()
+          const rules = Permission.fromConfig(cfg.permission ?? {})
           if (matches.length) yield* config.waitForDependencies()
           for (const match of matches) {
             const namespace = path.basename(match, path.extname(match))
+            const text = yield* Effect.promise(() => Bun.file(match).text())
+            const named = Array.from(
+              text.matchAll(/export\s+(?:const|let|var|async function|function)\s+([A-Za-z_$][\w$]*)/g),
+              (item) => `${namespace}_${item[1]}`,
+            )
+            const ids = [...(text.includes("export default") ? [namespace] : []), ...named]
+            const disabled = new Set([
+              ...ids.filter((id) => cfg.tools?.[id] === false),
+              ...Permission.disabled(ids, rules),
+            ])
+            if (ids.length && ids.every((id) => disabled.has(id))) continue
             const mod = yield* Effect.promise(
               () => import(process.platform === "win32" ? match : pathToFileURL(match).href),
             )
@@ -177,7 +190,6 @@ export namespace ToolRegistry {
             }
           }
 
-          const cfg = yield* config.get()
           const questionEnabled =
             ["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT) || Flag.OPENCODE_ENABLE_QUESTION_TOOL
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -154,4 +154,116 @@ describe("tool.registry", () => {
       },
     })
   })
+
+  test("skips disabled tools before importing them", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolDir = path.join(opencodeDir, "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        await Bun.write(
+          path.join(opencodeDir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            tools: {
+              boom: false,
+            },
+          }),
+        )
+
+        await Bun.write(
+          path.join(toolDir, "boom.ts"),
+          ['throw new Error("disabled tool imported")', "export default {}", ""].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).not.toContain("boom")
+      },
+    })
+  })
+
+  test("skips disabled named-export tools before importing them", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolDir = path.join(opencodeDir, "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        await Bun.write(
+          path.join(opencodeDir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            tools: {
+              math_add: false,
+              math_multiply: false,
+            },
+          }),
+        )
+
+        await Bun.write(
+          path.join(toolDir, "math.ts"),
+          [
+            'throw new Error("disabled named tool imported")',
+            "export const add = {}",
+            "export const multiply = {}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).not.toContain("math_add")
+        expect(ids).not.toContain("math_multiply")
+      },
+    })
+  })
+
+  test("skips permission-disabled tools before importing them", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolDir = path.join(opencodeDir, "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        await Bun.write(
+          path.join(opencodeDir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            permission: {
+              boom: "deny",
+            },
+          }),
+        )
+
+        await Bun.write(
+          path.join(toolDir, "boom.ts"),
+          ['throw new Error("permission disabled tool imported")', "export default {}", ""].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).not.toContain("boom")
+      },
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #22061

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents eager import of disabled repo-local custom tools for the documented local tool shapes.

The change adds a cheap pre-scan in the custom tool registry so OpenCode can skip importing a local tool file when every documented tool ID from that file is already disabled by config. It covers the documented local patterns (`export default`, direct `export const/function`) and also respects top-level `permission` denies.

This keeps the fix narrow to `#22061` and avoids changing unrelated dependency install behavior.

### How did you verify your code works?

- Ran `cd packages/opencode && bun test test/tool/registry.test.ts`
- Ran `cd packages/opencode && bun typecheck`
- Added regression coverage for:
  - disabled default-export local tools
  - disabled direct named-export local tools
  - top-level `permission` denies

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
