### PR TITLE
chore(nix): remove external ripgrep

### DIFF
--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -7,7 +7,6 @@
   sysctl,
   makeBinaryWrapper,
   models-dev,
-  ripgrep,
   installShellFiles,
   versionCheckHook,
   writableTmpDirAsHomeHook,
@@ -52,25 +51,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
-  installPhase = ''
-    runHook preInstall
+  installPhase =
+    ''
+      runHook preInstall
 
-    install -Dm755 dist/opencode-*/bin/opencode $out/bin/opencode
-    install -Dm644 schema.json $out/share/opencode/schema.json
-
-    wrapProgram $out/bin/opencode \
-      --prefix PATH : ${
-        lib.makeBinPath (
-          [
-            ripgrep
+      install -Dm755 dist/opencode-*/bin/opencode $out/bin/opencode
+      install -Dm644 schema.json $out/share/opencode/schema.json
+    ''
+    # bun runs sysctl to detect if dunning on rosetta2
+    + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      wrapProgram $out/bin/opencode \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            sysctl
           ]
-          # bun runs sysctl to detect if dunning on rosetta2
-          ++ lib.optional stdenvNoCC.hostPlatform.isDarwin sysctl
-        )
-      }
-
-    runHook postInstall
-  '';
+        }
+    ''
+    + ''
+      runHook postInstall
+    '';
 
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
     # trick yargs into also generating zsh completions


### PR DESCRIPTION
### Issue for this PR

Closes #22483

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode now does not reply on having (or downloading) the ripgrep binary so we can remove it from the nix package

### How did you verify your code works?

`nix run` and getting an agent to use the glob tool

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
