### PR TITLE
feat: add kimi-k2.6-code-preview model support

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx
@@ -112,6 +112,7 @@ const MODEL_COLORS: Record<string, string> = {
   "grok-code": "#8B5CF6",
   "big-pickle": "#10B981",
   "kimi-k2": "#F59E0B",
+  "kimi-k2.6-code-preview": "#D97706",
   "qwen3-coder": "#EC4899",
   "glm-4.6": "#14B8A6",
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -346,7 +346,7 @@ export namespace ProviderTransform {
   export function topP(model: Provider.Model) {
     const id = model.id.toLowerCase()
     if (id.includes("qwen")) return 1
-    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
+    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5", "kimi-k2.6-code-preview"].some((s) => id.includes(s))) {
       return 0.95
     }
     return undefined
@@ -807,7 +807,7 @@ export namespace ProviderTransform {
     const modelId = input.model.api.id.toLowerCase()
     if (
       (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
-      (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))
+      (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5") || modelId.includes("kimi-k2.6-code-preview"))
     ) {
       result["thinking"] = {
         type: "enabled",

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -3571,6 +3571,23 @@
         "open_weights": true,
         "cost": { "input": 0.5, "output": 2.85 },
         "limit": { "context": 262144, "output": 262144 }
+      },
+      "kimi-k2.6-code-preview": {
+        "id": "kimi-k2.6-code-preview",
+        "name": "Kimi K2.6 Code Preview",
+        "family": "kimi",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "temperature": true,
+        "knowledge": "2024-10",
+        "release_date": "2026-04",
+        "last_updated": "2026-04",
+        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0.6, "output": 3, "cache_read": 0.08 },
+        "limit": { "context": 262144, "output": 65536 }
       }
     }
   },
@@ -17840,6 +17857,23 @@
         "open_weights": true,
         "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
         "limit": { "context": 262144, "output": 32768 }
+      },
+      "kimi-k2.6-code-preview": {
+        "id": "kimi-k2.6-code-preview",
+        "name": "Kimi K2.6 Code Preview",
+        "family": "kimi-thinking",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04",
+        "last_updated": "2026-04",
+        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
+        "limit": { "context": 262144, "output": 65536 }
       }
     }
   },


### PR DESCRIPTION
### Issue for this PR

Relates to #22408

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds client-side support for the `kimi-k2.6-code-preview` model so users who configure it manually (e.g. via `opencode.json`) receive the correct provider transforms.

Specific changes:
- **`packages/opencode/src/provider/transform.ts`**: 
  - Added `kimi-k2.6-code-preview` to `topP()` so the model receives `topP: 0.95`.
  - Added `kimi-k2.6-code-preview` to the Anthropic SDK thinking logic so thinking is enabled by default.
  - `temperature()` already handles `kimi-k2.6-code-preview` correctly via the existing `k2.` pattern match.
- **`packages/opencode/test/tool/fixtures/models-api.json`**:
  - Added `kimi-k2.6-code-preview` fixture entries for the `kimi-for-coding` and `opencode` providers.
- **`packages/console/app/src/routes/workspace/[id]/usage/graph-section.tsx`**:
  - Added a color mapping for `kimi-k2.6-code-preview` in usage graphs.

The base `kimi-k2.6` model is intentionally left for a follow-up PR since its provider transforms need separate validation.

### How did you verify your code works?

- Ran `bun test test/provider/` and `bun test test/tool/` from `packages/opencode` — all tests pass.
- The pre-push `typecheck` hook also passes across the workspace.

### Screenshots / recordings

N/A — no UI behavior changes beyond the usage graph color mapping.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
