### PR TITLE
docs: add oh-my-opencode-slim to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -35,6 +35,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                    |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
+| [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim)                          | Slimmed, cleaned and fine-tuned oh-my-opencode fork — consumes much less tokens                   |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |


### PR DESCRIPTION
Closes #22136

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

Adds oh-my-opencode-slim to the ecosystem plugins table.

This is a slimmed, cleaned fork of oh-my-opencode that uses fewer tokens while keeping the same multi-agent features (Orchestrator, Explorer, Oracle, Council, Librarian, Designer, Fixer).

Tested by viewing the rendered markdown table locally.

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR