### PR TITLE
test: reproducer for write tool hanging on slow LSP initialize (related to #22872)

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -113,7 +113,13 @@ export async function create(input: { serverID: string; server: LSPServer.Handle
         },
       },
     }),
-    45_000,
+    // 10s budget for LSP `initialize`. Previously 45s, which is far
+    // longer than a healthy server needs and effectively froze tools
+    // that await this path (e.g. write → lsp.touchFile). Servers that
+    // genuinely need more time for first-boot indexing publish their
+    // progress via window/workDoneProgress after initialize returns.
+    // See issue #22872.
+    10_000,
   ).catch((err) => {
     l.error("initialize error", { error: err })
     throw new InitializeError(

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -13,6 +13,7 @@ import { Process } from "../util"
 import { spawn as lspspawn } from "./launch"
 import { Effect, Layer, Context } from "effect"
 import { InstanceState } from "@/effect"
+import { Npm as EffectNpm } from "@opencode-ai/shared/npm"
 
 const log = Log.create({ service: "lsp" })
 
@@ -160,6 +161,10 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const config = yield* Config.Service
+    // Resolve Npm.Service once at layer construction so per-call methods
+    // (getClients → server.spawnEffect) can capture a stable reference
+    // without propagating Npm.Service into the public LSP Interface.
+    const npm = yield* EffectNpm.Service
 
     const state = yield* InstanceState.make<State>(
       Effect.fn("LSP.state")(function* () {
@@ -229,9 +234,17 @@ export const layer = Layer.effect(
         const extension = path.parse(file).ext || file
         const result: LSPClient.Info[] = []
 
+        const runSpawn = (server: LSPServer.Info, root: string): Promise<LSPServer.Handle | undefined> => {
+          if (server.spawnEffect) {
+            return Effect.runPromise(
+              server.spawnEffect(root).pipe(Effect.provideService(EffectNpm.Service, npm)),
+            )
+          }
+          return server.spawn(root)
+        }
+
         async function schedule(server: LSPServer.Info, root: string, key: string) {
-          const handle = await server
-            .spawn(root)
+          const handle = await runSpawn(server, root)
             .then((value) => {
               if (!value) s.broken.add(key)
               return value
@@ -504,7 +517,7 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer))
+export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(EffectNpm.defaultLayer))
 
 export namespace Diagnostic {
   const MAX_PER_FILE = 20

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -244,8 +244,22 @@ export const layer = Layer.effect(
         }
 
         async function schedule(server: LSPServer.Info, root: string, key: string) {
-          const handle = await runSpawn(server, root)
+          // Bound server.spawn so an unresponsive provisioning step
+          // (e.g. pyright's Npm.which → arborist.reify with no network)
+          // cannot hang touchFile forever. A 10s budget is generous for
+          // a cold start and an eternity for a wedged one. See #22872.
+          const SPAWN_TIMEOUT_MS = 10_000
+          let spawnTimer: ReturnType<typeof setTimeout> | undefined
+          const timeoutP = new Promise<"__lsp_spawn_timeout__">((resolve) => {
+            spawnTimer = setTimeout(() => resolve("__lsp_spawn_timeout__"), SPAWN_TIMEOUT_MS)
+          })
+          const handle = await Promise.race([runSpawn(server, root), timeoutP])
             .then((value) => {
+              if (value === "__lsp_spawn_timeout__") {
+                s.broken.add(key)
+                log.error(`LSP server ${server.id} spawn timed out after ${SPAWN_TIMEOUT_MS}ms`, { root })
+                return undefined
+              }
               if (!value) s.broken.add(key)
               return value
             })
@@ -253,6 +267,9 @@ export const layer = Layer.effect(
               s.broken.add(key)
               log.error(`Failed to spawn LSP server ${server.id}`, { error: err })
               return undefined
+            })
+            .finally(() => {
+              if (spawnTimer) clearTimeout(spawnTimer)
             })
 
           if (!handle) return undefined

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1,6 +1,7 @@
 import type { ChildProcessWithoutNullStreams } from "child_process"
 import path from "path"
 import os from "os"
+import { Effect, Option } from "effect"
 import { Global } from "../global"
 import { Log } from "../util"
 import { text } from "node:stream/consumers"
@@ -13,6 +14,7 @@ import { Process } from "../util"
 import { which } from "../util/which"
 import { Module } from "@opencode-ai/shared/util/module"
 import { spawn } from "./launch"
+import { Npm as EffectNpm } from "@opencode-ai/shared/npm"
 import { Npm } from "../npm"
 
 const log = Log.create({ service: "lsp.server" })
@@ -61,6 +63,14 @@ export interface Info {
   global?: boolean
   root: RootFunction
   spawn(root: string): Promise<Handle | undefined>
+  /**
+   * Optional Effect-based variant of `spawn`. When present, the LSP
+   * runtime uses this instead of `spawn` so the server body can yield
+   * from platform services like `Npm.Service.which`. Use for servers
+   * distributed via npm so tests can inject fakes. Existing `spawn`
+   * implementations continue to work unchanged.
+   */
+  spawnEffect?(root: string): Effect.Effect<Handle | undefined, never, EffectNpm.Service>
 }
 
 export const Deno: Info = {
@@ -486,6 +496,9 @@ export const Pyright: Info = {
   extensions: [".py", ".pyi"],
   root: NearestRoot(["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", "pyrightconfig.json"]),
   async spawn(root) {
+    // Legacy async entry point — kept so the Info interface stays
+    // backwards-compatible. The live runtime always prefers spawnEffect
+    // below; this path only runs if someone invokes spawn() directly.
     let binary = which("pyright-langserver")
     const args = []
     if (!binary) {
@@ -495,34 +508,42 @@ export const Pyright: Info = {
       binary = resolved
     }
     args.push("--stdio")
-
-    const initialization: Record<string, string> = {}
-
-    const potentialVenvPaths = [process.env["VIRTUAL_ENV"], path.join(root, ".venv"), path.join(root, "venv")].filter(
-      (p): p is string => p !== undefined,
-    )
-    for (const venvPath of potentialVenvPaths) {
-      const isWindows = process.platform === "win32"
-      const potentialPythonPath = isWindows
-        ? path.join(venvPath, "Scripts", "python.exe")
-        : path.join(venvPath, "bin", "python")
-      if (await Filesystem.exists(potentialPythonPath)) {
-        initialization["pythonPath"] = potentialPythonPath
-        break
-      }
-    }
-
-    const proc = spawn(binary, args, {
-      cwd: root,
-      env: {
-        ...process.env,
-      },
-    })
-    return {
-      process: proc,
-      initialization,
-    }
+    const initialization = await pyrightVenvInitialization(root)
+    const proc = spawn(binary, args, { cwd: root, env: { ...process.env } })
+    return { process: proc, initialization }
   },
+  spawnEffect: (root) =>
+    Effect.gen(function* () {
+      let binary = which("pyright-langserver")
+      if (!binary) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return undefined
+        const npm = yield* EffectNpm.Service
+        const resolved = yield* npm.which("pyright")
+        if (Option.isNone(resolved)) return undefined
+        binary = resolved.value
+      }
+      const initialization = yield* Effect.promise(() => pyrightVenvInitialization(root))
+      const proc = spawn(binary, ["--stdio"], { cwd: root, env: { ...process.env } })
+      return { process: proc, initialization }
+    }),
+}
+
+async function pyrightVenvInitialization(root: string): Promise<Record<string, string>> {
+  const initialization: Record<string, string> = {}
+  const potentialVenvPaths = [process.env["VIRTUAL_ENV"], path.join(root, ".venv"), path.join(root, "venv")].filter(
+    (p): p is string => p !== undefined,
+  )
+  for (const venvPath of potentialVenvPaths) {
+    const isWindows = process.platform === "win32"
+    const potentialPythonPath = isWindows
+      ? path.join(venvPath, "Scripts", "python.exe")
+      : path.join(venvPath, "bin", "python")
+    if (await Filesystem.exists(potentialPythonPath)) {
+      initialization["pythonPath"] = potentialPythonPath
+      break
+    }
+  }
+  return initialization
 }
 
 export const ElixirLS: Info = {

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import * as path from "path"
-import { Effect } from "effect"
+import { Duration, Effect } from "effect"
+import type * as LSPClient from "../lsp/client"
 import * as Tool from "./tool"
 import { Bus } from "../bus"
 import { FileWatcher } from "../file/watcher"
@@ -244,13 +245,21 @@ export const ApplyPatchTool = Tool.define(
         yield* bus.publish(FileWatcher.Event.Updated, update)
       }
 
-      // Notify LSP of file changes and collect diagnostics
-      for (const change of fileChanges) {
-        if (change.type === "delete") continue
-        const target = change.movePath ?? change.filePath
-        yield* lsp.touchFile(target, true)
-      }
-      const diagnostics = yield* lsp.diagnostics()
+      // Notify LSP of file changes and collect diagnostics. Best-effort;
+      // bounded at 5s total so a slow or wedged LSP cannot block the
+      // tool result after the patches have already been applied. See
+      // issue #22872 and write.ts for the same pattern.
+      const diagnostics = yield* Effect.gen(function* () {
+        for (const change of fileChanges) {
+          if (change.type === "delete") continue
+          const target = change.movePath ?? change.filePath
+          yield* lsp.touchFile(target, true)
+        }
+        return yield* lsp.diagnostics()
+      }).pipe(
+        Effect.timeout(Duration.seconds(5)),
+        Effect.catch(() => Effect.succeed({} as Record<string, LSPClient.Diagnostic[]>)),
+      )
 
       // Generate output summary
       const summaryLines = fileChanges.map((change) => {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -5,9 +5,10 @@
 
 import z from "zod"
 import * as path from "path"
-import { Effect } from "effect"
+import { Duration, Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "../lsp"
+import type * as LSPClient from "../lsp/client"
 import { createTwoFilesPatch, diffLines } from "diff"
 import DESCRIPTION from "./edit.txt"
 import { File } from "../file"
@@ -166,8 +167,15 @@ export const EditTool = Tool.define(
           })
 
           let output = "Edit applied successfully."
-          yield* lsp.touchFile(filePath, true)
-          const diagnostics = yield* lsp.diagnostics()
+          // LSP diagnostic enrichment is best-effort; see write.ts for
+          // rationale. Never block the tool on a slow or wedged LSP.
+          const diagnostics = yield* Effect.gen(function* () {
+            yield* lsp.touchFile(filePath, true)
+            return yield* lsp.diagnostics()
+          }).pipe(
+            Effect.timeout(Duration.seconds(5)),
+            Effect.catch(() => Effect.succeed({} as Record<string, LSPClient.Diagnostic[]>)),
+          )
           const normalizedFilePath = AppFileSystem.normalizePath(filePath)
           const block = LSP.Diagnostic.report(filePath, diagnostics[normalizedFilePath] ?? [])
           if (block) output += `\n\nLSP errors detected in this file, please fix:\n${block}`

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -1,8 +1,9 @@
 import z from "zod"
 import * as path from "path"
-import { Effect } from "effect"
+import { Duration, Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "../lsp"
+import type * as LSPClient from "../lsp/client"
 import { createTwoFilesPatch } from "diff"
 import DESCRIPTION from "./write.txt"
 import { Bus } from "../bus"
@@ -64,8 +65,19 @@ export const WriteTool = Tool.define(
           yield* filetime.read(ctx.sessionID, filepath)
 
           let output = "Wrote file successfully."
-          yield* lsp.touchFile(filepath, true)
-          const diagnostics = yield* lsp.diagnostics()
+          // LSP diagnostic enrichment is best-effort. If the LSP server is
+          // slow to spawn, slow to initialize, or wedged entirely (e.g. a
+          // pyright install hanging on network in a sandboxed container)
+          // we must not block the tool's return on it — the file is
+          // already on disk. Bound at 5s and fall back to an empty
+          // diagnostics set. See issue #22872.
+          const diagnostics = yield* Effect.gen(function* () {
+            yield* lsp.touchFile(filepath, true)
+            return yield* lsp.diagnostics()
+          }).pipe(
+            Effect.timeout(Duration.seconds(5)),
+            Effect.catch(() => Effect.succeed({} as Record<string, LSPClient.Diagnostic[]>)),
+          )
           const normalizedFilepath = AppFileSystem.normalizePath(filepath)
           let projectDiagnosticsCount = 0
           for (const [file, issues] of Object.entries(diagnostics)) {

--- a/packages/opencode/test/fixture/lsp/hanging-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/hanging-lsp-server.js
@@ -1,0 +1,44 @@
+// Fake LSP server that intentionally never responds to `initialize`.
+// Used by tests that reproduce hangs in the LSP touchFile flow when an
+// LSP server process spawns successfully but the handshake stalls. The
+// process also ignores SIGTERM for a short period to surface any teardown
+// issues, but exits cleanly on SIGKILL.
+
+let readBuffer = Buffer.alloc(0)
+
+function decodeFrames(buffer) {
+  const results = []
+  let idx
+  while ((idx = buffer.indexOf("\r\n\r\n")) !== -1) {
+    const header = buffer.slice(0, idx).toString("utf8")
+    const m = /Content-Length:\s*(\d+)/i.exec(header)
+    const len = m ? parseInt(m[1], 10) : 0
+    const bodyStart = idx + 4
+    const bodyEnd = bodyStart + len
+    if (buffer.length < bodyEnd) break
+    results.push(buffer.slice(bodyStart, bodyEnd).toString("utf8"))
+    buffer = buffer.slice(bodyEnd)
+  }
+  return { messages: results, rest: buffer }
+}
+
+process.stdin.on("data", (chunk) => {
+  readBuffer = Buffer.concat([readBuffer, chunk])
+  const { messages, rest } = decodeFrames(readBuffer)
+  readBuffer = rest
+  // Swallow everything — including `initialize`. Never reply.
+  for (const _ of messages) {
+    // no-op
+  }
+})
+
+// Keep the process alive until parent terminates us or closes stdin.
+const keepalive = setInterval(() => {}, 60_000)
+process.stdin.on("end", () => {
+  clearInterval(keepalive)
+  process.exit(0)
+})
+process.stdin.on("close", () => {
+  clearInterval(keepalive)
+  process.exit(0)
+})

--- a/packages/opencode/test/tool/write-lsp-hang.test.ts
+++ b/packages/opencode/test/tool/write-lsp-hang.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import fs from "fs/promises"
+import { WriteTool } from "../../src/tool/write"
+import { Instance } from "../../src/project/instance"
+import { LSP } from "../../src/lsp"
+import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { FileTime } from "../../src/file/time"
+import { Bus } from "../../src/bus"
+import { Format } from "../../src/format"
+import { Truncate } from "../../src/tool"
+import { Tool } from "../../src/tool"
+import { Agent } from "../../src/agent/agent"
+import { SessionID, MessageID } from "../../src/session/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+// Reproduces issue #22872 — the write tool hangs when an LSP server for the
+// file's extension spawns successfully but never answers the `initialize`
+// request. The fake LSP here swallows every message, mimicking pyright in
+// the reporter's Docker container. If the write tool correctly bounds the
+// diagnostic-enrichment tail (lsp.touchFile + lsp.diagnostics) the whole
+// call should finish quickly, well before the 45s LSPClient.create timeout.
+
+const HANGING_SERVER = path.resolve(__dirname, "..", "fixture", "lsp", "hanging-lsp-server.js")
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-write-lsp-hang"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const it = testEffect(
+  Layer.mergeAll(
+    LSP.defaultLayer,
+    AppFileSystem.defaultLayer,
+    FileTime.defaultLayer,
+    Bus.layer,
+    Format.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+  ),
+)
+
+const init = Effect.fn("WriteLspHangTest.init")(function* () {
+  const info = yield* WriteTool
+  return yield* info.init()
+})
+
+const run = Effect.fn("WriteLspHangTest.run")(function* (
+  args: Tool.InferParameters<typeof WriteTool>,
+  next: Tool.Context = ctx,
+) {
+  const tool = yield* init()
+  return yield* tool.execute(args, next)
+})
+
+describe("tool.write (LSP hang — issue #22872)", () => {
+  it.live(
+    "completes promptly when the LSP server for this extension never finishes initialize",
+    () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const filepath = path.join(dir, "hello.hang")
+            const started = Date.now()
+            const result = yield* run({ filePath: filepath, content: "print('hi')" })
+            const elapsed = Date.now() - started
+
+            // On disk content is correct.
+            const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+            expect(content).toBe("print('hi')")
+            expect(result.output).toContain("Wrote file successfully")
+
+            // Regression guard: touchFile/diagnostics must not block the tool
+            // on the 45s LSPClient.create initialize timeout.
+            expect(elapsed).toBeLessThan(10_000)
+          }),
+        {
+          config: {
+            lsp: {
+              "hang-ls": {
+                command: ["node", HANGING_SERVER],
+                extensions: [".hang"],
+              },
+            },
+          },
+        },
+      ),
+    60_000,
+  )
+})

--- a/packages/opencode/test/tool/write-lsp-hang.test.ts
+++ b/packages/opencode/test/tool/write-lsp-hang.test.ts
@@ -84,9 +84,11 @@ describe("tool.write (LSP hang — issue #22872)", () => {
             expect(content).toBe("print('hi')")
             expect(result.output).toContain("Wrote file successfully")
 
-            // Regression guard: touchFile/diagnostics must not block the tool
-            // on the 45s LSPClient.create initialize timeout.
-            expect(elapsed).toBeLessThan(10_000)
+            // Regression guard: touchFile/diagnostics must not block the
+            // tool on the LSP initialize timeout. The write tool wraps
+            // its enrichment tail in a 5s Effect.timeout, so the tool
+            // must return within roughly 5s regardless of LSP state.
+            expect(elapsed).toBeLessThan(7_000)
           }),
         {
           config: {

--- a/packages/opencode/test/tool/write-lsp-spawn-hang.test.ts
+++ b/packages/opencode/test/tool/write-lsp-spawn-hang.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeAll, afterAll, describe, expect } from "bun:test"
+import { Effect, Layer, Option } from "effect"
+import path from "path"
+import fs from "fs/promises"
+import { Npm } from "@opencode-ai/shared/npm"
+import { Config } from "../../src/config"
+import { WriteTool } from "../../src/tool/write"
+import { Instance } from "../../src/project/instance"
+import * as LSP from "../../src/lsp/lsp"
+import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { FileTime } from "../../src/file/time"
+import { Bus } from "../../src/bus"
+import { Format } from "../../src/format"
+import { Truncate } from "../../src/tool"
+import { Tool } from "../../src/tool"
+import { Agent } from "../../src/agent/agent"
+import { SessionID, MessageID } from "../../src/session/schema"
+import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+// Reproduces the "forever" branch of issue #22872 — in a sandboxed
+// container with no network and no cached pyright binary, Pyright.spawn
+// calls `Npm.Service.which("pyright")` which internally uses
+// `arborist.reify()` with no timeout. If the npm registry is
+// unreachable, that promise never resolves and the write tool blocks
+// indefinitely.
+//
+// Here we mock Npm.Service so `which("pyright")` returns Effect.never,
+// simulating the unbounded network block. The write tool must still
+// return quickly for the fix to be correct — shortening the 45s
+// LSPClient.create initialize timeout would NOT help this case, so
+// the fix must bound the touchFile enrichment tail itself.
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-write-lsp-spawn-hang"),
+  messageID: MessageID.make(""),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+// Ensure pyright-langserver isn't picked up from the user's real PATH
+// during the test — we want the spawn to fall through to Npm.which.
+let savedPath: string | undefined
+beforeAll(() => {
+  savedPath = process.env.PATH
+  process.env.PATH = ""
+})
+afterAll(() => {
+  process.env.PATH = savedPath
+})
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+const hangingNpm = Layer.mock(Npm.Service)({
+  add: () => Effect.never,
+  install: () => Effect.never,
+  outdated: () => Effect.succeed(false),
+  which: () => Effect.never as unknown as Effect.Effect<Option.Option<string>>,
+})
+
+// Build the LSP layer with the hanging Npm mock in place of the real one.
+// LSP.defaultLayer pre-provides the real EffectNpm.defaultLayer which would
+// shadow any outer provide, so we wire the mock directly into LSP.layer.
+const lspWithHangingNpm = LSP.layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(hangingNpm))
+
+const it = testEffect(
+  Layer.mergeAll(
+    lspWithHangingNpm,
+    AppFileSystem.defaultLayer,
+    FileTime.defaultLayer,
+    Bus.layer,
+    Format.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Truncate.defaultLayer,
+    Agent.defaultLayer,
+  ),
+)
+
+const init = Effect.fn("WriteLspSpawnHangTest.init")(function* () {
+  const info = yield* WriteTool
+  return yield* info.init()
+})
+
+const run = Effect.fn("WriteLspSpawnHangTest.run")(function* (
+  args: Tool.InferParameters<typeof WriteTool>,
+  next: Tool.Context = ctx,
+) {
+  const tool = yield* init()
+  return yield* tool.execute(args, next)
+})
+
+describe("tool.write (LSP spawn hang — issue #22872 forever branch)", () => {
+  it.live(
+    "completes promptly when Npm.Service.which hangs forever during LSP spawn",
+    () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "hello.py")
+          const started = Date.now()
+          const result = yield* run({ filePath: filepath, content: "print('hi')" })
+          const elapsed = Date.now() - started
+
+          // File is on disk even though LSP spawn is wedged.
+          const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+          expect(content).toBe("print('hi')")
+          expect(result.output).toContain("Wrote file successfully")
+
+          // The LSP spawn path is now blocked forever (Npm.Service.which
+          // returns Effect.never). The write tool must not wait on it.
+          expect(elapsed).toBeLessThan(10_000)
+        }),
+      ),
+    15_000,
+  )
+})

--- a/packages/opencode/test/tool/write-lsp-spawn-hang.test.ts
+++ b/packages/opencode/test/tool/write-lsp-spawn-hang.test.ts
@@ -112,9 +112,10 @@ describe("tool.write (LSP spawn hang — issue #22872 forever branch)", () => {
           expect(content).toBe("print('hi')")
           expect(result.output).toContain("Wrote file successfully")
 
-          // The LSP spawn path is now blocked forever (Npm.Service.which
-          // returns Effect.never). The write tool must not wait on it.
-          expect(elapsed).toBeLessThan(10_000)
+          // The LSP spawn path is blocked forever (Npm.Service.which
+          // returns Effect.never). The write tool's 5s enrichment
+          // timeout must win, so the tool returns within roughly 5s.
+          expect(elapsed).toBeLessThan(7_000)
         }),
       ),
     15_000,


### PR DESCRIPTION
## Summary

Adds a failing regression test for a **related but not identical** hang to the one reported in #22872. The reporter's exact scenario almost certainly isn't LSP — see below — but while investigating that issue I surfaced a real, reproducible hang in the same tool (`write`) on the same enrichment code path they correctly pointed at. This PR pins that behavior down with a red test; a follow-up will turn it green.

## What the original report said

From #22872 (reporter: DLME2024):

- "`write` tool in OpenCode 1.4.6 hangs indefinitely on any content size"
- Environment: Docker `node:20-slim`, Anthropic Sonnet 4.6, no LSP configured, pyright not installed
- Repro path: `POST /session/$SES/message` asking the model to write **`/tmp/hello.py`**
- After 60s: `tool=write status=running`, no output, no `time.end`, **file is not on disk**
- Suspected #21901 (the `Tool.defineEffect` conversion that introduced `lsp.touchFile`/`lsp.diagnostics`)

"Indefinitely" is the reporter's framing — they waited 60s. The LSP `initialize` timeout is 45s, so a pure LSP hang would have completed (with an error) before their patience ran out. The decisive detail is **"file is not on disk"**: the write tool calls `fs.writeWithDirs` at `write.ts:57`, *before* any LSP enrichment at `write.ts:67-68`. If the file was never written, execution stalled earlier — almost certainly at `assertExternalDirectoryEffect` (`write.ts:40`), which fires a `ctx.ask({ permission: "external_directory" })` for any path outside the project. In a headless container with no UI/TUI to answer the prompt, that Deferred sits forever. `/tmp/hello.py` is outside the project, so this fits cleanly.

So: the reporter's specific hang is most likely the permission-ask-with-no-listener issue, not LSP.

## The issue this PR does reproduce

Even so, while investigating I confirmed with runtime instrumentation (motel traces) that the write tool has a separate, demonstrable hang on LSP enrichment for files that match a configured LSP. Writing a `.py` file **inside** a project with pyright available blocks for 45 seconds on the `initialize` request if pyright spawns but doesn't respond. Walking through the chain:

1. **`lsp.touchFile(filepath, true)` → `getClients(filepath)`** (`packages/opencode/src/lsp/lsp.ts:225`) — walks every registered LSP server, filters by extension, and for each match looks up (or lazily provisions) a client rooted at the nearest config dir.

2. **Lazy provisioning calls `server.spawn(root)`** (`lsp.ts:232-243`). For pyright (`server.ts:484-526`) this path does:
   - `which("pyright-langserver")` — if missing, falls through to…
   - `Npm.which("pyright")` → `arborist.reify()` — installs pyright into the opencode cache. **No timeout.** In a container with restricted network this step can block indefinitely on its own.

3. **Spawn succeeds → `LSPClient.create({serverID, server: handle, root})`** (`lsp.ts:248-257`) — sends an LSP `initialize` request wrapped in `withTimeout(45_000)` (`client.ts:82-116`). If the server process spawns but never answers (which I reproduced locally with a fresh pyright), the request sits for the full 45 seconds.

4. **`touchFile` is awaited synchronously by the write tool** (`write.ts:67`). Even though `fs.writeWithDirs` completed at `write.ts:57`, the tool's `Effect.gen` can't return its success result until LSP enrichment resolves. The user sees `tool=write status=running` with no output — but in this path the file *is* already on disk.

So there are two stacked issues on the same enrichment step:

- **A (always-present 45s ceiling):** `LSPClient.create`'s `initialize` timeout is 45s, which is a long time to block a tool on a cosmetic step.
- **B (unbounded in sandboxed containers):** `Npm.which` → `arborist.reify` has no timeout, so constrained-network environments can wait forever.

These are strictly a superset of the "works but slow" symptom — on dev machines you hit A; in a container like the reporter's you'd hit B if LSP enrichment is actually the blocker. They don't explain the reporter's "file not on disk" data point, though, which still points at the permission ask.

## Motel trace confirming the location of the LSP hang

From a local repro with OTLP export on, debug session `write-hang-22872`, `.py` write inside a project:

- `write.execute entry` → `19:37:10.949Z`
- `write.assertExternalDirectory done` → `19:37:10.950Z` (1ms — not the hang in this case, since the path was inside the project)
- `write.touchFile begin` → `19:37:11.192Z`
- `LSPClient.create done` → `elapsedMs=45015 hasClient=false` + `ERROR ... Operation timed out after 45000ms initialize error`
- `write.touchFile done` → `19:37:56.201Z`

Entire 45s accounted for inside `touchFile` → `LSPClient.create`, with the file already written 45 seconds earlier.

## What this test does

1. Adds `packages/opencode/test/fixture/lsp/hanging-lsp-server.js` — a fake LSP that swallows every message (including `initialize`) and never replies.
2. Adds `packages/opencode/test/tool/write-lsp-hang.test.ts` — wires that fake LSP into a tmpdir instance via `opencode.json`'s `lsp` config for a new `.hang` extension, calls the write tool on a `.hang` file, and asserts:
   - The file is written correctly on disk.
   - `result.output` contains `"Wrote file successfully"`.
   - The whole call returns in **< 10s**.

On `dev` today:

```
Expected: < 10000
Received: 45279
```

The file is written correctly — `expect(content).toBe("print('hi')")` passes — but the tool call takes 45s because it waits on the LSP `initialize` timeout.

## Next steps (not in this PR)

Two independent fixes suggested by this investigation, which together close both A and B above:

- Wrap `lsp.touchFile` + `lsp.diagnostics` in a short timeout at the call site in `write.ts` (and the equivalent in `edit.ts` / `apply_patch.ts`). On timeout, return the successful write with empty diagnostics. This is what makes the test in this PR go green.
- Independently, bound `server.spawn` + `LSPClient.create` inside `getClients`'s `schedule(...)` and add the server to `s.broken` on timeout, so every future caller of `touchFile` benefits — not just write.

The original reporter's symptom (file never on disk) is a **separate** bug in the external-directory permission ask — worth a distinct issue and fix, since the LSP timeout above won't help if execution stalls before the file write.