### PR TITLE
fix(cli): handlePluginAuth asks for api key only if authorize method exists

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -158,13 +158,13 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, 
   }
 
   if (method.type === "api") {
-    const key = await prompts.password({
-      message: "Enter your API key",
-      validate: (x) => (x && x.length > 0 ? undefined : "Required"),
-    })
-    if (prompts.isCancel(key)) throw new UI.CancelledError()
-
     if (method.authorize) {
+      const key = await prompts.password({
+        message: "Enter your API key",
+        validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+      })
+      if (prompts.isCancel(key)) throw new UI.CancelledError()
+
       const result = await method.authorize(inputs)
       if (result.type === "failed") {
         prompts.log.error("Failed to authorize")


### PR DESCRIPTION
### Issue for this PR

Closes #21637

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Followup for my prev fix in PR #21641 

The "opencode auth login" code in [providers.ts](https://github.com/anomalyco/opencode/blob/4f967d5bc05d545fde9deccdb632276ec642722e/packages/opencode/src/cli/cmd/providers.ts#L161) will ask for the "api key" twice if the auth plugin declares an auth of type "api" without an "authroize" method. 

### How did you verify your code works?

tested with this repro plugin: https://gist.github.com/goniz/81cf9b7538e2d537c2b42a891c5524e9


### Screenshots / recordings

before fix, on dev:
<img width="1206" height="474" alt="image" src="https://github.com/user-attachments/assets/d987d67a-1672-4008-abe2-e71e0579f582" />

on branch, after fix:
<img width="595" height="232" alt="image" src="https://github.com/user-attachments/assets/e04d3e45-d652-40b5-8df8-e09feb30e38e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR