### PR TITLE
fix(desktop): start tauri shell commands from home directory

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -452,6 +452,7 @@ pub fn spawn_command(
         };
 
         let mut cmd = Command::new(shell);
+        cmd.current_dir(app.path().home_dir().unwrap());
         cmd.args(["-l", "-c", &line]);
 
         for (key, value) in envs {


### PR DESCRIPTION
## Summary
Start Tauri shell commands from the user's home directory instead of the application directory.

## Changes
- Modified shell command execution to use home directory as working directory