### PR TITLE
feat: unwrap Heap namespace to flat exports + barrel

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -9,7 +9,7 @@ import { Config } from "@/config"
 import { GlobalBus } from "@/bus/global"
 import { Flag } from "@/flag/flag"
 import { writeHeapSnapshot } from "node:v8"
-import { Heap } from "@/cli/heap"
+import { Heap } from "@/cli"
 import { AppRuntime } from "@/effect/app-runtime"
 
 await Log.init({

--- a/packages/opencode/src/cli/heap.ts
+++ b/packages/opencode/src/cli/heap.ts
@@ -8,52 +8,50 @@ const log = Log.create({ service: "heap" })
 const MINUTE = 60_000
 const LIMIT = 2 * 1024 * 1024 * 1024
 
-export namespace Heap {
-  let timer: Timer | undefined
-  let lock = false
-  let armed = true
+let timer: Timer | undefined
+let lock = false
+let armed = true
 
-  export function start() {
-    if (!Flag.OPENCODE_AUTO_HEAP_SNAPSHOT) return
-    if (timer) return
+export function start() {
+  if (!Flag.OPENCODE_AUTO_HEAP_SNAPSHOT) return
+  if (timer) return
 
-    const run = async () => {
-      if (lock) return
+  const run = async () => {
+    if (lock) return
 
-      const stat = process.memoryUsage()
-      if (stat.rss <= LIMIT) {
-        armed = true
-        return
-      }
-      if (!armed) return
+    const stat = process.memoryUsage()
+    if (stat.rss <= LIMIT) {
+      armed = true
+      return
+    }
+    if (!armed) return
 
-      lock = true
-      armed = false
-      const file = path.join(
-        Global.Path.log,
-        `heap-${process.pid}-${new Date().toISOString().replace(/[:.]/g, "")}.heapsnapshot`,
-      )
-      log.warn("heap usage exceeded limit", {
-        rss: stat.rss,
-        heap: stat.heapUsed,
-        file,
+    lock = true
+    armed = false
+    const file = path.join(
+      Global.Path.log,
+      `heap-${process.pid}-${new Date().toISOString().replace(/[:.]/g, "")}.heapsnapshot`,
+    )
+    log.warn("heap usage exceeded limit", {
+      rss: stat.rss,
+      heap: stat.heapUsed,
+      file,
+    })
+
+    await Promise.resolve()
+      .then(() => writeHeapSnapshot(file))
+      .catch((err) => {
+        log.error("failed to write heap snapshot", {
+          error: err instanceof Error ? err.message : String(err),
+          file,
+        })
       })
 
-      await Promise.resolve()
-        .then(() => writeHeapSnapshot(file))
-        .catch((err) => {
-          log.error("failed to write heap snapshot", {
-            error: err instanceof Error ? err.message : String(err),
-            file,
-          })
-        })
-
-      lock = false
-    }
-
-    timer = setInterval(() => {
-      void run()
-    }, MINUTE)
-    timer.unref?.()
+    lock = false
   }
+
+  timer = setInterval(() => {
+    void run()
+  }, MINUTE)
+  timer.unref?.()
 }

--- a/packages/opencode/src/cli/index.ts
+++ b/packages/opencode/src/cli/index.ts
@@ -1,0 +1,1 @@
+export * as Heap from "./heap"

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -36,7 +36,7 @@ import { JsonMigration } from "./storage"
 import { Database } from "./storage"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
-import { Heap } from "./cli/heap"
+import { Heap } from "./cli"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 
 process.on("unhandledRejection", (e) => {


### PR DESCRIPTION
Convert `export namespace Heap` to flat named exports with `export * as` barrel. SDK build verified. Part of the [namespace tree-shake migration](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/specs/effect/namespace-treeshake.md).