### PR TITLE
fix(opencode): fix the read tool reports image/pdf read successfully when the LLM lacks vision capabilities

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -12,6 +12,7 @@ import DESCRIPTION from "./read.txt"
 import { Instance } from "../project/instance"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
+import type { Provider } from "../provider/provider"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -149,7 +150,35 @@ export const ReadTool = Tool.define(
       const isImage = mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
       const isPdf = mime === "application/pdf"
       if (isImage || isPdf) {
+        const model = ctx.extra?.model as Provider.Model | undefined
+        const supportsVision = model?.capabilities.input.image ?? false
+        const supportsPdf = model?.capabilities.input.pdf ?? false
         const msg = `${isImage ? "Image" : "PDF"} read successfully`
+
+        if (isImage && !supportsVision) {
+          return {
+            title,
+            output: `This model does not support image input. Image file: ${filepath}`,
+            metadata: {
+              preview: `Image file skipped (model does not support image input): ${filepath}`,
+              truncated: false,
+              loaded: loaded.map((item) => item.filepath),
+            },
+          }
+        }
+
+        if (isPdf && !supportsPdf) {
+          return {
+            title,
+            output: `This model does not support PDF input. PDF file: ${filepath}`,
+            metadata: {
+              preview: `PDF file skipped (model does not support PDF input): ${filepath}`,
+              truncated: false,
+              loaded: loaded.map((item) => item.filepath),
+            },
+          }
+        }
+
         return {
           title,
           output: msg,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -155,28 +155,8 @@ export const ReadTool = Tool.define(
         const supportsPdf = model?.capabilities.input.pdf ?? false
         const msg = `${isImage ? "Image" : "PDF"} read successfully`
 
-        if (isImage && !supportsVision) {
-          return {
-            title,
-            output: `This model does not support image input. Image file: ${filepath}`,
-            metadata: {
-              preview: `Image file skipped (model does not support image input): ${filepath}`,
-              truncated: false,
-              loaded: loaded.map((item) => item.filepath),
-            },
-          }
-        }
-
-        if (isPdf && !supportsPdf) {
-          return {
-            title,
-            output: `This model does not support PDF input. PDF file: ${filepath}`,
-            metadata: {
-              preview: `PDF file skipped (model does not support PDF input): ${filepath}`,
-              truncated: false,
-              loaded: loaded.map((item) => item.filepath),
-            },
-          }
+        if ((isImage && !supportsVision) || (isPdf && !supportsPdf)) {
+          return yield* Effect.fail(new Error(`This model does not support ${isImage ? "image" : "pdf"} input`))
         }
 
         return {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -156,7 +156,7 @@ export const ReadTool = Tool.define(
         const msg = `${isImage ? "Image" : "PDF"} read successfully`
 
         if ((isImage && !supportsVision) || (isPdf && !supportsPdf)) {
-          return yield* Effect.fail(new Error(`This model does not support ${isImage ? "image" : "pdf"} input`))
+          return yield* Effect.fail(new Error(`This model does not support ${isImage ? "image" : "pdf"} input, please try other tools`))
         }
 
         return {


### PR DESCRIPTION
### Issue for this PR

Closes #21800

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The description of the `read` tool can mislead text-only LLMs, causing them to hallucinate that they can understand image content.

To fix this issue, I first inspected the source code of the `read` tool and found that it does not verify the LLM vision capabilities when handling images and PDF files.

So fixed it.

### How did you verify your code works?

See Screenshots / recordings

### Screenshots / recordings

<img width="2935" height="771" alt="image" src="https://github.com/user-attachments/assets/db3ca667-5559-4718-9375-a4241c85bfe4" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
