### PR TITLE
fix(opencode): use low reasoning effort for GitHub Copilot gpt-5 models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -910,6 +910,10 @@ export function smallOptions(model: Provider.Model) {
       if (model.api.id.includes("5.")) {
         return { store: false, reasoningEffort: "low" }
       }
+      // github-copilot rejects "minimal" for gpt-5-mini; use "low" instead
+      if (model.api.npm === "@ai-sdk/github-copilot") {
+        return { store: false, reasoningEffort: "low" }
+      }
       return { store: false, reasoningEffort: "minimal" }
     }
     return { store: false }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -907,11 +907,7 @@ export function smallOptions(model: Provider.Model) {
     model.api.npm === "@ai-sdk/github-copilot"
   ) {
     if (model.api.id.includes("gpt-5")) {
-      if (model.api.id.includes("5.")) {
-        return { store: false, reasoningEffort: "low" }
-      }
-      // github-copilot rejects "minimal" for gpt-5-mini; use "low" instead
-      if (model.api.npm === "@ai-sdk/github-copilot") {
+      if (model.api.id.includes("5.") || model.api.id.includes("5-mini")) {
         return { store: false, reasoningEffort: "low" }
       }
       return { store: false, reasoningEffort: "minimal" }


### PR DESCRIPTION
### Issue for this PR

Closes #22806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Session title generation uses the provider's "small model" (gpt-5-mini for github-copilot). The `smallOptions()` function in `transform.ts` sends `reasoningEffort: "minimal"` for GPT-5 models, but GitHub Copilot's API only accepts `[low, medium, high]` — not `"minimal"`. This causes a 400 error that gets silently swallowed by `Effect.ignore` in the title generation fiber, so sessions stay stuck with the default "New session" title.

The fix adds a check in `smallOptions()`: if the model's adapter is `@ai-sdk/github-copilot`, use `"low"` instead of `"minimal"`.

### How did you verify your code works?

- Reproduced the bug: confirmed title generation 400 errors against the live Copilot API with `reasoningEffort: "minimal"`
- Applied the fix and confirmed title generation succeeds with `"low"`
- `bun typecheck` passes in `packages/opencode`

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR