### PR TITLE
fix(core): better global sync event structure

### DIFF
--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -460,8 +460,7 @@ export namespace Workspace {
           if (!("payload" in evt)) return
 
           if (evt.payload.type === "sync") {
-            // This name -> type is temporary
-            SyncEvent.replay({ ...evt.payload, type: evt.payload.name } as SyncEvent.SerializedEvent)
+            SyncEvent.replay(evt.payload.syncEvent as SyncEvent.SerializedEvent)
           }
 
           GlobalBus.emit("event", {

--- a/packages/opencode/src/sync/sync-event.ts
+++ b/packages/opencode/src/sync/sync-event.ts
@@ -155,20 +155,16 @@ function process<Def extends Definition>(def: Def, event: Event<Def>, options: {
           workspace: WorkspaceContext.workspaceID,
           payload: {
             type: "sync",
-            name: versionedType(def.type, def.version),
-            ...event,
+            syncEvent: {
+              type: versionedType(def.type, def.version),
+              ...event,
+            },
           },
         })
       }
     })
   })
 }
-
-// TODO:
-//
-// * Support applying multiple events at one time. One transaction,
-//   and it validets all the sequence ids
-// * when loading events from db, apply zod validation to ensure shape
 
 export function replay(event: SerializedEvent, options?: { publish: boolean }) {
   const def = registry.get(event.type)


### PR DESCRIPTION
It was messy before, I thought about changing `type` to `name` but this is easier for now