### PR TITLE
fix: skip slow file processing before write on large files

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1854,20 +1854,26 @@ function Write(props: ToolProps<typeof WriteTool>) {
     if (!props.input.content) return ""
     return props.input.content
   })
+  const truncated = createMemo(() => Boolean(props.metadata.truncated))
 
   return (
     <Switch>
       <Match when={props.metadata.diagnostics !== undefined}>
         <BlockTool title={"# Wrote " + normalizePath(props.input.filePath!)} part={props.part}>
-          <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
-            <code
-              conceal={false}
-              fg={theme.text}
-              filetype={filetype(props.input.filePath!)}
-              syntaxStyle={syntax()}
-              content={code()}
-            />
-          </line_number>
+          <Show
+            when={!truncated()}
+            fallback={<text fg={theme.textMuted}>(large file — content not shown)</text>}
+          >
+            <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
+              <code
+                conceal={false}
+                fg={theme.text}
+                filetype={filetype(props.input.filePath!)}
+                syntaxStyle={syntax()}
+                content={code()}
+              />
+            </line_number>
+          </Show>
           <Diagnostics diagnostics={props.metadata.diagnostics} filePath={props.input.filePath ?? ""} />
         </BlockTool>
       </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -55,6 +55,9 @@ function EditBody(props: { request: PermissionRequest }) {
 
   const filepath = createMemo(() => (props.request.metadata?.filepath as string) ?? "")
   const diff = createMemo(() => (props.request.metadata?.diff as string) ?? "")
+  const truncated = createMemo(() => Boolean(props.request.metadata?.truncated))
+  const additions = createMemo(() => (props.request.metadata?.additions as number) ?? 0)
+  const deletions = createMemo(() => (props.request.metadata?.deletions as number) ?? 0)
 
   const view = createMemo(() => {
     const diffStyle = config.diff_style
@@ -101,7 +104,11 @@ function EditBody(props: { request: PermissionRequest }) {
       </Show>
       <Show when={!diff()}>
         <box paddingLeft={1}>
-          <text fg={theme.textMuted}>No diff provided</text>
+          <text fg={theme.textMuted}>
+            {truncated()
+              ? `Large file — diff omitted (+${additions()} / -${deletions()} lines)`
+              : "No diff provided"}
+          </text>
         </box>
       </Show>
     </box>

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -6,9 +6,8 @@ import { Bus } from "../bus"
 import { FileWatcher } from "../file/watcher"
 import { Instance } from "../project/instance"
 import { Patch } from "../patch"
-import { createTwoFilesPatch, diffLines } from "diff"
 import { assertExternalDirectoryEffect } from "./external-directory"
-import { trimDiff } from "./edit"
+import { buildDisplayDiff, LARGE_FILE_FORMAT_BYTES } from "./edit"
 import { LSP } from "../lsp"
 import { AppFileSystem } from "../filesystem"
 import DESCRIPTION from "./apply_patch.txt"
@@ -59,6 +58,7 @@ export const ApplyPatchTool = Tool.define(
         diff: string
         additions: number
         deletions: number
+        truncated: boolean
       }> = []
 
       let totalDiff = ""
@@ -72,26 +72,20 @@ export const ApplyPatchTool = Tool.define(
             const oldContent = ""
             const newContent =
               hunk.contents.length === 0 || hunk.contents.endsWith("\n") ? hunk.contents : `${hunk.contents}\n`
-            const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
-
-            let additions = 0
-            let deletions = 0
-            for (const change of diffLines(oldContent, newContent)) {
-              if (change.added) additions += change.count || 0
-              if (change.removed) deletions += change.count || 0
-            }
+            const display = buildDisplayDiff(filePath, oldContent, newContent)
 
             fileChanges.push({
               filePath,
               oldContent,
               newContent,
               type: "add",
-              diff,
-              additions,
-              deletions,
+              diff: display.diff,
+              additions: display.additions,
+              deletions: display.deletions,
+              truncated: display.truncated,
             })
 
-            totalDiff += diff + "\n"
+            totalDiff += display.diff + "\n"
             break
           }
 
@@ -115,14 +109,7 @@ export const ApplyPatchTool = Tool.define(
               return yield* Effect.fail(new Error(`apply_patch verification failed: ${error}`))
             }
 
-            const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
-
-            let additions = 0
-            let deletions = 0
-            for (const change of diffLines(oldContent, newContent)) {
-              if (change.added) additions += change.count || 0
-              if (change.removed) deletions += change.count || 0
-            }
+            const display = buildDisplayDiff(filePath, oldContent, newContent)
 
             const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
             yield* assertExternalDirectoryEffect(ctx, movePath)
@@ -133,12 +120,13 @@ export const ApplyPatchTool = Tool.define(
               newContent,
               type: hunk.move_path ? "move" : "update",
               movePath,
-              diff,
-              additions,
-              deletions,
+              diff: display.diff,
+              additions: display.additions,
+              deletions: display.deletions,
+              truncated: display.truncated,
             })
 
-            totalDiff += diff + "\n"
+            totalDiff += display.diff + "\n"
             break
           }
 
@@ -146,21 +134,20 @@ export const ApplyPatchTool = Tool.define(
             const contentToDelete = yield* afs
               .readFileString(filePath)
               .pipe(Effect.catch((error) => Effect.fail(new Error(`apply_patch verification failed: ${error}`))))
-            const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
-
-            const deletions = contentToDelete.split("\n").length
+            const display = buildDisplayDiff(filePath, contentToDelete, "")
 
             fileChanges.push({
               filePath,
               oldContent: contentToDelete,
               newContent: "",
               type: "delete",
-              diff: deleteDiff,
+              diff: display.diff,
               additions: 0,
-              deletions,
+              deletions: display.truncated ? display.deletions : contentToDelete.split("\n").length,
+              truncated: display.truncated,
             })
 
-            totalDiff += deleteDiff + "\n"
+            totalDiff += display.diff + "\n"
             break
           }
         }
@@ -175,7 +162,9 @@ export const ApplyPatchTool = Tool.define(
         additions: change.additions,
         deletions: change.deletions,
         movePath: change.movePath,
+        truncated: change.truncated,
       }))
+      const anyTruncated = fileChanges.some((c) => c.truncated)
 
       // Check permissions if needed
       const relativePaths = fileChanges.map((c) => path.relative(Instance.worktree, c.filePath).replaceAll("\\", "/"))
@@ -187,6 +176,7 @@ export const ApplyPatchTool = Tool.define(
           filepath: relativePaths.join(", "),
           diff: totalDiff,
           files,
+          truncated: anyTruncated,
         },
       })
 
@@ -226,7 +216,10 @@ export const ApplyPatchTool = Tool.define(
         }
 
         if (edited) {
-          yield* format.file(edited)
+          const editedSize = Buffer.byteLength(change.newContent, "utf8")
+          if (editedSize <= LARGE_FILE_FORMAT_BYTES) {
+            yield* format.file(edited)
+          }
           yield* bus.publish(File.Event.Edited, { file: edited })
         }
       }
@@ -236,13 +229,17 @@ export const ApplyPatchTool = Tool.define(
         yield* bus.publish(FileWatcher.Event.Updated, update)
       }
 
-      // Notify LSP of file changes and collect diagnostics
-      for (const change of fileChanges) {
-        if (change.type === "delete") continue
-        const target = change.movePath ?? change.filePath
-        yield* lsp.touchFile(target, true)
+      // Notify LSP of file changes and collect diagnostics (skip for very large files)
+      const skipLsp = fileChanges.some((c) => Buffer.byteLength(c.newContent, "utf8") > LARGE_FILE_FORMAT_BYTES)
+      let diagnostics: Record<string, import("../lsp/client").LSPClient.Diagnostic[]> = {}
+      if (!skipLsp) {
+        for (const change of fileChanges) {
+          if (change.type === "delete") continue
+          const target = change.movePath ?? change.filePath
+          yield* lsp.touchFile(target, true)
+        }
+        diagnostics = yield* lsp.diagnostics()
       }
-      const diagnostics = yield* lsp.diagnostics()
 
       // Generate output summary
       const summaryLines = fileChanges.map((change) => {
@@ -272,6 +269,7 @@ export const ApplyPatchTool = Tool.define(
           diff: totalDiff,
           files,
           diagnostics,
+          truncated: anyTruncated,
         },
         output,
       }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -612,6 +612,39 @@ export const ContextAwareReplacer: Replacer = function* (content, find) {
   }
 }
 
+export const LARGE_FILE_DIFF_BYTES = 256 * 1024
+export const LARGE_FILE_FORMAT_BYTES = 2 * 1024 * 1024
+
+export interface DisplayDiff {
+  diff: string
+  truncated: boolean
+  additions: number
+  deletions: number
+}
+
+export function buildDisplayDiff(filepath: string, oldContent: string, newContent: string): DisplayDiff {
+  const oldSize = Buffer.byteLength(oldContent, "utf8")
+  const newSize = Buffer.byteLength(newContent, "utf8")
+  if (oldSize > LARGE_FILE_DIFF_BYTES || newSize > LARGE_FILE_DIFF_BYTES) {
+    const oldLines = oldContent ? oldContent.split("\n").length : 0
+    const newLines = newContent ? newContent.split("\n").length : 0
+    return {
+      diff: "",
+      truncated: true,
+      additions: Math.max(0, newLines - oldLines),
+      deletions: Math.max(0, oldLines - newLines),
+    }
+  }
+  let additions = 0
+  let deletions = 0
+  for (const change of diffLines(oldContent, newContent)) {
+    if (change.added) additions += change.count || 0
+    if (change.removed) deletions += change.count || 0
+  }
+  const diff = trimDiff(createTwoFilesPatch(filepath, filepath, oldContent, newContent))
+  return { diff, truncated: false, additions, deletions }
+}
+
 export function trimDiff(diff: string): string {
   const lines = diff.split("\n")
   const contentLines = lines.filter(

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { Effect } from "effect"
 import { Tool } from "./tool"
 import { LSP } from "../lsp"
-import { createTwoFilesPatch } from "diff"
+import { LSPClient } from "../lsp/client"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
 import { File } from "../file"
@@ -12,7 +12,7 @@ import { Format } from "../format"
 import { FileTime } from "../file/time"
 import { AppFileSystem } from "../filesystem"
 import { Instance } from "../project/instance"
-import { trimDiff } from "./edit"
+import { buildDisplayDiff, LARGE_FILE_FORMAT_BYTES } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
@@ -43,19 +43,24 @@ export const WriteTool = Tool.define(
           const contentOld = exists ? yield* fs.readFileString(filepath) : ""
           if (exists) yield* filetime.assert(ctx.sessionID, filepath)
 
-          const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, params.content))
+          const display = buildDisplayDiff(filepath, contentOld, params.content)
           yield* ctx.ask({
             permission: "edit",
             patterns: [path.relative(Instance.worktree, filepath)],
             always: ["*"],
             metadata: {
               filepath,
-              diff,
+              diff: display.diff,
+              truncated: display.truncated,
+              additions: display.additions,
+              deletions: display.deletions,
             },
           })
 
           yield* fs.writeWithDirs(filepath, params.content)
-          yield* format.file(filepath)
+          const newSize = Buffer.byteLength(params.content, "utf8")
+          const skipHeavy = newSize > LARGE_FILE_FORMAT_BYTES
+          if (!skipHeavy) yield* format.file(filepath)
           yield* bus.publish(File.Event.Edited, { file: filepath })
           yield* bus.publish(FileWatcher.Event.Updated, {
             file: filepath,
@@ -64,21 +69,24 @@ export const WriteTool = Tool.define(
           yield* filetime.read(ctx.sessionID, filepath)
 
           let output = "Wrote file successfully."
-          yield* lsp.touchFile(filepath, true)
-          const diagnostics = yield* lsp.diagnostics()
-          const normalizedFilepath = AppFileSystem.normalizePath(filepath)
-          let projectDiagnosticsCount = 0
-          for (const [file, issues] of Object.entries(diagnostics)) {
-            const current = file === normalizedFilepath
-            if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
-            const block = LSP.Diagnostic.report(current ? filepath : file, issues)
-            if (!block) continue
-            if (current) {
-              output += `\n\nLSP errors detected in this file, please fix:\n${block}`
-              continue
+          let diagnostics: Record<string, LSPClient.Diagnostic[]> = {}
+          if (!skipHeavy) {
+            yield* lsp.touchFile(filepath, true)
+            diagnostics = yield* lsp.diagnostics()
+            const normalizedFilepath = AppFileSystem.normalizePath(filepath)
+            let projectDiagnosticsCount = 0
+            for (const [file, issues] of Object.entries(diagnostics)) {
+              const current = file === normalizedFilepath
+              if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
+              const block = LSP.Diagnostic.report(current ? filepath : file, issues)
+              if (!block) continue
+              if (current) {
+                output += `\n\nLSP errors detected in this file, please fix:\n${block}`
+                continue
+              }
+              projectDiagnosticsCount++
+              output += `\n\nLSP errors detected in other files:\n${block}`
             }
-            projectDiagnosticsCount++
-            output += `\n\nLSP errors detected in other files:\n${block}`
           }
 
           return {
@@ -87,6 +95,7 @@ export const WriteTool = Tool.define(
               diagnostics,
               filepath,
               exists: exists,
+              truncated: display.truncated,
             },
             output,
           }

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -41,6 +41,7 @@ type AskInput = {
   metadata: {
     diff: string
     filepath: string
+    truncated?: boolean
     files: Array<{
       filePath: string
       relativePath: string
@@ -49,6 +50,7 @@ type AskInput = {
       additions: number
       deletions: number
       movePath?: string
+      truncated?: boolean
     }>
   }
 }
@@ -579,6 +581,36 @@ EOF`
         await execute({ patchText }, ctx)
         // Result has ASCII quotes because that's what the patch specifies
         expect(await fs.readFile(target, "utf-8")).toBe(`He said "hi"\nsome${emDash}dash\nend\n`)
+      },
+    })
+  })
+
+  test("skips Myers diff and marks truncated on large files", async () => {
+    await using fixture = await tmpdir()
+    const { ctx, calls } = makeCtx()
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        const target = path.join(fixture.path, "big.txt")
+        const padding = "a\n".repeat(200_000) // ~400 KB, above 256 KB threshold
+        await fs.writeFile(target, `head\n${padding}tail\n`, "utf-8")
+
+        const patchText = "*** Begin Patch\n*** Update File: big.txt\n@@\n-head\n+HEAD\n*** End Patch"
+
+        const start = performance.now()
+        const result = await execute({ patchText }, ctx)
+        const elapsed = performance.now() - start
+
+        expect(elapsed).toBeLessThan(2000)
+        expect(calls.length).toBe(1)
+        const file = calls[0].metadata.files[0] as any
+        expect(file.truncated).toBe(true)
+        expect(file.patch).toBe("")
+        expect((result.metadata as any).truncated).toBe(true)
+
+        const updated = await fs.readFile(target, "utf-8")
+        expect(updated.startsWith("HEAD\n")).toBe(true)
       },
     })
   })

--- a/packages/opencode/test/tool/display-diff.test.ts
+++ b/packages/opencode/test/tool/display-diff.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { buildDisplayDiff, LARGE_FILE_DIFF_BYTES } from "../../src/tool/edit"
+
+describe("buildDisplayDiff", () => {
+  test("returns a non-truncated unified diff for small files", () => {
+    const result = buildDisplayDiff("/tmp/a.txt", "line one\nline two\n", "line one\nLINE TWO\n")
+    expect(result.truncated).toBe(false)
+    expect(result.diff).toContain("+LINE TWO")
+    expect(result.diff).toContain("-line two")
+    expect(result.additions).toBeGreaterThan(0)
+    expect(result.deletions).toBeGreaterThan(0)
+  })
+
+  test("truncates when old content exceeds threshold", () => {
+    const old = "x\n".repeat(LARGE_FILE_DIFF_BYTES)
+    const result = buildDisplayDiff("/tmp/big.txt", old, "y\n")
+    expect(result.truncated).toBe(true)
+    expect(result.diff).toBe("")
+    expect(result.deletions).toBeGreaterThan(0)
+  })
+
+  test("truncates when new content exceeds threshold", () => {
+    const next = "y\n".repeat(LARGE_FILE_DIFF_BYTES)
+    const result = buildDisplayDiff("/tmp/big.txt", "x\n", next)
+    expect(result.truncated).toBe(true)
+    expect(result.diff).toBe("")
+    expect(result.additions).toBeGreaterThan(0)
+  })
+
+  test("boundary: content exactly at threshold is still diffed", () => {
+    const old = "a".repeat(LARGE_FILE_DIFF_BYTES - 1)
+    const next = old + "b"
+    const result = buildDisplayDiff("/tmp/boundary.txt", old, next)
+    expect(result.truncated).toBe(false)
+    expect(result.diff.length).toBeGreaterThan(0)
+  })
+
+  test("completes quickly for very large divergent rewrites", () => {
+    const old = "a".repeat(5 * 1024 * 1024)
+    const next = "b".repeat(5 * 1024 * 1024)
+    const start = performance.now()
+    const result = buildDisplayDiff("/tmp/huge.txt", old, next)
+    const elapsed = performance.now() - start
+    expect(result.truncated).toBe(true)
+    expect(elapsed).toBeLessThan(200)
+  })
+})

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -240,6 +240,66 @@ describe("tool.write", () => {
     )
   })
 
+  describe("large file handling", () => {
+    it.live("skips diff computation and sets truncated flag", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "big.txt")
+          const big = "a".repeat(400 * 1024) + "\n"
+          yield* Effect.promise(() => fs.writeFile(filepath, big, "utf-8"))
+          yield* markRead(ctx.sessionID, filepath)
+
+          let askMetadata: any
+          const askingCtx: Tool.Context = {
+            ...ctx,
+            ask: (input: any) =>
+              Effect.sync(() => {
+                askMetadata = input.metadata
+              }),
+          }
+
+          const start = performance.now()
+          const newContent = "b".repeat(400 * 1024) + "\n"
+          const result = yield* run({ filePath: filepath, content: newContent }, askingCtx)
+          const elapsed = performance.now() - start
+
+          expect(elapsed).toBeLessThan(1000)
+          expect(askMetadata).toBeDefined()
+          expect(askMetadata.truncated).toBe(true)
+          expect(askMetadata.diff).toBe("")
+          expect(result.metadata.truncated).toBe(true)
+
+          const onDisk = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(onDisk).toBe(newContent)
+        }),
+      ),
+    )
+
+    it.live("keeps full diff for small files", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "small.txt")
+          yield* Effect.promise(() => fs.writeFile(filepath, "old\n", "utf-8"))
+          yield* markRead(ctx.sessionID, filepath)
+
+          let askMetadata: any
+          const askingCtx: Tool.Context = {
+            ...ctx,
+            ask: (input: any) =>
+              Effect.sync(() => {
+                askMetadata = input.metadata
+              }),
+          }
+
+          yield* run({ filePath: filepath, content: "new\n" }, askingCtx)
+          expect(askMetadata.truncated).toBe(false)
+          expect(askMetadata.diff).toContain("+new")
+          expect(askMetadata.diff).toContain("-old")
+        }),
+      ),
+    )
+  })
+
   describe("title generation", () => {
     it.live("returns relative path as title", () =>
       provideTmpdirInstance((dir) =>


### PR DESCRIPTION
### Issue for this PR

Closes #11112, #22222, #16371,  and related bugs for formatting large files and lsp diagnostics. 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

This PR fixes "Pending write" issue that I've been noticing on large files. It adds a file size gate for write, apply_patch, format and lsp diagnostics runs. For write and apply_patch it prevents from running a slow two-file diff tool. 

### How did you verify your code works?

I have created unit tests, and I've also run a test with GLM model:
1. Created a large file.
2. Asked the agent to edit the file using "write" tool.
3. Made sure that the tool is called, and that it is not stuck on "Pending write".

Lmk if I need to verify anything else.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
