### PR TITLE
Fix desktop download asset names for beta channel

### DIFF
--- a/packages/console/app/src/routes/download/[channel]/[platform].ts
+++ b/packages/console/app/src/routes/download/[channel]/[platform].ts
@@ -1,13 +1,22 @@
 import type { APIEvent } from "@solidjs/start"
 import type { DownloadPlatform } from "../types"
 
-const assetNames: Record<string, string> = {
+const prodAssetNames: Record<string, string> = {
   "darwin-aarch64-dmg": "opencode-desktop-darwin-aarch64.dmg",
   "darwin-x64-dmg": "opencode-desktop-darwin-x64.dmg",
   "windows-x64-nsis": "opencode-desktop-windows-x64.exe",
   "linux-x64-deb": "opencode-desktop-linux-amd64.deb",
   "linux-x64-appimage": "opencode-desktop-linux-amd64.AppImage",
   "linux-x64-rpm": "opencode-desktop-linux-x86_64.rpm",
+} satisfies Record<DownloadPlatform, string>
+
+const betaAssetNames: Record<string, string> = {
+  "darwin-aarch64-dmg": "opencode-electron-mac-arm64.dmg",
+  "darwin-x64-dmg": "opencode-electron-mac-x64.dmg",
+  "windows-x64-nsis": "opencode-electron-win-x64.exe",
+  "linux-x64-deb": "opencode-electron-linux-amd64.deb",
+  "linux-x64-appimage": "opencode-electron-linux-x86_64.AppImage",
+  "linux-x64-rpm": "opencode-electron-linux-x86_64.rpm",
 } satisfies Record<DownloadPlatform, string>
 
 // Doing this on the server lets us preserve the original name for platforms we don't care to rename for
@@ -18,7 +27,7 @@ const downloadNames: Record<string, string> = {
 } satisfies { [K in DownloadPlatform]?: string }
 
 export async function GET({ params: { platform, channel } }: APIEvent) {
-  const assetName = assetNames[platform]
+  const assetName = channel === "stable" ? prodAssetNames[platform] : betaAssetNames[platform]
   if (!assetName) return new Response(null, { status: 404 })
 
   const resp = await fetch(


### PR DESCRIPTION
Updates the download route to use different asset name mappings for the beta channel vs stable channel.