### PR TITLE
fix: clean up final 16 no-unused-vars warnings

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -191,7 +191,7 @@ export const Terminal = (props: TerminalProps) => {
   const scrollY = typeof local.pty.scrollY === "number" ? local.pty.scrollY : undefined
   let ws: WebSocket | undefined
   let term: Term | undefined
-  let ghostty: Ghostty
+  let _ghostty: Ghostty
   let serializeAddon: SerializeAddon
   let fitAddon: FitAddon
   let handleResize: () => void
@@ -372,7 +372,7 @@ export const Terminal = (props: TerminalProps) => {
         cleanup()
         return
       }
-      ghostty = g
+      _ghostty = g
       term = t
       output = terminalWriter((data, done) =>
         t.write(data, () => {

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -1,5 +1,3 @@
-import { dict as en } from "./en"
-
 export const dict = {
   "command.category.suggested": "추천",
   "command.category.view": "보기",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -432,7 +432,6 @@ export default function Page() {
   const info = createMemo(() => (params.id ? sync.session.get(params.id) : undefined))
   const isChildSession = createMemo(() => !!info()?.parentID)
   const diffs = createMemo(() => (params.id ? list(sync.data.session_diff[params.id]) : []))
-  const sessionCount = createMemo(() => Math.max(info()?.summary?.files ?? 0, diffs().length))
   const canReview = createMemo(() => !!sync.project)
   const reviewTab = createMemo(() => isDesktop())
   const tabState = createSessionTabs({

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -12,7 +12,6 @@ import { Header } from "~/component/header"
 import { Footer } from "~/component/footer"
 import { Legal } from "~/component/legal"
 import { github } from "~/lib/github"
-import { createMemo } from "solid-js"
 import { config } from "~/config"
 import { useI18n } from "~/context/i18n"
 import { useLanguage } from "~/context/language"
@@ -30,7 +29,7 @@ function CopyStatus() {
 export default function Home() {
   const i18n = useI18n()
   const language = useLanguage()
-  const githubData = createAsync(() => github())
+  const _githubData = createAsync(() => github())
   const handleCopyClick = (event: Event) => {
     const button = event.currentTarget as HTMLButtonElement
     const text = button.textContent

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -68,23 +68,6 @@ function findBinary() {
   }
 }
 
-function prepareBinDirectory(binaryName) {
-  const binDir = path.join(__dirname, "bin")
-  const targetPath = path.join(binDir, binaryName)
-
-  // Ensure bin directory exists
-  if (!fs.existsSync(binDir)) {
-    fs.mkdirSync(binDir, { recursive: true })
-  }
-
-  // Remove existing binary/symlink if it exists
-  if (fs.existsSync(targetPath)) {
-    fs.unlinkSync(targetPath)
-  }
-
-  return { binDir, targetPath }
-}
-
 async function main() {
   try {
     if (os.platform() === "win32") {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1297,7 +1297,7 @@ export const layer: Layer.Layer<
       yield* Effect.promise(() => Npm.install(dir))
     })
 
-    const installDependencies = Effect.fn("Config.installDependencies")(function* (dir: string, input?: InstallInput) {
+    const installDependencies = Effect.fn("Config.installDependencies")(function* (dir: string, _input?: InstallInput) {
       if (
         !(yield* fs.access(dir, { writable: true }).pipe(
           Effect.as(true),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -277,11 +277,10 @@ export namespace LLM {
             }
 
             const id = PermissionID.ascending()
-            let reply: Permission.Reply | undefined
             let unsub: (() => void) | undefined
             try {
               unsub = Bus.subscribe(Permission.Event.Replied, (evt) => {
-                if (evt.properties.requestID === id) reply = evt.properties.reply
+                if (evt.properties.requestID === id) void evt.properties.reply
               })
               const toolPatterns = approvalTools.map((t: { name: string; args: string }) => {
                 try {

--- a/packages/opencode/test/acp/event-subscription.test.ts
+++ b/packages/opencode/test/acp/event-subscription.test.ts
@@ -463,9 +463,9 @@ describe("acp.agent event subscription", () => {
 
         // Make permission request for session A block until we release it
         const originalRequestPermission = connection.requestPermission.bind(connection)
-        let permissionCalls = 0
+        let _permissionCalls = 0
         connection.requestPermission = async (params: RequestPermissionParams) => {
-          permissionCalls++
+          _permissionCalls++
           if (params.sessionId.endsWith("1")) {
             await permissionABlocking
           }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -858,7 +858,6 @@ it.live("dedupes concurrent config dependency installs for the same dir", () =>
     let calls = 0
     const online = spyOn(Network, "online").mockReturnValue(false)
     const ready = Deferred.makeUnsafe<void>()
-    const blocked = Deferred.makeUnsafe<void>()
     const hold = Deferred.makeUnsafe<void>()
     const target = path.normalize(dir)
     const run = spyOn(Npm, "install").mockImplementation(async (d: string) => {
@@ -921,7 +920,6 @@ it.live("serializes config dependency installs across dirs", () =>
     let open = 0
     let peak = 0
     const ready = Deferred.makeUnsafe<void>()
-    const blocked = Deferred.makeUnsafe<void>()
     const hold = Deferred.makeUnsafe<void>()
 
     const online = spyOn(Network, "online").mockReturnValue(false)

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -395,7 +395,6 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      const gate = yield* Deferred.make<void>()
 
       const sh = yield* runner.startShell(Effect.never.pipe(Effect.as("aborted"))).pipe(Effect.forkChild)
       yield* Effect.sleep("10 millis")

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -652,9 +652,8 @@ test("McpOAuthCallback.cancelPending is keyed by mcpName but pendingAuths uses o
 
   // The callback should still be pending because cancelPending looked up
   // "my-mcp-server" in a map keyed by "abc123hexstate"
-  let resolved = false
   let rejected = false
-  callbackPromise.then(() => (resolved = true)).catch(() => (rejected = true))
+  callbackPromise.then(() => {}).catch(() => (rejected = true))
 
   // Give it a tick
   await new Promise((r) => setTimeout(r, 50))

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -385,7 +385,6 @@ export const SessionReview = (props: SessionReviewProps) => {
               <Accordion multiple value={open()} onChange={handleChange}>
                 <For each={items()}>
                   {(diff) => {
-                    let wrapper: HTMLDivElement | undefined
                     const file = diff.file
 
                     // binary files have empty diffs that we can't render
@@ -569,7 +568,6 @@ export const SessionReview = (props: SessionReviewProps) => {
                           <div
                             data-slot="session-review-diff-wrapper"
                             ref={(el) => {
-                              wrapper = el
                               anchors.set(file, el)
                               nodes.set(file, el)
                               queue()

--- a/packages/ui/src/components/timeline-playground.stories.tsx
+++ b/packages/ui/src/components/timeline-playground.stories.tsx
@@ -9,7 +9,6 @@ import type {
   TextPart,
   ReasoningPart,
   ToolPart,
-  CompactionPart,
   FilePart,
   AgentPart,
 } from "@opencode-ai/sdk/v2"


### PR DESCRIPTION
## Summary

- Remove 3 unused imports (`CompactionPart`, `createMemo`, `en`)
- Delete 1 unused function (`prepareBinDirectory` in postinstall)
- Delete 4 dead variables (`gate`, `sessionCount`, `wrapper`, `reply`)
- Delete 2 unused `Deferred` declarations in tests
- Prefix 4 intentional placeholders with `_` (`permissionCalls`, `ghostty`, `githubData`, `input`)

This should bring `no-unused-vars` warnings to zero.