### PR TITLE
app: limit diffs to 4 lines of context instead of full file

### DIFF
--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -48,9 +48,9 @@ function patch(diff: ReviewDiff) {
       diff.file,
       "before" in diff && typeof diff.before === "string" ? diff.before : "",
       "after" in diff && typeof diff.after === "string" ? diff.after : "",
-      "",
-      "",
-      { context: Number.MAX_SAFE_INTEGER },
+      undefined,
+      undefined,
+      { context: 4 },
     ),
   )
 }


### PR DESCRIPTION
Fixes a problem introduced by https://github.com/anomalyco/opencode/pull/21244 where the diff viewer would render the entire file, rather than just the changes with some surrounding context