### PR TITLE
feat(plugin): expose ask() on tool.execute.before hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -413,7 +413,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 const ctx = context(args, options)
                 yield* plugin.trigger(
                   "tool.execute.before",
-                  { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
+                  { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID!, ask: (req) => run.promise(ctx.ask(req)) },
                   { args },
                 )
                 const result = yield* item.execute(args, ctx)
@@ -454,7 +454,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               const ctx = context(args, opts)
               yield* plugin.trigger(
                 "tool.execute.before",
-                { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
+                { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, ask: (req) => run.promise(ctx.ask(req)) },
                 { args },
               )
               yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
@@ -574,12 +574,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         subagent_type: task.agent,
         command: task.command,
       }
-      yield* plugin.trigger(
-        "tool.execute.before",
-        { tool: TaskTool.id, sessionID, callID: part.id },
-        { args: taskArgs },
-      )
-
       const taskAgent = yield* agents.get(task.agent)
       if (!taskAgent) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
@@ -588,6 +582,26 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         yield* bus.publish(Session.Event.Error, { sessionID, error: error.toObject() })
         throw error
       }
+      yield* plugin.trigger(
+        "tool.execute.before",
+        {
+          tool: TaskTool.id,
+          sessionID,
+          callID: part.id,
+          ask: (req) =>
+            Effect.runPromise(
+              permission
+                .ask({
+                  ...req,
+                  sessionID,
+                  tool: { messageID: assistantMessage.id, callID: part.id },
+                  ruleset: Permission.merge(taskAgent.permission, session.permission ?? []),
+                })
+                .pipe(Effect.orDie),
+            ),
+        },
+        { args: taskArgs },
+      )
 
       let error: Error | undefined
       const taskAbort = new AbortController()

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -263,7 +263,17 @@ export interface Hooks {
     output: { parts: Part[] },
   ) => Promise<void>
   "tool.execute.before"?: (
-    input: { tool: string; sessionID: string; callID: string },
+    input: {
+      tool: string
+      sessionID: string
+      callID: string
+      ask: (input: {
+        permission: string
+        patterns: string[]
+        always: string[]
+        metadata: { [key: string]: any }
+      }) => Promise<void>
+    },
     output: { args: any },
   ) => Promise<void>
   "shell.env"?: (


### PR DESCRIPTION
### Issue for this PR

Closes #22311

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `ask` to the `tool.execute.before` hook input so plugins can initiate permission requests from the pre-tool interceptor. Currently the hook can only hard-block (throw) or silently allow.

Two files, three sites:
- Extended the hook type in `packages/plugin/src/index.ts`
- Pass `ask` at the built-in, MCP, and subtask trigger sites in `prompt.ts`
- Moved `agents.get()` before the trigger at the subtask site so the ask function can be constructed with the correct permission ruleset

### Screenshots / recordings
N/A

### How did you verify your code works?
bun turbo typecheck passes. Change is additive, existing plugins that don't use ask are unaffected.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR