### PR TITLE
fix: add support for ACP writeTextFile clientCapability

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -74,6 +74,8 @@ export class Subscription {
         return this.handlePartUpdated(event)
       case "message.part.delta":
         return this.handlePartDelta(event)
+      case "file.watcher.updated":
+        return this.handleFileUpdated(event)
     }
   }
 
@@ -194,6 +196,23 @@ export class Subscription {
           },
         },
       })
+    }
+  }
+
+  private async handleFileUpdated(event: Extract<Event, { type: "file.watcher.updated" }>) {
+    const props = event.properties
+    if (props.event === "unlink" || !this.input.connection.writeTextFile) return
+
+    const sessions = await Effect.runPromise(this.input.session.list())
+    for (const session of sessions) {
+      if (props.file.startsWith(session.cwd)) {
+        const content = await Bun.file(props.file).text()
+        await this.input.connection.writeTextFile({
+          sessionId: session.id,
+          path: props.file,
+          content,
+        })
+      }
     }
   }
 

--- a/packages/opencode/src/event-v2-bridge.ts
+++ b/packages/opencode/src/event-v2-bridge.ts
@@ -10,6 +10,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import "@opencode-ai/core/account"
 import "@opencode-ai/core/catalog"
 import "@opencode-ai/core/session/event"
+import "@opencode-ai/core/filesystem/watcher"
 import { Context, Effect, Layer } from "effect"
 
 export class Service extends Context.Service<Service, EventV2.Interface>()("@opencode/EventV2Bridge") {}


### PR DESCRIPTION
### Issue for this PR
Fixes [#4240](https://github.com/anomalyco/opencode/issues/4240
)

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes ACP file syncing for clients that advertise the `fs.writeTextFile` capability.
The change stores `clientCapabilities` during ACP initialization, includes `sessionID` in `file.edited` events, and on file edits sends the updated file contents back to the ACP client through `writeTextFile`. 

The SDK/OpenAPI types were updated as part of the event shape change.

### How did you verify your code works?

Zed editor

<img width="2560" height="1568" alt="2026-04-13-152258_hyprshot" src="https://github.com/user-attachments/assets/89aa62e7-9e23-4db6-8065-832f639ca478" />


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

I'm reopening this pull request [6902](https://github.com/anomalyco/opencode/pull/6902), as it was closed due to the time limit expiring. The issue is still relevant.
