### PR TITLE
feat: implement native request serialization (binary lock) and optimize compaction defaults for local LLMs`

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1136,8 +1136,8 @@ export namespace Config {
         .optional(),
       compaction: z
         .object({
-          auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),
-          prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
+          auto: z.boolean().optional().default(true).describe("Enable automatic compaction when context is full (default: true)"),
+          prune: z.boolean().optional().default(true).describe("Enable pruning of old tool outputs (default: true)"),
           reserved: z
             .number()
             .int()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -18,6 +18,23 @@ import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
 
+/**
+ * Serializes requests to prevent overloading local models (Ollama/M4).
+ * Ensures that even if multiple agents try to talk to the model at once,
+ * they wait in line natively.
+ */
+class RequestQueue {
+  private queue = Promise.resolve()
+
+  async add<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(fn)
+    this.queue = result.then(() => {}).catch(() => {})
+    return result
+  }
+}
+
+const globalRequestQueue = new RequestQueue()
+
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
@@ -1103,11 +1120,13 @@ export namespace Provider {
           }
         }
 
-        return fetchFn(input, {
-          ...opts,
-          // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
-          timeout: false,
-        })
+        return globalRequestQueue.add(() =>
+          fetchFn(input, {
+            ...opts,
+            // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
+            timeout: false,
+          }),
+        )
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]


### PR DESCRIPTION
### **PR Body Content**

#### **Issue for this PR**

Closes # (Add the issue number if you have one, or leave blank if this is a first-time find.)

#### **Type of change**

- [x] Bug fix
- [x] Refactor / code improvement

#### **What does this PR do?**

This PR permanently fixes the "Connection Reset" and high latency issues encountered when using local backends (like M4, Ollama, or llama.cpp) with multiple concurrent agents. 

1. **Native Request Serialization (Binary Lock)**: I’ve added a `RequestQueue` in `provider.ts` that wraps the AI SDK fetcher. This ensures that even if several agents (build, search, test) attempt parallel requests, they are queued and executed serially. This prevents local inference servers from being overwhelmed and throwing 500/timeout errors.

2. **Lean Compaction Defaults**: Revised the `Compaction` Zod schema in `config.ts` to default `auto: true` and `prune: true`. Previously, context could balloon silently (up to 78K+ tokens), which destroyed inference latency on local hardware. Forcing compaction by default ensures the model context stays manageable and snappy.

These changes eliminate the need for external "stability shields" (like proxy scripts) and make the local-only workflow significantly more stable.

#### **How did you verify your code works?**

I tested this locally by running a multi-agent "Build" task on an M4 setup. Before the fix, concurrent tool-calling would reliably trigger a "Connection Reset" from the local server. After the fix, the queue correctly serialized the requests, and the agents completed the task without a single drop in stability. I also verified the 78K context balloon is stopped by checking the metadata logs during long-running sessions.

#### **Screenshots / recordings**

_NA (Core stability change)_