### PR TITLE
fix: add support for ACP writeTextFile clientCapability

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -467,6 +467,27 @@ export namespace ACP {
           await this.processMessage({ info: msg.info, parts: [part] })
           return
         }
+        case "file.edited":
+          const props = event.properties
+          const session = this.sessionManager.tryGet(props.sessionID)
+          if (!session) return
+          const sessionId = session.id
+
+          if (this.config.clientCapabilities?.fs?.writeTextFile) {
+            const filepath = event.properties.file
+            try {
+              const content = await Bun.file(filepath).text()
+              await this.connection.writeTextFile({
+                sessionId,
+                path: filepath,
+                content,
+              })
+              log.info("synced file edit to ACP client", { filepath, sessionId})
+            } catch (err) {
+              log.error("failed to sync file edit to ACP client", { error: err, filepath, sessionId })
+            }
+          }
+          break
 
         case "message.part.delta": {
           const props = event.properties
@@ -536,7 +557,9 @@ export namespace ACP {
     }
 
     async initialize(params: InitializeRequest): Promise<InitializeResponse> {
-      log.info("initialize", { protocolVersion: params.protocolVersion })
+      log.info("initialize", { protocolVersion: params.protocolVersion, clientCapabilities: params.clientCapabilities })
+
+      this.config.clientCapabilities = params.clientCapabilities
 
       const authMethod: AuthMethod = {
         description: "Run `opencode auth login` in the terminal",

--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@agentclientprotocol/sdk"
+import type { McpServer, ClientCapabilities } from "@agentclientprotocol/sdk"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import type { ProviderID, ModelID } from "../provider/schema"
 
@@ -21,4 +21,5 @@ export interface ACPConfig {
     providerID: ProviderID
     modelID: ModelID
   }
+  clientCapabilities?: ClientCapabilities
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -78,6 +78,7 @@ export namespace File {
       "file.edited",
       z.object({
         file: z.string(),
+        sessionID: z.string().optional(),
       }),
     ),
   }

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -220,7 +220,7 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
 
       if (edited) {
         await Format.file(edited)
-        Bus.publish(File.Event.Edited, { file: edited })
+        Bus.publish(File.Event.Edited, { file: edited, sessionID: ctx.sessionID })
       }
     }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -73,7 +73,7 @@ export const EditTool = Tool.define("edit", {
         })
         await Filesystem.write(filePath, params.newString)
         await Format.file(filePath)
-        Bus.publish(File.Event.Edited, { file: filePath })
+        Bus.publish(File.Event.Edited, { file: filePath, sessionID: ctx.sessionID })
         await Bus.publish(FileWatcher.Event.Updated, {
           file: filePath,
           event: existed ? "change" : "add",
@@ -109,7 +109,7 @@ export const EditTool = Tool.define("edit", {
 
       await Filesystem.write(filePath, contentNew)
       await Format.file(filePath)
-      Bus.publish(File.Event.Edited, { file: filePath })
+      Bus.publish(File.Event.Edited, { file: filePath, sessionID: ctx.sessionID })
       await Bus.publish(FileWatcher.Event.Updated, {
         file: filePath,
         event: "change",

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -44,7 +44,7 @@ export const WriteTool = Tool.define("write", {
 
     await Filesystem.write(filepath, params.content)
     await Format.file(filepath)
-    Bus.publish(File.Event.Edited, { file: filepath })
+    Bus.publish(File.Event.Edited, { file: filepath, sessionID: ctx.sessionID })
     await Bus.publish(FileWatcher.Event.Updated, {
       file: filepath,
       event: exists ? "change" : "add",

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -490,6 +490,7 @@ export type EventFileEdited = {
   type: "file.edited"
   properties: {
     file: string
+    sessionID?: string
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -219,6 +219,7 @@ export type EventFileEdited = {
   type: "file.edited"
   properties: {
     file: string
+    sessionID?: string
   }
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -7682,6 +7682,9 @@
             "properties": {
               "file": {
                 "type": "string"
+              },
+              "sessionID": {
+                "type": "string"
               }
             },
             "required": ["file"]


### PR DESCRIPTION
### Issue for this PR
Fixes [#4240](https://github.com/anomalyco/opencode/issues/4240
)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes ACP file syncing for clients that advertise the `fs.writeTextFile` capability.
The change stores `clientCapabilities` during ACP initialization, includes `sessionID` in `file.edited` events, and on file edits sends the updated file contents back to the ACP client through `writeTextFile`. 

The SDK/OpenAPI types were updated as part of the event shape change.

### How did you verify your code works?

Zed editor

<img width="2560" height="1568" alt="2026-04-13-152258_hyprshot" src="https://github.com/user-attachments/assets/89aa62e7-9e23-4db6-8065-832f639ca478" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

I'm reopening this pull request [6902](https://github.com/anomalyco/opencode/pull/6902), as it was closed due to the time limit expiring. The issue is still relevant.