### PR TITLE
app: replace parsePatchFiles with parseDiffFromFile

### DIFF
--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -1,6 +1,5 @@
-import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
-import { sampledChecksum } from "@opencode-ai/util/encode"
-import { formatPatch, structuredPatch } from "diff"
+import { parseDiffFromFile, type FileDiffMetadata } from "@pierre/diffs"
+import { formatPatch, parsePatch, structuredPatch } from "diff"
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 
 type LegacyDiff = {
@@ -41,26 +40,50 @@ function empty(file: string, key: string) {
 }
 
 function patch(diff: ReviewDiff) {
-  if (typeof diff.patch === "string") return diff.patch
-  return formatPatch(
-    structuredPatch(
-      diff.file,
-      diff.file,
-      "before" in diff && typeof diff.before === "string" ? diff.before : "",
-      "after" in diff && typeof diff.after === "string" ? diff.after : "",
-      "",
-      "",
-      { context: Number.MAX_SAFE_INTEGER },
+  if (typeof diff.patch === "string") {
+    const [patch] = parsePatch(diff.patch)
+
+    const beforeLines = []
+    const afterLines = []
+
+    for (const hunk of patch.hunks) {
+      for (const line of hunk.lines) {
+        if (line.startsWith("-")) {
+          beforeLines.push(line.slice(1))
+        } else if (line.startsWith("+")) {
+          afterLines.push(line.slice(1))
+        } else {
+          // context line (starts with ' ')
+          beforeLines.push(line.slice(1))
+          afterLines.push(line.slice(1))
+        }
+      }
+    }
+
+    return { before: beforeLines.join("\n"), after: afterLines.join("\n"), patch: diff.patch }
+  }
+  return {
+    before: "before" in diff && typeof diff.before === "string" ? diff.before : "",
+    after: "after" in diff && typeof diff.after === "string" ? diff.after : "",
+    patch: formatPatch(
+      structuredPatch(
+        diff.file,
+        diff.file,
+        "before" in diff && typeof diff.before === "string" ? diff.before : "",
+        "after" in diff && typeof diff.after === "string" ? diff.after : "",
+        "",
+        "",
+        { context: Number.MAX_SAFE_INTEGER },
+      ),
     ),
-  )
+  }
 }
 
-function file(file: string, patch: string) {
+function file(file: string, patch: string, before: string, after: string) {
   const hit = cache.get(patch)
   if (hit) return hit
 
-  const key = sampledChecksum(patch) ?? file
-  const value = parsePatchFiles(patch, key).flatMap((item) => item.files)[0] ?? empty(file, key)
+  const value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
   cache.set(patch, value)
   return value
 }
@@ -69,11 +92,11 @@ export function normalize(diff: ReviewDiff): ViewDiff {
   const next = patch(diff)
   return {
     file: diff.file,
-    patch: next,
+    patch: next.patch,
     additions: diff.additions,
     deletions: diff.deletions,
     status: diff.status,
-    fileDiff: file(diff.file, next),
+    fileDiff: file(diff.file, next.patch, next.before, next.after),
   }
 }
 


### PR DESCRIPTION
In https://github.com/anomalyco/opencode/pull/21360 (via https://github.com/anomalyco/opencode/pull/21244) `parseDiffFromFile` was replaced with `parsePatchFiles` as the server now provides us one large unified diff per file instead of before and after states.
Afaict this isn't quite how `parseDiffFromFile` is supposed to be used. Using it with the diff viewer the way we do results in the entire file being rendered, and limiting the patch context beforehand just results in not being able to expand unchanged lines. It parses the entire file as one hunk with multiple content blocks.
`parsePatchFiles` is able to compute diffs properly so that the diff viewer can hide unchanged lines, but also allow expanding them into view if necessary. It computes multiple hunks with small hunks that reference the larger context.
https://github.com/orgs/anomalyco/projects/4/views/3?pane=issue&itemId=175020247