### PR TITLE
feat(opencode): trace tool execution spans

### DIFF
--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -80,8 +80,14 @@ export namespace Tool {
       Effect.gen(function* () {
         const toolInfo = init instanceof Function ? { ...(yield* init()) } : { ...init }
         const execute = toolInfo.execute
-        toolInfo.execute = (args, ctx) =>
-          Effect.gen(function* () {
+        toolInfo.execute = (args, ctx) => {
+          const attrs = {
+            "tool.name": id,
+            "session.id": ctx.sessionID,
+            "message.id": ctx.messageID,
+            ...(ctx.callID ? { "tool.call_id": ctx.callID } : {}),
+          }
+          return Effect.gen(function* () {
             yield* Effect.try({
               try: () => toolInfo.parameters.parse(args),
               catch: (error) => {
@@ -109,7 +115,8 @@ export namespace Tool {
                 ...(truncated.truncated && { outputPath: truncated.outputPath }),
               },
             }
-          }).pipe(Effect.orDie)
+          }).pipe(Effect.orDie, Effect.withSpan("Tool.execute", { attributes: attrs }))
+        }
         return toolInfo
       })
   }


### PR DESCRIPTION
## Summary
- add a shared `Tool.execute` span in the generic tool wrapper so every tool call is timed consistently
- attach `tool.name`, `tool.call_id`, `session.id`, and `message.id` attributes for easier Motel queries
- keep tool-specific spans like `ApplyPatchTool.execute` intact while adding one uniform top-level span for all tools

## Verification
- ran `bun turbo typecheck --filter=opencode` in the isolated worktree
- verified the change is isolated to `packages/opencode/src/tool/tool.ts`

## Why
- make it easier to compare actual tool execution timing with `Session.updatePart` / `Session.updatePartDelta`
- support debugging cases where the TUI appears to update slightly after the underlying tool side effect has already happened