### PR TITLE
fix: --continue should skip archived sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -384,7 +384,7 @@ export const RunCommand = cmd({
     }
 
     async function session(sdk: OpencodeClient) {
-      const baseID = args.continue ? (await sdk.session.list()).data?.find((s) => !s.parentID)?.id : args.session
+      const baseID = args.continue ? (await sdk.session.list()).data?.find((s) => !s.parentID && !s.time?.archived)?.id : args.session
 
       if (baseID && args.fork) {
         const forked = await sdk.session.fork({ sessionID: baseID })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -404,7 +404,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     if (continued || sync.status === "loading" || !args.continue) return
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
-      .find((x) => x.parentID === undefined)?.id
+      .find((x) => x.parentID === undefined && !x.time.archived)?.id
     if (match) {
       continued = true
       if (args.fork) {

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -81,6 +81,24 @@ describe("Session.list", () => {
     })
   })
 
+  test("includes archived sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const active = await Session.create({ title: "active-session" })
+        const archived = await Session.create({ title: "archived-session" })
+        await Session.setArchived({ sessionID: archived.id, time: Date.now() })
+
+        const sessions = [...Session.list()]
+        const ids = sessions.map((s) => s.id)
+
+        expect(ids).toContain(active.id)
+        expect(ids).toContain(archived.id)
+      },
+    })
+  })
+
   test("respects limit parameter", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Closes #22175

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`--continue` in both the CLI (`run.ts`) and TUI (`app.tsx`) resolves to the most recently updated root session by calling `.find((s) => !s.parentID)`. Neither path checks whether the session is archived, so `--continue` can resume an archived session.

`Session.listGlobal()` already filters archived sessions by default (via `isNull(SessionTable.time_archived)`), but `--continue` uses `Session.list()` via the `/session` endpoint, which has no such filtering.

This adds `&& !s.time?.archived` to the `.find()` predicate in both code paths. The fix is client-side so `Session.list()` behavior is unchanged. A test is included to document that `Session.list()` still returns archived sessions (confirming the filtering is intentionally in the `--continue` logic, not the query layer).

**Real-world use case:** Plugin systems can spawn headless agents via `opencode run --pure` for background tasks (code auditing, knowledge graph ingestion, etc.). These create real sessions in the database that are more recent than the user's interactive session. Archiving them on completion is the natural cleanup path, but `--continue` currently ignores the archived flag and picks them up anyway. With this fix, plugins can archive background sessions and `--continue` will correctly skip past them to the user's last interactive session.

### How did you verify your code works?

- `bun test test/server/session-list.test.ts` -- 6 pass (including new test)
- `bun test test/server/global-session-list.test.ts` -- 3 pass (no regressions)
- `bun turbo typecheck` -- 13 packages pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR