### PR TITLE
docs(ecosystem): add MiniMax-AI/cli as community skill

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -79,3 +79,13 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+
+---
+
+## Skills
+
+Skills are installable instruction sets that follow the [agentskills.io](https://agentskills.io) standard. Add them via `skills.urls` in your OpenCode config.
+
+| Name                                                    | Description                                                                          |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [mmx-cli](https://github.com/MiniMax-AI/cli)            | Generate text, images, video, speech, and music via the MiniMax AI platform          |


### PR DESCRIPTION
## Summary

- Add a **Skills** section to the ecosystem page
- List [mmx-cli](https://github.com/MiniMax-AI/cli) — a CLI tool for the MiniMax AI platform — as a community skill
- Skills follow the [agentskills.io](https://agentskills.io) standard and can be loaded via `skills.urls` in OpenCode config

**1 file changed, 10 insertions.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for MiniMax AI platform providing text, image, video, speech, and music generation. Its `skill/SKILL.md` follows the agentskills.io standard that OpenCode's skill system already supports.

## Test plan

- [ ] Ecosystem page renders the new Skills section correctly
- [ ] Link to https://github.com/MiniMax-AI/cli is valid