### PR TITLE
fix(opencode): resolve ripgrep worker path in compiled binary

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -187,6 +187,7 @@ for (const item of targets) {
   const rootPath = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
   const parserWorker = fs.realpathSync(fs.existsSync(localPath) ? localPath : rootPath)
   const workerPath = "./src/cli/cmd/tui/worker.ts"
+  const ripgrep = "./src/file/ripgrep.worker.ts"
 
   // Use platform-specific bunfs root path based on target OS
   const bunfsRoot = item.os === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/"
@@ -213,12 +214,13 @@ for (const item of targets) {
     files: {
       ...(embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {}),
     },
-    entrypoints: ["./src/index.ts", parserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
+    entrypoints: ["./src/index.ts", parserWorker, workerPath, ripgrep, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
       OPENCODE_WORKER_PATH: workerPath,
+      OPENCODE_RIPGREP_WORKER_PATH: ripgrep,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -268,7 +268,11 @@ export namespace Ripgrep {
       .flatMap((item) => (item.type === "match" ? [row(item.data)] : []))
   }
 
-  function target() {
+  declare const OPENCODE_RIPGREP_WORKER_PATH: string
+
+  function target(): Effect.Effect<string | URL, Error> {
+    if (typeof OPENCODE_RIPGREP_WORKER_PATH !== "undefined")
+      return Effect.succeed(OPENCODE_RIPGREP_WORKER_PATH)
     const js = new URL("./ripgrep.worker.js", import.meta.url)
     return Effect.tryPromise({
       try: () => Filesystem.exists(fileURLToPath(js)),


### PR DESCRIPTION
### Issue for this PR

Closes #22430

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After #21703 moved ripgrep to a Bun Worker, compiled binaries (`bun build --compile`) can't find `ripgrep.worker.ts` because `import.meta.url` resolves to a flattened `$bunfs/root/` path that doesn't match the worker's actual location.

The fix adds `ripgrep.worker.ts` as a build entrypoint and injects its compiled path via `OPENCODE_RIPGREP_WORKER_PATH` — the same pattern already used for `OPENCODE_WORKER_PATH` (TUI thread worker in `src/cli/cmd/tui/thread.ts`).

### How did you verify your code works?

1. Built with `bun run build -- --single`
2. Ran `dist/opencode-darwin-arm64/bin/opencode run --dir /tmp "search for hello using grep"`
3. Before fix: `ModuleNotFound resolving "/$bunfs/root/ripgrep.worker.ts"`
4. After fix: grep returns results normally

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR