### PR TITLE
fix: authoritative managed-settings.json applied after all user config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -49,12 +49,102 @@ function mergeConfig(target: Info, source: Info): Info {
   return mergeDeep(target, source) as Info
 }
 
+
 function mergeConfigConcatArrays(target: Info, source: Info): Info {
   const merged = mergeConfig(target, source)
   if (target.instructions && source.instructions) {
     merged.instructions = Array.from(new Set([...target.instructions, ...source.instructions]))
   }
+  if (target.allowed_models && source.allowed_models) {
+    merged.allowed_models = Array.from(new Set([...target.allowed_models, ...source.allowed_models]))
+  }
+  if (target.user_agent_suffixes && source.user_agent_suffixes) {
+    merged.user_agent_suffixes = [...target.user_agent_suffixes, ...source.user_agent_suffixes]
+  }
+  if (target.enabled_providers && source.enabled_providers) {
+    merged.enabled_providers = Array.from(new Set([...target.enabled_providers, ...source.enabled_providers]))
+  }
+  if (target.disabled_providers && source.disabled_providers) {
+    merged.disabled_providers = Array.from(new Set([...target.disabled_providers, ...source.disabled_providers]))
+  }
   return merged
+}
+
+const REPLACE_KEYS = [
+  "agent",
+  "allowed_models",
+  "command",
+  "disabled_providers",
+  "enabled_providers",
+  "experimental",
+  "formatter",
+  "instructions",
+  "lsp",
+  "mcp",
+  "mode",
+  "provider",
+  "skills",
+  "user_agent_suffixes",
+] as const
+
+function applyAuthoritative(target: Info, source: Info): Info {
+  const merged = mergeDeep(target, source)
+  for (const key of REPLACE_KEYS) {
+    if (key in source) {
+      ;(merged as Record<string, unknown>)[key] = (source as Record<string, unknown>)[key]
+    }
+  }
+  return merged
+}
+
+function parseManagedFile(text: string, source: string): Info {
+  const raw = ConfigParse.jsonc(text, source)
+  return ConfigParse.effectSchema(Info, raw, source)
+}
+
+async function loadManagedSettings(dir: string): Promise<Info> {
+  const baseFile = path.join(dir, "managed-settings.json")
+  const dropinDir = path.join(dir, "managed-settings.d")
+
+  let result: Info = {}
+
+  try {
+    const text = await fsNode.readFile(baseFile, "utf-8")
+    result = parseManagedFile(text, baseFile)
+    log.info("loaded managed settings", { path: baseFile })
+  } catch (err: any) {
+    if (err.code !== "ENOENT") {
+      log.warn("failed to parse managed-settings.json", { path: baseFile, error: String(err) })
+    }
+  }
+
+  let entries: string[] = []
+  try {
+    entries = await fsNode.readdir(dropinDir)
+  } catch (err: any) {
+    if (err.code !== "ENOENT" && err.code !== "ENOTDIR") {
+      log.warn("failed to read managed-settings.d", { path: dropinDir, error: String(err) })
+    }
+    return result
+  }
+
+  const fragments = entries.filter((name) => name.endsWith(".json") && !name.startsWith(".")).sort()
+
+  for (const name of fragments) {
+    const fragPath = path.join(dropinDir, name)
+    try {
+      const text = await fsNode.readFile(fragPath, "utf-8")
+      const parsed = parseManagedFile(text, fragPath)
+      result = mergeConfigConcatArrays(result, parsed)
+      log.info("loaded managed settings fragment", { path: fragPath })
+    } catch (err: any) {
+      if (err.code !== "ENOENT") {
+        log.warn("failed to parse managed settings fragment", { path: fragPath, error: String(err) })
+      }
+    }
+  }
+
+  return result
 }
 
 function normalizeLoadedConfig(data: unknown, source: string) {
@@ -162,6 +252,10 @@ export const Info = Schema.Struct({
   enabled_providers: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "When set, ONLY these providers will be enabled. All other providers will be ignored",
   }),
+  allowed_models: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+    description:
+      "When set, ONLY these models will be available. Values are in 'provider/model' format, e.g. 'google-vertex/gemini-2.5-pro'. If not set, all models from enabled providers are available.",
+  }),
   model: Schema.optional(ConfigModelID).annotate({
     description: "Model to use in the format of provider/model, eg anthropic/claude-2",
   }),
@@ -237,6 +331,10 @@ export const Info = Schema.Struct({
       url: Schema.optional(Schema.String).annotate({ description: "Enterprise URL" }),
     }),
   ),
+  user_agent_suffixes: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+    description:
+      "Additional strings appended to the User-Agent header, joined with spaces. Each managed-settings drop-in file can contribute its own entry; all values are concatenated across files.",
+  }),
   tool_output: Schema.optional(
     Schema.Struct({
       max_lines: Schema.optional(PositiveInt).annotate({
@@ -717,6 +815,15 @@ export const layer = Layer.effect(
             perms[tool] = action
           }
           result.permission = mergeDeep(perms, result.permission ?? {})
+        }
+
+        // managed-settings.json is the authoritative source, applied after all user,
+        // project, env, and legacy processing so it cannot be overridden by any of them.
+        // Only macOS MDM preferences (above) take higher priority.
+        const managedSettings = yield* Effect.promise(() => loadManagedSettings(managedDir))
+        if (Object.keys(managedSettings).length > 0) {
+          result = applyAuthoritative(result, managedSettings)
+          log.info("applied managed settings (authoritative override)", { source: managedDir })
         }
 
         if (!result.username) result.username = os.userInfo().username

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -99,7 +99,7 @@ function applyAuthoritative(target: Info, source: Info): Info {
 
 function parseManagedFile(text: string, source: string): Info {
   const raw = ConfigParse.jsonc(text, source)
-  return ConfigParse.effectSchema(Info, raw, source)
+  return ConfigParse.schema(Info, raw, source)
 }
 
 async function loadManagedSettings(dir: string): Promise<Info> {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -99,7 +99,7 @@ afterEach(async () => {
   await clear(true)
 })
 
-async function writeManagedSettings(settings: object, filename = "opencode.json") {
+async function writeManagedSettings(settings: object, filename = "managed-settings.json") {
   await fs.mkdir(managedConfigDir, { recursive: true })
   await Filesystem.write(path.join(managedConfigDir, filename), JSON.stringify(settings))
 }
@@ -1335,6 +1335,290 @@ it.instance("migrates legacy edit tool to edit permission", () =>
     const config = yield* Config.Service.use((svc) => svc.get())
     expect(config.agent?.["test"]?.permission).toEqual({ edit: "deny" })
   }),
+)
+
+test("mergeDeep semantics allow OPENCODE_PERMISSION to overwrite managed deny", async () => {
+  const { mergeDeep } = await import("remeda")
+
+  const managed = { bash: { "echo *": "deny" } }
+  const envvar = { bash: { "echo *": "allow" } }
+
+  const result = mergeDeep(managed, envvar) as Record<string, Record<string, string>>
+
+  expect(result.bash["echo *"]).toBe("allow")
+})
+
+it.instance(
+  "managed instructions should replace user instructions, not union",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      instructions: ["/etc/opencode/managed-instructions.md"],
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.instructions).toEqual(["/etc/opencode/managed-instructions.md"])
+  }),
+  { config: { instructions: ["./user-instructions.md"] } },
+)
+
+it.instance(
+  "managed agents should replace user agents, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      agent: {
+        build: { permission: { bash: { "echo *": "deny" } } },
+      },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.agent?.escape).toBeUndefined()
+  }),
+  { config: { agent: { escape: { permission: { bash: "allow" } } } } },
+)
+
+it.instance(
+  "drop-in fragments union enabled_providers with dedup",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      enabled_providers: [],
+    })
+    yield* Effect.promise(async () => {
+      const dropinDir = path.join(managedConfigDir, "managed-settings.d")
+      await fs.mkdir(dropinDir, { recursive: true })
+      await Filesystem.write(
+        path.join(dropinDir, "10-providers.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", enabled_providers: ["anthropic"] }),
+      )
+      await Filesystem.write(
+        path.join(dropinDir, "20-providers.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", enabled_providers: ["openai", "anthropic"] }),
+      )
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.enabled_providers).toEqual(["anthropic", "openai"])
+  }),
+  { config: {} },
+)
+
+it.instance(
+  "drop-in fragments union disabled_providers with dedup",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      disabled_providers: ["base"],
+    })
+    yield* Effect.promise(async () => {
+      const dropinDir = path.join(managedConfigDir, "managed-settings.d")
+      await fs.mkdir(dropinDir, { recursive: true })
+      await Filesystem.write(
+        path.join(dropinDir, "10-providers.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", disabled_providers: ["anthropic"] }),
+      )
+      await Filesystem.write(
+        path.join(dropinDir, "20-providers.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", disabled_providers: ["openai", "anthropic"] }),
+      )
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.disabled_providers).toEqual(["base", "anthropic", "openai"])
+  }),
+  { config: {} },
+)
+
+it.instance(
+  "managed mcp should replace user mcp, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      mcp: {
+        safe: { type: "local", command: ["safe"] },
+      },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.mcp?.evil).toBeUndefined()
+  }),
+  { config: { mcp: { evil: { type: "local", command: ["evil"] } } } },
+)
+
+it.instance(
+  "managed commands should replace user commands, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      command: {
+        safe: { template: "do something safe" },
+      },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.command?.evil).toBeUndefined()
+  }),
+  { config: { command: { evil: { template: "do something bad" } } } },
+)
+
+it.instance(
+  "managed providers should replace user providers, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      provider: {
+        "google-vertex": { models: { "gemini-2.5-pro": {} } },
+      },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.provider?.anthropic).toBeUndefined()
+  }),
+  { config: { provider: { anthropic: { models: {} } } } },
+)
+
+it.instance(
+  "managed formatters should replace user formatters, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      formatter: { safe: { command: ["safe-fmt"] } },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    const fmts = config.formatter as Record<string, unknown>
+    expect(fmts.evil).toBeUndefined()
+  }),
+  { config: { formatter: { evil: { command: ["evil-fmt"] } } } },
+)
+
+it.instance(
+  "managed lsp should replace user lsp, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      lsp: { safe: { command: ["safe-lsp"], extensions: [".ts"] } },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    const lsps = config.lsp as Record<string, unknown>
+    expect(lsps.evil).toBeUndefined()
+  }),
+  { config: { lsp: { evil: { command: ["evil-lsp"], extensions: [".txt"] } } } },
+)
+
+it.instance(
+  "managed experimental should replace user experimental, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      experimental: { disable_paste_summary: true },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.experimental?.batch_tool).toBeUndefined()
+    expect(config.experimental?.openTelemetry).toBeUndefined()
+  }),
+  { config: { experimental: { batch_tool: true, openTelemetry: true } } },
+)
+
+it.instance(
+  "managed skills should replace user skills, not additively merge",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      skills: { paths: ["/etc/opencode/skills/"] },
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.skills?.paths).toEqual(["/etc/opencode/skills/"])
+    expect(config.skills?.urls).toBeUndefined()
+  }),
+  { config: { skills: { paths: ["./user-skills/"], urls: ["https://evil.com/skills/"] } } },
+)
+
+it.instance(
+  "managed allowed_models should replace user allowed_models, not union",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      allowed_models: ["managed/model-a"],
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.allowed_models).toEqual(["managed/model-a"])
+  }),
+  { config: { allowed_models: ["user/model-b"] } },
+)
+
+it.instance(
+  "drop-in fragments union allowed_models with dedup",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      allowed_models: ["base/model"],
+    })
+    yield* Effect.promise(async () => {
+      const dropinDir = path.join(managedConfigDir, "managed-settings.d")
+      await fs.mkdir(dropinDir, { recursive: true })
+      await Filesystem.write(
+        path.join(dropinDir, "10-models.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", allowed_models: ["dropin/model-a"] }),
+      )
+      await Filesystem.write(
+        path.join(dropinDir, "20-models.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          allowed_models: ["dropin/model-b", "base/model"],
+        }),
+      )
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.allowed_models).toEqual(["base/model", "dropin/model-a", "dropin/model-b"])
+  }),
+  { config: { model: "user/model" } },
+)
+
+it.instance(
+  "managed user_agent_suffixes should replace user suffixes, not concatenate",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      user_agent_suffixes: ["managed-suffix"],
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.user_agent_suffixes).toEqual(["managed-suffix"])
+  }),
+  { config: { user_agent_suffixes: ["user-suffix"] } },
+)
+
+it.instance(
+  "drop-in fragments concatenate user_agent_suffixes",
+  Effect.gen(function* () {
+    yield* writeManagedSettingsEffect({
+      $schema: "https://opencode.ai/config.json",
+      user_agent_suffixes: ["base-suffix"],
+    })
+    yield* Effect.promise(async () => {
+      const dropinDir = path.join(managedConfigDir, "managed-settings.d")
+      await fs.mkdir(dropinDir, { recursive: true })
+      await Filesystem.write(
+        path.join(dropinDir, "10-suffix.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", user_agent_suffixes: ["frag-a"] }),
+      )
+      await Filesystem.write(
+        path.join(dropinDir, "20-suffix.json"),
+        JSON.stringify({ $schema: "https://opencode.ai/config.json", user_agent_suffixes: ["frag-b"] }),
+      )
+    })
+
+    const config = yield* Config.Service.use((svc) => svc.get())
+    expect(config.user_agent_suffixes).toEqual(["base-suffix", "frag-a", "frag-b"])
+  }),
+  { config: { model: "user/model" } },
 )
 
 it.instance("migrates legacy patch tool to edit permission", () =>

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -50,9 +50,10 @@ Config sources are loaded in this order (later sources override earlier ones):
 5. **`.opencode` directories** - agents, commands, plugins
 6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
 7. **Managed config files** (`/Library/Application Support/opencode/` on macOS) - admin-controlled
-8. **macOS managed preferences** (`.mobileconfig` via MDM) - highest priority, not user-overridable
+8. **macOS managed preferences** (`.mobileconfig` via MDM) - not user-overridable
+9. **`managed-settings.json`** (in the same system directory) - authoritative, cannot be bypassed by any env var or user config
 
-This means project configs can override global defaults, and global configs can override remote organizational defaults. Managed settings override everything.
+This means project configs can override global defaults, and global configs can override remote organizational defaults. `managed-settings.json` overrides everything, including the `OPENCODE_PERMISSION` environment variable.
 
 :::note
 The `.opencode` and `~/.config/opencode` directories use **plural names** for subdirectories: `agents/`, `commands/`, `modes/`, `plugins/`, `skills/`, `tools/`, and `themes/`. Singular names (e.g., `agent/`) are also supported for backwards compatibility.
@@ -166,6 +167,51 @@ Drop an `opencode.json` or `opencode.jsonc` file in the system managed config di
 | Windows  | `%ProgramData%\opencode`                 |
 
 These directories require admin/root access to write, so users cannot modify them.
+
+#### managed-settings.json
+
+For the strongest enforcement, one that cannot be bypassed by `OPENCODE_PERMISSION` or any other environment variable, use `managed-settings.json` in the same system directory:
+
+| Platform | Path                                                          |
+| -------- | ------------------------------------------------------------- |
+| macOS    | `/Library/Application Support/opencode/managed-settings.json` |
+| Linux    | `/etc/opencode/managed-settings.json`                         |
+| Windows  | `%ProgramData%\opencode\managed-settings.json`                |
+
+`managed-settings.json` is applied after all other config sources, including the `OPENCODE_PERMISSION` environment variable. Object and array fields (such as `mcp`, `agent`, `instructions`, `provider`, `formatter`, `lsp`, `command`, `mode`, `skills`, and `experimental`) are **replaced entirely** rather than merged, so users cannot inject additional entries alongside managed ones.
+
+```json title="/etc/opencode/managed-settings.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "permission": {
+    "*": "ask",
+    "bash": {
+      "*": "ask",
+      "rm -rf *": "deny"
+    }
+  }
+}
+```
+
+**Drop-in fragments (`managed-settings.d/`)**
+
+You can also place individual `.json` fragments in a `managed-settings.d/` subdirectory alongside `managed-settings.json`. Fragments are loaded in alphabetical order and merged on top of `managed-settings.json`. This is useful for deploying settings from multiple configuration management sources (Ansible, Puppet, Chef, etc.) without coordination.
+
+```
+/etc/opencode/
+  managed-settings.json          # base policy
+  managed-settings.d/
+    10-providers.json            # loaded first
+    20-permissions.json          # loaded second, overrides 10-*
+    99-override.json             # last word
+```
+
+Hidden files (starting with `.`) are ignored. Invalid JSON in any fragment logs a warning and is skipped; remaining fragments still apply.
+
+:::note
+`managed-settings.json` and `managed-settings.d/` require admin/root access to write, so users cannot modify them.
+:::
 
 #### macOS managed preferences
 


### PR DESCRIPTION
### Issue for this PR

Closes #22292

### Type of change

- [x] Bug fix

### What does this PR do?

Two bypass vectors allowed users to override enterprise managed config:

1. `OPENCODE_PERMISSION` env var was merged after managed config, so it won. A managed deny rule could be overwritten to allow.
2. Object fields like `mcp`, `agent`, `provider` etc. were additively merged. Users could inject extra entries alongside managed ones (e.g. adding an `evil` MCP server or an extra provider).

The fix introduces `managed-settings.json` (and a `managed-settings.d/` drop-in directory) in the system config location. It is loaded last, after all user config, project config, and `OPENCODE_PERMISSION`, so it cannot be overridden. Object fields in that file replace rather than merge, closing the injection vector.

The existing `opencode.json` managed config is unchanged and still loads earlier in the chain (for non-authoritative defaults). `managed-settings.json` is the opt-in high enforcement layer.

### How did you verify your code works?

Three commits in this PR, each with a specific purpose:

**Commit 1: `5c25db2` (tests only, no fix)**

11 tests fail against unpatched code. Run with:

```
git checkout 5c25db25b
cd packages/opencode
bun test --test-name-pattern "managed"
```

Output:

```
(fail) managed settings override user settings
(fail) managed settings override project settings
(fail) managed instructions should replace user instructions, not union
(fail) managed agents should replace user agents, not additively merge
(fail) managed mcp should replace user mcp, not additively merge
(fail) managed commands should replace user commands, not additively merge
(fail) managed providers should replace user providers, not additively merge
(fail) managed formatters should replace user formatters, not additively merge
(fail) managed lsp should replace user lsp, not additively merge
(fail) managed experimental should replace user experimental, not additively merge
(fail) managed skills should replace user skills, not additively merge

3 pass, 9 skip, 11 fail
```

**Commit 2: `c5ca9d1` (the fix)**

Same tests, now all pass:

```
git checkout c5ca9d10c
cd packages/opencode
bun test --test-name-pattern "managed"
```

Output:

```
14 pass, 9 skip, 0 fail
```

The 3 tests that already passed at commit 1 (permission deny via OPENCODE_PERMISSION, drop-in fragment ordering, dotfile ignore) continue to pass.

**Commit 3: `3a3c2f2` (docs)**

Adds documentation for `managed-settings.json` and `managed-settings.d/` drop-in fragments to `packages/web/src/content/docs/config.mdx`. No code changes.

### Screenshots / recordings

_N/A, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
