### PR TITLE
fix(opencode): preserve reasoning providerMetadata across model switches

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -793,7 +793,7 @@ export namespace MessageV2 {
             assistantMessage.parts.push({
               type: "reasoning",
               text: part.text,
-              ...(differentModel ? {} : { providerMetadata: part.metadata }),
+              providerMetadata: part.metadata,
             })
           }
         }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -434,6 +434,49 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("preserves reasoning providerMetadata even when assistant model differs", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "think about this",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID, undefined, { providerID: "other", modelID: "other" }),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "reasoning",
+            text: "reasoning trace",
+            time: { start: 0 },
+            metadata: { anthropic: { signature: "sig-abc" } },
+          },
+        ] as MessageV2.Part[],
+      } as MessageV2.WithParts,
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "think about this" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "reasoning trace", providerOptions: { anthropic: { signature: "sig-abc" } } },
+        ],
+      },
+    ])
+  })
+
   test("replaces compacted tool output with placeholder", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"


### PR DESCRIPTION
Fixes #22813
## What
Always preserve `providerMetadata` on reasoning parts when reconstructing conversation history, regardless of the `differentModel` flag.
## Why
The `differentModel` guard exists to prevent provider-specific metadata (e.g. OpenAI `itemId`) from leaking into other providers — correct for text and tool parts. But Anthropic thinking blocks carry a cryptographic signature inside `providerMetadata` that Anthropic verifies on every subsequent turn. Stripping it causes the API to reject the message with "thinking blocks cannot be modified".
## How I verified it
- Added a regression test: `"preserves reasoning providerMetadata even when assistant model differs"` in `test/session/message-v2.test.ts`
- Full test suite passes (1880/1882; the 2 failures are pre-existing and unrelated)
- Typecheck clean
- Manual testing in progress