### PR TITLE
fix(app): preserve undo history when inserting tag pills in prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -37,6 +37,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { promptEnabled, promptProbe } from "@/testing/prompt"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
+import { insertAtomicPartAtSelection } from "./prompt-input/editor-insert"
 import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
 import {
@@ -951,12 +952,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       }
 
       range.deleteContents()
-      range.insertNode(gap)
-      range.insertNode(pill)
-      range.setStartAfter(gap)
       range.collapse(true)
       selection.removeAllRanges()
       selection.addRange(range)
+      if (!insertAtomicPartAtSelection(part)) {
+        range.insertNode(gap)
+        range.insertNode(pill)
+        range.setStartAfter(gap)
+        range.collapse(true)
+        selection.removeAllRanges()
+        selection.addRange(range)
+      }
     }
 
     if (part.type === "text") {

--- a/packages/app/src/components/prompt-input/editor-insert.test.ts
+++ b/packages/app/src/components/prompt-input/editor-insert.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import type { AgentPart, FileAttachmentPart } from "@/context/prompt"
+import { insertAtomicPartAtSelection, serializeAtomicPartHtml } from "./editor-insert"
+
+const originalExecCommand = document.execCommand
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  if (originalExecCommand) {
+    document.execCommand = originalExecCommand
+  } else {
+    // @ts-expect-error happy-dom doesn't declare deletable execCommand
+    delete document.execCommand
+  }
+})
+
+describe("prompt-input editor insert", () => {
+  test("serializeAtomicPartHtml preserves file metadata for pill parsing", () => {
+    const part: FileAttachmentPart = {
+      type: "file",
+      content: "src/index.ts",
+      path: "/workspace/src/index.ts",
+      start: 0,
+      end: 12,
+    }
+
+    const html = serializeAtomicPartHtml(part)
+    expect(html).toContain('data-type="file"')
+    expect(html).toContain('data-path="/workspace/src/index.ts"')
+    expect(html).toContain('contenteditable="false"')
+    expect(html).toContain("src/index.ts")
+  })
+
+  test("serializeAtomicPartHtml preserves agent metadata", () => {
+    const part: AgentPart = {
+      type: "agent",
+      content: "codegen",
+      name: "codegen",
+      start: 0,
+      end: 7,
+    }
+
+    const html = serializeAtomicPartHtml(part)
+    expect(html).toContain('data-type="agent"')
+    expect(html).toContain('data-name="codegen"')
+  })
+
+  test("serializeAtomicPartHtml escapes HTML special characters", () => {
+    const part: FileAttachmentPart = {
+      type: "file",
+      content: '<script>alert("xss")</script>',
+      path: 'path/with"quotes',
+      start: 0,
+      end: 10,
+    }
+
+    const html = serializeAtomicPartHtml(part)
+    expect(html).not.toContain("<script>")
+    expect(html).toContain("&lt;script&gt;")
+  })
+
+  test("insertAtomicPartAtSelection prefers execCommand so the browser keeps undo history", () => {
+    const editor = document.createElement("div")
+    editor.setAttribute("contenteditable", "true")
+    editor.textContent = "hello @"
+    document.body.appendChild(editor)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(editor.firstChild!, editor.textContent!.length)
+    range.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    const execCommand = mock((_command: string, _showUi: boolean, _value: string) => true)
+    document.execCommand = execCommand as typeof document.execCommand
+
+    const part: FileAttachmentPart = {
+      type: "file",
+      content: "README.md",
+      path: "/workspace/README.md",
+      start: 0,
+      end: 9,
+    }
+
+    expect(insertAtomicPartAtSelection(part)).toBe(true)
+    expect(execCommand).toHaveBeenCalledTimes(1)
+    expect(execCommand.mock.calls[0]?.[0]).toBe("insertHTML")
+    expect(String(execCommand.mock.calls[0]?.[2] ?? "")).toContain('data-type="file"')
+  })
+
+  test("insertAtomicPartAtSelection returns false when execCommand is unavailable", () => {
+    // @ts-expect-error testing unavailable execCommand
+    document.execCommand = undefined
+
+    const part: AgentPart = {
+      type: "agent",
+      content: "codegen",
+      name: "codegen",
+      start: 0,
+      end: 7,
+    }
+
+    expect(insertAtomicPartAtSelection(part)).toBe(false)
+  })
+})

--- a/packages/app/src/components/prompt-input/editor-insert.ts
+++ b/packages/app/src/components/prompt-input/editor-insert.ts
@@ -1,0 +1,40 @@
+import type { AgentPart, FileAttachmentPart } from "@/context/prompt"
+
+type AtomicPart = FileAttachmentPart | AgentPart
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+export function serializeAtomicPartHtml(part: AtomicPart): string {
+  const attrs = [
+    'contenteditable="false"',
+    `data-type="${escapeHtml(part.type)}"`,
+    'style="user-select: text; cursor: default;"',
+  ]
+
+  if (part.type === "file") {
+    attrs.push(`data-path="${escapeHtml(part.path)}"`)
+  }
+  if (part.type === "agent") {
+    attrs.push(`data-name="${escapeHtml(part.name)}"`)
+  }
+
+  return `<span ${attrs.join(" ")}>${escapeHtml(part.content)}</span>\u00a0`
+}
+
+/**
+ * Insert a tag pill via execCommand("insertHTML") so the operation is pushed
+ * onto the browser's native undo stack. Returns false when execCommand is
+ * unavailable, letting callers fall back to direct DOM manipulation.
+ */
+export function insertAtomicPartAtSelection(part: AtomicPart): boolean {
+  const execCommand = document.execCommand?.bind(document)
+  if (typeof execCommand !== "function") return false
+  return execCommand("insertHTML", false, serializeAtomicPartHtml(part))
+}


### PR DESCRIPTION
### Issue for this PR

Closes #22234

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When inserting file/agent tag pills into the `contenteditable` prompt editor, the current code uses `range.insertNode()` — a direct DOM operation that bypasses the browser's native undo stack. This means pressing Ctrl+Z after inserting a tag doesn't undo the tag insertion; instead it undoes whatever happened *before* the tag (typically deleting preceding text).

This PR introduces a small helper (`editor-insert.ts`) that uses `document.execCommand("insertHTML")` to insert the pill HTML. Although `execCommand` is deprecated, it remains the only reliable way to push operations onto the browser's built-in undo/redo stack in a `contenteditable` element. The call site in `prompt-input.tsx` tries `insertAtomicPartAtSelection()` first, and falls back to the original `range.insertNode` path if `execCommand` is unavailable.

**Files changed:**
- `packages/app/src/components/prompt-input/editor-insert.ts` (new) — `serializeAtomicPartHtml()` + `insertAtomicPartAtSelection()` helper
- `packages/app/src/components/prompt-input/editor-insert.test.ts` (new) — unit tests for HTML serialization, XSS escaping, and execCommand usage
- `packages/app/src/components/prompt-input.tsx` — import the helper, replace the direct DOM insertion with the execCommand approach + fallback

### How did you verify your code works?

- Unit tests pass (`bun test editor-insert.test.ts` — 5 tests, 13 assertions)
- Manual test: type text → insert tag via `@` → Ctrl+Z correctly removes the tag pill (not the preceding text)
- Verified tag pills still render and function correctly after insertion
- Verified existing prompt-input behavior is unaffected

### Screenshots / recordings

_N/A — this is an interaction behavior fix, best verified by testing Ctrl+Z after inserting a tag pill._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR