### PR TITLE
test(generate): add sdk drift guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "typecheck": "bun turbo typecheck",
     "postinstall": "bun run --cwd packages/opencode fix-node-pty",
     "prepare": "husky",
+    "generate:check": "bun ./script/check-generate.ts",
     "random": "echo 'Random script'",
     "hello": "echo 'Hello World!'",
     "test": "echo 'do not run tests from root' && exit 1"

--- a/packages/opencode/test/server/question-openapi.test.ts
+++ b/packages/opencode/test/server/question-openapi.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+
+describe("question openapi", () => {
+  test("keeps the public reply body inline", async () => {
+    const spec = await Server.openapi()
+    const body = spec.paths["/question/{requestID}/reply"]?.post?.requestBody
+
+    expect(body).toBeDefined()
+    if (!body || "$ref" in body) throw new Error("expected inline request body")
+
+    const media = body.content["application/json"]
+    expect(media).toBeDefined()
+    if (!media || "$ref" in media) throw new Error("expected inline json media type")
+
+    expect(media.schema).toMatchObject({
+      type: "object",
+      required: ["answers"],
+      properties: {
+        answers: {
+          description: "User answers in order of questions (each answer is an array of selected labels)",
+          type: "array",
+          items: {
+            $ref: "#/components/schemas/QuestionAnswer",
+          },
+        },
+      },
+    })
+  })
+})

--- a/script/check-generate.ts
+++ b/script/check-generate.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+
+await $`bun ./script/generate.ts`
+await $`git diff --exit-code -- packages/sdk/openapi.json packages/sdk/js/src/gen packages/sdk/js/src/v2`


### PR DESCRIPTION
## Summary
- add a focused OpenAPI regression test to keep the public `question.reply` request body inline
- add `bun run generate:check` to regenerate the SDK/OpenAPI and fail on drift
- keep the current route implementation unchanged while adding guardrails around the contract

## Testing
- bun run test test/util/effect-zod.test.ts test/server/question-openapi.test.ts
- bun run typecheck
- bun run generate:check