### PR TITLE
feat(opencode): add request route spans

### DIFF
--- a/packages/opencode/src/server/instance/config.ts
+++ b/packages/opencode/src/server/instance/config.ts
@@ -5,12 +5,10 @@ import { Config } from "../../config/config"
 import { Provider } from "../../provider/provider"
 import { mapValues } from "remeda"
 import { errors } from "../error"
-import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { AppRuntime } from "../../effect/app-runtime"
 import { Effect } from "effect"
-
-const log = Log.create({ service: "server" })
+import { jsonRequest } from "./trace"
 
 export const ConfigRoutes = lazy(() =>
   new Hono()
@@ -31,9 +29,10 @@ export const ConfigRoutes = lazy(() =>
           },
         },
       }),
-      async (c) => {
-        return c.json(await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get())))
-      },
+      jsonRequest("ConfigRoutes.get", function* () {
+        const cfg = yield* Config.Service
+        return yield* cfg.get()
+      }),
     )
     .patch(
       "/",
@@ -82,18 +81,13 @@ export const ConfigRoutes = lazy(() =>
           },
         },
       }),
-      async (c) => {
-        using _ = log.time("providers")
-        const providers = await AppRuntime.runPromise(
-          Effect.gen(function* () {
-            const svc = yield* Provider.Service
-            return mapValues(yield* svc.list(), (item) => item)
-          }),
-        )
-        return c.json({
+      jsonRequest("ConfigRoutes.providers", function* () {
+        const svc = yield* Provider.Service
+        const providers = mapValues(yield* svc.list(), (item) => item)
+        return {
           providers: Object.values(providers),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
-        })
-      },
+        }
+      }),
     ),
 )

--- a/packages/opencode/src/server/instance/session.ts
+++ b/packages/opencode/src/server/instance/session.ts
@@ -26,6 +26,7 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
 import { NamedError } from "@opencode-ai/shared/util/error"
+import { jsonRequest } from "./trace"
 
 const log = Log.create({ service: "server" })
 
@@ -94,10 +95,10 @@ export const SessionRoutes = lazy(() =>
           ...errors(400),
         },
       }),
-      async (c) => {
-        const result = await AppRuntime.runPromise(SessionStatus.Service.use((svc) => svc.list()))
-        return c.json(Object.fromEntries(result))
-      },
+      jsonRequest("SessionRoutes.status", function* () {
+        const svc = yield* SessionStatus.Service
+        return Object.fromEntries(yield* svc.list())
+      }),
     )
     .get(
       "/:sessionID",
@@ -124,11 +125,11 @@ export const SessionRoutes = lazy(() =>
           sessionID: Session.GetInput,
         }),
       ),
-      async (c) => {
+      jsonRequest("SessionRoutes.get", function* (c) {
         const sessionID = c.req.valid("param").sessionID
-        const session = await AppRuntime.runPromise(Session.Service.use((svc) => svc.get(sessionID)))
-        return c.json(session)
-      },
+        const session = yield* Session.Service
+        return yield* session.get(sessionID)
+      }),
     )
     .get(
       "/:sessionID/children",
@@ -155,11 +156,11 @@ export const SessionRoutes = lazy(() =>
           sessionID: Session.ChildrenInput,
         }),
       ),
-      async (c) => {
+      jsonRequest("SessionRoutes.children", function* (c) {
         const sessionID = c.req.valid("param").sessionID
-        const session = await AppRuntime.runPromise(Session.Service.use((svc) => svc.children(sessionID)))
-        return c.json(session)
-      },
+        const session = yield* Session.Service
+        return yield* session.children(sessionID)
+      }),
     )
     .get(
       "/:sessionID/todo",
@@ -185,11 +186,11 @@ export const SessionRoutes = lazy(() =>
           sessionID: SessionID.zod,
         }),
       ),
-      async (c) => {
+      jsonRequest("SessionRoutes.todo", function* (c) {
         const sessionID = c.req.valid("param").sessionID
-        const todos = await AppRuntime.runPromise(Todo.Service.use((svc) => svc.get(sessionID)))
-        return c.json(todos)
-      },
+        const todo = yield* Todo.Service
+        return yield* todo.get(sessionID)
+      }),
     )
     .post(
       "/",

--- a/packages/opencode/src/server/instance/trace.ts
+++ b/packages/opencode/src/server/instance/trace.ts
@@ -1,0 +1,28 @@
+import type { Context } from "hono"
+import { Effect } from "effect"
+import { AppRuntime } from "../../effect/app-runtime"
+
+export function runRequest<A, E>(name: string, c: Context, effect: Effect.Effect<A, E, any>) {
+  const url = new URL(c.req.url)
+  return AppRuntime.runPromise(
+    effect.pipe(
+      Effect.withSpan(name, {
+        attributes: {
+          "http.method": c.req.method,
+          "http.path": url.pathname,
+        },
+      }),
+    ),
+  )
+}
+
+export function jsonRequest<A, E>(name: string, effect: (c: any) => Effect.gen.Return<A, E, any>) {
+  return async (c: Context) =>
+    c.json(
+      await runRequest(
+        name,
+        c,
+        Effect.gen(() => effect(c)),
+      ),
+    )
+}


### PR DESCRIPTION
## Summary
- add a small request tracing helper for instance HTTP handlers
- wrap the high-volume session/config read routes with top-level route spans like `SessionRoutes.get` and `ConfigRoutes.get`
- keep the call site generator-friendly so handlers can `yield*` services directly while still producing clear HTTP parent spans

## Verification
- verified in the current local branch and Motel that route spans like `SessionRoutes.get` now appear as parents of service spans like `Session.get`
- confirmed the ported files on this branch are byte-for-byte identical to the locally tested version
- note: fresh worktree `tsgo` hit the known `@tsconfig/bun` resolution quirk, so runtime verification was done in the active local branch before porting