### PR TITLE
feat: unwrap Color namespace to flat exports + barrel

### DIFF
--- a/packages/opencode/src/util/color.ts
+++ b/packages/opencode/src/util/color.ts
@@ -1,19 +1,17 @@
-export namespace Color {
-  export function isValidHex(hex?: string): hex is string {
-    if (!hex) return false
-    return /^#[0-9a-fA-F]{6}$/.test(hex)
-  }
+export function isValidHex(hex?: string): hex is string {
+  if (!hex) return false
+  return /^#[0-9a-fA-F]{6}$/.test(hex)
+}
 
-  export function hexToRgb(hex: string): { r: number; g: number; b: number } {
-    const r = parseInt(hex.slice(1, 3), 16)
-    const g = parseInt(hex.slice(3, 5), 16)
-    const b = parseInt(hex.slice(5, 7), 16)
-    return { r, g, b }
-  }
+export function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return { r, g, b }
+}
 
-  export function hexToAnsiBold(hex?: string): string | undefined {
-    if (!isValidHex(hex)) return undefined
-    const { r, g, b } = hexToRgb(hex)
-    return `\x1b[38;2;${r};${g};${b}m\x1b[1m`
-  }
+export function hexToAnsiBold(hex?: string): string | undefined {
+  if (!isValidHex(hex)) return undefined
+  const { r, g, b } = hexToRgb(hex)
+  return `\x1b[38;2;${r};${g};${b}m\x1b[1m`
 }

--- a/packages/opencode/src/util/index.ts
+++ b/packages/opencode/src/util/index.ts
@@ -1,1 +1,2 @@
 export * as Archive from "./archive"
+export * as Color from "./color"

--- a/packages/opencode/test/config/agent-color.test.ts
+++ b/packages/opencode/test/config/agent-color.test.ts
@@ -5,7 +5,7 @@ import { provideInstance, tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Config } from "../../src/config"
 import { Agent as AgentSvc } from "../../src/agent/agent"
-import { Color } from "../../src/util/color"
+import { Color } from "../../src/util"
 import { AppRuntime } from "../../src/effect/app-runtime"
 
 const load = () => AppRuntime.runPromise(Config.Service.use((svc) => svc.get()))


### PR DESCRIPTION
Convert `export namespace Color` in `util/color.ts` to flat named exports with `export * as` barrel. Part of the [namespace tree-shake migration](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/specs/effect/namespace-treeshake.md).