### PR TITLE
feat: enable type-aware no-misused-spread rule, fix 8 violations

### DIFF
--- a/.opencode/tool/github-pr-search.ts
+++ b/.opencode/tool/github-pr-search.ts
@@ -7,7 +7,7 @@ async function githubFetch(endpoint: string, options: RequestInit = {}) {
       Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
       Accept: "application/vnd.github+json",
       "Content-Type": "application/json",
-      ...options.headers,
+      ...(options.headers instanceof Headers ? Object.fromEntries(options.headers.entries()) : options.headers),
     },
   })
   if (!response.ok) {

--- a/.opencode/tool/github-triage.ts
+++ b/.opencode/tool/github-triage.ts
@@ -28,7 +28,7 @@ async function githubFetch(endpoint: string, options: RequestInit = {}) {
       Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
       Accept: "application/vnd.github+json",
       "Content-Type": "application/json",
-      ...options.headers,
+      ...(options.headers instanceof Headers ? Object.fromEntries(options.headers.entries()) : options.headers),
     },
   })
   if (!response.ok) {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -33,10 +33,15 @@
     "no-new": "off",
 
     // Type-aware: catch unhandled promises
-    "typescript/no-floating-promises": "warn"
+    "typescript/no-floating-promises": "warn",
+    // Warn when spreading non-plain objects (Headers, class instances, etc.)
+    "typescript/no-misused-spread": "warn"
   },
   "options": {
     "typeAware": true
   },
-  "ignorePatterns": ["**/node_modules", "**/dist", "**/.build", "**/.sst", "**/*.d.ts"]
+  "options": {
+    "typeAware": true
+  },
+  "ignorePatterns": ["**/node_modules", "**/dist", "**/.build", "**/.sst", "**/*.d.ts", "**/sdk.gen.ts"]
 }

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -16,7 +16,10 @@ export function createSdkForServer({
 
   return createOpencodeClient({
     ...config,
-    headers: { ...config.headers, ...auth },
+    headers: {
+      ...(config.headers instanceof Headers ? Object.fromEntries(config.headers.entries()) : config.headers),
+      ...auth,
+    },
     baseUrl: server.url,
   })
 }

--- a/packages/console/app/src/routes/download/[channel]/[platform].ts
+++ b/packages/console/app/src/routes/download/[channel]/[platform].ts
@@ -37,5 +37,5 @@ export async function GET({ params: { platform, channel } }: APIEvent) {
   const headers = new Headers(resp.headers)
   if (downloadName) headers.set("content-disposition", `attachment; filename="${downloadName}"`)
 
-  return new Response(resp.body, { ...resp, headers })
+  return new Response(resp.body, { status: resp.status, statusText: resp.statusText, headers })
 }

--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -520,7 +520,7 @@ export function Logo() {
     const shadow = tint(theme.background, ink, 0.25)
     const attrs = bold ? TextAttributes.BOLD : undefined
 
-    return [...line].map((char, i) => {
+    return Array.from(line).map((char, i) => {
       const h = field(off + i, y, frame)
       const n = wave(off + i, y, frame, lit(char)) + h
       const s = wave(off + i, y, dusk, false) + h

--- a/packages/opencode/src/server/ui/index.ts
+++ b/packages/opencode/src/server/ui/index.ts
@@ -37,9 +37,9 @@ export const UIRoutes = (): Hono =>
       }
     } else {
       const response = await proxy(`https://app.opencode.ai${path}`, {
-        ...c.req,
+        raw: c.req.raw,
         headers: {
-          ...c.req.raw.headers,
+          ...Object.fromEntries(c.req.raw.headers.entries()),
           host: "app.opencode.ai",
         },
       })

--- a/packages/opencode/src/v2/session-event.ts
+++ b/packages/opencode/src/v2/session-event.ts
@@ -39,7 +39,11 @@ export namespace SessionEvent {
   }) {
     static create(input: FileAttachment) {
       return new FileAttachment({
-        ...input,
+        uri: input.uri,
+        mime: input.mime,
+        name: input.name,
+        description: input.description,
+        source: input.source,
       })
     }
   }


### PR DESCRIPTION
## Summary

- Add `oxlint-tsgolint` and enable `no-misused-spread` rule
- Ignore `**/sdk.gen.ts` (70 hits in generated code)
- Fix 8 real violations in source code

### Fixes

| File | Issue | Fix |
|---|---|---|
| `server.ts` | Spreading `Headers` instance | Guard with `instanceof Headers` → `Object.fromEntries()` |
| `server/ui/index.ts` | Spreading `HonoRequest` class | Extract `raw` property explicitly |
| `server/ui/index.ts` | Spreading `Headers` | `Object.fromEntries(headers.entries())` |
| `session-event.ts` | Spreading Schema.Class instance | Explicit property assignment |
| `logo.tsx` | `[...string]` spread | `Array.from(line)` |
| `download/[channel]/[platform].ts` | **Spreading `Response`** — latent bug, produced empty object | Extract `status`, `statusText` explicitly |
| `.opencode/tool/*.ts` (2) | Spreading `RequestInit.headers` | Guard with `instanceof Headers` |