### PR TITLE
fix(opencode): wire permission.ask plugin hook with reason support

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -2,6 +2,7 @@ import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
+import { Plugin } from "@/plugin"
 import { ProjectID } from "@/project/schema"
 import { Instance } from "@/project/instance"
 import { MessageID, SessionID } from "@/session/schema"
@@ -142,6 +143,7 @@ export namespace Permission {
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
+      const plugin = yield* Plugin.Service
       const state = yield* InstanceState.make<State>(
         Effect.fn("Permission.state")(function* (ctx) {
           const row = Database.use((db) =>
@@ -183,6 +185,23 @@ export namespace Permission {
         }
 
         if (!needsAsk) return
+
+        const hook = yield* plugin.trigger(
+          "permission.ask",
+          { permission: request.permission, patterns: request.patterns, metadata: request.metadata },
+          { status: "ask" as Action, reason: undefined as string | undefined },
+        )
+        if (hook.status === "allow") {
+          log.info("plugin auto-approved", { permission: request.permission, patterns: request.patterns })
+          return
+        }
+        if (hook.status === "deny") {
+          log.info("plugin auto-denied", { permission: request.permission, patterns: request.patterns })
+          return yield* new DeniedError({
+            ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
+            reason: hook.reason,
+          })
+        }
 
         const id = request.id ?? PermissionID.ascending()
         const info: Request = {
@@ -308,5 +327,5 @@ export namespace Permission {
     return result
   }
 
-  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+  export const defaultLayer = layer.pipe(Layer.provide(Bus.layer), Layer.provide(Plugin.defaultLayer))
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -95,8 +95,10 @@ export namespace Permission {
 
   export class DeniedError extends Schema.TaggedErrorClass<DeniedError>()("PermissionDeniedError", {
     ruleset: Schema.Any,
+    reason: Schema.optional(Schema.String),
   }) {
     override get message() {
+      if (this.reason) return this.reason
       return `The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules ${JSON.stringify(this.ruleset)}`
     }
   }

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -545,6 +545,17 @@ it.live("ask - throws DeniedError when action is deny", () =>
   ),
 )
 
+test("DeniedError - uses reason as message when provided", () => {
+  const err = new Permission.DeniedError({ ruleset: [], reason: "blocked by TDD policy" })
+  expect(err.message).toBe("blocked by TDD policy")
+})
+
+test("DeniedError - uses default message when reason is absent", () => {
+  const err = new Permission.DeniedError({ ruleset: [{ permission: "bash", pattern: "*", action: "deny" }] })
+  expect(err.message).toContain("The user has specified a rule")
+  expect(err.message).toContain("bash")
+})
+
 it.live("ask - stays pending when action is ask", () =>
   withDir({ git: true }, () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -10,8 +10,7 @@ import { provideInstance, provideTmpdirInstance, tmpdir, tmpdirScoped } from "..
 import { testEffect } from "../lib/effect"
 import { MessageID, SessionID } from "../../src/session/schema"
 
-const bus = Bus.layer
-const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(bus)), bus, CrossSpawnSpawner.defaultLayer)
+const env = Layer.mergeAll(Permission.defaultLayer, Bus.layer, CrossSpawnSpawner.defaultLayer)
 const it = testEffect(env)
 
 afterEach(async () => {

--- a/packages/opencode/test/permission/permission-ask-hook.test.ts
+++ b/packages/opencode/test/permission/permission-ask-hook.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
+import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Bus } from "../../src/bus"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Plugin } = await import("../../src/plugin/index")
+
+const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(Bus.layer)), Plugin.defaultLayer)
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+afterAll(() => {
+  if (disableDefault === undefined) {
+    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+    return
+  }
+  process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+})
+
+async function project(source: string) {
+  return tmpdir({
+    git: true,
+    init: async (dir) => {
+      const file = path.join(dir, "plugin.ts")
+      await Bun.write(file, source)
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(file).href],
+          },
+          null,
+          2,
+        ),
+      )
+    },
+  })
+}
+
+describe("permission.ask hook", () => {
+  test("plugin hook denies with reason and DeniedError carries the reason", async () => {
+    await using tmp = await project(
+      [
+        "export default async () => ({",
+        '  "permission.ask": async (input, output) => {',
+        '    if (input.permission === "edit" && input.patterns.some(p => p.includes("src/"))) {',
+        '      output.status = "deny"',
+        '      output.reason = "Cannot edit production files during RED phase"',
+        "    }",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+    )
+
+    const err = await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          const exit = yield* permission
+            .ask({
+              sessionID: SessionID.make("session_test"),
+              permission: "edit",
+              patterns: ["src/services/foo.ts"],
+              metadata: {},
+              always: [],
+              ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+            })
+            .pipe(Effect.exit)
+
+          expect(Exit.isFailure(exit)).toBe(true)
+          if (!Exit.isFailure(exit)) throw new Error("expected failure")
+          const error = Cause.squash(exit.cause)
+          expect(error).toBeInstanceOf(Permission.DeniedError)
+          expect(String(error)).toContain("Cannot edit production files during RED phase")
+        }).pipe(Effect.provide(env), Effect.scoped, Effect.runPromise),
+    })
+  })
+
+  test("plugin hook allows bypasses user prompt", async () => {
+    await using tmp = await project(
+      [
+        "export default async () => ({",
+        '  "permission.ask": async (input, output) => {',
+        '    if (input.permission === "edit" && input.patterns.some(p => p.includes("test/"))) {',
+        '      output.status = "allow"',
+        "    }",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+    )
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          const result = yield* permission.ask({
+            sessionID: SessionID.make("session_test"),
+            permission: "edit",
+            patterns: ["test/foo.test.ts"],
+            metadata: {},
+            always: [],
+            ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+          })
+          expect(result).toBeUndefined()
+        }).pipe(Effect.provide(env), Effect.scoped, Effect.runPromise),
+    })
+  })
+
+  test("plugin hook leaves status as ask falls through to normal flow", async () => {
+    await using tmp = await project(
+      [
+        "export default async () => ({",
+        '  "permission.ask": async (_input, _output) => {',
+        "    // no-op, leaves status as ask",
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+    )
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () =>
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          const fiber = yield* permission
+            .ask({
+              sessionID: SessionID.make("session_test"),
+              permission: "edit",
+              patterns: ["src/foo.ts"],
+              metadata: {},
+              always: [],
+              ruleset: [{ permission: "edit", pattern: "*", action: "ask" }],
+            })
+            .pipe(Effect.forkScoped)
+
+          // Should still go to pending (normal ask flow)
+          for (let i = 0; i < 100; i++) {
+            const list = yield* permission.list()
+            if (list.length === 1) break
+            yield* Effect.sleep("10 millis")
+          }
+          const pending = yield* permission.list()
+          expect(pending).toHaveLength(1)
+
+          // Reject to clean up
+          yield* permission.reply({ requestID: pending[0].id, reply: "reject" })
+          yield* Fiber.await(fiber)
+        }).pipe(Effect.provide(env), Effect.scoped, Effect.runPromise),
+    })
+  })
+})

--- a/packages/opencode/test/permission/permission-ask-hook.test.ts
+++ b/packages/opencode/test/permission/permission-ask-hook.test.ts
@@ -13,7 +13,7 @@ process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
 
 const { Plugin } = await import("../../src/plugin/index")
 
-const env = Layer.mergeAll(Permission.layer.pipe(Layer.provide(Bus.layer)), Plugin.defaultLayer)
+const env = Layer.mergeAll(Permission.defaultLayer, Plugin.defaultLayer)
 
 afterEach(async () => {
   await Instance.disposeAll()

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -257,7 +257,7 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow"; reason?: string }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },


### PR DESCRIPTION
### Issue for this PR

Closes #7006
Related: #19469, #22558

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `permission.ask` plugin hook is declared in the SDK type system but never triggered at runtime. This PR wires it up.

After static permission rules evaluate to `ask`, the permission service now calls `plugin.trigger("permission.ask", ...)` before prompting the user. Plugins can override the status to `allow` (auto-approve) or `deny` (reject). If the plugin sets `deny`, it can also provide a `reason` string that becomes the error message the model sees, instead of the generic rule dump.

The `reason` field is the only addition beyond wiring the existing hook — it was needed to make the hook useful for dynamic policy (the motivating use case is a TDD state machine that restricts file edits by phase).

### How did you verify your code works?

- 5 new tests: 2 unit tests for `DeniedError.reason`, 3 integration tests that load a real plugin from disk and exercise deny/allow/fallthrough paths
- All 85 permission tests pass
- Full test suite passes (1917 pass; 13 pre-existing env-specific failures in `cross-spawn-spawner.test.ts` unrelated to this change)
- Typecheck clean across all 14 packages

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR