### PR TITLE
fix: fallback custom model output limit to OUTPUT_TOKEN_MAX instead of 0

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1192,7 +1192,7 @@ const layer: Layer.Layer<
               limit: {
                 context: model.limit?.context ?? existingModel?.limit?.context ?? 0,
                 input: model.limit?.input ?? existingModel?.limit?.input,
-                output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
+                output: model.limit?.output ?? existingModel?.limit?.output ?? ProviderTransform.OUTPUT_TOKEN_MAX,
               },
               headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
               family: model.family ?? existingModel?.family ?? "",

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -8,6 +8,7 @@ import { Instance } from "../../src/project/instance"
 import { Plugin } from "../../src/plugin/index"
 import { ModelsDev } from "../../src/provider"
 import { Provider } from "../../src/provider"
+import { OUTPUT_TOKEN_MAX } from "../../src/provider/transform"
 import { ProviderID, ModelID } from "../../src/provider/schema"
 import { Filesystem } from "../../src/util"
 import { Env } from "../../src/env"
@@ -1745,7 +1746,7 @@ test("model limit defaults to zero when not specified", async () => {
       const providers = await list()
       const model = providers[ProviderID.make("no-limit")].models["model"]
       expect(model.limit.context).toBe(0)
-      expect(model.limit.output).toBe(0)
+      expect(model.limit.output).toBe(OUTPUT_TOKEN_MAX)
     },
   })
 })
@@ -2639,4 +2640,39 @@ test("opencode loader keeps paid models when auth exists", async () => {
       } catch {}
     }
   }
+})
+
+test("custom model without output limit falls back to OUTPUT_TOKEN_MAX", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-provider": {
+              name: "Custom Provider",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "custom-model": {
+                  name: "Custom Model",
+                  tool_call: true,
+                },
+              },
+              options: { apiKey: "test" },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await list()
+      const model = providers[ProviderID.make("custom-provider")].models["custom-model"]
+      expect(model.limit.output).toBe(OUTPUT_TOKEN_MAX)
+    },
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #22253

### Type of change

- [x] Bug fix

### What does this PR do?

Custom provider models without an explicit `limit.output` get `output: 0` as a sentinel value. This 0 propagates to the API call, causing `maxOutputTokens must be >= 1` errors. Changed the fallback from `0` to `ProviderTransform.OUTPUT_TOKEN_MAX` (32000), consistent with built-in model behavior.

### How did you verify your code works?

Added a test: custom model without `limit.output` now gets `OUTPUT_TOKEN_MAX` instead of `0`. Also updated an existing test that was asserting the old (broken) behavior.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
