### PR TITLE
fix(db): disable SQLite mmap to prevent DB size inflating RSS

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -93,6 +93,7 @@ export namespace Database {
     db.run("PRAGMA cache_size = -64000")
     db.run("PRAGMA foreign_keys = ON")
     db.run("PRAGMA wal_checkpoint(PASSIVE)")
+    db.run("PRAGMA mmap_size = 0")
 
     // Apply schema migrations
     const entries =


### PR DESCRIPTION
### Issue for this PR

Ref #22428 (same fix, that PR is still open — this supersedes it).

### Type of change

- [x] Bug fix

### What does this PR do?

Bun enables SQLite memory-mapped I/O by default, mapping the entire DB file
into the process address space. A 1.1 GB database adds ~1.8 GB to RSS
regardless of how much data is actually accessed. One line added to the
existing PRAGMA initialization block in `src/storage/db.ts`:

```ts
db.run("PRAGMA mmap_size = 0")
```

Same fix as proposed by @jiangliang79 in #22428.

### How did you verify your code works?

- Full test suite passes (1890 pass, pre-existing 1 fail unrelated to this change)
- Confirmed `mmap_size` PRAGMA was not previously set in the codebase

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR