### PR TITLE
feat: unwrap Lock namespace to flat exports + barrel

### DIFF
--- a/packages/opencode/src/util/index.ts
+++ b/packages/opencode/src/util/index.ts
@@ -1,0 +1,1 @@
+export * as Lock from "./lock"

--- a/packages/opencode/src/util/lock.ts
+++ b/packages/opencode/src/util/lock.ts
@@ -1,54 +1,62 @@
-export namespace Lock {
-  const locks = new Map<
-    string,
-    {
-      readers: number
-      writer: boolean
-      waitingReaders: (() => void)[]
-      waitingWriters: (() => void)[]
-    }
-  >()
+const locks = new Map<
+  string,
+  {
+    readers: number
+    writer: boolean
+    waitingReaders: (() => void)[]
+    waitingWriters: (() => void)[]
+  }
+>()
 
-  function get(key: string) {
-    if (!locks.has(key)) {
-      locks.set(key, {
-        readers: 0,
-        writer: false,
-        waitingReaders: [],
-        waitingWriters: [],
+function get(key: string) {
+  if (!locks.has(key)) {
+    locks.set(key, {
+      readers: 0,
+      writer: false,
+      waitingReaders: [],
+      waitingWriters: [],
+    })
+  }
+  return locks.get(key)!
+}
+
+function process(key: string) {
+  const lock = locks.get(key)
+  if (!lock || lock.writer || lock.readers > 0) return
+
+  // Prioritize writers to prevent starvation
+  if (lock.waitingWriters.length > 0) {
+    const nextWriter = lock.waitingWriters.shift()!
+    nextWriter()
+    return
+  }
+
+  // Wake up all waiting readers
+  while (lock.waitingReaders.length > 0) {
+    const nextReader = lock.waitingReaders.shift()!
+    nextReader()
+  }
+
+  // Clean up empty locks
+  if (lock.readers === 0 && !lock.writer && lock.waitingReaders.length === 0 && lock.waitingWriters.length === 0) {
+    locks.delete(key)
+  }
+}
+
+export async function read(key: string): Promise<Disposable> {
+  const lock = get(key)
+
+  return new Promise((resolve) => {
+    if (!lock.writer && lock.waitingWriters.length === 0) {
+      lock.readers++
+      resolve({
+        [Symbol.dispose]: () => {
+          lock.readers--
+          process(key)
+        },
       })
-    }
-    return locks.get(key)!
-  }
-
-  function process(key: string) {
-    const lock = locks.get(key)
-    if (!lock || lock.writer || lock.readers > 0) return
-
-    // Prioritize writers to prevent starvation
-    if (lock.waitingWriters.length > 0) {
-      const nextWriter = lock.waitingWriters.shift()!
-      nextWriter()
-      return
-    }
-
-    // Wake up all waiting readers
-    while (lock.waitingReaders.length > 0) {
-      const nextReader = lock.waitingReaders.shift()!
-      nextReader()
-    }
-
-    // Clean up empty locks
-    if (lock.readers === 0 && !lock.writer && lock.waitingReaders.length === 0 && lock.waitingWriters.length === 0) {
-      locks.delete(key)
-    }
-  }
-
-  export async function read(key: string): Promise<Disposable> {
-    const lock = get(key)
-
-    return new Promise((resolve) => {
-      if (!lock.writer && lock.waitingWriters.length === 0) {
+    } else {
+      lock.waitingReaders.push(() => {
         lock.readers++
         resolve({
           [Symbol.dispose]: () => {
@@ -56,25 +64,25 @@ export namespace Lock {
             process(key)
           },
         })
-      } else {
-        lock.waitingReaders.push(() => {
-          lock.readers++
-          resolve({
-            [Symbol.dispose]: () => {
-              lock.readers--
-              process(key)
-            },
-          })
-        })
-      }
-    })
-  }
+      })
+    }
+  })
+}
 
-  export async function write(key: string): Promise<Disposable> {
-    const lock = get(key)
+export async function write(key: string): Promise<Disposable> {
+  const lock = get(key)
 
-    return new Promise((resolve) => {
-      if (!lock.writer && lock.readers === 0) {
+  return new Promise((resolve) => {
+    if (!lock.writer && lock.readers === 0) {
+      lock.writer = true
+      resolve({
+        [Symbol.dispose]: () => {
+          lock.writer = false
+          process(key)
+        },
+      })
+    } else {
+      lock.waitingWriters.push(() => {
         lock.writer = true
         resolve({
           [Symbol.dispose]: () => {
@@ -82,17 +90,7 @@ export namespace Lock {
             process(key)
           },
         })
-      } else {
-        lock.waitingWriters.push(() => {
-          lock.writer = true
-          resolve({
-            [Symbol.dispose]: () => {
-              lock.writer = false
-              process(key)
-            },
-          })
-        })
-      }
-    })
-  }
+      })
+    }
+  })
 }

--- a/packages/opencode/test/util/lock.test.ts
+++ b/packages/opencode/test/util/lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Lock } from "../../src/util/lock"
+import { Lock } from "../../src/util"
 
 function tick() {
   return new Promise<void>((r) => queueMicrotask(r))


### PR DESCRIPTION
Convert `export namespace Lock` in `util/lock.ts` to flat named exports with `export * as` barrel. Part of the [namespace tree-shake migration](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/specs/effect/namespace-treeshake.md).