### PR TITLE
fix: reuse OpenAI Responses previous_response_id across turns

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -464,7 +464,7 @@ export namespace ProviderTransform {
         }
         return Object.fromEntries(OPENAI_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
 
-      case "@ai-sdk/github-copilot":
+      case "@ai-sdk/github-copilot": {
         if (model.id.includes("gemini")) {
           // currently github copilot only returns thinking
           return {}
@@ -489,7 +489,7 @@ export namespace ProviderTransform {
             },
           ]),
         )
-
+      }
       case "@ai-sdk/cerebras":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cerebras
       case "@ai-sdk/togetherai":
@@ -503,7 +503,7 @@ export namespace ProviderTransform {
       case "@ai-sdk/openai-compatible":
         return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
 
-      case "@ai-sdk/azure":
+      case "@ai-sdk/azure": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
         if (id === "o1-mini") return {}
         const azureEfforts = ["low", "medium", "high"]
@@ -520,7 +520,8 @@ export namespace ProviderTransform {
             },
           ]),
         )
-      case "@ai-sdk/openai":
+      }
+      case "@ai-sdk/openai": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
         if (id === "gpt-5-pro") return {}
         const openaiEfforts = iife(() => {
@@ -550,7 +551,7 @@ export namespace ProviderTransform {
             },
           ]),
         )
-
+      }
       case "@ai-sdk/anthropic":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
       case "@ai-sdk/google-vertex/anthropic":
@@ -633,7 +634,7 @@ export namespace ProviderTransform {
 
       case "@ai-sdk/google-vertex":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex
-      case "@ai-sdk/google":
+      case "@ai-sdk/google": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai
         if (id.includes("2.5")) {
           return {
@@ -667,7 +668,7 @@ export namespace ProviderTransform {
             },
           ]),
         )
-
+      }
       case "@ai-sdk/mistral":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/mistral
         return {}
@@ -676,7 +677,7 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/cohere
         return {}
 
-      case "@ai-sdk/groq":
+      case "@ai-sdk/groq": {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/groq
         const groqEffort = ["none", ...WIDELY_SUPPORTED_EFFORTS]
         return Object.fromEntries(
@@ -687,7 +688,7 @@ export namespace ProviderTransform {
             },
           ]),
         )
-
+      }
       case "@ai-sdk/perplexity":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/perplexity
         return {}
@@ -753,12 +754,7 @@ export namespace ProviderTransform {
   }): Record<string, any> {
     const result: Record<string, any> = {}
 
-    // openai and providers using openai package should set store to false by default.
-    if (
-      input.model.providerID === "openai" ||
-      input.model.api.npm === "@ai-sdk/openai" ||
-      input.model.api.npm === "@ai-sdk/github-copilot"
-    ) {
+    if (input.model.api.npm === "@ai-sdk/github-copilot") {
       result["store"] = false
     }
 
@@ -788,7 +784,11 @@ export namespace ProviderTransform {
       }
     }
 
-    if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
+    if (
+      input.model.providerID === "openai" ||
+      input.model.api.npm === "@ai-sdk/openai" ||
+      input.providerOptions?.setCacheKey
+    ) {
       result["promptCacheKey"] = input.sessionID
     }
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -257,6 +257,7 @@ When constructing the summary, try to stick to this template:
           user: userMessage,
           agent,
           sessionID: input.sessionID,
+          previousResponseId: MessageV2.previousResponseId(input.messages, model),
           tools: {},
           system: [],
           messages: [

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -32,6 +32,7 @@ export namespace LLM {
     user: MessageV2.User
     sessionID: string
     parentSessionID?: string
+    previousResponseId?: string
     model: Provider.Model
     agent: Agent.Info
     permission?: Permission.Ruleset
@@ -129,14 +130,14 @@ export namespace LLM {
                 sessionID: input.sessionID,
                 providerOptions: item.options,
               })
-          const options: Record<string, any> = pipe(
+          const baseOptions: Record<string, any> = pipe(
             base,
             mergeDeep(input.model.options),
             mergeDeep(input.agent.options),
             mergeDeep(variant),
           )
           if (isOpenaiOauth) {
-            options.instructions = system.join("\n")
+            baseOptions.instructions = system.join("\n")
           }
 
           const isWorkflow = language instanceof GitLabWorkflowLanguageModel
@@ -170,9 +171,14 @@ export namespace LLM {
               topP: input.agent.topP ?? ProviderTransform.topP(input.model),
               topK: ProviderTransform.topK(input.model),
               maxOutputTokens: ProviderTransform.maxOutputTokens(input.model),
-              options,
+              options: baseOptions,
             },
           )
+
+          const options =
+            input.previousResponseId && input.model.api.npm === "@ai-sdk/openai"
+              ? mergeDeep(params.options, { previousResponseId: input.previousResponseId })
+              : params.options
 
           const { headers } = yield* plugin.trigger(
             "chat.headers",
@@ -338,7 +344,7 @@ export namespace LLM {
             temperature: params.temperature,
             topP: params.topP,
             topK: params.topK,
-            providerOptions: ProviderTransform.providerOptions(input.model, params.options),
+            providerOptions: ProviderTransform.providerOptions(input.model, options),
             activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
             tools,
             toolChoice: input.toolChoice,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -447,6 +447,7 @@ export namespace MessageV2 {
     structured: z.any().optional(),
     variant: z.string().optional(),
     finish: z.string().optional(),
+    responseId: z.string().optional(),
   }).meta({
     ref: "AssistantMessage",
   })
@@ -580,6 +581,20 @@ export namespace MessageV2 {
     if (!metadata) return undefined
     const { providerExecuted: _, ...rest } = metadata
     return Object.keys(rest).length > 0 ? rest : undefined
+  }
+
+  export function previousResponseId(msgs: WithParts[], model: Provider.Model) {
+    const msg = msgs.findLast((item) => {
+      const info = item.info
+      if (info.role !== "assistant") return false
+      if (!info.responseId) return false
+      if (info.providerID !== model.providerID) return false
+      return info.modelID === model.id || info.modelID === model.api.id
+    })
+    if (!msg) return
+    const info = msg.info
+    if (info.role !== "assistant") return
+    return info.responseId
   }
 
   export const toModelMessagesEffect = Effect.fnUntraced(function* (
@@ -945,7 +960,7 @@ export namespace MessageV2 {
   }
 
   export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: SessionID) {
-    return filterCompacted(stream(sessionID))
+    return yield* Effect.succeed(filterCompacted(stream(sessionID)))
   })
 
   export function fromError(
@@ -998,7 +1013,7 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
-      case APICallError.isInstance(e):
+      case APICallError.isInstance(e): {
         const parsed = ProviderError.parseAPICallError({
           providerID: ctx.providerID,
           error: e,
@@ -1024,6 +1039,7 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      }
       case e instanceof Error:
         return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
       default:

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -132,6 +132,13 @@ export namespace SessionProcessor {
             aborted,
           })
 
+        const responseId = (metadata: Record<string, any> | undefined) => {
+          if (!metadata) return
+          const openai = metadata.openai
+          if (!isRecord(openai)) return
+          return typeof openai.responseId === "string" ? openai.responseId : undefined
+        }
+
         const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {
           const done = ctx.toolcalls[toolCallID]?.done
           delete ctx.toolcalls[toolCallID]
@@ -256,7 +263,7 @@ export namespace SessionProcessor {
               delete ctx.reasoningMap[value.id]
               return
 
-            case "tool-input-start":
+            case "tool-input-start": {
               if (ctx.assistantMessage.summary) {
                 throw new Error(`Tool call not allowed while generating summary: ${value.toolName}`)
               }
@@ -277,6 +284,7 @@ export namespace SessionProcessor {
                 sessionID: part.sessionID,
               }
               return
+            }
 
             case "tool-input-delta":
               return
@@ -360,6 +368,8 @@ export namespace SessionProcessor {
                 usage: value.usage,
                 metadata: value.providerMetadata,
               })
+              const id = responseId(value.providerMetadata)
+              if (id) ctx.assistantMessage.responseId = id
               ctx.assistantMessage.finish = value.finishReason
               ctx.assistantMessage.cost += usage.cost
               ctx.assistantMessage.tokens = usage.tokens
@@ -431,7 +441,6 @@ export namespace SessionProcessor {
 
             case "text-end":
               if (!ctx.currentText) return
-              ctx.currentText.text = ctx.currentText.text
               ctx.currentText.text = (yield* plugin.trigger(
                 "experimental.text.complete",
                 {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1478,6 +1478,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               ])
               const system = [...env, ...(skills ? [skills] : []), ...instructions]
               const format = lastUser.format ?? { type: "text" as const }
+              const previousResponseId = MessageV2.previousResponseId(msgs, model)
               if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
               const result = yield* handle.process({
                 user: lastUser,
@@ -1485,6 +1486,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 permission: session.permission,
                 sessionID,
                 parentSessionID: session.parentID,
+                previousResponseId,
                 system,
                 messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
                 tools,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -85,7 +85,21 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
-  test("should set store=false for openai provider", () => {
+  test("should set promptCacheKey for @ai-sdk/openai custom providers", () => {
+    const openaiModel = {
+      ...mockModel,
+      providerID: "custom-openai",
+      api: {
+        id: "gpt-4",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+    }
+    const result = ProviderTransform.options({ model: openaiModel, sessionID, providerOptions: {} })
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should not force store=false for openai provider", () => {
     const openaiModel = {
       ...mockModel,
       providerID: "openai",
@@ -97,6 +111,24 @@ describe("ProviderTransform.options - setCacheKey", () => {
     }
     const result = ProviderTransform.options({
       model: openaiModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBeUndefined()
+  })
+
+  test("should keep store=false for github copilot sdk models", () => {
+    const copilotModel = {
+      ...mockModel,
+      providerID: "github-copilot",
+      api: {
+        id: "gpt-5-codex",
+        url: "https://api.githubcopilot.com",
+        npm: "@ai-sdk/github-copilot",
+      },
+    }
+    const result = ProviderTransform.options({
+      model: copilotModel,
       sessionID,
       providerOptions: {},
     })
@@ -642,11 +674,15 @@ describe("ProviderTransform.schema - gemini combiner nodes", () => {
       return
     }
     if (Array.isArray(node)) {
-      node.forEach((item, i) => walk(item, cb, [...path, i]))
+      node.forEach((item, i) => {
+        walk(item, cb, [...path, i])
+      })
       return
     }
     cb(node, path)
-    Object.entries(node).forEach(([key, value]) => walk(value, cb, [...path, key]))
+    Object.entries(node).forEach(([key, value]) => {
+      walk(value, cb, [...path, key])
+    })
   }
 
   test("keeps edits.items.anyOf without adding type", () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -668,9 +668,123 @@ describe("session.llm.stream", () => {
         expect(body.model).toBe(resolved.api.id)
         expect(body.stream).toBe(true)
         expect((body.reasoning as { effort?: string } | undefined)?.effort).toBe("high")
+        expect(body.prompt_cache_key).toBe(sessionID)
+        expect(body.store).toBeUndefined()
 
         const maxTokens = body.max_output_tokens as number | undefined
         expect(maxTokens).toBe(undefined) // match codex cli behavior
+      },
+    })
+  })
+
+  test("sends previous_response_id for follow-up OpenAI responses requests", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const source = await loadFixture("openai", "gpt-5.2")
+    const model = source.model
+    const responseChunks = [
+      {
+        type: "response.created",
+        response: {
+          id: "resp-2",
+          created_at: Math.floor(Date.now() / 1000),
+          model: model.id,
+          service_tier: null,
+        },
+      },
+      {
+        type: "response.output_text.delta",
+        item_id: "item-2",
+        delta: "Hi again",
+        logprobs: null,
+      },
+      {
+        type: "response.completed",
+        response: {
+          incomplete_details: null,
+          usage: {
+            input_tokens: 1,
+            input_tokens_details: null,
+            output_tokens: 1,
+            output_tokens_details: null,
+          },
+          service_tier: null,
+        },
+      },
+    ]
+    const request = waitRequest("/responses", createEventResponse(responseChunks, true))
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["openai"],
+            provider: {
+              openai: {
+                name: "OpenAI",
+                env: ["OPENAI_API_KEY"],
+                npm: "@ai-sdk/openai",
+                api: "https://api.openai.com/v1",
+                models: {
+                  [model.id]: model,
+                },
+                options: {
+                  apiKey: "test-openai-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.openai, ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-previous")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-previous"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("openai"), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          previousResponseId: "resp_prev",
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello again" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+
+        expect(body.previous_response_id).toBe("resp_prev")
+        expect(body.prompt_cache_key).toBe(sessionID)
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -747,7 +747,7 @@ describe("session.llm.stream", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const resolved = await Provider.getModel(ProviderID.openai, ModelID.make(model.id))
+        const resolved = await getModel(ProviderID.openai, ModelID.make(model.id))
         const sessionID = SessionID.make("session-test-previous")
         const agent = {
           name: "test",
@@ -765,20 +765,16 @@ describe("session.llm.stream", () => {
           model: { providerID: ProviderID.make("openai"), modelID: resolved.id },
         } satisfies MessageV2.User
 
-        const stream = await LLM.stream({
+        await drain({
           user,
           sessionID,
           previousResponseId: "resp_prev",
           model: resolved,
           agent,
           system: ["You are a helpful assistant."],
-          abort: new AbortController().signal,
           messages: [{ role: "user", content: "Hello again" }],
           tools: {},
         })
-
-        for await (const _ of stream.fullStream) {
-        }
 
         const capture = await request
         const body = capture.body

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -107,6 +107,55 @@ function basePart(messageID: string, id: string) {
   }
 }
 
+describe("session.message-v2.previousResponseId", () => {
+  test("returns the last matching assistant response id", () => {
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: userInfo("u1"),
+        parts: [],
+      },
+      {
+        info: {
+          ...assistantInfo("a1", "u1"),
+          responseId: "resp_1",
+        },
+        parts: [],
+      },
+      {
+        info: {
+          ...assistantInfo("a2", "u1", undefined, { providerID: "other", modelID: "test-model" }),
+          responseId: "resp_other",
+        },
+        parts: [],
+      },
+      {
+        info: {
+          ...assistantInfo("a3", "u1"),
+          responseId: "resp_2",
+        },
+        parts: [],
+      },
+    ]
+
+    expect(MessageV2.previousResponseId(msgs, model)).toBe("resp_2")
+  })
+
+  test("ignores assistants without a response id", () => {
+    const msgs: MessageV2.WithParts[] = [
+      {
+        info: userInfo("u1"),
+        parts: [],
+      },
+      {
+        info: assistantInfo("a1", "u1"),
+        parts: [],
+      },
+    ]
+
+    expect(MessageV2.previousResponseId(msgs, model)).toBeUndefined()
+  })
+})
+
 describe("session.message-v2.toModelMessage", () => {
   test("filters out messages with no parts", async () => {
     const input: MessageV2.WithParts[] = [


### PR DESCRIPTION
### Issue for this PR

Closes #20847

Related: #9045, #20848

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the OpenAI Responses continuity bug that makes long-running sessions slower over time.

Today, follow-up OpenAI Responses requests can miss `previous_response_id`, which means later turns fall back to replaying more history instead of continuing the existing response chain. The practical cost is worse latency and weaker cache continuity as the conversation grows.

This PR fixes that by persisting the response id in message history and reusing the latest matching one on later OpenAI follow-ups, including compaction follow-ups.

The reason this PR exists separately from #20848 is that it takes a smaller, more local approach:

- it derives continuity from the message history already being used to build the next request
- it reuses a response id only when the provider/model match
- it covers the compaction path explicitly
- it avoids schema, migration, projector, and extra session-surface changes

So the benefit is the same user-facing fix with less persistence surface and tighter coupling to the actual request context.

### How did you verify your code works?

- `bun typecheck`
- `bun test test/session/llm.test.ts`
- `bun test test/session/message-v2.test.ts`
- `bun test test/provider/transform.test.ts`

I also pushed the branch through the repo hook/typecheck path during `git push`, which passed.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
