### PR TITLE
fix(tui): guard against null/undefined MCP status in reactive computations

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -50,10 +50,10 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={Object.keys(sync.data.mcp ?? {}).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
-          <For each={Object.entries(sync.data.mcp)}>
+          <text fg={theme.text}>{Object.keys(sync.data.mcp ?? {}).length} MCP Servers</text>
+          <For each={Object.entries(sync.data.mcp ?? {})}>
             {([key, item]) => (
               <box flexDirection="row" gap={1}>
                 <text

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -369,11 +369,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const mcp = {
       isEnabled(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         return status?.status === "connected"
       },
       async toggle(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         if (status?.status === "connected") {
           // Disable: disconnect the MCP
           await sdk.client.mcp.disconnect({ name })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -420,7 +420,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data!))),
-            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data!))),
+            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
             sdk.client.experimental.resource
               .list({ workspace })
               .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),

--- a/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin/api.tsx
@@ -176,7 +176,7 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       return sync.data.lsp.map((item) => ({ id: item.id, root: item.root, status: item.status }))
     },
     mcp() {
-      return Object.entries(sync.data.mcp)
+      return Object.entries(sync.data.mcp ?? {})
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([name, item]) => ({
           name,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -10,8 +10,8 @@ export function Footer() {
   const { theme } = useTheme()
   const sync = useSync()
   const route = useRoute()
-  const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
-  const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
+  const mcp = createMemo(() => Object.values(sync.data.mcp ?? {}).filter((x) => x.status === "connected").length)
+  const mcpError = createMemo(() => Object.values(sync.data.mcp ?? {}).some((x) => x.status === "failed"))
   const lsp = createMemo(() => Object.keys(sync.data.lsp))
   const permissions = createMemo(() => {
     if (route.data.type !== "session") return []


### PR DESCRIPTION
### Issue for this PR

Closes #22102
Closes #21931
Closes #21645
Closes #21449
Closes #21290
Closes #20806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

During TUI bootstrap, `sync.tsx` fetches MCP status from the server and updates the store via:

```ts
sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data!)))
```

When `x.data` is `null` or `undefined` (e.g., the server hasn't finished initializing, a network hiccup, or an SDK edge case), `reconcile(undefined)` sets `store.mcp` to `undefined`. Every component that then calls `Object.entries(sync.data.mcp)`, `Object.keys(...)`, or `Object.values(...)` throws:

```
TypeError: Object.entries requires that input parameter not be null or undefined
```

This crash has been reported at least **6 times** (#22102, #21931, #21645, #21449, #21290, #20806), primarily on Windows but reproducible on any platform with the right timing.

**Root fix** (sync.tsx): replace `x.data!` with `x.data ?? {}` so the store is never set to undefined.

**Defense-in-depth** (5 consumption sites): add `?? {}` or `?.` at every call site that touches `sync.data.mcp`, so even if the store value is transiently undefined during a reactive recomputation, no component crashes. This matches the pattern already used in `dialog-mcp.tsx` (line 35: `mcpData ?? {}`).

### Files changed

| File | Change |
|------|--------|
| `context/sync.tsx` | `x.data!` → `x.data ?? {}` (root cause) |
| `component/dialog-status.tsx` | `sync.data.mcp` → `sync.data.mcp ?? {}` (3 sites) |
| `routes/session/footer.tsx` | `sync.data.mcp` → `sync.data.mcp ?? {}` (2 sites) |
| `plugin/api.tsx` | `sync.data.mcp` → `sync.data.mcp ?? {}` (1 site) |
| `context/local.tsx` | `sync.data.mcp[name]` → `sync.data.mcp?.[name]` (2 sites) |

### How did you verify your code works?

- `bun test` — all 1893 tests pass (0 fail)
- `bun typecheck` — all 13 packages pass (the husky pre-push hook ran this automatically)
- Manually inspected every `sync.data.mcp` access in the TUI codebase to confirm all are now guarded

### Screenshots / recordings

_N/A — not a visual change; this prevents a crash._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR