### PR TITLE
refactor: unwrap MDNS namespace + self-reexport

### DIFF
--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -3,58 +3,58 @@ import { Bonjour } from "bonjour-service"
 
 const log = Log.create({ service: "mdns" })
 
-export namespace MDNS {
-  let bonjour: Bonjour | undefined
-  let currentPort: number | undefined
+let bonjour: Bonjour | undefined
+let currentPort: number | undefined
 
-  export function publish(port: number, domain?: string) {
-    if (currentPort === port) return
-    if (bonjour) unpublish()
+export function publish(port: number, domain?: string) {
+  if (currentPort === port) return
+  if (bonjour) unpublish()
 
-    try {
-      const host = domain ?? "opencode.local"
-      const name = `opencode-${port}`
-      bonjour = new Bonjour()
-      const service = bonjour.publish({
-        name,
-        type: "http",
-        host,
-        port,
-        txt: { path: "/" },
-      })
+  try {
+    const host = domain ?? "opencode.local"
+    const name = `opencode-${port}`
+    bonjour = new Bonjour()
+    const service = bonjour.publish({
+      name,
+      type: "http",
+      host,
+      port,
+      txt: { path: "/" },
+    })
 
-      service.on("up", () => {
-        log.info("mDNS service published", { name, port })
-      })
+    service.on("up", () => {
+      log.info("mDNS service published", { name, port })
+    })
 
-      service.on("error", (err) => {
-        log.error("mDNS service error", { error: err })
-      })
+    service.on("error", (err) => {
+      log.error("mDNS service error", { error: err })
+    })
 
-      currentPort = port
-    } catch (err) {
-      log.error("mDNS publish failed", { error: err })
-      if (bonjour) {
-        try {
-          bonjour.destroy()
-        } catch {}
-      }
-      bonjour = undefined
-      currentPort = undefined
-    }
-  }
-
-  export function unpublish() {
+    currentPort = port
+  } catch (err) {
+    log.error("mDNS publish failed", { error: err })
     if (bonjour) {
       try {
-        bonjour.unpublishAll()
         bonjour.destroy()
-      } catch (err) {
-        log.error("mDNS unpublish failed", { error: err })
-      }
-      bonjour = undefined
-      currentPort = undefined
-      log.info("mDNS service unpublished")
+      } catch {}
     }
+    bonjour = undefined
+    currentPort = undefined
   }
 }
+
+export function unpublish() {
+  if (bonjour) {
+    try {
+      bonjour.unpublishAll()
+      bonjour.destroy()
+    } catch (err) {
+      log.error("mDNS unpublish failed", { error: err })
+    }
+    bonjour = undefined
+    currentPort = undefined
+    log.info("mDNS service unpublished")
+  }
+}
+
+export * as MDNS from "./mdns"


### PR DESCRIPTION
## Summary
- Unwrap the `MDNS` namespace in `packages/opencode/src/server/mdns.ts` to flat top-level exports.
- Append `export * as MDNS from "./mdns"` so consumers keep the same `MDNS.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/server` — all pass (if applicable).