### PR TITLE
fix(opencode): reroutes install dependencies to .cache instead

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -144,13 +144,22 @@ export namespace Config {
     waitTick?: (input: { dir: string; attempt: number; delay: number; waited: number }) => void | Promise<void>
   }
 
+  function installRoot(dir: string) {
+    if (Filesystem.resolve(dir) !== Filesystem.resolve(Global.Path.config)) return dir
+    return path.join(Global.Path.cache, "config", "deps")
+  }
+
   export async function installDependencies(dir: string, input?: InstallInput) {
-    if (!(await isWritable(dir))) return
-    await using _ = await Flock.acquire(`config-install:${Filesystem.resolve(dir)}`, {
+    const root = installRoot(dir)
+    if (!(await isWritable(root))) {
+      await fsNode.mkdir(root, { recursive: true }).catch(() => undefined)
+    }
+    if (!(await isWritable(root))) return
+    await using _ = await Flock.acquire(`config-install:${Filesystem.resolve(root)}`, {
       signal: input?.signal,
       onWait: (tick) =>
         input?.waitTick?.({
-          dir,
+          dir: root,
           attempt: tick.attempt,
           delay: tick.delay,
           waited: tick.waited,
@@ -158,7 +167,7 @@ export namespace Config {
     })
     input?.signal?.throwIfAborted()
 
-    const pkg = path.join(dir, "package.json")
+    const pkg = path.join(root, "package.json")
     const target = Installation.isLocal() ? "*" : Installation.VERSION
     const json = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(pkg).catch(() => ({
       dependencies: {},
@@ -169,7 +178,7 @@ export namespace Config {
     }
     await Filesystem.writeJson(pkg, json)
 
-    const gitignore = path.join(dir, ".gitignore")
+    const gitignore = path.join(root, ".gitignore") //seems like useless patch for package managers. 
     const ignore = await Filesystem.exists(gitignore)
     if (!ignore) {
       await Filesystem.write(
@@ -177,7 +186,7 @@ export namespace Config {
         ["node_modules", "package.json", "package-lock.json", "bun.lock", ".gitignore"].join("\n"),
       )
     }
-    await Npm.install(dir)
+    await Npm.install(root)
   }
 
   async function isWritable(dir: string) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -817,6 +817,57 @@ test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {
   }
 })
 
+test("installs global config dependencies in cache instead of config", async () => {
+  const root = path.join(Global.Path.cache, "config", "deps")
+  await fs.rm(root, { recursive: true, force: true }).catch(() => {})
+  await fs.rm(path.join(Global.Path.config, "package.json"), { force: true }).catch(() => {})
+  await fs.rm(path.join(Global.Path.config, ".gitignore"), { force: true }).catch(() => {})
+
+  const run = spyOn(Npm, "install").mockImplementation(async (dir: string) => {
+    const mod = path.join(dir, "node_modules", "@opencode-ai", "plugin")
+    await fs.mkdir(mod, { recursive: true })
+    await Filesystem.write(
+      path.join(mod, "package.json"),
+      JSON.stringify({ name: "@opencode-ai/plugin", version: "1.0.0" }),
+    )
+  })
+
+  try {
+    await Config.installDependencies(Global.Path.config)
+    expect(run).toHaveBeenCalledWith(root)
+    expect(await Filesystem.exists(path.join(root, "package.json"))).toBe(true)
+    expect(await Filesystem.exists(path.join(root, ".gitignore"))).toBe(true)
+    expect(await Filesystem.exists(path.join(Global.Path.config, "package.json"))).toBe(false)
+    expect(await Filesystem.exists(path.join(Global.Path.config, ".gitignore"))).toBe(false)
+  } finally {
+    run.mockRestore()
+  }
+})
+
+test("installs non-global config dependencies in place", async () => {
+  await using tmp = await tmpdir()
+  const dir = path.join(tmp.path, "custom")
+  await fs.mkdir(dir, { recursive: true })
+
+  const run = spyOn(Npm, "install").mockImplementation(async (cwd: string) => {
+    const mod = path.join(cwd, "node_modules", "@opencode-ai", "plugin")
+    await fs.mkdir(mod, { recursive: true })
+    await Filesystem.write(
+      path.join(mod, "package.json"),
+      JSON.stringify({ name: "@opencode-ai/plugin", version: "1.0.0" }),
+    )
+  })
+
+  try {
+    await Config.installDependencies(dir)
+    expect(run).toHaveBeenCalledWith(dir)
+    expect(await Filesystem.exists(path.join(dir, "package.json"))).toBe(true)
+    expect(await Filesystem.exists(path.join(dir, ".gitignore"))).toBe(true)
+  } finally {
+    run.mockRestore()
+  }
+})
+
 test("dedupes concurrent config dependency installs for the same dir", async () => {
   await using tmp = await tmpdir()
   const dir = path.join(tmp.path, "a")


### PR DESCRIPTION
small patch to make all packages write to .cache instead of dumping plugins to .config.

### Issue for this PR

Closes #21966, #3191 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Make all dependencies previously written to .config be written now to .cache/opencode/config/deps. 

### How did you verify your code works?

Ran tests. all passed expect one. the one who didn't pass was not touched during this patch. compared behaviour to current latest on homebrew (stable, not bleeding edge).

### Screenshots / recordings

```bash
bash-3.2$ ls ~/.config/opencode/
opencode.json
bash-3.2$ opencode
bash-3.2$ ls ~/.config/opencode/
node_modules            opencode.json           package-lock.json       package.json
bash-3.2$ #Current
bash-3.2$ rm -rf ~/.config/opencode/node_modules/
bash-3.2$ rm -rf ~/.config/opencode/package*
bash-3.2$ bun run src/index.ts
bash-3.2$ ls ~/.config/opencode/
opencode.json
bash-3.2$ ls ~/.cache/opencode/config/deps/
node_modules            package-lock.json       package.json
bash-3.2$ #Patch
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


