### PR TITLE
fix: remove 7 unnecessary `as any` casts in opencode core

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -597,7 +597,7 @@ export function Session() {
     {
       title: conceal() ? "Disable code concealment" : "Enable code concealment",
       value: "session.toggle.conceal",
-      keybind: "messages_toggle_conceal" as any,
+      keybind: "messages_toggle_conceal",
       category: "Session",
       onSelect: (dialog) => {
         setConceal((prev) => !prev)

--- a/packages/opencode/src/storage/json-migration.ts
+++ b/packages/opencode/src/storage/json-migration.ts
@@ -95,7 +95,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
     return items
   }
 
-  function insert(values: any[], table: any, label: string) {
+  function insert(values: unknown[], table: Parameters<typeof db.insert>[0], label: string) {
     if (values.length === 0) return 0
     try {
       db.insert(table).values(values).onConflictDoNothing().run()
@@ -152,7 +152,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
   // Migrate projects first (no FK deps)
   // Derive all IDs from file paths, not JSON content
   const projectIds = new Set<string>()
-  const projectValues = [] as any[]
+  const projectValues: unknown[] = []
   for (let i = 0; i < projectFiles.length; i += batchSize) {
     const end = Math.min(i + batchSize, projectFiles.length)
     const batch = await read(projectFiles, i, end)
@@ -186,7 +186,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
   // migrations may have moved sessions to new directories without updating the JSON
   const sessionProjects = sessionFiles.map((file) => path.basename(path.dirname(file)))
   const sessionIds = new Set<string>()
-  const sessionValues = [] as any[]
+  const sessionValues: unknown[] = []
   for (let i = 0; i < sessionFiles.length; i += batchSize) {
     const end = Math.min(i + batchSize, sessionFiles.length)
     const batch = await read(sessionFiles, i, end)
@@ -314,7 +314,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
   for (let i = 0; i < todoFiles.length; i += batchSize) {
     const end = Math.min(i + batchSize, todoFiles.length)
     const batch = await read(todoFiles, i, end)
-    const values = [] as any[]
+    const values: unknown[] = []
     for (let j = 0; j < batch.length; j++) {
       const data = batch[j]
       if (!data) continue
@@ -351,7 +351,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
 
   // Migrate permissions
   const permProjects = permFiles.map((file) => path.basename(file, ".json"))
-  const permValues = [] as any[]
+  const permValues: unknown[] = []
   for (let i = 0; i < permFiles.length; i += batchSize) {
     const end = Math.min(i + batchSize, permFiles.length)
     const batch = await read(permFiles, i, end)
@@ -376,7 +376,7 @@ export async function run(db: SQLiteBunDatabase<any, any> | NodeSQLiteDatabase<a
 
   // Migrate session shares
   const shareSessions = shareFiles.map((file) => path.basename(file, ".json"))
-  const shareValues = [] as any[]
+  const shareValues: unknown[] = []
   for (let i = 0; i < shareFiles.length; i += batchSize) {
     const end = Math.min(i + batchSize, shareFiles.length)
     const batch = await read(shareFiles, i, end)

--- a/packages/opencode/src/util/defer.ts
+++ b/packages/opencode/src/util/defer.ts
@@ -1,6 +1,4 @@
-export function defer<T extends () => void | Promise<void>>(
-  fn: T,
-): T extends () => Promise<void> ? { [Symbol.asyncDispose]: () => Promise<void> } : { [Symbol.dispose]: () => void } {
+export function defer(fn: () => void | Promise<void>): AsyncDisposable & Disposable {
   return {
     [Symbol.dispose]() {
       void fn()
@@ -8,5 +6,5 @@ export function defer<T extends () => void | Promise<void>>(
     [Symbol.asyncDispose]() {
       return Promise.resolve(fn())
     },
-  } as any
+  }
 }


### PR DESCRIPTION
## Summary

Remove 7 `as any` casts that were genuinely unnecessary — no replacement casts needed.

### Changes

| File | Cast removed | How |
|---|---|---|
| `json-migration.ts` (5) | `[] as any[]` | Type annotation `unknown[]` instead of cast |
| `json-migration.ts` (1) | `insert(values: any[], table: any, ...)` | Proper parameter types |
| `session/index.tsx` (1) | `"messages_toggle_conceal" as any` | String was already assignable to `keybind?: string` |
| `defer.ts` (1) | `} as any` on return | Simplified conditional return type to concrete `AsyncDisposable & Disposable` |

### What wasn't changed

The remaining ~32 `as any` casts in `packages/opencode/src/` are genuinely necessary — they work around third-party SDK type mismatches, dynamic plugin dispatch, or boundaries where the incoming data is untyped (`.json()` responses). Those would need schema validation or SDK type changes to remove properly.