### PR TITLE
fix(effect): preserve logger context in prompt runs

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -49,7 +49,7 @@ import { ShareNext } from "@/share/share-next"
 import { SessionShare } from "@/share/session"
 
 export const AppLayer = Layer.mergeAll(
-  // Observability.layer,
+  Observability.layer,
   AppFileSystem.defaultLayer,
   Bus.defaultLayer,
   Auth.defaultLayer,
@@ -95,6 +95,6 @@ export const AppLayer = Layer.mergeAll(
   Installation.defaultLayer,
   ShareNext.defaultLayer,
   SessionShare.defaultLayer,
-).pipe(Layer.provide(Observability.layer))
+)
 
 export const AppRuntime = ManagedRuntime.make(AppLayer, { memoMap })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -104,11 +104,11 @@ export namespace SessionPrompt {
       const summary = yield* SessionSummary.Service
       const sys = yield* SystemPrompt.Service
       const llm = yield* LLM.Service
+      const ctx = yield* Effect.context()
 
       const run = {
-        promise: <A, E>(effect: Effect.Effect<A, E>) =>
-          Effect.runPromise(effect.pipe(Effect.provide(EffectLogger.layer))),
-        fork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(effect.pipe(Effect.provide(EffectLogger.layer))),
+        promise: <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseWith(ctx)(effect),
+        fork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runForkWith(ctx)(effect),
       }
 
       const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {

--- a/packages/opencode/test/effect/app-runtime-logger.test.ts
+++ b/packages/opencode/test/effect/app-runtime-logger.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { Context, Effect, Layer, Logger } from "effect"
+import { AppRuntime } from "../../src/effect/app-runtime"
+import { EffectLogger } from "../../src/effect/logger"
+import { makeRuntime } from "../../src/effect/run-service"
+
+function check(loggers: ReadonlySet<Logger.Logger<unknown, any>>) {
+  return {
+    defaultLogger: loggers.has(Logger.defaultLogger),
+    tracerLogger: loggers.has(Logger.tracerLogger),
+    effectLogger: loggers.has(EffectLogger.logger),
+    size: loggers.size,
+  }
+}
+
+test("makeRuntime installs EffectLogger through Observability.layer", async () => {
+  class Dummy extends Context.Service<Dummy, { readonly current: () => Effect.Effect<ReturnType<typeof check>> }>()(
+    "@test/Dummy",
+  ) {}
+
+  const layer = Layer.effect(
+    Dummy,
+    Effect.gen(function* () {
+      return Dummy.of({
+        current: () => Effect.map(Effect.service(Logger.CurrentLoggers), check),
+      })
+    }),
+  )
+
+  const rt = makeRuntime(Dummy, layer)
+  const current = await rt.runPromise((svc) => svc.current())
+
+  expect(current.effectLogger).toBe(true)
+  expect(current.defaultLogger).toBe(false)
+})
+
+test("AppRuntime also installs EffectLogger through Observability.layer", async () => {
+  const current = await AppRuntime.runPromise(Effect.map(Effect.service(Logger.CurrentLoggers), check))
+
+  expect(current.effectLogger).toBe(true)
+  expect(current.defaultLogger).toBe(false)
+})


### PR DESCRIPTION
## Summary
- merge `Observability.layer` directly into `AppRuntime` so it installs the same logger set as `makeRuntime(...)`
- switch the internal `SessionPrompt` promise/fork bridge to `Effect.runPromiseWith(ctx)` and `Effect.runForkWith(ctx)` so prompt runs keep the active logger context
- add a regression test proving `AppRuntime` includes `EffectLogger` just like `makeRuntime(...)`

## Testing
- bun run test test/effect/app-runtime-logger.test.ts test/session/prompt-effect.test.ts
- bun run typecheck

## Notes
- replacement for the stale #22486 branch