### PR TITLE
improve bash timeout retry hint

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -437,7 +437,11 @@ export const BashTool = Tool.define(
       ).pipe(Effect.orDie)
 
       const meta: string[] = []
-      if (expired) meta.push(`bash tool terminated command after exceeding timeout ${input.timeout} ms`)
+      if (expired) {
+        meta.push(
+          `bash tool terminated command after exceeding timeout ${input.timeout} ms. If this command is expected to take longer and is not waiting for interactive input, retry with a larger timeout value in milliseconds.`,
+        )
+      }
       if (aborted) meta.push("User aborted the command")
       if (meta.length > 0) {
         output += "\n\n<bash_metadata>\n" + meta.join("\n") + "\n</bash_metadata>"

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -1024,6 +1024,7 @@ describe("tool.bash abort", () => {
         )
         expect(result.output).toContain("started")
         expect(result.output).toContain("bash tool terminated command after exceeding timeout")
+        expect(result.output).toContain("retry with a larger timeout value in milliseconds")
       },
     })
   }, 15_000)


### PR DESCRIPTION
## Summary
- make bash timeout metadata tell the model it can retry with a larger timeout for expected long-running commands
- keep the message explicit about avoiding blind retries when the command may be waiting for interactive input
- cover the new hint in the bash tool timeout test

Closes #4197