### PR TITLE
feat(app): replaced not yet dismiss button with view release notes on toaster

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -135,14 +135,14 @@ export const SettingsGeneral: Component = () => {
                   },
                 },
                 {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
+                  label: language.t("toast.update.action.viewRelease"),
+                  onClick: () => platform.openLink(`https://github.com/sst/opencode/releases/tag/v${result.version}`),
                 },
               ]
             : [
                 {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
+                  label: language.t("toast.update.action.viewRelease"),
+                  onClick: () => platform.openLink(`https://github.com/sst/opencode/releases/tag/v${result.version}`),
                 },
               ]
 

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -397,6 +397,7 @@ export const dict = {
   "toast.update.title": "تحديث متاح",
   "toast.update.description": "نسخة جديدة من OpenCode ({{version}}) متاحة الآن للتثبيت.",
   "toast.update.action.installRestart": "تثبيت وإعادة تشغيل",
+  "toast.update.action.viewRelease": "عرض الإصدار",
   "toast.update.action.notYet": "ليس الآن",
   "error.page.title": "حدث خطأ ما",
   "error.page.description": "حدث خطأ أثناء تحميل التطبيق.",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -398,6 +398,7 @@ export const dict = {
   "toast.update.title": "Atualização disponível",
   "toast.update.description": "Uma nova versão do OpenCode ({{version}}) está disponível para instalação.",
   "toast.update.action.installRestart": "Instalar e reiniciar",
+  "toast.update.action.viewRelease": "Ver lançamento",
   "toast.update.action.notYet": "Agora não",
   "error.page.title": "Algo deu errado",
   "error.page.description": "Ocorreu um erro ao carregar a aplicação.",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -443,6 +443,7 @@ export const dict = {
   "toast.update.title": "Dostupno ažuriranje",
   "toast.update.description": "Nova verzija OpenCode-a ({{version}}) je dostupna za instalaciju.",
   "toast.update.action.installRestart": "Instaliraj i restartuj",
+  "toast.update.action.viewRelease": "Pogledaj izdanje",
   "toast.update.action.notYet": "Ne još",
 
   "error.page.title": "Nešto je pošlo po zlu",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -440,6 +440,7 @@ export const dict = {
   "toast.update.title": "Opdatering tilgængelig",
   "toast.update.description": "En ny version af OpenCode ({{version}}) er nu tilgængelig til installation.",
   "toast.update.action.installRestart": "Installer og genstart",
+  "toast.update.action.viewRelease": "Se udgivelse",
   "toast.update.action.notYet": "Ikke endnu",
 
   "error.page.title": "Noget gik galt",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -405,6 +405,7 @@ export const dict = {
   "toast.update.title": "Update verfügbar",
   "toast.update.description": "Eine neue Version von OpenCode ({{version}}) ist zur Installation verfügbar.",
   "toast.update.action.installRestart": "Installieren und neu starten",
+  "toast.update.action.viewRelease": "Release ansehen",
   "toast.update.action.notYet": "Noch nicht",
   "error.page.title": "Etwas ist schiefgelaufen",
   "error.page.description": "Beim Laden der Anwendung ist ein Fehler aufgetreten.",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -459,6 +459,7 @@ export const dict = {
   "toast.update.title": "Update available",
   "toast.update.description": "A new version of OpenCode ({{version}}) is now available to install.",
   "toast.update.action.installRestart": "Install and restart",
+  "toast.update.action.viewRelease": "View release",
   "toast.update.action.notYet": "Not yet",
 
   "error.page.title": "Something went wrong",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -443,6 +443,7 @@ export const dict = {
   "toast.update.title": "Actualización disponible",
   "toast.update.description": "Una nueva versión de OpenCode ({{version}}) está disponible para instalar.",
   "toast.update.action.installRestart": "Instalar y reiniciar",
+  "toast.update.action.viewRelease": "Ver lanzamiento",
   "toast.update.action.notYet": "Todavía no",
 
   "error.page.title": "Algo salió mal",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -401,6 +401,7 @@ export const dict = {
   "toast.update.description":
     "Une nouvelle version d'OpenCode ({{version}}) est maintenant disponible pour installation.",
   "toast.update.action.installRestart": "Installer et redémarrer",
+  "toast.update.action.viewRelease": "Voir la version",
   "toast.update.action.notYet": "Pas encore",
   "error.page.title": "Quelque chose s'est mal passé",
   "error.page.description": "Une erreur s'est produite lors du chargement de l'application.",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -397,6 +397,7 @@ export const dict = {
   "toast.update.title": "アップデートが利用可能です",
   "toast.update.description": "OpenCodeの新しいバージョン ({{version}}) がインストール可能です。",
   "toast.update.action.installRestart": "インストールして再起動",
+  "toast.update.action.viewRelease": "リリースを見る",
   "toast.update.action.notYet": "今はしない",
   "error.page.title": "問題が発生しました",
   "error.page.description": "アプリケーションの読み込み中にエラーが発生しました。",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -400,6 +400,7 @@ export const dict = {
   "toast.update.title": "업데이트 가능",
   "toast.update.description": "OpenCode의 새 버전({{version}})을 설치할 수 있습니다.",
   "toast.update.action.installRestart": "설치 및 다시 시작",
+  "toast.update.action.viewRelease": "릴리스 보기",
   "toast.update.action.notYet": "나중에",
   "error.page.title": "문제가 발생했습니다",
   "error.page.description": "애플리케이션을 로드하는 동안 오류가 발생했습니다.",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -444,6 +444,7 @@ export const dict = {
   "toast.update.title": "Oppdatering tilgjengelig",
   "toast.update.description": "En ny versjon av OpenCode ({{version}}) er nå tilgjengelig for installasjon.",
   "toast.update.action.installRestart": "Installer og start på nytt",
+  "toast.update.action.viewRelease": "Se utgivelse",
   "toast.update.action.notYet": "Ikke nå",
 
   "error.page.title": "Noe gikk galt",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -398,6 +398,7 @@ export const dict = {
   "toast.update.title": "Dostępna aktualizacja",
   "toast.update.description": "Nowa wersja OpenCode ({{version}}) jest teraz dostępna do instalacji.",
   "toast.update.action.installRestart": "Zainstaluj i zrestartuj",
+  "toast.update.action.viewRelease": "Zobacz wydanie",
   "toast.update.action.notYet": "Jeszcze nie",
   "error.page.title": "Coś poszło nie tak",
   "error.page.description": "Wystąpił błąd podczas ładowania aplikacji.",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -442,6 +442,7 @@ export const dict = {
   "toast.update.title": "Доступно обновление",
   "toast.update.description": "Новая версия OpenCode ({{version}}) доступна для установки.",
   "toast.update.action.installRestart": "Установить и перезапустить",
+  "toast.update.action.viewRelease": "Посмотреть релиз",
   "toast.update.action.notYet": "Пока нет",
 
   "error.page.title": "Что-то пошло не так",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -441,6 +441,7 @@ export const dict = {
   "toast.update.title": "มีการอัปเดต",
   "toast.update.description": "เวอร์ชันใหม่ของ OpenCode ({{version}}) พร้อมใช้งานสำหรับติดตั้ง",
   "toast.update.action.installRestart": "ติดตั้งและรีสตาร์ท",
+  "toast.update.action.viewRelease": "ดูรีลีส",
   "toast.update.action.notYet": "ยังไม่",
 
   "error.page.title": "เกิดข้อผิดพลาด",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -446,6 +446,7 @@ export const dict = {
   "toast.update.title": "Güncelleme mevcut",
   "toast.update.description": "OpenCode'un yeni bir sürümü ({{version}}) yüklemeye hazır.",
   "toast.update.action.installRestart": "Yükle ve yeniden başlat",
+  "toast.update.action.viewRelease": "Sürümü görüntüle",
   "toast.update.action.notYet": "Şimdi değil",
 
   "error.page.title": "Bir şeyler yanlış gitti",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -446,6 +446,7 @@ export const dict = {
   "toast.update.title": "有可用更新",
   "toast.update.description": "OpenCode 有新版本 ({{version}}) 可安装。",
   "toast.update.action.installRestart": "安装并重启",
+  "toast.update.action.viewRelease": "查看版本",
   "toast.update.action.notYet": "稍后",
 
   "error.page.title": "出了点问题",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -439,6 +439,7 @@ export const dict = {
   "toast.update.title": "有可用更新",
   "toast.update.description": "OpenCode 有新版本 ({{version}}) 可安裝。",
   "toast.update.action.installRestart": "安裝並重新啟動",
+  "toast.update.action.viewRelease": "查看版本",
   "toast.update.action.notYet": "稍後",
 
   "error.page.title": "出了點問題",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -386,8 +386,8 @@ export default function Layout(props: ParentProps) {
                 },
               },
               {
-                label: language.t("toast.update.action.notYet"),
-                onClick: "dismiss",
+                label: language.t("toast.update.action.viewRelease"),
+                onClick: () => platform.openLink(`https://github.com/sst/opencode/releases/tag/v${version}`),
               },
             ],
           })


### PR DESCRIPTION
### Issue for this PR

Closes #21847 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a "View release" action button to the update available toast. It opens the GitHub releases tag page for the new version so users can see what changed without manually navigating to GitHub.

I've replaced the "Not yet" dismiss button since the toast already has an X close button that serves the same purpose. This keeps the toast to two actions max and avoids button wrapping.

I also went ahead and update the other languages for "View Release" as well, but let me know if there are any issues with this! 

### How did you verify your code works?

I've mocked `checkUpdate` in the web entry point to return `{updateAvailable: true, version "99.0.0"}` so that the toaster renders. This was removed after checking the UI looks good. 

I've also tested the "View Release" and confirms that the link does go to the proper release url. 
 
### Screenshots / recordings

Before the change:
<img width="892" height="366" alt="CleanShot 2026-04-11 at 23 28 03@2x" src="https://github.com/user-attachments/assets/8a053246-2af5-415f-8966-9edbcda5de5c" />

After the change:
<img width="854" height="324" alt="CleanShot 2026-04-11 at 23 31 34@2x" src="https://github.com/user-attachments/assets/f202ca96-2a9d-416d-b42f-20810f161481" />



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
