### PR TITLE
fix: prefix 32 unused parameters with underscore

### DIFF
--- a/packages/console/app/src/component/icon.tsx
+++ b/packages/console/app/src/component/icon.tsx
@@ -1,6 +1,6 @@
 import { JSX } from "solid-js"
 
-export function IconZen(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
+export function IconZen(_props: JSX.SvgSVGAttributes<SVGSVGElement>) {
   return (
     <svg width="84" height="30" viewBox="0 0 84 30" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M24 24H6V18H18V12H24V24ZM6 18H0V12H6V18Z" fill="currentColor" fill-opacity="0.2" />
@@ -13,7 +13,7 @@ export function IconZen(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
   )
 }
 
-export function IconGo(props: JSX.SvgSVGAttributes<SVGSVGElement>) {
+export function IconGo(_props: JSX.SvgSVGAttributes<SVGSVGElement>) {
   return (
     <svg width="54" height="30" viewBox="0 0 54 30" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M24 30H0V0H24V6H6V24H18V18H12V12H24V30Z" fill="currentColor" />

--- a/packages/console/app/src/routes/auth/status.ts
+++ b/packages/console/app/src/routes/auth/status.ts
@@ -1,7 +1,7 @@
 import { APIEvent } from "@solidjs/start"
 import { useAuthSession } from "~/context/auth"
 
-export async function GET(input: APIEvent) {
+export async function GET(_input: APIEvent) {
   const session = await useAuthSession()
   return Response.json(session.data)
 }

--- a/packages/console/app/src/routes/debug/index.ts
+++ b/packages/console/app/src/routes/debug/index.ts
@@ -3,7 +3,7 @@ import { json } from "@solidjs/router"
 import { Database } from "@opencode-ai/console-core/drizzle/index.js"
 import { UserTable } from "@opencode-ai/console-core/schema/user.sql.js"
 
-export async function GET(evt: APIEvent) {
+export async function GET(_evt: APIEvent) {
   return json({
     data: await Database.use(async (tx) => {
       const result = await tx.$count(UserTable)

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -30,7 +30,7 @@ export const oaCompatHelper: ProviderHelper = ({ adjustCacheUsage, safetyIdentif
     headers.set("authorization", `Bearer ${apiKey}`)
     headers.set("x-session-affinity", headers.get("x-opencode-session") ?? "")
   },
-  modifyBody: (body: Record<string, any>, workspaceID?: string) => {
+  modifyBody: (body: Record<string, any>, _workspaceID?: string) => {
     return {
       ...body,
       ...(body.stream ? { stream_options: { include_usage: true } } : {}),

--- a/packages/console/app/src/routes/zen/v1/models.ts
+++ b/packages/console/app/src/routes/zen/v1/models.ts
@@ -5,7 +5,7 @@ import { WorkspaceTable } from "@opencode-ai/console-core/schema/workspace.sql.j
 import { ModelTable } from "@opencode-ai/console-core/schema/model.sql.js"
 import { ZenData } from "@opencode-ai/console-core/model.js"
 
-export async function OPTIONS(input: APIEvent) {
+export async function OPTIONS(_input: APIEvent) {
   return new Response(null, {
     status: 200,
     headers: {

--- a/packages/console/app/src/routes/zen/v1/models/[model].ts
+++ b/packages/console/app/src/routes/zen/v1/models/[model].ts
@@ -6,8 +6,8 @@ export function POST(input: APIEvent) {
     format: "google",
     modelList: "full",
     parseApiKey: (headers: Headers) => headers.get("x-goog-api-key") ?? undefined,
-    parseModel: (url: string, body: any) => url.split("/").pop()?.split(":")?.[0] ?? "",
-    parseIsStream: (url: string, body: any) =>
+    parseModel: (url: string, _body: any) => url.split("/").pop()?.split(":")?.[0] ?? "",
+    parseIsStream: (url: string, _body: any) =>
       // ie. url: https://opencode.ai/zen/v1/models/gemini-3-pro:streamGenerateContent?alt=sse'
       url.split("/").pop()?.split(":")?.[1]?.startsWith("streamGenerateContent") ?? false,
   })

--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -49,9 +49,9 @@ export class SyncServer extends DurableObject<Env> {
     })
   }
 
-  async webSocketMessage(ws, message) {}
+  async webSocketMessage(_ws, _message) {}
 
-  async webSocketClose(ws, code, reason, wasClean) {
+  async webSocketClose(ws, code, _reason, _wasClean) {
     ws.close(code, "Durable Object is closing WebSocket")
   }
 

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -80,7 +80,7 @@ export namespace Agent {
       const provider = yield* Provider.Service
 
       const state = yield* InstanceState.make<State>(
-        Effect.fn("Agent.state")(function* (ctx) {
+        Effect.fn("Agent.state")(function* (_ctx) {
           const cfg = yield* config.get()
           const skillDirs = yield* skill.dirs()
           const whitelistedDirs = [Truncate.GLOB, ...skillDirs.map((dir) => path.join(dir, "*"))]

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
@@ -78,7 +78,7 @@ export function DialogMcp() {
       title="MCPs"
       options={options()}
       keybind={keybinds()}
-      onSelect={(option) => {
+      onSelect={(_option) => {
         // Don't close on select, only on escape
       }}
     />

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -54,7 +54,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
               paddingLeft={1}
               paddingRight={1}
               backgroundColor={key === store.active ? theme.primary : undefined}
-              onMouseUp={(evt) => {
+              onMouseUp={(_evt) => {
                 if (key === "confirm") props.onConfirm?.()
                 if (key === "cancel") props.onCancel?.()
                 dialog.clear()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -510,7 +510,7 @@ export const Agent = z
     permission: Permission.optional(),
   })
   .catchall(z.any())
-  .transform((agent, ctx) => {
+  .transform((agent, _ctx) => {
     const knownKeys = new Set([
       "name",
       "model",

--- a/packages/opencode/src/provider/schema.ts
+++ b/packages/opencode/src/provider/schema.ts
@@ -30,7 +30,7 @@ const modelIdSchema = Schema.String.pipe(Schema.brand("ModelID"))
 export type ModelID = typeof modelIdSchema.Type
 
 export const ModelID = modelIdSchema.pipe(
-  withStatics((schema: typeof modelIdSchema) => ({
+  withStatics((_schema: typeof modelIdSchema) => ({
     zod: z.string().pipe(z.custom<ModelID>()),
   })),
 )

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -49,7 +49,7 @@ export namespace ProviderTransform {
   function normalizeMessages(
     msgs: ModelMessage[],
     model: Provider.Model,
-    options: Record<string, unknown>,
+    _options: Record<string, unknown>,
   ): ModelMessage[] {
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content

--- a/packages/opencode/src/v2/session.ts
+++ b/packages/opencode/src/v2/session.ts
@@ -40,11 +40,11 @@ export namespace SessionV2 {
     Effect.gen(function* () {
       const session = yield* Session.Service
 
-      const create: Interface["create"] = Effect.fn("Session.create")(function* (input) {
+      const create: Interface["create"] = Effect.fn("Session.create")(function* (_input) {
         throw new Error("Not implemented")
       })
 
-      const prompt: Interface["prompt"] = Effect.fn("Session.prompt")(function* (input) {
+      const prompt: Interface["prompt"] = Effect.fn("Session.prompt")(function* (_input) {
         throw new Error("Not implemented")
       })
 

--- a/packages/opencode/test/session/prompt-effect.test.ts
+++ b/packages/opencode/test/session/prompt-effect.test.ts
@@ -786,7 +786,7 @@ it.live(
           const { task } = yield* registry.named()
           const original = task.execute
           task.execute = (_args, ctx) =>
-            Effect.callback<never>((resume) => {
+            Effect.callback<never>((_resume) => {
               ready.resolve()
               ctx.abort.addEventListener("abort", () => aborted.resolve(), { once: true })
               return Effect.sync(() => aborted.resolve())
@@ -856,7 +856,7 @@ it.live(
 
 it.live("concurrent loop callers get same result", () =>
   provideTmpdirInstance(
-    (dir) =>
+    (_dir) =>
       Effect.gen(function* () {
         const { prompt, run, chat } = yield* boot()
         yield* seed(chat.id, { finish: "stop" })
@@ -997,7 +997,7 @@ it.live(
 
 it.live("assertNotBusy succeeds when idle", () =>
   provideTmpdirInstance(
-    (dir) =>
+    (_dir) =>
       Effect.gen(function* () {
         const run = yield* SessionRunState.Service
         const sessions = yield* Session.Service
@@ -1042,7 +1042,7 @@ it.live(
 
 unix("shell captures stdout and stderr in completed tool output", () =>
   provideTmpdirInstance(
-    (dir) =>
+    (_dir) =>
       Effect.gen(function* () {
         const { prompt, run, chat } = yield* boot()
         const result = yield* prompt.shell({
@@ -1117,7 +1117,7 @@ unix("shell lists files from the project directory", () =>
 
 unix("shell captures stderr from a failing command", () =>
   provideTmpdirInstance(
-    (dir) =>
+    (_dir) =>
       Effect.gen(function* () {
         const { prompt, run, chat } = yield* boot()
         const result = yield* prompt.shell({
@@ -1143,7 +1143,7 @@ unix(
   () =>
     withSh(() =>
       provideTmpdirInstance(
-        (dir) =>
+        (_dir) =>
           Effect.gen(function* () {
             const { prompt, chat } = yield* boot()
 
@@ -1255,7 +1255,7 @@ unix(
   () =>
     withSh(() =>
       provideTmpdirInstance(
-        (dir) =>
+        (_dir) =>
           Effect.gen(function* () {
             const { prompt, run, chat } = yield* boot()
 
@@ -1292,7 +1292,7 @@ unix(
   () =>
     withSh(() =>
       provideTmpdirInstance(
-        (dir) =>
+        (_dir) =>
           Effect.gen(function* () {
             const { prompt, chat } = yield* boot()
 
@@ -1374,7 +1374,7 @@ unix(
   "cancel interrupts loop queued behind shell",
   () =>
     provideTmpdirInstance(
-      (dir) =>
+      (_dir) =>
         Effect.gen(function* () {
           const { prompt, chat } = yield* boot()
 
@@ -1403,7 +1403,7 @@ unix(
   () =>
     withSh(() =>
       provideTmpdirInstance(
-        (dir) =>
+        (_dir) =>
           Effect.gen(function* () {
             const { prompt, chat } = yield* boot()
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -239,7 +239,7 @@ describe("session.message-v2.fromError", () => {
       using server = Bun.serve({
         port: 0,
         idleTimeout: 8,
-        async fetch(req) {
+        async fetch(_req) {
           return new Response(
             new ReadableStream({
               async pull(controller) {

--- a/packages/plugin/src/example.ts
+++ b/packages/plugin/src/example.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "./index.js"
 import { tool } from "./tool.js"
 
-export const ExamplePlugin: Plugin = async (ctx) => {
+export const ExamplePlugin: Plugin = async (_ctx) => {
   return {
     tool: {
       mytool: tool({


### PR DESCRIPTION
## Summary

- Prefix 32 unused callback/handler parameters with `_` across 17 files
- No behavioral changes — parameter positions preserved for interface compliance
- Resolves all oxlint `no-unused-vars` warnings for unused parameters

Most are in test callbacks (`dir`, `resume`), framework handlers (`evt`, `props`, `input`), and Effect contexts (`ctx`).