### PR TITLE
fix: narrow more `from any` type assertions across packages

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -538,8 +538,8 @@ export const Terminal = (props: TerminalProps) => {
             if (bytes[0] !== 0) return
             const json = decoder.decode(bytes.subarray(1))
             try {
-              const meta = JSON.parse(json) as { cursor?: unknown }
-              const next = meta?.cursor
+              const meta: unknown = JSON.parse(json)
+              const next = meta && typeof meta === "object" && "cursor" in meta ? meta.cursor : undefined
               if (typeof next === "number" && Number.isSafeInteger(next) && next >= 0) {
                 cursor = next
                 seek = next

--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -179,8 +179,8 @@ function readStoredLocale() {
   try {
     const raw = localStorage.getItem("opencode.global.dat:language")
     if (!raw) return
-    const next = JSON.parse(raw) as { locale?: string }
-    if (typeof next?.locale !== "string") return
+    const next: unknown = JSON.parse(raw)
+    if (!next || typeof next !== "object" || !("locale" in next) || typeof next.locale !== "string") return
     return normalizeLocale(next.locale)
   } catch {
     return

--- a/packages/console/app/src/routes/workspace/[id]/billing/billing-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/billing/billing-section.tsx
@@ -17,7 +17,7 @@ const createSessionUrl = action(async (workspaceID: string, returnUrl: string) =
         Billing.generateSessionUrl({ returnUrl })
           .then((data) => ({ error: undefined, data }))
           .catch((e) => ({
-            error: e.message as string,
+            error: String(e?.message ?? e),
             data: undefined,
           })),
       workspaceID,

--- a/packages/console/app/src/routes/workspace/[id]/billing/black-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/billing/black-section.tsx
@@ -81,7 +81,7 @@ const cancelWaitlist = action(async (workspaceID: string) => {
           .where(eq(BillingTable.workspaceID, workspaceID)),
       )
       return { error: undefined }
-    }, workspaceID).catch((e) => ({ error: e.message as string })),
+    }, workspaceID).catch((e) => ({ error: String(e?.message ?? e) })),
     { revalidate: [queryBillingInfo.key, querySubscription.key] },
   )
 }, "cancelWaitlist")
@@ -92,7 +92,7 @@ const enroll = action(async (workspaceID: string) => {
     await withActor(async () => {
       await Billing.subscribeBlack({ seats: 1 })
       return { error: undefined }
-    }, workspaceID).catch((e) => ({ error: e.message as string })),
+    }, workspaceID).catch((e) => ({ error: String(e?.message ?? e) })),
     { revalidate: [queryBillingInfo.key, querySubscription.key] },
   )
 }, "enroll")
@@ -105,7 +105,7 @@ const createSessionUrl = action(async (workspaceID: string, returnUrl: string) =
         Billing.generateSessionUrl({ returnUrl })
           .then((data) => ({ error: undefined, data }))
           .catch((e) => ({
-            error: e.message as string,
+            error: String(e?.message ?? e),
             data: undefined,
           })),
       workspaceID,
@@ -133,7 +133,7 @@ const setUseBalance = action(async (form: FormData) => {
           .where(eq(BillingTable.workspaceID, workspaceID)),
       )
       return { error: undefined }
-    }, workspaceID).catch((e) => ({ error: e.message as string })),
+    }, workspaceID).catch((e) => ({ error: String(e?.message ?? e) })),
     { revalidate: [queryBillingInfo.key, querySubscription.key] },
   )
 }, "setUseBalance")

--- a/packages/console/app/src/routes/workspace/[id]/billing/monthly-limit-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/billing/monthly-limit-section.tsx
@@ -21,7 +21,7 @@ const setMonthlyLimit = action(async (form: FormData) => {
       () =>
         Billing.setMonthlyLimit(numericLimit)
           .then((data) => ({ error: undefined, data }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: queryBillingInfo.key },

--- a/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
@@ -90,7 +90,7 @@ const createLiteCheckoutUrl = action(
           Billing.generateLiteCheckoutUrl({ successUrl, cancelUrl, method })
             .then((data) => ({ error: undefined, data }))
             .catch((e) => ({
-              error: e.message as string,
+              error: String(e?.message ?? e),
               data: undefined,
             })),
         workspaceID,
@@ -109,7 +109,7 @@ const createSessionUrl = action(async (workspaceID: string, returnUrl: string) =
         Billing.generateSessionUrl({ returnUrl })
           .then((data) => ({ error: undefined, data }))
           .catch((e) => ({
-            error: e.message as string,
+            error: String(e?.message ?? e),
             data: undefined,
           })),
       workspaceID,
@@ -135,7 +135,7 @@ const setLiteUseBalance = action(async (form: FormData) => {
           .where(eq(BillingTable.workspaceID, workspaceID)),
       )
       return { error: undefined }
-    }, workspaceID).catch((e) => ({ error: e.message as string })),
+    }, workspaceID).catch((e) => ({ error: String(e?.message ?? e) })),
     { revalidate: [queryBillingInfo.key, queryLiteSubscription.key] },
   )
 }, "setLiteUseBalance")

--- a/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/keys/key-section.tsx
@@ -33,7 +33,7 @@ const createKey = action(async (form: FormData) => {
           name,
         })
           .then((data) => ({ error: undefined, data }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: listKeys.key },

--- a/packages/console/app/src/routes/workspace/[id]/members/member-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/members/member-section.tsx
@@ -38,7 +38,7 @@ const inviteMember = action(async (form: FormData) => {
       () =>
         User.invite({ email, role, monthlyLimit })
           .then((data) => ({ error: undefined, data }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: listMembers.key },
@@ -56,7 +56,7 @@ const removeMember = action(async (form: FormData) => {
       () =>
         User.remove(id)
           .then((data) => ({ error: undefined, data }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: listMembers.key },
@@ -81,7 +81,7 @@ const updateMember = action(async (form: FormData) => {
       () =>
         User.update({ id, role, monthlyLimit })
           .then((data) => ({ error: undefined, data }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: listMembers.key },

--- a/packages/console/app/src/routes/workspace/[id]/provider-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/provider-section.tsx
@@ -43,7 +43,7 @@ const saveProvider = action(async (form: FormData) => {
       () =>
         Provider.create({ provider, credentials })
           .then(() => ({ error: undefined }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
     { revalidate: listProviders.key },

--- a/packages/console/app/src/routes/workspace/[id]/settings/settings-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/settings/settings-section.tsx
@@ -40,7 +40,7 @@ const updateWorkspace = action(async (form: FormData) => {
       () =>
         Workspace.update({ name })
           .then(() => ({ error: undefined }))
-          .catch((e) => ({ error: e.message as string })),
+          .catch((e) => ({ error: String(e?.message ?? e) })),
       workspaceID,
     ),
   )

--- a/packages/console/app/src/routes/workspace/common.tsx
+++ b/packages/console/app/src/routes/workspace/common.tsx
@@ -80,7 +80,7 @@ export const createCheckoutUrl = action(
           Billing.generateCheckoutUrl({ amount, successUrl, cancelUrl })
             .then((data) => ({ error: undefined, data }))
             .catch((e) => ({
-              error: e.message as string,
+              error: String(e?.message ?? e),
               data: undefined,
             })),
         workspaceID,

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -127,17 +127,21 @@ const fetchApi = async () => {
   return { ok: result.ok, text: await result.text() }
 }
 
-export const Data = lazy(async () => {
-  const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+export const Data = lazy(async (): Promise<Record<string, Provider>> => {
+  const result = await Filesystem.readJson<Record<string, Provider>>(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(
+    () => undefined,
+  )
   if (result) return result
   // @ts-ignore
   const snapshot = await import("./models-snapshot.js")
-    .then((m) => m.snapshot as Record<string, unknown>)
+    .then((m) => m.snapshot as Record<string, Provider>)
     .catch(() => undefined)
   if (snapshot) return snapshot
   if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
   return Flock.withLock(`models-dev:${filepath}`, async () => {
-    const result = await Filesystem.readJson(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(() => {})
+    const result = await Filesystem.readJson<Record<string, Provider>>(Flag.OPENCODE_MODELS_PATH ?? filepath).catch(
+      () => undefined,
+    )
     if (result) return result
     const result2 = await fetchApi()
     if (result2.ok) {
@@ -145,13 +149,12 @@ export const Data = lazy(async () => {
         log.error("Failed to write models cache", { error: e })
       })
     }
-    return JSON.parse(result2.text)
+    return JSON.parse(result2.text) as Record<string, Provider>
   })
 })
 
 export async function get() {
-  const result = await Data()
-  return result as Record<string, Provider>
+  return await Data()
 }
 
 export async function refresh(force = false) {

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -32,9 +32,9 @@ export function Dialog(props: DialogProps) {
             [props.class ?? ""]: !!props.class,
           }}
           onOpenAutoFocus={(e) => {
-            const target = e.currentTarget as HTMLElement | null
-            const autofocusEl = target?.querySelector("[autofocus]") as HTMLElement | null
-            if (autofocusEl) {
+            const target = e.currentTarget
+            const autofocusEl = target instanceof Element ? target.querySelector("[autofocus]") : null
+            if (autofocusEl instanceof HTMLElement) {
               e.preventDefault()
               autofocusEl.focus()
             }


### PR DESCRIPTION
## Summary

Second pass at `typescript/no-unsafe-type-assertion`'s "Unsafe assertion from any" category. Expanded beyond `packages/opencode` into `console/app`, `app`, `ui`, and `opencode/provider/models.ts`.

**Impact:** 1073 → 1053 errors (20 removed).

## Changes

- **`packages/console/app`** — 16 call sites across 9 server action files used `.catch((e) => ({ error: e.message as string }))`. Replaced with `String(e?.message ?? e)`, which handles non-Error throws gracefully (a `throw "string"` would previously have `e.message` be `undefined`, now it coerces to the string value). Files: `common.tsx`, `billing/billing-section.tsx`, `billing/black-section.tsx`, `billing/monthly-limit-section.tsx`, `go/lite-section.tsx`, `keys/key-section.tsx`, `members/member-section.tsx`, `provider-section.tsx`, `settings/settings-section.tsx`.
- **`packages/app/src/context/language.tsx`** — `readStoredLocale` now types the `JSON.parse` result as `unknown` and uses `"locale" in next` + `typeof` narrowing instead of casting to `{ locale?: string }`.
- **`packages/app/src/components/terminal.tsx`** — WebSocket control frame parser uses the same `in`/`typeof` pattern on the JSON result for the `cursor` field (previously already did the runtime check, but was casting first).
- **`packages/opencode/src/provider/models.ts`** — annotate `Data()` return type as `Promise<Record<string, Provider>>` and pass explicit type params to `Filesystem.readJson` calls. Drops the `result as Record<string, Provider>` cast in `get()`.
- **`packages/ui/src/components/dialog.tsx`** — `onOpenAutoFocus` handler uses `instanceof Element` / `instanceof HTMLElement` narrowing instead of casting `e.currentTarget` and `.querySelector(...)` result to `HTMLElement | null`.

## Performance

No meaningful runtime impact. All changes are either pure type fixes (erased at compile) or swap a cast for a single `typeof`/`instanceof` check in code paths that are already slow (error handling, LLM response processing, dialog open). See commit message for details.

## Verification

- `bun turbo typecheck` passes (all 13 tasks).
- `bun run lint` passes (2394 warnings, 0 errors — same other than our fixes).
- `bun test test/session/` passes (271 tests).