### PR TITLE
feat(opencode): double-escape to clear prompt input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -78,6 +78,7 @@ export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
   let autocomplete: AutocompleteRef
+  let clearTimer: ReturnType<typeof setTimeout> | undefined
 
   const keybind = useKeybind()
   const local = useLocal()
@@ -166,6 +167,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal" | "shell"
     extmarkToPartIndex: Map<number, number>
     interrupt: number
+    clearCount: number
     placeholder: number
   }>({
     placeholder: randomIndex(list().length),
@@ -176,6 +178,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal",
     extmarkToPartIndex: new Map(),
     interrupt: 0,
+    clearCount: 0,
   })
 
   createEffect(
@@ -251,6 +254,31 @@ export function Prompt(props: PromptProps) {
               content: content.data,
             })
           }
+        },
+        },
+      {
+        title: "Clear input",
+        value: "prompt.clear_input",
+        keybind: "input_clear_prompt",
+        category: "Prompt",
+        hidden: true,
+        enabled: status().type === "idle" && !!store.prompt.input,
+        onSelect: () => {
+          if (!store.prompt.input) return
+          if (store.clearCount === 0) {
+            setStore("clearCount", 1)
+            clearTimer = setTimeout(() => {
+              setStore("clearCount", 0)
+            }, 2000)
+            return
+          }
+          clearTimeout(clearTimer)
+          clearTimer = undefined
+          input.clear()
+          input.extmarks.clear()
+          setStore("prompt", { input: "", parts: [] })
+          setStore("extmarkToPartIndex", new Map())
+          setStore("clearCount", 0)
         },
       },
       {
@@ -431,6 +459,7 @@ export function Prompt(props: PromptProps) {
   }
 
   onCleanup(() => {
+    clearTimeout(clearTimer)
     props.ref?.(undefined)
   })
 
@@ -1157,7 +1186,19 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between">
-          <Show when={status().type !== "idle"} fallback={props.hint ?? <text />}>
+          <Show
+            when={status().type !== "idle"}
+            fallback={
+              store.clearCount > 0 ? (
+                <text fg={theme.primary}>
+                  esc{" "}
+                  <span style={{ fg: theme.primary }}>again to clear</span>
+                </text>
+              ) : (
+                props.hint ?? <text />
+              )
+            }
+          >
             <box
               flexDirection="row"
               gap={1}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -675,6 +675,7 @@ export namespace Config {
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
       variant_list: z.string().optional().default("none").describe("List model variants"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
+      input_clear_prompt: z.string().optional().default("escape").describe("Clear input (double-press when idle)"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z


### PR DESCRIPTION
### Issue for this PR

Closes #7319

### Type of change

- [x] New feature

### What does this PR do?

Adds double-escape to clear the prompt input when idle. First Escape shows a hint (`esc again to clear`) in the status bar; second Escape within 2 seconds clears the input. No-op when input is empty or when a session is running.

There's already a solid implementation in #7320. This is an alternative approach in case maintainers want to compare:

- **Command-based** — uses `command.register()` like all other keybinds; the key is configurable as `input_clear_prompt` in config (defaults to `escape`)
- **Visual hint** — first press shows `esc again to clear` in the idle status bar, matching the existing session interrupt hint pattern
- **2s window** instead of 300ms — more forgiving timing
- **Timer cleanup on unmount** — `clearTimeout` in `onCleanup` to avoid a stale callback firing against a disposed store

Happy to close this if #7320 moves forward.

### How did you verify your code works?

`bun typecheck` passes. Manually tested:

1. Idle + non-empty: first Esc shows hint, second Esc within 2s clears input
2. Hint auto-dismisses after 2s with no second press, input unchanged
3. Idle + empty: Esc is a no-op (command guard prevents it)
4. Session running: Esc fires `session_interrupt` as before

### Screenshots / recordings

[![asciicast](https://asciinema.org/a/J0yQY3JvBt8okfkn.svg)](https://asciinema.org/a/J0yQY3JvBt8okfkn?t=5)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR