### PR TITLE
fix: remove 8 more unnecessary `as any` casts in opencode core

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -178,7 +178,7 @@ export namespace ACP {
         })
         for await (const event of events.stream) {
           if (this.eventAbort.signal.aborted) return
-          const payload = (event as any)?.payload
+          const payload = event?.payload
           if (!payload) continue
           await this.handleEvent(payload as Event).catch((error) => {
             log.error("failed to handle event", { error, type: payload.type })

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -297,7 +297,9 @@ export const ProvidersLoginCommand = cmd({
         prompts.intro("Add credential")
         if (args.url) {
           const url = args.url.replace(/\/+$/, "")
-          const wellknown = await fetch(`${url}/.well-known/opencode`).then((x) => x.json() as any)
+          const wellknown = (await fetch(`${url}/.well-known/opencode`).then((x) => x.json())) as {
+            auth: { command: string[]; env: string }
+          }
           prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
           const proc = Process.spawn(wellknown.auth.command, {
             stdout: "pipe",

--- a/packages/opencode/src/cli/cmd/tui/win32.ts
+++ b/packages/opencode/src/cli/cmd/tui/win32.ts
@@ -1,4 +1,5 @@
 import { dlopen, ptr } from "bun:ffi"
+import type { ReadStream } from "node:tty"
 
 const STD_INPUT_HANDLE = -10
 const ENABLE_PROCESSED_INPUT = 0x0001
@@ -71,7 +72,7 @@ export function win32InstallCtrlCGuard() {
   if (!load()) return
   if (unhook) return unhook
 
-  const stdin = process.stdin as any
+  const stdin = process.stdin as ReadStream
   const original = stdin.setRawMode
 
   const handle = k32!.symbols.GetStdHandle(STD_INPUT_HANDLE)
@@ -93,7 +94,7 @@ export function win32InstallCtrlCGuard() {
     setImmediate(enforce)
   }
 
-  let wrapped: ((mode: boolean) => unknown) | undefined
+  let wrapped: ReadStream["setRawMode"] | undefined
 
   if (typeof original === "function") {
     wrapped = (mode: boolean) => {

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -465,12 +465,12 @@ export const layer = Layer.effect(
       direction: "callHierarchy/incomingCalls" | "callHierarchy/outgoingCalls",
     ) {
       const results = yield* run(input.file, async (client) => {
-        const items = (await client.connection
-          .sendRequest("textDocument/prepareCallHierarchy", {
+        const items = await client.connection
+          .sendRequest<unknown[] | null>("textDocument/prepareCallHierarchy", {
             textDocument: { uri: pathToFileURL(input.file).href },
             position: { line: input.line, character: input.character },
           })
-          .catch(() => [])) as any[]
+          .catch(() => [] as unknown[])
         if (!items?.length) return []
         return client.connection.sendRequest(direction, { item: items[0] }).catch(() => [])
       })

--- a/packages/opencode/src/mcp/mcp.ts
+++ b/packages/opencode/src/mcp/mcp.ts
@@ -531,7 +531,7 @@ export const layer = Layer.effect(
               Object.values(s.clients),
               (client) =>
                 Effect.gen(function* () {
-                  const pid = (client.transport as any)?.pid
+                  const pid = client.transport instanceof StdioClientTransport ? client.transport.pid : null
                   if (typeof pid === "number") {
                     const pids = yield* descendants(pid)
                     for (const dpid of pids) {

--- a/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/responses/openai-responses-language-model.ts
@@ -354,7 +354,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
         details: "flex processing is only available for o3, o4-mini, and gpt-5 models",
       })
       // Remove from args if not supported
-      delete (baseArgs as any).service_tier
+      baseArgs.service_tier = undefined
     }
 
     // Validate priority processing support
@@ -366,7 +366,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
           "priority processing is only available for supported models (gpt-4, gpt-5, gpt-5-mini, o3, o4-mini) and requires Enterprise access. gpt-5-nano is not supported",
       })
       // Remove from args if not supported
-      delete (baseArgs as any).service_tier
+      baseArgs.service_tier = undefined
     }
 
     const {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -193,7 +193,7 @@ function normalizeMessages(
             providerOptions: {
               ...msg.providerOptions,
               openaiCompatible: {
-                ...(msg.providerOptions as any)?.openaiCompatible,
+                ...msg.providerOptions?.openaiCompatible,
                 [field]: reasoningText,
               },
             },

--- a/packages/opencode/src/util/effect-zod.ts
+++ b/packages/opencode/src/util/effect-zod.ts
@@ -77,8 +77,8 @@ function union(ast: SchemaAST.Union): z.ZodTypeAny {
   if (items.length === 1) return items[0]
   if (items.length < 2) return fail(ast)
 
-  const discriminator = (ast as any).annotations?.discriminator
-  if (discriminator) {
+  const discriminator = ast.annotations?.discriminator
+  if (typeof discriminator === "string") {
     return z.discriminatedUnion(discriminator, items as [z.ZodObject<any>, z.ZodObject<any>, ...z.ZodObject<any>[]])
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #22840. Removes 8 more `as any` casts from `packages/opencode/src/` by fixing the underlying type issue instead of suppressing it.

## Changes

- **`acp/agent.ts`** — SDK `GlobalEvent.payload` is already the full union type; the `(event as any)?.payload` cast was redundant. (The `as Event` narrowing cast is retained because the SDK union is broader than the local `Event` import.)
- **`lsp/lsp.ts`** — pass a type parameter to `client.connection.sendRequest<unknown[] | null>(...)` for `prepareCallHierarchy` instead of casting the awaited result.
- **`mcp/mcp.ts`** — use `client.transport instanceof StdioClientTransport` to narrow before reading `.pid` (only the stdio transport has a pid).
- **`provider/transform.ts`** — `msg.providerOptions` is already typed as `Record<string, Record<string, JSONValue>> | undefined` by the AI SDK; the cast was unnecessary.
- **`cli/cmd/providers.ts`** — inline the expected JSON shape of `.well-known/opencode` (`{ auth: { command: string[]; env: string } }`) instead of casting `.json() as any`. Also fixes a latent type bug: `wellknown.auth.env` is a string (env var name), not a `Record`, matching how `config.ts` consumes `value.key` as `process.env[value.key]`.
- **`cli/cmd/tui/win32.ts`** — cast `process.stdin` to `tty.ReadStream` (which has `setRawMode`) and type `wrapped` as `ReadStream["setRawMode"]` to match the signature.
- **`provider/sdk/copilot/responses/openai-responses-language-model.ts`** — replace `delete (baseArgs as any).service_tier` with `baseArgs.service_tier = undefined`, matching the existing pattern used for `temperature` and `top_p` a few lines up.
- **`util/effect-zod.ts`** — access `ast.annotations?.discriminator` directly. The `annotations` field has an `[x: string]: unknown` index signature, so no cast is needed; added a `typeof === "string"` check to narrow before passing to `z.discriminatedUnion`.

## Remaining

~24 `as any` casts still in `packages/opencode/src/` — most in `session/prompt.ts`, `plugin/plugin.ts` (dynamic hook dispatch), TUI render paths, and the `util/filesystem.ts` DOM↔Node `ReadableStream` bridge, which genuinely require a cast without changing function signatures.

## Verification

- `bun turbo typecheck` passes (all 13 tasks).
- `bun run lint` passes (oxlint warnings only, no errors).