### PR TITLE
fix(app): avoid bootstrap error popups during global sync init

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -122,20 +122,21 @@ export async function bootstrapGlobal(input: {
         }),
       ),
   ]
-
-  showErrors({
-    errors: errors(await runAll(fast)),
-    title: input.requestFailedTitle,
-    translate: input.translate,
-    formatMoreCount: input.formatMoreCount,
-  })
+  await runAll(fast)
+  // showErrors({
+  //   errors: errors(await runAll(fast)),
+  //   title: input.requestFailedTitle,
+  //   translate: input.translate,
+  //   formatMoreCount: input.formatMoreCount,
+  // })
   await waitForPaint()
-  showErrors({
-    errors: errors(await runAll(slow)),
-    title: input.requestFailedTitle,
-    translate: input.translate,
-    formatMoreCount: input.formatMoreCount,
-  })
+  await runAll(slow)
+  // showErrors({
+  //   errors: errors(),
+  //   title: input.requestFailedTitle,
+  //   translate: input.translate,
+  //   formatMoreCount: input.formatMoreCount,
+  // })
   input.setGlobalStore("ready", true)
 }
 


### PR DESCRIPTION
## Summary
- stop surfacing `showErrors` during the fast and slow global sync bootstrap phases
- still await both bootstrap phases and mark the global store as ready afterward

## Testing
- not run (not requested)