### PR TITLE
fix(opencode): convert bin script to ESM and fix local search path

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
-const childProcess = require("child_process")
-const fs = require("fs")
-const path = require("path")
-const os = require("os")
+import childProcess from "node:child_process"
+import fs from "node:fs"
+import path from "node:path"
+import os from "node:os"
+import { fileURLToPath } from "node:url"
+
+const __filename = fileURLToPath(import.meta.url)
 
 function run(target) {
   const result = childProcess.spawnSync(target, process.argv.slice(2), {

--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -161,6 +161,13 @@ function findBinary(startDir) {
         if (fs.existsSync(candidate)) return candidate
       }
     }
+    const dist = path.join(current, "dist")
+    if (fs.existsSync(dist)) {
+      for (const name of names) {
+        const candidate = path.join(dist, name, "bin", binary)
+        if (fs.existsSync(candidate)) return candidate
+      }
+    }
     const parent = path.dirname(current)
     if (parent === current) {
       return


### PR DESCRIPTION
### Issue for this PR

Closes #22769

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes two issues with the `opencode` binary wrapper:
1. **ReferenceError: require is not defined**: Converted the wrapper script to ESM to support Node.js 25+ environments where `"type": "module"` is set in `package.json`.
2. **Local Binary Search**: Updated the search logic in `findBinary` to also check the `dist` folder. This allows the wrapper to find locally built binaries in monorepo development environments, which was previously failing because the binaries weren't in `node_modules`.

### How did you verify your code works?

- Verified by running `node packages/opencode/bin/opencode --version` on Windows with Node.js v25.9.0.
- Confirmed it correctly finds and executes the binary in the `dist` folder after a local build (`bun run script/build.ts --single`).
- Smoke test in the build script also passed.

### Screenshots / recordings

_N/A (CLI change)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
