### PR TITLE
fix(opencode): support macOS cmd+v image paste in tui

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -37,6 +37,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { probePaste } from "./paste-key"
 
 export type PromptProps = {
   sessionID?: string
@@ -116,6 +117,7 @@ export function Prompt(props: PromptProps) {
   const agentStyleId = syntax().getStyleId("extmark.agent")!
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
+  let pasted = 0
   const event = useEvent()
 
   event.on(TuiEvent.PromptAppend.type, (evt) => {
@@ -243,14 +245,7 @@ export function Prompt(props: PromptProps) {
         category: "Prompt",
         hidden: true,
         onSelect: async () => {
-          const content = await Clipboard.read()
-          if (content?.mime.startsWith("image/")) {
-            await pasteAttachment({
-              filename: "clipboard",
-              mime: content.mime,
-              content: content.data,
-            })
-          }
+          await pasteClipboardAttachment()
         },
       },
       {
@@ -823,6 +818,19 @@ export function Prompt(props: PromptProps) {
     return
   }
 
+  async function pasteClipboardAttachment() {
+    const content = await Clipboard.read()
+    if (!content) return false
+    if (!content.mime.startsWith("image/") && content.mime !== "application/pdf") return false
+    await pasteAttachment({
+      filename: "clipboard",
+      mime: content.mime,
+      content: content.data,
+    })
+    pasted = Date.now()
+    return true
+  }
+
   const highlight = createMemo(() => {
     if (keybind.leader) return theme.border
     if (store.mode === "shell") return theme.primary
@@ -931,18 +939,9 @@ export function Prompt(props: PromptProps) {
                 // Check clipboard for images before terminal-handled paste runs.
                 // This helps terminals that forward Ctrl+V to the app; Windows
                 // Terminal 1.25+ usually handles Ctrl+V before this path.
-                if (keybind.match("input_paste", e)) {
-                  const content = await Clipboard.read()
-                  if (content?.mime.startsWith("image/")) {
-                    e.preventDefault()
-                    await pasteAttachment({
-                      filename: "clipboard",
-                      mime: content.mime,
-                      content: content.data,
-                    })
-                    return
-                  }
-                  // If no image, let the default paste behavior continue
+                if ((keybind.match("input_paste", e) || probePaste(e)) && (await pasteClipboardAttachment())) {
+                  e.preventDefault()
+                  return
                 }
                 if (keybind.match("input_clear", e) && store.prompt.input !== "") {
                   input.clear()
@@ -1021,7 +1020,14 @@ export function Prompt(props: PromptProps) {
                 // Windows Terminal <1.25 can surface image-only clipboard as an
                 // empty bracketed paste. Windows Terminal 1.25+ does not.
                 if (!pastedContent) {
-                  command.trigger("prompt.paste")
+                  if (Date.now() - pasted < 250) {
+                    event.preventDefault()
+                    return
+                  }
+                  if (await pasteClipboardAttachment()) {
+                    event.preventDefault()
+                    return
+                  }
                   return
                 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/paste-key.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/paste-key.ts
@@ -1,0 +1,9 @@
+import type { ParsedKey } from "@opentui/core"
+
+export const probePaste = (evt: ParsedKey, os = process.platform) => {
+  const key = evt.name.toLowerCase()
+  if (key !== "v") return false
+  if (evt.ctrl) return true
+  if (os !== "darwin") return false
+  return Boolean(evt.super || evt.meta)
+}

--- a/packages/opencode/test/cli/cmd/tui/paste-key.test.ts
+++ b/packages/opencode/test/cli/cmd/tui/paste-key.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import type { ParsedKey } from "@opentui/core"
+import { probePaste } from "../../../../src/cli/cmd/tui/component/prompt/paste-key"
+
+const key = (input: Partial<ParsedKey>) =>
+  ({
+    name: "",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    super: false,
+    ...input,
+  }) as ParsedKey
+
+describe("paste key", () => {
+  test("matches ctrl+v on any platform", () => {
+    expect(probePaste(key({ name: "v", ctrl: true }), "linux")).toBe(true)
+  })
+
+  test("matches cmd+v on macos via super", () => {
+    expect(probePaste(key({ name: "v", super: true }), "darwin")).toBe(true)
+  })
+
+  test("matches cmd+v on macos via meta", () => {
+    expect(probePaste(key({ name: "v", meta: true }), "darwin")).toBe(true)
+  })
+
+  test("does not match cmd+v on non-macos", () => {
+    expect(probePaste(key({ name: "v", super: true }), "linux")).toBe(false)
+  })
+
+  test("does not match other keys", () => {
+    expect(probePaste(key({ name: "c", ctrl: true }), "darwin")).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22194

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On macOS, clipboard image paste in the TUI only worked reliably through the existing `input_paste` path, so `cmd+v` could miss image attachments depending on the terminal.

This change adds a small `probePaste()` helper for macOS `cmd+v`, reuses one clipboard attachment path for both keydown and empty paste events, and avoids double-attaching when the key event and paste event happen back-to-back.

It works because image attachment now happens through the same code path whether the terminal reports paste as `ctrl+v`, `meta/super+v`, or an empty paste event.

### How did you verify your code works?

- `bun test test/cli/cmd/tui/paste-key.test.ts`
- `bun run typecheck`
- manual validation in Ghostty on macOS: copied an image to the clipboard, pressed `cmd+v`, and confirmed the image attached in the prompt

### Screenshots / recordings

N/A for this bug fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
