### PR TITLE
fix(app): persist reasoning effort across new sessions

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -6,7 +6,12 @@ import { createStore } from "solid-js/store"
 import { useModels } from "@/context/models"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
-import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
+import {
+  cycleModelVariant,
+  getConfiguredAgentVariant,
+  getSelectedModelVariant,
+  resolveModelVariant,
+} from "./model-variant"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 
@@ -241,7 +246,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
     }
 
-    const selected = () => scope()?.variant
+    const selected = () => {
+      const item = current()
+      return getSelectedModelVariant({
+        state: scope(),
+        stored: item ? models.variant.get({ providerID: item.provider.id, modelID: item.id }) : undefined,
+      })
+    }
 
     const snapshot = () => {
       const model = current()
@@ -334,6 +345,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               model: model ? { providerID: model.provider.id, modelID: model.id } : null,
               variant: value ?? null,
             })
+            if (model) {
+              models.variant.set({ providerID: model.provider.id, modelID: model.id }, value ?? null)
+            }
             write({ variant: value ?? null })
           })
         },
@@ -376,6 +390,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const session = id()
           if (!session) return
           if (msg.sessionID !== session) return
+
+          models.variant.set(
+            { providerID: msg.model.providerID, modelID: msg.model.modelID },
+            msg.model.variant ?? null,
+          )
+
           if (saved.session[session] !== undefined) return
           if (handoff.has(handoffKey(sdk.directory, session))) return
 

--- a/packages/app/src/context/model-variant.test.ts
+++ b/packages/app/src/context/model-variant.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
+import {
+  cycleModelVariant,
+  getConfiguredAgentVariant,
+  getSelectedModelVariant,
+  resolveModelVariant,
+} from "./model-variant"
 
 describe("model variant", () => {
   test("resolves configured agent variant when model matches", () => {
@@ -82,5 +87,23 @@ describe("model variant", () => {
     })
 
     expect(value).toBe("low")
+  })
+
+  test("falls back to the persisted model variant when session state has none", () => {
+    const value = getSelectedModelVariant({
+      state: {},
+      stored: "high",
+    })
+
+    expect(value).toBe("high")
+  })
+
+  test("keeps an explicit default from session state over the persisted variant", () => {
+    const value = getSelectedModelVariant({
+      state: { variant: null },
+      stored: "high",
+    })
+
+    expect(value).toBeNull()
   })
 })

--- a/packages/app/src/context/model-variant.ts
+++ b/packages/app/src/context/model-variant.ts
@@ -18,6 +18,10 @@ type VariantInput = {
   configured: string | undefined
 }
 
+type VariantState = {
+  variant?: string | null
+}
+
 export function getConfiguredAgentVariant(input: { agent: Agent | undefined; model: Model | undefined }) {
   if (!input.agent?.variant) return undefined
   if (!input.agent.model) return undefined
@@ -26,6 +30,11 @@ export function getConfiguredAgentVariant(input: { agent: Agent | undefined; mod
   if (input.agent.model.modelID !== input.model.modelID) return undefined
   if (!(input.agent.variant in input.model.variants)) return undefined
   return input.agent.variant
+}
+
+export function getSelectedModelVariant(input: { state: VariantState | undefined; stored: string | null | undefined }) {
+  if (input.state && Object.hasOwn(input.state, "variant")) return input.state.variant
+  return input.stored
 }
 
 export function resolveModelVariant(input: VariantInput) {

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -13,7 +13,7 @@ type User = ModelKey & { visibility: Visibility; favorite?: boolean }
 type Store = {
   user: User[]
   recent: ModelKey[]
-  variant?: Record<string, string | undefined>
+  variant?: Record<string, string | null | undefined>
 }
 
 const RECENT_LIMIT = 5
@@ -135,7 +135,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
     const variantKey = (model: ModelKey) => `${model.providerID}/${model.modelID}`
     const getVariant = (model: ModelKey) => store.variant?.[variantKey(model)]
 
-    const setVariant = (model: ModelKey, value: string | undefined) => {
+    const setVariant = (model: ModelKey, value: string | null | undefined) => {
       const key = variantKey(model)
       if (!store.variant) {
         setStore("variant", { [key]: value })


### PR DESCRIPTION
### Issue for this PR

Closes #20191

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Web and desktop were only using session-scoped variant state, so a new session fell back to the default effort even after a model variant had already been selected. This change falls back to the persisted per-model variant for new sessions, updates that persisted value when the variant changes, and syncs it from existing sessions so the next new session matches TUI behavior.

Disclaimer: Assisted by `gpt-5.4-xhigh-fast`. The behavior described here was verified by me locally.

### How did you verify your code works?

- Ran `bun test src/context/model-variant.test.ts src/pages/session/session-model-helpers.test.ts` in `packages/app`
- Reproduced locally by setting a non-default effort, starting a new session, and confirming the selection now persists
- Repeated the check after switching back to `Default` and confirmed new sessions also stay on `Default`

### Screenshots / recordings

https://github.com/user-attachments/assets/cc9d1361-66ba-463d-83d1-a1cb3b07d76a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR