### PR TITLE
fix(desktop): chdir to homedir on macOS to fix ripgrep issues

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -11,6 +11,11 @@ import pkg from "electron-updater"
 import contextMenu from "electron-context-menu"
 contextMenu({ showSaveImageAs: true, showLookUpSelection: false, showSearchWithGoogle: false })
 
+// on macOS apps run in `/` which can cause issues with ripgrep
+try {
+  process.chdir(homedir())
+} catch {}
+
 process.env.OPENCODE_DISABLE_EMBEDDED_WEB_UI = "true"
 
 const APP_NAMES: Record<string, string> = {


### PR DESCRIPTION
On macOS, Electron apps can run with a working directory of `/`, which causes issues with ripgrep. This change ensures the app changes to the user's home directory on startup.