### PR TITLE
fix: align stale bot message with actual 60-day threshold

### DIFF
--- a/script/github/close-issues.ts
+++ b/script/github/close-issues.ts
@@ -3,7 +3,7 @@
 const repo = "anomalyco/opencode"
 const days = 60
 const msg =
-  "To stay organized issues are automatically closed after 90 days of no activity. If the issue is still relevant please open a new one."
+  "To stay organized issues are automatically closed after 60 days of no activity. If the issue is still relevant please open a new one."
 
 const token = process.env.GITHUB_TOKEN
 if (!token) {

--- a/script/github/close-issues.ts
+++ b/script/github/close-issues.ts
@@ -2,8 +2,7 @@
 
 const repo = "anomalyco/opencode"
 const days = 60
-const msg =
-  "To stay organized issues are automatically closed after 60 days of no activity. If the issue is still relevant please open a new one."
+const msg = `To stay organized issues are automatically closed after ${days} days of no activity. If the issue is still relevant please open a new one.`
 
 const token = process.env.GITHUB_TOKEN
 if (!token) {


### PR DESCRIPTION
## What does this PR do?

Fixes a mismatch between the stale bot's closure message ("90 days") and the actual threshold (`const days = 60`).

## Type of change

- [x] Bug fix

## How did you verify your code works?

Grepped the file to confirm there are no other references to "90 days".

Closes #22841
