### PR TITLE
fix(opencode): centralize unsecured server warning

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,7 +1,6 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
-import { Flag } from "../../flag/flag"
 import { Workspace } from "../../control-plane/workspace"
 import { Project } from "../../project/project"
 import { Installation } from "../../installation"
@@ -11,9 +10,6 @@ export const ServeCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "starts a headless opencode server",
   handler: async (args) => {
-    if (!Flag.OPENCODE_SERVER_PASSWORD) {
-      console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
-    }
     const opts = await resolveNetworkOptions(args)
     const server = await Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -2,7 +2,6 @@ import { Server } from "../../server/server"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
-import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
 
@@ -33,9 +32,6 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
-    if (!Flag.OPENCODE_SERVER_PASSWORD) {
-      UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
-    }
     const opts = await resolveNetworkOptions(args)
     const server = await Server.listen(opts)
     UI.empty()

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -9,6 +9,7 @@ import { initProjectors } from "./projectors"
 import { Log } from "@/util/log"
 import { ControlPlaneRoutes } from "./control"
 import { UIRoutes } from "./ui"
+import { Flag } from "@/flag/flag"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -17,6 +18,7 @@ initProjectors()
 
 export namespace Server {
   const log = Log.create({ service: "server" })
+  let warnedUnsecured = false
 
   export type Listener = {
     hostname: string
@@ -72,6 +74,12 @@ export namespace Server {
     mdnsDomain?: string
     cors?: string[]
   }): Promise<Listener> {
+    if (!Flag.OPENCODE_SERVER_PASSWORD && !warnedUnsecured) {
+      warnedUnsecured = true
+      process.stderr.write("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.\n")
+      log.warn("OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
+    }
+
     const built = create(opts)
     const server = await built.runtime.listen(opts)
 


### PR DESCRIPTION
### Issue for this PR

Closes #22122

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes inconsistent unsecured-server warning behavior when `OPENCODE_SERVER_PASSWORD` is unset.

Before this change, warning output was handled in `serve` and `web` command handlers, so other startup paths (like `acp`) could start an unsecured server without showing the warning.

I moved the warning to the shared server startup path (`Server.listen`) and removed duplicated warning logic from `serve` and `web`.
This makes behavior consistent for all commands that start the server.

Files changed:
- `packages/opencode/src/server/server.ts`
- `packages/opencode/src/cli/cmd/serve.ts`
- `packages/opencode/src/cli/cmd/web.ts`

### How did you verify your code works?

- `bun run --cwd packages/opencode typecheck`
- `bun run --cwd packages/opencode test`
- Manual verification:
  1. `unset OPENCODE_SERVER_PASSWORD`
  2. `bun dev serve` -> warning shown
  3. `bun dev acp` -> warning shown

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
