### PR TITLE
fix(opencode): extract nested error message from API responses

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -65,7 +65,7 @@ export namespace ProviderError {
       try {
         const body = JSON.parse(e.responseBody)
         // try to extract common error message fields
-        const errMsg = body.message || body.error || body.error?.message
+        const errMsg = body.message || (typeof body.error === "string" ? body.error : body.error?.message)
         if (errMsg && typeof errMsg === "string") {
           return `${msg}: ${errMsg}`
         }


### PR DESCRIPTION
### Issue for this PR

Closes #22238

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Line 68 in `error.ts` uses `body.message || body.error || body.error?.message` to extract error messages from API responses. When `body.error` is an object (standard OpenAI/Anthropic format like `{ error: { message: "rate limit exceeded" } }`), the `||` short-circuits on the truthy object and never reaches `body.error?.message`. The `typeof errMsg === "string"` check on line 69 then rejects the object, so no useful message is shown.

Fix: check `typeof body.error === "string"` before using it directly, otherwise fall through to `body.error?.message`.

### How did you verify your code works?

Tested with mock API responses in both formats:
- `{ error: "string error" }` → correctly returns "string error"
- `{ error: { message: "rate limit exceeded" } }` → correctly returns "rate limit exceeded"
- `{ message: "direct message" }` → still works as before

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR