### PR TITLE
fix: restore prompt input when permission or question dock appears

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -33,6 +33,16 @@ export function healthPhase(page: Page) {
   return phase.get(page) ?? "test"
 }
 
+export async function setEditorRefDelay(page: Page, value: boolean) {
+  await page.evaluate((v) => {
+    const win = window as E2EWindow
+    win.__opencode_e2e = {
+      ...win.__opencode_e2e,
+      promptInput: { delayEditorRef: v },
+    }
+  }, value)
+}
+
 export async function defocus(page: Page) {
   await page
     .evaluate(() => {

--- a/packages/app/e2e/session/session-composer-dock.spec.ts
+++ b/packages/app/e2e/session/session-composer-dock.spec.ts
@@ -5,7 +5,14 @@ import {
   type ComposerProbeState,
   type ComposerWindow,
 } from "../../src/testing/session-composer"
-import { cleanupSession, clearSessionDockSeed, closeDialog, openSettings, seedSessionQuestion } from "../actions"
+import {
+  cleanupSession,
+  clearSessionDockSeed,
+  closeDialog,
+  openSettings,
+  seedSessionQuestion,
+  setEditorRefDelay,
+} from "../actions"
 import {
   permissionDockSelector,
   promptSelector,
@@ -382,6 +389,86 @@ test("blocked question flow supports escape dismiss", async ({ page, llm, projec
 
         await page.keyboard.press("Escape")
         await expectQuestionOpen(page)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("prompt text typed before question dock is restored after answer", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question prompt restore",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        const typed = `restore-${Date.now()}`
+        const prompt = page.locator(promptSelector)
+        await prompt.click()
+        await page.keyboard.type(typed)
+        await expect.poll(async () => ((await prompt.textContent()) ?? "").replace(/\u200B/g, "").trim()).toBe(typed)
+
+        // Simulate the production timing race: delay editorRef assignment by one
+        // microtask so it lands after the on() effect and onMount both fire.
+        await setEditorRefDelay(page, true)
+
+        await llm.toolMatch(inputMatch({ questions: defaultQuestions }), "question", { questions: defaultQuestions })
+        await seedSessionQuestion(project.sdk, { sessionID: session.id, questions: defaultQuestions })
+
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
+
+        await dock.locator('[data-slot="question-option"]').first().click()
+        await dock.getByRole("button", { name: /submit/i }).click()
+
+        await expectQuestionOpen(page)
+        await expect.poll(async () => ((await prompt.textContent()) ?? "").replace(/\u200B/g, "").trim()).toBe(typed)
+      })
+    },
+    { trackSession: project.trackSession },
+  )
+})
+
+test("prompt image attached before question dock is restored after answer", async ({ page, llm, project }) => {
+  await project.open()
+  await withDockSession(
+    project.sdk,
+    "e2e composer dock question image restore",
+    async (session) => {
+      await withDockSeed(project.sdk, session.id, async () => {
+        await project.gotoSession(session.id)
+
+        // Attach a minimal 1x1 PNG via the hidden file input
+        const filename = "test-attachment.png"
+        // prettier-ignore
+        const png = Buffer.from([
+          0x89,0x50,0x4e,0x47,0x0d,0x0a,0x1a,0x0a, // PNG signature
+          0x00,0x00,0x00,0x0d,0x49,0x48,0x44,0x52, // IHDR chunk length + type
+          0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x01, // 1x1
+          0x08,0x02,0x00,0x00,0x00,0x90,0x77,0x53, // 8-bit RGB
+          0xde,0x00,0x00,0x00,0x0c,0x49,0x44,0x41, // IDAT chunk
+          0x54,0x08,0xd7,0x63,0xf8,0xcf,0xc0,0x00,
+          0x00,0x00,0x02,0x00,0x01,0xe2,0x21,0xbc,
+          0x33,0x00,0x00,0x00,0x00,0x49,0x45,0x4e, // IEND chunk
+          0x44,0xae,0x42,0x60,0x82,
+        ])
+        const fileInput = page.locator('input[type="file"]').first()
+        await fileInput.setInputFiles({ name: filename, mimeType: "image/png", buffer: png })
+        await expect(page.getByAltText(filename)).toBeVisible()
+
+        await llm.toolMatch(inputMatch({ questions: defaultQuestions }), "question", { questions: defaultQuestions })
+        await seedSessionQuestion(project.sdk, { sessionID: session.id, questions: defaultQuestions })
+
+        const dock = page.locator(questionDockSelector)
+        await expectQuestionBlocked(page)
+
+        await dock.locator('[data-slot="question-option"]').first().click()
+        await dock.getByRole("button", { name: /submit/i }).click()
+
+        await expectQuestionOpen(page)
+        await expect(page.getByAltText(filename)).toBeVisible()
       })
     },
     { trackSession: project.trackSession },

--- a/packages/app/e2e/tsconfig.json
+++ b/packages/app/e2e/tsconfig.json
@@ -5,5 +5,10 @@
     "rootDir": "..",
     "types": ["node", "bun"]
   },
-  "include": ["./**/*.ts", "../src/testing/terminal.ts"]
+  "include": [
+    "./**/*.ts",
+    "../src/testing/terminal.ts",
+    "../src/testing/prompt.ts",
+    "../src/testing/session-composer.ts"
+  ]
 }

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1,6 +1,6 @@
 import { useFilteredList } from "@opencode-ai/ui/hooks"
 import { useSpring } from "@opencode-ai/ui/motion-spring"
-import { createEffect, on, Component, Show, onCleanup, createMemo, createSignal } from "solid-js"
+import { createEffect, on, onMount, Component, Show, onCleanup, createMemo, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { selectionFromLines, type SelectedLineRange, useFile } from "@/context/file"
@@ -35,7 +35,7 @@ import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
-import { promptEnabled, promptProbe } from "@/testing/prompt"
+import { promptEnabled, promptProbe, promptInputDriver } from "@/testing/prompt"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
 import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
@@ -551,7 +551,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setComposing(false)
     requestAnimationFrame(() => {
       if (composing()) return
-      reconcile(prompt.current().filter((part) => part.type !== "image"))
+      reconcile(parts())
     })
   }
 
@@ -762,7 +762,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
   }
 
+  const parts = createMemo(() => prompt.current().filter((part) => part.type !== "image"))
+
   const reconcile = (input: Prompt) => {
+    if (!editorRef) return
     if (mirror.input) {
       mirror.input = false
       if (isNormalizedEditor()) return
@@ -778,14 +781,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   createEffect(
-    on(
-      () => prompt.current(),
-      (parts) => {
-        if (composing()) return
-        reconcile(parts.filter((part) => part.type !== "image"))
-      },
-    ),
+    on(parts, (p) => {
+      if (composing()) return
+      reconcile(p)
+    }),
   )
+
+  onMount(() => reconcile(parts()))
 
   const parseFromDOM = (): Prompt => {
     const parts: Prompt = []
@@ -1336,6 +1338,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             <div
               data-component="prompt-input"
               ref={(el) => {
+                if (promptInputDriver.delayEditorRef()) {
+                  Promise.resolve().then(() => {
+                    editorRef = el
+                    props.ref?.(el)
+                    reconcile(parts())
+                  })
+                  return
+                }
                 editorRef = el
                 props.ref?.(el)
               }}

--- a/packages/app/src/testing/prompt.ts
+++ b/packages/app/src/testing/prompt.ts
@@ -81,3 +81,10 @@ export const promptProbe = {
     }
   },
 }
+
+export const promptInputDriver = {
+  delayEditorRef(): boolean {
+    if (typeof window === "undefined") return false
+    return (window as E2EWindow).__opencode_e2e?.promptInput?.delayEditorRef === true
+  },
+}

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -25,6 +25,9 @@ export type E2EWindow = Window & {
       current?: import("./prompt").PromptProbeState
       sent?: import("./prompt").PromptSendState
     }
+    promptInput?: {
+      delayEditorRef?: boolean
+    }
     terminal?: {
       enabled?: boolean
       terminals?: Record<string, TerminalProbeState>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1183,28 +1183,26 @@ export function Session() {
               <Show when={session()?.parentID}>
                 <SubagentFooter />
               </Show>
-              <Show when={visible()}>
-                <TuiPluginRuntime.Slot
-                  name="session_prompt"
-                  mode="replace"
-                  session_id={route.sessionID}
+              <TuiPluginRuntime.Slot
+                name="session_prompt"
+                mode="replace"
+                session_id={route.sessionID}
+                visible={visible()}
+                disabled={disabled()}
+                on_submit={toBottom}
+                ref={bind}
+              >
+                <Prompt
                   visible={visible()}
-                  disabled={disabled()}
-                  on_submit={toBottom}
                   ref={bind}
-                >
-                  <Prompt
-                    visible={visible()}
-                    ref={bind}
-                    disabled={disabled()}
-                    onSubmit={() => {
-                      toBottom()
-                    }}
-                    sessionID={route.sessionID}
-                    right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
-                  />
-                </TuiPluginRuntime.Slot>
-              </Show>
+                  disabled={disabled()}
+                  onSubmit={() => {
+                    toBottom()
+                  }}
+                  sessionID={route.sessionID}
+                  right={<TuiPluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
+                />
+              </TuiPluginRuntime.Slot>
             </box>
           </Show>
           <Toast />


### PR DESCRIPTION
### Issue for this PR
Closes #22301
### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
### What does this PR do?
When a permission or question dock appears mid-session, any text typed in the prompt is cleared. You have to retype it after dismissing the dock.
The cause: `<Prompt>` in `routes/session/index.tsx` was wrapped in `<Show when={visible()}>`. `visible()` goes false when a permission or question is pending, so Solid unmounts the component entirely, destroying all input state. Removing the `<Show>` wrapper keeps `<Prompt>` mounted at all times. The prompt already handles its own visibility internally via `<box visible={props.visible !== false}>`, so the visual behaviour is unchanged.
### How did you verify your code works?
Built a local binary with `bun run build --single --skip-embed-web-ui`, started a session, typed text into the prompt, triggered a permission dock, dismissed it, and confirmed the typed text was preserved.
### Screenshots / recordings
_N/A_
### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR