### PR TITLE
fix(otlp): split OTLP headers on first = only

### DIFF
--- a/packages/opencode/src/effect/oltp.ts
+++ b/packages/opencode/src/effect/oltp.ts
@@ -21,7 +21,9 @@ export namespace Observability {
   const headers = Flag.OTEL_EXPORTER_OTLP_HEADERS
     ? Flag.OTEL_EXPORTER_OTLP_HEADERS.split(",").reduce(
         (acc, x) => {
-          const [key, value] = x.split("=")
+          const idx = x.indexOf("=")
+          const key = x.slice(0, idx)
+          const value = x.slice(idx + 1)
           acc[key] = value
           return acc
         },


### PR DESCRIPTION
### Issue for this PR

Closes #22202

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OTLP header parser in `oltp.ts` uses `x.split("=")` with destructuring, which splits on every `=` in the string. When the header value itself contains `=` (e.g. Sentry's `x-sentry-auth=sentry sentry_key=abc123`), the actual key gets silently dropped.

Fixed by splitting on the first `=` only via `indexOf` + `slice`.

### How did you verify your code works?

Ran `opencode serve` with `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` set to a Sentry OTLP endpoint. Before the fix: traces silently fail (401). After: traces land in Sentry.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR