### PR TITLE
fix: remove new Function() code injection vulnerability

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -102,19 +102,12 @@ function parseToolParams(input?: string) {
   const trimmed = input.trim()
   if (trimmed.length === 0) return {}
 
-  const parsed = iife(() => {
-    try {
-      return JSON.parse(trimmed)
-    } catch (jsonError) {
-      try {
-        return new Function(`return (${trimmed})`)()
-      } catch (evalError) {
-        throw new Error(
-          `Failed to parse --params. Use JSON or a JS object literal. JSON error: ${jsonError}. Eval error: ${evalError}.`,
-        )
-      }
-    }
-  })
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch (jsonError) {
+    throw new Error(`Failed to parse --params. Use valid JSON. Error: ${jsonError}.`)
+  }
 
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("Tool params must be an object.")


### PR DESCRIPTION
## Summary
- Removes new Function() fallback in parseToolParams that allowed arbitrary JavaScript code execution
- Now only accepts JSON input for tool parameters
- Fixes VULN-001 (Critical code injection)