### PR TITLE
Add WSL notifications plugin to README community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,5 +137,13 @@ It's very similar to Claude Code in terms of capability. Here are the key differ
 - A client/server architecture. This, for example, can allow OpenCode to run on your computer while you drive it remotely from a mobile app, meaning that the TUI frontend is just one of the possible clients.
 
 ---
+## Community Plugins
 
+### WSL Windows Notifications
+
+Get native Windows toast notifications when using OpenCode inside WSL.
+
+Uses `powershell.exe` and BurntToast to bridge Linux and Windows notifications.
+
+Repo: https://github.com/captainmmd1304/opencode-wsl-notifications
 **Join our community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Refactor / code improvement
* [x] Documentation

### What does this PR do?

Adds a small README entry for a community plugin that enables native Windows notifications when using OpenCode inside WSL.

The plugin uses `powershell.exe` and BurntToast to trigger Windows toast notifications for session completion, errors, and permission prompts.

I thought this could be useful for users running OpenCode inside WSL.

### How did you verify your code works?

Checked the README formatting locally and confirmed the linked plugin repo works in my WSL setup.

### Screenshots / recordings

Not a UI change.

### Checklist

* [x] I have tested my changes locally
* [x] I have not included unrelated changes in this PR

