### PR TITLE
fix(windows): normalize backslash paths to posix in tool titles/patterns

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -17,6 +17,10 @@ import { Format } from "../format"
 import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
+
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
@@ -79,7 +83,7 @@ export const EditTool = Tool.define(
                 diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
                 yield* ctx.ask({
                   permission: "edit",
-                  patterns: [path.relative(Instance.worktree, filePath)],
+                  patterns: [toPosix(path.relative(Instance.worktree, filePath))],
                   always: ["*"],
                   metadata: {
                     filepath: filePath,
@@ -119,7 +123,7 @@ export const EditTool = Tool.define(
               )
               yield* ctx.ask({
                 permission: "edit",
-                patterns: [path.relative(Instance.worktree, filePath)],
+                patterns: [toPosix(path.relative(Instance.worktree, filePath))],
                 always: ["*"],
                 metadata: {
                   filepath: filePath,
@@ -179,7 +183,7 @@ export const EditTool = Tool.define(
               diff,
               filediff,
             },
-            title: `${path.relative(Instance.worktree, filePath)}`,
+            title: toPosix(path.relative(Instance.worktree, filePath)),
             output,
           }
         }),

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -9,6 +9,10 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const GlobTool = Tool.define(
   "glob",
   Effect.gen(function* () {
@@ -81,7 +85,7 @@ export const GlobTool = Tool.define(
           }
 
           return {
-            title: path.relative(Instance.worktree, search),
+            title: toPosix(path.relative(Instance.worktree, search)),
             metadata: {
               count: files.length,
               truncated,

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -8,6 +8,10 @@ import { Instance } from "../project/instance"
 import { Ripgrep } from "../file/ripgrep"
 import { assertExternalDirectoryEffect } from "./external-directory"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const IGNORE_PATTERNS = [
   "node_modules/",
   "__pycache__/",
@@ -121,7 +125,7 @@ export const ListTool = Tool.define(
           const output = `${searchPath}/\n` + renderDir(".", 0)
 
           return {
-            title: path.relative(Instance.worktree, searchPath),
+            title: toPosix(path.relative(Instance.worktree, searchPath)),
             metadata: {
               count: files.length,
               truncated: files.length >= LIMIT,

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -9,6 +9,10 @@ import { pathToFileURL } from "url"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "../filesystem"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 const operations = [
   "goToDefinition",
   "findReferences",
@@ -46,7 +50,7 @@ export const LspTool = Tool.define(
 
           const uri = pathToFileURL(file).href
           const position = { file, line: args.line - 1, character: args.character - 1 }
-          const relPath = path.relative(Instance.worktree, file)
+          const relPath = toPosix(path.relative(Instance.worktree, file))
           const title = `${args.operation} ${relPath}:${args.line}:${args.character}`
 
           const exists = yield* fs.existsSafe(file)

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -6,6 +6,10 @@ import DESCRIPTION from "./multiedit.txt"
 import path from "path"
 import { Instance } from "../project/instance"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const MultiEditTool = Tool.define(
   "multiedit",
   Effect.gen(function* () {
@@ -49,7 +53,7 @@ export const MultiEditTool = Tool.define(
             results.push(result)
           }
           return {
-            title: path.relative(Instance.worktree, params.filePath),
+            title: toPosix(path.relative(Instance.worktree, params.filePath)),
             metadata: {
               results: results.map((r) => r.metadata),
             },

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -10,6 +10,10 @@ import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 function getLastModel(sessionID: SessionID) {
   for (const item of MessageV2.stream(sessionID)) {
     if (item.info.role === "user" && item.info.model) return item.info.model
@@ -30,7 +34,7 @@ export const PlanExitTool = Tool.define(
       execute: (_params: {}, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const info = yield* session.get(ctx.sessionID)
-          const plan = path.relative(Instance.worktree, Session.plan(info))
+          const plan = toPosix(path.relative(Instance.worktree, Session.plan(info)))
           const answers = yield* question.ask({
             sessionID: ctx.sessionID,
             questions: [

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -13,6 +13,10 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
@@ -92,7 +96,7 @@ export const ReadTool = Tool.define(
       if (process.platform === "win32") {
         filepath = AppFileSystem.normalizePath(filepath)
       }
-      const title = path.relative(Instance.worktree, filepath)
+      const title = toPosix(path.relative(Instance.worktree, filepath))
 
       const stat = yield* fs.stat(filepath).pipe(
         Effect.catchIf(

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -17,6 +17,10 @@ import { assertExternalDirectoryEffect } from "./external-directory"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
+function toPosix(p: string): string {
+  return p.replaceAll("\\", "/")
+}
+
 export const WriteTool = Tool.define(
   "write",
   Effect.gen(function* () {
@@ -46,7 +50,7 @@ export const WriteTool = Tool.define(
           const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
           yield* ctx.ask({
             permission: "edit",
-            patterns: [path.relative(Instance.worktree, filepath)],
+            patterns: [toPosix(path.relative(Instance.worktree, filepath))],
             always: ["*"],
             metadata: {
               filepath,
@@ -82,7 +86,7 @@ export const WriteTool = Tool.define(
           }
 
           return {
-            title: path.relative(Instance.worktree, filepath),
+            title: toPosix(path.relative(Instance.worktree, filepath)),
             metadata: {
               diagnostics,
               filepath,


### PR DESCRIPTION
Closes #22189

### Issue for this PR  Closes #  ### Type of change  - [x] Bug fix  ### What does this PR do?  On Windows, tool calls like file search or grep receive paths with backslashes (e.g. src\foo\bar.ts), but internal patterns and titles use forward slashes. This mismatch causes tool invocations to silently fail since glob patterns don't match backslash paths.  The fix normalizes backslash paths to forward slashes in tool titles and pattern arguments before they reach the tool execution layer. This only affects the path strings passed to tools, not the filesystem operations themselves.  ### How did you verify your code works?  - Ran locally on Windows with backslash-containing paths - All 19 packages typecheck clean  ### Checklist  - [x] I have tested my changes locally - [x] I have not included unrelated changes in this PR