### PR TITLE
fix(electron): wait until ready before showing the main window

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -66,7 +66,7 @@ export function createMainWindow(globals: Globals) {
     y: state.y,
     width: state.width,
     height: state.height,
-    show: true,
+    show: false,
     title: "OpenCode",
     icon: iconPath(),
     backgroundColor,
@@ -93,6 +93,10 @@ export function createMainWindow(globals: Globals) {
   loadWindow(win, "index.html")
   wireZoom(win)
   injectGlobals(win, globals)
+
+  win.once("ready-to-show", () => {
+    win.show()
+  })
 
   return win
 }


### PR DESCRIPTION
## Summary
- keep the Electron main window hidden during initial setup
- show the window on `ready-to-show` to avoid exposing an unready frame during startup