### PR TITLE
core: prevent duplicate user messages in ACP clients

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -454,18 +454,9 @@ export namespace ACP {
             }
           }
           if (part.type !== "text" && part.type !== "file") return
-          const msg = await this.sdk.session
-            .message(
-              { sessionID: part.sessionID, messageID: part.messageID, directory: session.cwd },
-              { throwOnError: true },
-            )
-            .then((x) => x.data)
-            .catch((err) => {
-              log.error("failed to fetch message for user chunk", { error: err })
-              return undefined
-            })
-          if (!msg || msg.info.role !== "user") return
-          await this.processMessage({ info: msg.info, parts: [part] })
+          // ACP clients already know the prompt they just submitted, so replaying
+          // live user parts duplicates the message. We still replay user history in
+          // loadSession() and forkSession() via processMessage().
           return
         }
 

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -295,6 +295,46 @@ describe("acp.agent event subscription", () => {
     })
   })
 
+  test("does not emit user_message_chunk for live prompt parts", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { agent, controller, sessionUpdates, stop } = createFakeAgent()
+        const cwd = "/tmp/opencode-acp-test"
+        const sessionId = await agent.newSession({ cwd, mcpServers: [] } as any).then((x) => x.sessionId)
+
+        controller.push({
+          directory: cwd,
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              sessionID: sessionId,
+              time: Date.now(),
+              part: {
+                id: "part_1",
+                sessionID: sessionId,
+                messageID: "msg_user",
+                type: "text",
+                text: "hello",
+              },
+            },
+          },
+        } as any)
+
+        await new Promise((r) => setTimeout(r, 20))
+
+        expect(
+          sessionUpdates
+            .filter((u) => u.sessionId === sessionId)
+            .some((u) => u.update.sessionUpdate === "user_message_chunk"),
+        ).toBe(false)
+
+        stop()
+      },
+    })
+  })
+
   test("keeps concurrent sessions isolated when message.part.delta events are interleaved", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({


### PR DESCRIPTION
When using ACP (Agent Communication Protocol), clients already know the prompt they just submitted. Replaying live user parts as chunks was causing the same message to appear twice in the UI. Now we skip replaying user parts during live sessions while still maintaining full message history in loadSession() and forkSession().

### Issue for this PR

Closes #21910
