### PR TITLE
fix(session): use Log instead of EffectLogger in prompt loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -46,6 +46,7 @@ import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, Context } from "effect"
 import { EffectLogger } from "@/effect/logger"
 import { InstanceState } from "@/effect/instance-state"
+import { attach } from "@/effect/run-service"
 import { TaskTool, type TaskPromptOps } from "@/tool/task"
 import { SessionRunState } from "./run-state"
 
@@ -107,8 +108,8 @@ export namespace SessionPrompt {
 
       const run = {
         promise: <A, E>(effect: Effect.Effect<A, E>) =>
-          Effect.runPromise(effect.pipe(Effect.provide(EffectLogger.layer))),
-        fork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(effect.pipe(Effect.provide(EffectLogger.layer))),
+          Effect.runPromise(attach(effect).pipe(Effect.provide(EffectLogger.layer))),
+        fork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(attach(effect).pipe(Effect.provide(EffectLogger.layer))),
       }
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -112,7 +112,7 @@ export namespace SessionPrompt {
       }
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
-        yield* elog.info("cancel", { sessionID })
+        log.info("cancel", { sessionID })
         yield* state.cancel(sessionID)
       })
 
@@ -1302,14 +1302,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       const runLoop: (sessionID: SessionID) => Effect.Effect<MessageV2.WithParts> = Effect.fn("SessionPrompt.run")(
         function* (sessionID: SessionID) {
           const ctx = yield* InstanceState.context
-          const slog = elog.with({ sessionID })
+          const slog = log.clone().tag("sessionID", sessionID)
           let structured: unknown | undefined
           let step = 0
           const session = yield* sessions.get(sessionID)
 
           while (true) {
             yield* status.set(sessionID, { type: "busy" })
-            yield* slog.info("loop", { step })
+            slog.info("loop", { step })
 
             let msgs = yield* MessageV2.filterCompactedEffect(sessionID)
 
@@ -1345,7 +1345,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               !hasToolCalls &&
               lastUser.id < lastAssistant.id
             ) {
-              yield* slog.info("exiting loop")
+              slog.info("exiting loop")
               break
             }
 
@@ -1544,7 +1544,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       )
 
       const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
-        yield* elog.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
+        log.info("command", { sessionID: input.sessionID, command: input.command, agent: input.agent })
         const cmd = yield* commands.get(input.command)
         if (!cmd) {
           const available = (yield* commands.list()).map((c) => c.name)


### PR DESCRIPTION
### Issue for this PR

Closes #22499

### Type of change

- [x] Bug fix

### What does this PR do?

Two related fixes in `session/prompt.ts` after the facade removal in #22471:

1. **EffectLogger → Log migration**: The prompt loop still used `EffectLogger` (`yield* slog.info(...)`) after `processor.ts` was migrated to `Log` in #22460. The prompt loop fiber does not reliably run with the `EffectLogger` layer, so those log calls fall back to Effect's default logger and leak structured output to the TUI stderr.

2. **Restore `attach()` in `run.promise`/`run.fork`**: #22471 removed `attach()` from these helpers. `attach()` bridges the AsyncLocalStorage-based Instance context into Effect fibers. Without it, tools (grep, glob, read, etc.) fail with `No context found for instance` because `InstanceState.context` cannot resolve the working directory.

### How did you verify your code works?

- `bun typecheck` passes
- Reproduced both issues locally:
  - TUI log leakage: structured log lines no longer appear on TUI stderr
  - Instance context loss: `grep` tool now resolves working directory correctly in `run` mode

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR