### PR TITLE
app: fix scroll to bottom light mode style

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -642,10 +642,10 @@ export function MessageTimeline(props: {
             onClick={props.onResumeScroll}
           >
             <div
-              class="flex items-center justify-center w-8 h-6 rounded-[6px] border border-[var(--gray-dark-7)] bg-[color-mix(in_srgb,var(--gray-dark-3)_80%,transparent)] backdrop-blur-[0.75px] transition-colors group-hover:border-[var(--gray-dark-8)] [--icon-base:var(--gray-dark-10)] group-hover:[--icon-base:var(--gray-dark-11)]"
+              class="flex items-center justify-center w-8 h-6 rounded-[6px] border border-border-weaker-base bg-[color-mix(in_srgb,var(--surface-raised-stronger-non-alpha)_80%,transparent)] backdrop-blur-[0.75px] transition-colors group-hover:border-[var(--border-weak-base)] group-hover:[--icon-base:var(--icon-hover)]"
               style={{
                 "box-shadow":
-                  "0 51px 60px 0 rgba(0,0,0,0.13), 0 15.375px 18.088px 0 rgba(0,0,0,0.19), 0 6.386px 7.513px 0 rgba(0,0,0,0.25), 0 2.31px 2.717px 0 rgba(0,0,0,0.38)",
+                  "0 51px 60px 0 rgba(0,0,0,0.10), 0 15px 18px 0 rgba(0,0,0,0.12), 0 6.386px 7.513px 0 rgba(0,0,0,0.12), 0 2.31px 2.717px 0 rgba(0,0,0,0.20)",
               }}
             >
               <Icon name="arrow-down-to-line" size="small" />


### PR DESCRIPTION
|base|hover|
|-|-|
| <img width="88" height="60" alt="image" src="https://github.com/user-attachments/assets/9a73f495-1eaa-4e71-995e-768d1e6bb79c" /> | <img width="86" height="63" alt="image" src="https://github.com/user-attachments/assets/ba51af9d-923e-4aa8-a41b-76b6228438a6" /> |
| <img width="81" height="66" alt="image" src="https://github.com/user-attachments/assets/c77af1bb-95c8-46e8-9929-2f1a2e90443e" /> | <img width="83" height="72" alt="image" src="https://github.com/user-attachments/assets/c0576085-36d6-4c56-af3b-c390e1dc0d39" /> |