### PR TITLE
feat(cli): open session switcher when -s has no id

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -123,6 +123,16 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
 
+function openSessionSwitcher(input: {
+  args: Args
+  status: string
+  dialog: ReturnType<typeof useDialog>
+}) {
+  if (input.args.sessionID !== "" || input.status === "loading") return false
+  input.dialog.replace(() => <DialogSessionList />)
+  return true
+}
+
 function rendererConfig(_config: TuiConfig.Info): CliRendererConfig {
   const mouseEnabled = !Flag.OPENCODE_DISABLE_MOUSE && (_config.mouse ?? true)
 
@@ -419,6 +429,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
         route.navigate({ type: "session", sessionID: match })
       }
     }
+  })
+
+  let sessionSwitched = false
+  createEffect(() => {
+    if (sessionSwitched) return
+    sessionSwitched = openSessionSwitcher({
+      args,
+      status: sync.status,
+      dialog,
+    })
   })
 
   // Handle --session with --fork: wait for sync to be fully complete before forking


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This updates the local TUI startup flow so `opencode -s` works without requiring a session ID.

### How did you verify your code works?

Run:
```
bun run dev -- -s
```

### Screenshots / recordings

#### Before

![PixPin_2026-04-13_15-26-56](https://github.com/user-attachments/assets/917160d5-6436-40a1-8b40-dba9512da020)

#### After

![PixPin_2026-04-13_15-28-31](https://github.com/user-attachments/assets/3d283530-9116-4b88-84c0-c8b6e0bc4bbd)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
