### PR TITLE
fix: remove stale ripgrep references #22820

### DIFF
--- a/packages/opencode/src/server/instance/file.ts
+++ b/packages/opencode/src/server/instance/file.ts
@@ -15,7 +15,7 @@ export const FileRoutes = lazy(() =>
       "/find",
       describeRoute({
         summary: "Find text",
-        description: "Search for text patterns across files in the project using ripgrep.",
+        description: "Search for text patterns across files in the project.",
         operationId: "find.text",
         responses: {
           200: {

--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -2,7 +2,7 @@ You are OpenCode, You and the user share the same workspace and collaborate to a
 
 You are a deeply pragmatic, effective software engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements. You communicate efficiently, keeping the user clearly informed about ongoing actions without unnecessary detail. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior software engineer.
 
-- When searching for text or files, prefer using Glob and Grep tools (they are powered by `rg`)
+- When searching for text or files, prefer using Glob and Grep tools
 - Parallelize tool calls whenever possible - especially file reads. Use `multi_tool_use.parallel` to parallelize tool calls and only this. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
 
 ## Editing Approach

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -30,7 +30,7 @@ Usage notes:
 
   - Avoid using Bash with the `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
     - File search: Use Glob (NOT find or ls)
-    - Content search: Use Grep (NOT grep or rg)
+    - Content search: Use Grep (NOT grep)
     - Read files: Use Read (NOT cat/head/tail)
     - Edit files: Use Edit (NOT sed/awk)
     - Write files: Use Write (NOT echo >/cat <<EOF)

--- a/packages/opencode/src/tool/grep.txt
+++ b/packages/opencode/src/tool/grep.txt
@@ -4,5 +4,5 @@
 - Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
 - Returns file paths and line numbers with at least one match sorted by modification time
 - Use this tool when you need to find files containing specific patterns
-- If you need to identify/count the number of matches within files, use the Bash tool with `rg` (ripgrep) directly. Do NOT use `grep`.
+- If you need to identify/count the number of matches within files, use the Bash tool with `grep` directly.
 - When you are doing an open-ended search that may require multiple rounds of globbing and grepping, use the Task tool instead


### PR DESCRIPTION
## Description
Removed outdated ripgrep references in tool descriptions and prompts.

## Related Issues
Fixes #22820