### PR TITLE
feat(ui): improve subagent runtime visibility in chat UI

### DIFF
--- a/packages/app/e2e/session/session-child-navigation.spec.ts
+++ b/packages/app/e2e/session/session-child-navigation.spec.ts
@@ -37,6 +37,17 @@ test("task tool child-session link does not trigger stale show errors", async ({
         .filter({ hasText: /open child session/i })
         .first()
       await expect(card).toBeVisible({ timeout: 30_000 })
+      await expect
+        .poll(() => card.locator('[data-component="task-tool-state"]').textContent().then((value) => value ?? ""), {
+          timeout: 30_000,
+        })
+        .toMatch(/queued|running|completed/i)
+      await expect
+        .poll(
+          () => card.locator('[data-component="task-tool-elapsed"]').textContent().then((value) => value ?? "").catch(() => ""),
+          { timeout: 30_000 },
+        )
+        .toMatch(/^(?:\d+s|\d+m \d+s) elapsed$/i)
       await card.click()
 
       await expect(page).toHaveURL(new RegExp(`/session/${child.sessionID}(?:[/?#]|$)`), { timeout: 30_000 })

--- a/packages/ui/src/components/basic-tool.css
+++ b/packages/ui/src/components/basic-tool.css
@@ -201,10 +201,58 @@
     min-width: 0;
   }
 
+  [data-component="task-tool-body"] {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
   [data-slot="basic-tool-tool-info-main"] {
     flex: 1 1 auto;
     min-width: 0;
     align-items: center;
+  }
+
+  [data-component="task-tool-meta"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    font-family: var(--font-family-sans);
+    font-size: 12px;
+    font-style: normal;
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-normal);
+    letter-spacing: var(--letter-spacing-normal);
+    color: var(--text-weak);
+    font-variant-numeric: tabular-nums;
+  }
+
+  [data-component="task-tool-state"],
+  [data-component="task-tool-elapsed"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-component="task-tool-state"] {
+    color: var(--text-base);
+  }
+
+  [data-component="task-tool-state"][data-status="completed"] {
+    color: var(--text-weak);
+  }
+
+  [data-component="task-tool-state"][data-status="pending"],
+  [data-component="task-tool-state"][data-status="running"] {
+    color: var(--text-strong);
+  }
+
+  [data-component="task-tool-dot"] {
+    flex: none;
+    color: var(--text-dim);
   }
 
   [data-component="task-tool-spinner"] {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -58,6 +58,7 @@ import { patchFiles } from "./apply-patch-file"
 import { animate } from "motion"
 import { useLocation } from "@solidjs/router"
 import { attached, inline, kind } from "./message-file"
+import { elapsed as runtimeElapsed, formatDuration, type Runtime, taskState } from "./runtime"
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -1233,6 +1234,7 @@ export interface ToolProps {
   tool: string
   output?: string
   status?: string
+  time?: Runtime
   hideDetails?: boolean
   defaultOpen?: boolean
   forceOpen?: boolean
@@ -1330,6 +1332,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     if (typeof value === "string" && value) return value
     return taskId()
   })
+  const partTime = createMemo(() => {
+    const state = part().state
+    if (state.status === "pending") return undefined
+    return state.time
+  })
 
   const render = createMemo(() => ToolRegistry.render(part().tool) ?? GenericTool)
 
@@ -1366,6 +1373,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               input={input()}
               tool={part().tool}
               metadata={partMetadata()}
+              time={partTime()}
               // @ts-expect-error
               output={part().state.output}
               status={part().state.status}
@@ -1401,7 +1409,6 @@ PART_MAPPING["compaction"] = function CompactionPartDisplay() {
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
-  const numfmt = createMemo(() => new Intl.NumberFormat(i18n.locale()))
   const part = () => props.part as TextPart
   const interrupted = createMemo(
     () =>
@@ -1425,15 +1432,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
         : typeof completed === "number"
           ? completed - message.time.created
           : -1
-    if (!(ms >= 0)) return ""
-    const total = Math.round(ms / 1000)
-    if (total < 60) return i18n.t("ui.message.duration.seconds", { count: numfmt().format(total) })
-    const minutes = Math.floor(total / 60)
-    const seconds = total % 60
-    return i18n.t("ui.message.duration.minutesSeconds", {
-      minutes: numfmt().format(minutes),
-      seconds: numfmt().format(seconds),
-    })
+    return formatDuration(i18n, ms)
   })
 
   const meta = createMemo(() => {
@@ -1743,6 +1742,7 @@ ToolRegistry.register({
     const data = useData()
     const i18n = useI18n()
     const location = useLocation()
+    const [clock, setClock] = createStore({ now: Date.now() })
     const childSessionId = createMemo(() => {
       const value = props.metadata.sessionId
       if (typeof value === "string" && value) return value
@@ -1757,9 +1757,22 @@ ToolRegistry.register({
       return childSessionId()
     })
     const running = createMemo(() => props.status === "pending" || props.status === "running")
+    const label = createMemo(() => taskState(i18n, props.status))
+    const timer = createMemo(() => {
+      const ms = runtimeElapsed(props.time, clock.now)
+      if (ms === undefined) return
+      return i18n.t("ui.tool.task.elapsed", { duration: formatDuration(i18n, ms) })
+    })
 
     const href = createMemo(() => sessionLink(childSessionId(), location.pathname, data.sessionHref))
     const clickable = createMemo(() => !!(childSessionId() && (data.navigateToSession || href())))
+
+    createEffect(() => {
+      if (!running()) return
+      setClock("now", Date.now())
+      const id = setInterval(() => setClock("now", Date.now()), 1000)
+      onCleanup(() => clearInterval(id))
+    })
 
     const open = () => {
       const id = childSessionId()
@@ -1782,17 +1795,34 @@ ToolRegistry.register({
     const trigger = () => (
       <div data-component="task-tool-card">
         <div data-slot="basic-tool-tool-info-structured">
-          <div data-slot="basic-tool-tool-info-main">
-            <Show when={running()}>
-              <span data-component="task-tool-spinner" style={{ color: tone() ?? "var(--icon-interactive-base)" }}>
-                <Spinner />
+          <div data-component="task-tool-body">
+            <div data-slot="basic-tool-tool-info-main">
+              <Show when={running()}>
+                <span data-component="task-tool-spinner" style={{ color: tone() ?? "var(--icon-interactive-base)" }}>
+                  <Spinner />
+                </span>
+              </Show>
+              <span data-component="task-tool-title" style={{ color: tone() ?? "var(--text-strong)" }}>
+                {title()}
               </span>
-            </Show>
-            <span data-component="task-tool-title" style={{ color: tone() ?? "var(--text-strong)" }}>
-              {title()}
-            </span>
-            <Show when={subtitle()}>
-              <span data-slot="basic-tool-tool-subtitle">{subtitle()}</span>
+              <Show when={subtitle()}>
+                <span data-slot="basic-tool-tool-subtitle">{subtitle()}</span>
+              </Show>
+            </div>
+            <Show when={label() || timer()}>
+              <div data-component="task-tool-meta">
+                <Show when={label()}>
+                  <span data-component="task-tool-state" data-status={props.status}>
+                    {label()}
+                  </span>
+                </Show>
+                <Show when={label() && timer()}>
+                  <span data-component="task-tool-dot">&middot;</span>
+                </Show>
+                <Show when={timer()}>
+                  <span data-component="task-tool-elapsed">{timer()}</span>
+                </Show>
+              </div>
             </Show>
           </div>
         </div>

--- a/packages/ui/src/components/runtime.test.ts
+++ b/packages/ui/src/components/runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { elapsed, formatDuration, taskState } from "./runtime"
+
+const i18n = {
+  locale: () => "en",
+  t: (key: string, params?: Record<string, string | number | boolean>) => {
+    if (key === "ui.message.duration.seconds") return `${params?.count}s`
+    if (key === "ui.message.duration.minutesSeconds") return `${params?.minutes}m ${params?.seconds}s`
+    if (key === "ui.message.queued") return "Queued"
+    if (key === "ui.tool.task.running") return "Running"
+    if (key === "ui.tool.task.completed") return "Completed"
+    if (key === "ui.toolErrorCard.failed") return "Failed"
+    return key
+  },
+}
+
+describe("formatDuration", () => {
+  test("formats seconds", () => {
+    expect(formatDuration(i18n, 4_300)).toBe("4s")
+  })
+
+  test("formats minutes and seconds", () => {
+    expect(formatDuration(i18n, 61_000)).toBe("1m 1s")
+  })
+})
+
+describe("elapsed", () => {
+  test("uses the recorded end time when present", () => {
+    expect(elapsed({ start: 1_000, end: 4_200 }, 20_000)).toBe(3_200)
+  })
+
+  test("uses now for running tools", () => {
+    expect(elapsed({ start: 1_000 }, 4_200)).toBe(3_200)
+  })
+
+  test("skips invalid ranges", () => {
+    expect(elapsed({ start: 5_000, end: 1_000 })).toBeUndefined()
+  })
+})
+
+describe("taskState", () => {
+  test("maps tool states to labels", () => {
+    expect(taskState(i18n, "pending")).toBe("Queued")
+    expect(taskState(i18n, "running")).toBe("Running")
+    expect(taskState(i18n, "completed")).toBe("Completed")
+    expect(taskState(i18n, "error")).toBe("Failed")
+  })
+})

--- a/packages/ui/src/components/runtime.ts
+++ b/packages/ui/src/components/runtime.ts
@@ -1,0 +1,32 @@
+import type { UiI18n } from "../context/i18n"
+
+export type Runtime = {
+  start: number
+  end?: number
+}
+
+export function formatDuration(i18n: Pick<UiI18n, "locale" | "t">, ms: number) {
+  if (!(ms >= 0)) return ""
+  const num = new Intl.NumberFormat(i18n.locale())
+  const total = Math.round(ms / 1000)
+  if (total < 60) return i18n.t("ui.message.duration.seconds", { count: num.format(total) })
+  return i18n.t("ui.message.duration.minutesSeconds", {
+    minutes: num.format(Math.floor(total / 60)),
+    seconds: num.format(total % 60),
+  })
+}
+
+export function elapsed(time?: Runtime, now = Date.now()) {
+  if (!time) return
+  const end = typeof time.end === "number" ? time.end : now
+  const ms = end - time.start
+  if (!(ms >= 0)) return
+  return ms
+}
+
+export function taskState(i18n: Pick<UiI18n, "t">, status?: string) {
+  if (status === "pending") return i18n.t("ui.message.queued")
+  if (status === "running") return i18n.t("ui.tool.task.running")
+  if (status === "completed") return i18n.t("ui.tool.task.completed")
+  if (status === "error") return i18n.t("ui.toolErrorCard.failed")
+}

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -103,6 +103,9 @@ export const dict = {
   "ui.tool.questions": "أسئلة",
   "ui.tool.agent": "وكيل {{type}}",
   "ui.tool.agent.default": "وكيل",
+  "ui.tool.task.running": "جارٍ التشغيل",
+  "ui.tool.task.completed": "مكتمل",
+  "ui.tool.task.elapsed": "مضى {{duration}}",
 
   "ui.common.file.one": "ملف",
   "ui.common.file.other": "ملفات",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -103,6 +103,9 @@ export const dict = {
   "ui.tool.questions": "Perguntas",
   "ui.tool.agent": "Agente {{type}}",
   "ui.tool.agent.default": "Agente",
+  "ui.tool.task.running": "Em execução",
+  "ui.tool.task.completed": "Concluído",
+  "ui.tool.task.elapsed": "{{duration}} decorridos",
 
   "ui.common.file.one": "arquivo",
   "ui.common.file.other": "arquivos",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -107,6 +107,9 @@ export const dict = {
   "ui.tool.questions": "Pitanja",
   "ui.tool.agent": "{{type}} agent",
   "ui.tool.agent.default": "agent",
+  "ui.tool.task.running": "U toku",
+  "ui.tool.task.completed": "Završeno",
+  "ui.tool.task.elapsed": "{{duration}} proteklo",
 
   "ui.common.file.one": "datoteka",
   "ui.common.file.other": "datoteke",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -102,6 +102,9 @@ export const dict = {
   "ui.tool.questions": "Spørgsmål",
   "ui.tool.agent": "{{type}} Agent",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "Kører",
+  "ui.tool.task.completed": "Fuldført",
+  "ui.tool.task.elapsed": "{{duration}} forløbet",
 
   "ui.common.file.one": "fil",
   "ui.common.file.other": "filer",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -108,6 +108,9 @@ export const dict = {
   "ui.tool.questions": "Fragen",
   "ui.tool.agent": "{{type}} Agent",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "Läuft",
+  "ui.tool.task.completed": "Abgeschlossen",
+  "ui.tool.task.elapsed": "{{duration}} vergangen",
 
   "ui.common.file.one": "Datei",
   "ui.common.file.other": "Dateien",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -116,6 +116,9 @@ export const dict: Record<string, string> = {
   "ui.tool.questions": "Questions",
   "ui.tool.agent": "{{type}} Agent",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "Running",
+  "ui.tool.task.completed": "Completed",
+  "ui.tool.task.elapsed": "{{duration}} elapsed",
   "ui.tool.skill": "Skill",
 
   "ui.basicTool.called": "Called `{{tool}}`",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -103,6 +103,9 @@ export const dict = {
   "ui.tool.questions": "Preguntas",
   "ui.tool.agent": "Agente {{type}}",
   "ui.tool.agent.default": "Agente",
+  "ui.tool.task.running": "En ejecución",
+  "ui.tool.task.completed": "Completado",
+  "ui.tool.task.elapsed": "{{duration}} transcurridos",
 
   "ui.common.file.one": "archivo",
   "ui.common.file.other": "archivos",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -103,6 +103,9 @@ export const dict = {
   "ui.tool.questions": "Questions",
   "ui.tool.agent": "Agent {{type}}",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "En cours",
+  "ui.tool.task.completed": "Terminé",
+  "ui.tool.task.elapsed": "depuis {{duration}}",
 
   "ui.common.file.one": "fichier",
   "ui.common.file.other": "fichiers",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -102,6 +102,9 @@ export const dict = {
   "ui.tool.questions": "質問",
   "ui.tool.agent": "{{type}}エージェント",
   "ui.tool.agent.default": "エージェント",
+  "ui.tool.task.running": "実行中",
+  "ui.tool.task.completed": "完了",
+  "ui.tool.task.elapsed": "{{duration}} 経過",
 
   "ui.common.file.one": "ファイル",
   "ui.common.file.other": "ファイル",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -103,6 +103,9 @@ export const dict = {
   "ui.tool.questions": "질문",
   "ui.tool.agent": "{{type}} 에이전트",
   "ui.tool.agent.default": "에이전트",
+  "ui.tool.task.running": "실행 중",
+  "ui.tool.task.completed": "완료",
+  "ui.tool.task.elapsed": "{{duration}} 경과",
 
   "ui.common.file.one": "파일",
   "ui.common.file.other": "파일",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -106,6 +106,9 @@ export const dict: Record<Keys, string> = {
   "ui.tool.questions": "Spørsmål",
   "ui.tool.agent": "{{type}}-agent",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "Kjører",
+  "ui.tool.task.completed": "Fullført",
+  "ui.tool.task.elapsed": "{{duration}} forløpt",
 
   "ui.common.file.one": "fil",
   "ui.common.file.other": "filer",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -102,6 +102,9 @@ export const dict = {
   "ui.tool.questions": "Pytania",
   "ui.tool.agent": "Agent {{type}}",
   "ui.tool.agent.default": "Agent",
+  "ui.tool.task.running": "W trakcie",
+  "ui.tool.task.completed": "Ukończono",
+  "ui.tool.task.elapsed": "Minęło {{duration}}",
 
   "ui.common.file.one": "plik",
   "ui.common.file.other": "pliki",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -102,6 +102,9 @@ export const dict = {
   "ui.tool.questions": "Вопросы",
   "ui.tool.agent": "Агент {{type}}",
   "ui.tool.agent.default": "Агент",
+  "ui.tool.task.running": "Выполняется",
+  "ui.tool.task.completed": "Завершено",
+  "ui.tool.task.elapsed": "Прошло {{duration}}",
 
   "ui.common.file.one": "файл",
   "ui.common.file.other": "файлов",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -104,6 +104,9 @@ export const dict = {
   "ui.tool.questions": "คำถาม",
   "ui.tool.agent": "เอเจนต์ {{type}}",
   "ui.tool.agent.default": "เอเจนต์",
+  "ui.tool.task.running": "กำลังทำงาน",
+  "ui.tool.task.completed": "เสร็จสิ้น",
+  "ui.tool.task.elapsed": "ผ่านไป {{duration}}",
 
   "ui.common.file.one": "ไฟล์",
   "ui.common.file.other": "ไฟล์",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -109,6 +109,9 @@ export const dict = {
   "ui.tool.questions": "Sorular",
   "ui.tool.agent": "{{type}} Ajan",
   "ui.tool.agent.default": "Ajan",
+  "ui.tool.task.running": "Çalışıyor",
+  "ui.tool.task.completed": "Tamamlandı",
+  "ui.tool.task.elapsed": "{{duration}} geçti",
 
   "ui.common.file.one": "dosya",
   "ui.common.file.other": "dosya",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -107,6 +107,9 @@ export const dict = {
   "ui.tool.questions": "问题",
   "ui.tool.agent": "{{type}} 智能体",
   "ui.tool.agent.default": "智能体",
+  "ui.tool.task.running": "运行中",
+  "ui.tool.task.completed": "已完成",
+  "ui.tool.task.elapsed": "已耗时 {{duration}}",
 
   "ui.common.file.one": "个文件",
   "ui.common.file.other": "个文件",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -107,6 +107,9 @@ export const dict = {
   "ui.tool.questions": "問題",
   "ui.tool.agent": "{{type}} 代理程式",
   "ui.tool.agent.default": "代理程式",
+  "ui.tool.task.running": "執行中",
+  "ui.tool.task.completed": "已完成",
+  "ui.tool.task.elapsed": "已耗時 {{duration}}",
 
   "ui.common.file.one": "個檔案",
   "ui.common.file.other": "個檔案",


### PR DESCRIPTION
### Issue for this PR

Closes #22233

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This makes the parent task card more useful for subagent runs in chat. It shows explicit task state plus elapsed time on the existing card, keeps the current click-through behavior to the child session, and adds the missing task-card labels across the UI locale files so the change does not regress non-English surfaces.

### How did you verify your code works?

- `bun test src/components/runtime.test.ts` in `packages/ui`
- `bun typecheck` in `packages/ui`
- `bun typecheck` in `packages/app`
- `bun run build` in `packages/app`
- manual browser validation that the task card shows state + elapsed time and still opens the child session correctly

The targeted Playwright spec was also updated for the new metadata row, but the existing isolated e2e backend fixture still times out during setup before it reaches the UI assertions.

### Screenshots / recordings

I manually verified the updated task card in the browser during local testing. It now shows the task state and elapsed time on the card before navigating into the child session.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR