### PR TITLE
fix: persist clipboard images as temp files with file:// URLs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -247,6 +247,7 @@ export function Prompt(props: PromptProps) {
           if (content?.mime.startsWith("image/")) {
             await pasteAttachment({
               filename: "clipboard",
+              filepath: content.filepath,
               mime: content.mime,
               content: content.data,
             })
@@ -802,7 +803,7 @@ export function Prompt(props: PromptProps) {
       type: "file" as const,
       mime: file.mime,
       filename: file.filename,
-      url: `data:${file.mime};base64,${file.content}`,
+      url: file.filepath ? `file://${file.filepath}` : `data:${file.mime};base64,${file.content}`,
       source: {
         type: "file",
         path: file.filepath ?? file.filename ?? "",
@@ -937,6 +938,7 @@ export function Prompt(props: PromptProps) {
                     e.preventDefault()
                     await pasteAttachment({
                       filename: "clipboard",
+                      filepath: content.filepath,
                       mime: content.mime,
                       content: content.data,
                     })

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -26,6 +26,7 @@ export namespace Clipboard {
   export interface Content {
     data: string
     mime: string
+    filepath?: string
   }
 
   // Checks clipboard for images first, then falls back to text.
@@ -40,7 +41,7 @@ export namespace Clipboard {
     const os = platform()
 
     if (os === "darwin") {
-      const tmpfile = path.join(tmpdir(), "opencode-clipboard.png")
+      const tmpfile = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.png`)
       try {
         await Process.run(
           [
@@ -59,10 +60,8 @@ export namespace Clipboard {
           { nothrow: true },
         )
         const buffer = await Filesystem.readBytes(tmpfile)
-        return { data: buffer.toString("base64"), mime: "image/png" }
+        return { data: buffer.toString("base64"), mime: "image/png", filepath: tmpfile }
       } catch {
-      } finally {
-        await fs.rm(tmpfile, { force: true }).catch(() => {})
       }
     }
 
@@ -77,7 +76,9 @@ export namespace Clipboard {
       if (base64.text) {
         const imageBuffer = Buffer.from(base64.text.trim(), "base64")
         if (imageBuffer.length > 0) {
-          return { data: imageBuffer.toString("base64"), mime: "image/png" }
+          const tmpfile = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.png`)
+          await fs.writeFile(tmpfile, imageBuffer).catch(() => {})
+          return { data: imageBuffer.toString("base64"), mime: "image/png", filepath: tmpfile }
         }
       }
     }
@@ -85,13 +86,17 @@ export namespace Clipboard {
     if (os === "linux") {
       const wayland = await Process.run(["wl-paste", "-t", "image/png"], { nothrow: true })
       if (wayland.stdout.byteLength > 0) {
-        return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png" }
+        const tmpfile = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.png`)
+        await fs.writeFile(tmpfile, Buffer.from(wayland.stdout)).catch(() => {})
+        return { data: Buffer.from(wayland.stdout).toString("base64"), mime: "image/png", filepath: tmpfile }
       }
       const x11 = await Process.run(["xclip", "-selection", "clipboard", "-t", "image/png", "-o"], {
         nothrow: true,
       })
       if (x11.stdout.byteLength > 0) {
-        return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png" }
+        const tmpfile = path.join(tmpdir(), `opencode-clipboard-${Date.now()}.png`)
+        await fs.writeFile(tmpfile, Buffer.from(x11.stdout)).catch(() => {})
+        return { data: Buffer.from(x11.stdout).toString("base64"), mime: "image/png", filepath: tmpfile }
       }
     }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -16,6 +16,8 @@ import type { Provider } from "@/provider/provider"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Effect } from "effect"
 import { EffectLogger } from "@/effect/logger"
+import { fileURLToPath } from "url"
+import { readFileSync } from "fs"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
 interface FetchDecompressionError extends Error {
@@ -617,26 +619,33 @@ export namespace MessageV2 {
       }
 
       if (typeof output === "object") {
-        const outputObject = output as {
+        const obj = output as {
           text: string
           attachments?: Array<{ mime: string; url: string }>
         }
-        const attachments = (outputObject.attachments ?? []).filter((attachment) => {
-          return attachment.url.startsWith("data:") && attachment.url.includes(",")
-        })
+        const attachments = (obj.attachments ?? []).filter(
+          (a) => a.url.startsWith("data:") || a.url.startsWith("file://"),
+        )
 
         return {
           type: "content",
           value: [
-            { type: "text", text: outputObject.text },
-            ...attachments.map((attachment) => ({
-              type: "media",
-              mediaType: attachment.mime,
-              data: iife(() => {
-                const commaIndex = attachment.url.indexOf(",")
-                return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
-              }),
-            })),
+            { type: "text", text: obj.text },
+            ...attachments.map((attachment) => {
+              if (attachment.url.startsWith("file://")) {
+                return {
+                  type: "media" as const,
+                  mediaType: attachment.mime,
+                  data: readFileSync(fileURLToPath(attachment.url)).toString("base64"),
+                }
+              }
+              const comma = attachment.url.indexOf(",")
+              return {
+                type: "media" as const,
+                mediaType: attachment.mime,
+                data: comma === -1 ? attachment.url : attachment.url.slice(comma + 1),
+              }
+            }),
           ],
         }
       }
@@ -826,14 +835,30 @@ export namespace MessageV2 {
 
     const tools = Object.fromEntries(Array.from(toolNames).map((toolName) => [toolName, { toModelOutput }]))
 
-    return yield* Effect.promise(() =>
-      convertToModelMessages(
-        result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
-        {
-          //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
-          tools,
-        },
+    const filtered = result.filter((msg) => msg.parts.some((part) => part.type !== "step-start"))
+    const resolved = yield* Effect.promise(() =>
+      Promise.all(
+        filtered.map((msg) =>
+          Promise.all(
+            msg.parts.map((part) => {
+              if (part.type === "file" && part.url.startsWith("file://")) {
+                return {
+                  ...part,
+                  url: `data:${(part as any).mediaType};base64,${readFileSync(fileURLToPath(part.url)).toString("base64")}`,
+                }
+              }
+              return part
+            }),
+          ).then((parts) => ({ ...msg, parts })),
+        ),
       ),
+    )
+
+    return yield* Effect.promise(() =>
+      convertToModelMessages(resolved, {
+        //@ts-expect-error (convertToModelMessages expects a ToolSet but only actually needs tools[name]?.toModelOutput)
+        tools,
+      }),
     )
   })
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -18,6 +18,7 @@ import { Effect } from "effect"
 import { EffectLogger } from "@/effect/logger"
 import { fileURLToPath } from "url"
 import { readFileSync } from "fs"
+import { readFile } from "fs/promises"
 
 /** Error shape thrown by Bun's fetch() when gzip/br decompression fails mid-stream */
 interface FetchDecompressionError extends Error {
@@ -631,21 +632,30 @@ export namespace MessageV2 {
           type: "content",
           value: [
             { type: "text", text: obj.text },
-            ...attachments.map((attachment) => {
-              if (attachment.url.startsWith("file://")) {
+            ...attachments
+              .map((attachment) => {
+                if (attachment.url.startsWith("file://")) {
+                  try {
+                    return {
+                      type: "media" as const,
+                      mediaType: attachment.mime,
+                      data: readFileSync(fileURLToPath(attachment.url)).toString("base64"),
+                    }
+                  } catch {
+                    return {
+                      type: "text" as const,
+                      text: `[Attached ${attachment.mime}: file not found]`,
+                    }
+                  }
+                }
+                const comma = attachment.url.indexOf(",")
                 return {
                   type: "media" as const,
                   mediaType: attachment.mime,
-                  data: readFileSync(fileURLToPath(attachment.url)).toString("base64"),
+                  data: comma === -1 ? attachment.url : attachment.url.slice(comma + 1),
                 }
-              }
-              const comma = attachment.url.indexOf(",")
-              return {
-                type: "media" as const,
-                mediaType: attachment.mime,
-                data: comma === -1 ? attachment.url : attachment.url.slice(comma + 1),
-              }
-            }),
+              })
+              .filter((p): p is { type: "media"; mediaType: string; data: string } => p !== null),
           ],
         }
       }
@@ -840,11 +850,20 @@ export namespace MessageV2 {
       Promise.all(
         filtered.map((msg) =>
           Promise.all(
-            msg.parts.map((part) => {
+            msg.parts.map(async (part) => {
               if (part.type === "file" && part.url.startsWith("file://")) {
-                return {
-                  ...part,
-                  url: `data:${(part as any).mediaType};base64,${readFileSync(fileURLToPath(part.url)).toString("base64")}`,
+                try {
+                  const buf = await readFile(fileURLToPath(part.url))
+                  return {
+                    ...part,
+                    url: `data:${(part as any).mediaType};base64,${buf.toString("base64")}`,
+                  }
+                } catch {
+                  return {
+                    ...part,
+                    type: "text" as const,
+                    text: `[Attached ${(part as any).mediaType}: file not found]`,
+                  }
                 }
               }
               return part

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1191,9 +1191,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     messageID: info.id,
                     sessionID: input.sessionID,
                     type: "file",
-                    url:
-                      `data:${part.mime};base64,` +
-                      Buffer.from(yield* fsys.readFile(filepath).pipe(Effect.catch(Effect.die))).toString("base64"),
+                    url: part.url,
                     mime: part.mime,
                     filename: part.filename!,
                     source: part.source,


### PR DESCRIPTION
### Issue for this PR

Closes #14673

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an image is pasted from clipboard, OpenCode stored it as an inline `data:image/...;base64,...` URL. MCP tools (`look_at`, `understand_image`) expect a file path on disk, not a base64 string, so they couldn't analyze pasted images.

This PR:
1. Saves clipboard images to temp files (`os.tmpdir()/opencode-clipboard-<timestamp>.png`) and keeps the file path
2. Uses `file://` URLs so MCP tools can access the file
3. Converts `file://` back to `data:` URLs before sending to AI SDK (which rejects `file://` scheme)

Changes:
- `clipboard.ts` — save temp file, return `filepath` in Content, unique filenames with timestamp
- `prompt/index.tsx` — pass `filepath` through attachment flow, use `file://` URL when filepath exists
- `prompt.ts` — use `part.url` directly instead of re-reading the file
- `message-v2.ts` — convert `file://` → `data:` before AI SDK consumption (in both user message parts and tool output attachments)

### How did you verify your code works?

- All 23 `message-v2` tests pass
- All 45 prompt-related tests pass
- `tsgo --noEmit` typecheck passes
- CI: typecheck pass, unit (linux) pass, unit (windows) pass

### Screenshots / recordings

_No UI changes — purely internal data handling._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

> **Note:** There is an open PR #21633 addressing the same issue. This PR takes a more complete approach by also handling `file://` → `data:` conversion in `message-v2.ts` (both user parts and tool output attachments), ensuring the AI SDK never sees a `file://` URL it would reject.