### PR TITLE
fix(cli): add trailing newline to --help output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -57,9 +57,10 @@ function show(out: string) {
   if (!text.startsWith("opencode ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
     process.stderr.write(text)
-    return
+  } else {
+    process.stderr.write(out)
   }
-  process.stderr.write(out)
+  if (!out.endsWith("\n")) process.stderr.write(EOL)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
## Issue

Closes #22115

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Running `opencode --help` does not end with a newline, causing the shell prompt to appear on the same line as the last line of help output.

The `show()` function in `src/index.ts` writes help text to stderr without ensuring a trailing newline. This fix ensures the output always ends with a proper line break.

## How was this change verified?

- Reviewed yargs help output behavior
- Verified `show()` function appends EOL when missing
- Ran typecheck to confirm no type errors

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes