### PR TITLE
fix: delete 9 dead functions with zero callers

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -65,22 +65,6 @@ function runAll(list: Array<() => Promise<unknown>>) {
   return Promise.allSettled(list.map((item) => item()))
 }
 
-function showErrors(input: {
-  errors: unknown[]
-  title: string
-  translate: (key: string, vars?: Record<string, string | number>) => string
-  formatMoreCount: (count: number) => string
-}) {
-  if (input.errors.length === 0) return
-  const message = formatServerError(input.errors[0], input.translate)
-  const more = input.errors.length > 1 ? input.formatMoreCount(input.errors.length - 1) : ""
-  showToast({
-    variant: "error",
-    title: input.title,
-    description: message + more,
-  })
-}
-
 export async function bootstrapGlobal(input: {
   globalSDK: OpencodeClient
   requestFailedTitle: string

--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -12,20 +12,6 @@ type Env = {
   WEB_DOMAIN: string
 }
 
-async function getFeishuTenantToken(): Promise<string> {
-  const response = await fetch("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      app_id: Resource.FEISHU_APP_ID.value,
-      app_secret: Resource.FEISHU_APP_SECRET.value,
-    }),
-  })
-  const data = (await response.json()) as { tenant_access_token?: string }
-  if (!data.tenant_access_token) throw new Error("Failed to get Feishu tenant token")
-  return data.tenant_access_token
-}
-
 export class SyncServer extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env)

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -85,18 +85,6 @@ function prepareBinDirectory(binaryName) {
   return { binDir, targetPath }
 }
 
-function symlinkBinary(sourcePath, binaryName) {
-  const { targetPath } = prepareBinDirectory(binaryName)
-
-  fs.symlinkSync(sourcePath, targetPath)
-  console.log(`opencode binary symlinked: ${targetPath} -> ${sourcePath}`)
-
-  // Verify the file exists after operation
-  if (!fs.existsSync(targetPath)) {
-    throw new Error(`Failed to symlink binary to ${targetPath}`)
-  }
-}
-
 async function main() {
   try {
     if (os.platform() === "win32") {

--- a/packages/opencode/src/server/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/instance/httpapi/server.ts
@@ -26,10 +26,6 @@ const Headers = Schema.Struct({
 })
 
 export namespace ExperimentalHttpApiServer {
-  function text(input: string, status: number, headers?: Record<string, string>) {
-    return HttpServerResponse.text(input, { status, headers })
-  }
-
   function decode(input: string) {
     try {
       return decodeURIComponent(input)

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -596,33 +596,9 @@ function hit(url: string, body: unknown) {
   } satisfies Hit
 }
 
-/** Auto-acknowledging tool-result follow-ups avoids requiring tests to queue two responses per tool call. */
-function isToolResultFollowUp(body: unknown): boolean {
-  if (!body || typeof body !== "object") return false
-  // OpenAI chat format: last message has role "tool"
-  if ("messages" in body && Array.isArray(body.messages)) {
-    const last = body.messages[body.messages.length - 1]
-    return last?.role === "tool"
-  }
-  // Responses API: input contains function_call_output
-  if ("input" in body && Array.isArray(body.input)) {
-    return body.input.some((item: Record<string, unknown>) => item?.type === "function_call_output")
-  }
-  return false
-}
-
 function isTitleRequest(body: unknown): boolean {
   if (!body || typeof body !== "object") return false
   return JSON.stringify(body).includes("Generate a title for this conversation")
-}
-
-function requestSummary(body: unknown): string {
-  if (!body || typeof body !== "object") return "empty body"
-  if ("messages" in body && Array.isArray(body.messages)) {
-    const roles = body.messages.map((m: Record<string, unknown>) => m.role).join(",")
-    return `messages=[${roles}]`
-  }
-  return `keys=[${Object.keys(body).join(",")}]`
 }
 
 namespace TestLLMServer {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -143,25 +143,6 @@ async function assistant(sessionID: SessionID, parentID: MessageID, root: string
   return msg
 }
 
-async function tool(sessionID: SessionID, messageID: MessageID, tool: string, output: string) {
-  return svc.updatePart({
-    id: PartID.ascending(),
-    messageID,
-    sessionID,
-    type: "tool",
-    callID: crypto.randomUUID(),
-    tool,
-    state: {
-      status: "completed",
-      input: {},
-      output,
-      title: "done",
-      metadata: {},
-      time: { start: Date.now(), end: Date.now() },
-    },
-  })
-}
-
 function fake(
   input: Parameters<SessionProcessorModule.SessionProcessor.Interface["create"]>[0],
   result: "continue" | "compact",

--- a/packages/ui/src/components/session-diff.ts
+++ b/packages/ui/src/components/session-diff.ts
@@ -25,20 +25,6 @@ export type ViewDiff = {
 
 const cache = new Map<string, FileDiffMetadata>()
 
-function empty(file: string, key: string) {
-  return {
-    name: file,
-    type: "change",
-    hunks: [],
-    splitLineCount: 0,
-    unifiedLineCount: 0,
-    isPartial: true,
-    deletionLines: [],
-    additionLines: [],
-    cacheKey: key,
-  } satisfies FileDiffMetadata
-}
-
 function patch(diff: ReviewDiff) {
   if (typeof diff.patch === "string") {
     const [patch] = parsePatch(diff.patch)

--- a/packages/ui/src/components/timeline-playground.stories.tsx
+++ b/packages/ui/src/components/timeline-playground.stories.tsx
@@ -555,10 +555,6 @@ function toolPart(sample: (typeof TOOL_SAMPLES)[keyof typeof TOOL_SAMPLES], stat
   } as ToolPart
 }
 
-function compactionPart(): CompactionPart {
-  return { id: uid(), type: "compaction", auto: true } as CompactionPart
-}
-
 // ---------------------------------------------------------------------------
 // CSS Controls definition
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Delete 9 functions confirmed to have zero callers anywhere in the codebase
- Includes dead test helpers, module-private functions never wired up, and functions only referenced in commented-out code

### Functions removed:
| File | Function | Reason |
|---|---|---|
| `bootstrap.ts` | `showErrors` | Only referenced in commented-out code |
| `timeline-playground.stories.tsx` | `compactionPart` | Never called |
| `postinstall.mjs` | `symlinkBinary` | Never called; `main()` uses other functions |
| `session-diff.ts` | `empty` | Never called |
| `httpapi/server.ts` | `text` | Namespace-private, never called |
| `function/api.ts` | `getFeishuTenantToken` | Module-private, never called |
| `llm-server.ts` | `isToolResultFollowUp` | Test helper, never called |
| `llm-server.ts` | `requestSummary` | Test helper, never called |
| `compaction.test.ts` | `tool` | Test helper, never called |