### PR TITLE
refactor(file): stream ripgrep search parsing

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { Global } from "../global"
 import fs from "fs/promises"
 import z from "zod"
-import { Effect, Layer, Context } from "effect"
+import { Effect, Layer, Context, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
@@ -93,6 +93,40 @@ export namespace Ripgrep {
   })
 
   const Result = z.union([Begin, Match, End, Summary])
+
+  const Hit = Schema.Struct({
+    type: Schema.Literal("match"),
+    data: Schema.Struct({
+      path: Schema.Struct({
+        text: Schema.String,
+      }),
+      lines: Schema.Struct({
+        text: Schema.String,
+      }),
+      line_number: Schema.Number,
+      absolute_offset: Schema.Number,
+      submatches: Schema.mutable(
+        Schema.Array(
+          Schema.Struct({
+            match: Schema.Struct({
+              text: Schema.String,
+            }),
+            start: Schema.Number,
+            end: Schema.Number,
+          }),
+        ),
+      ),
+    }),
+  })
+
+  const Row = Schema.Union([
+    Schema.Struct({ type: Schema.Literal("begin"), data: Schema.Unknown }),
+    Hit,
+    Schema.Struct({ type: Schema.Literal("end"), data: Schema.Unknown }),
+    Schema.Struct({ type: Schema.Literal("summary"), data: Schema.Unknown }),
+  ])
+
+  const decode = Schema.decodeUnknownEffect(Schema.fromJsonString(Row))
 
   export type Result = z.infer<typeof Result>
   export type Match = z.infer<typeof Match>
@@ -374,14 +408,6 @@ export namespace Ripgrep {
       }) {
         return yield* Effect.scoped(
           Effect.gen(function* () {
-            const parse = Effect.fn("Ripgrep.parse")(function* (line: string) {
-              const row = yield* Effect.try({
-                try: () => Result.parse(JSON.parse(line)),
-                catch: (cause) => new Error(`invalid ripgrep output: ${cause}`),
-              })
-              if (row.type !== "match") return undefined
-              return row.data
-            })
             const cmd = yield* args({
               mode: "search",
               glob: input.glob,
@@ -402,8 +428,11 @@ export namespace Ripgrep {
                 Stream.decodeText(handle.stdout).pipe(
                   Stream.splitLines,
                   Stream.filter((line) => line.length > 0),
-                  Stream.mapEffect(parse),
-                  Stream.filter((item): item is Item => item !== undefined),
+                  Stream.mapEffect((line) =>
+                    decode(line).pipe(Effect.mapError((cause) => new Error("invalid ripgrep output", { cause }))),
+                  ),
+                  Stream.filter((row): row is Schema.Schema.Type<typeof Hit> => row.type === "match"),
+                  Stream.map((row): Item => row.data),
                   Stream.runCollect,
                   Effect.map((chunk) => [...chunk]),
                 ),

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -374,6 +374,14 @@ export namespace Ripgrep {
       }) {
         return yield* Effect.scoped(
           Effect.gen(function* () {
+            const parse = Effect.fn("Ripgrep.parse")(function* (line: string) {
+              const row = yield* Effect.try({
+                try: () => Result.parse(JSON.parse(line)),
+                catch: (cause) => new Error(`invalid ripgrep output: ${cause}`),
+              })
+              if (row.type !== "match") return undefined
+              return row.data
+            })
             const cmd = yield* args({
               mode: "search",
               glob: input.glob,
@@ -389,9 +397,16 @@ export namespace Ripgrep {
               }),
             )
 
-            const [stdout, stderr, code] = yield* Effect.all(
+            const [items, stderr, code] = yield* Effect.all(
               [
-                Stream.mkString(Stream.decodeText(handle.stdout)),
+                Stream.decodeText(handle.stdout).pipe(
+                  Stream.splitLines,
+                  Stream.filter((line) => line.length > 0),
+                  Stream.mapEffect(parse),
+                  Stream.filter((item): item is Item => item !== undefined),
+                  Stream.runCollect,
+                  Effect.map((chunk) => [...chunk]),
+                ),
                 Stream.mkString(Stream.decodeText(handle.stderr)),
                 handle.exitCode,
               ],
@@ -401,15 +416,6 @@ export namespace Ripgrep {
             if (code !== 0 && code !== 1 && code !== 2) {
               return yield* Effect.fail(new Error(`ripgrep failed: ${stderr}`))
             }
-
-            const items = stdout
-              .trim()
-              .split(/\r?\n/)
-              .filter(Boolean)
-              .map((line) => JSON.parse(line))
-              .map((parsed) => Result.parse(parsed))
-              .filter((row): row is Match => row.type === "match")
-              .map((row) => row.data)
 
             return {
               items,


### PR DESCRIPTION
## Summary
- stream ripgrep JSON search output line-by-line instead of buffering the full stdout payload first
- parse and validate rows incrementally, then keep only `match` rows in memory
- preserve the existing `Ripgrep.Service.search(...)` result shape while reducing intermediate allocation work

## Verification
- `bun run test test/tool/grep.test.ts test/file/ripgrep.test.ts`
- `bun typecheck`