### PR TITLE
fix(tui): Prevent out-of-order project.sync() responses from overwriting state with stale data.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/project.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/project.tsx
@@ -33,12 +33,15 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
       },
     })
 
-    async function sync() {
+    let sync_seqnr = 0
+    async function sync(seqnr = ++sync_seqnr) {
       const workspace = store.workspace.current
       const [path, project] = await Promise.all([
         sdk.client.path.get({ workspace }),
         sdk.client.project.current({ workspace }),
       ])
+
+      if (seqnr < sync_seqnr) return
 
       batch(() => {
         setStore("instance", "path", reconcile(path.data || defaultPath))

--- a/packages/opencode/src/cli/cmd/tui/context/project.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/project.tsx
@@ -10,6 +10,7 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
   name: "Project",
   init: () => {
     const sdk = useSDK()
+    let sync_seqnr = 0
 
     const defaultPath = {
       home: "",
@@ -33,7 +34,6 @@ export const { use: useProject, provider: ProjectProvider } = createSimpleContex
       },
     })
 
-    let sync_seqnr = 0
     async function sync(seqnr = ++sync_seqnr) {
       const workspace = store.workspace.current
       const [path, project] = await Promise.all([


### PR DESCRIPTION
### Issue for this PR

Closes #22450

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If results from project.sync() arrive out of order, only keep the most recent one.

### How did you verify your code works?

I had a 100% reproducible case where the race occurred and using the stale instance did break things for me. I added extensive debug output to determine exactly what was the root cause.
After applying this patch everything worked again as expected.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
