### PR TITLE
fix(desktop): add CREATE_NO_WINDOW flag to prevent console window flash on Windows

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -182,8 +182,11 @@ pub fn sync_cli(app: tauri::AppHandle) -> Result<(), String> {
     let cli_path =
         get_cli_install_path().ok_or_else(|| "Could not determine CLI install path".to_string())?;
 
-    let output = std::process::Command::new(&cli_path)
-        .arg("--version")
+    let mut cmd = std::process::Command::new(&cli_path);
+    cmd.arg("--version");
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    let output = cmd
         .output()
         .map_err(|e| format!("Failed to get CLI version: {}", e))?;
 
@@ -288,6 +291,10 @@ fn probe_shell_env(shell: &str, mode: &str) -> ShellEnvProbe {
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::null());
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
     let output = match command_output_with_timeout(cmd, SHELL_ENV_TIMEOUT) {
         Ok(Some(output)) => output,
         Ok(None) => return ShellEnvProbe::Timeout,


### PR DESCRIPTION
Issue for this PR
Closes #22414

Type of change
 Bug fix

What does this PR do?
On Windows, subprocess invocations in the desktop app (shell env probing, CLI version sync) spawn visible console windows because they lack the `CREATE_NO_WINDOW` flag. This causes a black console window to flash on screen at regular intervals even when the app is idle.

Two `std::process::Command` calls in `packages/desktop/src-tauri/src/cli.rs` are missing the flag:
- `probe_shell_env`: Runs `bash -il -c env -0` to probe shell environment on every `spawn_command` call (startup + during operations)
- `sync_cli`: Runs `opencode --version` at startup to check CLI version

Both now get `creation_flags(CREATE_NO_WINDOW)` under `#[cfg(windows)]`, consistent with the existing `WinCreationFlags` wrapper already used on the main `CommandWrap` spawn path.

How did you verify my code works?
Bug is Windows-only (cannot test on Linux). The fix follows the exact same pattern as the existing `WinCreationFlags` `CommandWrapper` and the `where` command in `windows.rs` that already uses `CREATE_NO_WINDOW`.

Screenshots / recordings
Not applicable (no UI change, fix is backend process spawning)

Checklist
 I have tested my changes locally
 I have not included unrelated changes in this PR