### PR TITLE
fix(provider): guard reasoningSummary injection for @ai-sdk/openai-compatible providers

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -832,7 +832,16 @@ export namespace ProviderTransform {
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"
-        result["reasoningSummary"] = "auto"
+        // Only inject reasoningSummary for providers that support it natively.
+        // @ai-sdk/openai-compatible proxies (e.g. LiteLLM) do not understand this
+        // parameter and return "Unknown parameter: 'reasoningSummary'".
+        if (
+          input.model.api.npm === "@ai-sdk/openai" ||
+          input.model.api.npm === "@ai-sdk/azure" ||
+          input.model.api.npm === "@ai-sdk/github-copilot"
+        ) {
+          result["reasoningSummary"] = "auto"
+        }
       }
 
       // Only set textVerbosity for non-chat gpt-5.x models


### PR DESCRIPTION
### Issue for this PR

Closes #21237
Closes #18882

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**The bug:** When using `@ai-sdk/openai-compatible` provider (e.g. LiteLLM proxy) with any GPT-5.x model, opencode injects `reasoningSummary: "auto"` into every request. LiteLLM does not recognize this parameter and rejects the request:

```
litellm.BadRequestError: OpenAIException - Unknown parameter: 'reasoningSummary'
```

**Why it happens:** In `options()` (transform.ts:835), `reasoningSummary` is set unconditionally for any provider whose `model.api.id` contains `"gpt-5"`. The `variants()` function in the same file already correctly guards `reasoningSummary` behind a provider check — only setting it for `@ai-sdk/openai`, `@ai-sdk/azure`, and `@ai-sdk/github-copilot`. The `options()` function lacks this guard.

**The fix:** Apply the same provider check in `options()` as already exists in `variants()`. `reasoningSummary` is now only injected for the three providers that translate it into the OpenAI Responses API format (`reasoning.summary`). For `@ai-sdk/openai-compatible`, the parameter is skipped entirely, which is correct — compatible proxies pass options directly in the request body without any translation.

### How did you verify your code works?

Reproduced the error locally using a LiteLLM proxy with `gpt-5.4` configured as an `@ai-sdk/openai-compatible` model. After this fix, the request succeeds without the `Unknown parameter: 'reasoningSummary'` error. Models on native `@ai-sdk/openai` continue to send `reasoningSummary: "auto"` as before.

### Screenshots / recordings

_N/A — no UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR