### PR TITLE
fix: dispose e2e tool warmup runtime

### DIFF
--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -25,7 +25,7 @@ const seed = async () => {
       init: () => AppRuntime.runPromise(InstanceBootstrap),
       fn: async () => {
         await Config.waitForDependencies()
-        await ToolRegistry.ids()
+        await AppRuntime.runPromise(ToolRegistry.Service.use((svc) => svc.ids()))
 
         const session = await Session.create({ title })
         const messageID = MessageID.ascending()
@@ -56,6 +56,7 @@ const seed = async () => {
     })
   } finally {
     await Instance.disposeAll().catch(() => {})
+    await AppRuntime.dispose().catch(() => {})
   }
 }
 


### PR DESCRIPTION
## Summary
- warm the seed script's tool registry preload through `AppRuntime` instead of the standalone `ToolRegistry.ids()` runtime
- dispose `AppRuntime` after seeding so scoped tool init fibers do not keep the process alive
- fixes the local repro where `bun script/seed-e2e.ts` created the session and then hung until timeout, which also blocked `test:e2e:local`

## Verification
- `bun typecheck`
- `OPENCODE_DISABLE_SHARE=true OPENCODE_DISABLE_LSP_DOWNLOAD=true OPENCODE_DISABLE_DEFAULT_PLUGINS=true OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true OPENCODE_TEST_HOME=/tmp/opencode-e2e-home-wt-fix XDG_DATA_HOME=/tmp/opencode-e2e-share-wt-fix XDG_CACHE_HOME=/tmp/opencode-e2e-cache-wt-fix XDG_CONFIG_HOME=/tmp/opencode-e2e-config-wt-fix XDG_STATE_HOME=/tmp/opencode-e2e-state-wt-fix OPENCODE_E2E_PROJECT_DIR=/Users/kit/code/open-source/opencode-e2e-seed-runtime-scope OPENCODE_E2E_SESSION_TITLE='E2E Session' OPENCODE_E2E_MESSAGE='Seeded for UI e2e' OPENCODE_E2E_MODEL=opencode/gpt-5-nano OPENCODE_CLIENT=app OPENCODE_STRICT_CONFIG_DEPS=true bun script/seed-e2e.ts`
- `bun run test:e2e:local e2e/app/session.spec.ts`