### PR TITLE
refactor: unwrap ConfigSkills namespace + self-reexport

### DIFF
--- a/packages/opencode/src/config/skills.ts
+++ b/packages/opencode/src/config/skills.ts
@@ -1,13 +1,13 @@
 import z from "zod"
 
-export namespace ConfigSkills {
-  export const Info = z.object({
-    paths: z.array(z.string()).optional().describe("Additional paths to skill folders"),
-    urls: z
-      .array(z.string())
-      .optional()
-      .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
-  })
+export const Info = z.object({
+  paths: z.array(z.string()).optional().describe("Additional paths to skill folders"),
+  urls: z
+    .array(z.string())
+    .optional()
+    .describe("URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)"),
+})
 
-  export type Info = z.infer<typeof Info>
-}
+export type Info = z.infer<typeof Info>
+
+export * as ConfigSkills from "./skills"


### PR DESCRIPTION
## Summary
- Unwrap the `ConfigSkills` namespace in `packages/opencode/src/config/skills.ts` to flat top-level exports.
- Append `export * as ConfigSkills from "./skills"` so consumers keep the same `ConfigSkills.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/config` — all pass (if applicable).