### PR TITLE
feat(core): pass auth data to workspace

### DIFF
--- a/packages/opencode/src/auth/auth.ts
+++ b/packages/opencode/src/auth/auth.ts
@@ -56,6 +56,12 @@ export const layer = Layer.effect(
     const decode = Schema.decodeUnknownOption(Info)
 
     const all = Effect.fn("Auth.all")(function* () {
+      if (process.env.OPENCODE_AUTH_CONTENT) {
+        try {
+          return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
+        } catch (err) {}
+      }
+
       const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
       return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
     })

--- a/packages/opencode/src/control-plane/types.ts
+++ b/packages/opencode/src/control-plane/types.ts
@@ -28,7 +28,7 @@ export type WorkspaceAdaptor = {
   name: string
   description: string
   configure(info: WorkspaceInfo): WorkspaceInfo | Promise<WorkspaceInfo>
-  create(info: WorkspaceInfo, from?: WorkspaceInfo): Promise<void>
+  create(info: WorkspaceInfo, env: Record<string, string>, from?: WorkspaceInfo): Promise<void>
   remove(info: WorkspaceInfo): Promise<void>
   target(info: WorkspaceInfo): Target | Promise<Target>
 }

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -5,6 +5,7 @@ import { Database, asc, eq, inArray } from "@/storage"
 import { Project } from "@/project"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
+import { Auth } from "@/auth"
 import { SyncEvent } from "@/sync"
 import { EventTable } from "@/sync/event.sql"
 import { Flag } from "@/flag/flag"
@@ -112,7 +113,12 @@ export namespace Workspace {
         .run()
     })
 
-    await adaptor.create(config)
+    const env = {
+      OPENCODE_AUTH_CONTENT: JSON.stringify(await AppRuntime.runPromise(Auth.Service.use((auth) => auth.all()))),
+      OPENCODE_WORKSPACE_ID: config.id,
+      OPENCODE_EXPERIMENTAL_WORKSPACES: "true"
+    }
+    await adaptor.create(config, env)
 
     startSync(info)
 

--- a/packages/opencode/src/server/proxy.ts
+++ b/packages/opencode/src/server/proxy.ts
@@ -110,12 +110,6 @@ export namespace ServerProxy {
     req: Request,
     workspaceID: WorkspaceID,
   ) {
-    console.log("proxy http request", {
-      method: req.method,
-      request: req.url,
-      url: String(url),
-    })
-
     if (!Workspace.isSyncing(workspaceID)) {
       return new Response(`broken sync connection for workspace: ${workspaceID}`, {
         status: 503,


### PR DESCRIPTION
Workspaces need model auth. This doesn't handle more complex auth providers yet but gets the basic ones working