### PR TITLE
fix: guard Anthropic thinking budgetTokens for unknown output limits

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -389,6 +389,14 @@ export function topK(model: Provider.Model) {
 const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
+// Returns safe budgetTokens for Anthropic's 'high' thinking variant, or undefined
+// when the output limit is unknown (0) or the result would be below Anthropic's
+// minimum of 1024. Both callers (variants() and kimi-k2.5) share this formula.
+function highBudget(output: number): number | undefined {
+  const tokens = Math.floor(output / 2 - 1)
+  return tokens >= 1024 ? Math.min(16_000, tokens) : undefined
+}
+
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
 
@@ -592,11 +600,14 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         )
       }
 
+      const high = highBudget(model.limit.output)
+      if (!high) return {}
+
       return {
         high: {
           thinking: {
             type: "enabled",
-            budgetTokens: Math.min(16_000, Math.floor(model.limit.output / 2 - 1)),
+            budgetTokens: high,
           },
         },
         max: {
@@ -831,9 +842,12 @@ export function options(input: {
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))
   ) {
-    result["thinking"] = {
-      type: "enabled",
-      budgetTokens: Math.min(16_000, Math.floor(input.model.limit.output / 2 - 1)),
+    const high = highBudget(input.model.limit.output)
+    if (high) {
+      result["thinking"] = {
+        type: "enabled",
+        budgetTokens: high,
+      }
     }
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2999,5 +2999,35 @@ describe("ProviderTransform.variants", () => {
       const result = ProviderTransform.variants(model)
       expect(result).toEqual({})
     })
+
+    test("returns empty object when limit.output is 0 (unknown)", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-4",
+        providerID: "anthropic",
+        api: {
+          id: "claude-4",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+        limit: { context: 200_000, output: 0 },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
+
+    test("returns empty object when limit.output is too small for valid budgetTokens", () => {
+      const model = createMockModel({
+        id: "anthropic/claude-4",
+        providerID: "anthropic",
+        api: {
+          id: "claude-4",
+          url: "https://api.anthropic.com",
+          npm: "@ai-sdk/anthropic",
+        },
+        limit: { context: 200_000, output: 2049 },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(result).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #22253

### Type of change

- [x] Bug fix

### What does this PR do?

Custom provider models without a limit field get limit.output = 0. The budgetTokens formula Math.floor(output / 2 - 1) returns -1 in this case, which causes an error when Anthropic's API validates the thinking config. Extracted highBudget() to centralize the formula and guard against invalid results (Anthropic requires budgetTokens >= 1024). Both variants() and the kimi-k2.5 path now share this helper, so the guard lives in one place instead of being duplicated.

### How did you verify your code works?

Added two unit tests in transform.test.ts:
- output: 0 → returns {}
- output: 2049 → returns {} (budgetTokens would be below Anthropic's 1024 minimum)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR