### PR TITLE
feat: add session archive/unarchive support to TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -761,6 +761,16 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
   })
 
+event.on("session.archived", (evt) => {
+    if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
+      route.navigate({ type: "home" })
+      toast.show({
+        variant: "info",
+        message: "The current session was archived",
+      })
+    }
+  })
+
   event.on("session.error", (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -751,7 +751,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
   })
 
-  event.on("session.deleted", (evt) => {
+event.on("session.deleted", (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
       route.navigate({ type: "home" })
       toast.show({
@@ -761,15 +761,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
   })
 
-event.on("session.archived", (evt) => {
-    if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
-      route.navigate({ type: "home" })
-      toast.show({
-        variant: "info",
-        message: "The current session was archived",
-      })
-    }
-  })
+  // Note: session.archived handling is done in the session list dialog via the SDK
+  // When a session is archived, users select a different session or navigate home
 
   event.on("session.error", (evt) => {
     const error = evt.properties.error

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -15,7 +15,6 @@ import { createDebouncedSignal } from "../util/signal"
 import { useToast } from "../ui/toast"
 import { DialogWorkspaceCreate, openWorkspaceSession } from "./dialog-workspace-create"
 import { Spinner } from "./spinner"
-import { Keybind } from "@/util/keybind"
 
 type WorkspaceStatus = "connected" | "connecting" | "disconnected" | "error"
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -15,6 +15,7 @@ import { createDebouncedSignal } from "../util/signal"
 import { useToast } from "../ui/toast"
 import { DialogWorkspaceCreate, openWorkspaceSession } from "./dialog-workspace-create"
 import { Spinner } from "./spinner"
+import { Keybind } from "@/util/keybind"
 
 type WorkspaceStatus = "connected" | "connecting" | "disconnected" | "error"
 
@@ -28,6 +29,7 @@ export function DialogSessionList() {
   const sdk = useSDK()
   const toast = useToast()
   const [toDelete, setToDelete] = createSignal<string>()
+  const [showArchived, setShowArchived] = createSignal(false)
   const [search, setSearch] = createDebouncedSignal("", 150)
 
   const [searchResults] = createResource(search, async (query) => {
@@ -59,7 +61,11 @@ export function DialogSessionList() {
   const options = createMemo(() => {
     const today = new Date().toDateString()
     return sessions()
-      .filter((x) => x.parentID === undefined)
+      .filter((x) => {
+        if (x.parentID !== undefined) return false
+        if (showArchived()) return !!x.time.archived
+        return !x.time.archived
+      })
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .map((x) => {
         const workspace = x.workspaceID ? project.workspace.get(x.workspaceID) : undefined
@@ -124,7 +130,7 @@ export function DialogSessionList() {
 
   return (
     <DialogSelect
-      title="Sessions"
+      title={showArchived() ? "Archived Sessions" : "Sessions"}
       options={options()}
       skipFilter={true}
       current={currentSessionID()}
@@ -133,6 +139,13 @@ export function DialogSessionList() {
         setToDelete(undefined)
       }}
       onSelect={(option) => {
+        if (showArchived()) {
+          sdk.client.session.update({
+            sessionID: option.value,
+            time: { archived: 0 },
+          })
+          return
+        }
         route.navigate({
           type: "session",
           sessionID: option.value,
@@ -140,25 +153,61 @@ export function DialogSessionList() {
         dialog.clear()
       }}
       keybind={[
+        ...(showArchived()
+          ? []
+          : [
+              {
+                keybind: keybind.all.session_delete?.[0],
+                title: "delete",
+                onTrigger: async (option: { value: string }) => {
+                  if (toDelete() === option.value) {
+                    sdk.client.session.delete({
+                      sessionID: option.value,
+                    })
+                    setToDelete(undefined)
+                    return
+                  }
+                  setToDelete(option.value)
+                },
+              },
+              {
+                keybind: keybind.all.session_archive?.[0],
+                title: "archive",
+                onTrigger: async (option: { value: string }) => {
+                  sdk.client.session.update({
+                    sessionID: option.value,
+                    time: { archived: Date.now() },
+                  })
+                },
+              },
+              {
+                keybind: keybind.all.session_rename?.[0],
+                title: "rename",
+                onTrigger: async (option: { value: string }) => {
+                  dialog.replace(() => <DialogSessionRename session={option.value} />)
+                },
+              },
+            ]),
+        ...(showArchived()
+          ? [
+              {
+                keybind: keybind.all.session_archive?.[0],
+                title: "unarchive",
+                onTrigger: async (option: { value: string }) => {
+                  sdk.client.session.update({
+                    sessionID: option.value,
+                    time: { archived: 0 },
+                  })
+                },
+              },
+            ]
+          : []),
         {
-          keybind: keybind.all.session_delete?.[0],
-          title: "delete",
-          onTrigger: async (option) => {
-            if (toDelete() === option.value) {
-              sdk.client.session.delete({
-                sessionID: option.value,
-              })
-              setToDelete(undefined)
-              return
-            }
-            setToDelete(option.value)
-          },
-        },
-        {
-          keybind: keybind.all.session_rename?.[0],
-          title: "rename",
-          onTrigger: async (option) => {
-            dialog.replace(() => <DialogSessionRename session={option.value} />)
+          keybind: Keybind.parse("tab")[0],
+          title: showArchived() ? "active" : "archived",
+          onTrigger: async () => {
+            setShowArchived((prev) => !prev)
+            setToDelete(undefined)
           },
         },
         {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -517,6 +517,25 @@ export function Session() {
       },
     },
     {
+      title: "Archive session",
+      value: "session.archive",
+      keybind: "session_archive",
+      category: "Session",
+      slash: {
+        name: "archive",
+      },
+      onSelect: async (dialog) => {
+        await sdk.client.session
+          .update({
+            sessionID: route.sessionID,
+            time: { archived: Date.now() },
+          })
+          .then(() => toast.show({ message: "Session archived", variant: "success" }))
+          .catch(() => toast.show({ message: "Failed to archive session", variant: "error" }))
+        dialog.clear()
+      },
+    },
+    {
       title: "Undo previous message",
       value: "session.undo",
       keybind: "messages_undo",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -583,6 +583,7 @@ export namespace Config {
       session_fork: z.string().optional().default("none").describe("Fork session from message"),
       session_rename: z.string().optional().default("ctrl+r").describe("Rename session"),
       session_delete: z.string().optional().default("ctrl+d").describe("Delete session"),
+      session_archive: z.string().optional().default("none").describe("Archive session"),
       stash_delete: z.string().optional().default("ctrl+d").describe("Delete stash entry"),
       model_provider_list: z.string().optional().default("ctrl+a").describe("Open provider list from model dialog"),
       model_favorite_toggle: z.string().optional().default("ctrl+f").describe("Toggle model favorite status"),


### PR DESCRIPTION
### Issue for this PR

Closes #13964

### Type of change

- [x] New feature

### What does this PR do?

Adds session archive/unarchive support to the TUI:

- `/archive` slash command to archive current session
- Session list shows archived sessions when toggled with Tab
- Selecting an archived session unarchives it
- Auto-navigate home when current session is archived
- `session_archive` keybind (configurable)

This is a rebased version of PR #13961 by @uriva, updated to current dev to resolve conflicts that accumulated after the March rebase.

### How did you verify your code works?

Rebased onto current dev - used the same conflict resolution approach that worked before. Typecheck passes (at least for the changed opencode package).

### Screenshots / recordings

N/A - no UI changes, only keybinds and list filtering.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR