### PR TITLE
fix(sse): prevent memory leak from zombie SSE connections

### DIFF
--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -10,3 +10,4 @@ export const GlobalBus = new EventEmitter<{
     },
   ]
 }>()
+GlobalBus.setMaxListeners(100)

--- a/packages/opencode/src/server/adapter.bun.ts
+++ b/packages/opencode/src/server/adapter.bun.ts
@@ -11,7 +11,11 @@ export const adapter: Adapter = {
         const args = {
           fetch: app.fetch,
           hostname: opts.hostname,
-          idleTimeout: 0,
+          // Default is 10s which is too aggressive for SSE connections.
+          // 0 disables the timeout entirely — dead connections (CLOSE_WAIT) are
+          // never cleaned up, causing unbounded memory growth. 120s gives the
+          // cleanup chain enough time to fire while still bounding leak duration.
+          idleTimeout: 120,
           websocket: ws.websocket,
         } as const
         const start = (port: number) => {

--- a/packages/opencode/src/server/instance/event.ts
+++ b/packages/opencode/src/server/instance/event.ts
@@ -75,11 +75,25 @@ export const EventRoutes = () =>
         })
 
         stream.onAbort(stop)
+        // Second abort path: req.raw.signal fires before stream.onAbort on direct
+        // connections (~2ms earlier), and provides an independent cleanup path when
+        // the responseReadable.cancel() chain is broken (e.g. reverse proxy).
+        // Hono only registers this on Bun 1.0/1.1 (isOldBunVersion gate); we add
+        // it unconditionally so Bun 1.2+ is also covered.
+        c.req.raw.signal.addEventListener("abort", stop)
 
         try {
           for await (const data of q) {
             if (data === null) return
-            await stream.writeSSE({ data })
+            try {
+              await stream.writeSSE({ data })
+            } catch {
+              // Hono 4.x StreamingApi.write() has an empty catch — this block
+              // never fires on the current version. Kept for forward compatibility
+              // in case a future Hono version propagates write errors.
+              stop()
+              return
+            }
           }
         } finally {
           stop()

--- a/packages/opencode/src/server/instance/global.ts
+++ b/packages/opencode/src/server/instance/global.ts
@@ -57,11 +57,25 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
     const unsub = subscribe(q)
 
     stream.onAbort(stop)
+    // Second abort path: req.raw.signal fires before stream.onAbort on direct
+    // connections (~2ms earlier), and provides an independent cleanup path when
+    // the responseReadable.cancel() chain is broken (e.g. reverse proxy).
+    // Hono only registers this on Bun 1.0/1.1 (isOldBunVersion gate); we add
+    // it unconditionally so Bun 1.2+ is also covered.
+    c.req.raw.signal.addEventListener("abort", stop)
 
     try {
       for await (const data of q) {
         if (data === null) return
-        await stream.writeSSE({ data })
+        try {
+          await stream.writeSSE({ data })
+        } catch {
+          // Hono 4.x StreamingApi.write() has an empty catch — this block
+          // never fires on the current version. Kept for forward compatibility
+          // in case a future Hono version propagates write errors.
+          stop()
+          return
+        }
       }
     } finally {
       stop()

--- a/packages/opencode/src/util/queue.ts
+++ b/packages/opencode/src/util/queue.ts
@@ -2,10 +2,18 @@ export class AsyncQueue<T> implements AsyncIterable<T> {
   private queue: T[] = []
   private resolvers: ((value: T) => void)[] = []
 
+  constructor(private limit = 1000) {}
+
   push(item: T) {
     const resolve = this.resolvers.shift()
-    if (resolve) resolve(item)
-    else this.queue.push(item)
+    if (resolve) {
+      resolve(item)
+    } else {
+      if (this.queue.length >= this.limit) {
+        this.queue.shift()
+      }
+      this.queue.push(item)
+    }
   }
 
   async next(): Promise<T> {

--- a/packages/opencode/test/util/queue.test.ts
+++ b/packages/opencode/test/util/queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { AsyncQueue } from "../../src/util/queue"
+
+describe("AsyncQueue", () => {
+  test("basic FIFO order", async () => {
+    const q = new AsyncQueue<number>()
+    q.push(1)
+    q.push(2)
+    q.push(3)
+    expect(await q.next()).toBe(1)
+    expect(await q.next()).toBe(2)
+    expect(await q.next()).toBe(3)
+  })
+
+  test("drops oldest entry when limit is reached", async () => {
+    const q = new AsyncQueue<number>(3)
+    q.push(1)
+    q.push(2)
+    q.push(3)
+    q.push(4) // should drop 1
+    expect(await q.next()).toBe(2)
+    expect(await q.next()).toBe(3)
+    expect(await q.next()).toBe(4)
+  })
+
+  test("queue length never exceeds limit", () => {
+    const limit = 5
+    const q = new AsyncQueue<number>(limit)
+    for (let i = 0; i < 100; i++) q.push(i)
+    // drain and count
+    let count = 0
+    while ((q as any).queue.length > 0) {
+      ;(q as any).queue.shift()
+      count++
+    }
+    expect(count).toBeLessThanOrEqual(limit)
+  })
+
+  test("item delivered directly to waiting resolver bypasses limit", async () => {
+    const q = new AsyncQueue<number>(2)
+    // consumer is already waiting
+    const result = q.next()
+    q.push(99)
+    expect(await result).toBe(99)
+    // internal queue should still be empty
+    expect((q as any).queue.length).toBe(0)
+  })
+
+  test("null sentinel terminates async iteration", async () => {
+    const q = new AsyncQueue<number | null>()
+    q.push(1)
+    q.push(2)
+    q.push(null)
+    const collected: number[] = []
+    for await (const item of q) {
+      if (item === null) break
+      collected.push(item)
+    }
+    expect(collected).toEqual([1, 2])
+  })
+
+  test("zombie scenario: 10000 pushes with no consumer stays bounded", () => {
+    const limit = 100
+    const q = new AsyncQueue<number>(limit)
+    for (let i = 0; i < 10_000; i++) q.push(i)
+    expect((q as any).queue.length).toBe(limit)
+    // most recent items are retained
+    expect((q as any).queue[(q as any).queue.length - 1]).toBe(9999)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22198, closes #22422.

### Type of change

- [x] Bug fix

### What does this PR do?

**Root cause:** `adapter.bun.ts` sets `idleTimeout: 0`, disabling Bun's idle timeout
entirely. When an SSE connection enters TCP CLOSE_WAIT (Electron shell reconnecting on
minimize/restore, or a reverse proxy swallowing the client FIN), the server has no
signal that the connection is dead. Three resources leak per zombie connection: the
heartbeat `setInterval`, the `Bus.subscribeAll` subscription, and the `AsyncQueue`.
The queue keeps receiving every Bus event with no consumer draining it — at 66+ zombie
connections this was ~14 MB/sec, peaking at 24.5 GB before OOM.

The `finally { stop() }` block does not help — `for await` is suspended on `q.next()`
which returns a Promise that never resolves when the queue has no consumer.

Five changes:

1. **`adapter.bun.ts`: `idleTimeout: 0` → `120`** — the root fix. Bun's idle timeout
   fires after 120s of no successful writes, aborting `Request.signal` and triggering
   cleanup. The 10s heartbeat resets the timer on every beat for active connections, so
   live connections are never affected.

2. **`c.req.raw.signal.addEventListener("abort", stop)`** in `event.ts` and `global.ts`
   — adds an independent cleanup path that fires before `stream.onAbort` on direct
   connections (~2ms earlier). Hono gates this listener behind `isOldBunVersion()` and
   skips it on Bun 1.2+; we add it unconditionally.

3. **`writeSSE` wrapped in try/catch** in the same files — kept for forward
   compatibility if a future Hono version propagates write errors. Hono 4.x
   `StreamingApi.write()` has an empty catch block so this does not fire on the current
   version (noted in code comments).

4. **`AsyncQueue` capacity limit** (default 1000, drop oldest on overflow) — defensive
   backstop so growth is bounded even if a cleanup signal is missed.

5. **`GlobalBus.setMaxListeners(100)`** — each SSE connection adds one listener; the
   default of 10 causes `MaxListenersExceededWarning` under normal usage.

Reproduction attempt and detailed analysis: https://gist.github.com/zhumengzhu/091076a04491762659c3cd210d02cee7

Inspired by #18395 and #15646, both closed without merging.

### How did you verify your code works?

- Full test suite: 1890 pass, 1 fail (the failure is pre-existing on `upstream/dev`
  before any changes — same result on unmodified upstream)
- Local reproduction attempt with nginx `proxy_ignore_client_abort on` (20 SSE
  connections, kill all clients, monitor VmRSS for 120s) — detailed in the gist above
- Signal timing instrumentation to verify `req.raw.signal` vs `stream.onAbort` firing
  order in both direct and proxied scenarios

### Screenshots / recordings

N/A — server-side memory fix

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR