### PR TITLE
fix: revert "core: move plugin initialisation to config layer override"

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -47,31 +47,13 @@ import { Pty } from "@/pty"
 import { Installation } from "@/installation"
 import { ShareNext } from "@/share/share-next"
 import { SessionShare } from "@/share/session"
-import * as Effect from "effect/Effect"
-
-// Adjusts the default Config layer to ensure that plugins are always initialised before
-// any other layers read the current config
-const ConfigWithPluginPriority = Layer.effect(
-  Config.Service,
-  Effect.gen(function* () {
-    const config = yield* Config.Service
-    const plugin = yield* Plugin.Service
-
-    return {
-      ...config,
-      get: () => Effect.andThen(plugin.init(), config.get),
-      getGlobal: () => Effect.andThen(plugin.init(), config.getGlobal),
-      getConsoleState: () => Effect.andThen(plugin.init(), config.getConsoleState),
-    }
-  }),
-).pipe(Layer.provide(Layer.merge(Plugin.defaultLayer, Config.defaultLayer)))
 
 export const AppLayer = Layer.mergeAll(
   AppFileSystem.defaultLayer,
   Bus.defaultLayer,
   Auth.defaultLayer,
   Account.defaultLayer,
-  ConfigWithPluginPriority,
+  Config.defaultLayer,
   Git.defaultLayer,
   Ripgrep.defaultLayer,
   FileTime.defaultLayer,

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -15,6 +15,7 @@ import * as Effect from "effect/Effect"
 
 export const InstanceBootstrap = Effect.gen(function* () {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
+  yield* Plugin.Service.use((svc) => svc.init())
   yield* Effect.all(
     [
       LSP.Service,


### PR DESCRIPTION
## Summary

- Reverts 916131be1 which moved `plugin.init()` from `InstanceBootstrap` into a `ConfigWithPluginPriority` layer wrapper
- The wrapper called `plugin.init()` on every `config.get()`, but `plugin.init()` requires Instance context (via `InstanceState`), which isn't available when Config is read before `Instance.provide` (e.g. the worker's first RPC fetch)
- This caused a startup crash: `No context found for instance`
- Plugin init stays in `InstanceBootstrap` where it has proper instance context