### PR TITLE
fix: add support for ACP writeTextFile clientCapability

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -461,6 +461,27 @@ export namespace ACP {
 
           return
         }
+        case "file.edited":
+          const props = event.properties
+          const session = this.sessionManager.tryGet(props.sessionID)
+          if (!session) return
+          const sessionId = session.id
+
+          if (this.config.clientCapabilities?.fs?.writeTextFile) {
+            const filepath = event.properties.file
+            try {
+              const content = await Bun.file(filepath).text()
+              await this.connection.writeTextFile({
+                sessionId,
+                path: filepath,
+                content,
+              })
+              log.info("synced file edit to ACP client", { filepath, sessionId})
+            } catch (err) {
+              log.error("failed to sync file edit to ACP client", { error: err, filepath, sessionId })
+            }
+          }
+          break
 
         case "message.part.delta": {
           const props = event.properties
@@ -530,7 +551,9 @@ export namespace ACP {
     }
 
     async initialize(params: InitializeRequest): Promise<InitializeResponse> {
-      log.info("initialize", { protocolVersion: params.protocolVersion })
+      log.info("initialize", { protocolVersion: params.protocolVersion, clientCapabilities: params.clientCapabilities })
+
+      this.config.clientCapabilities = params.clientCapabilities
 
       const authMethod: AuthMethod = {
         description: "Run `opencode auth login` in the terminal",

--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@agentclientprotocol/sdk"
+import type { McpServer, ClientCapabilities } from "@agentclientprotocol/sdk"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import type { ProviderID, ModelID } from "../provider/schema"
 
@@ -21,4 +21,5 @@ export interface ACPConfig {
     providerID: ProviderID
     modelID: ModelID
   }
+  clientCapabilities?: ClientCapabilities
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -79,6 +79,7 @@ export namespace File {
       "file.edited",
       z.object({
         file: z.string(),
+        sessionID: z.string(),
       }),
     ),
   }

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -227,7 +227,7 @@ export const ApplyPatchTool = Tool.define(
 
         if (edited) {
           yield* format.file(edited)
-          yield* bus.publish(File.Event.Edited, { file: edited })
+          yield* bus.publish(File.Event.Edited, { file: edited, sessionID: ctx.sessionID })
         }
       }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -88,7 +88,7 @@ export const EditTool = Tool.define(
                 })
                 yield* afs.writeWithDirs(filePath, params.newString)
                 yield* format.file(filePath)
-                yield* bus.publish(File.Event.Edited, { file: filePath })
+                yield* bus.publish(File.Event.Edited, { file: filePath, sessionID: ctx.sessionID })
                 yield* bus.publish(FileWatcher.Event.Updated, {
                   file: filePath,
                   event: existed ? "change" : "add",
@@ -129,7 +129,7 @@ export const EditTool = Tool.define(
 
               yield* afs.writeWithDirs(filePath, contentNew)
               yield* format.file(filePath)
-              yield* bus.publish(File.Event.Edited, { file: filePath })
+              yield* bus.publish(File.Event.Edited, { file: filePath, sessionID: ctx.sessionID })
               yield* bus.publish(FileWatcher.Event.Updated, {
                 file: filePath,
                 event: "change",

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -56,7 +56,7 @@ export const WriteTool = Tool.define(
 
           yield* fs.writeWithDirs(filepath, params.content)
           yield* format.file(filepath)
-          yield* bus.publish(File.Event.Edited, { file: filepath })
+          yield* bus.publish(File.Event.Edited, { file: filepath, sessionID: ctx.sessionID })
           yield* bus.publish(FileWatcher.Event.Updated, {
             file: filepath,
             event: exists ? "change" : "add",

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -490,6 +490,7 @@ export type EventFileEdited = {
   type: "file.edited"
   properties: {
     file: string
+    sessionID?: string
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -72,6 +72,7 @@ export type EventFileEdited = {
   type: "file.edited"
   properties: {
     file: string
+    sessionID: string
   }
 }
 


### PR DESCRIPTION
### Issue for this PR
Fixes [#4240](https://github.com/anomalyco/opencode/issues/4240
)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes ACP file syncing for clients that advertise the `fs.writeTextFile` capability.
The change stores `clientCapabilities` during ACP initialization, includes `sessionID` in `file.edited` events, and on file edits sends the updated file contents back to the ACP client through `writeTextFile`. 

The SDK/OpenAPI types were updated as part of the event shape change.

### How did you verify your code works?

Zed editor

<img width="2560" height="1568" alt="2026-04-13-152258_hyprshot" src="https://github.com/user-attachments/assets/89aa62e7-9e23-4db6-8065-832f639ca478" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

I'm reopening this pull request [6902](https://github.com/anomalyco/opencode/pull/6902), as it was closed due to the time limit expiring. The issue is still relevant.
