### PR TITLE
[codex] inline skills and shared truncation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -358,6 +358,7 @@ export function Autocomplete(props: {
     const results = sync.data.skill.map(
       (skill): AutocompleteOption => ({
         display: skill.name,
+        value: skill.name,
         description: skill.description,
         onSelect: () => {
           insertPart(skill.name, {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -48,7 +48,7 @@ function extractLineRange(input: string) {
 export type AutocompleteRef = {
   onInput: (value: string) => void
   onKeyDown: (e: KeyEvent) => void
-  visible: false | "@" | "/"
+  visible: false | "@" | "/" | "$"
 }
 
 export type AutocompleteOption = {
@@ -72,6 +72,7 @@ export function Autocomplete(props: {
   ref: (ref: AutocompleteRef) => void
   fileStyleId: number
   agentStyleId: number
+  skillStyleId: number
   promptPartTypeId: () => number
 }) {
   const sdk = useSDK()
@@ -143,7 +144,8 @@ export function Autocomplete(props: {
 
     const charAfterCursor = props.value.at(currentCursorOffset)
     const needsSpace = charAfterCursor !== " "
-    const append = "@" + text + (needsSpace ? " " : "")
+    const prefix = part.type === "skill" ? "$" : "@"
+    const append = prefix + text + (needsSpace ? " " : "")
 
     input.cursorOffset = store.index
     const startCursor = input.logicalCursor
@@ -153,11 +155,18 @@ export function Autocomplete(props: {
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
     input.insertText(append)
 
-    const virtualText = "@" + text
+    const virtualText = prefix + text
     const extmarkStart = store.index
     const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
 
-    const styleId = part.type === "file" ? props.fileStyleId : part.type === "agent" ? props.agentStyleId : undefined
+    const styleId =
+      part.type === "file"
+        ? props.fileStyleId
+        : part.type === "agent"
+          ? props.agentStyleId
+          : part.type === "skill"
+            ? props.skillStyleId
+            : undefined
 
     const extmarkId = input.extmarks.create({
       start: extmarkStart,
@@ -193,6 +202,10 @@ export function Autocomplete(props: {
         part.source.text.end = extmarkEnd
         part.source.text.value = virtualText
       } else if (part.type === "agent" && part.source) {
+        part.source.start = extmarkStart
+        part.source.end = extmarkEnd
+        part.source.value = virtualText
+      } else if (part.type === "skill" && part.source) {
         part.source.start = extmarkStart
         part.source.end = extmarkEnd
         part.source.value = virtualText
@@ -341,6 +354,36 @@ export function Autocomplete(props: {
       )
   })
 
+  const skills = createMemo((): AutocompleteOption[] => {
+    const results = sync.data.skill.map(
+      (skill): AutocompleteOption => ({
+        display: skill.name,
+        description: skill.description,
+        onSelect: () => {
+          insertPart(skill.name, {
+            type: "skill",
+            name: skill.name,
+            source: {
+              start: 0,
+              end: 0,
+              value: "$" + skill.name,
+            },
+          })
+        },
+      }),
+    )
+
+    results.sort((a, b) => a.display.localeCompare(b.display))
+
+    const max = firstBy(results, [(x) => x.display.length, "desc"])?.display.length
+    if (!max) return results
+    const maxDisplay = Math.min(max!, 20)
+    return results.map((item) => ({
+      ...item,
+      display: item.display.length > 20 ? item.display.slice(0, 17) + "... " : item.display.padEnd(maxDisplay + 1),
+    }))
+  })
+
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = [...command.slashes()]
 
@@ -372,9 +415,14 @@ export function Autocomplete(props: {
     const filesValue = files()
     const agentsValue = agents()
     const commandsValue = commands()
+    const skillsValue = skills()
 
     const mixed: AutocompleteOption[] =
-      store.visible === "@" ? [...agentsValue, ...(filesValue || []), ...mcpResources()] : [...commandsValue]
+      store.visible === "@"
+        ? [...agentsValue, ...(filesValue || []), ...mcpResources()]
+        : store.visible === "$"
+          ? [...skillsValue]
+          : [...commandsValue]
 
     const currentFilter = filter()
 
@@ -461,7 +509,7 @@ export function Autocomplete(props: {
     setStore("selected", 0)
   }
 
-  function show(mode: "@" | "/") {
+  function show(mode: "@" | "/" | "$") {
     command.keybinds(false)
     setStore({
       visible: mode,
@@ -517,13 +565,25 @@ export function Autocomplete(props: {
         // Check for "@" trigger - find the nearest "@" before cursor with no whitespace between
         const text = value.slice(0, offset)
         const idx = text.lastIndexOf("@")
-        if (idx === -1) return
+        if (idx !== -1) {
+          const between = text.slice(idx)
+          const before = idx === 0 ? undefined : value[idx - 1]
+          if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
+            show("@")
+            setStore("index", idx)
+            return
+          }
+        }
 
-        const between = text.slice(idx)
-        const before = idx === 0 ? undefined : value[idx - 1]
-        if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
-          show("@")
-          setStore("index", idx)
+        // Check for "$" trigger - find the nearest "$" before cursor with no whitespace between
+        const dollarIdx = text.lastIndexOf("$")
+        if (dollarIdx !== -1) {
+          const between = text.slice(dollarIdx)
+          const before = dollarIdx === 0 ? undefined : value[dollarIdx - 1]
+          if ((before === undefined || /\s/.test(before)) && !between.match(/\s/)) {
+            show("$")
+            setStore("index", dollarIdx)
+          }
         }
       },
       onKeyDown(e: KeyEvent) {
@@ -577,6 +637,14 @@ export function Autocomplete(props: {
 
           if (e.name === "/") {
             if (props.input().cursorOffset === 0) show("/")
+          }
+
+          if (e.name === "$") {
+            const cursorOffset = props.input().cursorOffset
+            const charBeforeCursor =
+              cursorOffset === 0 ? undefined : props.input().getTextRange(cursorOffset - 1, cursorOffset)
+            const canTrigger = charBeforeCursor === undefined || charBeforeCursor === "" || /\s/.test(charBeforeCursor)
+            if (canTrigger) show("$")
           }
         }
       },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -5,7 +5,7 @@ import { createStore, produce } from "solid-js/store"
 import { clone } from "remeda"
 import { createSimpleContext } from "../../context/helper"
 import { appendFile, writeFile } from "fs/promises"
-import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
+import type { AgentPart, FilePart, TextPart, SkillPart } from "@opencode-ai/sdk/v2"
 
 export type PromptInfo = {
   input: string
@@ -13,6 +13,7 @@ export type PromptInfo = {
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
+    | Omit<SkillPart, "id" | "messageID" | "sessionID">
     | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
         source?: {
           text: {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -89,6 +89,7 @@ export function Prompt(props: PromptProps) {
 
   const fileStyleId = syntax().getStyleId("extmark.file")!
   const agentStyleId = syntax().getStyleId("extmark.agent")!
+  const skillStyleId = syntax().getStyleId("extmark.skill")!
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId = 0
 
@@ -373,6 +374,11 @@ export function Prompt(props: PromptProps) {
         end = part.source.end
         virtualText = part.source.value
         styleId = agentStyleId
+      } else if (part.type === "skill" && part.source) {
+        start = part.source.start
+        end = part.source.end
+        virtualText = part.source.value
+        styleId = skillStyleId
       } else if (part.type === "text" && part.source?.text) {
         start = part.source.text.start
         end = part.source.text.end
@@ -410,6 +416,9 @@ export function Prompt(props: PromptProps) {
             const part = draft.prompt.parts[partIndex]
             if (part) {
               if (part.type === "agent" && part.source) {
+                part.source.start = extmark.start
+                part.source.end = extmark.end
+              } else if (part.type === "skill" && part.source) {
                 part.source.start = extmark.start
                 part.source.end = extmark.end
               } else if (part.type === "file" && part.source?.text) {
@@ -750,6 +759,7 @@ export function Prompt(props: PromptProps) {
         value={store.prompt.input}
         fileStyleId={fileStyleId}
         agentStyleId={agentStyleId}
+        skillStyleId={skillStyleId}
         promptPartTypeId={() => promptPartTypeId}
       />
       <box ref={(r) => (anchor = r)} visible={props.visible !== false}>

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -29,6 +29,13 @@ import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
 
+// Skill type from API response
+type Skill = {
+  name: string
+  description: string
+  location: string
+}
+
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
   init: () => {
@@ -40,6 +47,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       provider_auth: Record<string, ProviderAuthMethod[]>
       agent: Agent[]
       command: Command[]
+      skill: Skill[]
       permission: {
         [sessionID: string]: PermissionRequest[]
       }
@@ -86,6 +94,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       permission: {},
       question: {},
       command: [],
+      skill: [],
       provider: [],
       provider_default: {},
       session: [],
@@ -360,6 +369,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           Promise.all([
             ...(args.continue ? [] : [sessionListPromise]),
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
+            sdk.client.app.skills().then((x) => setStore("skill", reconcile((x.data as Skill[] | undefined) ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -676,6 +676,13 @@ function getSyntaxRules(theme: Theme) {
       },
     },
     {
+      scope: ["extmark.skill"],
+      style: {
+        foreground: theme.primary,
+        bold: true,
+      },
+    },
+    {
       scope: ["extmark.paste"],
       style: {
         foreground: theme.background,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -155,6 +155,21 @@ export namespace MessageV2 {
   })
   export type AgentPart = z.infer<typeof AgentPart>
 
+  export const SkillPart = PartBase.extend({
+    type: z.literal("skill"),
+    name: z.string(),
+    source: z
+      .object({
+        value: z.string(),
+        start: z.number().int(),
+        end: z.number().int(),
+      })
+      .optional(),
+  }).meta({
+    ref: "SkillPart",
+  })
+  export type SkillPart = z.infer<typeof SkillPart>
+
   export const CompactionPart = PartBase.extend({
     type: z.literal("compaction"),
     auto: z.boolean(),
@@ -338,6 +353,7 @@ export namespace MessageV2 {
       SnapshotPart,
       PatchPart,
       AgentPart,
+      SkillPart,
       RetryPart,
       CompactionPart,
     ])

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "buffer"
 import path from "path"
 import os from "os"
-import fs, { appendFile } from "fs/promises"
+import fs from "fs/promises"
 import z from "zod"
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
@@ -1177,6 +1177,8 @@ export namespace SessionPrompt {
           const { Skill } = await import("@/skill/skill")
           const skillInfo = await Skill.get(part.name)
           if (skillInfo) {
+            const parsed = await ConfigMarkdown.parse(skillInfo.location).catch(() => undefined)
+            const skillContent = parsed?.content?.trim()
             return [
               {
                 id: Identifier.ascending("part"),
@@ -1190,7 +1192,9 @@ export namespace SessionPrompt {
                 sessionID: input.sessionID,
                 type: "text",
                 synthetic: true,
-                text: `## Skill: ${skillInfo.name}\n\n${skillInfo.description}`,
+                text: skillContent
+                  ? `## Skill: ${skillInfo.name}\n\n${skillContent}`
+                  : `## Skill: ${skillInfo.name}\n\n${skillInfo.description}`,
               },
             ]
           }
@@ -1529,13 +1533,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const matchingInvocation = invocations[shellName] ?? invocations[""]
     const args = matchingInvocation?.args
 
-    const tmpId = Identifier.ascending("tool")
-    const tmpPath = path.join(Truncate.DIR, tmpId)
+    const stream = await Truncate.Stream.create()
     const WINDOW_SIZE = 50 * 1024
-    let output: Buffer | null = null
-    let outputSize = 0
-    let truncated = false
-    let writer: ReturnType<Bun.BunFile["writer"]> | null = null
 
     const proc = spawn(shell, args, {
       cwd: Instance.directory,
@@ -1548,29 +1547,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     })
 
     const handleChunk = (chunk: Buffer) => {
-      const str = chunk.toString()
-      outputSize += str.length
-
-      if (outputSize > WINDOW_SIZE) {
-        truncated = true
-        if (!writer) {
-          const tmpFile = Bun.file(tmpPath)
-          writer = tmpFile.writer()
-          if (output) {
-            writer.write(output)
-          }
-        }
-        writer.write(chunk)
-      } else {
-        if (output) {
-          output = Buffer.concat([output, chunk])
-        } else {
-          output = chunk
-        }
-      }
-
-      if (output) {
-        const preview = output.toString()
+      const preview = stream.append(chunk, { maxBytes: WINDOW_SIZE })
+      if (preview) {
         if (part.state.status === "running") {
           part.state.metadata = {
             output: preview,
@@ -1609,9 +1587,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
     })
 
-    if (truncated) {
-      await writer!.flush()
-    }
+    await stream.flush()
 
     msg.time.completed = Date.now()
     await Session.updateMessage(msg)
@@ -1619,18 +1595,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     if (part.state.status === "running") {
       if (aborted) {
         const metadataText = "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
-        if (truncated) {
-          await appendFile(tmpPath, metadataText)
-        } else if (output) {
-          output = Buffer.concat([output, Buffer.from(metadataText)])
+        if (stream.truncated) {
+          await stream.appendText(metadataText)
+        } else if (stream.output) {
+          stream.output = Buffer.concat([stream.output, Buffer.from(metadataText)])
         } else {
-          output = Buffer.from(metadataText)
+          stream.output = Buffer.from(metadataText)
         }
       }
 
-      if (truncated) {
-        const userPreview = output ? output.toString() : ""
-        const agentPreview = `${userPreview}\n\n...${outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${tmpPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
+      if (stream.truncated) {
+        const userPreview = stream.output ? stream.output.toString() : ""
+        const agentPreview = `${userPreview}\n\n...${stream.outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${stream.outputPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
         part.state = {
           status: "completed",
           time: {
@@ -1642,7 +1618,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           metadata: {
             output: userPreview,
             description: "",
-            outputPath: tmpPath,
+            outputPath: stream.outputPath,
           },
           output: agentPreview,
         }
@@ -1656,10 +1632,10 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           input: part.state.input,
           title: "",
           metadata: {
-            output: output ? output.toString("utf8") : "",
+            output: stream.output ? stream.output.toString("utf8") : "",
             description: "",
           },
-          output: output ? output.toString("utf8") : "",
+          output: stream.output ? stream.output.toString("utf8") : "",
         }
       }
       await Session.updatePart(part)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -134,6 +134,16 @@ export namespace SessionPrompt {
           .meta({
             ref: "AgentPartInput",
           }),
+        MessageV2.SkillPart.omit({
+          messageID: true,
+          sessionID: true,
+        })
+          .partial({
+            id: true,
+          })
+          .meta({
+            ref: "SkillPartInput",
+          }),
         MessageV2.SubtaskPart.omit({
           messageID: true,
           sessionID: true,
@@ -1162,6 +1172,39 @@ export namespace SessionPrompt {
           ]
         }
 
+        if (part.type === "skill") {
+          // Load skill content and add as synthetic text
+          const { Skill } = await import("@/skill/skill")
+          const skillInfo = await Skill.get(part.name)
+          if (skillInfo) {
+            return [
+              {
+                id: Identifier.ascending("part"),
+                ...part,
+                messageID: info.id,
+                sessionID: input.sessionID,
+              },
+              {
+                id: Identifier.ascending("part"),
+                messageID: info.id,
+                sessionID: input.sessionID,
+                type: "text",
+                synthetic: true,
+                text: `## Skill: ${skillInfo.name}\n\n${skillInfo.description}`,
+              },
+            ]
+          }
+          // If skill not found, just store the part without expansion
+          return [
+            {
+              id: Identifier.ascending("part"),
+              ...part,
+              messageID: info.id,
+              sessionID: input.sessionID,
+            },
+          ]
+        }
+
         return [
           {
             id: Identifier.ascending("part"),
@@ -1546,23 +1589,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const kill = () => Shell.killTree(proc, { exited: () => exited })
 
-    const cleanupFile = async () => {
-      if (!truncated) return
-      try {
-        await fs.unlink(tmpPath)
-      } catch {}
-    }
-
     if (abort.aborted) {
       aborted = true
       await kill()
-      await cleanupFile()
     }
 
     const abortHandler = () => {
       aborted = true
       void kill()
-      void cleanupFile()
     }
 
     abort.addEventListener("abort", abortHandler, { once: true })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1,6 +1,7 @@
+import { Buffer } from "buffer"
 import path from "path"
 import os from "os"
-import fs from "fs/promises"
+import fs, { appendFile } from "fs/promises"
 import z from "zod"
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
@@ -1485,6 +1486,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const matchingInvocation = invocations[shellName] ?? invocations[""]
     const args = matchingInvocation?.args
 
+    const tmpId = Identifier.ascending("tool")
+    const tmpPath = path.join(Truncate.DIR, tmpId)
+    const WINDOW_SIZE = 50 * 1024
+    let output: Buffer | null = null
+    let outputSize = 0
+    let truncated = false
+    let writer: ReturnType<Bun.BunFile["writer"]> | null = null
+
     const proc = spawn(shell, args, {
       cwd: Instance.directory,
       detached: process.platform !== "win32",
@@ -1495,43 +1504,65 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     })
 
-    let output = ""
+    const handleChunk = (chunk: Buffer) => {
+      const str = chunk.toString()
+      outputSize += str.length
 
-    proc.stdout?.on("data", (chunk) => {
-      output += chunk.toString()
-      if (part.state.status === "running") {
-        part.state.metadata = {
-          output: output,
-          description: "",
+      if (outputSize > WINDOW_SIZE) {
+        truncated = true
+        if (!writer) {
+          const tmpFile = Bun.file(tmpPath)
+          writer = tmpFile.writer()
+          if (output) {
+            writer.write(output)
+          }
         }
-        Session.updatePart(part)
+        writer.write(chunk)
+      } else {
+        if (output) {
+          output = Buffer.concat([output, chunk])
+        } else {
+          output = chunk
+        }
       }
-    })
 
-    proc.stderr?.on("data", (chunk) => {
-      output += chunk.toString()
-      if (part.state.status === "running") {
-        part.state.metadata = {
-          output: output,
-          description: "",
+      if (output) {
+        const preview = output.toString()
+        if (part.state.status === "running") {
+          part.state.metadata = {
+            output: preview,
+            description: "",
+          }
+          Session.updatePart(part)
         }
-        Session.updatePart(part)
       }
-    })
+    }
+
+    proc.stdout?.on("data", handleChunk)
+    proc.stderr?.on("data", handleChunk)
 
     let aborted = false
     let exited = false
 
     const kill = () => Shell.killTree(proc, { exited: () => exited })
 
+    const cleanupFile = async () => {
+      if (!truncated) return
+      try {
+        await fs.unlink(tmpPath)
+      } catch {}
+    }
+
     if (abort.aborted) {
       aborted = true
       await kill()
+      await cleanupFile()
     }
 
     const abortHandler = () => {
       aborted = true
       void kill()
+      void cleanupFile()
     }
 
     abort.addEventListener("abort", abortHandler, { once: true })
@@ -1544,25 +1575,58 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
     })
 
-    if (aborted) {
-      output += "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+    if (truncated) {
+      await writer!.flush()
     }
+
     msg.time.completed = Date.now()
     await Session.updateMessage(msg)
+
     if (part.state.status === "running") {
-      part.state = {
-        status: "completed",
-        time: {
-          ...part.state.time,
-          end: Date.now(),
-        },
-        input: part.state.input,
-        title: "",
-        metadata: {
-          output,
-          description: "",
-        },
-        output,
+      if (aborted) {
+        const metadataText = "\n\n" + ["<metadata>", "User aborted the command", "</metadata>"].join("\n")
+        if (truncated) {
+          await appendFile(tmpPath, metadataText)
+        } else if (output) {
+          output = Buffer.concat([output, Buffer.from(metadataText)])
+        } else {
+          output = Buffer.from(metadataText)
+        }
+      }
+
+      if (truncated) {
+        const userPreview = output ? output.toString() : ""
+        const agentPreview = `${userPreview}\n\n...${outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${tmpPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
+        part.state = {
+          status: "completed",
+          time: {
+            ...part.state.time,
+            end: Date.now(),
+          },
+          input: part.state.input,
+          title: "",
+          metadata: {
+            output: userPreview,
+            description: "",
+            outputPath: tmpPath,
+          },
+          output: agentPreview,
+        }
+      } else {
+        part.state = {
+          status: "completed",
+          time: {
+            ...part.state.time,
+            end: Date.now(),
+          },
+          input: part.state.input,
+          title: "",
+          metadata: {
+            output: output ? output.toString("utf8") : "",
+            description: "",
+          },
+          output: output ? output.toString("utf8") : "",
+        }
       }
       await Session.updatePart(part)
     }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,12 +1,9 @@
 import { Buffer } from "buffer"
 import z from "zod"
-import { appendFile } from "fs/promises"
-import fs from "fs/promises"
 import { spawn } from "child_process"
 import { Tool } from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
-import { Identifier } from "../id/id"
 import { Instance } from "../project/instance"
 import { lazy } from "@/util/lazy"
 import { Language } from "web-tree-sitter"
@@ -81,7 +78,20 @@ export const BashTool = Tool.define("bash", async () => {
     formatValidationError(error: any): string {
       return error.errors.map((e: any) => `${e.path.join(".")}: ${e.message}`).join("\n")
     },
-    async execute(params, ctx) {
+    async execute(
+      params,
+      ctx,
+    ): Promise<{
+      title: string
+      metadata: {
+        output: string
+        truncated: boolean
+        exit: number | null
+        description: string
+        outputPath: string
+      }
+      output: string
+    }> {
       const cwd = params.workdir || Instance.directory
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
@@ -161,17 +171,8 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
-      // Use Buffer for accumulation. When exceeding WINDOW_SIZE,
-      // switch to file streaming to avoid O(n²) memory growth.
-      const tmpId = Identifier.ascending("tool")
-      const tmpPath = path.join(Truncate.DIR, tmpId)
-      await fs.mkdir(Truncate.DIR, { recursive: true })
+      const stream = await Truncate.Stream.create()
       const WINDOW_SIZE = 50 * 1024
-      let output: Buffer | null = null
-      let outputSize = 0
-      let lineCount = 0
-      let truncated = false
-      let writer: ReturnType<Bun.BunFile["writer"]> | null = null
 
       const proc = spawn(params.command, {
         shell,
@@ -191,30 +192,8 @@ export const BashTool = Tool.define("bash", async () => {
       })
 
       const append = (chunk: Buffer) => {
-        const str = chunk.toString()
-        outputSize += str.length
-        lineCount += (str.match(/\n/g) || []).length
-
-        if (lineCount > Truncate.MAX_LINES || outputSize > WINDOW_SIZE) {
-          truncated = true
-          if (!writer) {
-            const tmpFile = Bun.file(tmpPath)
-            writer = tmpFile.writer()
-            if (output) {
-              writer.write(output)
-            }
-          }
-          writer.write(chunk)
-        } else {
-          if (output) {
-            output = Buffer.concat([output, chunk])
-          } else {
-            output = chunk
-          }
-        }
-
-        if (output) {
-          const preview = output.toString()
+        const preview = stream.append(chunk, { maxBytes: WINDOW_SIZE, maxLines: Truncate.MAX_LINES })
+        if (preview) {
           ctx.metadata({
             metadata: {
               output: preview,
@@ -233,23 +212,14 @@ export const BashTool = Tool.define("bash", async () => {
 
       const kill = () => Shell.killTree(proc, { exited: () => exited })
 
-      const cleanupFile = async () => {
-        if (!truncated) return
-        try {
-          await fs.unlink(tmpPath)
-        } catch {}
-      }
-
       if (ctx.abort.aborted) {
         aborted = true
         await kill()
-        await cleanupFile()
       }
 
       const abortHandler = () => {
         aborted = true
         void kill()
-        void cleanupFile()
       }
 
       ctx.abort.addEventListener("abort", abortHandler, { once: true })
@@ -279,13 +249,11 @@ export const BashTool = Tool.define("bash", async () => {
           })
         })
       } catch (err) {
-        await cleanupFile()
+        await stream.cleanup()
         throw err
       }
 
-      if (truncated) {
-        await writer!.flush()
-      }
+      await stream.flush()
 
       const resultMetadata: string[] = []
 
@@ -297,23 +265,23 @@ export const BashTool = Tool.define("bash", async () => {
         resultMetadata.push("User aborted the command")
       }
 
-      if (truncated) {
+      if (stream.truncated) {
         if (resultMetadata.length > 0) {
           const metadataText = "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
-          await appendFile(tmpPath, metadataText)
+          await stream.appendText(metadataText)
         }
 
-        const userPreview = output ? (output as Buffer).toString() : ""
-        const agentPreview = `${userPreview}\n\n...${outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${tmpPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
+        const userPreview = stream.output ? stream.output.toString() : ""
+        const agentPreview = `${userPreview}\n\n...${stream.outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${stream.outputPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
 
         return {
           title: params.description,
           metadata: {
             output: userPreview,
-            truncated,
+            truncated: stream.truncated,
             exit: proc.exitCode,
             description: params.description,
-            outputPath: tmpPath,
+            outputPath: stream.outputPath,
           },
           output: agentPreview,
         }
@@ -321,20 +289,20 @@ export const BashTool = Tool.define("bash", async () => {
 
       if (resultMetadata.length > 0) {
         const metadataText = "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
-        if (output) {
-          output = Buffer.concat([output, Buffer.from(metadataText)])
+        if (stream.output) {
+          stream.output = Buffer.concat([stream.output, Buffer.from(metadataText)])
         } else {
-          output = Buffer.from(metadataText)
+          stream.output = Buffer.from(metadataText)
         }
       }
 
-      const outputStr = output ? (output as Buffer).toString() : ""
+      const outputStr = stream.output ? stream.output.toString() : ""
 
       return {
         title: params.description,
         metadata: {
           output: outputStr,
-          truncated,
+          truncated: stream.truncated,
           exit: proc.exitCode,
           description: params.description,
           outputPath: "",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,9 +1,12 @@
+import { Buffer } from "buffer"
 import z from "zod"
+import { appendFile } from "fs/promises"
+import fs from "fs/promises"
 import { spawn } from "child_process"
 import { Tool } from "./tool"
 import path from "path"
 import DESCRIPTION from "./bash.txt"
-import { Log } from "../util/log"
+import { Identifier } from "../id/id"
 import { Instance } from "../project/instance"
 import { lazy } from "@/util/lazy"
 import { Language } from "web-tree-sitter"
@@ -17,7 +20,8 @@ import { Shell } from "@/shell/shell"
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
 
-const MAX_METADATA_LENGTH = 30_000
+import { Log } from "../util/log"
+
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 
 export const log = Log.create({ service: "bash-tool" })
@@ -71,9 +75,12 @@ export const BashTool = Tool.define("bash", async () => {
       description: z
         .string()
         .describe(
-          "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
+          "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working directory status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
         ),
     }),
+    formatValidationError(error: any): string {
+      return error.errors.map((e: any) => `${e.path.join(".")}: ${e.message}`).join("\n")
+    },
     async execute(params, ctx) {
       const cwd = params.workdir || Instance.directory
       if (params.timeout !== undefined && params.timeout < 0) {
@@ -154,6 +161,18 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
+      // Use Buffer for accumulation. When exceeding WINDOW_SIZE,
+      // switch to file streaming to avoid O(n²) memory growth.
+      const tmpId = Identifier.ascending("tool")
+      const tmpPath = path.join(Truncate.DIR, tmpId)
+      await fs.mkdir(Truncate.DIR, { recursive: true })
+      const WINDOW_SIZE = 50 * 1024
+      let output: Buffer | null = null
+      let outputSize = 0
+      let lineCount = 0
+      let truncated = false
+      let writer: ReturnType<Bun.BunFile["writer"]> | null = null
+
       const proc = spawn(params.command, {
         shell,
         cwd,
@@ -164,9 +183,6 @@ export const BashTool = Tool.define("bash", async () => {
         detached: process.platform !== "win32",
       })
 
-      let output = ""
-
-      // Initialize metadata with empty output
       ctx.metadata({
         metadata: {
           output: "",
@@ -175,14 +191,37 @@ export const BashTool = Tool.define("bash", async () => {
       })
 
       const append = (chunk: Buffer) => {
-        output += chunk.toString()
-        ctx.metadata({
-          metadata: {
-            // truncate the metadata to avoid GIANT blobs of data (has nothing to do w/ what agent can access)
-            output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
-            description: params.description,
-          },
-        })
+        const str = chunk.toString()
+        outputSize += str.length
+        lineCount += (str.match(/\n/g) || []).length
+
+        if (lineCount > Truncate.MAX_LINES || outputSize > WINDOW_SIZE) {
+          truncated = true
+          if (!writer) {
+            const tmpFile = Bun.file(tmpPath)
+            writer = tmpFile.writer()
+            if (output) {
+              writer.write(output)
+            }
+          }
+          writer.write(chunk)
+        } else {
+          if (output) {
+            output = Buffer.concat([output, chunk])
+          } else {
+            output = chunk
+          }
+        }
+
+        if (output) {
+          const preview = output.toString()
+          ctx.metadata({
+            metadata: {
+              output: preview,
+              description: params.description,
+            },
+          })
+        }
       }
 
       proc.stdout?.on("data", append)
@@ -194,14 +233,23 @@ export const BashTool = Tool.define("bash", async () => {
 
       const kill = () => Shell.killTree(proc, { exited: () => exited })
 
+      const cleanupFile = async () => {
+        if (!truncated) return
+        try {
+          await fs.unlink(tmpPath)
+        } catch {}
+      }
+
       if (ctx.abort.aborted) {
         aborted = true
         await kill()
+        await cleanupFile()
       }
 
       const abortHandler = () => {
         aborted = true
         void kill()
+        void cleanupFile()
       }
 
       ctx.abort.addEventListener("abort", abortHandler, { once: true })
@@ -211,24 +259,33 @@ export const BashTool = Tool.define("bash", async () => {
         void kill()
       }, timeout + 100)
 
-      await new Promise<void>((resolve, reject) => {
-        const cleanup = () => {
-          clearTimeout(timeoutTimer)
-          ctx.abort.removeEventListener("abort", abortHandler)
-        }
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const cleanup = () => {
+            clearTimeout(timeoutTimer)
+            ctx.abort.removeEventListener("abort", abortHandler)
+          }
 
-        proc.once("exit", () => {
-          exited = true
-          cleanup()
-          resolve()
-        })
+          proc.once("exit", () => {
+            exited = true
+            cleanup()
+            resolve()
+          })
 
-        proc.once("error", (error) => {
-          exited = true
-          cleanup()
-          reject(error)
+          proc.once("error", (error) => {
+            exited = true
+            cleanup()
+            reject(error)
+          })
         })
-      })
+      } catch (err) {
+        await cleanupFile()
+        throw err
+      }
+
+      if (truncated) {
+        await writer!.flush()
+      }
 
       const resultMetadata: string[] = []
 
@@ -240,18 +297,49 @@ export const BashTool = Tool.define("bash", async () => {
         resultMetadata.push("User aborted the command")
       }
 
-      if (resultMetadata.length > 0) {
-        output += "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
+      if (truncated) {
+        if (resultMetadata.length > 0) {
+          const metadataText = "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
+          await appendFile(tmpPath, metadataText)
+        }
+
+        const userPreview = output ? (output as Buffer).toString() : ""
+        const agentPreview = `${userPreview}\n\n...${outputSize - WINDOW_SIZE} bytes truncated...\n\nThe tool call succeeded but the output was truncated. Full output saved to: ${tmpPath}\nGrep to search the full content or Read with offset/limit to view specific sections.\nIf Task tool is available, delegate that to an explore agent.`
+
+        return {
+          title: params.description,
+          metadata: {
+            output: userPreview,
+            truncated,
+            exit: proc.exitCode,
+            description: params.description,
+            outputPath: tmpPath,
+          },
+          output: agentPreview,
+        }
       }
+
+      if (resultMetadata.length > 0) {
+        const metadataText = "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
+        if (output) {
+          output = Buffer.concat([output, Buffer.from(metadataText)])
+        } else {
+          output = Buffer.from(metadataText)
+        }
+      }
+
+      const outputStr = output ? (output as Buffer).toString() : ""
 
       return {
         title: params.description,
         metadata: {
-          output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
+          output: outputStr,
+          truncated,
           exit: proc.exitCode,
           description: params.description,
+          outputPath: "",
         },
-        output,
+        output: outputStr,
       }
     },
   }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -6,6 +6,7 @@ import { Truncate } from "./truncation"
 
 export namespace Tool {
   interface Metadata {
+    truncated?: boolean
     [key: string]: any
   }
 

--- a/packages/opencode/src/tool/truncation.ts
+++ b/packages/opencode/src/tool/truncation.ts
@@ -1,4 +1,4 @@
-import fs from "fs/promises"
+import fs, { appendFile } from "fs/promises"
 import path from "path"
 import { Global } from "../global"
 import { Identifier } from "../id/id"
@@ -20,6 +20,80 @@ export namespace Truncate {
     maxLines?: number
     maxBytes?: number
     direction?: "head" | "tail"
+  }
+
+  export class Stream {
+    static async create() {
+      await fs.mkdir(DIR, { recursive: true })
+      return new Stream(path.join(DIR, Identifier.ascending("tool")))
+    }
+
+    readonly outputPath: string
+    output: Buffer | null = null
+    outputSize = 0
+    lineCount = 0
+    truncated = false
+    private writer: ReturnType<Bun.BunFile["writer"]> | null = null
+
+    private constructor(outputPath: string) {
+      this.outputPath = outputPath
+    }
+
+    append(
+      chunk: Buffer,
+      options: {
+        maxBytes?: number
+        maxLines?: number
+      } = {},
+    ) {
+      const str = chunk.toString()
+      const nextOutputSize = this.outputSize + str.length
+      const nextLineCount = this.lineCount + (str.match(/\n/g) || []).length
+      const shouldTruncate =
+        nextOutputSize > (options.maxBytes ?? Number.POSITIVE_INFINITY) ||
+        nextLineCount > (options.maxLines ?? Number.POSITIVE_INFINITY)
+
+      this.outputSize += str.length
+      this.lineCount = nextLineCount
+      if (shouldTruncate) {
+        this.truncated = true
+      }
+
+      if (this.truncated) {
+        if (!this.writer) {
+          const tmpFile = Bun.file(this.outputPath)
+          this.writer = tmpFile.writer()
+          if (this.output) {
+            this.writer.write(this.output)
+          }
+        }
+        this.writer.write(chunk)
+      } else if (this.output) {
+        this.output = Buffer.concat([this.output, chunk])
+      } else {
+        this.output = chunk
+      }
+
+      return this.output ? this.output.toString() : null
+    }
+
+    async flush() {
+      if (!this.truncated || !this.writer) return
+      await this.writer.flush()
+    }
+
+    async appendText(text: string) {
+      if (!this.truncated) return
+      await this.flush()
+      await appendFile(this.outputPath, text)
+    }
+
+    async cleanup() {
+      if (!this.truncated) return
+      try {
+        await fs.unlink(this.outputPath)
+      } catch {}
+    }
   }
 
   export function init() {

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -317,4 +317,37 @@ describe("tool.bash truncation", () => {
       },
     })
   })
+
+  test("preserves truncated output file when aborted", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const controller = new AbortController()
+
+        setTimeout(() => controller.abort(), 50)
+
+        const lineCount = Truncate.MAX_LINES + 500
+        const result = await bash.execute(
+          {
+            command: `seq 1 ${lineCount}; sleep 5`,
+            description: "Generate output then wait for abort",
+          },
+          {
+            ...ctx,
+            abort: controller.signal,
+          },
+        )
+
+        expect((result.metadata as any).truncated).toBe(true)
+        const filepath = (result.metadata as any).outputPath
+        expect(filepath).toBeTruthy()
+
+        const saved = await Bun.file(filepath).text()
+        expect(saved).toContain("1\n")
+        expect(saved).toContain(String(lineCount))
+        expect(saved).toContain("User aborted the command")
+      },
+    })
+  })
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -134,6 +134,7 @@ import type {
   SessionUnshareResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SkillPartInput,
   SubtaskPartInput,
   TextPartInput,
   ToolIdsErrors,
@@ -1364,7 +1365,7 @@ export class Session extends HeyApiClient {
       }
       system?: string
       variant?: string
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1452,7 +1453,7 @@ export class Session extends HeyApiClient {
       }
       system?: string
       variant?: string
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -421,6 +421,19 @@ export type AgentPart = {
   }
 }
 
+export type SkillPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "skill"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
 export type RetryPart = {
   id: string
   sessionID: string
@@ -465,6 +478,7 @@ export type Part =
   | SnapshotPart
   | PatchPart
   | AgentPart
+  | SkillPart
   | RetryPart
   | CompactionPart
 
@@ -1960,6 +1974,17 @@ export type AgentPartInput = {
   }
 }
 
+export type SkillPartInput = {
+  id?: string
+  type: "skill"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
 export type SubtaskPartInput = {
   id?: string
   type: "subtask"
@@ -3233,7 +3258,7 @@ export type SessionPromptData = {
     }
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     /**
@@ -3420,7 +3445,7 @@ export type SessionPromptAsyncData = {
     }
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2267,6 +2267,9 @@
                           "$ref": "#/components/schemas/AgentPartInput"
                         },
                         {
+                          "$ref": "#/components/schemas/SkillPartInput"
+                        },
+                        {
                           "$ref": "#/components/schemas/SubtaskPartInput"
                         }
                       ]
@@ -2641,6 +2644,9 @@
                         },
                         {
                           "$ref": "#/components/schemas/AgentPartInput"
+                        },
+                        {
+                          "$ref": "#/components/schemas/SkillPartInput"
                         },
                         {
                           "$ref": "#/components/schemas/SubtaskPartInput"
@@ -6942,6 +6948,47 @@
         },
         "required": ["id", "sessionID", "messageID", "type", "name"]
       },
+      "SkillPart": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sessionID": {
+            "type": "string"
+          },
+          "messageID": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "skill"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "start": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "end": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": ["value", "start", "end"]
+          }
+        },
+        "required": ["id", "sessionID", "messageID", "type", "name"]
+      },
       "RetryPart": {
         "type": "object",
         "properties": {
@@ -7069,6 +7116,9 @@
           },
           {
             "$ref": "#/components/schemas/AgentPart"
+          },
+          {
+            "$ref": "#/components/schemas/SkillPart"
           },
           {
             "$ref": "#/components/schemas/RetryPart"
@@ -10212,6 +10262,41 @@
           "type": {
             "type": "string",
             "const": "agent"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              },
+              "start": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              },
+              "end": {
+                "type": "integer",
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": ["value", "start", "end"]
+          }
+        },
+        "required": ["type", "name"]
+      },
+      "SkillPartInput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "const": "skill"
           },
           "name": {
             "type": "string"


### PR DESCRIPTION
## What changed

- Added inline `$skill` autocomplete and ensured skill parts load actual `SKILL.md` instructions.
- Fixed truncation/file handling regressions in the session shell path and bash tool.
- Shared the streaming truncation implementation through `Truncate.Stream` to remove duplicated logic.

## Validation

- `bun test test/tool/bash.test.ts`
- `bun run typecheck`
