### PR TITLE
fix(opencode): remove spurious scripts and randomField from package.json

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -14,18 +14,11 @@
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
-    "random": "echo 'Random script updated at $(date)' && echo 'Change queued successfully' && echo 'Another change made' && echo 'Yet another change' && echo 'One more change' && echo 'Final change' && echo 'Another final change' && echo 'Yet another final change'",
-    "clean": "echo 'Cleaning up...' && rm -rf node_modules dist",
-    "lint": "echo 'Running lint checks...' && bun test --coverage",
-    "format": "echo 'Formatting code...' && bun run --prettier --write src/**/*.ts",
-    "docs": "echo 'Generating documentation...' && find src -name '*.ts' -exec echo 'Processing: {}' \\;",
-    "deploy": "echo 'Deploying application...' && bun run build && echo 'Deployment completed successfully'",
     "db": "bun drizzle-kit"
   },
   "bin": {
     "opencode": "./bin/opencode"
   },
-  "randomField": "this-is-a-random-value-12345",
   "exports": {
     "./*": "./src/*.ts"
   },


### PR DESCRIPTION
### Issue for this PR

Closes #22159

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/package.json` had two categories of junk entries that appear to have been accidentally committed:

1. A `randomField` top-level key (`"this-is-a-random-value-12345"`) — not a valid `package.json` field, has no effect but pollutes the manifest.

2. Six fake scripts: `random`, `clean`, `lint`, `format`, `docs`, `deploy`. These are echo-only stubs with incorrect implementations — for example, `lint` just runs `bun test --coverage` (not a linter), and `format` passes `--prettier` as a flag to `bun run` which is invalid. The real formatting and lint tooling (`biome`, `turbo`) lives at the monorepo level and these scripts are not wired up to anything.

The fix removes all seven entries. No logic was changed.

### How did you verify your code works?

- `bun run --cwd packages/opencode typecheck` — passed
- `bun run --cwd packages/opencode test` — 1901 tests passed (1 pre-existing flaky failure unrelated to this change)

### Screenshots / recordings

N/A (non-UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
