### PR TITLE
perf: make vcs init non-blocking by forking git branch resolution

### DIFF
--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -39,6 +39,12 @@ See `specs/effect/migration.md` for the compact pattern reference and examples.
 - Do the work directly in the `InstanceState.make` closure — `ScopedCache` handles run-once semantics. Don't add fibers, `ensure()` callbacks, or `started` flags on top.
 - Use `Effect.addFinalizer` or `Effect.acquireRelease` inside the `InstanceState.make` closure for cleanup (subscriptions, process teardown, etc.).
 - Use `Effect.forkScoped` inside the closure for background stream consumers — the fiber is interrupted when the instance is disposed.
+- To make a service's `init()` non-blocking, fork `InstanceState.get(state)` at the `init()` call site (e.g. `Effect.forkIn(scope)`), not by forking work inside the `InstanceState.make` closure. Forking inside the closure leaves state incomplete for other methods that read it.
+- `src/project/bootstrap.ts` already wraps every service `init()` in `Effect.forkDetach`, so `init()` is fire-and-forget in production. Keep `init()` methods synchronous internally; the caller controls concurrency.
+
+## Effect v4 beta API
+
+- `Effect.fork` and `Effect.forkDaemon` do not exist. Use `Effect.forkIn(scope)` to fork a fiber into a specific scope.
 
 ## Preferred Effect services
 

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Context, Stream } from "effect"
+import { Effect, Layer, Context, Stream, Scope } from "effect"
 import { formatPatch, structuredPatch } from "diff"
 import path from "path"
 import { Bus } from "@/bus"
@@ -157,6 +157,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Git.Serv
     const fs = yield* AppFileSystem.Service
     const git = yield* Git.Service
     const bus = yield* Bus.Service
+    const scope = yield* Scope.Scope
 
     const state = yield* InstanceState.make<State>(
       Effect.fn("Vcs.state")(function* (ctx) {
@@ -164,21 +165,14 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Git.Serv
           return { current: undefined, root: undefined }
         }
 
-        const value: State = { current: undefined, root: undefined }
-
         const get = Effect.fnUntraced(function* () {
           return yield* git.branch(ctx.directory)
         })
-
-        yield* Effect.gen(function* () {
-          const [current, root] = yield* Effect.all([git.branch(ctx.directory), git.defaultBranch(ctx.directory)], {
-            concurrency: 2,
-          })
-          value.current = current
-          value.root = root
-          log.info("initialized", { branch: value.current, default_branch: value.root?.name })
-          yield* bus.publish(Event.BranchUpdated, { branch: current })
-        }).pipe(Effect.forkScoped)
+        const [current, root] = yield* Effect.all([git.branch(ctx.directory), git.defaultBranch(ctx.directory)], {
+          concurrency: 2,
+        })
+        const value = { current, root }
+        log.info("initialized", { branch: value.current, default_branch: value.root?.name })
 
         yield* bus.subscribe(FileWatcher.Event.Updated).pipe(
           Stream.filter((evt) => evt.properties.file.endsWith("HEAD")),
@@ -201,7 +195,7 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Git.Serv
 
     return Service.of({
       init: Effect.fn("Vcs.init")(function* () {
-        yield* InstanceState.get(state)
+        yield* InstanceState.get(state).pipe(Effect.forkIn(scope))
       }),
       branch: Effect.fn("Vcs.branch")(function* () {
         return yield* InstanceState.use(state, (x) => x.current)

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -164,14 +164,21 @@ export const layer: Layer.Layer<Service, never, AppFileSystem.Service | Git.Serv
           return { current: undefined, root: undefined }
         }
 
+        const value: State = { current: undefined, root: undefined }
+
         const get = Effect.fnUntraced(function* () {
           return yield* git.branch(ctx.directory)
         })
-        const [current, root] = yield* Effect.all([git.branch(ctx.directory), git.defaultBranch(ctx.directory)], {
-          concurrency: 2,
-        })
-        const value = { current, root }
-        log.info("initialized", { branch: value.current, default_branch: value.root?.name })
+
+        yield* Effect.gen(function* () {
+          const [current, root] = yield* Effect.all([git.branch(ctx.directory), git.defaultBranch(ctx.directory)], {
+            concurrency: 2,
+          })
+          value.current = current
+          value.root = root
+          log.info("initialized", { branch: value.current, default_branch: value.root?.name })
+          yield* bus.publish(Event.BranchUpdated, { branch: current })
+        }).pipe(Effect.forkScoped)
 
         yield* bus.subscribe(FileWatcher.Event.Updated).pipe(
           Stream.filter((evt) => evt.properties.file.endsWith("HEAD")),


### PR DESCRIPTION
## Summary
- Fork `git.branch` and `git.defaultBranch` resolution into a scoped fiber so `Vcs.init` returns immediately after subscribing to the bus
- Publishes `BranchUpdated` once the forked fiber completes so downstream consumers are notified when branch info becomes available