### PR TITLE
refactor: unwrap Shell namespace + self-reexport

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/kv.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/kv.tsx
@@ -12,7 +12,7 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
     const [store, setStore] = createStore<Record<string, any>>()
     const filePath = path.join(Global.Path.state, "kv.json")
 
-    Filesystem.readJson(filePath)
+    Filesystem.readJson<Record<string, any>>(filePath)
       .then((x) => {
         setStore(x)
       })

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -28,10 +28,10 @@ export function FormatError(input: unknown) {
   // ProviderModelNotFoundError: { providerID: string, modelID: string, suggestions?: string[] }
   if (NamedError.hasName(input, "ProviderModelNotFoundError")) {
     const data = (input as ErrorLike).data
-    const suggestions = data?.suggestions as string[] | undefined
+    const suggestions: string[] = Array.isArray(data?.suggestions) ? data.suggestions : []
     return [
       `Model not found: ${data?.providerID}/${data?.modelID}`,
-      ...(Array.isArray(suggestions) && suggestions.length ? ["Did you mean: " + suggestions.join(", ")] : []),
+      ...(suggestions.length ? ["Did you mean: " + suggestions.join(", ")] : []),
       `Try: \`opencode models\` to list available models`,
       `Or check your config (opencode.json) provider/model names`,
     ].join("\n")
@@ -64,10 +64,10 @@ export function FormatError(input: unknown) {
     const data = (input as ErrorLike).data
     const path = data?.path
     const message = data?.message
-    const issues = data?.issues as Array<{ message: string; path: string[] }> | undefined
+    const issues: Array<{ message: string; path: string[] }> = Array.isArray(data?.issues) ? data.issues : []
     return [
       `Configuration is invalid${path && path !== "config" ? ` at ${path}` : ""}` + (message ? `: ${message}` : ""),
-      ...(issues?.map((issue) => "↳ " + issue.message + " " + issue.path.join(".")) ?? []),
+      ...issues.map((issue) => "↳ " + issue.message + " " + issue.path.join(".")),
     ].join("\n")
   }
 

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -440,12 +440,11 @@ export const layer = Layer.effect(
     const workspaceSymbol = Effect.fn("LSP.workspaceSymbol")(function* (query: string) {
       const results = yield* runAll((client) =>
         client.connection
-          .sendRequest("workspace/symbol", { query })
-          .then((result: any) => result.filter((x: Symbol) => kinds.includes(x.kind)))
-          .then((result: any) => result.slice(0, 10))
-          .catch(() => []),
+          .sendRequest<Symbol[]>("workspace/symbol", { query })
+          .then((result) => result.filter((x) => kinds.includes(x.kind)).slice(0, 10))
+          .catch(() => [] as Symbol[]),
       )
-      return results.flat() as Symbol[]
+      return results.flat()
     })
 
     const prepareCallHierarchy = Effect.fn("LSP.prepareCallHierarchy")(function* (input: LocInput) {

--- a/packages/opencode/src/npm/index.ts
+++ b/packages/opencode/src/npm/index.ts
@@ -124,8 +124,17 @@ export async function install(dir: string) {
     return
   }
 
-  const pkg = await Filesystem.readJson(path.join(dir, "package.json")).catch(() => ({}))
-  const lock = await Filesystem.readJson(path.join(dir, "package-lock.json")).catch(() => ({}))
+  type PackageDeps = Record<string, string>
+  type PackageJson = {
+    dependencies?: PackageDeps
+    devDependencies?: PackageDeps
+    peerDependencies?: PackageDeps
+    optionalDependencies?: PackageDeps
+  }
+  const pkg: PackageJson = await Filesystem.readJson<PackageJson>(path.join(dir, "package.json")).catch(() => ({}))
+  const lock: { packages?: Record<string, PackageJson> } = await Filesystem.readJson<{
+    packages?: Record<string, PackageJson>
+  }>(path.join(dir, "package-lock.json")).catch(() => ({}))
 
   const declared = new Set([
     ...Object.keys(pkg.dependencies || {}),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -547,12 +547,14 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (modelID.startsWith("duo-workflow-")) {
-            const workflowRef = options?.workflowRef as string | undefined
+            const workflowRef = typeof options?.workflowRef === "string" ? options.workflowRef : undefined
             // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
             const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
+            const workflowDefinition =
+              typeof options?.workflowDefinition === "string" ? options.workflowDefinition : undefined
             const model = sdk.workflowChat(sdkModelID, {
               featureFlags,
-              workflowDefinition: options?.workflowDefinition as string | undefined,
+              workflowDefinition,
             })
             if (workflowRef) {
               model.selectedModelRef = workflowRef

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -272,16 +272,18 @@ export const getUsage = (input: { model: Provider.Model; usage: LanguageModelUsa
     input.usage.inputTokenDetails?.cacheReadTokens ?? input.usage.cachedInputTokens ?? 0,
   )
   const cacheWriteInputTokens = safe(
-    (input.usage.inputTokenDetails?.cacheWriteTokens ??
-      input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
-      // google-vertex-anthropic returns metadata under "vertex" key
-      // (AnthropicMessagesLanguageModel custom provider key from 'vertex.anthropic.messages')
-      input.metadata?.["vertex"]?.["cacheCreationInputTokens"] ??
-      // @ts-expect-error
-      input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
-      // @ts-expect-error
-      input.metadata?.["venice"]?.["usage"]?.["cacheCreationInputTokens"] ??
-      0) as number,
+    Number(
+      input.usage.inputTokenDetails?.cacheWriteTokens ??
+        input.metadata?.["anthropic"]?.["cacheCreationInputTokens"] ??
+        // google-vertex-anthropic returns metadata under "vertex" key
+        // (AnthropicMessagesLanguageModel custom provider key from 'vertex.anthropic.messages')
+        input.metadata?.["vertex"]?.["cacheCreationInputTokens"] ??
+        // @ts-expect-error
+        input.metadata?.["bedrock"]?.["usage"]?.["cacheWriteInputTokens"] ??
+        // @ts-expect-error
+        input.metadata?.["venice"]?.["usage"]?.["cacheCreationInputTokens"] ??
+        0,
+    ),
   )
 
   // AI SDK v6 normalized inputTokens to include cached tokens across all providers

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -8,103 +8,103 @@ import { setTimeout as sleep } from "node:timers/promises"
 
 const SIGKILL_TIMEOUT_MS = 200
 
-export namespace Shell {
-  const BLACKLIST = new Set(["fish", "nu"])
-  const LOGIN = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"])
-  const POSIX = new Set(["bash", "dash", "ksh", "sh", "zsh"])
+const BLACKLIST = new Set(["fish", "nu"])
+const LOGIN = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"])
+const POSIX = new Set(["bash", "dash", "ksh", "sh", "zsh"])
 
-  export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
-    const pid = proc.pid
-    if (!pid || opts?.exited?.()) return
+export async function killTree(proc: ChildProcess, opts?: { exited?: () => boolean }): Promise<void> {
+  const pid = proc.pid
+  if (!pid || opts?.exited?.()) return
 
-    if (process.platform === "win32") {
-      await new Promise<void>((resolve) => {
-        const killer = spawn("taskkill", ["/pid", String(pid), "/f", "/t"], {
-          stdio: "ignore",
-          windowsHide: true,
-        })
-        killer.once("exit", () => resolve())
-        killer.once("error", () => resolve())
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve) => {
+      const killer = spawn("taskkill", ["/pid", String(pid), "/f", "/t"], {
+        stdio: "ignore",
+        windowsHide: true,
       })
-      return
+      killer.once("exit", () => resolve())
+      killer.once("error", () => resolve())
+    })
+    return
+  }
+
+  try {
+    process.kill(-pid, "SIGTERM")
+    await sleep(SIGKILL_TIMEOUT_MS)
+    if (!opts?.exited?.()) {
+      process.kill(-pid, "SIGKILL")
     }
-
-    try {
-      process.kill(-pid, "SIGTERM")
-      await sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        process.kill(-pid, "SIGKILL")
-      }
-    } catch (_e) {
-      proc.kill("SIGTERM")
-      await sleep(SIGKILL_TIMEOUT_MS)
-      if (!opts?.exited?.()) {
-        proc.kill("SIGKILL")
-      }
+  } catch (_e) {
+    proc.kill("SIGTERM")
+    await sleep(SIGKILL_TIMEOUT_MS)
+    if (!opts?.exited?.()) {
+      proc.kill("SIGKILL")
     }
   }
-
-  function full(file: string) {
-    if (process.platform !== "win32") return file
-    const shell = Filesystem.windowsPath(file)
-    if (path.win32.dirname(shell) !== ".") {
-      if (shell.startsWith("/") && name(shell) === "bash") return gitbash() || shell
-      return shell
-    }
-    return which(shell) || shell
-  }
-
-  function pick() {
-    const pwsh = which("pwsh.exe")
-    if (pwsh) return pwsh
-    const powershell = which("powershell.exe")
-    if (powershell) return powershell
-  }
-
-  function select(file: string | undefined, opts?: { acceptable?: boolean }) {
-    if (file && (!opts?.acceptable || !BLACKLIST.has(name(file)))) return full(file)
-    if (process.platform === "win32") {
-      const shell = pick()
-      if (shell) return shell
-    }
-    return fallback()
-  }
-
-  export function gitbash() {
-    if (process.platform !== "win32") return
-    if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
-    const git = which("git")
-    if (!git) return
-    const file = path.join(git, "..", "..", "bin", "bash.exe")
-    if (Filesystem.stat(file)?.size) return file
-  }
-
-  function fallback() {
-    if (process.platform === "win32") {
-      const file = gitbash()
-      if (file) return file
-      return process.env.COMSPEC || "cmd.exe"
-    }
-    if (process.platform === "darwin") return "/bin/zsh"
-    const bash = which("bash")
-    if (bash) return bash
-    return "/bin/sh"
-  }
-
-  export function name(file: string) {
-    if (process.platform === "win32") return path.win32.parse(Filesystem.windowsPath(file)).name.toLowerCase()
-    return path.basename(file).toLowerCase()
-  }
-
-  export function login(file: string) {
-    return LOGIN.has(name(file))
-  }
-
-  export function posix(file: string) {
-    return POSIX.has(name(file))
-  }
-
-  export const preferred = lazy(() => select(process.env.SHELL))
-
-  export const acceptable = lazy(() => select(process.env.SHELL, { acceptable: true }))
 }
+
+function full(file: string) {
+  if (process.platform !== "win32") return file
+  const shell = Filesystem.windowsPath(file)
+  if (path.win32.dirname(shell) !== ".") {
+    if (shell.startsWith("/") && name(shell) === "bash") return gitbash() || shell
+    return shell
+  }
+  return which(shell) || shell
+}
+
+function pick() {
+  const pwsh = which("pwsh.exe")
+  if (pwsh) return pwsh
+  const powershell = which("powershell.exe")
+  if (powershell) return powershell
+}
+
+function select(file: string | undefined, opts?: { acceptable?: boolean }) {
+  if (file && (!opts?.acceptable || !BLACKLIST.has(name(file)))) return full(file)
+  if (process.platform === "win32") {
+    const shell = pick()
+    if (shell) return shell
+  }
+  return fallback()
+}
+
+export function gitbash() {
+  if (process.platform !== "win32") return
+  if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
+  const git = which("git")
+  if (!git) return
+  const file = path.join(git, "..", "..", "bin", "bash.exe")
+  if (Filesystem.stat(file)?.size) return file
+}
+
+function fallback() {
+  if (process.platform === "win32") {
+    const file = gitbash()
+    if (file) return file
+    return process.env.COMSPEC || "cmd.exe"
+  }
+  if (process.platform === "darwin") return "/bin/zsh"
+  const bash = which("bash")
+  if (bash) return bash
+  return "/bin/sh"
+}
+
+export function name(file: string) {
+  if (process.platform === "win32") return path.win32.parse(Filesystem.windowsPath(file)).name.toLowerCase()
+  return path.basename(file).toLowerCase()
+}
+
+export function login(file: string) {
+  return LOGIN.has(name(file))
+}
+
+export function posix(file: string) {
+  return POSIX.has(name(file))
+}
+
+export const preferred = lazy(() => select(process.env.SHELL))
+
+export const acceptable = lazy(() => select(process.env.SHELL, { acceptable: true }))
+
+export * as Shell from "./shell"

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -19,7 +19,7 @@ export type Context<M extends Metadata = Metadata> = {
   agent: string
   abort: AbortSignal
   callID?: string
-  extra?: { [key: string]: any }
+  extra?: { [key: string]: unknown }
   messages: MessageV2.WithParts[]
   metadata(input: { title?: string; metadata?: M }): Effect.Effect<void>
   ask(input: Omit<Permission.Request, "id" | "sessionID" | "tool">): Effect.Effect<void>

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -39,7 +39,7 @@ export async function readText(p: string): Promise<string> {
   return readFile(p, "utf-8")
 }
 
-export async function readJson<T = any>(p: string): Promise<T> {
+export async function readJson<T = unknown>(p: string): Promise<T> {
   return JSON.parse(await readFile(p, "utf-8"))
 }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -757,7 +757,7 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await save(newConfig as any)
 
-      const writtenConfig = await Filesystem.readJson(path.join(tmp.path, "config.json"))
+      const writtenConfig = await Filesystem.readJson<{ model: string }>(path.join(tmp.path, "config.json"))
       expect(writtenConfig.model).toBe("updated/model")
     },
   })


### PR DESCRIPTION
## Summary
- Unwrap the `Shell` namespace in `packages/opencode/src/shell/shell.ts` to flat top-level exports.
- Append `export * as Shell from "./shell"` so consumers keep the same `Shell.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/shell` — all pass (if applicable).