### PR TITLE
refactor: unwrap FileIgnore namespace + self-reexport

### DIFF
--- a/packages/opencode/src/file/ignore.ts
+++ b/packages/opencode/src/file/ignore.ts
@@ -1,81 +1,81 @@
 import { Glob } from "@opencode-ai/shared/util/glob"
 
-export namespace FileIgnore {
-  const FOLDERS = new Set([
-    "node_modules",
-    "bower_components",
-    ".pnpm-store",
-    "vendor",
-    ".npm",
-    "dist",
-    "build",
-    "out",
-    ".next",
-    "target",
-    "bin",
-    "obj",
-    ".git",
-    ".svn",
-    ".hg",
-    ".vscode",
-    ".idea",
-    ".turbo",
-    ".output",
-    "desktop",
-    ".sst",
-    ".cache",
-    ".webkit-cache",
-    "__pycache__",
-    ".pytest_cache",
-    "mypy_cache",
-    ".history",
-    ".gradle",
-  ])
+const FOLDERS = new Set([
+  "node_modules",
+  "bower_components",
+  ".pnpm-store",
+  "vendor",
+  ".npm",
+  "dist",
+  "build",
+  "out",
+  ".next",
+  "target",
+  "bin",
+  "obj",
+  ".git",
+  ".svn",
+  ".hg",
+  ".vscode",
+  ".idea",
+  ".turbo",
+  ".output",
+  "desktop",
+  ".sst",
+  ".cache",
+  ".webkit-cache",
+  "__pycache__",
+  ".pytest_cache",
+  "mypy_cache",
+  ".history",
+  ".gradle",
+])
 
-  const FILES = [
-    "**/*.swp",
-    "**/*.swo",
+const FILES = [
+  "**/*.swp",
+  "**/*.swo",
 
-    "**/*.pyc",
+  "**/*.pyc",
 
-    // OS
-    "**/.DS_Store",
-    "**/Thumbs.db",
+  // OS
+  "**/.DS_Store",
+  "**/Thumbs.db",
 
-    // Logs & temp
-    "**/logs/**",
-    "**/tmp/**",
-    "**/temp/**",
-    "**/*.log",
+  // Logs & temp
+  "**/logs/**",
+  "**/tmp/**",
+  "**/temp/**",
+  "**/*.log",
 
-    // Coverage/test outputs
-    "**/coverage/**",
-    "**/.nyc_output/**",
-  ]
+  // Coverage/test outputs
+  "**/coverage/**",
+  "**/.nyc_output/**",
+]
 
-  export const PATTERNS = [...FILES, ...FOLDERS]
+export const PATTERNS = [...FILES, ...FOLDERS]
 
-  export function match(
-    filepath: string,
-    opts?: {
-      extra?: string[]
-      whitelist?: string[]
-    },
-  ) {
-    for (const pattern of opts?.whitelist || []) {
-      if (Glob.match(pattern, filepath)) return false
-    }
-
-    const parts = filepath.split(/[/\\]/)
-    for (let i = 0; i < parts.length; i++) {
-      if (FOLDERS.has(parts[i])) return true
-    }
-
-    const extra = opts?.extra || []
-    for (const pattern of [...FILES, ...extra]) {
-      if (Glob.match(pattern, filepath)) return true
-    }
-
-    return false
+export function match(
+  filepath: string,
+  opts?: {
+    extra?: string[]
+    whitelist?: string[]
+  },
+) {
+  for (const pattern of opts?.whitelist || []) {
+    if (Glob.match(pattern, filepath)) return false
   }
+
+  const parts = filepath.split(/[/\\]/)
+  for (let i = 0; i < parts.length; i++) {
+    if (FOLDERS.has(parts[i])) return true
+  }
+
+  const extra = opts?.extra || []
+  for (const pattern of [...FILES, ...extra]) {
+    if (Glob.match(pattern, filepath)) return true
+  }
+
+  return false
 }
+
+export * as FileIgnore from "./ignore"


### PR DESCRIPTION
## Summary
- Unwrap the `FileIgnore` namespace in `packages/opencode/src/file/ignore.ts` to flat top-level exports.
- Append `export * as FileIgnore from "./ignore"` so consumers keep the same `FileIgnore.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/file` — all pass (if applicable).