### PR TITLE
fix: web streaming bash output

### DIFF
--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -119,7 +119,7 @@ export function BasicTool(props: BasicToolProps) {
   })
 
   const handleOpenChange = (value: boolean) => {
-    if (pending()) return
+    if (props.status === "pending") return
     if (props.locked && !value) return
     setState("open", value)
   }
@@ -189,7 +189,7 @@ export function BasicTool(props: BasicToolProps) {
           </Switch>
         </div>
       </div>
-      <Show when={props.children && !props.hideDetails && !props.locked && !pending()}>
+      <Show when={props.children && !props.hideDetails && !props.locked && props.status !== "pending"}>
         <Collapsible.Arrow />
       </Show>
     </div>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1849,7 +1849,7 @@ ToolRegistry.register({
               <span data-slot="basic-tool-tool-title">
                 <TextShimmer text={i18n.t("ui.tool.shell")} active={pending()} />
               </span>
-              <Show when={!pending() && props.input.description}>
+              <Show when={props.status !== "pending" && props.input.description}>
                 <ShellSubmessage text={props.input.description} animate={sawPending} />
               </Show>
             </div>

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1843,6 +1843,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="console"
+        forceOpen={props.status === "running"}
         trigger={
           <div data-slot="basic-tool-tool-info-structured">
             <div data-slot="basic-tool-tool-info-main">


### PR DESCRIPTION
### Issue for this PR

Closes #22116

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web UI hides bash tool output during execution even though the streaming data pipeline already delivers it to the client. The TUI shows output in real-time; this PR makes the web UI match.

Three changes:

**`basic-tool.tsx`**: Changed the `handleOpenChange` and `Collapsible.Arrow` gates from `pending()` (which blocks both `pending` AND `running`) to only block during `pending` (LLM still streaming tool call args). During `running`, users can toggle the collapsible.

**`message-part.tsx`**: 
- Added `forceOpen={props.status === "running"}` to the bash `BasicTool` so the collapsible auto-opens when a command starts executing, showing streaming output immediately.
- Changed the description subtitle gate from `!pending()` to `props.status !== "pending"` so it shows during execution.

### How did you verify your code works?

Tested locally with `!for i in 1 2 3 4 5; do echo $i; sleep 1; done` -- output streams in real-time with the collapsible auto-opened during execution.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR