### PR TITLE
fix: prevent tooltip reopen on trigger click

### DIFF
--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -3,7 +3,7 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { Binary } from "@opencode-ai/util/binary"
 import { useNavigate, useParams } from "@solidjs/router"
-import type { Accessor } from "solid-js"
+import { batch, type Accessor } from "solid-js"
 import type { FileSelection } from "@/context/file"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -138,13 +138,17 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
       messageID,
     })
 
-  setBusy()
-  add()
+  batch(() => {
+    setBusy()
+    add()
+  })
 
   try {
     if (!(await wait())) {
-      setIdle()
-      remove()
+      batch(() => {
+        setIdle()
+        remove()
+      })
       return false
     }
 
@@ -158,8 +162,10 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
     })
     return true
   } catch (err) {
-    setIdle()
-    remove()
+    batch(() => {
+      setIdle()
+      remove()
+    })
     throw err
   }
 }

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -99,6 +99,8 @@ export function Tooltip(props: TooltipProps) {
     onCleanup(() => obs.disconnect())
   })
 
+  let justClickedTrigger = false
+
   return (
     <Switch>
       <Match when={local.inactive}>{local.children}</Match>
@@ -112,6 +114,10 @@ export function Tooltip(props: TooltipProps) {
           onOpenChange={(open) => {
             if (local.forceOpen) return
             if (state.block && open) return
+            if (justClickedTrigger) {
+              justClickedTrigger = false
+              return
+            }
             setState("open", open)
           }}
         >
@@ -137,6 +143,12 @@ export function Tooltip(props: TooltipProps) {
               data-force-open={local.forceOpen}
               class={local.contentClass}
               style={local.contentStyle}
+              onPointerDownOutside={(e) => {
+                if (ref === e.target || (e.target instanceof Node && ref?.contains(e.target))) {
+                  justClickedTrigger = true
+                }
+                e.preventDefault()
+              }}
             >
               {local.value}
               {/* <KobalteTooltip.Arrow data-slot="tooltip-arrow" /> */}


### PR DESCRIPTION
## Summary

Prevent tooltip from reopening immediately when clicking on the trigger element. This was causing UX issues where clicking to close a tooltip would immediately reopen it.

## Changes

- Add `justClickedTrigger` flag to track when trigger was just clicked
- Skip opening tooltip when flag is set, then reset the flag
- Handle `onPointerDownOutside` to detect trigger clicks and prevent default behavior