### PR TITLE
fix(test): make plugin loader theme source path separator-safe

### DIFF
--- a/packages/opencode/test/cli/tui/plugin-loader.test.ts
+++ b/packages/opencode/test/cli/tui/plugin-loader.test.ts
@@ -331,7 +331,7 @@ export default {
     const localOpts = {
       fn_marker: tmp.extra.fnMarker,
       marker: tmp.extra.localMarker,
-      source: tmp.extra.localDest.replace(".opencode/themes/", ""),
+      source: path.join(tmp.path, tmp.extra.localThemeFile),
       dest: tmp.extra.localDest,
       theme_path: `./${tmp.extra.localThemeFile}`,
       theme_name: tmp.extra.localThemeName,


### PR DESCRIPTION
## Summary
- fix a Windows-only path separator bug in `plugin-loader.test.ts` by using an explicit source path instead of string replacement on the destination path
- keep the test behavior the same on Unix while ensuring `source` and `dest` remain distinct on Windows
- this addresses the `unit (windows)` CI failure in `tui.plugin.loader > installs themes in the correct scope and remains resilient`

## Verification
- bun test test/cli/tui/plugin-loader.test.ts