### PR TITLE
fix: add missing glob dependency 

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -516,6 +516,7 @@
         "@effect/platform-node": "catalog:",
         "@npmcli/arborist": "catalog:",
         "effect": "catalog:",
+        "glob": "13.0.5",
         "mime-types": "3.0.2",
         "minimatch": "10.2.5",
         "semver": "catalog:",

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-NJAK+cPjwn+2ojDLyyDmBQyx2pD+rILetp7VCylgjek=",
+    "x86_64-linux": "sha256-b9tsgqQDXd2uM/j+rZnvkoXbXzB4iYCEasXsy9kgIl4=",
     "aarch64-linux": "sha256-q8NTtFQJoyM7TTvErGA6RtmUscxoZKD/mj9N6S5YhkA=",
     "aarch64-darwin": "sha256-/ccoSZNLef6j9j14HzpVqhKCR+czM3mhPKPH51mHO24=",
     "x86_64-darwin": "sha256-6Pd10sMHL/5ZoWNvGPwPn4/AIs1TKjt/3gFyrVpBaE0="

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,6 +26,7 @@
     "@effect/platform-node": "catalog:",
     "@npmcli/arborist": "catalog:",
     "effect": "catalog:",
+    "glob": "13.0.5",
     "mime-types": "3.0.2",
     "minimatch": "10.2.5",
     "semver": "catalog:",


### PR DESCRIPTION
### Issue for this PR

Closes #22854 

### Type of change

- [x] Bug fix


### What does this PR do?

Building opencode for nix fails with: 

```
error: Cannot build '/nix/store/2v2yaph2wk89bl5v1s9iggndhb0pl26v-opencode-1.4.6+8ab17f5.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/z17k3csyr7xqslw8zyg43ims6chi6i1g-opencode-1.4.6+8ab17f5
       Last 25 log lines:
       > dist/assets/tsx-COt5Ahok.js                                 175.54 kB │ gzip:  16.59 kB
       > dist/assets/jsx-g9-lgVsj.js                                 177.79 kB │ gzip:  16.72 kB
       > dist/assets/typescript-BPQ3VLAy.js                          181.08 kB │ gzip:  16.11 kB
       > dist/assets/angular-ts-BwZT4LLn.js                          183.82 kB │ gzip:  16.70 kB
       > dist/assets/vue-vine-8moa0y9V.js                            190.22 kB │ gzip:  18.12 kB
       > dist/assets/wolfram-lXgVvXCa.js                             262.39 kB │ gzip:  77.07 kB
       > dist/assets/session-HP8ZIqIR.js                             526.68 kB │ gzip: 173.87 kB
       > dist/assets/wasm-CG6Dc4jp.js                                622.34 kB │ gzip: 231.16 kB
       > dist/assets/cpp-CofmeUqb.js                                 626.08 kB │ gzip:  44.90 kB
       > dist/assets/ghostty-web-C3xmbZge.js                         651.43 kB │ gzip: 188.25 kB
       > dist/assets/emacs-lisp-C9XAeP06.js                          779.85 kB │ gzip: 196.53 kB
       > dist/assets/index-Vism255b.js                             1,762.76 kB │ gzip: 505.12 kB
       >
       > (!) Some chunks are larger than 500 kB after minification. Consider:
       > - Using dynamic import() to code-split the application
       > - Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
       > - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
       > ✓ built in 7.90s
       > building opencode-linux-x64
       > 1 | import { glob, globSync, type GlobOptions } from "glob"
       >                                                      ^
       > error: Could not resolve: "glob". Maybe you need to "bun install"?
       >     at /build/source/packages/shared/src/util/glob.ts:1:50
       >
       > Bun v1.3.11 (Linux x64)
       For full logs, run:
         nix log /nix/store/2v2yaph2wk89bl5v1s9iggndhb0pl26v-opencode-1.4.6+8ab17f5.drv
```

### How did you verify your code works?

Updating my flake to use my fork: 

```
    opencode = {
      url = "github:trbutler4/opencode/fix/glob-missing-failing-nix-build";
      inputs.nixpkgs.follows = "nixpkgs";
    };
```
and rebuilding my system 

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally (with the caveat that i just tested that building from my fork works)
- [x] I have not included unrelated changes in this PR

