### PR TITLE
fix: disable SQLite mmap to prevent memory growing with DB size

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -92,6 +92,7 @@ export namespace Database {
     db.run("PRAGMA busy_timeout = 5000")
     db.run("PRAGMA cache_size = -64000")
     db.run("PRAGMA foreign_keys = ON")
+    db.run("PRAGMA mmap_size = 0")
     db.run("PRAGMA wal_checkpoint(PASSIVE)")
 
     // Apply schema migrations


### PR DESCRIPTION
### Issue for this PR
Closes #22429

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bun's bundled SQLite enables memory-mapped I/O by default, which maps the entire DB file into the process address space. This causes the process footprint to grow proportionally with the DB file size regardless of actual data access patterns.
Observed on macOS ARM64: a 1.1 GB opencode.db results in ~1.8 GB of IOAccelerator memory in the process footprint snapshot.
Setting PRAGMA mmap_size = 0 restores SQLite's official default behavior, bounding SQLite's memory contribution to the cache_size limit (~64 MB). The performance impact is negligible — sub-millisecond extra latency on cache misses, dwarfed by LLM API call latency.

### How did you verify your code works?
Took a footprint snapshot of the opencode process on macOS ARM64 before and after the change with a 1.1 GB DB. The IOAccelerator region (SQLite mmap pages) dropped from ~1.8 GB to negligible. Functional behavior is unchanged — mmap only affects how pages are loaded from disk, not what data SQLite returns.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

