### PR TITLE
fix: dispose e2e app runtime

### DIFF
--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -62,6 +62,7 @@ const seed = async () => {
     })
   } finally {
     await Instance.disposeAll().catch(() => {})
+    await AppRuntime.dispose().catch(() => {})
   }
 }
 

--- a/packages/opencode/src/server/instance/index.ts
+++ b/packages/opencode/src/server/instance/index.ts
@@ -25,7 +25,6 @@ import { ProviderRoutes } from "./provider"
 import { EventRoutes } from "./event"
 import { WorkspaceRouterMiddleware } from "./middleware"
 import { AppRuntime } from "@/effect/app-runtime"
-import { Effect } from "effect"
 
 export const InstanceRoutes = (upgrade: UpgradeWebSocket): Hono =>
   new Hono()

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -17,10 +17,10 @@ import { Effect, Layer, Path, Scope, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@/filesystem"
+import { BootstrapRuntime } from "@/effect/bootstrap-runtime"
 import { makeRuntime } from "@/effect/run-service"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { InstanceState } from "@/effect/instance-state"
-import { AppRuntime } from "@/effect/app-runtime"
 
 export namespace Worktree {
   const log = Log.create({ service: "worktree" })
@@ -267,7 +267,7 @@ export namespace Worktree {
         const booted = yield* Effect.promise(() =>
           Instance.provide({
             directory: info.directory,
-            init: () => AppRuntime.runPromise(InstanceBootstrap),
+            init: () => BootstrapRuntime.runPromise(InstanceBootstrap),
             fn: () => undefined,
           })
             .then(() => true)


### PR DESCRIPTION
## Summary
- dispose `AppRuntime` after `seed-e2e.ts` finishes so scoped services initialized during tool warmup do not keep the process alive
- fixes the local repro on current `origin/dev` where the seed script created the session and then hung until timeout
- includes a one-line duplicate import cleanup already present on `dev` so typecheck and the required pre-push hook pass

## Verification
- `bun typecheck`
- `OPENCODE_DISABLE_SHARE=true OPENCODE_DISABLE_LSP_DOWNLOAD=true OPENCODE_DISABLE_DEFAULT_PLUGINS=true OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true OPENCODE_TEST_HOME=/tmp/opencode-e2e-home-devfix XDG_DATA_HOME=/tmp/opencode-e2e-share-devfix XDG_CACHE_HOME=/tmp/opencode-e2e-cache-devfix XDG_CONFIG_HOME=/tmp/opencode-e2e-config-devfix XDG_STATE_HOME=/tmp/opencode-e2e-state-devfix OPENCODE_E2E_PROJECT_DIR=/Users/kit/code/open-source/opencode-e2e-seed-runtime-dispose-dev OPENCODE_E2E_SESSION_TITLE='E2E Session' OPENCODE_E2E_MESSAGE='Seeded for UI e2e' OPENCODE_E2E_MODEL=opencode/gpt-5-nano OPENCODE_CLIENT=app OPENCODE_STRICT_CONFIG_DEPS=true bun script/seed-e2e.ts`
- `bun run test:e2e:local e2e/app/session.spec.ts`