### PR TITLE
Fix diff line number contrast for built-in themes

### DIFF
--- a/.opencode/themes/mytheme.json
+++ b/.opencode/themes/mytheme.json
@@ -116,8 +116,8 @@
       "light": "nord5"
     },
     "diffLineNumber": {
-      "dark": "nord2",
-      "light": "nord4"
+      "dark": "#abafb7",
+      "light": "#65686d"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3B4252",

--- a/.opencode/themes/mytheme.json
+++ b/.opencode/themes/mytheme.json
@@ -117,7 +117,7 @@
     },
     "diffLineNumber": {
       "dark": "#abafb7",
-      "light": "#65686d"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3B4252",

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -542,8 +542,10 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
   const diffAlpha = isDark ? 0.22 : 0.14
   const diffAddedBg = tint(bg, ansiColors.green, diffAlpha)
   const diffRemovedBg = tint(bg, ansiColors.red, diffAlpha)
-  const diffAddedLineNumberBg = tint(grays[3], ansiColors.green, diffAlpha)
-  const diffRemovedLineNumberBg = tint(grays[3], ansiColors.red, diffAlpha)
+  const diffContextBg = grays[2]
+  const diffAddedLineNumberBg = tint(diffContextBg, ansiColors.green, diffAlpha)
+  const diffRemovedLineNumberBg = tint(diffContextBg, ansiColors.red, diffAlpha)
+  const diffLineNumber = textMuted
 
   return {
     theme: {
@@ -583,8 +585,8 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
       diffHighlightRemoved: ansiColors.redBright,
       diffAddedBg,
       diffRemovedBg,
-      diffContextBg: grays[1],
-      diffLineNumber: grays[6],
+      diffContextBg,
+      diffLineNumber,
       diffAddedLineNumberBg,
       diffRemovedLineNumberBg,
 

--- a/packages/opencode/src/cli/cmd/tui/context/theme/aura.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/aura.json
@@ -39,7 +39,7 @@
     "diffAddedBg": "#354933",
     "diffRemovedBg": "#3f191a",
     "diffContextBg": "darkBgPanel",
-    "diffLineNumber": "darkBorder",
+    "diffLineNumber": "#898989",
     "diffAddedLineNumberBg": "#162620",
     "diffRemovedLineNumberBg": "#26161a",
     "markdownText": "darkFg",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
@@ -50,7 +50,7 @@
     "diffAddedBg": "#20303b",
     "diffRemovedBg": "#37222c",
     "diffContextBg": "darkPanel",
-    "diffLineNumber": "darkGutter",
+    "diffLineNumber": "#8c919c",
     "diffAddedLineNumberBg": "#1b2b34",
     "diffRemovedLineNumberBg": "#2d1f26",
     "markdownText": "darkFg",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/ayu.json
@@ -50,7 +50,7 @@
     "diffAddedBg": "#20303b",
     "diffRemovedBg": "#37222c",
     "diffContextBg": "darkPanel",
-    "diffLineNumber": "#8c919c",
+    "diffLineNumber": "diffContext",
     "diffAddedLineNumberBg": "#1b2b34",
     "diffRemovedLineNumberBg": "#2d1f26",
     "markdownText": "darkFg",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
@@ -142,7 +142,7 @@
     },
     "diffLineNumber": {
       "dark": "#808792",
-      "light": "lfg3"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "diffGreenBg",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/carbonfox.json
@@ -141,7 +141,7 @@
       "light": "lbg1"
     },
     "diffLineNumber": {
-      "dark": "fg3",
+      "dark": "#808792",
       "light": "lfg3"
     },
     "diffAddedLineNumberBg": {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
@@ -126,8 +126,8 @@
       "light": "frappeMantle"
     },
     "diffLineNumber": {
-      "dark": "frappeSurface1",
-      "light": "frappeSurface1"
+      "dark": "#8f93a1",
+      "light": "#8f93a1"
     },
     "diffAddedLineNumberBg": {
       "dark": "#223025",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-frappe.json
@@ -125,10 +125,7 @@
       "dark": "frappeMantle",
       "light": "frappeMantle"
     },
-    "diffLineNumber": {
-      "dark": "#8f93a1",
-      "light": "#8f93a1"
-    },
+    "diffLineNumber": "textMuted",
     "diffAddedLineNumberBg": {
       "dark": "#223025",
       "light": "#223025"

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
@@ -126,8 +126,8 @@
       "light": "macMantle"
     },
     "diffLineNumber": {
-      "dark": "macSurface1",
-      "light": "macSurface1"
+      "dark": "#9294a2",
+      "light": "#9294a2"
     },
     "diffAddedLineNumberBg": {
       "dark": "#223025",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin-macchiato.json
@@ -125,10 +125,7 @@
       "dark": "macMantle",
       "light": "macMantle"
     },
-    "diffLineNumber": {
-      "dark": "#9294a2",
-      "light": "#9294a2"
-    },
+    "diffLineNumber": "textMuted",
     "diffAddedLineNumberBg": {
       "dark": "#223025",
       "light": "#223025"

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
@@ -79,7 +79,7 @@
     "diffAddedBg": { "dark": "#24312b", "light": "#d6f0d9" },
     "diffRemovedBg": { "dark": "#3c2a32", "light": "#f6dfe2" },
     "diffContextBg": { "dark": "darkMantle", "light": "lightMantle" },
-    "diffLineNumber": { "dark": "#8c8d99", "light": "#5b5d63" },
+    "diffLineNumber": { "dark": "textMuted", "light": "#5b5d63" },
     "diffAddedLineNumberBg": { "dark": "#1e2a25", "light": "#c9e3cb" },
     "diffRemovedLineNumberBg": { "dark": "#32232a", "light": "#e9d3d6" },
     "markdownText": { "dark": "darkText", "light": "lightText" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/catppuccin.json
@@ -79,7 +79,7 @@
     "diffAddedBg": { "dark": "#24312b", "light": "#d6f0d9" },
     "diffRemovedBg": { "dark": "#3c2a32", "light": "#f6dfe2" },
     "diffContextBg": { "dark": "darkMantle", "light": "lightMantle" },
-    "diffLineNumber": { "dark": "darkSurface1", "light": "lightSurface1" },
+    "diffLineNumber": { "dark": "#8c8d99", "light": "#5b5d63" },
     "diffAddedLineNumberBg": { "dark": "#1e2a25", "light": "#c9e3cb" },
     "diffRemovedLineNumberBg": { "dark": "#32232a", "light": "#e9d3d6" },
     "markdownText": { "dark": "darkText", "light": "lightText" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
@@ -120,10 +120,7 @@
       "dark": "#122738",
       "light": "#f5f7fa"
     },
-    "diffLineNumber": {
-      "dark": "#849fb2",
-      "light": "#656d71"
-    },
+    "diffLineNumber": "textMuted",
     "diffAddedLineNumberBg": {
       "dark": "#1a3a2a",
       "light": "#e8f5e9"

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cobalt2.json
@@ -121,8 +121,8 @@
       "light": "#f5f7fa"
     },
     "diffLineNumber": {
-      "dark": "#2d5a7b",
-      "light": "#b0bec5"
+      "dark": "#849fb2",
+      "light": "#656d71"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1a3a2a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
@@ -142,8 +142,8 @@
       "light": "lightPanel"
     },
     "diffLineNumber": {
-      "dark": "#e4e4e442",
-      "light": "#1414147a"
+      "dark": "#eeeeee87",
+      "light": "#10101099"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3fa26633",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
@@ -143,7 +143,7 @@
     },
     "diffLineNumber": {
       "dark": "#eeeeee87",
-      "light": "#10101099"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3fa26633",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/dracula.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/dracula.json
@@ -112,8 +112,8 @@
       "light": "#e8e8e2"
     },
     "diffLineNumber": {
-      "dark": "currentLine",
-      "light": "#c8c8c2"
+      "dark": "#989aa4",
+      "light": "#686865"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1a3a1a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/everforest.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/everforest.json
@@ -134,8 +134,8 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "darkStep3",
-      "light": "lightStep3"
+      "dark": "#a0a5a7",
+      "light": "#5b5951"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1b2b34",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/flexoki.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/flexoki.json
@@ -130,8 +130,8 @@
       "light": "base50"
     },
     "diffLineNumber": {
-      "dark": "base600",
-      "light": "base600"
+      "dark": "#888883",
+      "light": "#5a5955"
     },
     "diffAddedLineNumberBg": {
       "dark": "#152515",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/github.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/github.json
@@ -126,8 +126,8 @@
       "light": "lightBgAlt"
     },
     "diffLineNumber": {
-      "dark": "#484f58",
-      "light": "#afb8c1"
+      "dark": "#95999e",
+      "light": "#676c71"
     },
     "diffAddedLineNumberBg": {
       "dark": "#033a16",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/github.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/github.json
@@ -127,7 +127,7 @@
     },
     "diffLineNumber": {
       "dark": "#95999e",
-      "light": "#676c71"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#033a16",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/gruvbox.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/gruvbox.json
@@ -135,8 +135,8 @@
       "light": "lightBg1"
     },
     "diffLineNumber": {
-      "dark": "darkBg3",
-      "light": "lightBg3"
+      "dark": "#a8a29e",
+      "light": "#564f43"
     },
     "diffAddedLineNumberBg": {
       "dark": "#2a2827",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/kanagawa.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/kanagawa.json
@@ -47,7 +47,7 @@
     "diffAddedBg": { "dark": "#252E25", "light": "#EAF3E4" },
     "diffRemovedBg": { "dark": "#362020", "light": "#FBE6E6" },
     "diffContextBg": { "dark": "sumiInk1", "light": "lightPaper" },
-    "diffLineNumber": { "dark": "sumiInk3", "light": "#C7BEB4" },
+    "diffLineNumber": { "dark": "#9090a0", "light": "#65615c" },
     "diffAddedLineNumberBg": { "dark": "#202820", "light": "#DDE8D6" },
     "diffRemovedLineNumberBg": { "dark": "#2D1C1C", "light": "#F2DADA" },
     "markdownText": { "dark": "fujiWhite", "light": "lightText" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
@@ -129,10 +129,7 @@
       "dark": "transparent",
       "light": "transparent"
     },
-    "diffLineNumber": {
-      "dark": "#767676",
-      "light": "#999999"
-    },
+    "diffLineNumber": "textMuted",
     "diffAddedLineNumberBg": {
       "dark": "transparent",
       "light": "transparent"

--- a/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
@@ -130,7 +130,7 @@
       "light": "transparent"
     },
     "diffLineNumber": {
-      "dark": "#666666",
+      "dark": "#767676",
       "light": "#999999"
     },
     "diffAddedLineNumberBg": {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/material.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/material.json
@@ -128,8 +128,8 @@
       "light": "lightBgAlt"
     },
     "diffLineNumber": {
-      "dark": "#37474f",
-      "light": "#cfd8dc"
+      "dark": "#9aa2a6",
+      "light": "#6a6e70"
     },
     "diffAddedLineNumberBg": {
       "dark": "#2e3c2b",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
@@ -47,7 +47,7 @@
     "diffAddedBg": { "dark": "#132616", "light": "#e0efde" },
     "diffRemovedBg": { "dark": "#261212", "light": "#f9e5e5" },
     "diffContextBg": { "dark": "matrixInk1", "light": "lightPaper" },
-    "diffLineNumber": { "dark": "#7d847c", "light": "#556156" },
+    "diffLineNumber": { "dark": "textMuted", "light": "#556156" },
     "diffAddedLineNumberBg": { "dark": "#0f1b11", "light": "#d6e7d2" },
     "diffRemovedLineNumberBg": { "dark": "#1b1414", "light": "#f2d2d2" },
     "markdownText": { "dark": "rainGreenHi", "light": "lightText" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/matrix.json
@@ -47,7 +47,7 @@
     "diffAddedBg": { "dark": "#132616", "light": "#e0efde" },
     "diffRemovedBg": { "dark": "#261212", "light": "#f9e5e5" },
     "diffContextBg": { "dark": "matrixInk1", "light": "lightPaper" },
-    "diffLineNumber": { "dark": "matrixInk3", "light": "lightGray" },
+    "diffLineNumber": { "dark": "#7d847c", "light": "#556156" },
     "diffAddedLineNumberBg": { "dark": "#0f1b11", "light": "#d6e7d2" },
     "diffRemovedLineNumberBg": { "dark": "#1b1414", "light": "#f2d2d2" },
     "markdownText": { "dark": "rainGreenHi", "light": "lightText" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/monokai.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/monokai.json
@@ -114,8 +114,8 @@
       "light": "#f0f0f0"
     },
     "diffLineNumber": {
-      "dark": "#3e3d32",
-      "light": "#d0d0d0"
+      "dark": "#9b9b95",
+      "light": "#686868"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1a3a1a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/nightowl.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/nightowl.json
@@ -114,8 +114,8 @@
       "light": "nightOwlPanel"
     },
     "diffLineNumber": {
-      "dark": "nightOwlMuted",
-      "light": "nightOwlMuted"
+      "dark": "#7791a6",
+      "light": "#7791a6"
     },
     "diffAddedLineNumberBg": {
       "dark": "#0a2e1a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
@@ -116,8 +116,8 @@
       "light": "nord5"
     },
     "diffLineNumber": {
-      "dark": "nord2",
-      "light": "nord4"
+      "dark": "#a9aeb6",
+      "light": "#66696f"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3B4252",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/nord.json
@@ -117,7 +117,7 @@
     },
     "diffLineNumber": {
       "dark": "#a9aeb6",
-      "light": "#66696f"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#3B4252",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/one-dark.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/one-dark.json
@@ -51,7 +51,7 @@
     "diffAddedBg": { "dark": "#2c382b", "light": "#eafbe9" },
     "diffRemovedBg": { "dark": "#3a2d2f", "light": "#fce9e8" },
     "diffContextBg": { "dark": "darkBgAlt", "light": "lightBgAlt" },
-    "diffLineNumber": { "dark": "#495162", "light": "#c9c9ca" },
+    "diffLineNumber": { "dark": "#9398a2", "light": "#666666" },
     "diffAddedLineNumberBg": { "dark": "#283427", "light": "#e1f3df" },
     "diffRemovedLineNumberBg": { "dark": "#36292b", "light": "#f5e2e1" },
     "markdownText": { "dark": "darkFg", "light": "lightFg" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
@@ -138,8 +138,8 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "darkStep3",
-      "light": "lightStep3"
+      "dark": "#8f8f8f",
+      "light": "#595959"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1b2b34",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
@@ -142,7 +142,7 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "#8a8a8a",
+      "dark": "diffContext",
       "light": "#595755"
     },
     "diffAddedLineNumberBg": {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/orng.json
@@ -142,8 +142,8 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "darkStep3",
-      "light": "lightStep3"
+      "dark": "#8a8a8a",
+      "light": "#595755"
     },
     "diffAddedLineNumberBg": {
       "dark": "#162535",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/osaka-jade.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/osaka-jade.json
@@ -60,7 +60,7 @@
     "diffAddedBg": { "dark": "#15241c", "light": "#e0eee5" },
     "diffRemovedBg": { "dark": "#241515", "light": "#eee0e0" },
     "diffContextBg": { "dark": "darkBg1", "light": "lightBg1" },
-    "diffLineNumber": { "dark": "darkBg3", "light": "lightBg3" },
+    "diffLineNumber": { "dark": "#828b87", "light": "#5f5e4f" },
     "diffAddedLineNumberBg": { "dark": "#121f18", "light": "#d5e5da" },
     "diffRemovedLineNumberBg": { "dark": "#1f1212", "light": "#e5d5d5" },
     "markdownText": { "dark": "darkFg0", "light": "lightFg0" },

--- a/packages/opencode/src/cli/cmd/tui/context/theme/palenight.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/palenight.json
@@ -115,8 +115,8 @@
       "light": "#f5f5f5"
     },
     "diffLineNumber": {
-      "dark": "#444760",
-      "light": "#cfd8dc"
+      "dark": "#a0a2af",
+      "light": "#6a6e70"
     },
     "diffAddedLineNumberBg": {
       "dark": "#2e3c2b",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/rosepine.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/rosepine.json
@@ -127,8 +127,8 @@
       "light": "dawnSurface"
     },
     "diffLineNumber": {
-      "dark": "muted",
-      "light": "dawnMuted"
+      "dark": "#9491a6",
+      "light": "#6c6875"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1f2d3a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/solarized.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/solarized.json
@@ -116,8 +116,8 @@
       "light": "base2"
     },
     "diffLineNumber": {
-      "dark": "base01",
-      "light": "base1"
+      "dark": "#8b9b9f",
+      "light": "#5f6969"
     },
     "diffAddedLineNumberBg": {
       "dark": "#073642",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
@@ -119,8 +119,8 @@
       "light": "#f5f5f5"
     },
     "diffLineNumber": {
-      "dark": "#495495",
-      "light": "#b0b0b0"
+      "dark": "#959bc1",
+      "light": "#6d6d6d"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1a3a2a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/synthwave84.json
@@ -120,7 +120,7 @@
     },
     "diffLineNumber": {
       "dark": "#959bc1",
-      "light": "#6d6d6d"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1a3a2a",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/tokyonight.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/tokyonight.json
@@ -136,8 +136,8 @@
       "light": "lightStep2"
     },
     "diffLineNumber": {
-      "dark": "darkStep3",
-      "light": "lightStep3"
+      "dark": "#8f909a",
+      "light": "#59595b"
     },
     "diffAddedLineNumberBg": {
       "dark": "#1b2b34",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
@@ -138,7 +138,7 @@
       "light": "lightBackground"
     },
     "diffLineNumber": {
-      "dark": "gray600",
+      "dark": "#8a8a8a",
       "light": "lightGray600"
     },
     "diffAddedLineNumberBg": {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vercel.json
@@ -139,7 +139,7 @@
     },
     "diffLineNumber": {
       "dark": "#8a8a8a",
-      "light": "lightGray600"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#0F2613",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
@@ -111,7 +111,7 @@
       "light": "#F8F8F8"
     },
     "diffLineNumber": {
-      "dark": "#898989",
+      "dark": "textMuted",
       "light": "#6a6a6a"
     },
     "diffAddedLineNumberBg": {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/vesper.json
@@ -111,8 +111,8 @@
       "light": "#F8F8F8"
     },
     "diffLineNumber": {
-      "dark": "#505050",
-      "light": "#808080"
+      "dark": "#898989",
+      "light": "#6a6a6a"
     },
     "diffAddedLineNumberBg": {
       "dark": "#0d2818",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
@@ -117,7 +117,7 @@
     },
     "diffLineNumber": {
       "dark": "#d2d2d2",
-      "light": "#6e6e64"
+      "light": "textMuted"
     },
     "diffAddedLineNumberBg": {
       "dark": "#4f5f4f",

--- a/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/zenburn.json
@@ -116,8 +116,8 @@
       "light": "#f5f5e5"
     },
     "diffLineNumber": {
-      "dark": "#6f6f6f",
-      "light": "#b0b0a0"
+      "dark": "#d2d2d2",
+      "light": "#6e6e64"
     },
     "diffAddedLineNumberBg": {
       "dark": "#4f5f4f",


### PR DESCRIPTION
The diff line numbers were not actually using theme colors until just recently, which revealed that the diff line number color contrast was off for all themes. This should fix it.