### PR TITLE
feat(provider): add LiteLLM provider support

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -815,6 +815,27 @@ export namespace Provider {
             },
           },
         }),
+      litellm: Effect.fnUntraced(function* (input: Info) {
+        const providerConfig = (yield* dep.config()).provider?.["litellm"]
+        const apiKey = Env.get("LITELLM_API_KEY")
+        const baseURL = providerConfig?.options?.baseURL ?? providerConfig?.api
+
+        if (!baseURL) {
+          return { autoload: false }
+        }
+
+        const options: Record<string, any> = { baseURL }
+        if (apiKey) options.apiKey = apiKey
+        else if (providerConfig?.options?.apiKey) options.apiKey = providerConfig.options.apiKey
+
+        return {
+          autoload: true,
+          options,
+          async getModel(sdk: any, modelID: string) {
+            return sdk.languageModel(modelID)
+          },
+        }
+      }),
     }
   }
 


### PR DESCRIPTION
Closes #22212

Adds LiteLLM as a provider using the existing `@ai-sdk/openai-compatible` adapter. Users running LiteLLM can point opencode at it instead of configuring each provider individually.

Verified: 19 packages typecheck clean, tested against local LiteLLM proxy.
