### PR TITLE
fix: merge per-token reasoning chunks into single part for GLM models

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -314,7 +314,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               const part = draft[result.index]
               const field = event.properties.field as keyof typeof part
               const existing = part[field] as string | undefined
-              ;(part[field] as string) = (existing ?? "") + event.properties.delta
+              const delta = event.properties.delta
+              ;(part[field] as string) = (existing ?? "") + delta
             }),
           )
           break

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1443,7 +1443,17 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
   const content = createMemo(() => {
     // Filter out redacted reasoning chunks from OpenRouter
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
-    return props.part.text.replace("[REDACTED]", "").trim()
+    let text = props.part.text.replace("[REDACTED]", "").trim()
+    // Normalize newlines for models that stream each token with its own newline
+    // (e.g., zhipu/glm). Preserve paragraph breaks (\n\n) but collapse single
+    // newlines that are just token boundaries into spaces.
+    text = text
+      .replace(/\r\n/g, "\n")
+      .replace(/\n{2,}/g, "\x00PARA\x00") // Protect paragraph breaks
+      .replace(/\n/g, " ")                 // Single newlines → space
+      .replace(/\x00PARA\x00/g, "\n\n")    // Restore paragraph breaks
+      .replace(/ {2,}/g, " ")              // Collapse multiple spaces
+    return text
   })
   return (
     <Show when={content() && ctx.showThinking()}>

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -212,6 +212,17 @@ export namespace SessionProcessor {
         })
 
         const handleEvent = Effect.fn("SessionProcessor.handleEvent")(function* (value: StreamEvent) {
+          // Finalize a merged reasoning part (for models that emit per-token reasoning chunks)
+          function* finalizeReasoning() {
+            const entry = (ctx as any)._lastReasoningEntry
+            if (!entry) return
+            entry.text = entry.text.trimEnd()
+            entry.time = { ...entry.time, end: Date.now() }
+            yield* session.updatePart(entry)
+            ;(ctx as any)._lastReasoningPartId = undefined
+            ;(ctx as any)._lastReasoningEntry = undefined
+          }
+
           switch (value.type) {
             case "start":
               yield* status.set(ctx.sessionID, { type: "busy" })
@@ -219,6 +230,17 @@ export namespace SessionProcessor {
 
             case "reasoning-start":
               if (value.id in ctx.reasoningMap) return
+              // Some models (e.g., zhipu/glm) emit a separate reasoning-start/delta/end
+              // cycle for every single token. Merge consecutive reasoning chunks into
+              // one part to avoid per-token line rendering in the TUI.
+              if ((ctx as any)._lastReasoningPartId) {
+                // Reuse the previous reasoning part — map this new id to the same part
+                const prev = (ctx as any)._lastReasoningEntry
+                if (prev) {
+                  ctx.reasoningMap[value.id] = prev
+                  return
+                }
+              }
               ctx.reasoningMap[value.id] = {
                 id: PartID.ascending(),
                 messageID: ctx.assistantMessage.id,
@@ -228,6 +250,8 @@ export namespace SessionProcessor {
                 time: { start: Date.now() },
                 metadata: value.providerMetadata,
               }
+              ;(ctx as any)._lastReasoningPartId = ctx.reasoningMap[value.id].id
+              ;(ctx as any)._lastReasoningEntry = ctx.reasoningMap[value.id]
               yield* session.updatePart(ctx.reasoningMap[value.id])
               return
 
@@ -246,10 +270,10 @@ export namespace SessionProcessor {
 
             case "reasoning-end":
               if (!(value.id in ctx.reasoningMap)) return
-              ctx.reasoningMap[value.id].text = ctx.reasoningMap[value.id].text
-              ctx.reasoningMap[value.id].time = { ...ctx.reasoningMap[value.id].time, end: Date.now() }
+              // Don't trimEnd or finalize yet — more reasoning chunks may follow.
+              // Just clean up the map entry for this id but keep the part reference
+              // alive via _lastReasoningEntry for potential reuse.
               if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
-              yield* session.updatePart(ctx.reasoningMap[value.id])
               delete ctx.reasoningMap[value.id]
               return
 
@@ -352,6 +376,7 @@ export namespace SessionProcessor {
               return
 
             case "finish-step": {
+              yield* finalizeReasoning()
               const usage = Session.getUsage({
                 model: ctx.model,
                 usage: value.usage,
@@ -399,6 +424,7 @@ export namespace SessionProcessor {
             }
 
             case "text-start":
+              yield* finalizeReasoning()
               ctx.currentText = {
                 id: PartID.ascending(),
                 messageID: ctx.assistantMessage.id,


### PR DESCRIPTION
### Issue for this PR

Closes #22241

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some models (e.g., zhipu/glm) emit a separate `reasoning-start` → `reasoning-delta` → `reasoning-end` cycle **for every single token** during reasoning/thinking output. This causes each token to create an independent reasoning `Part` with a unique `partID`, resulting in the TUI rendering each token as a separate `Thinking:` line:

```
Thinking: The
Thinking: user
Thinking: said
Thinking: hello
```

**Root cause**: The AI SDK adapter for these models wraps each token in its own reasoning lifecycle event, unlike models such as DeepSeek which emit one `reasoning-start`, many `reasoning-delta`s, and one `reasoning-end`.

**Fix in `processor.ts`**: Track the last reasoning part via `_lastReasoningEntry`. When a new `reasoning-start` arrives and a previous reasoning part exists, reuse it instead of creating a new one. `reasoning-end` no longer finalizes the part — it just cleans up the map entry. The merged part is finalized when `text-start` or `finish-step` fires (via `finalizeReasoning()`).

**Defense-in-depth in `index.tsx`**: Normalize newlines in `ReasoningPart`'s `createMemo` — collapse single `\n` (token boundaries) to spaces while preserving `\n\n` (paragraph breaks).

### How did you verify your code works?

- Tested with `zhipu/glm-5` via Mify gateway — thinking content now renders as a continuous paragraph
- Three-layer debug logging (processor → sync → render) confirmed all deltas now share the same `partID`
- DeepSeek thinking output unaffected (single start/end cycle works as before)

### Screenshots / recordings

_N/A — terminal behavior fix, not UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR