### PR TITLE
fix(opencode): resolve ripgrep worker path in builds

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -187,6 +187,7 @@ for (const item of targets) {
   const rootPath = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
   const parserWorker = fs.realpathSync(fs.existsSync(localPath) ? localPath : rootPath)
   const workerPath = "./src/cli/cmd/tui/worker.ts"
+  const rgPath = "./src/file/ripgrep.worker.ts"
 
   // Use platform-specific bunfs root path based on target OS
   const bunfsRoot = item.os === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/"
@@ -213,12 +214,19 @@ for (const item of targets) {
     files: {
       ...(embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {}),
     },
-    entrypoints: ["./src/index.ts", parserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
+    entrypoints: [
+      "./src/index.ts",
+      parserWorker,
+      workerPath,
+      rgPath,
+      ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : []),
+    ],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
       OPENCODE_WORKER_PATH: workerPath,
+      OPENCODE_RIPGREP_WORKER_PATH: rgPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -268,7 +268,12 @@ export namespace Ripgrep {
       .flatMap((item) => (item.type === "match" ? [row(item.data)] : []))
   }
 
-  function target() {
+  declare const OPENCODE_RIPGREP_WORKER_PATH: string
+
+  function target(): Effect.Effect<string | URL, Error> {
+    if (typeof OPENCODE_RIPGREP_WORKER_PATH !== "undefined") {
+      return Effect.succeed(OPENCODE_RIPGREP_WORKER_PATH)
+    }
     const js = new URL("./ripgrep.worker.js", import.meta.url)
     return Effect.tryPromise({
       try: () => Filesystem.exists(fileURLToPath(js)),


### PR DESCRIPTION
## summary
- add `ripgrep.worker.ts` as a compiled build entrypoint for `packages/opencode`
- inject `OPENCODE_RIPGREP_WORKER_PATH` so compiled binaries do not fall back to `/$bunfs/root/ripgrep.worker.ts`
- keep the existing source-mode `ripgrep.worker.js` -> `ripgrep.worker.ts` fallback for local dev

## testing
- `bun typecheck`
- `bun run build -- --single --skip-embed-web-ui --skip-install`