### PR TITLE
feat: Use proper globbing for "edit", "read" and "external_directory" permi…

### DIFF
--- a/packages/opencode/src/permission/evaluate-path-permission.ts
+++ b/packages/opencode/src/permission/evaluate-path-permission.ts
@@ -1,0 +1,29 @@
+import path from "path"
+import { minimatch } from "minimatch"
+import { Wildcard } from "@/util"
+
+type Rule = {
+  permission: string
+  pattern: string
+  action: "allow" | "deny" | "ask"
+}
+
+function normalizeForGlob(input: string) {
+  return input.replaceAll("\\", "/")
+}
+
+export function evaluatePathPermission(
+  permission: string,
+  paths: { absolutePath: string; relativePath: string },
+  ...rulesets: Rule[][]
+): Rule {
+  const rules = rulesets.flat()
+  const match = rules.findLast((rule) => {
+    if (!Wildcard.match(permission, rule.permission)) return false
+    // As an exception to the proper globbing rules, treat "*" as meaning 'match *any* file or directory'.
+    if (rule.pattern === "*") return true
+    const filepath = path.isAbsolute(rule.pattern) ? paths.absolutePath : paths.relativePath
+    return minimatch(normalizeForGlob(filepath), normalizeForGlob(rule.pattern))
+  })
+  return match ?? { action: "ask", permission, pattern: "*" }
+}

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -12,7 +12,10 @@ import { withStatics } from "@/util/schema"
 import { Wildcard } from "@/util"
 import { Deferred, Effect, Layer, Schema, Context } from "effect"
 import os from "os"
+import path from "path"
 import { evaluate as evalRule } from "./evaluate"
+import { evaluatePathPermission } from "./evaluate-path-permission"
+import { Instance } from "@/project/instance"
 import { PermissionID } from "./schema"
 
 const log = Log.create({ service: "permission" })
@@ -178,11 +181,17 @@ export const layer = Layer.effect(
     const ask = Effect.fn("Permission.ask")(function* (input: AskInput) {
       const { approved, pending } = yield* InstanceState.get(state)
       const { ruleset, ...request } = input
+      const GLOB_TOOLS = ["read", "edit", "external_directory"]
+      const isGlobTool = GLOB_TOOLS.includes(request.permission)
       let needsAsk = false
 
       for (const pattern of request.patterns) {
-        const rule = evaluate(request.permission, pattern, ruleset, approved)
-        log.info("evaluated", { permission: request.permission, pattern, action: rule })
+        const absolutePath = path.isAbsolute(pattern) ? path.normalize(pattern) : path.resolve(Instance.worktree, pattern)
+        const relativePath = path.relative(Instance.worktree, absolutePath).replaceAll("\\", "/")
+        const rule = isGlobTool
+          ? evaluatePathPermission(request.permission, { absolutePath, relativePath }, ruleset, approved)
+          : evaluate(request.permission, pattern, ruleset, approved)
+        log.info("evaluated", { absolutePath, relativePath, isGlobTool, permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {
           return yield* new DeniedError({
             ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),


### PR DESCRIPTION
…ssions.

Exception: "*" still means "any file (anywhere)".
Note that "**" does not match paths starting with a period (including `..`).

### Issue for this PR

Closes #22465

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Changes how permission patterns on "read", "edit" and "external_directory" are used:
A single "*" still matches absolutely everything ("always true").
Otherwise the pattern is treated as a proper globbing pattern where a '*' matches a single path component that doesn't start with period (and it doesn't match a '/').

Furthermore, if the pattern looks like an absolute path (i.e. starts with a '/' on linux) then it is matched against the absolute path of the filepath under test. Otherwise it is matched against the relative path of the filepath under test (relative to the current worktree).

### How did you verify your code works?

Extensive testing including adding loads of debug output to understand exactly what was going on. Among other it was found that path.matchesGlob is unusable as its implementation varies between node and bun implementations and you can't rely on what will be used during runtime. `minimatch` on the other hand has the same implementation in both cases. 

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

