### PR TITLE
refactor(project): remove async facade exports

### DIFF
--- a/packages/opencode/script/seed-e2e.ts
+++ b/packages/opencode/script/seed-e2e.ts
@@ -57,7 +57,9 @@ const seed = async () => {
         }
         await Session.updateMessage(message)
         await Session.updatePart(part)
-        await Project.update({ projectID: Instance.project.id, name: "E2E Project" })
+        await AppRuntime.runPromise(
+          Project.Service.use((svc) => svc.update({ projectID: Instance.project.id, name: "E2E Project" })),
+        )
       },
     })
   } finally {

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -7,6 +7,7 @@ import { LocalContext } from "../util/local-context"
 import { Project } from "./project"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { State } from "./state"
+import { makeRuntime } from "@/effect/run-service"
 
 export interface InstanceContext {
   directory: string
@@ -16,6 +17,7 @@ export interface InstanceContext {
 
 const context = LocalContext.create<InstanceContext>("instance")
 const cache = new Map<string, Promise<InstanceContext>>()
+const project = makeRuntime(Project.Service, Project.defaultLayer)
 
 const disposal = {
   all: undefined as Promise<void> | undefined,
@@ -30,11 +32,13 @@ function boot(input: { directory: string; init?: () => Promise<any>; worktree?: 
             worktree: input.worktree,
             project: input.project,
           }
-        : await Project.fromDirectory(input.directory).then(({ project, sandbox }) => ({
-            directory: input.directory,
-            worktree: sandbox,
-            project,
-          }))
+        : await project
+            .runPromise((svc) => svc.fromDirectory(input.directory))
+            .then(({ project, sandbox }) => ({
+              directory: input.directory,
+              worktree: sandbox,
+              project,
+            }))
     await context.provide(ctx, async () => {
       await input.init?.()
     })

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -10,8 +10,7 @@ import { which } from "../util/which"
 import { ProjectID } from "./schema"
 import { Effect, Layer, Path, Scope, Context, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { NodeFileSystem, NodePath } from "@effect/platform-node"
-import { makeRuntime } from "@/effect/run-service"
+import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "@/filesystem"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 
@@ -463,19 +462,6 @@ export namespace Project {
     Layer.provide(AppFileSystem.defaultLayer),
     Layer.provide(NodePath.layer),
   )
-  const { runPromise } = makeRuntime(Service, defaultLayer)
-
-  // ---------------------------------------------------------------------------
-  // Promise-based API (delegates to Effect service via runPromise)
-  // ---------------------------------------------------------------------------
-
-  export function fromDirectory(directory: string) {
-    return runPromise((svc) => svc.fromDirectory(directory))
-  }
-
-  export function discover(input: Info) {
-    return runPromise((svc) => svc.discover(input))
-  }
 
   export function list() {
     return Database.use((db) =>
@@ -497,25 +483,5 @@ export namespace Project {
     Database.use((db) =>
       db.update(ProjectTable).set({ time_initialized: Date.now() }).where(eq(ProjectTable.id, id)).run(),
     )
-  }
-
-  export function initGit(input: { directory: string; project: Info }) {
-    return runPromise((svc) => svc.initGit(input))
-  }
-
-  export function update(input: UpdateInput) {
-    return runPromise((svc) => svc.update(input))
-  }
-
-  export function sandboxes(id: ProjectID) {
-    return runPromise((svc) => svc.sandboxes(id))
-  }
-
-  export function addSandbox(id: ProjectID, directory: string) {
-    return runPromise((svc) => svc.addSandbox(id, directory))
-  }
-
-  export function removeSandbox(id: ProjectID, directory: string) {
-    return runPromise((svc) => svc.removeSandbox(id, directory))
   }
 }

--- a/packages/opencode/src/server/instance/experimental.ts
+++ b/packages/opencode/src/server/instance/experimental.ts
@@ -276,7 +276,7 @@ export const ExperimentalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const sandboxes = await Project.sandboxes(Instance.project.id)
+        const sandboxes = await AppRuntime.runPromise(Project.Service.use((svc) => svc.sandboxes(Instance.project.id)))
         return c.json(sandboxes)
       },
     )
@@ -302,7 +302,9 @@ export const ExperimentalRoutes = lazy(() =>
       async (c) => {
         const body = c.req.valid("json")
         await Worktree.remove(body)
-        await Project.removeSandbox(Instance.project.id, body.directory)
+        await AppRuntime.runPromise(
+          Project.Service.use((svc) => svc.removeSandbox(Instance.project.id, body.directory)),
+        )
         return c.json(true)
       },
     )

--- a/packages/opencode/src/server/instance/project.ts
+++ b/packages/opencode/src/server/instance/project.ts
@@ -75,10 +75,9 @@ export const ProjectRoutes = lazy(() =>
       async (c) => {
         const dir = Instance.directory
         const prev = Instance.project
-        const next = await Project.initGit({
-          directory: dir,
-          project: prev,
-        })
+        const next = await AppRuntime.runPromise(
+          Project.Service.use((svc) => svc.initGit({ directory: dir, project: prev })),
+        )
         if (next.id === prev.id && next.vcs === prev.vcs && next.worktree === prev.worktree) return c.json(next)
         await Instance.reload({
           directory: dir,
@@ -112,7 +111,7 @@ export const ProjectRoutes = lazy(() =>
       async (c) => {
         const projectID = c.req.valid("param").projectID
         const body = c.req.valid("json")
-        const project = await Project.update({ ...body, projectID })
+        const project = await AppRuntime.runPromise(Project.Service.use((svc) => svc.update({ ...body, projectID })))
         return c.json(project)
       },
     ),

--- a/packages/opencode/test/project/migrate-global.test.ts
+++ b/packages/opencode/test/project/migrate-global.test.ts
@@ -8,8 +8,18 @@ import { SessionID } from "../../src/session/schema"
 import { Log } from "../../src/util/log"
 import { $ } from "bun"
 import { tmpdir } from "../fixture/fixture"
+import { Effect } from "effect"
 
 Log.init({ print: false })
+
+function run<A>(fn: (svc: Project.Interface) => Effect.Effect<A>) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* Project.Service
+      return yield* fn(svc)
+    }).pipe(Effect.provide(Project.defaultLayer)),
+  )
+}
 
 function uid() {
   return SessionID.make(crypto.randomUUID())
@@ -58,7 +68,7 @@ describe("migrateFromGlobal", () => {
     await $`git config user.name "Test"`.cwd(tmp.path).quiet()
     await $`git config user.email "test@opencode.test"`.cwd(tmp.path).quiet()
     await $`git config commit.gpgsign false`.cwd(tmp.path).quiet()
-    const { project: pre } = await Project.fromDirectory(tmp.path)
+    const { project: pre } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(pre.id).toBe(ProjectID.global)
 
     // 2. Seed a session under "global" with matching directory
@@ -68,7 +78,7 @@ describe("migrateFromGlobal", () => {
     // 3. Make a commit so the project gets a real ID
     await $`git commit --allow-empty -m "root"`.cwd(tmp.path).quiet()
 
-    const { project: real } = await Project.fromDirectory(tmp.path)
+    const { project: real } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(real.id).not.toBe(ProjectID.global)
 
     // 4. The session should have been migrated to the real project ID
@@ -80,7 +90,7 @@ describe("migrateFromGlobal", () => {
   test("migrates global sessions even when project row already exists", async () => {
     // 1. Create a repo with a commit — real project ID created immediately
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(project.id).not.toBe(ProjectID.global)
 
     // 2. Ensure "global" project row exists (as it would from a prior no-git session)
@@ -94,7 +104,7 @@ describe("migrateFromGlobal", () => {
 
     // 4. Call fromDirectory again — project row already exists,
     //    so the current code skips migration entirely. This is the bug.
-    await Project.fromDirectory(tmp.path)
+    await run((svc) => svc.fromDirectory(tmp.path))
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()
@@ -103,7 +113,7 @@ describe("migrateFromGlobal", () => {
 
   test("does not claim sessions with empty directory", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(project.id).not.toBe(ProjectID.global)
 
     ensureGlobal()
@@ -113,7 +123,7 @@ describe("migrateFromGlobal", () => {
     const id = uid()
     seed({ id, dir: "", project: ProjectID.global })
 
-    await Project.fromDirectory(tmp.path)
+    await run((svc) => svc.fromDirectory(tmp.path))
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()
@@ -122,7 +132,7 @@ describe("migrateFromGlobal", () => {
 
   test("does not steal sessions from unrelated directories", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(project.id).not.toBe(ProjectID.global)
 
     ensureGlobal()
@@ -131,7 +141,7 @@ describe("migrateFromGlobal", () => {
     const id = uid()
     seed({ id, dir: "/some/other/dir", project: ProjectID.global })
 
-    await Project.fromDirectory(tmp.path)
+    await run((svc) => svc.fromDirectory(tmp.path))
 
     const row = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, id)).get())
     expect(row).toBeDefined()

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -8,13 +8,22 @@ import { GlobalBus } from "../../src/bus/global"
 import { ProjectID } from "../../src/project/schema"
 import { Effect, Layer, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import { NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "../../src/filesystem"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 
 Log.init({ print: false })
 
 const encoder = new TextEncoder()
+
+function run<A>(fn: (svc: Project.Interface) => Effect.Effect<A>, layer = Project.defaultLayer) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* Project.Service
+      return yield* fn(svc)
+    }).pipe(Effect.provide(layer)),
+  )
+}
 
 /**
  * Creates a mock ChildProcessSpawner layer that intercepts git subcommands
@@ -64,7 +73,7 @@ describe("Project.fromDirectory", () => {
     await using tmp = await tmpdir()
     await $`git init`.cwd(tmp.path).quiet()
 
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     expect(project).toBeDefined()
     expect(project.id).toBe(ProjectID.global)
@@ -78,7 +87,7 @@ describe("Project.fromDirectory", () => {
   test("should handle git repository with commits", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     expect(project).toBeDefined()
     expect(project.id).not.toBe(ProjectID.global)
@@ -91,14 +100,14 @@ describe("Project.fromDirectory", () => {
 
   test("returns global for non-git directory", async () => {
     await using tmp = await tmpdir()
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(project.id).toBe(ProjectID.global)
   })
 
   test("derives stable project ID from root commit", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project: a } = await Project.fromDirectory(tmp.path)
-    const { project: b } = await Project.fromDirectory(tmp.path)
+    const { project: a } = await run((svc) => svc.fromDirectory(tmp.path))
+    const { project: b } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(b.id).toBe(a.id)
   })
 })
@@ -109,7 +118,7 @@ describe("Project.fromDirectory git failure paths", () => {
     await $`git init`.cwd(tmp.path).quiet()
 
     // rev-list fails because HEAD doesn't exist yet — this is the natural scenario
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     expect(project.vcs).toBe("git")
     expect(project.id).toBe(ProjectID.global)
     expect(project.worktree).toBe(tmp.path)
@@ -119,9 +128,7 @@ describe("Project.fromDirectory git failure paths", () => {
     await using tmp = await tmpdir({ git: true })
     const layer = projectLayerWithFailure("--show-toplevel")
 
-    const { project, sandbox } = await Effect.runPromise(
-      Project.Service.use((svc) => svc.fromDirectory(tmp.path)).pipe(Effect.provide(layer)),
-    )
+    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path), layer)
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
   })
@@ -130,9 +137,7 @@ describe("Project.fromDirectory git failure paths", () => {
     await using tmp = await tmpdir({ git: true })
     const layer = projectLayerWithFailure("--git-common-dir")
 
-    const { project, sandbox } = await Effect.runPromise(
-      Project.Service.use((svc) => svc.fromDirectory(tmp.path)).pipe(Effect.provide(layer)),
-    )
+    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path), layer)
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
   })
@@ -142,7 +147,7 @@ describe("Project.fromDirectory with worktrees", () => {
   test("should set worktree to root when called from root", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project, sandbox } = await Project.fromDirectory(tmp.path)
+    const { project, sandbox } = await run((svc) => svc.fromDirectory(tmp.path))
 
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
@@ -156,7 +161,7 @@ describe("Project.fromDirectory with worktrees", () => {
     try {
       await $`git worktree add ${worktreePath} -b test-branch-${Date.now()}`.cwd(tmp.path).quiet()
 
-      const { project, sandbox } = await Project.fromDirectory(worktreePath)
+      const { project, sandbox } = await run((svc) => svc.fromDirectory(worktreePath))
 
       expect(project.worktree).toBe(tmp.path)
       expect(sandbox).toBe(worktreePath)
@@ -173,13 +178,13 @@ describe("Project.fromDirectory with worktrees", () => {
   test("worktree should share project ID with main repo", async () => {
     await using tmp = await tmpdir({ git: true })
 
-    const { project: main } = await Project.fromDirectory(tmp.path)
+    const { project: main } = await run((svc) => svc.fromDirectory(tmp.path))
 
     const worktreePath = path.join(tmp.path, "..", path.basename(tmp.path) + "-wt-shared")
     try {
       await $`git worktree add ${worktreePath} -b shared-${Date.now()}`.cwd(tmp.path).quiet()
 
-      const { project: wt } = await Project.fromDirectory(worktreePath)
+      const { project: wt } = await run((svc) => svc.fromDirectory(worktreePath))
 
       expect(wt.id).toBe(main.id)
 
@@ -205,8 +210,8 @@ describe("Project.fromDirectory with worktrees", () => {
       await $`git clone --bare ${tmp.path} ${bare}`.quiet()
       await $`git clone ${bare} ${clone}`.quiet()
 
-      const { project: a } = await Project.fromDirectory(tmp.path)
-      const { project: b } = await Project.fromDirectory(clone)
+      const { project: a } = await run((svc) => svc.fromDirectory(tmp.path))
+      const { project: b } = await run((svc) => svc.fromDirectory(clone))
 
       expect(b.id).toBe(a.id)
     } finally {
@@ -223,8 +228,8 @@ describe("Project.fromDirectory with worktrees", () => {
       await $`git worktree add ${worktree1} -b branch-${Date.now()}`.cwd(tmp.path).quiet()
       await $`git worktree add ${worktree2} -b branch-${Date.now() + 1}`.cwd(tmp.path).quiet()
 
-      await Project.fromDirectory(worktree1)
-      const { project } = await Project.fromDirectory(worktree2)
+      await run((svc) => svc.fromDirectory(worktree1))
+      const { project } = await run((svc) => svc.fromDirectory(worktree2))
 
       expect(project.worktree).toBe(tmp.path)
       expect(project.sandboxes).toContain(worktree1)
@@ -246,12 +251,12 @@ describe("Project.fromDirectory with worktrees", () => {
 describe("Project.discover", () => {
   test("should discover favicon.png in root", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     await Bun.write(path.join(tmp.path, "favicon.png"), pngData)
 
-    await Project.discover(project)
+    await run((svc) => svc.discover(project))
 
     const updated = Project.get(project.id)
     expect(updated).toBeDefined()
@@ -263,11 +268,11 @@ describe("Project.discover", () => {
 
   test("should not discover non-image files", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     await Bun.write(path.join(tmp.path, "favicon.txt"), "not an image")
 
-    await Project.discover(project)
+    await run((svc) => svc.discover(project))
 
     const updated = Project.get(project.id)
     expect(updated).toBeDefined()
@@ -278,12 +283,14 @@ describe("Project.discover", () => {
 describe("Project.update", () => {
   test("should update name", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
-    const updated = await Project.update({
-      projectID: project.id,
-      name: "New Project Name",
-    })
+    const updated = await run((svc) =>
+      svc.update({
+        projectID: project.id,
+        name: "New Project Name",
+      }),
+    )
 
     expect(updated.name).toBe("New Project Name")
 
@@ -293,12 +300,14 @@ describe("Project.update", () => {
 
   test("should update icon url", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
-    const updated = await Project.update({
-      projectID: project.id,
-      icon: { url: "https://example.com/icon.png" },
-    })
+    const updated = await run((svc) =>
+      svc.update({
+        projectID: project.id,
+        icon: { url: "https://example.com/icon.png" },
+      }),
+    )
 
     expect(updated.icon?.url).toBe("https://example.com/icon.png")
 
@@ -308,12 +317,14 @@ describe("Project.update", () => {
 
   test("should update icon color", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
-    const updated = await Project.update({
-      projectID: project.id,
-      icon: { color: "#ff0000" },
-    })
+    const updated = await run((svc) =>
+      svc.update({
+        projectID: project.id,
+        icon: { color: "#ff0000" },
+      }),
+    )
 
     expect(updated.icon?.color).toBe("#ff0000")
 
@@ -323,12 +334,14 @@ describe("Project.update", () => {
 
   test("should update commands", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
-    const updated = await Project.update({
-      projectID: project.id,
-      commands: { start: "npm run dev" },
-    })
+    const updated = await run((svc) =>
+      svc.update({
+        projectID: project.id,
+        commands: { start: "npm run dev" },
+      }),
+    )
 
     expect(updated.commands?.start).toBe("npm run dev")
 
@@ -338,16 +351,18 @@ describe("Project.update", () => {
 
   test("should throw error when project not found", async () => {
     await expect(
-      Project.update({
-        projectID: ProjectID.make("nonexistent-project-id"),
-        name: "Should Fail",
-      }),
+      run((svc) =>
+        svc.update({
+          projectID: ProjectID.make("nonexistent-project-id"),
+          name: "Should Fail",
+        }),
+      ),
     ).rejects.toThrow("Project not found: nonexistent-project-id")
   })
 
   test("should emit GlobalBus event on update", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     let eventPayload: any = null
     const on = (data: any) => {
@@ -356,10 +371,7 @@ describe("Project.update", () => {
     GlobalBus.on("event", on)
 
     try {
-      await Project.update({
-        projectID: project.id,
-        name: "Updated Name",
-      })
+      await run((svc) => svc.update({ projectID: project.id, name: "Updated Name" }))
 
       expect(eventPayload).not.toBeNull()
       expect(eventPayload.payload.type).toBe("project.updated")
@@ -371,14 +383,16 @@ describe("Project.update", () => {
 
   test("should update multiple fields at once", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
-    const updated = await Project.update({
-      projectID: project.id,
-      name: "Multi Update",
-      icon: { url: "https://example.com/favicon.ico", color: "#00ff00" },
-      commands: { start: "make start" },
-    })
+    const updated = await run((svc) =>
+      svc.update({
+        projectID: project.id,
+        name: "Multi Update",
+        icon: { url: "https://example.com/favicon.ico", color: "#00ff00" },
+        commands: { start: "make start" },
+      }),
+    )
 
     expect(updated.name).toBe("Multi Update")
     expect(updated.icon?.url).toBe("https://example.com/favicon.ico")
@@ -390,7 +404,7 @@ describe("Project.update", () => {
 describe("Project.list and Project.get", () => {
   test("list returns all projects", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     const all = Project.list()
     expect(all.length).toBeGreaterThan(0)
@@ -399,7 +413,7 @@ describe("Project.list and Project.get", () => {
 
   test("get returns project by id", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     const found = Project.get(project.id)
     expect(found).toBeDefined()
@@ -415,7 +429,7 @@ describe("Project.list and Project.get", () => {
 describe("Project.setInitialized", () => {
   test("sets time_initialized on project", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
 
     expect(project.time.initialized).toBeUndefined()
 
@@ -429,15 +443,15 @@ describe("Project.setInitialized", () => {
 describe("Project.addSandbox and Project.removeSandbox", () => {
   test("addSandbox adds directory and removeSandbox removes it", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     const sandboxDir = path.join(tmp.path, "sandbox-test")
 
-    await Project.addSandbox(project.id, sandboxDir)
+    await run((svc) => svc.addSandbox(project.id, sandboxDir))
 
     let found = Project.get(project.id)
     expect(found?.sandboxes).toContain(sandboxDir)
 
-    await Project.removeSandbox(project.id, sandboxDir)
+    await run((svc) => svc.removeSandbox(project.id, sandboxDir))
 
     found = Project.get(project.id)
     expect(found?.sandboxes).not.toContain(sandboxDir)
@@ -445,14 +459,14 @@ describe("Project.addSandbox and Project.removeSandbox", () => {
 
   test("addSandbox emits GlobalBus event", async () => {
     await using tmp = await tmpdir({ git: true })
-    const { project } = await Project.fromDirectory(tmp.path)
+    const { project } = await run((svc) => svc.fromDirectory(tmp.path))
     const sandboxDir = path.join(tmp.path, "sandbox-event")
 
     const events: any[] = []
     const on = (evt: any) => events.push(evt)
     GlobalBus.on("event", on)
 
-    await Project.addSandbox(project.id, sandboxDir)
+    await run((svc) => svc.addSandbox(project.id, sandboxDir))
 
     GlobalBus.off("event", on)
     expect(events.some((e) => e.payload.type === Project.Event.Updated.type)).toBe(true)


### PR DESCRIPTION
## Summary
- remove the remaining `Project` runtime-backed async facade exports and service-local runtime
- migrate instance, server, and seed script callers to use `Project.Service` through a runtime instead of facade helpers
- convert project tests to yield the service from context and keep instance bootstrap on a non-facade runtime path

## Testing
- bun typecheck
- bun run test test/project/project.test.ts test/project/migrate-global.test.ts