### PR TITLE
docs: add Sakura Shinobi to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -68,6 +68,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Sakura Shinobi](https://github.com/RushabhRatnaparkhi/opencode-theme-sakura-shinobi)     | Purple-forward custom OpenCode theme with subtle pink accents.   |
 
 ---
 


### PR DESCRIPTION
## Summary
- add Sakura Shinobi to the OpenCode ecosystem Projects list
- link to the public theme repository and include a concise description

## Notes
- docs-only change in packages/web/src/content/docs/ecosystem.mdx