### PR TITLE
fix: clean up 49 unused variables, catch params, and stale imports

### DIFF
--- a/infra/enterprise.ts
+++ b/infra/enterprise.ts
@@ -3,7 +3,7 @@ import { shortDomain } from "./stage"
 
 const storage = new sst.cloudflare.Bucket("EnterpriseStorage")
 
-const teams = new sst.cloudflare.x.SolidStart("Teams", {
+new sst.cloudflare.x.SolidStart("Teams", {
   domain: shortDomain,
   path: "packages/enterprise",
   buildCommand: "bun run build:cloudflare",

--- a/packages/app/src/addons/serialize.test.ts
+++ b/packages/app/src/addons/serialize.test.ts
@@ -180,8 +180,8 @@ describe("SerializeAddon", () => {
       await writeAndWait(term, input)
 
       const origLine = term.buffer.active.getLine(0)
-      const origFg = origLine!.getCell(0)!.getFgColor()
-      const origBg = origLine!.getCell(0)!.getBgColor()
+      const _origFg = origLine!.getCell(0)!.getFgColor()
+      const _origBg = origLine!.getCell(0)!.getBgColor()
       expect(origLine!.getCell(0)!.isBold()).toBe(1)
 
       const serialized = addon.serialize({ range: { start: 0, end: 0 } })

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from "@opencode-ai/ui/theme/context"
 import { MetaProvider } from "@solidjs/meta"
 import { type BaseRouterProps, Navigate, Route, Router } from "@solidjs/router"
 import { QueryClient, QueryClientProvider } from "@tanstack/solid-query"
-import { type Duration, Effect } from "effect"
+import { Effect } from "effect"
 import {
   type Component,
   createMemo,
@@ -155,11 +155,6 @@ export function AppBaseProviders(props: ParentProps<{ locale?: Locale }>) {
     </MetaProvider>
   )
 }
-
-const effectMinDuration =
-  (duration: Duration.Input) =>
-  <A, E, R>(e: Effect.Effect<A, E, R>) =>
-    Effect.all([e, Effect.sleep(duration)], { concurrency: "unbounded" }).pipe(Effect.map((v) => v[0]))
 
 function ConnectionGate(props: ParentProps<{ disableHealthCheck?: boolean }>) {
   const server = useServer()

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -433,7 +433,6 @@ export default function Page() {
   const isChildSession = createMemo(() => !!info()?.parentID)
   const diffs = createMemo(() => (params.id ? list(sync.data.session_diff[params.id]) : []))
   const sessionCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
-  const hasSessionReview = createMemo(() => sessionCount() > 0)
   const canReview = createMemo(() => !!sync.project)
   const reviewTab = createMemo(() => isDesktop())
   const tabState = createSessionTabs({
@@ -443,8 +442,6 @@ export default function Page() {
     review: reviewTab,
     hasReview: canReview,
   })
-  const contextOpen = tabState.contextOpen
-  const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
   const revertMessageID = createMemo(() => info()?.revert?.messageID)

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -378,12 +378,6 @@ export function FileTabContent(props: { tab: string }) {
     requestAnimationFrame(() => comments.clearFocus())
   })
 
-  const cancelCommenting = () => {
-    const p = path()
-    if (p) file.setSelectedLines(p, null)
-    setNote("commenting", null)
-  }
-
   let prev = {
     loaded: false,
     ready: false,

--- a/packages/console/app/script/generate-sitemap.ts
+++ b/packages/console/app/script/generate-sitemap.ts
@@ -8,7 +8,6 @@ import { LOCALES, route } from "../src/lib/language.js"
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const BASE_URL = config.baseUrl
 const PUBLIC_DIR = join(__dirname, "../public")
-const ROUTES_DIR = join(__dirname, "../src/routes")
 const DOCS_DIR = join(__dirname, "../../../web/src/content/docs")
 
 interface SitemapEntry {

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -31,8 +31,6 @@ export default function Home() {
   const i18n = useI18n()
   const language = useLanguage()
   const githubData = createAsync(() => github())
-  const release = createMemo(() => githubData()?.release)
-
   const handleCopyClick = (event: Event) => {
     const button = event.currentTarget as HTMLButtonElement
     const text = button.textContent

--- a/packages/console/app/src/routes/user-menu.tsx
+++ b/packages/console/app/src/routes/user-menu.tsx
@@ -6,7 +6,7 @@ import { useI18n } from "~/context/i18n"
 import { useLanguage } from "~/context/language"
 import "./user-menu.css"
 
-const logout = action(async () => {
+const _logout = action(async () => {
   "use server"
   const auth = await useAuthSession()
   const event = getRequestEvent()

--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -195,7 +195,7 @@ export default new Hono<{ Bindings: Env }>()
     let info
     const messages: Record<string, any> = {}
     data.forEach((d) => {
-      const [root, type, ...splits] = d.key.split("/")
+      const [root, type] = d.key.split("/")
       if (root !== "session") return
       if (type === "info") {
         info = d.content

--- a/packages/opencode/src/bus/bus.ts
+++ b/packages/opencode/src/bus/bus.ts
@@ -4,7 +4,6 @@ import { EffectBridge } from "@/effect/bridge"
 import { Log } from "../util/log"
 import { BusEvent } from "./bus-event"
 import { GlobalBus } from "./global"
-import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -111,7 +111,7 @@ export function Autocomplete(props: {
 
   const position = createMemo(() => {
     if (!store.visible) return { x: 0, y: 0, width: 0 }
-    const dims = dimensions()
+    dimensions()
     positionTick()
     const anchor = props.anchor()
     const parent = anchor.parent

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -157,10 +157,10 @@ export function Session() {
   const [showThinking, setShowThinking] = kv.signal("thinking_visibility", true)
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
-  const [showAssistantMetadata, setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
+  const [showAssistantMetadata, _setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
   const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
-  const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
+  const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
   const wide = createMemo(() => dimensions().width > 120)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -599,7 +599,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   })
 
   const hint = createMemo(() => (store.expanded ? "minimize" : "fullscreen"))
-  const renderer = useRenderer()
+  useRenderer()
 
   const content = () => (
     <box

--- a/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/subagent-footer.tsx
@@ -59,7 +59,7 @@ export function SubagentFooter() {
   const keybind = useKeybind()
   const command = useCommandDialog()
   const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
-  const dimensions = useTerminalDimensions()
+  useTerminalDimensions()
 
   return (
     <box flexShrink={0}>

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -43,8 +43,6 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const hostnameExplicitlySet = process.argv.includes("--hostname")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
-  const corsExplicitlySet = process.argv.includes("--cors")
-
   const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
   const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
   const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -8,13 +8,10 @@ import z from "zod"
 import { Config } from "../config"
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
-import { Log } from "../util/log"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 
 export namespace Command {
-  const log = Log.create({ service: "command" })
-
   type State = {
     commands: Record<string, Info>
   }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1095,7 +1095,7 @@ function patchJsonc(input: string, patch: unknown, path: string[] = []): string 
 }
 
 function writable(info: Info) {
-  const { plugin_origins, ...next } = info
+  const { plugin_origins: _plugin_origins, ...next } = info
   return next
 }
 

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -328,7 +328,7 @@ export namespace Workspace {
       try {
         const adaptor = await getAdaptor(info.projectID, row.type)
         await adaptor.remove(info)
-      } catch (err) {
+      } catch {
         log.error("adaptor not available when removing workspace", { type: row.type })
       }
       Database.use((db) => db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run())
@@ -404,7 +404,7 @@ export namespace Workspace {
           return synced(state)
         },
       })
-    } catch (error) {
+    } catch {
       if (signal?.aborted) throw signal.reason ?? new Error("Request aborted")
       throw new Error(`Timed out waiting for sync fence: ${JSON.stringify(state)}`)
     }

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -218,7 +218,7 @@ export namespace McpOAuthCallback {
       log.info("oauth callback server stopped")
     }
 
-    for (const [name, pending] of pendingAuths) {
+    for (const [_name, pending] of pendingAuths) {
       clearTimeout(pending.timeout)
       pending.reject(new Error("OAuth callback server stopped"))
     }

--- a/packages/opencode/src/server/fence.ts
+++ b/packages/opencode/src/server/fence.ts
@@ -40,7 +40,7 @@ export function parse(headers: Headers) {
 
   try {
     data = JSON.parse(raw)
-  } catch (err) {
+  } catch {
     return
   }
 

--- a/packages/opencode/src/server/instance/middleware.ts
+++ b/packages/opencode/src/server/instance/middleware.ts
@@ -16,8 +16,6 @@ import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 
 type Rule = { method?: string; path: string; exact?: boolean; action: "local" | "forward" }
 
-const OPENCODE_WORKSPACE = process.env.OPENCODE_WORKSPACE
-
 const RULES: Array<Rule> = [
   { path: "/session/status", action: "forward" },
   { method: "GET", path: "/session", action: "local" },

--- a/packages/opencode/src/server/instance/provider.ts
+++ b/packages/opencode/src/server/instance/provider.ts
@@ -10,10 +10,7 @@ import { AppRuntime } from "../../effect/app-runtime"
 import { mapValues } from "remeda"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
-import { Log } from "../../util/log"
 import { Effect } from "effect"
-
-const log = Log.create({ service: "server" })
 
 export const ProviderRoutes = lazy(() =>
   new Hono()

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1825,7 +1825,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     onSuccess: (output: unknown) => void
   }): AITool {
     // Remove $schema property if present (not needed for tool input)
-    const { $schema, ...toolSchema } = input.schema
+    const { $schema: _, ...toolSchema } = input.schema
 
     return tool({
       id: "StructuredOutput" as any,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -176,7 +176,7 @@ export namespace ToolRegistry {
             }
           }
 
-          const cfg = yield* config.get()
+          yield* config.get()
           const questionEnabled =
             ["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT) || Flag.OPENCODE_ENABLE_QUESTION_TOOL
 

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -276,7 +276,7 @@ describe("file/index Filesystem patterns", () => {
 
     test("returns empty array buffer on error for images", async () => {
       await using tmp = await tmpdir()
-      const filepath = path.join(tmp.path, "broken.png")
+      const _filepath = path.join(tmp.path, "broken.png")
       // Don't create the file
 
       await Instance.provide({

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -1,8 +1,6 @@
 // Simple JSON-RPC 2.0 LSP-like fake server over stdio
 // Implements a minimal LSP handshake and triggers a request upon notification
 
-const net = require("net")
-
 let nextId = 1
 
 function encode(message) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, test } from "bun:test"
 import { ProviderTransform } from "../../src/provider/transform"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
-const OUTPUT_TOKEN_MAX = 32000
-
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
 

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -67,7 +67,7 @@ describe("session.list", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        const session = await svc.create({ title: "new-session" })
+        await svc.create({ title: "new-session" })
         const futureStart = Date.now() + 86400000
 
         const sessions = [...svc.list({ start: futureStart })]

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1181,7 +1181,6 @@ describe("session.llm.stream", () => {
     const providerID = "google"
     const modelID = "gemini-2.5-flash"
     const fixture = await loadFixture(providerID, modelID)
-    const provider = fixture.provider
     const model = fixture.model
     const pathSuffix = `/v1beta/models/${model.id}:streamGenerateContent`
 

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -724,7 +724,7 @@ describe("MessageV2.filterCompacted", () => {
 
         const u1 = await addUser(session.id, "hello")
         await addCompactionPart(session.id, u1)
-        const u2 = await addUser(session.id, "world")
+        await addUser(session.id, "world")
 
         const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
         expect(result).toHaveLength(2)
@@ -748,7 +748,7 @@ describe("MessageV2.filterCompacted", () => {
           isRetryable: true,
         }).toObject() as MessageV2.Assistant["error"]
         await addAssistant(session.id, u1, { summary: true, finish: "end_turn", error })
-        const u2 = await addUser(session.id, "retry")
+        await addUser(session.id, "retry")
 
         const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
         // Error assistant doesn't add to completed, so compaction boundary never triggers
@@ -770,7 +770,7 @@ describe("MessageV2.filterCompacted", () => {
 
         // summary=true but no finish
         await addAssistant(session.id, u1, { summary: true })
-        const u2 = await addUser(session.id, "next")
+        await addUser(session.id, "next")
 
         const result = MessageV2.filterCompacted(MessageV2.stream(session.id))
         expect(result).toHaveLength(3)
@@ -892,7 +892,7 @@ describe("MessageV2 consistency", () => {
       directory: root,
       fn: async () => {
         const session = await svc.create({})
-        const ids = await fill(session.id, 4)
+        await fill(session.id, 4)
 
         const filtered = MessageV2.filterCompacted(MessageV2.stream(session.id))
         const all = Array.from(MessageV2.stream(session.id)).reverse()

--- a/packages/sdk/js/src/v2/data.ts
+++ b/packages/sdk/js/src/v2/data.ts
@@ -5,7 +5,7 @@ export const message = {
     info: UserMessage
     parts: Part[]
   } {
-    const { parts, ...rest } = input
+    const { parts: _parts, ...rest } = input
 
     const info: UserMessage = {
       ...rest,

--- a/packages/shared/test/filesystem/filesystem.test.ts
+++ b/packages/shared/test/filesystem/filesystem.test.ts
@@ -290,7 +290,7 @@ describe("AppFileSystem", () => {
     it(
       "exists works",
       Effect.gen(function* () {
-        const fs = yield* AppFileSystem.Service
+        yield* AppFileSystem.Service
         const filesys = yield* FileSystem.FileSystem
         const tmp = yield* filesys.makeTempDirectoryScoped()
         const file = path.join(tmp, "exists.txt")
@@ -304,7 +304,7 @@ describe("AppFileSystem", () => {
     it(
       "remove works",
       Effect.gen(function* () {
-        const fs = yield* AppFileSystem.Service
+        yield* AppFileSystem.Service
         const filesys = yield* FileSystem.FileSystem
         const tmp = yield* filesys.makeTempDirectoryScoped()
         const file = path.join(tmp, "delete-me.txt")

--- a/packages/shared/test/fixture/effect-flock-worker.ts
+++ b/packages/shared/test/fixture/effect-flock-worker.ts
@@ -1,5 +1,4 @@
 import fs from "fs/promises"
-import path from "path"
 import os from "os"
 import { Effect, Layer } from "effect"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -27,7 +27,7 @@ const sessions = new Map<string, { client: any; server: any; sessionId: string; 
       const part = event.properties.part
       if (part.type === "tool") {
         // Find the session for this tool update
-        for (const [sessionKey, session] of sessions.entries()) {
+        for (const [_sessionKey, session] of sessions.entries()) {
           if (session.sessionId === part.sessionID) {
             handleToolUpdate(part, session.channel, session.thread)
             break

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -4,34 +4,6 @@ import { Script } from "@opencode-ai/script"
 import { $ } from "bun"
 import { fileURLToPath } from "url"
 
-const highlightsTemplate = `
-<!--
-Add highlights before publishing. Delete this section if no highlights.
-
-- For multiple highlights, use multiple <highlight> tags
-- Highlights with the same source attribute get grouped together
--->
-
-<!--
-<highlight source="SourceName (TUI/Desktop/Web/Core)">
-  <h2>Feature title goes here</h2>
-  <p short="Short description used for Desktop Recap">
-    Full description of the feature or change
-  </p>
-
-  https://github.com/user-attachments/assets/uuid-for-video (you will want to drag & drop the video or picture)
-
-  <img
-    width="1912"
-    height="1164"
-    alt="image"
-    src="https://github.com/user-attachments/assets/uuid-for-image"
-  />
-</highlight>
--->
-
-`
-
 console.log("=== publishing ===\n")
 
 const pkgjsons = await Array.fromAsync(

--- a/script/stats.ts
+++ b/script/stats.ts
@@ -193,7 +193,7 @@ console.log("Fetching GitHub releases for anomalyco/opencode...\n")
 const releases = await fetchReleases()
 console.log(`\nFetched ${releases.length} releases total\n`)
 
-const { total: githubTotal, stats } = calculate(releases)
+const { total: githubTotal } = calculate(releases)
 
 console.log("Fetching npm all-time downloads for opencode-ai...\n")
 const npmDownloads = await fetchNpmDownloads("opencode-ai")

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -6,11 +6,11 @@ import * as vscode from "vscode"
 const TERMINAL_NAME = "opencode"
 
 export function activate(context: vscode.ExtensionContext) {
-  let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
+  const openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
     await openTerminal()
   })
 
-  let openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
+  const openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
     // An opencode terminal already exists => focus it
     const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME)
     if (existingTerminal) {
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   })
 
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
+  context.subscriptions.push(openNewTerminalDisposable, openTerminalDisposable, addFilepathDisposable)
 
   async function openTerminal() {
     // Create a new terminal in split screen


### PR DESCRIPTION
## Summary

- Remove or prefix 43 unused variables flagged by oxlint
- Fix 5 additional catch param / stale import issues
- Includes one actual bug fix: VS Code extension disposable wasn't being tracked in `context.subscriptions`

### Fix strategies used:
- **Dead code from refactors**: deleted entirely (e.g. `effectMinDuration`, `cancelCommenting`, `ROUTES_DIR`)
- **Side-effecting assignments**: kept the call, removed the unused binding
- **Intentional placeholders**: prefixed with `_` (e.g. test setup, destructuring)
- **Unused `log` instances**: deleted along with their `Log` import
- **Catch params**: removed bindings where error wasn't referenced