### PR TITLE
refactor: unwrap Heap namespace + self-reexport

### DIFF
--- a/packages/opencode/src/cli/heap.ts
+++ b/packages/opencode/src/cli/heap.ts
@@ -8,52 +8,52 @@ const log = Log.create({ service: "heap" })
 const MINUTE = 60_000
 const LIMIT = 2 * 1024 * 1024 * 1024
 
-export namespace Heap {
-  let timer: Timer | undefined
-  let lock = false
-  let armed = true
+let timer: Timer | undefined
+let lock = false
+let armed = true
 
-  export function start() {
-    if (!Flag.OPENCODE_AUTO_HEAP_SNAPSHOT) return
-    if (timer) return
+export function start() {
+  if (!Flag.OPENCODE_AUTO_HEAP_SNAPSHOT) return
+  if (timer) return
 
-    const run = async () => {
-      if (lock) return
+  const run = async () => {
+    if (lock) return
 
-      const stat = process.memoryUsage()
-      if (stat.rss <= LIMIT) {
-        armed = true
-        return
-      }
-      if (!armed) return
+    const stat = process.memoryUsage()
+    if (stat.rss <= LIMIT) {
+      armed = true
+      return
+    }
+    if (!armed) return
 
-      lock = true
-      armed = false
-      const file = path.join(
-        Global.Path.log,
-        `heap-${process.pid}-${new Date().toISOString().replace(/[:.]/g, "")}.heapsnapshot`,
-      )
-      log.warn("heap usage exceeded limit", {
-        rss: stat.rss,
-        heap: stat.heapUsed,
-        file,
+    lock = true
+    armed = false
+    const file = path.join(
+      Global.Path.log,
+      `heap-${process.pid}-${new Date().toISOString().replace(/[:.]/g, "")}.heapsnapshot`,
+    )
+    log.warn("heap usage exceeded limit", {
+      rss: stat.rss,
+      heap: stat.heapUsed,
+      file,
+    })
+
+    await Promise.resolve()
+      .then(() => writeHeapSnapshot(file))
+      .catch((err) => {
+        log.error("failed to write heap snapshot", {
+          error: err instanceof Error ? err.message : String(err),
+          file,
+        })
       })
 
-      await Promise.resolve()
-        .then(() => writeHeapSnapshot(file))
-        .catch((err) => {
-          log.error("failed to write heap snapshot", {
-            error: err instanceof Error ? err.message : String(err),
-            file,
-          })
-        })
-
-      lock = false
-    }
-
-    timer = setInterval(() => {
-      void run()
-    }, MINUTE)
-    timer.unref?.()
+    lock = false
   }
+
+  timer = setInterval(() => {
+    void run()
+  }, MINUTE)
+  timer.unref?.()
 }
+
+export * as Heap from "./heap"


### PR DESCRIPTION
## Summary
- Unwrap the `Heap` namespace in `packages/opencode/src/cli/heap.ts` to flat top-level exports.
- Append `export * as Heap from "./heap"` so consumers keep the same `Heap.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/cli` — all pass (if applicable).