### PR TITLE
feat(tui): add F# tree-sitter syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -286,5 +286,13 @@ export default {
         ],
       },
     },
+    {
+      filetype: "fsharp",
+      wasm: "https://github.com/ionide/tree-sitter-fsharp/releases/download/0.2.2/tree-sitter-fsharp.wasm",
+      queries: {
+        highlights: ["https://raw.githubusercontent.com/ionide/tree-sitter-fsharp/main/queries/highlights.scm"],
+        locals: ["https://raw.githubusercontent.com/ionide/tree-sitter-fsharp/main/queries/locals.scm"],
+      },
+    },
   ],
 }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds F# (`fsharp`) to the tree-sitter parser config (`packages/opencode/parsers-config.ts`) so that `.fs` and `.fsx` files get syntax highlighting in the TUI.

Uses the tree-sitter-fsharp v0.2.2 WASM and highlight/locals queries from ionide/tree-sitter-fsharp. The web/desktop UI (Shiki) already bundles fsharp support, so no changes needed there.

### How did you verify your code works?

- Verified the config file loads correctly by importing it with Bun and confirming the `fsharp` entry resolves with the correct filetype, wasm URL, and query URLs.
- No existing parser-config tests exist; the change is a static data addition matching the exact structure of all other parser entries.

### Screenshots / recordings

_N/A — TUI syntax highlighting only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
