### PR TITLE
fix(question): restore flat reply sdk shape

### DIFF
--- a/packages/opencode/src/server/instance/httpapi/question.ts
+++ b/packages/opencode/src/server/instance/httpapi/question.ts
@@ -9,6 +9,11 @@ import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from 
 import type { Handler } from "hono"
 
 const root = "/experimental/httpapi/question"
+const Reply = Schema.Struct({
+  answers: Schema.Array(Question.Answer).annotate({
+    description: "User answers in order of questions (each answer is an array of selected labels)",
+  }),
+})
 
 const Api = HttpApi.make("question")
   .add(
@@ -25,7 +30,7 @@ const Api = HttpApi.make("question")
         ),
         HttpApiEndpoint.post("reply", `${root}/:requestID/reply`, {
           params: { requestID: QuestionID },
-          payload: Question.Reply,
+          payload: Reply,
           success: Schema.Boolean,
         }).annotateMerge(
           OpenApi.annotations({
@@ -62,7 +67,7 @@ const QuestionLive = HttpApiBuilder.group(
 
     const reply = Effect.fn("QuestionHttpApi.reply")(function* (ctx: {
       params: { requestID: QuestionID }
-      payload: Question.Reply
+      payload: Schema.Schema.Type<typeof Reply>
     }) {
       yield* svc.reply({
         requestID: ctx.params.requestID,

--- a/packages/opencode/src/server/instance/question.ts
+++ b/packages/opencode/src/server/instance/question.ts
@@ -8,6 +8,12 @@ import z from "zod"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 
+const Reply = z.object({
+  answers: Question.Answer.zod
+    .array()
+    .describe("User answers in order of questions (each answer is an array of selected labels)"),
+})
+
 export const QuestionRoutes = lazy(() =>
   new Hono()
     .get(
@@ -56,7 +62,7 @@ export const QuestionRoutes = lazy(() =>
           requestID: QuestionID.zod,
         }),
       ),
-      validator("json", Question.Reply.zod),
+      validator("json", Reply),
       async (c) => {
         const params = c.req.valid("param")
         const json = c.req.valid("json")

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -105,10 +105,10 @@ import type {
   PtyRemoveResponses,
   PtyUpdateErrors,
   PtyUpdateResponses,
+  QuestionAnswer,
   QuestionListResponses,
   QuestionRejectErrors,
   QuestionRejectResponses,
-  QuestionReply,
   QuestionReplyErrors,
   QuestionReplyResponses,
   SessionAbortErrors,
@@ -2738,7 +2738,7 @@ export class Question extends HeyApiClient {
       requestID: string
       directory?: string
       workspace?: string
-      questionReply?: QuestionReply
+      answers?: Array<QuestionAnswer>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2750,7 +2750,7 @@ export class Question extends HeyApiClient {
             { in: "path", key: "requestID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { key: "questionReply", map: "body" },
+            { in: "body", key: "answers" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1925,13 +1925,6 @@ export type SubtaskPartInput = {
   command?: string
 }
 
-export type QuestionReply = {
-  /**
-   * User answers in order of questions (each answer is an array of selected labels)
-   */
-  answers: Array<QuestionAnswer>
-}
-
 export type ProviderAuthMethod = {
   type: "oauth" | "api"
   label: string
@@ -4259,7 +4252,12 @@ export type QuestionListResponses = {
 export type QuestionListResponse = QuestionListResponses[keyof QuestionListResponses]
 
 export type QuestionReplyData = {
-  body?: QuestionReply
+  body?: {
+    /**
+     * User answers in order of questions (each answer is an array of selected labels)
+     */
+    answers: Array<QuestionAnswer>
+  }
   path: {
     requestID: string
   }


### PR DESCRIPTION
## Summary
- restore the public question reply routes to use an inline `{ answers }` body instead of the named `QuestionReply` wrapper
- keep the experimental question HttpApi route aligned with the public route shape
- regenerate the JS SDK so `client.question.reply({ requestID, answers })` works again

## Testing
- bun run typecheck