### PR TITLE
refactor(mcp): remove mcp auth async facade exports

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -361,7 +361,6 @@ export const McpLogoutCommand = cmd({
         UI.empty()
         prompts.intro("MCP OAuth Logout")
 
-        const authPath = path.join(Global.Path.data, "mcp-auth.json")
         const credentials = await AppRuntime.runPromise(McpAuth.Service.use((auth) => auth.all()))
         const serverNames = Object.keys(credentials)
 

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -716,6 +716,11 @@ export const McpDebugCommand = cmd({
 
             // Try to discover OAuth metadata
             const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined
+            const auth = await AppRuntime.runPromise(
+              Effect.gen(function* () {
+                return yield* McpAuth.Service
+              }),
+            )
             const authProvider = new McpOAuthProvider(
               serverName,
               serverConfig.url,
@@ -728,6 +733,7 @@ export const McpDebugCommand = cmd({
               {
                 onRedirect: async () => {},
               },
+              auth,
             )
 
             prompts.log.info("Testing OAuth flow (without completing authorization)...")

--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -3,7 +3,6 @@ import z from "zod"
 import { Global } from "../global"
 import { Effect, Layer, Context } from "effect"
 import { AppFileSystem } from "@/filesystem"
-import { makeRuntime } from "@/effect/run-service"
 
 export namespace McpAuth {
   export const Tokens = z.object({
@@ -142,32 +141,4 @@ export namespace McpAuth {
   )
 
   export const defaultLayer = layer.pipe(Layer.provide(AppFileSystem.defaultLayer))
-
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  // Async facades for backward compat (used by McpOAuthProvider, CLI)
-
-  export const get = async (mcpName: string) => runPromise((svc) => svc.get(mcpName))
-
-  export const getForUrl = async (mcpName: string, serverUrl: string) =>
-    runPromise((svc) => svc.getForUrl(mcpName, serverUrl))
-
-  export const all = async () => runPromise((svc) => svc.all())
-
-  export const set = async (mcpName: string, entry: Entry, serverUrl?: string) =>
-    runPromise((svc) => svc.set(mcpName, entry, serverUrl))
-
-  export const remove = async (mcpName: string) => runPromise((svc) => svc.remove(mcpName))
-
-  export const updateTokens = async (mcpName: string, tokens: Tokens, serverUrl?: string) =>
-    runPromise((svc) => svc.updateTokens(mcpName, tokens, serverUrl))
-
-  export const updateClientInfo = async (mcpName: string, clientInfo: ClientInfo, serverUrl?: string) =>
-    runPromise((svc) => svc.updateClientInfo(mcpName, clientInfo, serverUrl))
-
-  export const updateCodeVerifier = async (mcpName: string, codeVerifier: string) =>
-    runPromise((svc) => svc.updateCodeVerifier(mcpName, codeVerifier))
-
-  export const updateOAuthState = async (mcpName: string, oauthState: string) =>
-    runPromise((svc) => svc.updateOAuthState(mcpName, oauthState))
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -293,6 +293,7 @@ export namespace MCP {
                 log.info("oauth redirect requested", { key, url: url.toString() })
               },
             },
+            auth,
           )
         }
 
@@ -744,6 +745,7 @@ export namespace MCP {
               capturedUrl = url
             },
           },
+          auth,
         )
 
         const transport = new StreamableHTTPClientTransport(new URL(mcpConfig.url), { authProvider })

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -11,9 +11,6 @@ import { Log } from "../util/log"
 
 const log = Log.create({ service: "mcp.oauth" })
 
-const run = <A, E>(fx: Effect.Effect<A, E, McpAuth.Service>) =>
-  Effect.runPromise(fx.pipe(Effect.provide(McpAuth.defaultLayer)))
-
 const OAUTH_CALLBACK_PORT = 19876
 const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
 
@@ -34,6 +31,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     private serverUrl: string,
     private config: McpOAuthConfig,
     private callbacks: McpOAuthCallbacks,
+    private auth: McpAuth.Interface,
   ) {}
 
   get redirectUrl(): string {
@@ -65,7 +63,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
-    const entry = await run(McpAuth.Service.use((auth) => auth.getForUrl(this.mcpName, this.serverUrl)))
+    const entry = await Effect.runPromise(this.auth.getForUrl(this.mcpName, this.serverUrl))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -83,18 +81,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
-    await run(
-      McpAuth.Service.use((auth) =>
-        auth.updateClientInfo(
-          this.mcpName,
-          {
-            clientId: info.client_id,
-            clientSecret: info.client_secret,
-            clientIdIssuedAt: info.client_id_issued_at,
-            clientSecretExpiresAt: info.client_secret_expires_at,
-          },
-          this.serverUrl,
-        ),
+    await Effect.runPromise(
+      this.auth.updateClientInfo(
+        this.mcpName,
+        {
+          clientId: info.client_id,
+          clientSecret: info.client_secret,
+          clientIdIssuedAt: info.client_id_issued_at,
+          clientSecretExpiresAt: info.client_secret_expires_at,
+        },
+        this.serverUrl,
       ),
     )
     log.info("saved dynamically registered client", {
@@ -105,7 +101,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async tokens(): Promise<OAuthTokens | undefined> {
     // Use getForUrl to validate tokens are for the current server URL
-    const entry = await run(McpAuth.Service.use((auth) => auth.getForUrl(this.mcpName, this.serverUrl)))
+    const entry = await Effect.runPromise(this.auth.getForUrl(this.mcpName, this.serverUrl))
     if (!entry?.tokens) return undefined
 
     return {
@@ -120,18 +116,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await run(
-      McpAuth.Service.use((auth) =>
-        auth.updateTokens(
-          this.mcpName,
-          {
-            accessToken: tokens.access_token,
-            refreshToken: tokens.refresh_token,
-            expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
-            scope: tokens.scope,
-          },
-          this.serverUrl,
-        ),
+    await Effect.runPromise(
+      this.auth.updateTokens(
+        this.mcpName,
+        {
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token,
+          expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+          scope: tokens.scope,
+        },
+        this.serverUrl,
       ),
     )
     log.info("saved oauth tokens", { mcpName: this.mcpName })
@@ -143,11 +137,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await run(McpAuth.Service.use((auth) => auth.updateCodeVerifier(this.mcpName, codeVerifier)))
+    await Effect.runPromise(this.auth.updateCodeVerifier(this.mcpName, codeVerifier))
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
+    const entry = await Effect.runPromise(this.auth.get(this.mcpName))
     if (!entry?.codeVerifier) {
       throw new Error(`No code verifier saved for MCP server: ${this.mcpName}`)
     }
@@ -155,11 +149,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveState(state: string): Promise<void> {
-    await run(McpAuth.Service.use((auth) => auth.updateOAuthState(this.mcpName, state)))
+    await Effect.runPromise(this.auth.updateOAuthState(this.mcpName, state))
   }
 
   async state(): Promise<string> {
-    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
+    const entry = await Effect.runPromise(this.auth.get(this.mcpName))
     if (entry?.oauthState) {
       return entry.oauthState
     }
@@ -171,28 +165,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
     const newState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("")
-    await run(McpAuth.Service.use((auth) => auth.updateOAuthState(this.mcpName, newState)))
+    await Effect.runPromise(this.auth.updateOAuthState(this.mcpName, newState))
     return newState
   }
 
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
     log.info("invalidating credentials", { mcpName: this.mcpName, type })
-    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
+    const entry = await Effect.runPromise(this.auth.get(this.mcpName))
     if (!entry) {
       return
     }
 
     switch (type) {
       case "all":
-        await run(McpAuth.Service.use((auth) => auth.remove(this.mcpName)))
+        await Effect.runPromise(this.auth.remove(this.mcpName))
         break
       case "client":
         delete entry.clientInfo
-        await run(McpAuth.Service.use((auth) => auth.set(this.mcpName, entry)))
+        await Effect.runPromise(this.auth.set(this.mcpName, entry))
         break
       case "tokens":
         delete entry.tokens
-        await run(McpAuth.Service.use((auth) => auth.set(this.mcpName, entry)))
+        await Effect.runPromise(this.auth.set(this.mcpName, entry))
         break
     }
   }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -5,10 +5,14 @@ import type {
   OAuthClientInformation,
   OAuthClientInformationFull,
 } from "@modelcontextprotocol/sdk/shared/auth.js"
+import { Effect } from "effect"
 import { McpAuth } from "./auth"
 import { Log } from "../util/log"
 
 const log = Log.create({ service: "mcp.oauth" })
+
+const run = <A, E>(fx: Effect.Effect<A, E, McpAuth.Service>) =>
+  Effect.runPromise(fx.pipe(Effect.provide(McpAuth.defaultLayer)))
 
 const OAUTH_CALLBACK_PORT = 19876
 const OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
@@ -61,7 +65,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
     // Check stored client info (from dynamic registration)
     // Use getForUrl to validate credentials are for the current server URL
-    const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    const entry = await run(McpAuth.Service.use((auth) => auth.getForUrl(this.mcpName, this.serverUrl)))
     if (entry?.clientInfo) {
       // Check if client secret has expired
       if (entry.clientInfo.clientSecretExpiresAt && entry.clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
@@ -79,15 +83,19 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
-    await McpAuth.updateClientInfo(
-      this.mcpName,
-      {
-        clientId: info.client_id,
-        clientSecret: info.client_secret,
-        clientIdIssuedAt: info.client_id_issued_at,
-        clientSecretExpiresAt: info.client_secret_expires_at,
-      },
-      this.serverUrl,
+    await run(
+      McpAuth.Service.use((auth) =>
+        auth.updateClientInfo(
+          this.mcpName,
+          {
+            clientId: info.client_id,
+            clientSecret: info.client_secret,
+            clientIdIssuedAt: info.client_id_issued_at,
+            clientSecretExpiresAt: info.client_secret_expires_at,
+          },
+          this.serverUrl,
+        ),
+      ),
     )
     log.info("saved dynamically registered client", {
       mcpName: this.mcpName,
@@ -97,7 +105,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   async tokens(): Promise<OAuthTokens | undefined> {
     // Use getForUrl to validate tokens are for the current server URL
-    const entry = await McpAuth.getForUrl(this.mcpName, this.serverUrl)
+    const entry = await run(McpAuth.Service.use((auth) => auth.getForUrl(this.mcpName, this.serverUrl)))
     if (!entry?.tokens) return undefined
 
     return {
@@ -112,15 +120,19 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await McpAuth.updateTokens(
-      this.mcpName,
-      {
-        accessToken: tokens.access_token,
-        refreshToken: tokens.refresh_token,
-        expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
-        scope: tokens.scope,
-      },
-      this.serverUrl,
+    await run(
+      McpAuth.Service.use((auth) =>
+        auth.updateTokens(
+          this.mcpName,
+          {
+            accessToken: tokens.access_token,
+            refreshToken: tokens.refresh_token,
+            expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+            scope: tokens.scope,
+          },
+          this.serverUrl,
+        ),
+      ),
     )
     log.info("saved oauth tokens", { mcpName: this.mcpName })
   }
@@ -131,11 +143,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    await McpAuth.updateCodeVerifier(this.mcpName, codeVerifier)
+    await run(McpAuth.Service.use((auth) => auth.updateCodeVerifier(this.mcpName, codeVerifier)))
   }
 
   async codeVerifier(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
     if (!entry?.codeVerifier) {
       throw new Error(`No code verifier saved for MCP server: ${this.mcpName}`)
     }
@@ -143,11 +155,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveState(state: string): Promise<void> {
-    await McpAuth.updateOAuthState(this.mcpName, state)
+    await run(McpAuth.Service.use((auth) => auth.updateOAuthState(this.mcpName, state)))
   }
 
   async state(): Promise<string> {
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
     if (entry?.oauthState) {
       return entry.oauthState
     }
@@ -159,28 +171,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
     const newState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("")
-    await McpAuth.updateOAuthState(this.mcpName, newState)
+    await run(McpAuth.Service.use((auth) => auth.updateOAuthState(this.mcpName, newState)))
     return newState
   }
 
   async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
     log.info("invalidating credentials", { mcpName: this.mcpName, type })
-    const entry = await McpAuth.get(this.mcpName)
+    const entry = await run(McpAuth.Service.use((auth) => auth.get(this.mcpName)))
     if (!entry) {
       return
     }
 
     switch (type) {
       case "all":
-        await McpAuth.remove(this.mcpName)
+        await run(McpAuth.Service.use((auth) => auth.remove(this.mcpName)))
         break
       case "client":
         delete entry.clientInfo
-        await McpAuth.set(this.mcpName, entry)
+        await run(McpAuth.Service.use((auth) => auth.set(this.mcpName, entry)))
         break
       case "tokens":
         delete entry.tokens
-        await McpAuth.set(this.mcpName, entry)
+        await run(McpAuth.Service.use((auth) => auth.set(this.mcpName, entry)))
         break
     }
   }

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -161,8 +161,9 @@ test("state() generates a new state when none is saved", async () => {
         { onRedirect: async () => {} },
       )
 
-      // Ensure no state exists
-      const entryBefore = await McpAuth.get("test-state-gen")
+      const entryBefore = await Effect.runPromise(
+        McpAuth.Service.use((auth) => auth.get("test-state-gen")).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
       expect(entryBefore?.oauthState).toBeUndefined()
 
       // state() should generate and return a new state, not throw
@@ -171,7 +172,9 @@ test("state() generates a new state when none is saved", async () => {
       expect(state.length).toBe(64) // 32 bytes as hex
 
       // The generated state should be persisted
-      const entryAfter = await McpAuth.get("test-state-gen")
+      const entryAfter = await Effect.runPromise(
+        McpAuth.Service.use((auth) => auth.get("test-state-gen")).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
       expect(entryAfter?.oauthState).toBe(state)
     },
   })
@@ -195,7 +198,11 @@ test("state() returns existing state when one is saved", async () => {
 
       // Pre-save a state
       const existingState = "pre-saved-state-value"
-      await McpAuth.updateOAuthState("test-state-existing", existingState)
+      await Effect.runPromise(
+        McpAuth.Service.use((auth) => auth.updateOAuthState("test-state-existing", existingState)).pipe(
+          Effect.provide(McpAuth.defaultLayer),
+        ),
+      )
 
       // state() should return the existing state
       const state = await provider.state()

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -154,11 +154,17 @@ test("state() generates a new state when none is saved", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
+      const auth = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* McpAuth.Service
+        }).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
       const provider = new McpOAuthProvider(
         "test-state-gen",
         "https://example.com/mcp",
         {},
         { onRedirect: async () => {} },
+        auth,
       )
 
       const entryBefore = await Effect.runPromise(
@@ -189,11 +195,17 @@ test("state() returns existing state when one is saved", async () => {
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
+      const auth = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* McpAuth.Service
+        }).pipe(Effect.provide(McpAuth.defaultLayer)),
+      )
       const provider = new McpOAuthProvider(
         "test-state-existing",
         "https://example.com/mcp",
         {},
         { onRedirect: async () => {} },
+        auth,
       )
 
       // Pre-save a state


### PR DESCRIPTION
## Summary
- remove the `makeRuntime(...)`-backed async facade exports from `src/mcp/auth.ts`
- switch the OAuth provider and CLI caller to use `McpAuth.Service` directly
- convert the OAuth auto-connect test to provide `McpAuth.defaultLayer` instead of calling async facades

## Validation
- `bun run test test/mcp/oauth-auto-connect.test.ts`
- `bun typecheck`