### PR TITLE
[FEATURE]: Add skill usage tracking to CLI

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -1,4 +1,6 @@
 import path from "path"
+import fs from "fs"
+import os from "os"
 import { pathToFileURL } from "url"
 import z from "zod"
 import { Effect } from "effect"
@@ -7,6 +9,39 @@ import * as Stream from "effect/Stream"
 import { Tool } from "./tool"
 import { Skill } from "../skill"
 import { Ripgrep } from "../file/ripgrep"
+
+const USAGE_FILE = path.join(os.homedir(), ".config/opencode/skills/usage.json")
+
+// Helper function to track skill usage
+async function trackSkillUsage(skillName: string): Promise<void> {
+  try {
+    // Ensure directory exists
+    const dir = path.dirname(USAGE_FILE)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+
+    // Read existing usage or create new
+    let usage: Record<string, number> = {}
+    if (fs.existsSync(USAGE_FILE)) {
+      const content = fs.readFileSync(USAGE_FILE, "utf-8")
+      try {
+        usage = JSON.parse(content)
+      } catch {
+        usage = {}
+      }
+    }
+
+    // Increment counter
+    usage[skillName] = (usage[skillName] || 0) + 1
+
+    // Write back
+    fs.writeFileSync(USAGE_FILE, JSON.stringify(usage, null, 2))
+  } catch (err) {
+    // Silently fail - tracking should not break the tool
+    console.error("Failed to track skill usage:", err)
+  }
+}
 
 const Parameters = z.object({
   name: z.string().describe("The name of the skill from available_skills"),
@@ -51,6 +86,12 @@ export const SkillTool = Tool.define(
                 const available = all.map((s) => s.name).join(", ")
                 throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
               }
+
+              // Track skill usage
+              yield* Effect.tryPromise({
+                try: () => trackSkillUsage(params.name),
+                catch: () => Effect.unit,
+              })
 
               yield* ctx.ask({
                 permission: "skill",


### PR DESCRIPTION
## What

Track which skills are used. Every time a skill is invoked, increment its counter in a local JSON file.

## Why

I built a personal JavaFX app (OpenCode Manager) with this feature - wanted the same in CLI.

Helps developers know:
- Which skills do I actually use?
- Which am I ignoring?
- Am I over-relying on one?

## Implementation

Added `trackSkillUsage()` to `packages/opencode/src/tool/skill.ts`.

Writes to `~/.config/opencode/skills/usage.json`:
```json
{
  "go-testing": 12,
  "issue-maker": 5
}
```

- Silent failures - never breaks CLI
- Zero setup - just a JSON file
- Stays local - no telemetry

## Compatibility

My OpenCode Manager app reads this file and shows usage stats:
https://github.com/zokan121522/OpenCodeManager-app

## Test
- [x] Counter increments on skill use
- [x] File created if missing
- [x] Handles errors gracefully

## Related
Issue #22225