### PR TITLE
fix(opencode): stabilize windows ci file handling

### DIFF
--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -1,4 +1,5 @@
 research
+.artifacts
 dist
 dist-*
 gen

--- a/packages/opencode/src/plugin/meta.ts
+++ b/packages/opencode/src/plugin/meta.ts
@@ -8,181 +8,187 @@ import { Flock } from "@opencode-ai/shared/util/flock"
 
 import { parsePluginSpecifier, pluginSource } from "./shared"
 
-type Source = "file" | "npm"
+export namespace PluginMeta {
+  type Source = "file" | "npm"
 
-export type Theme = {
-  src: string
-  dest: string
-  mtime?: number
-  size?: number
-}
+  export type Theme = {
+    src: string
+    dest: string
+    mtime?: number
+    size?: number
+  }
 
-export type Entry = {
-  id: string
-  source: Source
-  spec: string
-  target: string
-  requested?: string
-  version?: string
-  modified?: number
-  first_time: number
-  last_time: number
-  time_changed: number
-  load_count: number
-  fingerprint: string
-  themes?: Record<string, Theme>
-}
+  export type Entry = {
+    id: string
+    source: Source
+    spec: string
+    target: string
+    requested?: string
+    version?: string
+    modified?: number
+    size?: number
+    first_time: number
+    last_time: number
+    time_changed: number
+    load_count: number
+    fingerprint: string
+    themes?: Record<string, Theme>
+  }
 
-export type State = "first" | "updated" | "same"
+  export type State = "first" | "updated" | "same"
 
-export type Touch = {
-  spec: string
-  target: string
-  id: string
-}
+  export type Touch = {
+    spec: string
+    target: string
+    id: string
+  }
 
-type Store = Record<string, Entry>
-type Core = Omit<Entry, "first_time" | "last_time" | "time_changed" | "load_count" | "fingerprint" | "themes">
-type Row = Touch & { core: Core }
+  type Store = Record<string, Entry>
+  type Core = Omit<Entry, "first_time" | "last_time" | "time_changed" | "load_count" | "fingerprint" | "themes">
+  type Row = Touch & { core: Core }
 
-function storePath() {
-  return Flag.OPENCODE_PLUGIN_META_FILE ?? path.join(Global.Path.state, "plugin-meta.json")
-}
+  function storePath() {
+    return Flag.OPENCODE_PLUGIN_META_FILE ?? path.join(Global.Path.state, "plugin-meta.json")
+  }
 
-function lock(file: string) {
-  return `plugin-meta:${file}`
-}
+  function lock(file: string) {
+    return `plugin-meta:${file}`
+  }
 
-function fileTarget(spec: string, target: string) {
-  if (spec.startsWith("file://")) return fileURLToPath(spec)
-  if (target.startsWith("file://")) return fileURLToPath(target)
-  return
-}
+  function fileTarget(spec: string, target: string) {
+    if (spec.startsWith("file://")) return fileURLToPath(spec)
+    if (target.startsWith("file://")) return fileURLToPath(target)
+    return
+  }
 
-async function modifiedAt(file: string) {
-  const stat = await Filesystem.statAsync(file)
-  if (!stat) return
-  const mtime = stat.mtimeMs
-  return Math.floor(typeof mtime === "bigint" ? Number(mtime) : mtime)
-}
+  async function fileState(file: string) {
+    const stat = await Filesystem.statAsync(file)
+    if (!stat) return
+    const mtime = stat.mtimeMs
+    return {
+      modified: Math.floor(typeof mtime === "bigint" ? Number(mtime) : mtime),
+      size: typeof stat.size === "bigint" ? Number(stat.size) : stat.size,
+    }
+  }
 
-function resolvedTarget(target: string) {
-  if (target.startsWith("file://")) return fileURLToPath(target)
-  return target
-}
+  function resolvedTarget(target: string) {
+    if (target.startsWith("file://")) return fileURLToPath(target)
+    return target
+  }
 
-async function npmVersion(target: string) {
-  const resolved = resolvedTarget(target)
-  const stat = await Filesystem.statAsync(resolved)
-  const dir = stat?.isDirectory() ? resolved : path.dirname(resolved)
-  return Filesystem.readJson<{ version?: string }>(path.join(dir, "package.json"))
-    .then((item) => item.version)
-    .catch(() => undefined)
-}
+  async function npmVersion(target: string) {
+    const resolved = resolvedTarget(target)
+    const stat = await Filesystem.statAsync(resolved)
+    const dir = stat?.isDirectory() ? resolved : path.dirname(resolved)
+    return Filesystem.readJson<{ version?: string }>(path.join(dir, "package.json"))
+      .then((item) => item.version)
+      .catch(() => undefined)
+  }
 
-async function entryCore(item: Touch): Promise<Core> {
-  const spec = item.spec
-  const target = item.target
-  const source = pluginSource(spec)
-  if (source === "file") {
-    const file = fileTarget(spec, target)
+  async function entryCore(item: Touch): Promise<Core> {
+    const spec = item.spec
+    const target = item.target
+    const source = pluginSource(spec)
+    if (source === "file") {
+      const file = fileTarget(spec, target)
+      const state = file ? await fileState(file) : undefined
+      return {
+        id: item.id,
+        source,
+        spec,
+        target,
+        modified: state?.modified,
+        size: state?.size,
+      }
+    }
+
     return {
       id: item.id,
       source,
       spec,
       target,
-      modified: file ? await modifiedAt(file) : undefined,
+      requested: parsePluginSpecifier(spec).version,
+      version: await npmVersion(target),
     }
   }
 
-  return {
-    id: item.id,
-    source,
-    spec,
-    target,
-    requested: parsePluginSpecifier(spec).version,
-    version: await npmVersion(target),
+  function fingerprint(value: Core) {
+    if (value.source === "file") return [value.target, value.modified ?? "", value.size ?? ""].join("|")
+    return [value.target, value.requested ?? "", value.version ?? ""].join("|")
   }
-}
 
-function fingerprint(value: Core) {
-  if (value.source === "file") return [value.target, value.modified ?? ""].join("|")
-  return [value.target, value.requested ?? "", value.version ?? ""].join("|")
-}
-
-async function read(file: string): Promise<Store> {
-  return Filesystem.readJson<Store>(file).catch(() => ({}) as Store)
-}
-
-async function row(item: Touch): Promise<Row> {
-  return {
-    ...item,
-    core: await entryCore(item),
+  async function read(file: string): Promise<Store> {
+    return Filesystem.readJson<Store>(file).catch(() => ({}) as Store)
   }
-}
 
-function next(prev: Entry | undefined, core: Core, now: number): { state: State; entry: Entry } {
-  const entry: Entry = {
-    ...core,
-    first_time: prev?.first_time ?? now,
-    last_time: now,
-    time_changed: prev?.time_changed ?? now,
-    load_count: (prev?.load_count ?? 0) + 1,
-    fingerprint: fingerprint(core),
-    themes: prev?.themes,
-  }
-  const state: State = !prev ? "first" : prev.fingerprint === entry.fingerprint ? "same" : "updated"
-  if (state === "updated") entry.time_changed = now
-  return {
-    state,
-    entry,
-  }
-}
-
-export async function touchMany(items: Touch[]): Promise<Array<{ state: State; entry: Entry }>> {
-  if (!items.length) return []
-  const file = storePath()
-  const rows = await Promise.all(items.map((item) => row(item)))
-
-  return Flock.withLock(lock(file), async () => {
-    const store = await read(file)
-    const now = Date.now()
-    const out: Array<{ state: State; entry: Entry }> = []
-    for (const item of rows) {
-      const hit = next(store[item.id], item.core, now)
-      store[item.id] = hit.entry
-      out.push(hit)
+  async function row(item: Touch): Promise<Row> {
+    return {
+      ...item,
+      core: await entryCore(item),
     }
-    await Filesystem.writeJson(file, store)
-    return out
-  })
-}
+  }
 
-export async function touch(spec: string, target: string, id: string): Promise<{ state: State; entry: Entry }> {
-  return touchMany([{ spec, target, id }]).then((item) => {
-    const hit = item[0]
-    if (hit) return hit
-    throw new Error("Failed to touch plugin metadata.")
-  })
-}
-
-export async function setTheme(id: string, name: string, theme: Theme): Promise<void> {
-  const file = storePath()
-  await Flock.withLock(lock(file), async () => {
-    const store = await read(file)
-    const entry = store[id]
-    if (!entry) return
-    entry.themes = {
-      ...entry.themes,
-      [name]: theme,
+  function next(prev: Entry | undefined, core: Core, now: number): { state: State; entry: Entry } {
+    const entry: Entry = {
+      ...core,
+      first_time: prev?.first_time ?? now,
+      last_time: now,
+      time_changed: prev?.time_changed ?? now,
+      load_count: (prev?.load_count ?? 0) + 1,
+      fingerprint: fingerprint(core),
+      themes: prev?.themes,
     }
-    await Filesystem.writeJson(file, store)
-  })
-}
+    const state: State = !prev ? "first" : prev.fingerprint === entry.fingerprint ? "same" : "updated"
+    if (state === "updated") entry.time_changed = now
+    return {
+      state,
+      entry,
+    }
+  }
 
-export async function list(): Promise<Store> {
-  const file = storePath()
-  return Flock.withLock(lock(file), async () => read(file))
-}
+  export async function touchMany(items: Touch[]): Promise<Array<{ state: State; entry: Entry }>> {
+    if (!items.length) return []
+    const file = storePath()
+    const rows = await Promise.all(items.map((item) => row(item)))
 
-export * as PluginMeta from "./meta"
+    return Flock.withLock(lock(file), async () => {
+      const store = await read(file)
+      const now = Date.now()
+      const out: Array<{ state: State; entry: Entry }> = []
+      for (const item of rows) {
+        const hit = next(store[item.id], item.core, now)
+        store[item.id] = hit.entry
+        out.push(hit)
+      }
+      await Filesystem.writeJson(file, store)
+      return out
+    })
+  }
+
+  export async function touch(spec: string, target: string, id: string): Promise<{ state: State; entry: Entry }> {
+    return touchMany([{ spec, target, id }]).then((item) => {
+      const hit = item[0]
+      if (hit) return hit
+      throw new Error("Failed to touch plugin metadata.")
+    })
+  }
+
+  export async function setTheme(id: string, name: string, theme: Theme): Promise<void> {
+    const file = storePath()
+    await Flock.withLock(lock(file), async () => {
+      const store = await read(file)
+      const entry = store[id]
+      if (!entry) return
+      entry.themes = {
+        ...entry.themes,
+        [name]: theme,
+      }
+      await Filesystem.writeJson(file, store)
+    })
+  }
+
+  export async function list(): Promise<Store> {
+    const file = storePath()
+    return Flock.withLock(lock(file), async () => read(file))
+  }
+}

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -16,7 +16,7 @@ import { Bus } from "../bus"
 import { Format } from "../format"
 import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
-import { assertExternalDirectoryEffect } from "./external-directory"
+import { assertExternalDirectoryEffect, resolveWindowsPathFromDirectory } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 
 function normalizeLineEndings(text: string): string {
@@ -72,9 +72,12 @@ export const EditTool = Tool.define(
             throw new Error("No changes to apply: oldString and newString are identical.")
           }
 
-          const filePath = path.isAbsolute(params.filePath)
-            ? params.filePath
-            : path.join(Instance.directory, params.filePath)
+          let filePath =
+            process.platform === "win32"
+              ? resolveWindowsPathFromDirectory(params.filePath, Instance.directory)
+              : params.filePath
+          if (!path.isAbsolute(filePath)) filePath = path.resolve(Instance.directory, filePath)
+          if (process.platform === "win32") filePath = AppFileSystem.normalizePath(filePath)
           yield* assertExternalDirectoryEffect(ctx, filePath)
 
           let diff = ""

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -13,6 +13,13 @@ type Options = {
   kind?: Kind
 }
 
+export function resolveWindowsPathFromDirectory(target: string, directory: string) {
+  const next = AppFileSystem.windowsPath(target)
+  const root = path.win32.parse(next).root
+  if (root !== "/" && root !== "\\") return next
+  return path.resolve(directory, next)
+}
+
 export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirectory")(function* (
   ctx: Tool.Context,
   target?: string,
@@ -23,7 +30,10 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   if (options?.bypass) return
 
   const ins = yield* InstanceState.context
-  const full = process.platform === "win32" ? AppFileSystem.normalizePath(target) : target
+  const full =
+    process.platform === "win32"
+      ? AppFileSystem.normalizePath(resolveWindowsPathFromDirectory(target, ins.directory))
+      : target
   if (Instance.containsPath(full, ins)) return
 
   const kind = options?.kind ?? "file"

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -6,7 +6,7 @@ import { LSP } from "../lsp"
 import DESCRIPTION from "./lsp.txt"
 import { Instance } from "../project/instance"
 import { pathToFileURL } from "url"
-import { assertExternalDirectoryEffect } from "./external-directory"
+import { assertExternalDirectoryEffect, resolveWindowsPathFromDirectory } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 
 const operations = [
@@ -40,7 +40,12 @@ export const LspTool = Tool.define(
         ctx: Tool.Context,
       ) =>
         Effect.gen(function* () {
-          const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
+          let file =
+            process.platform === "win32"
+              ? resolveWindowsPathFromDirectory(args.filePath, Instance.directory)
+              : args.filePath
+          if (!path.isAbsolute(file)) file = path.resolve(Instance.directory, file)
+          if (process.platform === "win32") file = AppFileSystem.normalizePath(file)
           yield* assertExternalDirectoryEffect(ctx, file)
           yield* ctx.ask({ permission: "lsp", patterns: ["*"], always: ["*"], metadata: {} })
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -8,7 +8,7 @@ import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { LSP } from "../lsp"
 import DESCRIPTION from "./read.txt"
 import { Instance } from "../project/instance"
-import { assertExternalDirectoryEffect } from "./external-directory"
+import { assertExternalDirectoryEffect, resolveWindowsPathFromDirectory } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isImageAttachment, isPdfAttachment, sniffAttachmentMime } from "@/util/media"
 
@@ -145,13 +145,12 @@ export const ReadTool = Tool.define(
         return yield* Effect.fail(new Error("offset must be greater than or equal to 1"))
       }
 
-      let filepath = params.filePath
-      if (!path.isAbsolute(filepath)) {
-        filepath = path.resolve(Instance.directory, filepath)
-      }
-      if (process.platform === "win32") {
-        filepath = AppFileSystem.normalizePath(filepath)
-      }
+      let filepath =
+        process.platform === "win32"
+          ? resolveWindowsPathFromDirectory(params.filePath, Instance.directory)
+          : params.filePath
+      if (!path.isAbsolute(filepath)) filepath = path.resolve(Instance.directory, filepath)
+      if (process.platform === "win32") filepath = AppFileSystem.normalizePath(filepath)
       const title = path.relative(Instance.worktree, filepath)
 
       const stat = yield* fs.stat(filepath).pipe(

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -12,7 +12,7 @@ import { Format } from "../format"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
-import { assertExternalDirectoryEffect } from "./external-directory"
+import { assertExternalDirectoryEffect, resolveWindowsPathFromDirectory } from "./external-directory"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
@@ -32,9 +32,12 @@ export const WriteTool = Tool.define(
       }),
       execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const filepath = path.isAbsolute(params.filePath)
-            ? params.filePath
-            : path.join(Instance.directory, params.filePath)
+          let filepath =
+            process.platform === "win32"
+              ? resolveWindowsPathFromDirectory(params.filePath, Instance.directory)
+              : params.filePath
+          if (!path.isAbsolute(filepath)) filepath = path.resolve(Instance.directory, filepath)
+          if (process.platform === "win32") filepath = AppFileSystem.normalizePath(filepath)
           yield* assertExternalDirectoryEffect(ctx, filepath)
 
           const exists = yield* fs.existsSafe(filepath)

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
-import { dirname, join, relative, resolve as pathResolve, win32 } from "path"
+import { dirname, isAbsolute, join, relative, resolve as pathResolve, win32 } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "@opencode-ai/shared/util/glob"
@@ -162,7 +162,8 @@ export function overlaps(a: string, b: string) {
 }
 
 export function contains(parent: string, child: string) {
-  return !relative(parent, child).startsWith("..")
+  const rel = relative(parent, child)
+  return !rel || (!isAbsolute(rel) && !rel.startsWith(".."))
 }
 
 export async function findUp(

--- a/packages/opencode/test/cli/tui/plugin-loader.test.ts
+++ b/packages/opencode/test/cli/tui/plugin-loader.test.ts
@@ -296,6 +296,7 @@ export default {
 
       return {
         localThemeFile,
+        localThemePath,
         invalidThemeFile,
         globalThemeFile,
         preloadedThemeFile,

--- a/packages/opencode/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/opencode/test/effect/cross-spawn-spawner.test.ts
@@ -180,7 +180,7 @@ describe("cross-spawn spawner", () => {
     fx.effect(
       "captures stdout via .all when no stderr",
       Effect.gen(function* () {
-        const handle = yield* ChildProcess.make("echo", ["hello from stdout"])
+        const handle = yield* js('process.stdout.write("hello from stdout")')
         const all = yield* decodeByteStream(handle.all)
         expect(all).toBe("hello from stdout")
       }),

--- a/packages/opencode/test/file/path-traversal.test.ts
+++ b/packages/opencode/test/file/path-traversal.test.ts
@@ -35,6 +35,12 @@ describe("Filesystem.contains", () => {
     expect(Filesystem.contains("/project", "/project-other/file")).toBe(false)
     expect(Filesystem.contains("/project", "/projectfile")).toBe(false)
   })
+
+  if (process.platform === "win32") {
+    test("blocks cross-drive absolute paths", () => {
+      expect(Filesystem.contains("X:\\project", "Y:\\outside\\file.txt")).toBe(false)
+    })
+  }
 })
 
 /*
@@ -133,6 +139,24 @@ describe("Instance.containsPath", () => {
       },
     })
   })
+
+  if (process.platform === "win32") {
+    test("returns true for drive-less rooted paths resolved on the instance drive", async () => {
+      await using tmp = await tmpdir({ git: true })
+      const target = path.join(tmp.path, "src", "file.ts")
+      const alt = target
+        .replace(/^[A-Za-z]:/, "")
+        .replaceAll("\\", "/")
+        .toLowerCase()
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: () => {
+          expect(Instance.containsPath(path.resolve(Instance.directory, alt))).toBe(true)
+        },
+      })
+    })
+  }
 
   test("returns true for path inside worktree but outside directory (monorepo subdirectory scenario)", async () => {
     await using tmp = await tmpdir({ git: true })

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -9,6 +9,21 @@ import * as Formatter from "../../src/format/formatter"
 
 const it = testEffect(Layer.mergeAll(Format.defaultLayer, CrossSpawnSpawner.defaultLayer, NodeFileSystem.layer))
 
+function appendToFile(suffix: string, delay = 0) {
+  return [
+    process.execPath,
+    "--input-type=module",
+    "-e",
+    [
+      'import { readFile, writeFile } from "node:fs/promises"',
+      "const file = process.argv.at(-1)",
+      `await new Promise((resolve) => setTimeout(resolve, ${delay}))`,
+      `await writeFile(file, (await readFile(file, "utf8")) + ${JSON.stringify(suffix)})`,
+    ].join("\n"),
+    "$FILE",
+  ]
+}
+
 describe("Format", () => {
   it.live("status() returns empty list when no formatters are configured", () =>
     provideTmpdirInstance(() =>
@@ -229,11 +244,11 @@ describe("Format", () => {
         config: {
           formatter: {
             first: {
-              command: ["sh", "-c", 'sleep 0.05; v=$(cat "$1"); printf \'%sA\' "$v" > "$1"', "sh", "$FILE"],
+              command: appendToFile("A", 50),
               extensions: [".seq"],
             },
             second: {
-              command: ["sh", "-c", 'v=$(cat "$1"); printf \'%sB\' "$v" > "$1"', "sh", "$FILE"],
+              command: appendToFile("B"),
               extensions: [".seq"],
             },
           },

--- a/packages/opencode/test/plugin/meta.test.ts
+++ b/packages/opencode/test/plugin/meta.test.ts
@@ -66,6 +66,34 @@ describe("plugin.meta", () => {
     expect(saved["demo.file"]?.load_count).toBe(3)
   })
 
+  test("treats file plugins as updated when size changes at the same mtime", async () => {
+    await using tmp = await tmpdir<{ file: string }>({
+      init: async (dir) => {
+        const file = path.join(dir, "plugin.ts")
+        await Bun.write(file, "export default async () => ({})\n")
+        return { file }
+      },
+    })
+
+    process.env.OPENCODE_PLUGIN_META_FILE = path.join(tmp.path, "state", "plugin-meta.json")
+    const spec = pathToFileURL(tmp.extra.file).href
+    const stamp = new Date("2025-01-01T00:00:00.000Z")
+
+    await fs.utimes(tmp.extra.file, stamp, stamp)
+    const one = await PluginMeta.touch(spec, spec, "demo.file.same-mtime")
+    expect(one.state).toBe("first")
+    expect(one.entry.modified).toBeDefined()
+    expect(one.entry.size).toBeDefined()
+
+    await Bun.write(tmp.extra.file, 'export default async () => ({ message: "expanded payload" })\n')
+    await fs.utimes(tmp.extra.file, stamp, stamp)
+
+    const two = await PluginMeta.touch(spec, spec, "demo.file.same-mtime")
+    expect(two.state).toBe("updated")
+    expect(two.entry.modified).toBe(one.entry.modified)
+    expect(two.entry.size).toBeGreaterThan(one.entry.size ?? 0)
+  })
+
   test("tracks npm plugin versions", async () => {
     await using tmp = await tmpdir<{ mod: string; pkg: string }>({
       init: async (dir) => {

--- a/packages/opencode/test/pty/pty-output-isolation.test.ts
+++ b/packages/opencode/test/pty/pty-output-isolation.test.ts
@@ -6,6 +6,20 @@ import { Pty } from "../../src/pty"
 import { tmpdir } from "../fixture/fixture"
 import { setTimeout as sleep } from "node:timers/promises"
 
+const echo = {
+  command: process.execPath,
+  args: ["-e", 'process.stdin.setEncoding("utf8"); process.stdin.on("data", (chunk) => process.stdout.write(chunk))'],
+}
+
+const waitFor = async (fn: () => boolean, ms = 5000) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (fn()) return
+    await sleep(25)
+  }
+  throw new Error("timeout waiting for pty output")
+}
+
 describe("pty", () => {
   test("does not leak output when websocket objects are reused", async () => {
     await using dir = await tmpdir({ git: true })
@@ -16,8 +30,8 @@ describe("pty", () => {
         AppRuntime.runPromise(
           Effect.gen(function* () {
             const pty = yield* Pty.Service
-            const a = yield* pty.create({ command: "cat", title: "a" })
-            const b = yield* pty.create({ command: "cat", title: "b" })
+            const a = yield* pty.create({ ...echo, title: "a" })
+            const b = yield* pty.create({ ...echo, title: "b" })
             try {
               const outA: string[] = []
               const outB: string[] = []
@@ -45,7 +59,16 @@ describe("pty", () => {
               outB.length = 0
 
               yield* pty.write(a.id, "AAA\n")
-              yield* Effect.promise(() => sleep(100))
+              const replay: string[] = []
+              yield* pty.connect(a.id, {
+                readyState: 1,
+                data: { events: { connection: "a-replay" } },
+                send: (data: unknown) => {
+                  replay.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
+                },
+                close: () => {},
+              } as any)
+              yield* Effect.promise(() => waitFor(() => replay.join("").includes("AAA")))
 
               expect(outB.join("")).not.toContain("AAA")
             } finally {
@@ -66,7 +89,7 @@ describe("pty", () => {
         AppRuntime.runPromise(
           Effect.gen(function* () {
             const pty = yield* Pty.Service
-            const a = yield* pty.create({ command: "cat", title: "a" })
+            const a = yield* pty.create({ ...echo, title: "a" })
             try {
               const outA: string[] = []
               const outB: string[] = []
@@ -91,7 +114,16 @@ describe("pty", () => {
               }
 
               yield* pty.write(a.id, "AAA\n")
-              yield* Effect.promise(() => sleep(100))
+              const replay: string[] = []
+              yield* pty.connect(a.id, {
+                readyState: 1,
+                data: { events: { connection: "a-replay" } },
+                send: (data: unknown) => {
+                  replay.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
+                },
+                close: () => {},
+              } as any)
+              yield* Effect.promise(() => waitFor(() => replay.join("").includes("AAA")))
 
               expect(outB.join("")).not.toContain("AAA")
             } finally {
@@ -111,7 +143,7 @@ describe("pty", () => {
         AppRuntime.runPromise(
           Effect.gen(function* () {
             const pty = yield* Pty.Service
-            const a = yield* pty.create({ command: "cat", title: "a" })
+            const a = yield* pty.create({ ...echo, title: "a" })
             try {
               const out: string[] = []
 
@@ -133,7 +165,7 @@ describe("pty", () => {
               ctx.connId = 2
 
               yield* pty.write(a.id, "AAA\n")
-              yield* Effect.promise(() => sleep(100))
+              yield* Effect.promise(() => waitFor(() => out.join("").includes("AAA")))
 
               expect(out.join("")).toContain("AAA")
             } finally {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -493,22 +493,23 @@ test("nested symlinks", async () => {
   })
 })
 
-test("file permissions and ownership changes", async () => {
+test("file permission-only changes do not produce a patch", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
+      const file = `${tmp.path}/a.txt`
       const before = await run(tmp.path, (snapshot) => snapshot.track())
       expect(before).toBeTruthy()
 
-      // Change permissions multiple times
-      await $`chmod 600 ${tmp.path}/a.txt`.quiet()
-      await $`chmod 755 ${tmp.path}/a.txt`.quiet()
-      await $`chmod 644 ${tmp.path}/a.txt`.quiet()
+      // Toggle the writable bit in a way that works on both POSIX and Windows.
+      const initialMode = (await fs.stat(file)).mode
+      await fs.chmod(file, initialMode & ~0o222)
+      await fs.chmod(file, initialMode | 0o200)
+      await fs.chmod(file, initialMode)
 
       const patch = await run(tmp.path, (snapshot) => snapshot.patch(before!))
-      // Note: git doesn't track permission changes on existing files by default
-      // Only tracks executable bit when files are first added
+      // Git should ignore permission-only changes for this existing file.
       expect(patch.files.length).toBe(0)
     },
   })

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -13,6 +13,7 @@ import { Bus } from "../../src/bus"
 import { BusEvent } from "../../src/bus/bus-event"
 import { Truncate } from "../../src/tool"
 import { SessionID, MessageID } from "../../src/session/schema"
+import type { Permission } from "../../src/permission"
 
 const ctx = {
   sessionID: SessionID.make("ses_test-edit-session"),
@@ -64,6 +65,20 @@ async function onceBus<D extends BusEvent.Definition>(def: D) {
   return {
     wait: result.promise,
     unsub,
+  }
+}
+
+const asks = () => {
+  const items: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+  return {
+    items,
+    next: {
+      ...ctx,
+      ask: (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) =>
+        Effect.sync(() => {
+          items.push(req)
+        }),
+    },
   }
 }
 
@@ -182,6 +197,42 @@ describe("tool.edit", () => {
         },
       })
     })
+
+    if (process.platform === "win32") {
+      test("edits a drive-less rooted Windows path inside the project", async () => {
+        await using tmp = await tmpdir()
+        const filepath = path.join(tmp.path, "existing.txt")
+        const alt = filepath
+          .replace(/^[A-Za-z]:/, "")
+          .replaceAll("\\", "/")
+          .toLowerCase()
+        await fs.writeFile(filepath, "old content here", "utf-8")
+
+        await Instance.provide({
+          directory: tmp.path,
+          fn: async () => {
+            await readFileTime(ctx.sessionID, filepath)
+
+            const { items, next } = asks()
+            const edit = await resolve()
+            await Effect.runPromise(
+              edit.execute(
+                {
+                  filePath: alt,
+                  oldString: "old content",
+                  newString: "new content",
+                },
+                next,
+              ),
+            )
+
+            expect(items.find((item) => item.permission === "external_directory")).toBeUndefined()
+            const content = await fs.readFile(filepath, "utf-8")
+            expect(content).toBe("new content here")
+          },
+        })
+      })
+    }
 
     test("throws error when file does not exist", async () => {
       await using tmp = await tmpdir()

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect } from "bun:test"
+import path from "path"
+import { Cause, Effect, Exit, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { LSP } from "../../src/lsp"
+import type { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { LspTool } from "../../src/tool/lsp"
+import { Truncate } from "../../src/tool"
+import { Tool } from "../../src/tool"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-lsp-session"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const it = testEffect(
+  Layer.mergeAll(
+    LSP.defaultLayer,
+    AppFileSystem.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+  ),
+)
+
+const init = Effect.fn("LspToolTest.init")(function* () {
+  const info = yield* LspTool
+  return yield* info.init()
+})
+
+const run = Effect.fn("LspToolTest.run")(function* (
+  args: Tool.InferParameters<typeof LspTool>,
+  next: Tool.Context = ctx,
+) {
+  const tool = yield* init()
+  return yield* tool.execute(args, next)
+})
+
+const fail = Effect.fn("LspToolTest.fail")(function* (
+  args: Tool.InferParameters<typeof LspTool>,
+  next: Tool.Context = ctx,
+) {
+  const exit = yield* run(args, next).pipe(Effect.exit)
+  if (Exit.isFailure(exit)) {
+    const err = Cause.squash(exit.cause)
+    return err instanceof Error ? err : new Error(String(err))
+  }
+  throw new Error("expected lsp to fail")
+})
+
+const asks = () => {
+  const items: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+  return {
+    items,
+    next: {
+      ...ctx,
+      ask: (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) =>
+        Effect.sync(() => {
+          items.push(req)
+        }),
+    },
+  }
+}
+
+describe("tool.lsp", () => {
+  if (process.platform === "win32") {
+    it.live("does not ask for external_directory for drive-less rooted Windows paths inside the project", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "fixture.opencode-no-lsp")
+          const alt = filepath
+            .replace(/^[A-Za-z]:/, "")
+            .replaceAll("\\", "/")
+            .toLowerCase()
+          const { items, next } = asks()
+
+          yield* Effect.promise(() => Bun.write(filepath, "fixture"))
+          const err = yield* fail(
+            {
+              operation: "hover",
+              filePath: alt,
+              line: 1,
+              character: 1,
+            },
+            next,
+          )
+
+          expect(err.message).toBe("No LSP server available for this file type.")
+          expect(items.find((item) => item.permission === "external_directory")).toBeUndefined()
+          expect(items.find((item) => item.permission === "lsp")).toBeDefined()
+        }),
+      ),
+    )
+  }
+})

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -6,6 +6,7 @@ import { WriteTool } from "../../src/tool/write"
 import { Instance } from "../../src/project/instance"
 import { LSP } from "../../src/lsp"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { FileTime } from "../../src/file/time"
 import { Bus } from "../../src/bus"
 import { Format } from "../../src/format"
 import { Truncate } from "../../src/tool"
@@ -13,6 +14,7 @@ import { Tool } from "../../src/tool"
 import { Agent } from "../../src/agent/agent"
 import { SessionID, MessageID } from "../../src/session/schema"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import type { Permission } from "../../src/permission"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -35,6 +37,7 @@ const it = testEffect(
   Layer.mergeAll(
     LSP.defaultLayer,
     AppFileSystem.defaultLayer,
+    FileTime.defaultLayer,
     Bus.layer,
     Format.defaultLayer,
     CrossSpawnSpawner.defaultLayer,
@@ -55,6 +58,25 @@ const run = Effect.fn("WriteToolTest.run")(function* (
   const tool = yield* init()
   return yield* tool.execute(args, next)
 })
+
+const markRead = Effect.fn("WriteToolTest.markRead")(function* (sessionID: string, filepath: string) {
+  const ft = yield* FileTime.Service
+  yield* ft.read(sessionID as any, filepath)
+})
+
+const asks = () => {
+  const items: Array<Omit<Permission.Request, "id" | "sessionID" | "tool">> = []
+  return {
+    items,
+    next: {
+      ...ctx,
+      ask: (req: Omit<Permission.Request, "id" | "sessionID" | "tool">) =>
+        Effect.sync(() => {
+          items.push(req)
+        }),
+    },
+  }
+}
 
 describe("tool.write", () => {
   describe("new file creation", () => {
@@ -95,6 +117,27 @@ describe("tool.write", () => {
         }),
       ),
     )
+
+    if (process.platform === "win32") {
+      it.live("writes a drive-less rooted Windows path inside the project", () =>
+        provideTmpdirInstance((dir) =>
+          Effect.gen(function* () {
+            const filepath = path.join(dir, "nested", "variant.txt")
+            const alt = filepath
+              .replace(/^[A-Za-z]:/, "")
+              .replaceAll("\\", "/")
+              .toLowerCase()
+            const { items, next } = asks()
+
+            yield* run({ filePath: alt, content: "variant content" }, next)
+
+            expect(items.find((item) => item.permission === "external_directory")).toBeUndefined()
+            const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+            expect(content).toBe("variant content")
+          }),
+        ),
+      )
+    }
   })
 
   describe("existing file overwrite", () => {
@@ -103,6 +146,8 @@ describe("tool.write", () => {
         Effect.gen(function* () {
           const filepath = path.join(dir, "existing.txt")
           yield* Effect.promise(() => fs.writeFile(filepath, "old content", "utf-8"))
+          yield* markRead(ctx.sessionID, filepath)
+
           const result = yield* run({ filePath: filepath, content: "new content" })
 
           expect(result.output).toContain("Wrote file successfully")
@@ -119,6 +164,8 @@ describe("tool.write", () => {
         Effect.gen(function* () {
           const filepath = path.join(dir, "file.txt")
           yield* Effect.promise(() => fs.writeFile(filepath, "old", "utf-8"))
+          yield* markRead(ctx.sessionID, filepath)
+
           const result = yield* run({ filePath: filepath, content: "new" })
 
           expect(result.metadata).toHaveProperty("filepath", filepath)
@@ -220,6 +267,8 @@ describe("tool.write", () => {
           const readonlyPath = path.join(dir, "readonly.txt")
           yield* Effect.promise(() => fs.writeFile(readonlyPath, "test", "utf-8"))
           yield* Effect.promise(() => fs.chmod(readonlyPath, 0o444))
+          yield* markRead(ctx.sessionID, readonlyPath)
+
           const exit = yield* run({ filePath: readonlyPath, content: "new content" }).pipe(Effect.exit)
           expect(exit._tag).toBe("Failure")
         }),

--- a/packages/shared/src/filesystem.ts
+++ b/packages/shared/src/filesystem.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, join, relative, resolve as pathResolve } from "path"
+import { dirname, isAbsolute, join, relative, resolve as pathResolve } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -231,6 +231,7 @@ export namespace AppFileSystem {
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    const rel = relative(parent, child)
+    return !rel || (!isAbsolute(rel) && !rel.startsWith(".."))
   }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #22799

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the Windows-specific failures behind the `fix/windows-plugin-loader-ci` branch.

At the product level, it makes drive-less rooted Windows paths resolve consistently at the `read`, `write`, `edit`, `lsp`, and `external_directory` boundaries, and it tightens file-backed plugin metadata fingerprinting so refresh/install does not miss content changes when mtime is unchanged.

It also keeps the Windows CI coverage meaningful by replacing a few Unix-only test commands with cross-platform equivalents and by adding regression coverage for the affected Windows path cases.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/opencode`
- Ran `bun run test:ci` from `packages/opencode`
- Result after the correction pass: `2003 pass`, `17 skip`, `1 todo`, `0 fail`
- Pushing the branch also ran the repo pre-push hook (`bun turbo typecheck`) successfully after restoring the expected tracked symlinks in this Windows checkout

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR