### PR TITLE
feat(tui): add average TPS to status bar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -155,9 +155,12 @@ export function Prompt(props: PromptProps) {
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = msg.reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0)
+    const elapsed = last.time.completed ? last.time.completed - last.time.created : 0
+    const tps = elapsed > 0 ? last.tokens.output / (elapsed / 1000) : undefined
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
+      tps: tps ? `${tps.toFixed(0)} t/s` : undefined,
     }
   })
 
@@ -1245,7 +1248,7 @@ export function Prompt(props: PromptProps) {
                     <Match when={usage()}>
                       {(item) => (
                         <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
+                          {[item().tps, item().context, item().cost].filter(Boolean).join(" · ")}
                         </text>
                       )}
                     </Match>

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -20,15 +20,19 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       return {
         tokens: 0,
         percent: null,
+        tps: null,
       }
     }
 
     const tokens =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    const elapsed = last.time.completed ? last.time.completed - last.time.created : 0
+    const tps = elapsed > 0 ? last.tokens.output / (elapsed / 1000) : null
     return {
       tokens,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+      tps,
     }
   })
 
@@ -39,6 +43,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
+      {state().tps !== null && <text fg={theme().textMuted}>{state().tps!.toFixed(0)} t/s</text>}
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
     </box>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -49,9 +49,13 @@ export function SubagentFooter() {
       currency: "USD",
     })
 
+    const elapsed = last.time.completed ? last.time.completed - last.time.created : 0
+    const tps = elapsed > 0 ? last.tokens.output / (elapsed / 1000) : undefined
+
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
+      tps: tps ? `${tps.toFixed(0)} t/s` : undefined,
     }
   })
 
@@ -87,7 +91,7 @@ export function SubagentFooter() {
             <Show when={usage()}>
               {(item) => (
                 <text fg={theme.textMuted} wrapMode="none">
-                  {[item().context, item().cost].filter(Boolean).join(" · ")}
+                  {[item().tps, item().context, item().cost].filter(Boolean).join(" · ")}
                 </text>
               )}
             </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #22344

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds average output tokens-per-second (TPS) to the TUI status bar, displayed before context size after a response completes. The metric is computed from data already on `AssistantMessage`: `tokens.output / ((time.completed - time.created) / 1000)`.

Shows up as "42 t/s · 1.2K (12%) · $0.05" in:
- Prompt footer
- Subagent footer  
- Sidebar context plugin

TPS only appears on completed messages (requires `time.completed`), so it won't show mid-stream or for incomplete responses.

### How did you verify your code works?

- `bun typecheck` passes across all packages
- Manually tested in TUI: TPS appears alongside context/cost after a response completes

### Screenshots / recordings

N/A — TUI text change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR