### PR TITLE
feat(opencode): add Vercel sandbox substrate [WIP]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -365,6 +365,7 @@
         "@solid-primitives/event-bus": "1.1.2",
         "@solid-primitives/scheduled": "1.5.2",
         "@standard-schema/spec": "1.0.0",
+        "@vercel/sandbox": "2.0.0-beta.13",
         "@zip.js/zip.js": "2.7.62",
         "ai": "catalog:",
         "ai-gateway-provider": "3.1.2",
@@ -2331,6 +2332,8 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
+    "@vercel/sandbox": ["@vercel/sandbox@2.0.0-beta.13", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-p05ShlOrrL4C2OnR68AEksP3HUaXsvgIlwAOu8NQjsk2qNoXaq4gCKQscHOb44/TdLQGT0EkdADxQIzPY8Eoug=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
@@ -2364,6 +2367,8 @@
     "@vscode/l10n": ["@vscode/l10n@0.0.18", "", {}, "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="],
 
     "@webgpu/types": ["@webgpu/types@0.1.54", "", {}, "sha512-81oaalC8LFrXjhsczomEQ0u3jG+TqE6V9QHLA8GNZq/Rnot0KDugu3LhSYSlie8tSdooAN1Hov05asrUUp9qgg=="],
+
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.12", "", {}, "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg=="],
 
@@ -2464,6 +2469,8 @@
     "async-exit-hook": ["async-exit-hook@2.0.1", "", {}, "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -3529,6 +3536,8 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "jsonlines": ["jsonlines@0.1.1", "", {}, "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="],
+
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
@@ -3979,6 +3988,8 @@
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
+    "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
+
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
     "oxc-minify": ["oxc-minify@0.96.0", "", { "optionalDependencies": { "@oxc-minify/binding-android-arm64": "0.96.0", "@oxc-minify/binding-darwin-arm64": "0.96.0", "@oxc-minify/binding-darwin-x64": "0.96.0", "@oxc-minify/binding-freebsd-x64": "0.96.0", "@oxc-minify/binding-linux-arm-gnueabihf": "0.96.0", "@oxc-minify/binding-linux-arm-musleabihf": "0.96.0", "@oxc-minify/binding-linux-arm64-gnu": "0.96.0", "@oxc-minify/binding-linux-arm64-musl": "0.96.0", "@oxc-minify/binding-linux-riscv64-gnu": "0.96.0", "@oxc-minify/binding-linux-s390x-gnu": "0.96.0", "@oxc-minify/binding-linux-x64-gnu": "0.96.0", "@oxc-minify/binding-linux-x64-musl": "0.96.0", "@oxc-minify/binding-wasm32-wasi": "0.96.0", "@oxc-minify/binding-win32-arm64-msvc": "0.96.0", "@oxc-minify/binding-win32-x64-msvc": "0.96.0" } }, "sha512-dXeeGrfPJJ4rMdw+NrqiCRtbzVX2ogq//R0Xns08zql2HjV3Zi2SBJ65saqfDaJzd2bcHqvGWH+M44EQCHPAcA=="],
@@ -4337,7 +4348,7 @@
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
-    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
@@ -4609,7 +4620,7 @@
 
     "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
 
-    "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
+    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
 
     "tarn": ["tarn@3.0.2", "", {}, "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="],
 
@@ -4949,7 +4960,11 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
+    "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
+
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
+    "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
 
     "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
 
@@ -5553,6 +5568,10 @@
 
     "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
+    "@vercel/sandbox/@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@vercel/sandbox/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
+
     "@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
@@ -5584,6 +5603,8 @@
     "app-builder-lib/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "app-builder-lib/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
+
+    "archiver/tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
 
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -5807,8 +5828,6 @@
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
-    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
-
     "parse-bmfont-xml/xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -5835,7 +5854,11 @@
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -122,6 +122,7 @@
     "@solid-primitives/event-bus": "1.1.2",
     "@solid-primitives/scheduled": "1.5.2",
     "@standard-schema/spec": "1.0.0",
+    "@vercel/sandbox": "2.0.0-beta.13",
     "@zip.js/zip.js": "2.7.62",
     "ai": "catalog:",
     "ai-gateway-provider": "3.1.2",

--- a/packages/opencode/script/sandbox-image/build.ts
+++ b/packages/opencode/script/sandbox-image/build.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env bun
+// Builds the snapshot that VercelBackend uses as its `source`. The image
+// contains every tool the L4 services need (git, rg, prettier, gofmt,
+// rustfmt, black, shfmt, 4 language servers, node/npm, python3, go,
+// coreutils) plus the exec-channel gateway daemon pre-installed.
+//
+// Layered rebuild on top of a previous snapshot — cuts build time from
+// ~15m to ~4m. Drop `baseSnapshotId` for a clean-slate rebuild.
+//
+// Prints `SNAPSHOT_ID=<id>` on completion; a shell wrapper parses this
+// into VERCEL_SANDBOX_IMAGE_ID.
+
+import { Sandbox } from "@vercel/sandbox"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+// The gateway ships as a small npm package next to this build script.
+// package.json declares `bin: { "opencode-gateway": "./gateway.js" }`
+// and a runtime dependency on `ws@8`. Installing it with `npm
+// install -g` places the bin on the sandbox PATH (alongside the
+// other globally-installed tools like typescript-language-server)
+// and resolves `ws` via standard node module lookup — no NODE_PATH
+// hacks and no client-side knowledge of where anything lives.
+const GATEWAY_DIR = path.join(import.meta.dir, "gateway")
+const GATEWAY_SOURCES: Record<string, string> = {
+  "package.json": readFileSync(path.join(GATEWAY_DIR, "package.json"), "utf8"),
+  "gateway.js": readFileSync(path.join(GATEWAY_DIR, "gateway.js"), "utf8"),
+}
+
+// The name of the bin exposed by the gateway package. After
+// `npm install -g` it's on PATH; the client just runs it by name.
+const GATEWAY_BIN = "opencode-gateway"
+
+const token = process.env["VERCEL_TOKEN"]
+const teamId = process.env["VERCEL_TEAM_ID"]
+const projectId = process.env["VERCEL_PROJECT_ID"]
+const baseSnapshotId = process.env["VERCEL_SANDBOX_IMAGE_ID"]
+
+if (!token || !teamId || !projectId) {
+  console.error("missing VERCEL_TOKEN / VERCEL_TEAM_ID / VERCEL_PROJECT_ID")
+  process.exit(2)
+}
+
+const START = Date.now()
+const elapsed = () => `${((Date.now() - START) / 1000).toFixed(1)}s`
+const log = (step: string, msg: string) => console.log(`[build] ${elapsed()} ${step}: ${msg}`)
+
+const sh = async (
+  sb: Sandbox,
+  script: string,
+  label: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
+  log(label, script.length > 90 ? script.slice(0, 90) + "..." : script)
+  const res = await sb.runCommand("bash", ["-lc", script])
+  const [stdout, stderr] = await Promise.all([res.stdout(), res.stderr()])
+  if (res.exitCode !== 0) {
+    console.error(`[build]   FAIL (exit ${res.exitCode}): ${label}`)
+    if (stdout.trim()) {
+      console.error(`  --- stdout ---\n${stdout.trim().slice(-4000)}`)
+    }
+    if (stderr.trim()) {
+      console.error(`  --- stderr ---\n${stderr.trim().slice(-4000)}`)
+    }
+    throw new Error(`${label} failed`)
+  }
+  return { exitCode: res.exitCode ?? 0, stdout, stderr }
+}
+
+const REQUIRED_TOOLS = [
+  "git",
+  "prettier",
+  "gofmt",
+  "rustfmt",
+  "black",
+  "shfmt",
+  "rg",
+  "typescript-language-server",
+  "pyright",
+  "gopls",
+  "rust-analyzer",
+  "node",
+  "npm",
+  "python3",
+  "go",
+]
+
+let sandbox: Sandbox | null = null
+
+try {
+  log("create", `creating sandbox from base ${baseSnapshotId ?? "(no base)"}`)
+  const createParams: Parameters<typeof Sandbox.create>[0] = {
+    token,
+    teamId,
+    projectId,
+    timeout: 30 * 60 * 1000,
+  } as Parameters<typeof Sandbox.create>[0]
+  if (baseSnapshotId) {
+    ;(createParams as any).source = { type: "snapshot", snapshotId: baseSnapshotId }
+  }
+  sandbox = await Sandbox.create(createParams)
+  log("create", `sandbox ${sandbox.name} ready`)
+
+  // ---- typescript-language-server (+ typescript) ----
+  //
+  // `sudo` isn't reliably present in every base image; npm install -g
+  // lands under /vercel/runtimes/node24/ which the vercel user owns
+  // so sudo isn't needed.
+  await sh(
+    sandbox,
+    "npm install -g --no-audit --no-fund typescript typescript-language-server",
+    "install typescript-language-server",
+  )
+
+  // ---- pyright ----
+  await sh(
+    sandbox,
+    "npm install -g --no-audit --no-fund pyright",
+    "install pyright",
+  )
+
+  // ---- gopls ----
+  //
+  // `go install` drops the binary under $GOBIN. Compiling gopls is
+  // memory-hungry; the vercel sandbox's default resources run out of
+  // RAM on parallel compilation → silent kill + exit 1. GOMAXPROCS=1
+  // serializes the compile, and GOMEMLIMIT caps the heap so the Go
+  // runtime runs GC more aggressively. Using gopls@latest so the
+  // transitive golang.org/x/tools matches the sandbox's Go 1.25
+  // compiler (older gopls pins break on `tokeninternal.go` compile-
+  // time assertions).
+  //
+  // /usr/local/bin is read-only for the vercel user in this image —
+  // use /vercel/runtimes/node24/bin which npm install -g already
+  // writes to, meaning it's writable and on $PATH.
+  await sh(
+    sandbox,
+    `set -euo pipefail
+export GOPATH=/tmp/go
+export GOBIN=/tmp/go/bin
+export PATH="/tmp/go/bin:$PATH"
+export GOMAXPROCS=1
+export GOMEMLIMIT=900MiB
+mkdir -p /tmp/go/bin
+go install golang.org/x/tools/gopls@latest 2>&1 | tail -100
+install -m 755 /tmp/go/bin/gopls /vercel/runtimes/node24/bin/gopls
+gopls version`,
+    "install gopls",
+  )
+
+  // ---- rust-analyzer ----
+  //
+  // Pre-built release tarball from GitHub, no cargo build required.
+  await sh(
+    sandbox,
+    `set -euo pipefail
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  TRIPLE="x86_64-unknown-linux-gnu" ;;
+  aarch64) TRIPLE="aarch64-unknown-linux-gnu" ;;
+  *) echo "unsupported $ARCH" >&2; exit 1 ;;
+esac
+URL="https://github.com/rust-lang/rust-analyzer/releases/latest/download/rust-analyzer-\${TRIPLE}.gz"
+curl -fsSL "$URL" -o /tmp/rust-analyzer.gz
+gunzip -f /tmp/rust-analyzer.gz
+install -m 755 /tmp/rust-analyzer /vercel/runtimes/node24/bin/rust-analyzer
+rm -f /tmp/rust-analyzer.gz
+rust-analyzer --version`,
+    "install rust-analyzer",
+  )
+
+  // ---- exec-channel gateway daemon ----
+  //
+  // Bake the gateway into the image so VercelBackend doesn't upload
+  // anything on cold start. Flow:
+  //   1. writeFiles the gateway package (package.json + gateway.js)
+  //      into /tmp/opencode-gateway/ — /tmp is always user-writable.
+  //   2. `npm install -g /tmp/opencode-gateway` — installs the bin
+  //      under npm's global prefix so `opencode-gateway` becomes a
+  //      PATH command, and pulls `ws@8` into the package's own
+  //      node_modules so require("ws") resolves via standard node
+  //      module lookup from the gateway's __dirname.
+  log("gateway", "installing gateway package globally")
+  await sandbox.writeFiles(
+    Object.entries(GATEWAY_SOURCES).map(([name, content]) => ({
+      path: `/tmp/opencode-gateway/${name}`,
+      content: Buffer.from(content),
+    })),
+  )
+  // `npm install -g <dir>` packs the directory first, which drops
+  // node_modules. We pack explicitly to a tarball and install from
+  // that — npm then resolves the package's `dependencies` against
+  // the global npm cache and installs `ws` into the proper place
+  // so the gateway's `require("ws")` works at runtime.
+  await sh(
+    sandbox,
+    [
+      "set -euo pipefail",
+      "cd /tmp/opencode-gateway",
+      // pack produces opencode-gateway-0.0.0.tgz in cwd
+      "npm pack --silent",
+      "TGZ=$(ls opencode-gateway-*.tgz | head -1)",
+      "npm install -g --no-audit --no-fund ./${TGZ}",
+    ].join("\n"),
+    "pack + install opencode-gateway",
+  )
+  // Verify the gateway binary exists and can actually load ws from
+  // its own node_modules (not just "is on PATH").
+  await sh(
+    sandbox,
+    [
+      "set -euo pipefail",
+      `GW_BIN=$(command -v ${GATEWAY_BIN})`,
+      `test -n "$GW_BIN"`,
+      // Resolve the realpath of the bin so we find the installed
+      // package root, then assert ws is reachable from there.
+      `GW_REAL=$(readlink -f "$GW_BIN")`,
+      `GW_PKG_DIR=$(dirname "$GW_REAL")`,
+      `test -d "$GW_PKG_DIR/node_modules/ws" || test -d "$GW_PKG_DIR/../node_modules/ws"`,
+      `echo gateway-ready`,
+    ].join("\n"),
+    "verify opencode-gateway deps",
+  )
+
+  // ---- sanity check every required tool ----
+  log("verify", "checking every required binary is on PATH")
+  for (const bin of REQUIRED_TOOLS) {
+    const r = await sandbox.runCommand("sh", ["-c", `command -v ${bin}`])
+    if (r.exitCode !== 0) {
+      throw new Error(`sanity check failed: ${bin} not on PATH`)
+    }
+    const out = (await r.stdout()).trim()
+    console.log(`[build] ${elapsed()}   ${bin.padEnd(30)} -> ${out}`)
+  }
+
+  // ---- sanity check gateway ----
+  log("verify", `checking ${GATEWAY_BIN} is on PATH`)
+  const gwCheck = await sandbox.runCommand("sh", ["-c", `command -v ${GATEWAY_BIN}`])
+  if (gwCheck.exitCode !== 0) {
+    throw new Error(`gateway sanity check failed — ${GATEWAY_BIN} not on PATH`)
+  }
+  const gwPath = (await gwCheck.stdout()).trim()
+  console.log(`[build] ${elapsed()}   ${GATEWAY_BIN.padEnd(30)} -> ${gwPath}`)
+
+  // ---- snapshot ----
+  log("snapshot", "creating snapshot (no expiration)...")
+  const snap = (await (sandbox as any).snapshot({ expiration: 0 })) as {
+    snapshotId: string
+  }
+  log("snapshot", `done: ${snap.snapshotId}`)
+  console.log(`\nSNAPSHOT_ID=${snap.snapshotId}`)
+} catch (err) {
+  console.error("[build] FAILED:", err)
+  process.exitCode = 1
+} finally {
+  if (sandbox) {
+    log("cleanup", "stopping sandbox...")
+    try {
+      await sandbox.stop()
+    } catch (e) {
+      console.error("[build] cleanup stop failed:", e)
+    }
+  }
+}

--- a/packages/opencode/script/sandbox-image/gateway/gateway.js
+++ b/packages/opencode/script/sandbox-image/gateway/gateway.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Exec gateway — runs INSIDE a Vercel sandbox VM.
+//
+// Binds :3000 with:
+//   GET  /health  → 200 "ok"
+//   WS   /exec    → per-process execution channel (token-authed)
+//
+// Auth: first WebSocket frame MUST be {type:"auth", token:<GATEWAY_TOKEN>}.
+// Wrong or missing auth closes with code 4401.
+//
+// Frame protocol (post-auth):
+//   client → {type:"spawn", cmd, args, cwd?, env?}
+//   client → {type:"stdin", data:<base64>}
+//   client → {type:"stdin-close"}
+//   client → {type:"kill",  signal?}
+//   gateway → {type:"ready"|"stdout"|"stderr"|"exit"|"error", ...}
+//
+// Keepalive: native WebSocket ping every 25s; no pong within 55s → close.
+
+const { WebSocketServer } = require("ws")
+const http = require("node:http")
+const { spawn } = require("node:child_process")
+
+const PORT = 3000
+const EXPECTED_TOKEN = process.env.GATEWAY_TOKEN ?? ""
+
+if (!EXPECTED_TOKEN) {
+  console.error("[gateway] GATEWAY_TOKEN env var is required")
+  process.exit(2)
+}
+
+const KEEPALIVE_INTERVAL_MS = 25_000
+const KEEPALIVE_GRACE_MS = 55_000
+
+const httpServer = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "content-type": "text/plain" })
+    res.end("ok")
+    return
+  }
+  res.writeHead(404)
+  res.end()
+})
+
+const wss = new WebSocketServer({ server: httpServer, path: "/exec" })
+
+const close = (socket, code, reason) => {
+  try {
+    socket.close(code, reason)
+  } catch {}
+}
+
+wss.on("connection", (socket, req) => {
+  console.log(`[gateway] connection from ${req.socket.remoteAddress}`)
+
+  let authed = false
+  let lastPong = Date.now()
+  let proc = null
+
+  socket.on("pong", () => {
+    lastPong = Date.now()
+  })
+
+  const keepalive = setInterval(() => {
+    if (Date.now() - lastPong > KEEPALIVE_GRACE_MS) {
+      console.log("[gateway] keepalive grace exceeded — closing")
+      close(socket, 1001, "keepalive timeout")
+      return
+    }
+    try {
+      socket.ping()
+    } catch {}
+  }, KEEPALIVE_INTERVAL_MS)
+
+  const send = (obj) => {
+    try {
+      socket.send(JSON.stringify(obj))
+    } catch (err) {
+      console.error("[gateway] send failed:", err.message)
+    }
+  }
+
+  socket.on("message", (raw) => {
+    let msg
+    try {
+      msg = JSON.parse(raw.toString("utf8"))
+    } catch (err) {
+      send({ type: "error", message: `bad frame: ${err.message}` })
+      return
+    }
+
+    if (!authed) {
+      if (msg.type !== "auth" || msg.token !== EXPECTED_TOKEN) {
+        console.log("[gateway] auth failed")
+        close(socket, 4401, "auth required")
+        return
+      }
+      authed = true
+      send({ type: "auth-ok" })
+      return
+    }
+
+    if (msg.type === "spawn") {
+      if (proc) {
+        send({ type: "error", message: "already spawned" })
+        return
+      }
+      console.log(`[gateway] spawn ${msg.cmd} ${(msg.args || []).join(" ")}`)
+      try {
+        proc = spawn(msg.cmd, msg.args || [], {
+          cwd: msg.cwd,
+          env: { ...process.env, ...(msg.env || {}) },
+          stdio: ["pipe", "pipe", "pipe"],
+        })
+      } catch (err) {
+        send({ type: "error", message: `spawn failed: ${err.message}` })
+        close(socket, 1011, "spawn failed")
+        return
+      }
+      proc.stdout.on("data", (chunk) =>
+        send({ type: "stdout", data: Buffer.from(chunk).toString("base64") }),
+      )
+      proc.stderr.on("data", (chunk) =>
+        send({ type: "stderr", data: Buffer.from(chunk).toString("base64") }),
+      )
+      proc.on("error", (err) => {
+        send({ type: "error", message: `proc error: ${err.message}` })
+      })
+      proc.on("exit", (code) => {
+        console.log(`[gateway] proc exit ${code}`)
+        send({ type: "exit", code })
+        close(socket, 1000, "proc exit")
+      })
+      send({ type: "ready", pid: proc.pid })
+      return
+    }
+
+    if (msg.type === "stdin") {
+      if (!proc) {
+        send({ type: "error", message: "no process" })
+        return
+      }
+      const bytes = Buffer.from(msg.data, "base64")
+      proc.stdin.write(bytes)
+      return
+    }
+
+    if (msg.type === "stdin-close") {
+      if (proc) proc.stdin.end()
+      return
+    }
+
+    if (msg.type === "kill") {
+      if (proc) proc.kill(msg.signal || "SIGTERM")
+      return
+    }
+
+    send({ type: "error", message: `unknown type: ${msg.type}` })
+  })
+
+  socket.on("close", () => {
+    console.log("[gateway] socket closed")
+    clearInterval(keepalive)
+    if (proc) {
+      try {
+        proc.kill()
+      } catch {}
+    }
+  })
+})
+
+httpServer.listen(PORT, () => {
+  console.log(`[gateway] listening on :${PORT} (GET /health, WS /exec)`)
+})

--- a/packages/opencode/script/sandbox-image/gateway/package.json
+++ b/packages/opencode/script/sandbox-image/gateway/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "opencode-gateway",
+  "version": "0.0.0",
+  "private": true,
+  "description": "In-sandbox WebSocket exec gateway used by opencode's VercelBackend.",
+  "bin": {
+    "opencode-gateway": "./gateway.js"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  }
+}

--- a/packages/opencode/script/vercel-proof.test.ts
+++ b/packages/opencode/script/vercel-proof.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Black-box end-to-end proof for the Vercel sandbox backend.
+ *
+ * Spawns `opencode serve` as a subprocess, drives it through the public
+ * `@opencode-ai/sdk` HTTP client, and asserts things a real integrator
+ * would observe: a fresh session has zero messages, the bash tool
+ * returns Linux + /vercel/sandbox, filesystem writes survive across
+ * prompts in the same tenant. No in-process tricks.
+ *
+ * Prerequisites:
+ *   - An opencode binary on PATH, built from THIS branch (not the
+ *     released one; it needs the workspace substrate dispatch).
+ *     From packages/opencode: `bun run build --single` puts one at
+ *     dist/opencode-<platform>-<arch>/bin/opencode — prepend that
+ *     dir to PATH.
+ *   - VERCEL_TOKEN / VERCEL_TEAM_ID / VERCEL_PROJECT_ID / VERCEL_SANDBOX_IMAGE_ID
+ *     in the env (or put them in a .env and source it).
+ *   - ANTHROPIC_API_KEY only if you override OC_TEST_PROVIDER=anthropic.
+ *     By default the tests use opencode's built-in free models so the
+ *     whole thing runs with just the vercel creds.
+ *
+ * Running (from packages/opencode):
+ *
+ *   # Everything, real sandbox, real LLM (~40–90 s):
+ *   OPENCODE_WORKSPACE_BACKEND=vercel bun test script/vercel-proof.test.ts
+ *
+ *   # Infra-only, no LLM (~5 s):
+ *   OPENCODE_WORKSPACE_BACKEND=vercel bun test script/vercel-proof.test.ts -t "A.0"
+ *
+ *   # One LLM scenario:
+ *   OPENCODE_WORKSPACE_BACKEND=vercel bun test script/vercel-proof.test.ts -t "A.1"
+ *
+ *   # A single sub-step:
+ *   OPENCODE_WORKSPACE_BACKEND=vercel bun test script/vercel-proof.test.ts -t "A.1.3"
+ *
+ * The file skips itself when VERCEL_* is missing (via `describe.skipIf`)
+ * so it's safe to leave enabled in the normal `bun test` run.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { spawn, type Subprocess } from "bun"
+import * as NFS from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+
+// ───────────────────────── env gating ─────────────────────────
+
+const HAS_VERCEL =
+  !!process.env["VERCEL_TOKEN"] && !!process.env["VERCEL_TEAM_ID"] && !!process.env["VERCEL_PROJECT_ID"]
+
+// LLM provider: opencode's built-in free models are always loaded
+// and need no credentials. Good enough for "does the agent call the
+// bash tool when asked" — we're not benchmarking reasoning quality.
+// Switch to anthropic/claude-sonnet-4-6 if you need higher-quality
+// multi-step reasoning in a specific scenario and have credits.
+const LLM_PROVIDER_ID = process.env["OC_TEST_PROVIDER"] ?? "opencode"
+const LLM_MODEL_ID = process.env["OC_TEST_MODEL"] ?? "gpt-5-nano"
+
+// We always need a real opencode server. If VERCEL_* is missing we
+// skip the whole file — bun:test's `describe.skipIf` handles this
+// gracefully with a clear "skipped" marker in the report.
+const skipAll = !HAS_VERCEL
+// Free models are always available inside opencode, so LLM tests
+// never skip on credentials. Override via OC_TEST_PROVIDER /
+// OC_TEST_MODEL if you want a different provider.
+const skipLLM = false
+
+// ───────────────────────── types ─────────────────────────
+
+type Client = ReturnType<typeof createOpencodeClient>
+
+interface Server {
+  readonly baseUrl: string
+  readonly client: Client
+  readonly stop: () => Promise<void>
+}
+
+interface ToolPart {
+  readonly tool: string
+  readonly status: string
+  readonly output: string
+  readonly metadata: Record<string, unknown>
+  readonly input: Record<string, unknown>
+}
+
+interface Snapshot {
+  readonly assistantText: string
+  readonly toolParts: ToolPart[]
+  readonly assistantCount: number
+}
+
+// ───────────────────────── subprocess ─────────────────────────
+
+const pipeLines = async (stream: ReadableStream<Uint8Array>, prefix: string) => {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      let idx: number
+      while ((idx = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, idx)
+        buf = buf.slice(idx + 1)
+        if (line.trim()) console.log(`${prefix} ${line}`)
+      }
+    }
+  } catch {
+    /* stream closed */
+  }
+}
+
+const randomPort = () => 4100 + Math.floor(Math.random() * 500)
+
+async function waitForServer(baseUrl: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/doc`)
+      if (res.status < 500) return
+    } catch {
+      /* still booting */
+    }
+    await new Promise((r) => setTimeout(r, 200))
+  }
+  throw new Error(`opencode server did not become ready at ${baseUrl}`)
+}
+
+async function spawnServer(envOverrides: Record<string, string> = {}): Promise<Server> {
+  const opencodeBin = Bun.which("opencode")
+  if (!opencodeBin) throw new Error("opencode binary not on PATH")
+
+  const port = randomPort()
+  const baseUrl = `http://127.0.0.1:${port}`
+
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    OPENCODE_WORKSPACE_BACKEND: "vercel",
+    OPENCODE_PERMISSION: JSON.stringify({
+      edit: "allow",
+      bash: "allow",
+      write: "allow",
+      read: "allow",
+      external_directory: "allow",
+    }),
+    ...envOverrides,
+  }
+
+  const proc: Subprocess = spawn({
+    cmd: [opencodeBin, "serve", "--port", String(port), "--hostname", "127.0.0.1"],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  pipeLines(proc.stdout as ReadableStream<Uint8Array>, "[opencode.out]").catch(() => {})
+  pipeLines(proc.stderr as ReadableStream<Uint8Array>, "[opencode.err]").catch(() => {})
+
+  try {
+    await waitForServer(baseUrl)
+  } catch (err) {
+    try {
+      proc.kill()
+    } catch {}
+    throw err
+  }
+
+  const client = createOpencodeClient({ baseUrl } as any)
+  return {
+    baseUrl,
+    client,
+    stop: async () => {
+      try {
+        proc.kill()
+      } catch {}
+    },
+  }
+}
+
+// ───────────────────────── session helpers ─────────────────────────
+
+async function makeTenant(slug: string): Promise<string> {
+  const dir = await NFS.mkdtemp(path.join(os.tmpdir(), `oc-proof-${slug}-${Date.now()}-`))
+  return await NFS.realpath(dir)
+}
+
+async function createSession(client: Client, directory: string, title: string): Promise<string> {
+  const res = await (client.session as any).create({
+    query: { directory },
+    body: { title },
+    throwOnError: true,
+  })
+  return res.data.id as string
+}
+
+async function sendPrompt(
+  client: Client,
+  directory: string,
+  sessionID: string,
+  text: string,
+): Promise<void> {
+  await (client.session as any).promptAsync({
+    query: { directory },
+    path: { id: sessionID },
+    body: {
+      model: { providerID: LLM_PROVIDER_ID, modelID: LLM_MODEL_ID },
+      agent: "build",
+      parts: [{ type: "text", text }],
+    },
+    throwOnError: true,
+  })
+}
+
+async function fetchMessages(client: Client, directory: string, sessionID: string): Promise<any[]> {
+  const res = await (client.session as any).messages({
+    query: { directory },
+    path: { id: sessionID },
+  })
+  return res.data as any[]
+}
+
+function extractTurn(messages: any[], fromIndex: number): Snapshot {
+  const toolParts: ToolPart[] = []
+  let assistantText = ""
+  let assistantCount = 0
+  for (let i = fromIndex; i < messages.length; i++) {
+    const m = messages[i]
+    if (m?.info?.role !== "assistant") continue
+    assistantCount++
+    for (const p of m.parts ?? []) {
+      if (p.type === "tool") {
+        toolParts.push({
+          tool: p.tool,
+          status: p.state?.status ?? "unknown",
+          output: typeof p.state?.output === "string" ? p.state.output : "",
+          metadata: p.state?.metadata ?? {},
+          input: p.state?.input ?? {},
+        })
+      }
+      if (p.type === "text" && p.text) assistantText = p.text
+    }
+  }
+  return { assistantText, toolParts, assistantCount }
+}
+
+/**
+ * Poll until `until(snapshot)` returns true or the deadline elapses.
+ * Returns the last snapshot — caller decides whether timeout is a
+ * failure. `fromIndex` is the `messages.length` captured before the
+ * prompt was sent, so we only look at the new turn.
+ */
+async function pollUntil(
+  client: Client,
+  directory: string,
+  sessionID: string,
+  fromIndex: number,
+  until: (s: Snapshot) => boolean,
+  timeoutMs: number,
+): Promise<Snapshot> {
+  const deadline = Date.now() + timeoutMs
+  let last: Snapshot = { assistantText: "", toolParts: [], assistantCount: 0 }
+  while (Date.now() < deadline) {
+    const all = await fetchMessages(client, directory, sessionID)
+    last = extractTurn(all, fromIndex)
+    if (until(last)) return last
+    await new Promise((r) => setTimeout(r, 500))
+  }
+  return last
+}
+
+function bashOutputOf(snapshot: Snapshot): string {
+  const parts: string[] = []
+  for (const t of snapshot.toolParts) {
+    if (t.tool !== "bash") continue
+    const metaStdout = typeof (t.metadata as any)?.stdout === "string" ? (t.metadata as any).stdout : ""
+    parts.push(t.output + metaStdout)
+  }
+  return parts.join("\n")
+}
+
+// ───────────────────────── server lifecycle ─────────────────────────
+
+let server: Server
+
+beforeAll(async () => {
+  if (skipAll) return
+  const opencodeBin = Bun.which("opencode")
+  if (!opencodeBin) {
+    throw new Error(
+      "opencode binary not on PATH — build and install it:\n" +
+        "  cd ~/Projects/opencode/packages/opencode && bun run script/build.ts --single --skip-embed-web-ui\n" +
+        "  ln -sf ~/Projects/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode ~/.local/bin/opencode",
+    )
+  }
+  server = await spawnServer()
+})
+
+afterAll(async () => {
+  if (server) await server.stop()
+})
+
+// ───────────────────────── scenarios ─────────────────────────
+
+describe.skipIf(skipAll)("vercel-proof", () => {
+  // ━━━━━━━━━━━ A.0  infra (no LLM)  ━━━━━━━━━━━
+  describe("A.0 infra (no LLM)", () => {
+    let directory: string
+    let sessionID: string
+
+    beforeAll(async () => {
+      directory = await makeTenant("A0")
+      sessionID = await createSession(server.client, directory, "A.0 infra")
+    })
+
+    test("A.0.1 opencode /doc responds", async () => {
+      const res = await fetch(`${server.baseUrl}/doc`)
+      expect(res.status).toBeLessThan(500)
+    }, 5_000)
+
+    test("A.0.2 session.create returned a ses_* id", () => {
+      expect(sessionID).toMatch(/^ses_/)
+    })
+
+    test("A.0.3 fresh session has 0 messages", async () => {
+      const messages = await fetchMessages(server.client, directory, sessionID)
+      expect(messages.length).toBe(0)
+    }, 5_000)
+  })
+
+  // ━━━━━━━━━━━ A.1  bash roundtrip (LLM)  ━━━━━━━━━━━
+  describe.skipIf(skipLLM)("A.1 baseline: bash in vercel sandbox (LLM)", () => {
+    let directory: string
+    let sessionID: string
+    let before: number
+
+    beforeAll(async () => {
+      directory = await makeTenant("A1")
+      sessionID = await createSession(server.client, directory, "A.1 baseline")
+      before = (await fetchMessages(server.client, directory, sessionID)).length
+      await sendPrompt(
+        server.client,
+        directory,
+        sessionID,
+        "Call the bash tool with this command: `uname -a && pwd`. Do NOT set the workdir parameter — leave it out entirely so the tool uses its default working directory. After the tool completes, reply with one short sentence.",
+      )
+    }, 15_000)
+
+    test("A.1.1 agent invokes the bash tool", async () => {
+      const snap = await pollUntil(
+        server.client,
+        directory,
+        sessionID,
+        before,
+        (s) => s.toolParts.some((t) => t.tool === "bash"),
+        25_000,
+      )
+      expect(snap.toolParts.find((t) => t.tool === "bash")).toBeDefined()
+    }, 28_000)
+
+    test("A.1.2 bash tool completes with Linux + /vercel/sandbox", async () => {
+      const snap = await pollUntil(
+        server.client,
+        directory,
+        sessionID,
+        before,
+        (s) =>
+          s.toolParts.some((t) => t.tool === "bash" && (t.status === "completed" || t.status === "error")),
+        25_000,
+      )
+      const bash = snap.toolParts.find((t) => t.tool === "bash")
+      expect(bash).toBeDefined()
+      expect(bash!.status).toMatch(/completed|error/)
+      const out = bashOutputOf(snap)
+      expect(out).not.toContain("Darwin")
+      expect(out).toContain("Linux")
+      expect(out).toContain("/vercel/sandbox")
+    }, 28_000)
+
+    test("A.1.3 assistant text reply arrives", async () => {
+      const snap = await pollUntil(
+        server.client,
+        directory,
+        sessionID,
+        before,
+        (s) => s.assistantText.length > 0,
+        25_000,
+      )
+      expect(snap.assistantText.length).toBeGreaterThan(0)
+    }, 28_000)
+  })
+
+  // ━━━━━━━━━━━ B.1  sandbox filesystem state across prompts (LLM)  ━━━━━━━━━━━
+  describe.skipIf(skipLLM)("B.1 filesystem state persists across prompts", () => {
+    const tag = `b1-marker-${Date.now()}`
+    let directory: string
+    let sessionID: string
+    let beforeFirst: number
+    let beforeSecond: number
+
+    beforeAll(async () => {
+      directory = await makeTenant("B1")
+      sessionID = await createSession(server.client, directory, "B.1 state")
+      beforeFirst = (await fetchMessages(server.client, directory, sessionID)).length
+      await sendPrompt(
+        server.client,
+        directory,
+        sessionID,
+        `Use the bash tool to run EXACTLY: \`echo ${tag} > /tmp/probe-b1.txt\`. Reply "done".`,
+      )
+    }, 15_000)
+
+    test("B.1.1 first prompt (write) completes", async () => {
+      const snap = await pollUntil(
+        server.client,
+        directory,
+        sessionID,
+        beforeFirst,
+        (s) =>
+          s.toolParts.some((t) => t.tool === "bash" && (t.status === "completed" || t.status === "error")) &&
+          s.assistantText.length > 0,
+        28_000,
+      )
+      expect(snap.toolParts.find((t) => t.tool === "bash")).toBeDefined()
+      beforeSecond = (await fetchMessages(server.client, directory, sessionID)).length
+      await sendPrompt(
+        server.client,
+        directory,
+        sessionID,
+        "Use the bash tool to run EXACTLY: `cat /tmp/probe-b1.txt`. Reply with just the file contents.",
+      )
+    }, 30_000)
+
+    test("B.1.2 second prompt (read) contains the tag", async () => {
+      const snap = await pollUntil(
+        server.client,
+        directory,
+        sessionID,
+        beforeSecond,
+        (s) =>
+          s.toolParts.some((t) => t.tool === "bash" && (t.status === "completed" || t.status === "error")) &&
+          s.assistantText.length > 0,
+        28_000,
+      )
+      const out = bashOutputOf(snap)
+      expect(out).toContain(tag)
+    }, 30_000)
+  })
+})

--- a/packages/opencode/script/verify-sandbox-image.ts
+++ b/packages/opencode/script/verify-sandbox-image.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+// Vercel sandbox image sanity check. Given VERCEL_SANDBOX_IMAGE_ID,
+// creates a throwaway sandbox, confirms every binary our L4 services
+// need is on PATH, runs --version on each, and stops the sandbox.
+// Exits 0 on success, 1 on any missing binary or failing smoke.
+
+import { Sandbox } from "@vercel/sandbox"
+
+const token = process.env["VERCEL_TOKEN"]
+const teamId = process.env["VERCEL_TEAM_ID"]
+const projectId = process.env["VERCEL_PROJECT_ID"]
+const snapshotId = process.env["VERCEL_SANDBOX_IMAGE_ID"]
+
+if (!token || !teamId || !projectId || !snapshotId) {
+  console.error("missing VERCEL_TOKEN / VERCEL_TEAM_ID / VERCEL_PROJECT_ID / VERCEL_SANDBOX_IMAGE_ID")
+  process.exit(2)
+}
+
+const REQUIRED = [
+  "git",
+  "prettier",
+  "gofmt",
+  "rustfmt",
+  "black",
+  "shfmt",
+  "rg",
+  "typescript-language-server",
+  "pyright",
+  "gopls",
+  "rust-analyzer",
+  "bash",
+  "sh",
+  "node",
+  "npm",
+  "python3",
+  "go",
+  "stat",
+  "find",
+  "curl",
+]
+
+const SMOKES: Array<[string, string[]]> = [
+  ["git", ["--version"]],
+  ["prettier", ["--version"]],
+  ["rg", ["--version"]],
+  ["typescript-language-server", ["--version"]],
+  ["pyright", ["--version"]],
+  ["gopls", ["version"]],
+  ["rust-analyzer", ["--version"]],
+  ["black", ["--version"]],
+  ["shfmt", ["--version"]],
+]
+
+let sandbox: Sandbox | null = null
+let failures = 0
+
+try {
+  console.log(`[verify] creating sandbox from ${snapshotId}`)
+  sandbox = await Sandbox.create({
+    source: { type: "snapshot", snapshotId },
+    token,
+    teamId,
+    projectId,
+    timeout: 10 * 60 * 1000,
+  } as Parameters<typeof Sandbox.create>[0])
+  console.log(`[verify] sandbox ${sandbox.name} ready`)
+
+  console.log("\n[verify] checking binary presence:")
+  for (const bin of REQUIRED) {
+    const r = await sandbox.runCommand("sh", ["-c", `command -v ${bin}`])
+    const out = (await r.stdout()).trim()
+    if (r.exitCode !== 0 || !out) {
+      console.error(`  ✗ ${bin} — NOT FOUND`)
+      failures++
+    } else {
+      console.log(`  ✓ ${bin.padEnd(30)} ${out}`)
+    }
+  }
+
+  console.log("\n[verify] per-service smoke tests:")
+  for (const [cmd, args] of SMOKES) {
+    const r = await sandbox.runCommand(cmd, args)
+    const out = (await r.stdout()).trim() || (await r.stderr()).trim()
+    if (r.exitCode !== 0) {
+      console.error(`  ✗ ${cmd} ${args.join(" ")} — exit ${r.exitCode}: ${out.slice(0, 200)}`)
+      failures++
+    } else {
+      const first = out.split("\n")[0]
+      console.log(`  ✓ ${cmd.padEnd(30)} ${first.slice(0, 80)}`)
+    }
+  }
+
+  console.log("\n[verify] checking workspace root writable:")
+  const r = await sandbox.runCommand("sh", [
+    "-c",
+    "mkdir -p /vercel/sandbox && echo ok > /vercel/sandbox/.verify-probe && rm /vercel/sandbox/.verify-probe && echo OK",
+  ])
+  const out = (await r.stdout()).trim()
+  if (r.exitCode !== 0 || out !== "OK") {
+    console.error(`  ✗ /vercel/sandbox not usable — exit ${r.exitCode}: ${out}`)
+    failures++
+  } else {
+    console.log("  ✓ /vercel/sandbox writable")
+  }
+} catch (err) {
+  console.error("\n[verify] FAILED:", err)
+  failures++
+} finally {
+  if (sandbox) {
+    try {
+      await sandbox.stop()
+    } catch {}
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n[verify] image verification FAILED (${failures} issue${failures === 1 ? "" : "s"})`)
+  process.exit(1)
+}
+console.log("\n[verify] image verification OK")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1032,6 +1032,30 @@ export namespace Config {
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
         })
         .optional(),
+      workspace: z
+        .discriminatedUnion("backend", [
+          z.object({ backend: z.literal("local") }).strict(),
+          z
+            .object({
+              backend: z.literal("vercel"),
+              vercel: z
+                .object({
+                  token: z.string().optional(),
+                  teamId: z.string().optional(),
+                  projectId: z.string().optional(),
+                  snapshotId: z.string().optional(),
+                  timeoutMs: z.number().int().positive().optional(),
+                  worktree: z.string().optional(),
+                })
+                .strict()
+                .optional(),
+            })
+            .strict(),
+        ])
+        .optional()
+        .describe(
+          "Workspace backend selection. When present, picks which substrate tools operate on. 'local' (default) runs on the host; 'vercel' routes tool operations into an isolated Vercel sandbox keyed by Instance.directory.",
+        ),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/opencode/src/effect/cross-spawn-spawner.ts
+++ b/packages/opencode/src/effect/cross-spawn-spawner.ts
@@ -500,7 +500,31 @@ export const layer: Layer.Layer<ChildProcessSpawner, never, FileSystem.FileSyste
   make,
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(NodeFileSystem.layer), Layer.provide(NodePath.layer))
+const crossSpawnDefault = layer.pipe(
+  Layer.provide(NodeFileSystem.layer),
+  Layer.provide(NodePath.layer),
+)
+
+// When OPENCODE_WORKSPACE_BACKEND=vercel, route spawn() calls through
+// the in-sandbox exec gateway so consumers (bash tool, Git, Format,
+// Snapshot, Ripgrep) transparently run in the tenant's substrate.
+// Local mode keeps the existing cross-spawn implementation.
+//
+// Dynamic `import()` keeps workspace/* out of the static module graph;
+// @/global has a top-level await that collides with cross-spawn-spawner
+// being loaded by low-level services, so the vercel branch must be
+// deferred until the runtime actually needs a spawner.
+export const defaultLayer: Layer.Layer<ChildProcessSpawner, never, never> = Layer.unwrap(
+  Effect.suspend(() => {
+    if ((globalThis.process?.env?.OPENCODE_WORKSPACE_BACKEND ?? "").toLowerCase() !== "vercel") {
+      return Effect.succeed(crossSpawnDefault)
+    }
+    return Effect.promise(async () => {
+      const mod = await import("@/workspace/vercel-spawner")
+      return mod.VercelChildProcessSpawner.defaultLayer
+    })
+  }),
+)
 
 import { lazy } from "@/util/lazy"
 

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -159,5 +159,23 @@ export namespace FileWatcher {
     }),
   )
 
-  export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(Git.defaultLayer))
+  const localDefaultLayer = layer.pipe(Layer.provide(Config.defaultLayer), Layer.provide(Git.defaultLayer))
+
+  // Parcel's native binding can't run inside a Vercel sandbox. On
+  // vercel mode the agent is the only writer to the tenant fs, so
+  // external fs-change events carry no information — dispatch to a
+  // no-op layer. Dynamic import defers the workspace module graph
+  // (which transitively pulls in @/global's top-level await) until
+  // first use.
+  export const defaultLayer: Layer.Layer<Service, never, never> = Layer.unwrap(
+    Effect.suspend(() => {
+      if ((globalThis.process?.env?.OPENCODE_WORKSPACE_BACKEND ?? "").toLowerCase() !== "vercel") {
+        return Effect.succeed(localDefaultLayer)
+      }
+      return Effect.promise(async () => {
+        const mod = await import("@/workspace/vercel-filewatcher")
+        return mod.layer as Layer.Layer<Service, never, never>
+      })
+    }),
+  )
 }

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -45,6 +45,7 @@ export namespace Flag {
   export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
   export declare const OPENCODE_CLIENT: string
+  export declare const OPENCODE_WORKSPACE_BACKEND: string | undefined
   export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
   export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
@@ -153,6 +154,17 @@ Object.defineProperty(Flag, "OPENCODE_PLUGIN_META_FILE", {
 Object.defineProperty(Flag, "OPENCODE_CLIENT", {
   get() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_WORKSPACE_BACKEND — evaluated at access
+// time, not module load, because the conformance test runner mutates
+// this env var at runtime to force the router into a specific backend.
+Object.defineProperty(Flag, "OPENCODE_WORKSPACE_BACKEND", {
+  get() {
+    return process.env["OPENCODE_WORKSPACE_BACKEND"]
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -21,7 +21,14 @@ import { Wildcard } from "@/util/wildcard"
 import { SessionID } from "@/session/schema"
 import { Auth } from "@/auth"
 import { Installation } from "@/installation"
-import { AppRuntime } from "@/effect/app-runtime"
+// Note: AppRuntime is loaded lazily inside the one function that uses it
+// (see `stream` below). A top-level `import { AppRuntime } from
+// "@/effect/app-runtime"` introduces a runtime cycle:
+//   llm.ts → app-runtime.ts → (line 83) read LLM.defaultLayer while
+//   llm.ts is still mid-load → undefined → TypeError.
+// Lazy import via `await import(...)` defers the load until after the
+// initial module-eval pass has finished, breaking the cycle without
+// touching app-runtime.ts.
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
@@ -306,6 +313,7 @@ export namespace LLM {
             }
           })
           const uniquePatterns = [...new Set(toolPatterns)] as string[]
+          const { AppRuntime } = await import("@/effect/app-runtime")
           await AppRuntime.runPromise(
             Permission.Service.use((svc) =>
               svc.ask({

--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -58,6 +58,16 @@ export namespace Process {
 
   export function spawn(cmd: string[], opts: Options = {}): Child {
     if (cmd.length === 0) throw new Error("Command is required")
+    // When OPENCODE_WORKSPACE_BACKEND=vercel, route through the
+    // in-sandbox exec gateway so LSP servers and other spawn consumers
+    // run in the tenant substrate. Require is dynamic because
+    // workspace/* transitively pulls in @/global (top-level await),
+    // which must not be loaded during util/process's eval phase.
+    if ((globalThis.process?.env?.OPENCODE_WORKSPACE_BACKEND ?? "").toLowerCase() === "vercel") {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require("@/workspace/vercel-process") as typeof import("@/workspace/vercel-process")
+      return mod.spawnViaVercel(cmd, opts)
+    }
     opts.abort?.throwIfAborted()
 
     const proc = launch(cmd[0], cmd.slice(1), {

--- a/packages/opencode/src/workspace/backends/local.ts
+++ b/packages/opencode/src/workspace/backends/local.ts
@@ -1,0 +1,319 @@
+import { Cause, Effect, Fiber, Queue, Scope, Sink, Stream } from "effect"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import path from "node:path"
+// @ts-ignore — @parcel/watcher's main entry requires a precompiled binding we
+// load manually; see src/file/watcher.ts for the reference pattern.
+import { createWrapper } from "@parcel/watcher/wrapper"
+import type ParcelWatcher from "@parcel/watcher"
+import * as NFS from "node:fs/promises"
+import { Shell } from "@/shell/shell"
+import { Workspace as WorkspaceErrors } from "../errors"
+import type { Workspace } from "../types"
+
+declare const OPENCODE_LIBC: string | undefined
+
+export namespace LocalBackend {
+  export interface Config {
+    readonly worktree: string
+  }
+
+  const BACKEND_ID = "local"
+
+  const toBackendError =
+    (method: string, p?: string) =>
+    (cause: unknown): WorkspaceErrors.BackendError =>
+      new WorkspaceErrors.BackendError({
+        backend: BACKEND_ID,
+        method,
+        path: p,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      })
+
+  const fileType = (stat: import("node:fs").Stats): Workspace.FileType => {
+    if (stat.isFile()) return "file"
+    if (stat.isDirectory()) return "directory"
+    if (stat.isSymbolicLink()) return "symlink"
+    return "other"
+  }
+
+  const direntType = (ent: import("node:fs").Dirent): Workspace.FileType => {
+    if (ent.isFile()) return "file"
+    if (ent.isDirectory()) return "directory"
+    if (ent.isSymbolicLink()) return "symlink"
+    return "other"
+  }
+
+  const loadParcelWatcher = (): typeof import("@parcel/watcher") | undefined => {
+    try {
+      const libc = typeof OPENCODE_LIBC !== "undefined" && OPENCODE_LIBC ? OPENCODE_LIBC : "glibc"
+      const name = `@parcel/watcher-${process.platform}-${process.arch}${
+        process.platform === "linux" ? `-${libc}` : ""
+      }`
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const binding = require(name)
+      return createWrapper(binding) as typeof import("@parcel/watcher")
+    } catch {
+      return undefined
+    }
+  }
+
+  const parcelBackend = (): ParcelWatcher.BackendType | undefined => {
+    if (process.platform === "win32") return "windows"
+    if (process.platform === "darwin") return "fs-events"
+    if (process.platform === "linux") return "inotify"
+    return undefined
+  }
+
+  export const make = (
+    config: Config,
+  ): Effect.Effect<Workspace.Backend, never, ChildProcessSpawner | Scope.Scope> =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner
+      const rootPath = path.resolve(config.worktree)
+
+      const stat: Workspace.Backend["stat"] = (p) =>
+        // `stat` (not `lstat`) — the Backend contract follows symlinks so
+        // that callers treating a symlinked file as a file Just Work.
+        Effect.tryPromise({
+          try: () => NFS.stat(p),
+          catch: toBackendError("stat", p),
+        }).pipe(
+          Effect.map((s) => ({
+            type: fileType(s),
+            size: s.size,
+            mtime: s.mtime,
+          })),
+        )
+
+      const exists: Workspace.Backend["exists"] = (p) =>
+        Effect.tryPromise({
+          try: async () => {
+            try {
+              await NFS.stat(p)
+              return true
+            } catch (e: any) {
+              if (e?.code === "ENOENT" || e?.code === "ENOTDIR") return false
+              throw e
+            }
+          },
+          catch: toBackendError("exists", p),
+        })
+
+      const readFile: Workspace.Backend["readFile"] = (p) =>
+        Effect.tryPromise({
+          try: () => NFS.readFile(p),
+          catch: toBackendError("readFile", p),
+        }).pipe(Effect.map((b) => new Uint8Array(b.buffer, b.byteOffset, b.byteLength)))
+
+      // NOTE: raw write. Parent-directory creation is a Workspace.Service
+      // concern, not a Backend primitive. If the parent is missing we let
+      // NFS.writeFile throw ENOENT.
+      const writeFile: Workspace.Backend["writeFile"] = (p, data) =>
+        Effect.tryPromise({
+          try: () => NFS.writeFile(p, data),
+          catch: toBackendError("writeFile", p),
+        })
+
+      const mkDir: Workspace.Backend["mkDir"] = (p, opts) =>
+        Effect.tryPromise({
+          try: async () => {
+            await NFS.mkdir(p, { recursive: opts.recursive })
+          },
+          catch: toBackendError("mkDir", p),
+        })
+
+      const readDir: Workspace.Backend["readDir"] = (p) =>
+        Effect.tryPromise({
+          try: () => NFS.readdir(p, { withFileTypes: true }),
+          catch: toBackendError("readDir", p),
+        }).pipe(
+          Effect.map((entries) =>
+            entries.map((ent) => ({
+              name: ent.name,
+              type: direntType(ent),
+            })),
+          ),
+        )
+
+      const remove: Workspace.Backend["remove"] = (p, opts) =>
+        Effect.tryPromise({
+          try: () => NFS.rm(p, { recursive: opts.recursive, force: false }),
+          catch: toBackendError("remove", p),
+        })
+
+      const rename: Workspace.Backend["rename"] = (from, to) =>
+        Effect.tryPromise({
+          try: () => NFS.rename(from, to),
+          catch: toBackendError("rename", from),
+        })
+
+      const execStream: Workspace.Backend["execStream"] = (cmd, args, opts) => {
+        const program: Effect.Effect<Workspace.ExecStreamHandle, WorkspaceErrors.BackendError, Scope.Scope> =
+          Effect.gen(function* () {
+            const command = ChildProcess.make(cmd, args, {
+              cwd: opts?.cwd,
+              env: opts?.env,
+              extendEnv: opts?.env === undefined,
+            })
+            const handle = yield* spawner.spawn(command).pipe(Effect.mapError(toBackendError("execStream")))
+
+            // If caller supplied initial stdin bytes, feed them to the
+            // handle's stdin sink eagerly. Fork so the caller can still
+            // stream more bytes via the returned handle's stdin Sink.
+            if (opts?.stdin !== undefined) {
+              const bytes =
+                typeof opts.stdin === "string" ? new TextEncoder().encode(opts.stdin) : opts.stdin
+              const initial = Stream.fromIterable([bytes])
+              yield* Effect.forkScoped(Stream.run(initial, handle.stdin).pipe(Effect.ignore))
+            }
+
+            if (opts?.signal) {
+              const signal = opts.signal
+              const abortWatch: Effect.Effect<void> = Effect.callback<void>((resume) => {
+                const onAbort = () => {
+                  Effect.runFork(handle.kill().pipe(Effect.ignore))
+                  resume(Effect.void)
+                }
+                if (signal.aborted) {
+                  onAbort()
+                  return
+                }
+                signal.addEventListener("abort", onAbort, { once: true })
+                return Effect.sync(() => signal.removeEventListener("abort", onAbort))
+              })
+              yield* Effect.forkScoped(abortWatch)
+            }
+
+            const killEff: Effect.Effect<void> = handle.kill().pipe(Effect.ignore) as Effect.Effect<void>
+
+            const baseExit: Effect.Effect<number | null, WorkspaceErrors.BackendError> = handle.exitCode.pipe(
+              Effect.map((code) => code as number | null),
+              Effect.mapError(toBackendError("execStream.exitCode")),
+            )
+            const withTimeout: Effect.Effect<number | null, WorkspaceErrors.BackendError> = opts?.timeoutMs
+              ? Effect.timeoutOrElse(baseExit, {
+                  duration: `${opts.timeoutMs} millis`,
+                  orElse: () =>
+                    Effect.fail(
+                      toBackendError("execStream.timeout")(
+                        new Error(`exec timed out after ${opts.timeoutMs}ms`),
+                      ),
+                    ),
+                })
+              : baseExit
+
+            const stdinSink: Sink.Sink<void, Uint8Array, never, WorkspaceErrors.BackendError> = handle.stdin.pipe(
+              Sink.mapError(toBackendError("execStream.stdin")),
+            )
+
+            const result: Workspace.ExecStreamHandle = {
+              stdin: stdinSink,
+              stdout: handle.stdout.pipe(Stream.mapError(toBackendError("execStream.stdout"))),
+              stderr: handle.stderr.pipe(Stream.mapError(toBackendError("execStream.stderr"))),
+              all: handle.all.pipe(Stream.mapError(toBackendError("execStream.all"))),
+              exitCode: withTimeout,
+              kill: killEff,
+            }
+            return result
+          })
+        return program
+      }
+
+      // exec() is execStream() + collect. ZERO duplication.
+      const exec: Workspace.Backend["exec"] = (cmd, args, opts) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* execStream(cmd, args, opts)
+            const decoder = new TextDecoder()
+            const collect = (
+              s: Stream.Stream<Uint8Array, WorkspaceErrors.BackendError>,
+            ): Effect.Effect<string, WorkspaceErrors.BackendError> =>
+              Stream.runFold(
+                s,
+                () => "",
+                (acc, chunk) => acc + decoder.decode(chunk, { stream: true }),
+              )
+
+            const stdoutFiber = yield* Effect.forkChild(collect(handle.stdout))
+            const stderrFiber = yield* Effect.forkChild(collect(handle.stderr))
+            const code = yield* handle.exitCode
+            const stdout = yield* Fiber.join(stdoutFiber)
+            const stderr = yield* Fiber.join(stderrFiber)
+            const result: Workspace.ExecResult = { exitCode: code ?? -1, stdout, stderr }
+            return result
+          }),
+        )
+
+      const watch: Workspace.Backend["watch"] = (p, opts) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const w = loadParcelWatcher()
+            if (!w) {
+              return Stream.fail(
+                toBackendError("watch", p)(new Error("parcel watcher binding unavailable")),
+              ) as Stream.Stream<Workspace.FsEvent, WorkspaceErrors.BackendError>
+            }
+            const pbackend = parcelBackend()
+            if (!pbackend) {
+              return Stream.fail(
+                toBackendError("watch", p)(new Error(`unsupported platform for watch: ${process.platform}`)),
+              ) as Stream.Stream<Workspace.FsEvent, WorkspaceErrors.BackendError>
+            }
+
+            const queue = yield* Queue.unbounded<Workspace.FsEvent, WorkspaceErrors.BackendError | Cause.Done>()
+
+            const pending = w.subscribe(
+              p,
+              (err, evts) => {
+                if (err) {
+                  Queue.failCauseUnsafe(queue, Cause.fail(toBackendError("watch", p)(err)))
+                  return
+                }
+                for (const evt of evts) {
+                  let type: Workspace.FsEventType | undefined
+                  if (evt.type === "create") type = "add"
+                  else if (evt.type === "update") type = "change"
+                  else if (evt.type === "delete") type = "unlink"
+                  if (type) Queue.offerUnsafe(queue, { type, path: evt.path })
+                }
+              },
+              { backend: pbackend, ignore: opts?.ignore ? [...opts.ignore] : undefined },
+            )
+
+            const sub = yield* Effect.tryPromise({
+              try: () => pending,
+              catch: toBackendError("watch", p),
+            })
+
+            yield* Effect.addFinalizer(() =>
+              Effect.gen(function* () {
+                yield* Effect.promise(() => sub.unsubscribe().catch(() => {}))
+                yield* Queue.end(queue)
+              }),
+            )
+
+            return Stream.fromQueue(queue)
+          }),
+        )
+
+      const backend: Workspace.Backend = {
+        id: BACKEND_ID,
+        rootPath,
+        shell: Shell.acceptable(),
+        stat,
+        exists,
+        readFile,
+        writeFile,
+        mkDir,
+        readDir,
+        remove,
+        rename,
+        exec,
+        execStream,
+        watch,
+        close: Effect.void,
+      }
+      return backend
+    })
+}

--- a/packages/opencode/src/workspace/backends/vercel-exec-channel.ts
+++ b/packages/opencode/src/workspace/backends/vercel-exec-channel.ts
@@ -1,0 +1,461 @@
+// WebSocket transport for VercelBackend.execStream. Each call opens a
+// dedicated socket to the in-sandbox gateway daemon (source at
+// script/sandbox-image/gateway/gateway.js, baked into the image) and
+// translates the Effect Sink/Stream of ExecStreamHandle into
+// send/receive frames. Gateway bootstrap is lazy per sandbox and cached.
+
+import { Cause, Deferred, Effect, Queue, Sink, Stream } from "effect"
+import { randomBytes } from "node:crypto"
+import { AsyncResource } from "node:async_hooks"
+import type { Sandbox } from "@vercel/sandbox"
+import { Workspace as WorkspaceErrors } from "../errors"
+import type { Workspace } from "../types"
+// The gateway is a globally-installed npm package inside the sandbox
+// image (see `script/sandbox-image/build.ts`). Its `bin` field publishes
+// the `opencode-gateway` command onto the sandbox PATH, so the client
+// calls it by name — no filesystem paths, no NODE_PATH.
+const GATEWAY_BIN = "opencode-gateway"
+
+export interface GatewayState {
+  readonly token: string
+  readonly healthUrl: string
+  readonly execUrl: string
+}
+
+// One cache per (sandbox, backend instance). Keyed by the sandbox's
+// `sandboxId` string so two VercelBackend.make calls targeting the
+// same sandbox share the same gateway without double-bootstrapping.
+const gatewayCache = new Map<string, Promise<GatewayState>>()
+
+const wrap =
+  (method: string, p?: string) =>
+  (cause: unknown): WorkspaceErrors.BackendError =>
+    new WorkspaceErrors.BackendError({
+      backend: "vercel",
+      method,
+      path: p,
+      cause: cause instanceof Error ? cause : new Error(String(cause)),
+    })
+
+// Path inside the sandbox where the gateway's current auth token is
+// stored. The token MUST be recoverable across opencode processes that
+// share a sandbox, because the gateway's `GATEWAY_TOKEN` env is fixed
+// at spawn time and a second process running on the same sandbox sees
+// a stale gateway (port 3000 already bound) with a token only the
+// first process knew. Persisting the token into the sandbox FS lets
+// any subsequent client reuse the running gateway.
+const GATEWAY_TOKEN_PATH = "/tmp/opencode-gateway-token"
+
+export const ensureGateway = (sb: Sandbox): Promise<GatewayState> => {
+  // Cache key: the sandbox's public `name` getter. One gateway per
+  // sandbox; two backends pointing at the same sandbox share it.
+  const sbId = sb.name
+  const cached = gatewayCache.get(sbId)
+  if (cached) return cached
+
+  const bootstrap = (async (): Promise<GatewayState> => {
+    const domain = sb.domain(3000)
+    const healthUrl = domain + "/health"
+    const execUrl = domain.replace(/^http/, "ws") + "/exec"
+
+    // Fast path: a gateway may already be running from a previous
+    // opencode process on the same persistent sandbox. If `/health`
+    // answers, read the token the running gateway wrote to
+    // `GATEWAY_TOKEN_PATH` via a shell command (the sandbox SDK's
+    // `writeFiles`/`readFileToBuffer` reject paths outside the
+    // worktree with HTTP 400, so all token FS I/O goes through shell).
+    const readExistingToken = async (): Promise<string | null> => {
+      try {
+        const res = await fetch(healthUrl, { signal: AbortSignal.timeout(2_000) })
+        if (res.status !== 200) return null
+        if ((await res.text()).trim() !== "ok") return null
+      } catch {
+        return null
+      }
+      try {
+        const finished = await sb.runCommand({ cmd: "cat", args: [GATEWAY_TOKEN_PATH] } as any)
+        if ((finished as { exitCode?: number }).exitCode !== 0) return null
+        const out = (await (finished as { stdout(): Promise<string> }).stdout()).trim()
+        return out.length > 0 ? out : null
+      } catch {
+        return null
+      }
+    }
+
+    const existingToken = await readExistingToken()
+    if (existingToken !== null) {
+      return { token: existingToken, healthUrl, execUrl }
+    }
+    // Cold bootstrap: no gateway answering /health, or no valid token
+    // file. Replace whatever may still be bound to :3000 and launch a
+    // fresh gateway with a fresh token (persisted for future reuse).
+
+    // Cold path: launch a fresh gateway. Run three steps atomically
+    // inside a single shell invocation so there is no window where
+    // port 3000 is half-free and no race between kill / write / spawn:
+    //
+    //   1. kill any straggler bound to :3000 (by port, not pname — a
+    //      shell arg could otherwise match its own grep string)
+    //   2. write the token to GATEWAY_TOKEN_PATH atomically
+    //   3. `exec` the gateway so the shell PID is replaced by the
+    //      gateway PID; `detached: true` keeps it alive after the
+    //      runCommand call returns.
+    //
+    // Tokens are passed via env (the shell script only references
+    // `$GATEWAY_TOKEN`), so nothing token-related ends up in `/proc/PID/cmdline`.
+    const token = randomBytes(24).toString("hex")
+    const launch = [
+      `pids=$(ss -lntp 2>/dev/null | awk '/:3000 /{print $NF}' | grep -oE 'pid=[0-9]+' | cut -d= -f2)`,
+      `if [ -n "$pids" ]; then kill -9 $pids 2>/dev/null || true; sleep 0.2; fi`,
+      `printf '%s' "$GATEWAY_TOKEN" > ${JSON.stringify(GATEWAY_TOKEN_PATH)}`,
+      `exec ${GATEWAY_BIN}`,
+    ].join("; ")
+    await sb.runCommand({
+      cmd: "bash",
+      args: ["-c", launch],
+      env: {
+        GATEWAY_TOKEN: token,
+      },
+      detached: true,
+    } as any)
+
+    // Poll /health until 200.
+    const deadline = Date.now() + 30_000
+    let lastErr: unknown = null
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(healthUrl)
+        if (res.status === 200 && (await res.text()).trim() === "ok") {
+          return { token, healthUrl, execUrl }
+        }
+      } catch (err) {
+        lastErr = err
+      }
+      await new Promise((r) => setTimeout(r, 250))
+    }
+    throw new Error(
+      `gateway never became healthy at ${healthUrl}${lastErr ? `: ${String(lastErr)}` : ""}`,
+    )
+  })()
+
+  // Cache the promise. On failure, evict so the next call can retry.
+  bootstrap.catch(() => {
+    gatewayCache.delete(sbId)
+  })
+  gatewayCache.set(sbId, bootstrap)
+  return bootstrap
+}
+
+// ---------- exec channel ----------
+
+interface SpawnSpec {
+  readonly cmd: string
+  readonly args: readonly string[]
+  readonly cwd?: string
+  readonly env?: Record<string, string>
+}
+
+/**
+ * Open an exec channel over the hardened gateway and return a
+ * Workspace.ExecStreamHandle. The returned Effect is scoped: closing
+ * its scope kills the child process and the socket.
+ */
+export const openExecChannel = (
+  sb: Sandbox,
+  spec: SpawnSpec,
+): Effect.Effect<Workspace.ExecStreamHandle, WorkspaceErrors.BackendError, import("effect/Scope").Scope> =>
+  Effect.gen(function* () {
+    const gw = yield* Effect.tryPromise({
+      try: () => ensureGateway(sb),
+      catch: wrap("execStream.gateway"),
+    })
+
+    // One queue per output channel. `all` interleaves both.
+    const stdoutQueue = yield* Queue.unbounded<Uint8Array, WorkspaceErrors.BackendError | Cause.Done>()
+    const stderrQueue = yield* Queue.unbounded<Uint8Array, WorkspaceErrors.BackendError | Cause.Done>()
+    const allQueue = yield* Queue.unbounded<Uint8Array, WorkspaceErrors.BackendError | Cause.Done>()
+    const exitDeferred = yield* Deferred.make<number | null, WorkspaceErrors.BackendError>()
+
+    // Shared state for the socket lifecycle.
+    type State = "pending" | "authed" | "spawned" | "closed"
+    let state: State = "pending"
+    let closeReason: WorkspaceErrors.BackendError | null = null
+    const endAllQueues = () => {
+      Queue.endUnsafe(stdoutQueue)
+      Queue.endUnsafe(stderrQueue)
+      Queue.endUnsafe(allQueue)
+    }
+
+    // VercelBackend mirrors LocalBackend's semantics: `handle.exitCode`
+    // MUST only resolve after `handle.all` has been fully drained by
+    // its consumer. Otherwise the bash tool's `Effect.raceAll` sees
+    // exit while forked stream consumers still have items in-flight,
+    // and the scope-close races through, dropping the final bytes.
+    //
+    // Node's ChildProcess gives us that invariant for free (its
+    // "close" event fires after stdio is drained). For WebSocket
+    // frames we enforce it at the exitCode seam itself: the "exit"
+    // message handler just stores the code, and `handle.exitCode`
+    // is a polling Effect that yields the scheduler each tick and
+    // returns only when (a) the exit code is known AND (b) every
+    // queue has been fully drained by its consumer. No timeouts:
+    // cooperative scheduling drains the queues inside a finite
+    // number of scheduler ticks.
+    let pendingExit: { code: number | null } | null = null
+
+    // Open the WebSocket and wait for readyState = OPEN.
+    //
+    // WebSocket event listeners (`message`, `close`, `error`) fire from
+    // Node's native event loop, outside any AsyncLocalStorage frame. On
+    // remote substrates the fiber that called into the backend resumes
+    // from those native callbacks via `Deferred.doneUnsafe(...)`, and
+    // its continuation runs in an empty ALS context — which breaks
+    // opencode business logic that reads `Instance.current` (or any
+    // other `LocalContext`) after the await.
+    //
+    // Capture the CURRENT async resource while we're still inside the
+    // Effect fiber (with ALS intact) and restore it around every
+    // callback body. This is platform-level, substrate-agnostic, and
+    // preserves every active `AsyncLocalStorage` store — not just
+    // opencode's `instance` one — so any business-logic `LocalContext`
+    // sees the same view as it would on LocalBackend.
+    const channelRes = new AsyncResource("vercel-exec-channel")
+    const bindCb = <A extends unknown[]>(fn: (...args: A) => void) =>
+      (...args: A) =>
+        channelRes.runInAsyncScope(fn, undefined, ...args)
+
+    const socket = yield* Effect.tryPromise({
+      try: () =>
+        new Promise<WebSocket>((resolve, reject) => {
+          const ws = new WebSocket(gw.execUrl)
+          const t = setTimeout(() => reject(new Error("exec ws open timeout")), 15_000)
+          ws.addEventListener(
+            "open",
+            () => {
+              clearTimeout(t)
+              resolve(ws)
+            },
+            { once: true },
+          )
+          ws.addEventListener(
+            "error",
+            () => {
+              clearTimeout(t)
+              reject(new Error("exec ws error on open"))
+            },
+            { once: true },
+          )
+        }),
+      catch: wrap("execStream.open"),
+    })
+
+    const sendJson = (obj: unknown) => {
+      try {
+        socket.send(JSON.stringify(obj))
+      } catch (err) {
+        closeReason = wrap("execStream.send")(err)
+      }
+    }
+
+    // Drive the socket: auth, spawn, then pump bytes.
+    const authOkDeferred = yield* Deferred.make<void, WorkspaceErrors.BackendError>()
+    const readyDeferred = yield* Deferred.make<void, WorkspaceErrors.BackendError>()
+
+    socket.addEventListener("message", bindCb((evt: MessageEvent) => {
+      let msg: any
+      try {
+        msg = JSON.parse(typeof evt.data === "string" ? evt.data : evt.data.toString())
+      } catch {
+        return
+      }
+      if (msg.type === "auth-ok") {
+        Deferred.doneUnsafe(authOkDeferred, Effect.void)
+        return
+      }
+      if (msg.type === "ready") {
+        Deferred.doneUnsafe(readyDeferred, Effect.void)
+        return
+      }
+      if (msg.type === "stdout" && typeof msg.data === "string") {
+        const bytes = new Uint8Array(Buffer.from(msg.data, "base64"))
+        Queue.offerUnsafe(stdoutQueue, bytes)
+        Queue.offerUnsafe(allQueue, bytes)
+        return
+      }
+      if (msg.type === "stderr" && typeof msg.data === "string") {
+        const bytes = new Uint8Array(Buffer.from(msg.data, "base64"))
+        Queue.offerUnsafe(stderrQueue, bytes)
+        Queue.offerUnsafe(allQueue, bytes)
+        return
+      }
+      if (msg.type === "exit") {
+        const code = typeof msg.code === "number" ? msg.code : null
+        // Store the exit code and signal that an exit frame has
+        // arrived. `handle.exitCode` parks on `exitDeferred` until
+        // now, then polls the queue sizes until the forked consumer
+        // has drained every pending byte. End the queues so the
+        // consumer's `Stream.fromQueue` terminates naturally.
+        pendingExit = { code }
+        Deferred.doneUnsafe(exitDeferred, Effect.succeed(code))
+        endAllQueues()
+        state = "closed"
+        return
+      }
+      if (msg.type === "error") {
+        const err = wrap("execStream.gateway-error")(new Error(String(msg.message ?? "unknown")))
+        closeReason = err
+        Deferred.doneUnsafe(authOkDeferred, Effect.fail(err))
+        Deferred.doneUnsafe(readyDeferred, Effect.fail(err))
+        Deferred.doneUnsafe(exitDeferred, Effect.fail(err))
+        Queue.failCauseUnsafe(stdoutQueue, Cause.fail(err))
+        Queue.failCauseUnsafe(stderrQueue, Cause.fail(err))
+        Queue.failCauseUnsafe(allQueue, Cause.fail(err))
+        return
+      }
+    }))
+
+    socket.addEventListener("close", bindCb(() => {
+      // Synthesize a null exit if we didn't get an explicit exit
+      // frame before the socket dropped. Unblock `exitDeferred` so
+      // the polling loop in `handle.exitCode` can start draining.
+      state = "closed"
+      if (pendingExit === null) {
+        pendingExit = { code: null }
+        Deferred.doneUnsafe(exitDeferred, Effect.succeed(null))
+      }
+      endAllQueues()
+    }))
+
+    socket.addEventListener("error", bindCb(() => {
+      const err = wrap("execStream.socket-error")(new Error("websocket error"))
+      closeReason = err
+      Deferred.doneUnsafe(exitDeferred, Effect.fail(err))
+      Queue.failCauseUnsafe(stdoutQueue, Cause.fail(err))
+      Queue.failCauseUnsafe(stderrQueue, Cause.fail(err))
+      Queue.failCauseUnsafe(allQueue, Cause.fail(err))
+      endAllQueues()
+    }))
+
+    // Authenticate.
+    sendJson({ type: "auth", token: gw.token })
+    yield* Deferred.await(authOkDeferred).pipe(
+      Effect.timeoutOrElse({
+        duration: "10 seconds",
+        orElse: () => Effect.fail(wrap("execStream.auth")(new Error("auth-ok timeout"))),
+      }),
+    )
+    state = "authed"
+
+    // Spawn the child process.
+    sendJson({
+      type: "spawn",
+      cmd: spec.cmd,
+      args: spec.args,
+      cwd: spec.cwd,
+      env: spec.env,
+    })
+    yield* Deferred.await(readyDeferred).pipe(
+      Effect.timeoutOrElse({
+        duration: "10 seconds",
+        orElse: () => Effect.fail(wrap("execStream.ready")(new Error("ready timeout"))),
+      }),
+    )
+    state = "spawned"
+
+    // Finalizer: close the socket and kill the child on scope close.
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        try {
+          if (state !== "closed") sendJson({ type: "kill" })
+        } catch {}
+        try {
+          socket.close()
+        } catch {}
+      }),
+    )
+
+    // ---- Build the handle ----
+
+    // Write each chunk as a `stdin` frame; when the upstream Stream
+    // finishes (the source is exhausted / its Queue is ended), send
+    // `stdin-close` so the child sees EOF and exits cleanly. This
+    // matches the natural Sink lifecycle: a single Stream.run(source,
+    // sink) is one end-to-end write session.
+    //
+    // For incremental / bidirectional I/O (LSP), the correct pattern
+    // is ONE long-lived Stream.run whose source is a Queue that the
+    // caller feeds over the session's lifetime. When the caller wants
+    // the child to terminate gracefully, it closes the queue; the
+    // Sink's ensuring clause then fires stdin-close, and the handle's
+    // exitCode resolves. Callers that need to write AND then keep the
+    // child alive without EOF should not end their upstream stream.
+    const stdinSink: Sink.Sink<void, Uint8Array, never, WorkspaceErrors.BackendError> = Sink.forEach(
+      (chunk: Uint8Array) =>
+        Effect.sync(() => {
+          sendJson({
+            type: "stdin",
+            data: Buffer.from(chunk).toString("base64"),
+          })
+        }),
+    ).pipe(
+      Sink.ensuring(
+        Effect.sync(() => {
+          if (state !== "closed") sendJson({ type: "stdin-close" })
+        }),
+      ),
+    )
+
+    // `handle.exitCode` is a single cooperative-polling loop that
+    // returns only when (a) the exit code is known (either the
+    // gateway sent an `exit` frame or the socket dropped) AND (b)
+    // every stream queue has been fully drained by its consumer.
+    // Each iteration yields the scheduler so the forked consumer
+    // fiber (created by the caller e.g. bash.ts's forkScoped
+    // Stream.runForEach) gets ticks to pump through pending items.
+    //
+    // This matches LocalBackend's native semantics: Node's
+    // ChildProcess fires 'close' AFTER stdio is drained, so
+    // `handle.exitCode` on local naturally waits for drain. For
+    // WebSocket frames we emulate the same guarantee here.
+    //
+    // See `script/probe-queue-stream.ts` for the minimal
+    // reproduction demonstrating why bare `Deferred.await` drops
+    // frames under the `Effect.forkScoped + Stream.runForEach +
+    // Effect.raceAll` pattern bash.ts uses.
+    const exitCodeEffect: Effect.Effect<number | null, WorkspaceErrors.BackendError> = Effect.gen(
+      function* () {
+        while (true) {
+          if (closeReason !== null) return yield* Effect.fail(closeReason)
+          if (pendingExit !== null) {
+            // Wait only for `allQueue` to drain. `stdoutQueue` and
+            // `stderrQueue` are duplicates of the same bytes for
+            // callers that prefer per-stream consumption; whether
+            // they're drained is the caller's concern. Checking all
+            // three would deadlock any caller that only subscribes
+            // to one of them (the bash tool reads `handle.all`).
+            const allSize = yield* Queue.size(allQueue)
+            if (allSize <= 0) {
+              return pendingExit.code
+            }
+          }
+          // Yield a macrotask to the Node event loop so WebSocket
+          // `message` events can fire and the forked consumer fiber
+          // gets a chance to drain. `Effect.yieldNow` (microtask-
+          // only) would starve both.
+          yield* Effect.sleep("1 millis")
+        }
+      },
+    )
+
+    const handle: Workspace.ExecStreamHandle = {
+      stdin: stdinSink,
+      stdout: Stream.fromQueue(stdoutQueue),
+      stderr: Stream.fromQueue(stderrQueue),
+      all: Stream.fromQueue(allQueue),
+      exitCode: exitCodeEffect,
+      kill: Effect.sync(() => {
+        sendJson({ type: "kill" })
+      }),
+    }
+    return handle
+  })

--- a/packages/opencode/src/workspace/backends/vercel.ts
+++ b/packages/opencode/src/workspace/backends/vercel.ts
@@ -1,0 +1,596 @@
+import { createHash } from "node:crypto"
+import { Cause, Effect, Fiber, Queue, Stream } from "effect"
+import { Sandbox } from "@vercel/sandbox"
+import { Workspace as WorkspaceErrors } from "../errors"
+import type { Workspace } from "../types"
+import { openExecChannel } from "./vercel-exec-channel"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "vercel-backend" })
+
+export namespace VercelBackend {
+  export interface Config {
+    readonly token: string
+    readonly teamId: string
+    readonly projectId: string
+    /** Tenant key; hashed to derive sandbox name. */
+    readonly directory: string
+    /** Sandbox image snapshot ID. Undefined → blank AL2023 sandbox. */
+    readonly snapshotId?: string
+    /** Idle timeout in ms. Default 30 min. */
+    readonly timeoutMs?: number
+    /** VM-side workspace root. Default "/vercel/sandbox". */
+    readonly worktree?: string
+    /** Polling interval for `watch`. Default 2000 ms. */
+    readonly watchPollMs?: number
+  }
+
+  const BACKEND_ID = "vercel"
+  const DEFAULT_WORKTREE = "/vercel/sandbox"
+  const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000
+  const DEFAULT_WATCH_POLL_MS = 2000
+
+  /**
+   * Deterministic sandbox name from a tenant directory.
+   *
+   * Hashing `directory` rather than passing it through verbatim:
+   *   - keeps the name within Vercel's character constraints (lowercase
+   *     alnum + `-`, length cap)
+   *   - guarantees uniqueness across tenants without leaking the
+   *     gateway's tenant scheme into Vercel's UI
+   */
+  export const nameFor = (directory: string): string =>
+    `oc-${createHash("sha1").update(directory).digest("hex").slice(0, 20)}`
+
+  // ------------- error wrappers -------------
+
+  const toBackendError =
+    (method: string, p?: string) =>
+    (cause: unknown): WorkspaceErrors.BackendError =>
+      new WorkspaceErrors.BackendError({
+        backend: BACKEND_ID,
+        method,
+        path: p,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      })
+
+  // ------------- shell helpers -------------
+
+  /** Wrap an arbitrary string for safe inclusion inside single quotes. */
+  const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`
+
+  /**
+   * Parse `stat -c "%F|%s|%Y" path` output into a FileInfo.
+   *
+   * Coreutils `%F` returns one of:
+   *   "regular file" | "regular empty file" | "directory" |
+   *   "symbolic link" | "character special file" | ...
+   */
+  const parseStatLine = (line: string): Workspace.FileInfo | null => {
+    const parts = line.split("|")
+    if (parts.length < 3) return null
+    const [kind, sizeStr, mtimeStr] = parts
+    let type: Workspace.FileType = "other"
+    if (kind.includes("directory")) type = "directory"
+    else if (kind.includes("symbolic link")) type = "symlink"
+    else if (kind.includes("regular")) type = "file"
+    const size = Number(sizeStr)
+    const mtimeSec = Number(mtimeStr)
+    return {
+      type,
+      size: Number.isFinite(size) ? size : 0,
+      mtime: Number.isFinite(mtimeSec) && mtimeSec > 0 ? new Date(mtimeSec * 1000) : null,
+    }
+  }
+
+  // ------------- backend factory -------------
+
+  export const make = (config: Config): Effect.Effect<Workspace.Backend> =>
+    Effect.sync(() => {
+      const rootPath = config.worktree ?? DEFAULT_WORKTREE
+      const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS
+      const watchPollMs = config.watchPollMs ?? DEFAULT_WATCH_POLL_MS
+      const sandboxName = nameFor(config.directory)
+
+      const credentials = {
+        token: config.token,
+        teamId: config.teamId,
+        projectId: config.projectId,
+      }
+
+      // ---- lazy sandbox resolution ----
+
+      let sandboxPromise: Promise<Sandbox> | null = null
+
+      const getSandbox = (): Promise<Sandbox> => {
+        if (sandboxPromise) return sandboxPromise
+        sandboxPromise = (async () => {
+          try {
+            return await Sandbox.get({ name: sandboxName, ...credentials })
+          } catch (err: any) {
+            // The SDK throws ApiError-shaped objects with a `status` /
+            // `code`. 404 means "no such sandbox" — create one.
+            const status = err?.status ?? err?.statusCode ?? err?.response?.status
+            const code = err?.code ?? err?.error?.code
+            const isNotFound =
+              status === 404 ||
+              code === "not_found" ||
+              code === "sandbox_not_found" ||
+              /not.?found/i.test(String(err?.message ?? ""))
+            if (!isNotFound) {
+              sandboxPromise = null
+              throw err
+            }
+            const createParams: Parameters<typeof Sandbox.create>[0] = {
+              name: sandboxName,
+              persistent: true,
+              timeout: timeoutMs,
+              // :3000 hosts the exec gateway. Ports are fixed at
+              // sandbox-create time, so declare up-front even when the
+              // current session doesn't need execStream.
+              ports: [3000],
+              ...credentials,
+            } as Parameters<typeof Sandbox.create>[0]
+            if (config.snapshotId) {
+              ;(createParams as any).source = { type: "snapshot", snapshotId: config.snapshotId }
+            }
+            return await Sandbox.create(createParams)
+          }
+        })()
+        // Reset on hard failure so a future call may retry; resolved
+        // value is cached forever.
+        sandboxPromise.catch(() => {
+          sandboxPromise = null
+        })
+        return sandboxPromise
+      }
+
+      // ---- keepalive throttle ----
+
+      let lastExtend = 0
+      const KEEPALIVE_INTERVAL = Math.max(30_000, Math.floor(timeoutMs / 4))
+      const maybeExtend = async (sb: Sandbox): Promise<void> => {
+        const now = Date.now()
+        if (now - lastExtend < KEEPALIVE_INTERVAL) return
+        lastExtend = now
+        try {
+          await sb.extendTimeout(timeoutMs)
+        } catch (err) {
+          log.error("extendTimeout failed", {
+            sandbox: sandboxName,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+
+      const withSandbox = <A>(
+        method: string,
+        p: string | undefined,
+        fn: (sb: Sandbox) => Promise<A>,
+      ): Effect.Effect<A, WorkspaceErrors.BackendError> =>
+        Effect.tryPromise({
+          try: async () => {
+            const sb = await getSandbox()
+            // Fire-and-forget keepalive so primitives stay fast.
+            maybeExtend(sb).catch(() => {})
+            return await fn(sb)
+          },
+          catch: toBackendError(method, p),
+        })
+
+      // ---- host→sandbox path aliasing ----
+      //
+      // opencode business logic treats `Instance.directory` (a host-
+      // side canonical path, e.g. `/private/var/folders/.../oc-proof-…`)
+      // as the absolute root of the agent's workspace. On LocalBackend
+      // that path IS the workspace. On VercelBackend the real workspace
+      // lives at `rootPath` (e.g. `/vercel/sandbox`) inside the sandbox
+      // filesystem, so any inbound path rooted under the host
+      // Instance.directory is an alias for the same location under
+      // rootPath.
+      //
+      // The backend is the only layer allowed to know both identifiers,
+      // so the translation lives here. Every primitive that takes a
+      // path forwards it through `mapPath` before touching the sandbox
+      // SDK. Paths not rooted under the alias pass through unchanged
+      // (absolute sandbox-local paths are legal too).
+      const hostDir = config.directory.replace(/\/+$/, "")
+      const mapPath = (p: string | undefined): string | undefined => {
+        if (p === undefined) return undefined
+        if (p === hostDir) return rootPath
+        if (p.startsWith(hostDir + "/")) return rootPath + p.slice(hostDir.length)
+        return p
+      }
+
+      // ---- raw shell helper used by stat/readDir/exists/remove/rename/mkDir ----
+
+      const runShell = async (
+        sb: Sandbox,
+        script: string,
+      ): Promise<{ exitCode: number; stdout: string; stderr: string }> => {
+        const finished = await sb.runCommand({ cmd: "bash", args: ["-lc", script] })
+        const [stdout, stderr] = await Promise.all([finished.stdout(), finished.stderr()])
+        return { exitCode: finished.exitCode, stdout, stderr }
+      }
+
+      // ---- fs primitives ----
+
+      const stat: Workspace.Backend["stat"] = (p) =>
+        withSandbox("stat", p, async (sb) => {
+          const sp = mapPath(p)!
+          const res = await runShell(sb, `stat -c '%F|%s|%Y' ${shq(sp)}`)
+          if (res.exitCode !== 0) {
+            throw new Error(`stat failed (${res.exitCode}): ${res.stderr.trim()}`)
+          }
+          const info = parseStatLine(res.stdout.trim())
+          if (!info) throw new Error(`stat: unparsable output: ${res.stdout}`)
+          return info
+        })
+
+      const exists: Workspace.Backend["exists"] = (p) =>
+        withSandbox("exists", p, async (sb) => {
+          const sp = mapPath(p)!
+          const res = await runShell(sb, `test -e ${shq(sp)}`)
+          return res.exitCode === 0
+        })
+
+      // `sb.readFileToBuffer` and `sb.writeFiles` only accept paths
+      // inside the sandbox's worktree (the server rejects anything
+      // else with HTTP 400). opencode business logic freely writes
+      // outside the worktree — /tmp/, /var/, absolute paths the agent
+      // chooses, etc. — and on LocalBackend that works because the
+      // whole filesystem IS the host. To match that semantics we
+      // detect the worktree boundary and fall back to shell I/O for
+      // paths outside it.
+      const inWorktree = (sp: string) => sp === rootPath || sp.startsWith(rootPath + "/")
+
+      const readFile: Workspace.Backend["readFile"] = (p) =>
+        withSandbox("readFile", p, async (sb) => {
+          const sp = mapPath(p)!
+          if (inWorktree(sp)) {
+            const buf = await sb.readFileToBuffer({ path: sp })
+            if (buf === null) throw new Error(`ENOENT: ${sp}`)
+            return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+          }
+          // Out-of-worktree fallback: `cat` + base64 to survive binary.
+          const res = await runShell(sb, `base64 -w0 ${shq(sp)} 2>/dev/null || base64 ${shq(sp)}`)
+          if (res.exitCode !== 0) {
+            throw new Error(`readFile failed (${res.exitCode}): ${res.stderr.trim() || `ENOENT: ${sp}`}`)
+          }
+          // BSD `base64` wraps at 76 cols; strip whitespace before decoding.
+          const b64 = res.stdout.replace(/\s+/g, "")
+          return new Uint8Array(Buffer.from(b64, "base64"))
+        })
+
+      // Raw write — Backend contract is "no auto-mkdir". Consumers
+      // (Workspace.Service) are responsible for creating parent
+      // directories before calling this. Enforce with `test -d` first.
+      const writeFile: Workspace.Backend["writeFile"] = (p, data) =>
+        withSandbox("writeFile", p, async (sb) => {
+          const sp = mapPath(p)!
+          const slash = sp.lastIndexOf("/")
+          if (slash > 0) {
+            const parent = sp.slice(0, slash)
+            const check = await runShell(sb, `test -d ${shq(parent)}`)
+            if (check.exitCode !== 0) {
+              throw new Error(`ENOENT: parent directory does not exist: ${parent}`)
+            }
+          }
+          if (inWorktree(sp)) {
+            await sb.writeFiles([{ path: sp, content: data }])
+            return
+          }
+          // Out-of-worktree fallback. sb.writeFiles rejects paths
+          // outside the worktree with HTTP 400, so stream bytes through
+          // a single shell command that base64-decodes into the target.
+          const bytes = typeof data === "string" ? new TextEncoder().encode(data) : data
+          const b64 = Buffer.from(bytes).toString("base64")
+          const res = await runShell(
+            sb,
+            `printf '%s' ${shq(b64)} | base64 -d > ${shq(sp)}`,
+          )
+          if (res.exitCode !== 0) {
+            throw new Error(`writeFile failed (${res.exitCode}): ${res.stderr.trim()}`)
+          }
+        })
+
+      const mkDir: Workspace.Backend["mkDir"] = (p, opts) =>
+        withSandbox("mkDir", p, async (sb) => {
+          const sp = mapPath(p)!
+          if (opts.recursive) {
+            const res = await runShell(sb, `mkdir -p ${shq(sp)}`)
+            if (res.exitCode !== 0) throw new Error(`mkdir -p failed: ${res.stderr.trim()}`)
+            return
+          }
+          // Non-recursive: prefer the SDK helper if available.
+          if (typeof (sb as { mkDir?: unknown }).mkDir === "function") {
+            await (sb as { mkDir: (path: string) => Promise<void> }).mkDir(sp)
+            return
+          }
+          const res = await runShell(sb, `mkdir ${shq(sp)}`)
+          if (res.exitCode !== 0) throw new Error(`mkdir failed: ${res.stderr.trim()}`)
+        })
+
+      const readDir: Workspace.Backend["readDir"] = (p) =>
+        withSandbox("readDir", p, async (sb) => {
+          const sp = mapPath(p)!
+          // GNU find with NUL-delimited records, format `name\ttype`
+          // where `type` is one of f/d/l/etc.
+          const script = `find ${shq(sp)} -mindepth 1 -maxdepth 1 -printf '%f\t%y\\0'`
+          const res = await runShell(sb, script)
+          if (res.exitCode !== 0) {
+            throw new Error(`readDir failed (${res.exitCode}): ${res.stderr.trim()}`)
+          }
+          const records = res.stdout.split("\0").filter((r) => r.length > 0)
+          const entries: Workspace.DirEntry[] = []
+          for (const rec of records) {
+            const tab = rec.lastIndexOf("\t")
+            if (tab < 0) continue
+            const name = rec.slice(0, tab)
+            const t = rec.slice(tab + 1)
+            let type: Workspace.FileType = "other"
+            if (t === "f") type = "file"
+            else if (t === "d") type = "directory"
+            else if (t === "l") type = "symlink"
+            entries.push({ name, type })
+          }
+          return entries
+        })
+
+      const remove: Workspace.Backend["remove"] = (p, opts) =>
+        withSandbox("remove", p, async (sb) => {
+          const sp = mapPath(p)!
+          const flags = opts.recursive ? "-r" : ""
+          const res = await runShell(sb, `rm ${flags} ${shq(sp)}`)
+          if (res.exitCode !== 0) throw new Error(`rm failed: ${res.stderr.trim()}`)
+        })
+
+      const rename: Workspace.Backend["rename"] = (from, to) =>
+        withSandbox("rename", from, async (sb) => {
+          const sFrom = mapPath(from)!
+          const sTo = mapPath(to)!
+          const res = await runShell(sb, `mv ${shq(sFrom)} ${shq(sTo)}`)
+          if (res.exitCode !== 0) throw new Error(`mv failed: ${res.stderr.trim()}`)
+        })
+
+      // ---- exec (one-shot, via sb.runCommand directly) ----
+      //
+      // L4 services (Format, Snapshot, File, FileTime, stat/readDir/
+      // exists/remove/rename helpers) do dozens of one-shot exec calls
+      // per operation. Routing these through the WebSocket gateway would
+      // force a ~500ms handshake + auth + spawn frame per call. The
+      // gateway path is reserved for `execStream` only (LSP + anything
+      // needing true bidirectional I/O).
+      const exec: Workspace.Backend["exec"] = (cmd, args, opts) =>
+        withSandbox("exec", undefined, async (sb) => {
+          const cwd = mapPath(opts?.cwd) ?? rootPath
+          // `sb.runCommand` merges env with the container's default when
+          // `env` is omitted; we pass it only if the caller provided one.
+          const params: Parameters<typeof sb.runCommand>[0] = opts?.env
+            ? ({
+                cmd,
+                args,
+                cwd,
+                env: opts.env,
+              } as Parameters<typeof sb.runCommand>[0])
+            : ({
+                cmd,
+                args,
+                cwd,
+              } as Parameters<typeof sb.runCommand>[0])
+          const finished = await sb.runCommand(params as any)
+          const [stdout, stderr] = await Promise.all([finished.stdout(), finished.stderr()])
+          const result: Workspace.ExecResult = {
+            exitCode: finished.exitCode ?? -1,
+            stdout,
+            stderr,
+          }
+          return result
+        })
+
+      // ---- execStream (bidirectional, via in-sandbox WebSocket gateway) ----
+      //
+      // True live stdio: each call opens a fresh WebSocket to the
+      // in-sandbox gateway daemon, which spawns the child process and
+      // pipes its real stdin/stdout/stderr over the socket. Writes to
+      // the returned `stdin` Sink land in a still-alive process — LSP
+      // JSON-RPC round trips work correctly.
+      //
+      // ExecOpts.signal and ExecOpts.timeoutMs are honoured via
+      // post-composition: if a timeout is set, we race the returned
+      // `exitCode` effect against a timeout; if a signal is supplied,
+      // we fork a listener that triggers `handle.kill` on abort.
+      const execStream: Workspace.Backend["execStream"] = (cmd, args, opts) =>
+        Effect.gen(function* () {
+          const sb = yield* Effect.tryPromise({
+            try: () => getSandbox(),
+            catch: toBackendError("execStream.getSandbox"),
+          })
+          maybeExtend(sb).catch(() => {})
+
+          const baseHandle = yield* openExecChannel(sb, {
+            cmd,
+            args: args ?? [],
+            cwd: mapPath(opts?.cwd) ?? rootPath,
+            env: opts?.env,
+          })
+
+          // Feed eager opts.stdin into the Sink up-front. Callers that
+          // want fully interactive I/O drive `baseHandle.stdin`
+          // directly from their own Stream.
+          if (opts?.stdin !== undefined) {
+            const bytes =
+              typeof opts.stdin === "string" ? new TextEncoder().encode(opts.stdin) : opts.stdin
+            yield* Stream.fromIterable([bytes]).pipe(Stream.run(baseHandle.stdin), Effect.ignore)
+          }
+
+          // Honour ExecOpts.signal: abort → kill.
+          if (opts?.signal) {
+            const ext = opts.signal
+            const onAbort = () => Effect.runFork(baseHandle.kill)
+            if (ext.aborted) onAbort()
+            else ext.addEventListener("abort", onAbort, { once: true })
+            yield* Effect.addFinalizer(() =>
+              Effect.sync(() => ext.removeEventListener("abort", onAbort)),
+            )
+          }
+
+          // Optional timeout: if exitCode doesn't arrive in time, kill
+          // the child and surface a BackendError.
+          const exitCode: Effect.Effect<number | null, WorkspaceErrors.BackendError> = opts?.timeoutMs
+            ? Effect.timeoutOrElse(baseHandle.exitCode, {
+                duration: `${opts.timeoutMs} millis`,
+                orElse: () =>
+                  Effect.gen(function* () {
+                    yield* baseHandle.kill.pipe(Effect.ignore)
+                    return yield* Effect.fail(
+                      toBackendError("execStream.timeout")(
+                        new Error(`exec timed out after ${opts.timeoutMs}ms`),
+                      ),
+                    )
+                  }),
+              })
+            : baseHandle.exitCode
+
+          const result: Workspace.ExecStreamHandle = {
+            stdin: baseHandle.stdin,
+            stdout: baseHandle.stdout,
+            stderr: baseHandle.stderr,
+            all: baseHandle.all,
+            exitCode,
+            kill: baseHandle.kill,
+          }
+          return result
+        })
+
+      // ---- watch (polling) ----
+
+      /**
+       * Polling watcher with `watchPollMs` latency (default 2000ms).
+       *
+       * On each tick we list the directory + stat each entry and diff
+       * against the previous snapshot:
+       *   - new name           → "add"
+       *   - mtime/size changed → "change"
+       *   - vanished name      → "unlink"
+       *
+       */
+      const watch: Workspace.Backend["watch"] = (p, opts) =>
+        Stream.callback<Workspace.FsEvent, WorkspaceErrors.BackendError>((q) =>
+          Effect.gen(function* () {
+            const sp = mapPath(p)!
+            interface Snapshot {
+              readonly mtime: number
+              readonly size: number
+            }
+            let previous = new Map<string, Snapshot>()
+            let stopped = false
+
+            yield* Effect.addFinalizer(() => Effect.sync(() => (stopped = true)))
+
+            // find(1) -not -path filters: one per ignore pattern. Match the
+            // pattern as a substring under the watch root. Keeps the event
+            // surface comparable to parcel's `ignore` list.
+            const ignoreClauses = (opts?.ignore ?? [])
+              .map((ig) => ` -not -path ${shq(`*/${ig}*`)} -not -path ${shq(`*/${ig}`)}`)
+              .join("")
+
+            const snapshot = async (): Promise<Map<string, Snapshot>> => {
+              const sb = await getSandbox()
+              const script =
+                `find ${shq(sp)} -mindepth 1 -maxdepth 1 -type f${ignoreClauses} ` +
+                `-printf '%f\t%s\t%T@\\0'`
+              const res = await runShell(sb, script)
+              const next = new Map<string, Snapshot>()
+              if (res.exitCode !== 0) return next
+              for (const rec of res.stdout.split("\0")) {
+                if (!rec) continue
+                const parts = rec.split("\t")
+                if (parts.length < 3) continue
+                const [name, sizeStr, mtimeStr] = parts
+                next.set(name, {
+                  size: Number(sizeStr) || 0,
+                  mtime: Number(mtimeStr) || 0,
+                })
+              }
+              return next
+            }
+
+            const tick = async (): Promise<void> => {
+              try {
+                const next = await snapshot()
+                for (const [name, info] of next) {
+                  const prev = previous.get(name)
+                  const fullPath = `${p}/${name}`
+                  if (!prev) {
+                    Queue.offerUnsafe(q, { type: "add", path: fullPath })
+                  } else if (prev.mtime !== info.mtime || prev.size !== info.size) {
+                    Queue.offerUnsafe(q, { type: "change", path: fullPath })
+                  }
+                }
+                for (const name of previous.keys()) {
+                  if (!next.has(name)) {
+                    Queue.offerUnsafe(q, { type: "unlink", path: `${p}/${name}` })
+                  }
+                }
+                previous = next
+              } catch (err) {
+                Queue.failCauseUnsafe(q, Cause.fail(toBackendError("watch", p)(err)))
+                stopped = true
+              }
+            }
+
+            // Prime the baseline snapshot WITHOUT emitting events.
+            // Any pre-existing file should not surface as an "add" on
+            // the first real tick.
+            previous = yield* Effect.promise(() => snapshot())
+
+            // Spawn a polling loop on a forked fiber so the Stream
+            // finalization can interrupt it cleanly.
+            yield* Effect.forkScoped(
+              Effect.gen(function* () {
+                while (!stopped) {
+                  yield* Effect.sleep(`${watchPollMs} millis`)
+                  if (stopped) break
+                  yield* Effect.promise(() => tick())
+                }
+              }),
+            )
+          }),
+        )
+
+      // ---- close ----
+
+      // We deliberately do NOT stop the sandbox on `close`. The whole
+      // point of `persistent: true` is that the filesystem outlives a
+      // single opencode session — stopping here would defeat that. The
+      // conformance runner stops sandboxes explicitly in its cleanup
+      // hook so this stays a no-op.
+      const close: Effect.Effect<void> = Effect.void
+
+      const id = `${BACKEND_ID}:${sandboxName}`
+
+      const backend: Workspace.Backend = {
+        id,
+        rootPath,
+        // The sandbox image is Amazon Linux 2023 — zsh isn't installed
+        // and only bash/sh are available. Hardcoding /bin/bash keeps
+        // cross-substrate flows (macOS host driving a Linux sandbox)
+        // from asking the sandbox to spawn a shell it doesn't have.
+        shell: "/bin/bash",
+        stat,
+        exists,
+        readFile,
+        writeFile,
+        mkDir,
+        readDir,
+        remove,
+        rename,
+        exec,
+        execStream: execStream as Workspace.Backend["execStream"],
+        watch,
+        close,
+      }
+      return backend
+    })
+}

--- a/packages/opencode/src/workspace/errors.ts
+++ b/packages/opencode/src/workspace/errors.ts
@@ -1,0 +1,10 @@
+import { Schema } from "effect"
+
+export namespace Workspace {
+  export class BackendError extends Schema.TaggedErrorClass<BackendError>()("WorkspaceBackendError", {
+    backend: Schema.String,
+    method: Schema.String,
+    path: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect),
+  }) {}
+}

--- a/packages/opencode/src/workspace/helpers/is-binary.ts
+++ b/packages/opencode/src/workspace/helpers/is-binary.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure binary-file detection. Two signals:
+ *
+ *   1. Extension is on a known-binary list (zip/tar/exe/etc).
+ *   2. First ~4 KB of bytes contains a NUL, or > 30% non-printable
+ *      characters.
+ *
+ * The caller passes the extension separately so this helper stays pure
+ * (no path parsing, no fs). Workspace.Primitives.isBinary wires this to
+ * `path.extname(p).toLowerCase()` + a single `readFile` call.
+ */
+
+const KNOWN_BINARY_EXT: ReadonlySet<string> = new Set<string>([
+  ".zip",
+  ".tar",
+  ".gz",
+  ".exe",
+  ".dll",
+  ".so",
+  ".class",
+  ".jar",
+  ".war",
+  ".7z",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  ".odt",
+  ".ods",
+  ".odp",
+  ".bin",
+  ".dat",
+  ".obj",
+  ".o",
+  ".a",
+  ".lib",
+  ".wasm",
+  ".pyc",
+  ".pyo",
+])
+
+export function isBinaryBytes(ext: string, bytes: Uint8Array): boolean {
+  if (KNOWN_BINARY_EXT.has(ext.toLowerCase())) return true
+  if (bytes.length === 0) return false
+  const sample = Math.min(4096, bytes.length)
+  let nonPrintable = 0
+  for (let i = 0; i < sample; i++) {
+    const b = bytes[i]
+    if (b === 0) return true
+    // Accept \t (9), \n (10), \v (11), \f (12), \r (13), and 32..126 printable
+    if (b < 9 || (b > 13 && b < 32)) nonPrintable++
+  }
+  return nonPrintable / sample > 0.3
+}

--- a/packages/opencode/src/workspace/helpers/lines.ts
+++ b/packages/opencode/src/workspace/helpers/lines.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure line-slicing helper used by Workspace.Primitives.readFileLines.
+ *
+ * Operates on raw UTF-8 bytes so it is substrate-agnostic: whether the
+ * bytes came from a local file or a remote sandbox, the algorithm is
+ * identical.
+ */
+
+export interface LinesView {
+  /** The sliced, possibly-truncated lines. */
+  readonly raw: string[]
+  /** Total number of lines encountered up to where we stopped. */
+  readonly count: number
+  /**
+   * True if the slice stopped because the cumulative byte budget was
+   * exceeded — callers often use this to hint "content was truncated".
+   */
+  readonly cut: boolean
+  /** True if more lines exist beyond what we returned. */
+  readonly more: boolean
+  /** Echo of `opts.offset` so callers can trace back. */
+  readonly offset: number
+}
+
+const MAX_LINE_LENGTH = 2000
+const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
+const MAX_BYTES = 50 * 1024
+
+/**
+ * Slice `bytes` into a LinesView given a 1-based `offset` and `limit`.
+ *
+ *  - Lines are split by `\n` / `\r\n` (crlfDelay).
+ *  - Lines longer than MAX_LINE_LENGTH are truncated with a suffix.
+ *  - Total byte budget is MAX_BYTES; exceeding it sets `cut = more = true`.
+ *  - `offset` is 1-based (matches the tool-facing contract in v1).
+ */
+export function sliceLines(bytes: Uint8Array, opts: { offset: number; limit: number }): LinesView {
+  const text = new TextDecoder("utf8").decode(bytes)
+  // Normalize CRLF so line counts match the tool-level contract.
+  const allLines = text.split(/\r?\n/)
+  // A trailing "" from a final newline should NOT count as an extra
+  // line. v1 used readline which elides it too.
+  if (allLines.length > 0 && allLines[allLines.length - 1] === "") allLines.pop()
+
+  const start = opts.offset - 1
+  const raw: string[] = []
+  let bytesUsed = 0
+  let count = 0
+  let cut = false
+  let more = false
+
+  for (let i = 0; i < allLines.length; i++) {
+    count += 1
+    if (count <= start) continue
+
+    if (raw.length >= opts.limit) {
+      more = true
+      continue
+    }
+
+    const src = allLines[i]
+    const line = src.length > MAX_LINE_LENGTH ? src.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : src
+    const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+    if (bytesUsed + size > MAX_BYTES) {
+      cut = true
+      more = true
+      break
+    }
+    raw.push(line)
+    bytesUsed += size
+  }
+
+  return { raw, count, cut, more, offset: opts.offset }
+}

--- a/packages/opencode/src/workspace/helpers/mailbox.ts
+++ b/packages/opencode/src/workspace/helpers/mailbox.ts
@@ -1,0 +1,163 @@
+/**
+ * mailbox — pure async-iterator fan-out for `cmd.logs()`.
+ *
+ * The Vercel sandbox SDK exposes a single `AsyncGenerator` that yields
+ * tagged `{ stream: "stdout" | "stderr", data: string }` chunks. Every
+ * consumer of the generator must share the same underlying source, but
+ * each downstream reader (stdout/stderr/all) wants its own queue with
+ * its own backpressure.
+ *
+ * `createMailboxFanout` solves this with a single driver task that
+ * consumes the source iterator once, classifies each chunk by tag, and
+ * pushes it into the matching mailboxes. Mailboxes are bounded async
+ * iterables backed by arrays + a resolver pair (no Effect dependency,
+ * so this file is host-runtime free and trivially unit-testable).
+ *
+ * The fan-out semantics:
+ *   - `stdout` receives every `{ stream: "stdout" }` chunk (decoded → bytes)
+ *   - `stderr` receives every `{ stream: "stderr" }` chunk (decoded → bytes)
+ *   - `all`    receives both, in driver order
+ *   - On driver completion, all three mailboxes finish (return done)
+ *   - On driver error, all three mailboxes throw the same error on the
+ *     next pull (consumers can decide to ignore via try/catch)
+ *
+ * The mailbox is intentionally not a Stream/Queue from Effect: that
+ * would couple the helper to the runtime and make the unit test require
+ * a runtime layer. The Vercel backend wraps each mailbox in
+ * `Stream.fromAsyncIterable` at the Backend boundary instead.
+ */
+
+export type LogChunk =
+  | { readonly stream: "stdout"; readonly data: string }
+  | { readonly stream: "stderr"; readonly data: string }
+
+export interface Mailbox<T> {
+  readonly iterator: AsyncIterableIterator<T>
+}
+
+export interface MailboxFanout {
+  readonly stdout: Mailbox<Uint8Array>
+  readonly stderr: Mailbox<Uint8Array>
+  readonly all: Mailbox<Uint8Array>
+  /** Resolves when the driver finishes (success or error). */
+  readonly done: Promise<void>
+}
+
+interface MailboxState<T> {
+  readonly buffer: T[]
+  done: boolean
+  error: unknown
+  resolve: (() => void) | null
+}
+
+const newMailbox = <T>(): { mb: Mailbox<T>; state: MailboxState<T> } => {
+  const state: MailboxState<T> = {
+    buffer: [],
+    done: false,
+    error: null,
+    resolve: null,
+  }
+
+  const wake = () => {
+    if (state.resolve) {
+      const r = state.resolve
+      state.resolve = null
+      r()
+    }
+  }
+
+  const iterator: AsyncIterableIterator<T> = {
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    async next(): Promise<IteratorResult<T>> {
+      while (true) {
+        if (state.buffer.length > 0) {
+          const value = state.buffer.shift()!
+          return { value, done: false }
+        }
+        if (state.error !== null) {
+          // Re-throw once; subsequent calls return done.
+          const err = state.error
+          state.error = null
+          state.done = true
+          throw err
+        }
+        if (state.done) return { value: undefined, done: true }
+        await new Promise<void>((res) => {
+          state.resolve = res
+        })
+      }
+    },
+    async return(): Promise<IteratorResult<T>> {
+      state.done = true
+      state.buffer.length = 0
+      wake()
+      return { value: undefined, done: true }
+    },
+  }
+
+  // Expose wake via a closure so the driver can push.
+  ;(state as any).__wake = wake
+  return { mb: { iterator }, state }
+}
+
+const push = <T>(state: MailboxState<T>, value: T): void => {
+  state.buffer.push(value)
+  ;(state as any).__wake?.()
+}
+
+const finish = <T>(state: MailboxState<T>, error?: unknown): void => {
+  if (error !== undefined) state.error = error
+  state.done = true
+  ;(state as any).__wake?.()
+}
+
+/**
+ * Fan-out one driver async-iterator into three mailboxes.
+ *
+ * The `decode` function is injected so tests can pass an identity
+ * decoder when working with strings, while production code passes a
+ * real `TextEncoder` to convert string log payloads into bytes.
+ */
+export const createMailboxFanout = (
+  source: AsyncIterable<LogChunk>,
+  options?: {
+    readonly encode?: (s: string) => Uint8Array
+  },
+): MailboxFanout => {
+  const encode = options?.encode ?? ((s: string) => new TextEncoder().encode(s))
+  const stdout = newMailbox<Uint8Array>()
+  const stderr = newMailbox<Uint8Array>()
+  const all = newMailbox<Uint8Array>()
+
+  const drive = async (): Promise<void> => {
+    try {
+      for await (const chunk of source) {
+        const bytes = encode(chunk.data)
+        if (chunk.stream === "stdout") {
+          push(stdout.state, bytes)
+        } else if (chunk.stream === "stderr") {
+          push(stderr.state, bytes)
+        }
+        push(all.state, bytes)
+      }
+      finish(stdout.state)
+      finish(stderr.state)
+      finish(all.state)
+    } catch (err) {
+      finish(stdout.state, err)
+      finish(stderr.state, err)
+      finish(all.state, err)
+    }
+  }
+
+  const done = drive()
+
+  return {
+    stdout: stdout.mb,
+    stderr: stderr.mb,
+    all: all.mb,
+    done,
+  }
+}

--- a/packages/opencode/src/workspace/helpers/ripgrep.ts
+++ b/packages/opencode/src/workspace/helpers/ripgrep.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for driving `rg`. No fs, no subprocess — the primitive
+ * layer calls `exec`/`execStream` through the Backend and feeds the
+ * stdout into `parseRgJsonLine`.
+ *
+ *   rgArgs(...)              → string[] argv (WITHOUT the rg binary path)
+ *   parseRgJsonLine(line)    → typed hit or null (non-match rows)
+ */
+
+export interface RgHit {
+  readonly path: { readonly text: string }
+  readonly lines: { readonly text: string }
+  readonly line_number: number
+  readonly absolute_offset: number
+  readonly submatches: ReadonlyArray<{
+    readonly match: { readonly text: string }
+    readonly start: number
+    readonly end: number
+  }>
+}
+
+export interface RgArgsInput {
+  readonly mode: "files" | "search"
+  readonly glob?: ReadonlyArray<string>
+  readonly hidden?: boolean
+  readonly follow?: boolean
+  readonly maxDepth?: number
+  readonly limit?: number
+  readonly pattern?: string
+  readonly file?: ReadonlyArray<string>
+}
+
+/**
+ * Build a ripgrep argv suffix (without the binary path at argv[0]).
+ * Matches the shape Ripgrep.args from v1 to preserve semantics.
+ */
+export function rgArgs(input: RgArgsInput): string[] {
+  const out: string[] = [input.mode === "search" ? "--json" : "--files", "--glob=!.git/*"]
+  if (input.follow) out.push("--follow")
+  if (input.hidden !== false) out.push("--hidden")
+  if (input.maxDepth !== undefined) out.push(`--max-depth=${input.maxDepth}`)
+  if (input.glob) {
+    for (const g of input.glob) out.push(`--glob=${g}`)
+  }
+  if (input.limit) out.push(`--max-count=${input.limit}`)
+  if (input.mode === "search") out.push("--no-messages")
+  if (input.pattern !== undefined) {
+    out.push("--", input.pattern)
+    if (input.file && input.file.length > 0) {
+      for (const f of input.file) out.push(f)
+    } else {
+      // Explicit "." forces rg to search the cwd instead of reading
+      // stdin when the spawn leaves stdin open (the default). Without
+      // this, rg --json with no path blocks forever waiting on stdin.
+      out.push(".")
+    }
+  }
+  return out
+}
+
+/**
+ * Parse a single `rg --json` stdout line into an RgHit, or `null` for
+ * non-match rows (begin/end/summary/invalid).
+ */
+export function parseRgJsonLine(line: string): RgHit | null {
+  if (!line) return null
+  try {
+    const row = JSON.parse(line)
+    if (row?.type !== "match") return null
+    const data = row.data
+    if (!data || typeof data !== "object") return null
+    if (!data.path?.text || !data.lines?.text || typeof data.line_number !== "number") return null
+    return data as RgHit
+  } catch {
+    return null
+  }
+}

--- a/packages/opencode/src/workspace/index.ts
+++ b/packages/opencode/src/workspace/index.ts
@@ -1,0 +1,470 @@
+// Workspace — substrate-agnostic tool-facing surface.
+//
+//   Primitives.Service  — L4-internal. Consumed by Format / LSP / FileTime
+//                         / Snapshot / Instruction / File / FileWatcher.
+//   Service.Tag         — L5-facing. Wraps Primitives with post-write
+//                         orchestration; returns {diagnostics} from writeFile.
+
+import { Context, Effect, Layer, Stream } from "effect"
+import path from "node:path"
+import type { Scope } from "effect/Scope"
+import type { Workspace as WorkspaceTypes } from "./types"
+import { WorkspaceError as WorkspaceErrorCls } from "./workspace-error"
+import { WorkspaceRouter } from "./router"
+import { sliceLines, type LinesView as LinesViewHelper } from "./helpers/lines"
+import { isBinaryBytes } from "./helpers/is-binary"
+import { parseRgJsonLine, rgArgs, type RgHit } from "./helpers/ripgrep"
+import { WorkspaceBus, WorkspaceFormat, WorkspaceLsp } from "./internal-services"
+
+export namespace Workspace {
+  // ------------- re-exports of the Backend-level types -------------
+
+  export type FileInfo = WorkspaceTypes.FileInfo
+  export type DirEntry = WorkspaceTypes.DirEntry
+  export type FsEvent = WorkspaceTypes.FsEvent
+  export type ExecOpts = WorkspaceTypes.ExecOpts
+  export type ExecResult = WorkspaceTypes.ExecResult
+  export type ExecStreamHandle = WorkspaceTypes.ExecStreamHandle
+  export type WatchOpts = WorkspaceTypes.WatchOpts
+
+  // ------------- Primitives-level types -------------
+
+  // Re-export the pure LinesView shape. Aliased to dodge a TS circular
+  // alias error (top-level `import { LinesView }` + `export LinesView`
+  // inside a namespace with the same name is illegal).
+  export interface LinesView extends Readonly<LinesViewHelper> {}
+  export interface LinesOpts {
+    readonly offset: number
+    readonly limit: number
+  }
+
+  export interface SearchHit {
+    readonly path: string
+    readonly lineNumber: number
+    readonly lineText: string
+    readonly absoluteOffset: number
+    readonly submatches: ReadonlyArray<{
+      readonly match: string
+      readonly start: number
+      readonly end: number
+    }>
+  }
+
+  export interface SearchResult {
+    readonly items: ReadonlyArray<SearchHit>
+    readonly partial: boolean
+  }
+
+  export interface SearchOpts {
+    readonly cwd?: string
+    readonly pattern: string
+    readonly glob?: ReadonlyArray<string>
+    readonly limit?: number
+    readonly follow?: boolean
+    readonly file?: ReadonlyArray<string>
+  }
+
+  export interface FilesOpts {
+    readonly cwd?: string
+    readonly glob?: ReadonlyArray<string>
+    readonly hidden?: boolean
+    readonly follow?: boolean
+    readonly maxDepth?: number
+  }
+
+  // Re-export the error class under the namespace so L4/L5 code can
+  // refer to `Workspace.WorkspaceError`. Aliased to dodge TS's ban on
+  // export-declarations inside a namespace.
+  export const WorkspaceError = WorkspaceErrorCls
+  export type WorkspaceError = WorkspaceErrorCls
+
+  // ------------- Primitives -------------
+
+  export namespace Primitives {
+    export interface Interface {
+      readonly rootPath: Effect.Effect<string, WorkspaceError>
+      /**
+       * Absolute path to the backend's preferred shell interpreter.
+       * Bash-tool callers should pass this to `execStream` instead of
+       * querying `process.env.SHELL` so that cross-substrate flows
+       * (macOS host → Linux sandbox) don't try to spawn a shell the
+       * backend's image doesn't provide.
+       */
+      readonly shell: Effect.Effect<string, WorkspaceError>
+      readonly stat: (p: string) => Effect.Effect<FileInfo, WorkspaceError>
+      readonly exists: (p: string) => Effect.Effect<boolean, WorkspaceError>
+      readonly readFile: (p: string) => Effect.Effect<Uint8Array, WorkspaceError>
+      readonly readFileString: (p: string) => Effect.Effect<string, WorkspaceError>
+      /** Raw write — does NOT create parents. Use writeFileWithDirs for that. */
+      readonly writeFile: (p: string, data: Uint8Array | string) => Effect.Effect<void, WorkspaceError>
+      readonly mkDir: (p: string, opts?: { recursive?: boolean }) => Effect.Effect<void, WorkspaceError>
+      readonly readDir: (p: string) => Effect.Effect<DirEntry[], WorkspaceError>
+      readonly remove: (p: string, opts?: { recursive?: boolean }) => Effect.Effect<void, WorkspaceError>
+      readonly rename: (from: string, to: string) => Effect.Effect<void, WorkspaceError>
+
+      readonly writeFileWithDirs: (p: string, data: Uint8Array | string) => Effect.Effect<void, WorkspaceError>
+      readonly readFileLines: (p: string, opts: LinesOpts) => Effect.Effect<LinesView, WorkspaceError>
+      readonly isBinary: (p: string, sizeBytes: number) => Effect.Effect<boolean, WorkspaceError>
+      readonly isDir: (p: string) => Effect.Effect<boolean, WorkspaceError>
+
+      readonly exec: (cmd: string, args: string[], opts?: ExecOpts) => Effect.Effect<ExecResult, WorkspaceError>
+      readonly execStream: (
+        cmd: string,
+        args: string[],
+        opts?: ExecOpts,
+      ) => Effect.Effect<ExecStreamHandle, WorkspaceError, Scope>
+
+      readonly search: (input: SearchOpts) => Effect.Effect<SearchResult, WorkspaceError>
+      readonly files: (input: FilesOpts) => Stream.Stream<string, WorkspaceError>
+
+      readonly watch: (p: string, opts?: WatchOpts) => Stream.Stream<FsEvent, WorkspaceError>
+
+      readonly resolve: (pathOrRelative: string) => Effect.Effect<string, WorkspaceError>
+      readonly containsPath: (absolutePath: string) => Effect.Effect<boolean, WorkspaceError>
+    }
+
+    export class Service extends Context.Service<Service, Interface>()("@opencode/WorkspacePrimitives") {}
+
+    // Internal helper — map a BackendError (or any thrown value) into
+    // a WorkspaceError so consumers see the Workspace-level error shape.
+    const wrapError = (method: string, p?: string) => (cause: unknown) =>
+      new WorkspaceError({
+        method,
+        path: p,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      })
+
+    export const layer: Layer.Layer<Service, never, WorkspaceRouter.Service> = Layer.effect(
+      Service,
+      Effect.gen(function* () {
+        const router = yield* WorkspaceRouter.Service
+
+        // All primitive calls go through `withBackend` so a router
+        // failure (misconfigured tenant) fails the specific call with a
+        // WorkspaceError rather than crashing the layer.
+        const withBackend = <A>(
+          method: string,
+          p: string | undefined,
+          fn: (b: WorkspaceTypes.Backend) => Effect.Effect<A, unknown>,
+        ): Effect.Effect<A, WorkspaceError> =>
+          router.backend.pipe(
+            Effect.flatMap((b) => fn(b).pipe(Effect.mapError(wrapError(method, p)))),
+          )
+
+        const withBackendScoped = <A>(
+          method: string,
+          p: string | undefined,
+          fn: (b: WorkspaceTypes.Backend) => Effect.Effect<A, unknown, Scope>,
+        ): Effect.Effect<A, WorkspaceError, Scope> =>
+          router.backend.pipe(
+            Effect.flatMap((b) => fn(b).pipe(Effect.mapError(wrapError(method, p)))),
+          ) as Effect.Effect<A, WorkspaceError, Scope>
+
+        const withBackendStream = <A>(
+          method: string,
+          p: string | undefined,
+          fn: (b: WorkspaceTypes.Backend) => Stream.Stream<A, unknown>,
+        ): Stream.Stream<A, WorkspaceError> =>
+          Stream.unwrap(
+            router.backend.pipe(
+              Effect.map((b) => fn(b).pipe(Stream.mapError(wrapError(method, p)))),
+            ),
+          ) as Stream.Stream<A, WorkspaceError>
+
+        // ---- basic forwards ----
+
+        const rootPath: Interface["rootPath"] = router.backend.pipe(
+          Effect.map((b) => b.rootPath),
+          Effect.mapError((err) =>
+            err instanceof WorkspaceError ? err : wrapError("rootPath")(err),
+          ),
+        )
+
+        const shell: Interface["shell"] = router.backend.pipe(
+          Effect.map((b) => b.shell),
+          Effect.mapError((err) =>
+            err instanceof WorkspaceError ? err : wrapError("shell")(err),
+          ),
+        )
+
+        const stat: Interface["stat"] = (p) => withBackend("stat", p, (b) => b.stat(p))
+        const exists: Interface["exists"] = (p) => withBackend("exists", p, (b) => b.exists(p))
+        const readFile: Interface["readFile"] = (p) => withBackend("readFile", p, (b) => b.readFile(p))
+
+        const readFileString: Interface["readFileString"] = (p) =>
+          readFile(p).pipe(Effect.map((bytes) => new TextDecoder("utf8").decode(bytes)))
+
+        const encodeMaybe = (data: Uint8Array | string): Uint8Array =>
+          typeof data === "string" ? new TextEncoder().encode(data) : data
+
+        const writeFile: Interface["writeFile"] = (p, data) =>
+          withBackend("writeFile", p, (b) => b.writeFile(p, encodeMaybe(data)))
+
+        const mkDir: Interface["mkDir"] = (p, opts) =>
+          withBackend("mkDir", p, (b) => b.mkDir(p, { recursive: opts?.recursive ?? false }))
+
+        const readDir: Interface["readDir"] = (p) => withBackend("readDir", p, (b) => b.readDir(p))
+
+        const remove: Interface["remove"] = (p, opts) =>
+          withBackend("remove", p, (b) => b.remove(p, { recursive: opts?.recursive ?? false }))
+
+        const rename: Interface["rename"] = (from, to) =>
+          withBackend("rename", from, (b) => b.rename(from, to))
+
+        // writeFileWithDirs = ensure parent chain then raw writeFile. We
+        // compute the parent via posix.dirname — every Backend rootPath
+        // is POSIX-shaped for v2 tenants.
+        const writeFileWithDirs: Interface["writeFileWithDirs"] = (p, data) =>
+          Effect.gen(function* () {
+            const parent = path.posix.dirname(p)
+            if (parent && parent !== "." && parent !== "/") {
+              yield* mkDir(parent, { recursive: true })
+            }
+            yield* writeFile(p, data)
+          })
+
+        // readFileLines = readFile + pure sliceLines.
+        const readFileLines: Interface["readFileLines"] = (p, opts) =>
+          readFile(p).pipe(Effect.map((bytes) => sliceLines(bytes, opts)))
+
+        // isBinary: stat-size threshold + small read + helper. sizeBytes
+        // is a hint from the caller so we can short-circuit huge files.
+        const isBinary: Interface["isBinary"] = (p, _sizeBytes) => {
+          const ext = path.extname(p).toLowerCase()
+          // Known-binary extensions short-circuit without reading.
+          if (isBinaryBytes(ext, new Uint8Array(0))) return Effect.succeed(true)
+          // Otherwise read the file (helper samples first 4 KB).
+          return readFile(p).pipe(Effect.map((bytes) => isBinaryBytes(ext, bytes)))
+        }
+
+        const isDir: Interface["isDir"] = (p) =>
+          stat(p).pipe(
+            Effect.map((info) => info.type === "directory"),
+            Effect.catch(() => Effect.succeed(false)),
+          )
+
+        // ---- exec ----
+
+        const exec: Interface["exec"] = (cmd, args, opts) =>
+          withBackend("exec", undefined, (b) => b.exec(cmd, args, opts))
+
+        const execStream: Interface["execStream"] = (cmd, args, opts) =>
+          withBackendScoped("execStream", undefined, (b) => b.execStream(cmd, args, opts))
+
+        // search / files shell out to `rg` via Backend.exec so the
+        // command runs in the tenant substrate. If `rg` is missing we
+        // fail with a WorkspaceError rather than leaking the spawn shape.
+
+        const search: Interface["search"] = (input) =>
+          Effect.gen(function* () {
+            const b = yield* router.backend
+            const cwd = input.cwd ?? b.rootPath
+            const argv = rgArgs({
+              mode: "search",
+              glob: input.glob ? [...input.glob] : undefined,
+              follow: input.follow,
+              limit: input.limit,
+              pattern: input.pattern,
+              file: input.file ? [...input.file] : undefined,
+            })
+            const result = yield* b
+              .exec("rg", argv, { cwd })
+              .pipe(Effect.mapError(wrapError("search", cwd)))
+            // rg exit codes: 0 match, 1 no-match, 2 partial/io error.
+            // Accept 0/1/2 per upstream Ripgrep.search.
+            if (result.exitCode !== 0 && result.exitCode !== 1 && result.exitCode !== 2) {
+              return yield* Effect.fail(
+                new WorkspaceError({
+                  method: "search",
+                  cause: new Error(`rg failed exit=${result.exitCode}: ${result.stderr}`),
+                }),
+              )
+            }
+            const items: SearchHit[] = []
+            for (const line of result.stdout.split("\n")) {
+              const hit: RgHit | null = parseRgJsonLine(line)
+              if (!hit) continue
+              items.push({
+                path: hit.path.text,
+                lineNumber: hit.line_number,
+                lineText: hit.lines.text,
+                absoluteOffset: hit.absolute_offset,
+                submatches: hit.submatches.map((sm) => ({
+                  match: sm.match.text,
+                  start: sm.start,
+                  end: sm.end,
+                })),
+              })
+            }
+            const partial = result.exitCode === 2
+            return { items, partial } as SearchResult
+          })
+
+        const files: Interface["files"] = (input) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const b = yield* router.backend
+              const cwd = input.cwd ?? b.rootPath
+              const argv = rgArgs({
+                mode: "files",
+                glob: input.glob ? [...input.glob] : undefined,
+                hidden: input.hidden,
+                follow: input.follow,
+                maxDepth: input.maxDepth,
+              })
+              // exec then split — avoids needing streaming stdout from
+              // the backend for a first-cut implementation.
+              const result = yield* b
+                .exec("rg", argv, { cwd })
+                .pipe(Effect.mapError(wrapError("files", cwd)))
+              if (result.exitCode !== 0 && result.exitCode !== 1 && result.exitCode !== 2) {
+                return Stream.fail(
+                  new WorkspaceError({
+                    method: "files",
+                    cause: new Error(`rg failed exit=${result.exitCode}: ${result.stderr}`),
+                  }),
+                ) as Stream.Stream<string, WorkspaceError>
+              }
+              const lines = result.stdout.split("\n").filter((l) => l.length > 0)
+              return Stream.fromIterable(lines) as Stream.Stream<string, WorkspaceError>
+            }),
+          )
+
+        const watch: Interface["watch"] = (p, opts) => withBackendStream("watch", p, (b) => b.watch(p, opts))
+
+        // ---- resolve / containsPath ----
+        //
+        // resolve turns a relative path (or an absolute one already
+        // inside the workspace) into an absolute posix path under
+        // rootPath. This is purely a string operation — no realpath
+        // (that would require a backend round-trip and would leak host
+        // semantics into the remote sandbox).
+        const resolve: Interface["resolve"] = (pathOrRelative) =>
+          router.backend.pipe(
+            Effect.mapError((err) => (err instanceof WorkspaceError ? err : wrapError("resolve")(err))),
+            Effect.map((b) => {
+              if (path.posix.isAbsolute(pathOrRelative)) return pathOrRelative
+              return path.posix.join(b.rootPath, pathOrRelative)
+            }),
+          )
+
+        const containsPath: Interface["containsPath"] = (absolutePath) =>
+          router.backend.pipe(
+            Effect.mapError((err) => (err instanceof WorkspaceError ? err : wrapError("containsPath")(err))),
+            Effect.map((b) => {
+              if (!path.posix.isAbsolute(absolutePath)) return false
+              const rel = path.posix.relative(b.rootPath, absolutePath)
+              return rel === "" || (!rel.startsWith("..") && !path.posix.isAbsolute(rel))
+            }),
+          )
+
+        return Service.of({
+          rootPath,
+          shell,
+          stat,
+          exists,
+          readFile,
+          readFileString,
+          writeFile,
+          mkDir,
+          readDir,
+          remove,
+          rename,
+          writeFileWithDirs,
+          readFileLines,
+          isBinary,
+          isDir,
+          exec,
+          execStream,
+          search,
+          files,
+          watch,
+          resolve,
+          containsPath,
+        })
+      }),
+    )
+
+    export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(
+      Layer.provide(WorkspaceRouter.defaultLayer),
+    )
+  }
+
+  // ------------- Service (tool-facing wrapper) -------------
+
+  export namespace Service {
+    export interface WriteResult {
+      readonly diagnostics: Record<string, unknown[]>
+    }
+
+    export interface Interface extends Omit<Primitives.Interface, "writeFile" | "writeFileWithDirs"> {
+      readonly writeFile: (p: string, data: Uint8Array | string) => Effect.Effect<WriteResult, WorkspaceError>
+      readonly writeFileWithDirs: (p: string, data: Uint8Array | string) => Effect.Effect<WriteResult, WorkspaceError>
+    }
+
+    export class Tag extends Context.Service<Tag, Interface>()("@opencode/WorkspaceService") {}
+
+    export const layer: Layer.Layer<
+      Tag,
+      never,
+      Primitives.Service | WorkspaceFormat.Service | WorkspaceBus.Service | WorkspaceLsp.Service
+    > = Layer.effect(
+      Tag,
+      Effect.gen(function* () {
+        const primitives = yield* Primitives.Service
+        const format = yield* WorkspaceFormat.Service
+        const bus = yield* WorkspaceBus.Service
+        const lsp = yield* WorkspaceLsp.Service
+
+        // Shared post-write orchestration: format, publish events,
+        // re-open in LSP, collect diagnostics. With null providers
+        // this reduces to {diagnostics: {}}.
+        const orchestrate = (p: string): Effect.Effect<WriteResult, WorkspaceError> =>
+          Effect.gen(function* () {
+            yield* format.file(p).pipe(Effect.catch(() => Effect.void))
+            yield* bus.fileEdited(p)
+            yield* bus.fileWatcherUpdated(p, "change")
+            yield* lsp.touchFile(p, true).pipe(Effect.catch(() => Effect.void))
+            const diagnostics = yield* lsp
+              .diagnostics()
+              .pipe(Effect.catch(() => Effect.succeed({} as Record<string, unknown[]>)))
+            return { diagnostics }
+          })
+
+        const writeFile: Interface["writeFile"] = (p: string, data: Uint8Array | string) =>
+          primitives.writeFile(p, data).pipe(Effect.flatMap(() => orchestrate(p)))
+
+        const writeFileWithDirs: Interface["writeFileWithDirs"] = (p: string, data: Uint8Array | string) =>
+          primitives.writeFileWithDirs(p, data).pipe(Effect.flatMap(() => orchestrate(p)))
+
+        return Tag.of({
+          rootPath: primitives.rootPath,
+          shell: primitives.shell,
+          stat: primitives.stat,
+          exists: primitives.exists,
+          readFile: primitives.readFile,
+          readFileString: primitives.readFileString,
+          writeFile,
+          mkDir: primitives.mkDir,
+          readDir: primitives.readDir,
+          remove: primitives.remove,
+          rename: primitives.rename,
+          writeFileWithDirs,
+          readFileLines: primitives.readFileLines,
+          isBinary: primitives.isBinary,
+          isDir: primitives.isDir,
+          exec: primitives.exec,
+          execStream: primitives.execStream,
+          search: primitives.search,
+          files: primitives.files,
+          watch: primitives.watch,
+          resolve: primitives.resolve,
+          containsPath: primitives.containsPath,
+        })
+      }),
+    )
+
+    // defaultLayer lives in ./runtime.ts to avoid a module-eval cycle:
+    // Format/LSP/Bus/File/FileWatcher statically import this file.
+  }
+}

--- a/packages/opencode/src/workspace/internal-services.ts
+++ b/packages/opencode/src/workspace/internal-services.ts
@@ -1,0 +1,55 @@
+// Internal L4 surfaces used by Workspace.Service's post-write orchestration.
+// `nullLayer` provides no-op implementations for test fixtures that don't
+// wire the real Format/Bus/LSP graph. Real implementations live in
+// ./runtime.ts — the app-level assembly point.
+
+import { Context, Effect, Layer } from "effect"
+
+export namespace WorkspaceFormat {
+  export interface Interface {
+    readonly file: (path: string) => Effect.Effect<void>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/WorkspaceFormat") {}
+
+  export const nullLayer: Layer.Layer<Service> = Layer.succeed(
+    Service,
+    Service.of({
+      file: () => Effect.void,
+    }),
+  )
+}
+
+export namespace WorkspaceBus {
+  export interface Interface {
+    readonly fileEdited: (file: string) => Effect.Effect<void>
+    readonly fileWatcherUpdated: (file: string, event: "add" | "change" | "unlink") => Effect.Effect<void>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/WorkspaceBus") {}
+
+  export const nullLayer: Layer.Layer<Service> = Layer.succeed(
+    Service,
+    Service.of({
+      fileEdited: () => Effect.void,
+      fileWatcherUpdated: () => Effect.void,
+    }),
+  )
+}
+
+export namespace WorkspaceLsp {
+  export interface Interface {
+    readonly touchFile: (file: string, wait: boolean) => Effect.Effect<void>
+    readonly diagnostics: () => Effect.Effect<Record<string, unknown[]>>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/WorkspaceLsp") {}
+
+  export const nullLayer: Layer.Layer<Service> = Layer.succeed(
+    Service,
+    Service.of({
+      touchFile: () => Effect.void,
+      diagnostics: () => Effect.succeed({} as Record<string, unknown[]>),
+    }),
+  )
+}

--- a/packages/opencode/src/workspace/node-stream-adapters.ts
+++ b/packages/opencode/src/workspace/node-stream-adapters.ts
@@ -1,0 +1,119 @@
+// Effect ↔ Node stream bridges for LSP transport. `vscode-jsonrpc/node`
+// wants Node Readable/Writable; `Workspace.Primitives.execStream` yields
+// Effect Stream/Sink. These adapters bridge between the two.
+//
+// Critical: ONE long-lived `Stream.run(fromQueue, sink)` per writable.
+// Re-running the sink per chunk would fire `Sink.ensuring` after every
+// write, closing stdin and breaking LSP's bidirectional JSON-RPC.
+
+import { Cause, Effect, Fiber, ManagedRuntime, Queue, Scope, Sink, Stream } from "effect"
+import { Readable, Writable } from "stream"
+
+export type LspRuntime = ManagedRuntime.ManagedRuntime<never, never>
+
+const registerInterrupt = (
+  runtime: LspRuntime,
+  scope: Scope.Closeable,
+  fiber: Fiber.Fiber<unknown, unknown>,
+) => {
+  runtime.runFork(
+    Scope.addFinalizer(scope, Fiber.interrupt(fiber)) as Effect.Effect<void>,
+  )
+}
+
+export const streamToNodeReadable = <E>(
+  source: Stream.Stream<Uint8Array, E>,
+  runtime: LspRuntime,
+  scope: Scope.Closeable,
+): Readable => {
+  const readable = new Readable({
+    read() {
+      // Pull model; we push unconditionally.
+    },
+  })
+  let closed = false
+  const push = (chunk: Uint8Array | null) => {
+    if (closed) return
+    if (chunk === null) {
+      closed = true
+      readable.push(null)
+      return
+    }
+    readable.push(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+  }
+
+  const drain = Stream.runForEach(source, (chunk) =>
+    Effect.sync(() => push(chunk)),
+  ).pipe(
+    Effect.ensuring(Effect.sync(() => push(null))),
+    Effect.catchCause((cause: Cause.Cause<unknown>) =>
+      Effect.sync(() => {
+        if (closed) return
+        closed = true
+        readable.destroy(new Error(Cause.pretty(cause)))
+      }),
+    ),
+  )
+
+  const fiber = runtime.runFork(drain as Effect.Effect<void>)
+  registerInterrupt(runtime, scope, fiber)
+
+  readable.on("close", () => {
+    if (closed) return
+    closed = true
+    runtime.runFork(Fiber.interrupt(fiber) as Effect.Effect<void>)
+  })
+  return readable
+}
+
+export const sinkToNodeWritable = <E>(
+  sink: Sink.Sink<void, Uint8Array, never, E>,
+  runtime: LspRuntime,
+  scope: Scope.Closeable,
+): Writable => {
+  const queue = Effect.runSync(Queue.unbounded<Uint8Array, Cause.Done>())
+
+  const run = Stream.fromQueue(queue).pipe(
+    Stream.run(sink as Sink.Sink<void, Uint8Array, never, E>),
+    Effect.ignore,
+  )
+  const fiber = runtime.runFork(run as Effect.Effect<void>)
+  registerInterrupt(runtime, scope, fiber)
+
+  const writable = new Writable({
+    write(
+      chunk: Buffer | Uint8Array | string,
+      _encoding: BufferEncoding,
+      callback: (err?: Error | null) => void,
+    ) {
+      try {
+        const bytes: Uint8Array =
+          typeof chunk === "string"
+            ? new TextEncoder().encode(chunk)
+            : chunk instanceof Uint8Array
+              ? chunk
+              : new Uint8Array(chunk as any)
+        Queue.offerUnsafe(queue, bytes)
+        callback()
+      } catch (err) {
+        callback(err as Error)
+      }
+    },
+    final(callback: (err?: Error | null) => void) {
+      try {
+        Queue.endUnsafe(queue)
+        callback()
+      } catch (err) {
+        callback(err as Error)
+      }
+    },
+    destroy(err: Error | null, callback: (err?: Error | null) => void) {
+      try {
+        Queue.endUnsafe(queue)
+      } catch {}
+      runtime.runFork(Fiber.interrupt(fiber) as Effect.Effect<void>)
+      callback(err)
+    },
+  })
+  return writable
+}

--- a/packages/opencode/src/workspace/router.ts
+++ b/packages/opencode/src/workspace/router.ts
@@ -1,0 +1,97 @@
+// Per-Instance Backend selection. Precedence: Flag > Config > "local".
+// Errors surface at backend-access time, not layer-build time — a
+// misconfigured tenant fails only its own requests.
+
+import { Context, Effect, Layer } from "effect"
+import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
+import { Config } from "@/config/config"
+import { Flag } from "@/flag/flag"
+import { Instance } from "@/project/instance"
+import { InstanceState } from "@/effect/instance-state"
+import { LocalBackend } from "./backends/local"
+import { VercelBackend } from "./backends/vercel"
+import type { Workspace } from "./types"
+import { WorkspaceError } from "./workspace-error"
+
+type BackendKind = "local" | "vercel"
+
+const isBackendKind = (s: unknown): s is BackendKind => s === "local" || s === "vercel"
+
+export namespace WorkspaceRouter {
+  export interface Interface {
+    readonly backend: Effect.Effect<Workspace.Backend, WorkspaceError>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/WorkspaceRouter") {}
+
+  const pickBackendKind = (cfg: Config.Info): BackendKind => {
+    const flag = Flag.OPENCODE_WORKSPACE_BACKEND?.toLowerCase()
+    if (isBackendKind(flag)) return flag
+    const fromConfig = cfg.workspace?.backend
+    if (isBackendKind(fromConfig)) return fromConfig
+    return "local"
+  }
+
+  const toWorkspaceError =
+    (method: string) =>
+    (cause: unknown): WorkspaceError =>
+      new WorkspaceError({
+        method,
+        cause: cause instanceof Error ? cause : new Error(String(cause)),
+      })
+
+  export const layer: Layer.Layer<Service, never, Config.Service> = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const config = yield* Config.Service
+
+      const state = yield* InstanceState.make<Workspace.Backend, WorkspaceError>(
+        Effect.fn("WorkspaceRouter.state")(function* () {
+          const cfg = yield* config.get()
+          const kind = pickBackendKind(cfg)
+
+          if (kind === "local") {
+            return yield* LocalBackend.make({ worktree: Instance.worktree }).pipe(
+              Effect.provide(CrossSpawnSpawner.defaultLayer),
+            )
+          }
+
+          // vercel
+          const vcfg = (cfg.workspace?.backend === "vercel" ? cfg.workspace.vercel : undefined) ?? {}
+          const token = vcfg.token ?? process.env["VERCEL_TOKEN"]
+          const teamId = vcfg.teamId ?? process.env["VERCEL_TEAM_ID"]
+          const projectId = vcfg.projectId ?? process.env["VERCEL_PROJECT_ID"]
+          if (!token || !teamId || !projectId) {
+            return yield* Effect.fail(
+              new WorkspaceError({
+                method: "router.vercel.credentials",
+                cause: new Error(
+                  "vercel workspace backend requires VERCEL_TOKEN/VERCEL_TEAM_ID/VERCEL_PROJECT_ID (env or config.workspace.vercel.*)",
+                ),
+              }),
+            )
+          }
+          return yield* VercelBackend.make({
+            token,
+            teamId,
+            projectId,
+            directory: Instance.directory,
+            snapshotId: vcfg.snapshotId ?? process.env["VERCEL_SANDBOX_IMAGE_ID"],
+            timeoutMs: vcfg.timeoutMs,
+            worktree: vcfg.worktree,
+          })
+        }),
+      )
+
+      return Service.of({
+        backend: InstanceState.get(state).pipe(
+          Effect.mapError((err) =>
+            err instanceof (WorkspaceError as any) ? (err as WorkspaceError) : toWorkspaceError("router.backend")(err),
+          ),
+        ) as Effect.Effect<Workspace.Backend, WorkspaceError>,
+      })
+    }),
+  )
+
+  export const defaultLayer: Layer.Layer<Service, never, never> = layer.pipe(Layer.provide(Config.defaultLayer))
+}

--- a/packages/opencode/src/workspace/runtime.ts
+++ b/packages/opencode/src/workspace/runtime.ts
@@ -1,0 +1,63 @@
+// App-level composition point for Workspace.Service. Split from index.ts
+// so Format/Bus/LSP can be wired with ordinary imports without cycling
+// back through Primitives.
+
+import { Effect, Layer } from "effect"
+import { Workspace } from "./index"
+import { WorkspaceBus, WorkspaceFormat, WorkspaceLsp } from "./internal-services"
+import { Bus } from "@/bus"
+import { File } from "@/file"
+import { FileWatcher } from "@/file/watcher"
+import { Format } from "@/format"
+import { LSP } from "@/lsp"
+
+export namespace WorkspaceRuntime {
+  const workspaceFormatLayer: Layer.Layer<WorkspaceFormat.Service, never, never> = Layer.effect(
+    WorkspaceFormat.Service,
+    Effect.gen(function* () {
+      const format = yield* Format.Service
+      return WorkspaceFormat.Service.of({
+        file: (p: string) => format.file(p).pipe(Effect.catch(() => Effect.void)),
+      })
+    }),
+  ).pipe(Layer.provide(Format.defaultLayer))
+
+  // Publishes through the module-global Bus.publish static rather than
+  // yielding Bus.Service — matches the singleton bus the server runtime
+  // uses and keeps this layer's requirement set empty.
+  const workspaceBusLayer: Layer.Layer<WorkspaceBus.Service> = Layer.succeed(
+    WorkspaceBus.Service,
+    WorkspaceBus.Service.of({
+      fileEdited: (file) =>
+        Effect.promise(async () => {
+          await Bus.publish(File.Event.Edited, { file })
+        }).pipe(Effect.catch(() => Effect.void)),
+      fileWatcherUpdated: (file, event) =>
+        Effect.promise(async () => {
+          await Bus.publish(FileWatcher.Event.Updated, { file, event })
+        }).pipe(Effect.catch(() => Effect.void)),
+    }),
+  )
+
+  const workspaceLspLayer: Layer.Layer<WorkspaceLsp.Service, never, never> = Layer.effect(
+    WorkspaceLsp.Service,
+    Effect.gen(function* () {
+      const lsp = yield* LSP.Service
+      return WorkspaceLsp.Service.of({
+        touchFile: (file: string, wait: boolean) =>
+          lsp.touchFile(file, wait).pipe(Effect.catch(() => Effect.void)),
+        diagnostics: () =>
+          lsp
+            .diagnostics()
+            .pipe(Effect.catch(() => Effect.succeed({} as Record<string, unknown[]>))),
+      })
+    }),
+  ).pipe(Layer.provide(LSP.defaultLayer))
+
+  export const defaultLayer: Layer.Layer<Workspace.Service.Tag, never, never> = Workspace.Service.layer.pipe(
+    Layer.provide(Workspace.Primitives.defaultLayer),
+    Layer.provide(workspaceFormatLayer),
+    Layer.provide(workspaceBusLayer),
+    Layer.provide(workspaceLspLayer),
+  )
+}

--- a/packages/opencode/src/workspace/testing/throwing-backend.ts
+++ b/packages/opencode/src/workspace/testing/throwing-backend.ts
@@ -1,0 +1,33 @@
+import { Effect, Stream } from "effect"
+import { Workspace as WorkspaceErrors } from "../errors"
+import type { Workspace } from "../types"
+
+export const THROWING_BACKEND_MARKER = "throwing-backend"
+
+export namespace ThrowingBackend {
+  const err = (method: string, p?: string) =>
+    new WorkspaceErrors.BackendError({
+      backend: THROWING_BACKEND_MARKER,
+      method,
+      path: p,
+      cause: new Error(`${THROWING_BACKEND_MARKER}: ${method} not supported`),
+    })
+
+  export const make = (rootPath = "/throwing"): Workspace.Backend => ({
+    id: THROWING_BACKEND_MARKER,
+    rootPath,
+    shell: "/bin/sh",
+    close: Effect.void,
+    stat: (p) => Effect.fail(err("stat", p)),
+    exists: (p) => Effect.fail(err("exists", p)),
+    readFile: (p) => Effect.fail(err("readFile", p)),
+    writeFile: (p) => Effect.fail(err("writeFile", p)),
+    mkDir: (p) => Effect.fail(err("mkDir", p)),
+    readDir: (p) => Effect.fail(err("readDir", p)),
+    remove: (p) => Effect.fail(err("remove", p)),
+    rename: (from) => Effect.fail(err("rename", from)),
+    exec: () => Effect.fail(err("exec")),
+    execStream: () => Effect.fail(err("execStream")),
+    watch: (p) => Stream.fail(err("watch", p)),
+  })
+}

--- a/packages/opencode/src/workspace/types.ts
+++ b/packages/opencode/src/workspace/types.ts
@@ -1,0 +1,99 @@
+import type { Effect, Scope, Sink, Stream } from "effect"
+import { Workspace as WorkspaceErrors } from "./errors"
+
+export namespace Workspace {
+  export type FileType = "file" | "directory" | "symlink" | "other"
+
+  export interface FileInfo {
+    readonly type: FileType
+    readonly size: number
+    readonly mtime: Date | null
+  }
+
+  export interface DirEntry {
+    readonly name: string
+    readonly type: FileType
+  }
+
+  export interface ExecOpts {
+    readonly cwd?: string
+    readonly env?: Record<string, string>
+    readonly timeoutMs?: number
+    readonly signal?: AbortSignal
+    readonly stdin?: Uint8Array | string
+  }
+
+  export interface ExecResult {
+    readonly exitCode: number
+    readonly stdout: string
+    readonly stderr: string
+  }
+
+  export interface ExecStreamHandle {
+    readonly stdin: Sink.Sink<void, Uint8Array, never, WorkspaceErrors.BackendError>
+    readonly stdout: Stream.Stream<Uint8Array, WorkspaceErrors.BackendError>
+    readonly stderr: Stream.Stream<Uint8Array, WorkspaceErrors.BackendError>
+    readonly all: Stream.Stream<Uint8Array, WorkspaceErrors.BackendError>
+    readonly exitCode: Effect.Effect<number | null, WorkspaceErrors.BackendError>
+    readonly kill: Effect.Effect<void>
+  }
+
+  export type FsEventType = "add" | "change" | "unlink"
+  export interface FsEvent {
+    readonly type: FsEventType
+    readonly path: string
+  }
+
+  export interface WatchOpts {
+    /** Path patterns the backend should not emit events for. */
+    readonly ignore?: ReadonlyArray<string>
+  }
+
+  export interface Backend {
+    /** Opaque identifier. Callers MUST NOT parse this. */
+    readonly id: string
+
+    /** Absolute workspace root in the backend's own filesystem. */
+    readonly rootPath: string
+
+    /**
+     * Absolute path to the shell the backend wants callers to use for
+     * `execStream` / `exec`. Cross-substrate flows (macOS host → Linux
+     * sandbox) read this instead of `process.env.SHELL` so we don't try
+     * to spawn `/bin/zsh` in an image that only has `/bin/bash`.
+     */
+    readonly shell: string
+
+    readonly stat: (path: string) => Effect.Effect<FileInfo, WorkspaceErrors.BackendError>
+    readonly exists: (path: string) => Effect.Effect<boolean, WorkspaceErrors.BackendError>
+    readonly readFile: (path: string) => Effect.Effect<Uint8Array, WorkspaceErrors.BackendError>
+    /** Raw write. Does NOT create parent directories. */
+    readonly writeFile: (path: string, data: Uint8Array) => Effect.Effect<void, WorkspaceErrors.BackendError>
+    readonly mkDir: (
+      path: string,
+      opts: { readonly recursive: boolean },
+    ) => Effect.Effect<void, WorkspaceErrors.BackendError>
+    readonly readDir: (path: string) => Effect.Effect<DirEntry[], WorkspaceErrors.BackendError>
+    readonly remove: (
+      path: string,
+      opts: { readonly recursive: boolean },
+    ) => Effect.Effect<void, WorkspaceErrors.BackendError>
+    readonly rename: (from: string, to: string) => Effect.Effect<void, WorkspaceErrors.BackendError>
+
+    readonly exec: (
+      cmd: string,
+      args: string[],
+      opts?: ExecOpts,
+    ) => Effect.Effect<ExecResult, WorkspaceErrors.BackendError>
+
+    readonly execStream: (
+      cmd: string,
+      args: string[],
+      opts?: ExecOpts,
+    ) => Effect.Effect<ExecStreamHandle, WorkspaceErrors.BackendError, Scope.Scope>
+
+    readonly watch: (path: string, opts?: WatchOpts) => Stream.Stream<FsEvent, WorkspaceErrors.BackendError>
+
+    readonly close: Effect.Effect<void>
+  }
+}

--- a/packages/opencode/src/workspace/vercel-filewatcher.ts
+++ b/packages/opencode/src/workspace/vercel-filewatcher.ts
@@ -1,0 +1,18 @@
+// Vercel-backend FileWatcher.Service implementation.
+//
+// The host FileWatcher uses @parcel/watcher with a native binding,
+// which can't run inside a Vercel sandbox. On vercel mode the agent
+// is the only writer to the tenant filesystem, so external fs events
+// carry no information — a no-op service is the correct behavior.
+// FileWatcher.defaultLayer dispatches to this layer when
+// OPENCODE_WORKSPACE_BACKEND=vercel.
+
+import { Effect, Layer } from "effect"
+import { FileWatcher } from "@/file/watcher"
+
+export const layer: Layer.Layer<FileWatcher.Service> = Layer.succeed(
+  FileWatcher.Service,
+  FileWatcher.Service.of({
+    init: () => Effect.void,
+  }),
+)

--- a/packages/opencode/src/workspace/vercel-process.ts
+++ b/packages/opencode/src/workspace/vercel-process.ts
@@ -1,0 +1,156 @@
+// Vercel-backed implementation of `Process.spawn` from util/process.
+//
+// Process.spawn is sync and returns a Node ChildProcess-like object.
+// VercelBackend.execStream is async (WebSocket handshake). We bridge by
+// returning PassThrough streams immediately; writes queue until the
+// socket is ready, reads start flowing once the exec channel opens.
+//
+// The workspace/* module graph is NOT touched at top-level here — it
+// transitively pulls in @/global, which has a top-level `await`. That
+// TLA cannot be loaded during util/process's eval phase. Dynamic
+// `import()` inside the async setup defers the load until first call,
+// breaking the cycle.
+
+import { PassThrough, type Readable, type Writable } from "stream"
+import type { Process } from "../util/process"
+
+const POSIX_SHELL_ALLOWLIST: ReadonlySet<string> = new Set(["/bin/bash", "/bin/sh"])
+const remapShell = (shell: Process.Shell | undefined): string | undefined => {
+  if (shell === undefined || shell === false) return undefined
+  if (shell === true) return "/bin/bash"
+  return POSIX_SHELL_ALLOWLIST.has(shell) ? shell : "/bin/bash"
+}
+
+const buildEnv = (envOpt: Process.Options["env"]): Record<string, string> | undefined => {
+  if (envOpt === null) return {}
+  const base: Record<string, string> = {}
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) base[k] = v
+  if (envOpt) for (const [k, v] of Object.entries(envOpt)) if (typeof v === "string") base[k] = v
+  return base
+}
+
+type RuntimeHandle = {
+  run: <A>(eff: unknown) => Promise<A>
+  fork: (eff: unknown) => void
+}
+
+// Lazy module-wide runtime factory. First spawn call triggers the
+// dynamic imports; subsequent calls reuse the runtime. Returning the
+// shape as `any`-typed Effect handles keeps the top of this file free
+// of effect type imports.
+let runtimePromise: Promise<RuntimeHandle> | null = null
+const getRuntime = (): Promise<RuntimeHandle> => {
+  if (runtimePromise) return runtimePromise
+  runtimePromise = (async () => {
+    const { Layer, ManagedRuntime } = await import("effect")
+    const { Workspace } = await import("./index")
+    const rt = ManagedRuntime.make(Layer.mergeAll(Workspace.Primitives.defaultLayer))
+    return {
+      run: (eff: unknown) => rt.runPromise(eff as never) as Promise<any>,
+      fork: (eff: unknown) => {
+        rt.runFork(eff as never)
+      },
+    }
+  })()
+  return runtimePromise
+}
+
+export function spawnViaVercel(cmd: string[], opts: Process.Options = {}): Process.Child {
+  if (cmd.length === 0) throw new Error("Command is required")
+  opts.abort?.throwIfAborted()
+
+  const shellPath = remapShell(opts.shell)
+  const spawnCmd = shellPath ?? cmd[0]
+  const spawnArgs = shellPath ? ["-c", cmd.join(" ")] : cmd.slice(1)
+  const cwd = typeof opts.cwd === "string" ? opts.cwd : undefined
+  const env = buildEnv(opts.env)
+
+  const stdin = new PassThrough()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+
+  let exitCode: number | null = null
+  let signalCode: string | null = null
+  let pid: number | undefined
+  const killerBox: { current: (() => void) | null } = { current: null }
+  let resolveExited!: (code: number) => void
+  let rejectExited!: (err: unknown) => void
+  const exited = new Promise<number>((resolve, reject) => {
+    resolveExited = resolve
+    rejectExited = reject
+  })
+  exited.catch(() => undefined)
+
+  ;(async () => {
+    try {
+      const { Effect, Scope } = await import("effect")
+      const { Workspace } = await import("./index")
+      const { streamToNodeReadable, sinkToNodeWritable } = await import("./node-stream-adapters")
+
+      const rt = await getRuntime()
+      const scope = (Effect as any).runSync((Scope as any).make())
+      killerBox.current = () =>
+        rt.fork(
+          (Scope as any).close(scope, { _tag: "Success", value: undefined }),
+        )
+
+      const handle: any = await rt.run(
+        (Workspace.Primitives.Service.use as any)((ws: any) =>
+          ws.execStream(spawnCmd, spawnArgs, { cwd, env }).pipe(
+            (Effect as any).provideService((Scope as any).Scope, scope),
+          ),
+        ),
+      )
+
+      const outNode: Readable = streamToNodeReadable(handle.stdout, rt as any, scope)
+      const errNode: Readable = streamToNodeReadable(handle.stderr, rt as any, scope)
+      const inNode: Writable = sinkToNodeWritable(handle.stdin, rt as any, scope)
+
+      outNode.pipe(stdout)
+      errNode.pipe(stderr)
+      stdin.pipe(inNode)
+      outNode.on("error", (err) => stdout.destroy(err))
+      errNode.on("error", (err) => stderr.destroy(err))
+      inNode.on("error", (err) => stdin.destroy(err))
+
+      const code: number | null = await rt.run(
+        (Effect as any).catch((handle.exitCode as unknown), () => (Effect as any).succeed(null)),
+      )
+      exitCode = code ?? 0
+      resolveExited(code ?? 0)
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      stdout.destroy(error)
+      stderr.destroy(error)
+      stdin.destroy(error)
+      rejectExited(error)
+    }
+  })()
+
+  const childLike = {
+    stdin,
+    stdout,
+    stderr,
+    exited,
+    get exitCode() {
+      return exitCode
+    },
+    get signalCode() {
+      return signalCode
+    },
+    get pid() {
+      return pid
+    },
+    kill: (_signal?: any) => {
+      killerBox.current && killerBox.current()
+      return true
+    },
+  }
+
+  if (opts.abort) {
+    opts.abort.addEventListener("abort", () => killerBox.current && killerBox.current(), { once: true })
+    if (opts.abort.aborted) killerBox.current && killerBox.current()
+  }
+
+  return childLike as unknown as Process.Child
+}

--- a/packages/opencode/src/workspace/vercel-spawner.ts
+++ b/packages/opencode/src/workspace/vercel-spawner.ts
@@ -1,0 +1,167 @@
+// Vercel-backed ChildProcessSpawner. Satisfies the Effect
+// ChildProcessSpawner contract by routing spawn() calls through
+// Workspace.Primitives.execStream, which in turn hits VercelBackend's
+// in-sandbox exec gateway. Consumers (bash tool, Git.Service,
+// Format.Service, Snapshot.Service, Ripgrep.Service) keep yielding
+// ChildProcessSpawner unchanged; when OPENCODE_WORKSPACE_BACKEND is
+// "vercel", cross-spawn-spawner's defaultLayer wires this impl instead
+// of the local cross-spawn one.
+
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Sink from "effect/Sink"
+import * as Stream from "effect/Stream"
+import * as PlatformError from "effect/PlatformError"
+import * as ChildProcess from "effect/unstable/process/ChildProcess"
+import {
+  ChildProcessSpawner,
+  ExitCode,
+  make as makeSpawner,
+  makeHandle,
+  ProcessId,
+  type ChildProcessHandle,
+} from "effect/unstable/process/ChildProcessSpawner"
+import { Workspace } from "./index"
+
+const toPlatformError =
+  (method: string, command: ChildProcess.Command) =>
+  (cause: unknown): PlatformError.PlatformError => {
+    const label = flattenForLabel(command)
+    return PlatformError.systemError({
+      _tag: "Unknown",
+      module: "ChildProcess",
+      method,
+      pathOrDescriptor: label,
+      cause: cause instanceof Error ? cause : new Error(String(cause)),
+    })
+  }
+
+// Flatten Command tree to a label + a single StandardCommand. Pipelines
+// aren't expressible through ws.execStream (it takes one cmd/args), so
+// we reject PipedCommand with a descriptive error.
+const flatten = (command: ChildProcess.Command): ChildProcess.StandardCommand => {
+  if (command._tag === "StandardCommand") return command
+  throw new Error(
+    "VercelChildProcessSpawner: piped commands are not supported over the sandbox exec gateway",
+  )
+}
+
+const flattenForLabel = (command: ChildProcess.Command): string => {
+  const walk = (cmd: ChildProcess.Command): string => {
+    if (cmd._tag === "StandardCommand") return `${cmd.command} ${cmd.args.join(" ")}`
+    return `${walk(cmd.left)} | ${walk(cmd.right)}`
+  }
+  return walk(command)
+}
+
+const resolveEnv = (opts: ChildProcess.CommandOptions): Record<string, string> | undefined => {
+  if (opts.env === undefined && !opts.extendEnv) return undefined
+  const base: Record<string, string> = {}
+  if (opts.extendEnv) {
+    for (const [k, v] of Object.entries(process.env)) if (v !== undefined) base[k] = v
+  }
+  if (opts.env) for (const [k, v] of Object.entries(opts.env)) if (v !== undefined) base[k] = v
+  return base
+}
+
+const SANDBOX_SHELL_ALLOWLIST: ReadonlySet<string> = new Set(["/bin/bash", "/bin/sh"])
+const remapShellForSandbox = (shell: string): string =>
+  SANDBOX_SHELL_ALLOWLIST.has(shell) ? shell : "/bin/bash"
+
+const resolveStdin = (
+  opts: ChildProcess.CommandOptions,
+): Uint8Array | string | undefined => {
+  const s = opts.stdin
+  if (s === undefined || s === "pipe" || s === "ignore" || s === "inherit") return undefined
+  if (typeof s === "string") return undefined
+  // Stream / StdinConfig stdin is driven via the returned Sink; we
+  // only pass eager initial bytes when callers literally handed a
+  // buffer. Not common for opencode's call sites.
+  return undefined
+}
+
+export namespace VercelChildProcessSpawner {
+  export const layer: Layer.Layer<
+    ChildProcessSpawner,
+    never,
+    Workspace.Primitives.Service
+  > = Layer.effect(
+    ChildProcessSpawner,
+    Effect.gen(function* () {
+      const ws = yield* Workspace.Primitives.Service
+
+      return makeSpawner((command) =>
+        Effect.gen(function* () {
+          const std = flatten(command)
+          const envObj = resolveEnv(std.options)
+          const cwd = typeof std.options.cwd === "string" ? std.options.cwd : undefined
+          const stdinData = resolveStdin(std.options)
+
+          // When the caller sets `shell`, Node's ChildProcess invokes
+          // `{shell} -c "{command}"`. The sandbox image is Linux with
+          // /bin/bash + /bin/sh only; if the host's shell (/bin/zsh on
+          // darwin) doesn't exist in-sandbox the spawn would fail with
+          // "no such file". Remap host-specific shells to /bin/bash,
+          // which the sandbox image always has.
+          const shellOpt = std.options.shell
+          const shellPath =
+            shellOpt === true
+              ? "/bin/bash"
+              : typeof shellOpt === "string"
+                ? remapShellForSandbox(shellOpt)
+                : undefined
+          const spawnCmd = shellPath ?? std.command
+          const spawnArgs = shellPath
+            ? ["-c", [std.command, ...std.args].join(" ")]
+            : [...std.args]
+
+          const handle = yield* ws
+            .execStream(spawnCmd, spawnArgs, {
+              cwd,
+              env: envObj,
+              stdin: stdinData,
+            })
+            .pipe(Effect.mapError(toPlatformError("spawn", command)))
+
+          const mapStreamErr = <A>(s: Stream.Stream<A, any>): Stream.Stream<A, PlatformError.PlatformError> =>
+            s.pipe(Stream.mapError(toPlatformError("stdio", command))) as Stream.Stream<A, PlatformError.PlatformError>
+          const mapSinkErr = (
+            sk: Sink.Sink<void, Uint8Array, never, any>,
+          ): Sink.Sink<void, Uint8Array, never, PlatformError.PlatformError> =>
+            sk.pipe(Sink.mapError(toPlatformError("stdin", command)))
+
+          const exit: ChildProcessHandle["exitCode"] = handle.exitCode.pipe(
+            Effect.map((code) => ExitCode(code ?? -1)),
+            Effect.mapError(toPlatformError("exitCode", command)),
+          )
+
+          const kill: ChildProcessHandle["kill"] = (_opts) =>
+            handle.kill.pipe(Effect.mapError(toPlatformError("kill", command)))
+
+          const result = makeHandle({
+            pid: ProcessId(0),
+            exitCode: exit,
+            isRunning: Effect.succeed(false).pipe(
+              Effect.mapError(toPlatformError("isRunning", command)),
+            ) as ChildProcessHandle["isRunning"],
+            kill,
+            stdin: mapSinkErr(handle.stdin),
+            stdout: mapStreamErr(handle.stdout),
+            stderr: mapStreamErr(handle.stderr),
+            all: mapStreamErr(handle.all),
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+            unref: Effect.succeed(Effect.void).pipe(
+              Effect.mapError(toPlatformError("unref", command)),
+            ) as ChildProcessHandle["unref"],
+          })
+          return result
+        }),
+      )
+    }),
+  )
+
+  export const defaultLayer: Layer.Layer<ChildProcessSpawner, never, never> = layer.pipe(
+    Layer.provide(Workspace.Primitives.defaultLayer),
+  )
+}

--- a/packages/opencode/src/workspace/workspace-error.ts
+++ b/packages/opencode/src/workspace/workspace-error.ts
@@ -1,0 +1,11 @@
+// L3/L4 error surface. Distinct from BackendError (L2) in ./errors.ts;
+// Primitives maps BackendError → WorkspaceError. Kept in its own file
+// so router.ts, index.ts, and the Primitives layer can all import it
+// without cyclic-module issues during class construction.
+import { Schema } from "effect"
+
+export class WorkspaceError extends Schema.TaggedErrorClass<WorkspaceError>()("WorkspaceError", {
+  method: Schema.String,
+  path: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.Defect),
+}) {}

--- a/packages/opencode/test/workspace/conformance/_runner.ts
+++ b/packages/opencode/test/workspace/conformance/_runner.ts
@@ -1,0 +1,354 @@
+// Backend conformance runner. Picks the Backend implementation from
+// OPENCODE_CONFORMANCE_BACKEND (local / throwing / vercel), registers
+// one `describe` per `conformance(name, body)` call, and fails the
+// run if any test fails or zero tests ran.
+
+import { afterAll, beforeAll, describe, test } from "bun:test"
+import { Effect, Exit, Layer, ManagedRuntime, Scope } from "effect"
+import { mkdtempSync, rmSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import * as CrossSpawnSpawner from "../../../src/effect/cross-spawn-spawner"
+import { LocalBackend } from "../../../src/workspace/backends/local"
+import { VercelBackend } from "../../../src/workspace/backends/vercel"
+import { THROWING_BACKEND_MARKER, ThrowingBackend } from "../../../src/workspace/testing/throwing-backend"
+import type { Workspace as WorkspaceTypes } from "../../../src/workspace/types"
+import { Workspace } from "../../../src/workspace"
+import { WorkspaceRouter } from "../../../src/workspace/router"
+import {
+  WorkspaceBus,
+  WorkspaceFormat,
+  WorkspaceLsp,
+} from "../../../src/workspace/internal-services"
+import { WorkspaceError } from "../../../src/workspace/workspace-error"
+import { Sandbox } from "@vercel/sandbox"
+
+export type BackendKind = "local" | "throwing" | "vercel"
+
+const rawKind = (process.env["OPENCODE_CONFORMANCE_BACKEND"] ?? "").trim().toLowerCase()
+export const BACKEND_KIND: BackendKind = ((): BackendKind => {
+  if (rawKind === "local" || rawKind === "throwing" || rawKind === "vercel") return rawKind
+  return "local"
+})()
+
+export interface ConformanceContext {
+  readonly kind: BackendKind
+  readonly backend: WorkspaceTypes.Backend
+  // Primitives (L3) wired over the selected backend via a test-only
+  // WorkspaceRouter layer. Use this instead of `backend` to exercise
+  // the same surface tools consume.
+  readonly ws: Workspace.Primitives.Interface
+  /**
+   * The Workspace.Service.Tag interface (Primitives + null orchestration).
+   * Used by service-write-ok.test.ts to assert the writeFile →
+   * {diagnostics} contract.
+   */
+  readonly svc: Workspace.Service.Interface
+  /**
+   * How long the watch test should wait for an event before giving
+   * up. Local backends use the upstream parcel watcher which fires in
+   * <100ms; vercel polls every `watchPollMs` and round-trips through
+   * the sandbox API, so the test budget needs to be `pollMs * 3` or
+   * more.
+   */
+  readonly watchTimeoutMs: number
+  /**
+   * Expect the effect to fail at the Backend seam on the throwing
+   * backend, or succeed on local / vercel. Returns the success value
+   * on local / vercel, or a marker object on throwing.
+   */
+  readonly expectSubstrateOrSuccess: <A, E>(
+    eff: Effect.Effect<A, E>,
+  ) => Promise<A | { marker: typeof THROWING_BACKEND_MARKER }>
+  /**
+   * Same shape as expectSubstrateOrSuccess but for effects that carry
+   * the L3 WorkspaceError channel instead of the raw BackendError one.
+   * The throwing backend's BackendError is mapped through Primitives
+   * into a WorkspaceError whose `cause` preserves the marker string,
+   * so we look inside the cause rather than the tagged error.
+   */
+  readonly expectWorkspaceSubstrateOrSuccess: <A, E>(
+    eff: Effect.Effect<A, E>,
+  ) => Promise<A | { marker: typeof THROWING_BACKEND_MARKER }>
+}
+
+// Narrowing guard for the throwing-backend marker returned by
+// `expectSubstrateOrSuccess` / `expectWorkspaceSubstrateOrSuccess`.
+export const isMarker = (v: unknown): v is { marker: string } =>
+  typeof v === "object" && v !== null && "marker" in (v as object)
+
+// ---------------- counters ----------------
+
+const counters = { pass: 0, fail: 0, skip: 0 }
+
+// ---------------- backend lifecycle ----------------
+
+interface RuntimeState {
+  readonly backend: WorkspaceTypes.Backend
+  readonly release: () => Promise<void>
+  readonly watchTimeoutMs: number
+}
+
+let runtimeState: RuntimeState | null = null
+let runtimeInitPromise: Promise<RuntimeState> | null = null
+
+const initLocal = async (): Promise<RuntimeState> => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "opencode-conformance-local-"))
+  const rt = ManagedRuntime.make(CrossSpawnSpawner.defaultLayer)
+  const scope = Effect.runSync(Scope.make())
+  const backend = await rt.runPromise(
+    LocalBackend.make({ worktree: tmp }).pipe(Effect.provideService(Scope.Scope, scope)),
+  )
+  return {
+    backend,
+    watchTimeoutMs: 3000,
+    release: async () => {
+      try {
+        await Effect.runPromise(Scope.close(scope, Exit.void))
+      } catch {}
+      try {
+        await rt.dispose()
+      } catch {}
+      try {
+        rmSync(tmp, { recursive: true, force: true })
+      } catch {}
+    },
+  }
+}
+
+const initThrowing = async (): Promise<RuntimeState> => ({
+  backend: ThrowingBackend.make(path.join(os.tmpdir(), "opencode-conformance-throwing")),
+  watchTimeoutMs: 3000,
+  release: async () => {},
+})
+
+const initVercel = async (): Promise<RuntimeState> => {
+  const token = process.env["VERCEL_TOKEN"]
+  const teamId = process.env["VERCEL_TEAM_ID"]
+  const projectId = process.env["VERCEL_PROJECT_ID"]
+  if (!token || !teamId || !projectId) {
+    throw new Error(
+      "vercel conformance requires VERCEL_TOKEN/VERCEL_TEAM_ID/VERCEL_PROJECT_ID",
+    )
+  }
+  // One fresh sandbox per process invocation. Using a random testId
+  // keeps concurrent file runs isolated from each other.
+  const testId = `conformance-${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+  const directory = `/conformance/${testId}`
+  // Faster polling than the doc's 1000ms default to give the
+  // hard-coded 3000ms test timeout (3 polls + jitter + sandbox RTT)
+  // some slack on vercel.
+  const watchPollMs = 500
+  const backend = await Effect.runPromise(
+    VercelBackend.make({
+      token,
+      teamId,
+      projectId,
+      directory,
+      snapshotId: process.env["VERCEL_SANDBOX_IMAGE_ID"],
+      timeoutMs: 10 * 60 * 1000,
+      watchPollMs,
+    }),
+  )
+  // Pre-create the workspace root so writeFile inside rootPath works
+  // even when the sandbox starts blank.
+  await Effect.runPromise(
+    backend.mkDir(backend.rootPath, { recursive: true }).pipe(Effect.ignore),
+  )
+  return {
+    backend,
+    // Doc: the watch test should tolerate `pollMs * 3` latency on
+    // vercel. Bump generously to absorb network jitter.
+    watchTimeoutMs: Math.max(3000, watchPollMs * 5),
+    release: async () => {
+      try {
+        const sb = await Sandbox.get({
+          name: VercelBackend.nameFor(directory),
+          token,
+          teamId,
+          projectId,
+        })
+        await sb.stop()
+      } catch {}
+    },
+  }
+}
+
+const ensureRuntime = (): Promise<RuntimeState> => {
+  if (runtimeState) return Promise.resolve(runtimeState)
+  if (!runtimeInitPromise) {
+    if (BACKEND_KIND === "vercel") {
+      runtimeInitPromise = initVercel()
+    } else if (BACKEND_KIND === "throwing") {
+      runtimeInitPromise = initThrowing()
+    } else {
+      runtimeInitPromise = initLocal()
+    }
+    runtimeInitPromise.then((s) => {
+      runtimeState = s
+    })
+  }
+  return runtimeInitPromise
+}
+
+// ---------------- invariant installer ----------------
+
+// The invariant runs once at process exit. bun:test's afterAll runs
+// per-file, which means it fires before sibling conformance files have
+// loaded, so the cumulative counters are not yet known. Installing a
+// node `exit` handler lets us assert on the final totals after every
+// test file has run.
+let invariantInstalled = false
+
+const installFinalInvariant = () => {
+  if (invariantInstalled) return
+  invariantInstalled = true
+
+  // Per-file cleanup: release the backend + tmpdir if this file was the
+  // last to touch it. Safe to call multiple times.
+  afterAll(async () => {
+    if (runtimeState) {
+      const state = runtimeState
+      runtimeState = null
+      runtimeInitPromise = null
+      await state.release()
+    }
+  })
+
+  process.on("exit", () => {
+    const { pass, fail } = counters
+    if (fail > 0) {
+      console.error(`conformance[${BACKEND_KIND}]: ${fail} test(s) failed`)
+      process.exitCode = 1
+      return
+    }
+    // Zero-passes means the test registrar never ran — treat as failure.
+    if (pass === 0) {
+      console.error(`conformance[${BACKEND_KIND}]: no tests ran`)
+      process.exitCode = 1
+    }
+  })
+}
+
+// Test-only layer wiring: given a concrete Backend, build
+// Workspace.Primitives.Service + Workspace.Service.Tag that forward
+// to it. Fakes WorkspaceRouter with Layer.succeed — no Config/Instance
+// involvement.
+
+const fixedRouterLayer = (backend: WorkspaceTypes.Backend): Layer.Layer<WorkspaceRouter.Service> =>
+  Layer.succeed(
+    WorkspaceRouter.Service,
+    WorkspaceRouter.Service.of({
+      backend: Effect.succeed(backend) as Effect.Effect<WorkspaceTypes.Backend, WorkspaceError>,
+    }),
+  )
+
+const buildPrimitivesAndService = async (
+  backend: WorkspaceTypes.Backend,
+): Promise<{
+  ws: Workspace.Primitives.Interface
+  svc: Workspace.Service.Interface
+  release: () => Promise<void>
+}> => {
+  const layer = Layer.mergeAll(
+    Workspace.Primitives.layer.pipe(Layer.provide(fixedRouterLayer(backend))),
+    Workspace.Service.layer.pipe(
+      Layer.provide(Workspace.Primitives.layer.pipe(Layer.provide(fixedRouterLayer(backend)))),
+      Layer.provide(WorkspaceFormat.nullLayer),
+      Layer.provide(WorkspaceBus.nullLayer),
+      Layer.provide(WorkspaceLsp.nullLayer),
+    ),
+  )
+  const rt = ManagedRuntime.make(layer)
+  const ws = await rt.runPromise(Effect.gen(function* () {
+    return yield* Workspace.Primitives.Service
+  }))
+  const svc = await rt.runPromise(Effect.gen(function* () {
+    return yield* Workspace.Service.Tag
+  }))
+  return {
+    ws,
+    svc,
+    release: async () => {
+      try {
+        await rt.dispose()
+      } catch {}
+    },
+  }
+}
+
+// ---------------- public API ----------------
+
+interface RegisterTest {
+  (name: string, fn: (ctx: ConformanceContext) => void | Promise<void>): void
+}
+
+/**
+ * Register a named conformance suite. `body` is invoked synchronously
+ * at module-load time with a `test` helper that registers bun tests
+ * lazily against the current backend. The backend is created in a
+ * `beforeAll` and disposed at the end of the whole conformance run.
+ */
+export const conformance = (
+  name: string,
+  body: (register: RegisterTest, kind: BackendKind) => void,
+): void => {
+  installFinalInvariant()
+  describe(`[conformance:${BACKEND_KIND}] ${name}`, () => {
+    let ctxRef: ConformanceContext | null = null
+    const suiteReleases: Array<() => Promise<void>> = []
+
+    afterAll(async () => {
+      while (suiteReleases.length) {
+        const r = suiteReleases.pop()
+        if (r) await r()
+      }
+    })
+
+    beforeAll(async () => {
+      const state = await ensureRuntime()
+      const built = await buildPrimitivesAndService(state.backend)
+      suiteReleases.push(built.release)
+      const markerCheck = async <A, E>(eff: Effect.Effect<A, E>) => {
+        if (BACKEND_KIND === "throwing") {
+          const exit = await Effect.runPromiseExit(eff)
+          if (Exit.isSuccess(exit)) {
+            throw new Error(
+              `expected substrate leak: effect succeeded on throwing backend with ${JSON.stringify(exit.value)}`,
+            )
+          }
+          const repr = JSON.stringify(exit.cause)
+          if (!repr.includes(THROWING_BACKEND_MARKER)) {
+            throw new Error(`expected marker ${THROWING_BACKEND_MARKER} in cause, got ${repr}`)
+          }
+          return { marker: THROWING_BACKEND_MARKER as typeof THROWING_BACKEND_MARKER }
+        }
+        return (await Effect.runPromise(eff as Effect.Effect<A, E>)) as A
+      }
+      ctxRef = {
+        kind: BACKEND_KIND,
+        backend: state.backend,
+        ws: built.ws,
+        svc: built.svc,
+        watchTimeoutMs: state.watchTimeoutMs,
+        expectSubstrateOrSuccess: markerCheck,
+        expectWorkspaceSubstrateOrSuccess: markerCheck,
+      }
+    })
+
+    const register: RegisterTest = (n, fn) => {
+      test(n, async () => {
+        if (!ctxRef) throw new Error("conformance context uninitialised")
+        try {
+          await fn(ctxRef)
+          counters.pass++
+        } catch (err) {
+          counters.fail++
+          throw err
+        }
+      })
+    }
+
+    body(register, BACKEND_KIND)
+  })
+}

--- a/packages/opencode/test/workspace/conformance/exec.test.ts
+++ b/packages/opencode/test/workspace/conformance/exec.test.ts
@@ -1,0 +1,87 @@
+// exec / execStream conformance. The stdin Sink test is the critical
+// one — LSP wiring relies on ExecStreamHandle.stdin being a real
+// writable Sink that delivers bytes to the child process.
+
+import { expect } from "bun:test"
+import { Effect, Stream } from "effect"
+import { conformance, isMarker } from "./_runner"
+
+const dec = new TextDecoder()
+const enc = new TextEncoder()
+
+conformance("exec", (register) => {
+  register("exec captures stdout + exit code", async (ctx) => {
+    const eff = ctx.backend.exec("node", ["-e", "process.stdout.write('hi')"])
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const res = out as { exitCode: number; stdout: string; stderr: string }
+    expect(res.exitCode).toBe(0)
+    expect(res.stdout).toBe("hi")
+  })
+
+  register("execStream without stdin drains stdout", async (ctx) => {
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.backend.execStream("node", ["-e", "process.stdout.write('stream')"])
+        const chunks = yield* Stream.runCollect(handle.stdout)
+        const code = yield* handle.exitCode
+        const joined = chunks.map((b) => dec.decode(b)).join("")
+        return { joined, code }
+      }),
+    )
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { joined: string; code: number | null }
+    expect(r.joined).toBe("stream")
+    expect(r.code).toBe(0)
+  })
+
+  register("execStream stdin Sink echoes via cat (LSP-critical)", async (ctx) => {
+    const payload = "hello via sink\n"
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.backend.execStream("cat", [])
+        // Feed bytes to the child process's stdin via the returned
+        // Sink. On close, cat echoes them to stdout.
+        yield* Stream.run(Stream.make(enc.encode(payload)), handle.stdin)
+        const chunks = yield* Stream.runCollect(handle.stdout)
+        const code = yield* handle.exitCode
+        const joined = chunks.map((b) => dec.decode(b)).join("")
+        return { joined, code }
+      }),
+    )
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { joined: string; code: number | null }
+    expect(r.joined).toBe(payload)
+    expect(r.code).toBe(0)
+  })
+
+  register("kill interrupts a long-running command", async (ctx) => {
+    // kill() may race with process termination. The child can either
+    // exit cleanly with a non-zero code OR die from the signal and
+    // have exitCode fail with a BackendError. Both outcomes prove kill
+    // worked. The real contract is: the scoped block resolves — no
+    // hang. We recover from a failing exitCode so we can still run
+    // per-backend assertions.
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.backend.execStream("node", [
+          "-e",
+          "setInterval(() => {}, 1000); console.log('up'); setTimeout(() => {}, 60_000)",
+        ])
+        yield* Effect.forkScoped(Stream.runDrain(handle.stdout).pipe(Effect.ignore))
+        yield* Effect.sleep("50 millis")
+        yield* handle.kill
+        const code = yield* handle.exitCode.pipe(
+          Effect.catch(() => Effect.succeed(null as number | null)),
+        )
+        return { code }
+      }),
+    )
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const code = (out as { code: number | null }).code
+    expect(code === null || code !== 0).toBe(true)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/fs-ops.test.ts
+++ b/packages/opencode/test/workspace/conformance/fs-ops.test.ts
@@ -1,0 +1,128 @@
+// Backend fs-op conformance — every Backend method is exercised once.
+// On local the happy path runs; on throwing each call is expected to
+// surface the THROWING_BACKEND_MARKER.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+const join = (root: string, ...segs: string[]) => path.join(root, ...segs)
+
+conformance("fs-ops", (register) => {
+  register("writeFile / readFile round trip", async (ctx) => {
+    const p = join(ctx.backend.rootPath, "rt.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.writeFile(p, enc.encode("hello conformance"))
+      return yield* ctx.backend.readFile(p)
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(dec.decode(out as Uint8Array)).toBe("hello conformance")
+  })
+
+  register("stat returns file type/size/mtime", async (ctx) => {
+    const p = join(ctx.backend.rootPath, "stat.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.writeFile(p, enc.encode("abc"))
+      return yield* ctx.backend.stat(p)
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const info = out as import("../../../src/workspace/types").Workspace.FileInfo
+    expect(info.type).toBe("file")
+    expect(info.size).toBe(3)
+    // local backend returns a Date; throwing path already returned above
+    expect(info.mtime instanceof Date || info.mtime === null).toBe(true)
+  })
+
+  register("exists returns true then false", async (ctx) => {
+    const p = join(ctx.backend.rootPath, "exists.txt")
+    const missing = join(ctx.backend.rootPath, "nope-does-not-exist.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.writeFile(p, enc.encode("x"))
+      const a = yield* ctx.backend.exists(p)
+      const b = yield* ctx.backend.exists(missing)
+      return [a, b] as const
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const [a, b] = out as readonly [boolean, boolean]
+    expect(a).toBe(true)
+    expect(b).toBe(false)
+  })
+
+  register("mkDir recursive creates nested directories", async (ctx) => {
+    const d = join(ctx.backend.rootPath, "a/b/c")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.mkDir(d, { recursive: true })
+      return yield* ctx.backend.stat(d)
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).type).toBe("directory")
+  })
+
+  register("readDir returns entries with types", async (ctx) => {
+    const d = join(ctx.backend.rootPath, "readdir-test")
+    const f = join(d, "hello.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.mkDir(d, { recursive: true })
+      yield* ctx.backend.writeFile(f, enc.encode("."))
+      return yield* ctx.backend.readDir(d)
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const entries = out as Array<{ name: string; type: string }>
+    const hello = entries.find((e) => e.name === "hello.txt")
+    expect(hello?.type).toBe("file")
+  })
+
+  register("remove deletes a file", async (ctx) => {
+    const p = join(ctx.backend.rootPath, "to-delete.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.writeFile(p, enc.encode("bye"))
+      yield* ctx.backend.remove(p, { recursive: false })
+      return yield* ctx.backend.exists(p)
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe(false)
+  })
+
+  register("rename moves a file", async (ctx) => {
+    const from = join(ctx.backend.rootPath, "from.txt")
+    const to = join(ctx.backend.rootPath, "to.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.backend.writeFile(from, enc.encode("mv"))
+      yield* ctx.backend.rename(from, to)
+      const a = yield* ctx.backend.exists(from)
+      const b = yield* ctx.backend.readFile(to)
+      return { a, b: new TextDecoder().decode(b) } as const
+    })
+    const out = await ctx.expectSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).a).toBe(false)
+    expect((out as any).b).toBe("mv")
+  })
+
+  register("writeFile does NOT create parent directories", async (ctx) => {
+    // Contract: writeFile is raw. If the parent is missing we expect
+    // a BackendError on local; on throwing we still expect a
+    // BackendError (for the substrate marker check).
+    const p = join(ctx.backend.rootPath, "missing-parent", "file.txt")
+    const eff = ctx.backend.writeFile(p, enc.encode("!"))
+    if (ctx.kind === "throwing") {
+      const out = await ctx.expectSubstrateOrSuccess(eff)
+      expect(isMarker(out)).toBe(true)
+      return
+    }
+    // On local we expect the Effect to fail (ENOENT). Just assert a
+    // BackendError exit, don't assert the specific errno.
+    const exit = await Effect.runPromiseExit(eff)
+    expect(exit._tag).toBe("Failure")
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-binary.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-binary.test.ts
@@ -1,0 +1,42 @@
+// Primitives.isBinary conformance.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("primitives-binary", (register) => {
+  register("known binary extension short-circuits to true", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-bin-a.zip")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "plain text inside a .zip filename")
+      return yield* ctx.ws.isBinary(p, 64)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe(true)
+  })
+
+  register("text file returns false", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-bin-b.ts")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "const x = 1\nexport default x\n")
+      return yield* ctx.ws.isBinary(p, 30)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe(false)
+  })
+
+  register("file with NUL byte returns true via sampling", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-bin-c.dat-like")
+    const bytes = new Uint8Array([65, 66, 67, 0, 68, 69, 70])
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, bytes)
+      return yield* ctx.ws.isBinary(p, bytes.byteLength)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe(true)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-exec-edges.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-exec-edges.test.ts
@@ -1,0 +1,259 @@
+// Primitives.execStream edge cases — forked-consumer drain must complete
+// before `exitCode` resolves, otherwise the scope closes and the tail of
+// the output is lost. LocalBackend inherits this from Node's ChildProcess;
+// VercelBackend enforces it at the exit-code seam.
+
+import { expect } from "bun:test"
+import { Effect, Stream } from "effect"
+import { Workspace } from "../../../src/workspace"
+import { conformance, isMarker } from "./_runner"
+
+const dec = new TextDecoder()
+const enc = new TextEncoder()
+
+const runBashShape = (
+  ws: Workspace.Primitives.Interface,
+  cmd: string,
+  args: string[],
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      let output = ""
+      const handle = yield* ws.execStream(cmd, args)
+      yield* Effect.forkScoped(
+        Stream.runForEach(Stream.decodeText(handle.all), (chunk: string) =>
+          Effect.sync(() => {
+            output += chunk
+          }),
+        ),
+      )
+      const code = yield* handle.exitCode
+      return { output, code }
+    }),
+  )
+
+conformance("primitives-exec-edges", (register) => {
+  // ─────────── drain: forked consumer races exit ───────────
+
+  register("D.1 bash-shape: small stdout captured before exit wins race", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", ["-c", "printf 'hello world'"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output).toContain("hello world")
+  })
+
+  register("D.2 bash-shape: multiline stdout fully captured", async (ctx) => {
+    // 50 lines of distinct markers. Any dropped bytes will break the line count.
+    const eff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      "for i in $(seq 1 50); do echo line-$i; done",
+    ])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    const lines = r.output.trim().split("\n")
+    expect(lines.length).toBe(50)
+    expect(lines[0]).toBe("line-1")
+    expect(lines[49]).toBe("line-50")
+  })
+
+  register("D.3 bash-shape: interleaved stdout + stderr both captured via handle.all", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      "echo to-stdout; echo to-stderr >&2; echo more-stdout",
+    ])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output).toContain("to-stdout")
+    expect(r.output).toContain("to-stderr")
+    expect(r.output).toContain("more-stdout")
+  })
+
+  register("D.4 bash-shape: empty stdout + exit 0 returns cleanly (no hang)", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", ["-c", ":"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output).toBe("")
+  })
+
+  register("D.5 bash-shape: 1000 small chunks captured without loss", async (ctx) => {
+    // One echo per iteration creates many separate gateway frames on
+    // the vercel backend. Catches races in per-chunk drain.
+    const eff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      "i=0; while [ $i -lt 200 ]; do printf '.'; i=$((i+1)); done",
+    ])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output.length).toBe(200)
+    expect(/^\.+$/.test(r.output)).toBe(true)
+  })
+
+  // ─────────── exit codes ───────────
+
+  register("E.1 exit 0 on success", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", ["-c", "true"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).code).toBe(0)
+  })
+
+  register("E.2 non-zero exit captured", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", ["-c", "exit 7"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).code).toBe(7)
+  })
+
+  register("E.3 exit 2 on bad command", async (ctx) => {
+    const eff = runBashShape(ctx.ws, "sh", ["-c", "command-that-does-not-exist-12345 || exit 2"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).code).toBe(2)
+  })
+
+  // ─────────── I/O semantics ───────────
+
+  register("I.1 binary stdout preserved byte-for-byte via handle.all", async (ctx) => {
+    // Emit a fixed non-UTF-8 byte sequence (0xC3 0x28 is a classic invalid
+    // UTF-8). Collect via handle.all (raw Uint8Array union) and compare
+    // bytes. We read `handle.all` rather than `handle.stdout` because
+    // VercelBackend's exit-code gating tracks allQueue drain only — that
+    // is the stream the bash tool actually consumes in production. Per-
+    // stream subscription tracking for stdoutQueue/stderrQueue is
+    // future work documented in the exitCodeEffect in
+    // vercel-exec-channel.ts.
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.ws.execStream("sh", [
+          "-c",
+          "printf '\\xc3\\x28\\x00\\xff'",
+        ])
+        const chunks = yield* Stream.runCollect(handle.all)
+        const code = yield* handle.exitCode
+        let total = 0
+        for (const c of chunks) total += c.length
+        const buf = new Uint8Array(total)
+        let off = 0
+        for (const c of chunks) {
+          buf.set(c, off)
+          off += c.length
+        }
+        return { buf, code }
+      }),
+    )
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { buf: Uint8Array; code: number | null }
+    expect(r.code).toBe(0)
+    expect(Array.from(r.buf)).toEqual([0xc3, 0x28, 0x00, 0xff])
+  })
+
+  register("I.2 large stdout (4 KB) captured fully via bash-shape drain", async (ctx) => {
+    // 4096 'a' characters. If any block is dropped the length check fails.
+    const eff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      "printf 'a%.0s' $(seq 1 4096)",
+    ])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output.length).toBe(4096)
+    expect(/^a+$/.test(r.output)).toBe(true)
+  })
+
+  register("I.3 stdin sink into cat echoes back via bash-shape", async (ctx) => {
+    const payload = "edges stdin sink\n"
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        let output = ""
+        const handle = yield* ctx.ws.execStream("cat", [])
+        yield* Stream.run(Stream.make(enc.encode(payload)), handle.stdin)
+        yield* Effect.forkScoped(
+          Stream.runForEach(Stream.decodeText(handle.all), (chunk: string) =>
+            Effect.sync(() => {
+              output += chunk
+            }),
+          ),
+        )
+        const code = yield* handle.exitCode
+        return { output, code }
+      }),
+    )
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { output: string; code: number | null }
+    expect(r.code).toBe(0)
+    expect(r.output).toContain("edges stdin sink")
+  })
+
+  // ─────────── sandbox filesystem state ───────────
+
+  register("S.1 sequential execStream calls share the same sandbox (write → read)", async (ctx) => {
+    const tag = `edges-s1-${Date.now()}`
+    const writeEff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      `echo ${tag} > /tmp/oc-edges-s1.txt`,
+    ])
+    const readEff = runBashShape(ctx.ws, "sh", [
+      "-c",
+      "cat /tmp/oc-edges-s1.txt",
+    ])
+    const write = await ctx.expectWorkspaceSubstrateOrSuccess(writeEff)
+    if (isMarker(write)) return
+    expect((write as any).code).toBe(0)
+    const read = await ctx.expectWorkspaceSubstrateOrSuccess(readEff)
+    if (isMarker(read)) return
+    expect((read as any).code).toBe(0)
+    expect((read as any).output).toContain(tag)
+  })
+
+  register("S.2 each bash call is a fresh shell (cwd does not persist)", async (ctx) => {
+    await ctx.expectWorkspaceSubstrateOrSuccess(
+      runBashShape(ctx.ws, "sh", ["-c", "cd /tmp"]),
+    )
+    const second = await ctx.expectWorkspaceSubstrateOrSuccess(
+      runBashShape(ctx.ws, "sh", ["-c", "pwd"]),
+    )
+    if (isMarker(second)) return
+    const out = (second as any).output as string
+    // The second shell's pwd must NOT be /tmp (/tmp was set in the
+    // first, disjoint shell). We accept any other cwd as "cleanly
+    // isolated". On vercel the default is /vercel/sandbox; on local
+    // it's whatever the backend's rootPath was.
+    expect(out.trim()).not.toBe("/tmp")
+  })
+
+  // ─────────── cancellation ───────────
+
+  register("C.1 kill() on a long-running child unblocks the scope", async (ctx) => {
+    // Throwing backend fails at execStream itself — covered by the
+    // substrate-leak marker elsewhere. This test only makes sense
+    // against backends that can actually spawn.
+    if (ctx.kind === "throwing") return
+    const t0 = Date.now()
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.ws.execStream("sh", ["-c", "sleep 30"])
+        yield* Effect.sleep("300 millis")
+        yield* handle.kill
+        // Kill-signal exit is backend-specific (PlatformError on local,
+        // null on vercel). Don't assert on the value.
+        yield* handle.exitCode.pipe(Effect.option)
+      }),
+    )
+    await Effect.runPromise(eff.pipe(Effect.orElseSucceed(() => undefined)))
+    const elapsed = Date.now() - t0
+    expect(elapsed).toBeLessThan(10_000)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-exec.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-exec.test.ts
@@ -1,0 +1,53 @@
+// Primitives.exec / execStream conformance.
+
+import { expect } from "bun:test"
+import { Effect, Stream } from "effect"
+import { conformance, isMarker } from "./_runner"
+
+const dec = new TextDecoder()
+const enc = new TextEncoder()
+
+conformance("primitives-exec", (register) => {
+  register("exec captures stdout + exit code via primitives", async (ctx) => {
+    const eff = ctx.ws.exec("node", ["-e", "process.stdout.write('ok')"])
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const res = out as { exitCode: number; stdout: string }
+    expect(res.exitCode).toBe(0)
+    expect(res.stdout).toBe("ok")
+  })
+
+  register("execStream without stdin drains stdout via primitives", async (ctx) => {
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.ws.execStream("node", ["-e", "process.stdout.write('stream')"])
+        const chunks = yield* Stream.runCollect(handle.stdout)
+        const code = yield* handle.exitCode
+        return { joined: chunks.map((b) => dec.decode(b)).join(""), code }
+      }),
+    )
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { joined: string; code: number | null }
+    expect(r.joined).toBe("stream")
+    expect(r.code).toBe(0)
+  })
+
+  register("execStream stdin Sink echoes via cat (LSP-critical)", async (ctx) => {
+    const payload = "primitives stdin sink\n"
+    const eff = Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* ctx.ws.execStream("cat", [])
+        yield* Stream.run(Stream.make(enc.encode(payload)), handle.stdin)
+        const chunks = yield* Stream.runCollect(handle.stdout)
+        const code = yield* handle.exitCode
+        return { joined: chunks.map((b) => dec.decode(b)).join(""), code }
+      }),
+    )
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { joined: string; code: number | null }
+    expect(r.joined).toBe(payload)
+    expect(r.code).toBe(0)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-files.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-files.test.ts
@@ -1,0 +1,25 @@
+// Primitives.files() streaming conformance.
+
+import { expect } from "bun:test"
+import { Effect, Stream } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("primitives-files", (register) => {
+  register("files() streams paths under a fixture directory", async (ctx) => {
+    const dir = path.posix.join(ctx.backend.rootPath, "prim-files-tree")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.mkDir(dir, { recursive: true })
+      yield* ctx.ws.writeFile(path.posix.join(dir, "one.txt"), "1")
+      yield* ctx.ws.writeFile(path.posix.join(dir, "two.txt"), "2")
+      const paths = yield* Stream.runCollect(ctx.ws.files({ cwd: dir }))
+      yield* ctx.ws.remove(dir, { recursive: true })
+      return [...paths]
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const arr = out as string[]
+    const names = arr.map((p) => p.split("/").pop())
+    expect(names.sort()).toEqual(["one.txt", "two.txt"])
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-fs.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-fs.test.ts
@@ -1,0 +1,112 @@
+// Primitives-layer fs conformance — exercises Workspace.Primitives.Service
+// (not the raw Backend). All paths are under ws.rootPath.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+conformance("primitives-fs", (register) => {
+  register("writeFile + readFile round trip via primitives", async (ctx) => {
+    const root = ctx.backend.rootPath
+    const p = path.posix.join(root, "prim-rt.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "hello primitives")
+      return yield* ctx.ws.readFile(p)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(dec.decode(out as Uint8Array)).toBe("hello primitives")
+  })
+
+  register("readFileString returns decoded text", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-rs.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "utf8 body")
+      return yield* ctx.ws.readFileString(p)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe("utf8 body")
+  })
+
+  register("stat returns file info shape", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-stat.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "abc")
+      return yield* ctx.ws.stat(p)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).type).toBe("file")
+    expect((out as any).size).toBe(3)
+  })
+
+  register("exists true then false", async (ctx) => {
+    const root = ctx.backend.rootPath
+    const present = path.posix.join(root, "prim-exists.txt")
+    const missing = path.posix.join(root, "prim-exists-nope.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(present, "x")
+      const a = yield* ctx.ws.exists(present)
+      const b = yield* ctx.ws.exists(missing)
+      return [a, b] as const
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const [a, b] = out as readonly [boolean, boolean]
+    expect(a).toBe(true)
+    expect(b).toBe(false)
+  })
+
+  register("mkDir recursive + readDir", async (ctx) => {
+    const d = path.posix.join(ctx.backend.rootPath, "prim-nested/a/b")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.mkDir(d, { recursive: true })
+      yield* ctx.ws.writeFile(path.posix.join(d, "hi.txt"), "H")
+      return yield* ctx.ws.readDir(d)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const entries = out as Array<{ name: string; type: string }>
+    expect(entries.some((e) => e.name === "hi.txt" && e.type === "file")).toBe(true)
+  })
+
+  register("writeFileWithDirs creates missing parents", async (ctx) => {
+    const root = ctx.backend.rootPath
+    const p = path.posix.join(root, "prim-wfd/deep/tree/out.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFileWithDirs(p, "deep")
+      return yield* ctx.ws.readFileString(p)
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe("deep")
+  })
+
+  register("remove + rename + isDir", async (ctx) => {
+    const root = ctx.backend.rootPath
+    const a = path.posix.join(root, "prim-mv-a.txt")
+    const b = path.posix.join(root, "prim-mv-b.txt")
+    const d = path.posix.join(root, "prim-isdir")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(a, "m")
+      yield* ctx.ws.rename(a, b)
+      const existedAfter = yield* ctx.ws.exists(a)
+      const newExists = yield* ctx.ws.exists(b)
+      yield* ctx.ws.remove(b, { recursive: false })
+      yield* ctx.ws.mkDir(d, { recursive: true })
+      const dirflag = yield* ctx.ws.isDir(d)
+      return { existedAfter, newExists, dirflag } as const
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { existedAfter: boolean; newExists: boolean; dirflag: boolean }
+    expect(r.existedAfter).toBe(false)
+    expect(r.newExists).toBe(true)
+    expect(r.dirflag).toBe(true)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-lines.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-lines.test.ts
@@ -1,0 +1,45 @@
+// Primitives.readFileLines conformance.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("primitives-lines", (register) => {
+  register("readFileLines offset=1 limit=2 truncates on limit", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-lines-a.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "l1\nl2\nl3\nl4\n")
+      return yield* ctx.ws.readFileLines(p, { offset: 1, limit: 2 })
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).raw).toEqual(["l1", "l2"])
+    expect((out as any).more).toBe(true)
+  })
+
+  register("readFileLines offset beyond EOF returns empty raw", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-lines-b.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "only-one\n")
+      return yield* ctx.ws.readFileLines(p, { offset: 10, limit: 5 })
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).raw).toEqual([])
+    expect((out as any).more).toBe(false)
+  })
+
+  register("readFileLines returns more=false when file fits under limit", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "prim-lines-c.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(p, "a\nb\n")
+      return yield* ctx.ws.readFileLines(p, { offset: 1, limit: 10 })
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect((out as any).raw).toEqual(["a", "b"])
+    expect((out as any).more).toBe(false)
+    expect((out as any).cut).toBe(false)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-resolve.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-resolve.test.ts
@@ -1,0 +1,37 @@
+// Primitives.resolve() / containsPath() conformance.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("primitives-resolve", (register) => {
+  // resolve / containsPath are pure string ops over `rootPath`: they
+  // do not touch the substrate, so they succeed on every backend —
+  // including throwing. The conformance assertions are identical
+  // across kinds.
+  register("resolve leaves absolute paths unchanged", async (ctx) => {
+    const abs = path.posix.join(ctx.backend.rootPath, "sub/file.txt")
+    const out = await Effect.runPromise(ctx.ws.resolve(abs))
+    expect(out).toBe(abs)
+  })
+
+  register("resolve joins relative to rootPath", async (ctx) => {
+    const out = await Effect.runPromise(ctx.ws.resolve("inner/file.txt"))
+    expect(out).toBe(path.posix.join(ctx.backend.rootPath, "inner/file.txt"))
+  })
+
+  register("containsPath true for path inside root, false for outside", async (ctx) => {
+    const inside = path.posix.join(ctx.backend.rootPath, "a/b/c")
+    const outside = "/absolutely/elsewhere-not-in-root"
+    const [a, b] = await Effect.runPromise(
+      Effect.gen(function* () {
+        const a = yield* ctx.ws.containsPath(inside)
+        const b = yield* ctx.ws.containsPath(outside)
+        return [a, b] as const
+      }),
+    )
+    expect(a).toBe(true)
+    expect(b).toBe(false)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-search.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-search.test.ts
@@ -1,0 +1,49 @@
+// Primitives.search() conformance. Depends on `rg` being available in
+// the backend — host PATH on local, snapshot image on vercel.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("primitives-search", (register) => {
+  register("search finds matches in a fixture tree", async (ctx) => {
+    const root = ctx.backend.rootPath
+    const dir = path.posix.join(root, "prim-search-tree")
+    const a = path.posix.join(dir, "a.txt")
+    const b = path.posix.join(dir, "b.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.mkDir(dir, { recursive: true })
+      yield* ctx.ws.writeFile(a, "hello SEARCH_NEEDLE world\n")
+      yield* ctx.ws.writeFile(b, "no trace here\n")
+      const result = yield* ctx.ws.search({ cwd: dir, pattern: "SEARCH_NEEDLE" })
+      yield* ctx.ws.remove(dir, { recursive: true })
+      return result
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as unknown as { items: Array<{ lineText: string; path: string }>; partial: boolean }
+    expect(r.items.length).toBeGreaterThanOrEqual(1)
+    expect(r.items[0].lineText).toContain("SEARCH_NEEDLE")
+    expect(r.partial).toBe(false)
+  })
+
+  register("search with no matches returns empty items and partial=false", async (ctx) => {
+    const dir = path.posix.join(ctx.backend.rootPath, "prim-search-empty")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.mkDir(dir, { recursive: true })
+      yield* ctx.ws.writeFile(path.posix.join(dir, "x.txt"), "just plain text\n")
+      const result = yield* ctx.ws.search({
+        cwd: dir,
+        pattern: "SURELY_NOT_PRESENT_XYZ",
+      })
+      yield* ctx.ws.remove(dir, { recursive: true })
+      return result
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as { items: unknown[]; partial: boolean }
+    expect(r.items.length).toBe(0)
+    expect(r.partial).toBe(false)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/primitives-watch.test.ts
+++ b/packages/opencode/test/workspace/conformance/primitives-watch.test.ts
@@ -1,0 +1,60 @@
+// Primitives.watch() conformance. Mirrors watch.test.ts but routes
+// through ctx.ws.watch to exercise the WorkspaceError mapping layer.
+
+import { expect } from "bun:test"
+import { Effect, Exit, Fiber, Option, Stream } from "effect"
+import path from "node:path"
+import { conformance } from "./_runner"
+import type { Workspace } from "../../../src/workspace/types"
+import { THROWING_BACKEND_MARKER } from "../../../src/workspace/testing/throwing-backend"
+
+const enc = new TextEncoder()
+
+const collectUpTo = <E>(
+  stream: Stream.Stream<Workspace.FsEvent, E>,
+  n: number,
+  ms: number,
+): Effect.Effect<Workspace.FsEvent[], E> =>
+  Stream.runCollect(stream.pipe(Stream.take(n))).pipe(
+    Effect.timeoutOption(`${ms} millis`),
+    Effect.map((opt) => (Option.isSome(opt) ? opt.value : ([] as Workspace.FsEvent[]))),
+  )
+
+let dirSeq = 0
+const makeDir = async (ws: { mkDir: (p: string, opts: { recursive: boolean }) => Effect.Effect<void, any> }, root: string, label: string): Promise<string> => {
+  const name = `pws-watch-${label}-${Date.now()}-${++dirSeq}`
+  const dir = path.posix.join(root, name)
+  await Effect.runPromise(ws.mkDir(dir, { recursive: true }))
+  return dir
+}
+
+conformance("primitives-watch", (register) => {
+  register("primitives watch fires an add event after write", async (ctx) => {
+    if (ctx.kind === "throwing") {
+      const exit = await Effect.runPromiseExit(Stream.runDrain(ctx.ws.watch("/throwing")))
+      if (Exit.isSuccess(exit)) {
+        throw new Error("expected throwing-backend watch stream to fail through primitives")
+      }
+      const repr = JSON.stringify(exit.cause)
+      expect(repr.includes(THROWING_BACKEND_MARKER)).toBe(true)
+      return
+    }
+
+    const dir = await makeDir(ctx.ws, ctx.backend.rootPath, "add")
+    try {
+      const target = path.posix.join(dir, "new.txt")
+      const eff = Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(collectUpTo(ctx.ws.watch(dir), 1, ctx.watchTimeoutMs))
+          yield* Effect.sleep("500 millis")
+          yield* ctx.ws.writeFile(target, enc.encode("hi"))
+          return yield* Fiber.join(fiber)
+        }),
+      )
+      const events = await Effect.runPromise(eff)
+      expect(events.some((e) => e.type === "add" || e.type === "change")).toBe(true)
+    } finally {
+      await Effect.runPromise(ctx.ws.remove(dir, { recursive: true }).pipe(Effect.ignore))
+    }
+  })
+})

--- a/packages/opencode/test/workspace/conformance/service-write-ok.test.ts
+++ b/packages/opencode/test/workspace/conformance/service-write-ok.test.ts
@@ -1,0 +1,32 @@
+// Workspace.Service.writeFile contract: the file lands at `p`, the
+// return value carries a `diagnostics` record, and (with the null LSP
+// layer the conformance runner provides) that record is empty.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "./_runner"
+
+conformance("service-write-ok", (register) => {
+  register("Workspace.Service.writeFile returns {diagnostics}", async (ctx) => {
+    const p = path.posix.join(ctx.backend.rootPath, "svc-write.txt")
+    const eff = Effect.gen(function* () {
+      const result = yield* ctx.svc.writeFile(p, "svc body")
+      const readBack = yield* ctx.ws.readFileString(p).pipe(Effect.catch(() => Effect.succeed("")))
+      return { result, readBack } as const
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    const r = out as {
+      result: { diagnostics: Record<string, unknown[]> }
+      readBack: string
+    }
+    expect(r.result).toBeDefined()
+    expect(typeof r.result.diagnostics).toBe("object")
+    expect(r.result.diagnostics).not.toBeNull()
+    expect(Array.isArray(r.result.diagnostics)).toBe(false)
+    // Conformance runner wires the null LSP → diagnostics is always {}.
+    expect(Object.keys(r.result.diagnostics).length).toBe(0)
+    expect(r.readBack).toBe("svc body")
+  })
+})

--- a/packages/opencode/test/workspace/conformance/services/filewatcher.test.ts
+++ b/packages/opencode/test/workspace/conformance/services/filewatcher.test.ts
@@ -1,0 +1,41 @@
+// Substrate-seam smoke for FileWatcher.Service — asserts ws.watch emits
+// add/change/unlink events within watchTimeoutMs when files are mutated
+// through the primitives.
+
+import { expect } from "bun:test"
+import { Deferred, Effect, Fiber, Stream } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "../_runner"
+
+conformance("services/filewatcher", (register) => {
+  register("ws.watch surfaces write events within watchTimeoutMs", async (ctx) => {
+    const target = path.posix.join(ctx.backend.rootPath, "filewatcher-probe.txt")
+    const eff = Effect.gen(function* () {
+      const deferred = yield* Deferred.make<true>()
+      const fiber = yield* Effect.forkChild(
+        ctx.ws.watch(ctx.backend.rootPath).pipe(
+          Stream.runForEach((evt) =>
+            Effect.gen(function* () {
+              if (evt.path.endsWith("filewatcher-probe.txt")) {
+                Deferred.doneUnsafe(deferred, Effect.succeed(true))
+              }
+              return yield* Effect.void
+            }),
+          ),
+        ),
+      )
+      // Small settle so the subscription is live before we write.
+      yield* Effect.sleep("200 millis")
+      yield* ctx.ws.writeFile(target, "hello")
+      const got = yield* Deferred.await(deferred).pipe(
+        Effect.timeout(`${ctx.watchTimeoutMs} millis`),
+        Effect.catch(() => Effect.succeed(false as const)),
+      )
+      yield* Fiber.interrupt(fiber)
+      return got
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out).toBe(true)
+  })
+})

--- a/packages/opencode/test/workspace/conformance/services/format.test.ts
+++ b/packages/opencode/test/workspace/conformance/services/format.test.ts
@@ -1,0 +1,24 @@
+// Substrate-seam smoke for Format.Service — asserts ws.exec can rewrite
+// a workspace file in place, which is Format's only substrate touchpoint.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "../_runner"
+
+conformance("services/format", (register) => {
+  register("ws.exec can rewrite a workspace file in place (format-style)", async (ctx) => {
+    const file = path.posix.join(ctx.backend.rootPath, "format-target.txt")
+    const eff = Effect.gen(function* () {
+      yield* ctx.ws.writeFile(file, "unformatted")
+      // Simulated formatter: overwrite the file with a well-known token.
+      const result = yield* ctx.ws.exec("sh", ["-c", `printf '%s' FORMATTED > "${file}"`])
+      const readBack = yield* ctx.ws.readFileString(file)
+      return { result, readBack } as const
+    })
+    const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+    if (isMarker(out)) return
+    expect(out.result.exitCode).toBe(0)
+    expect(out.readBack).toBe("FORMATTED")
+  })
+})

--- a/packages/opencode/test/workspace/conformance/services/lsp.test.ts
+++ b/packages/opencode/test/workspace/conformance/services/lsp.test.ts
@@ -1,0 +1,55 @@
+// Substrate-seam smoke for LSP.Service. Pins the two primitives LSP
+// depends on — `ws.execStream` for the language-server subprocess and
+// `ws.readFileString` for didOpen payloads — across all backends.
+// Full LSP tests against a real tsserver live under test/lsp/.
+
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import path from "node:path"
+import { conformance, isMarker } from "../_runner"
+
+conformance("services/lsp", (register) => {
+  register(
+    "ws.readFileString round-trips a source file (didOpen substrate seam)",
+    async (ctx) => {
+      const file = path.posix.join(ctx.backend.rootPath, "lsp-probe.ts")
+      const bad = "const x: string = 42\n"
+      const eff = Effect.gen(function* () {
+        yield* ctx.ws.writeFile(file, bad)
+        const read = yield* ctx.ws.readFileString(file)
+        return { read } as const
+      })
+      const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+      if (isMarker(out)) return
+      expect(out.read).toBe(bad)
+    },
+  )
+
+  register(
+    "ws.execStream fails at the backend seam on throwing backend",
+    async (ctx) => {
+      // This test is structured so it only actually asserts on the
+      // throwing backend — on local/vercel it would try to spawn a
+      // real LSP binary and is out of scope for this phase. The
+      // expectWorkspaceSubstrateOrSuccess helper returns the marker
+      // on throwing and the effect value elsewhere, letting us treat
+      // both as passing.
+      const eff = Effect.scoped(
+        Effect.gen(function* () {
+          const handle = yield* ctx.ws.execStream(
+            "true",
+            [],
+            { cwd: ctx.backend.rootPath },
+          )
+          // Drain exitCode so any seam errors surface here.
+          const code = yield* handle.exitCode
+          return { code } as const
+        }),
+      )
+      const out = await ctx.expectWorkspaceSubstrateOrSuccess(eff)
+      if (isMarker(out)) return
+      // On local/vercel `true` exits 0.
+      expect(out.code === 0 || out.code === null).toBe(true)
+    },
+  )
+})

--- a/packages/opencode/test/workspace/conformance/watch.test.ts
+++ b/packages/opencode/test/workspace/conformance/watch.test.ts
@@ -1,0 +1,138 @@
+/**
+ * watch() conformance tests.
+ *
+ * Local: @parcel/watcher fires add/change/unlink within ~50ms of the
+ * underlying fs-op. Throwing: the Stream itself fails immediately with
+ * the marker. Vercel: polling watcher round-trips through the sandbox
+ * API; `ctx.watchTimeoutMs` is widened accordingly.
+ *
+ * All temp directories are created under `ctx.backend.rootPath` via
+ * `backend.mkDir` so the tests are substrate-agnostic — no `os.tmpdir()`
+ * host paths leak across the Backend seam.
+ */
+import { expect } from "bun:test"
+import { Effect, Exit, Fiber, Option, Stream } from "effect"
+import path from "node:path"
+import { conformance } from "./_runner"
+import type { Workspace } from "../../../src/workspace/types"
+import { THROWING_BACKEND_MARKER } from "../../../src/workspace/testing/throwing-backend"
+
+const enc = new TextEncoder()
+
+const collectUpTo = <E>(
+  stream: Stream.Stream<Workspace.FsEvent, E>,
+  n: number,
+  ms: number,
+): Effect.Effect<Workspace.FsEvent[], E> =>
+  Stream.runCollect(stream.pipe(Stream.take(n))).pipe(
+    Effect.timeoutOption(`${ms} millis`),
+    Effect.map((opt) => (Option.isSome(opt) ? opt.value : ([] as Workspace.FsEvent[]))),
+  )
+
+let dirSeq = 0
+const makeDir = async (backend: Workspace.Backend, label: string): Promise<string> => {
+  const name = `watch-${label}-${Date.now()}-${++dirSeq}`
+  const dir = path.posix.join(backend.rootPath, name)
+  await Effect.runPromise(backend.mkDir(dir, { recursive: true }))
+  return dir
+}
+
+const removeDir = async (backend: Workspace.Backend, dir: string): Promise<void> => {
+  await Effect.runPromise(backend.remove(dir, { recursive: true }).pipe(Effect.ignore))
+}
+
+conformance("watch", (register) => {
+  register("fires an add event when a file is created", async (ctx) => {
+    if (ctx.kind === "throwing") {
+      const exit = await Effect.runPromiseExit(Stream.runDrain(ctx.backend.watch("/throwing")))
+      if (Exit.isSuccess(exit)) {
+        throw new Error("expected throwing backend watch stream to fail")
+      }
+      const repr = JSON.stringify(exit.cause)
+      expect(repr.includes(THROWING_BACKEND_MARKER)).toBe(true)
+      return
+    }
+
+    const dir = await makeDir(ctx.backend, "add")
+    try {
+      const target = path.posix.join(dir, "new.txt")
+      const eff = Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(collectUpTo(ctx.backend.watch(dir), 1, ctx.watchTimeoutMs))
+          yield* Effect.sleep("500 millis")
+          yield* ctx.backend.writeFile(target, enc.encode("hello"))
+          return yield* Fiber.join(fiber)
+        }),
+      )
+      const events = await Effect.runPromise(eff)
+      const names = events.map((e) => `${e.type}:${path.posix.basename(e.path)}`)
+      expect(names.some((n) => n.startsWith("add:"))).toBe(true)
+    } finally {
+      await removeDir(ctx.backend, dir)
+    }
+  })
+
+  register("fires a change event when a file is modified", async (ctx) => {
+    if (ctx.kind === "throwing") {
+      const exit = await Effect.runPromiseExit(Stream.runDrain(ctx.backend.watch("/throwing")))
+      if (Exit.isSuccess(exit)) {
+        throw new Error("expected throwing backend watch stream to fail")
+      }
+      const repr = JSON.stringify(exit.cause)
+      expect(repr.includes(THROWING_BACKEND_MARKER)).toBe(true)
+      return
+    }
+
+    const dir = await makeDir(ctx.backend, "change")
+    try {
+      const target = path.posix.join(dir, "m.txt")
+      await Effect.runPromise(ctx.backend.writeFile(target, enc.encode("v1")))
+      const eff = Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(collectUpTo(ctx.backend.watch(dir), 1, ctx.watchTimeoutMs))
+          yield* Effect.sleep("500 millis")
+          yield* ctx.backend.writeFile(target, enc.encode("v2-modified"))
+          return yield* Fiber.join(fiber)
+        }),
+      )
+      const events = await Effect.runPromise(eff)
+      expect(events.some((e) => e.type === "change" || e.type === "add")).toBe(true)
+    } finally {
+      await removeDir(ctx.backend, dir)
+    }
+  })
+
+  register("fires an unlink event when a file is removed", async (ctx) => {
+    if (ctx.kind === "throwing") {
+      const exit = await Effect.runPromiseExit(Stream.runDrain(ctx.backend.watch("/throwing")))
+      if (Exit.isSuccess(exit)) {
+        throw new Error("expected throwing backend watch stream to fail")
+      }
+      const repr = JSON.stringify(exit.cause)
+      expect(repr.includes(THROWING_BACKEND_MARKER)).toBe(true)
+      return
+    }
+
+    const dir = await makeDir(ctx.backend, "unlink")
+    try {
+      const target = path.posix.join(dir, "u.txt")
+      await Effect.runPromise(ctx.backend.writeFile(target, enc.encode("bye")))
+      // @parcel/watcher's fs-events backend can coalesce rapid
+      // create+delete into a single event. Wait for the file to
+      // stabilise before subscribing so the remove is unambiguous.
+      await new Promise((r) => setTimeout(r, 600))
+      const eff = Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* Effect.forkChild(collectUpTo(ctx.backend.watch(dir), 1, ctx.watchTimeoutMs))
+          yield* Effect.sleep("500 millis")
+          yield* ctx.backend.remove(target, { recursive: false })
+          return yield* Fiber.join(fiber)
+        }),
+      )
+      const events = await Effect.runPromise(eff)
+      expect(events.some((e) => e.type === "unlink")).toBe(true)
+    } finally {
+      await removeDir(ctx.backend, dir)
+    }
+  })
+})

--- a/packages/opencode/test/workspace/helpers/is-binary.test.ts
+++ b/packages/opencode/test/workspace/helpers/is-binary.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { isBinaryBytes } from "../../../src/workspace/helpers/is-binary"
+
+const enc = new TextEncoder()
+
+describe("helpers/is-binary — isBinaryBytes", () => {
+  test("known binary extension short-circuits regardless of bytes", () => {
+    expect(isBinaryBytes(".zip", new Uint8Array(0))).toBe(true)
+    expect(isBinaryBytes(".EXE", enc.encode("plain text"))).toBe(true)
+  })
+
+  test("text extension + printable bytes → false", () => {
+    expect(isBinaryBytes(".ts", enc.encode("const x = 1\n"))).toBe(false)
+    expect(isBinaryBytes(".md", enc.encode("# hello\n\nworld"))).toBe(false)
+  })
+
+  test("empty bytes with unknown extension → false", () => {
+    expect(isBinaryBytes(".unknown", new Uint8Array(0))).toBe(false)
+  })
+
+  test("NUL byte in sample triggers binary", () => {
+    const buf = new Uint8Array([65, 66, 67, 0, 68])
+    expect(isBinaryBytes(".bin-like", buf)).toBe(true)
+  })
+
+  test(">30% non-printable bytes triggers binary", () => {
+    const buf = new Uint8Array(100)
+    for (let i = 0; i < 100; i++) buf[i] = i < 40 ? 0x01 : 65 // first 40 non-printable
+    expect(isBinaryBytes(".mystery", buf)).toBe(true)
+  })
+
+  test("tab / newline / carriage return are printable", () => {
+    const buf = enc.encode("a\tb\nc\rd")
+    expect(isBinaryBytes(".txt", buf)).toBe(false)
+  })
+})

--- a/packages/opencode/test/workspace/helpers/lines.test.ts
+++ b/packages/opencode/test/workspace/helpers/lines.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { sliceLines } from "../../../src/workspace/helpers/lines"
+
+const enc = new TextEncoder()
+const bytes = (s: string) => enc.encode(s)
+
+describe("helpers/lines — sliceLines", () => {
+  test("offset=1 returns from first line; limit bounds output", () => {
+    const view = sliceLines(bytes("a\nb\nc\nd\n"), { offset: 1, limit: 2 })
+    expect(view.raw).toEqual(["a", "b"])
+    expect(view.offset).toBe(1)
+    expect(view.more).toBe(true)
+    expect(view.cut).toBe(false)
+  })
+
+  test("offset=3 skips the first two lines", () => {
+    const view = sliceLines(bytes("a\nb\nc\nd"), { offset: 3, limit: 2 })
+    expect(view.raw).toEqual(["c", "d"])
+    expect(view.more).toBe(false)
+  })
+
+  test("returning fewer than limit sets more=false", () => {
+    const view = sliceLines(bytes("x\n"), { offset: 1, limit: 10 })
+    expect(view.raw).toEqual(["x"])
+    expect(view.more).toBe(false)
+    expect(view.cut).toBe(false)
+    expect(view.count).toBe(1)
+  })
+
+  test("very long line is truncated with suffix", () => {
+    const long = "a".repeat(3000)
+    const view = sliceLines(bytes(long + "\nb"), { offset: 1, limit: 10 })
+    expect(view.raw[0].startsWith("a".repeat(2000))).toBe(true)
+    expect(view.raw[0].endsWith("line truncated to 2000 chars)")).toBe(true)
+    expect(view.raw[1]).toBe("b")
+  })
+
+  test("CRLF line endings are treated as a single break", () => {
+    const view = sliceLines(bytes("one\r\ntwo\r\nthree"), { offset: 1, limit: 10 })
+    expect(view.raw).toEqual(["one", "two", "three"])
+  })
+
+  test("empty input returns empty view", () => {
+    const view = sliceLines(bytes(""), { offset: 1, limit: 5 })
+    expect(view.raw).toEqual([])
+    expect(view.count).toBe(0)
+    expect(view.more).toBe(false)
+  })
+
+  test("byte budget exceeded sets cut=true and more=true", () => {
+    // Each line is ~1 KB; 100 lines easily overflows 50 KB.
+    const line = "x".repeat(1000)
+    const lines = Array.from({ length: 200 }, () => line).join("\n")
+    const view = sliceLines(bytes(lines), { offset: 1, limit: 500 })
+    expect(view.cut).toBe(true)
+    expect(view.more).toBe(true)
+  })
+})

--- a/packages/opencode/test/workspace/helpers/mailbox.test.ts
+++ b/packages/opencode/test/workspace/helpers/mailbox.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the pure mailbox fan-out. No backend, no Effect runtime
+ * — these tests must pass standalone so failures point at the helper
+ * itself, not the substrate it's wired into.
+ */
+import { describe, expect, test } from "bun:test"
+import { createMailboxFanout, type LogChunk } from "../../../src/workspace/helpers/mailbox"
+
+const dec = new TextDecoder()
+const idEncode = (s: string): Uint8Array => new TextEncoder().encode(s)
+
+const collect = async (it: AsyncIterableIterator<Uint8Array>): Promise<string[]> => {
+  const out: string[] = []
+  for await (const chunk of it) out.push(dec.decode(chunk))
+  return out
+}
+
+const arrayToAsync = async function* <T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) yield item
+}
+
+describe("mailbox fan-out", () => {
+  test("classifies stdout / stderr into separate mailboxes", async () => {
+    const chunks: LogChunk[] = [
+      { stream: "stdout", data: "out-1\n" },
+      { stream: "stderr", data: "err-1\n" },
+      { stream: "stdout", data: "out-2\n" },
+    ]
+    const fan = createMailboxFanout(arrayToAsync(chunks), { encode: idEncode })
+    const [outs, errs, alls] = await Promise.all([
+      collect(fan.stdout.iterator),
+      collect(fan.stderr.iterator),
+      collect(fan.all.iterator),
+    ])
+    expect(outs).toEqual(["out-1\n", "out-2\n"])
+    expect(errs).toEqual(["err-1\n"])
+    // `all` preserves driver order
+    expect(alls).toEqual(["out-1\n", "err-1\n", "out-2\n"])
+  })
+
+  test("empty driver finishes cleanly", async () => {
+    const fan = createMailboxFanout(arrayToAsync<LogChunk>([]), { encode: idEncode })
+    expect(await collect(fan.stdout.iterator)).toEqual([])
+    expect(await collect(fan.stderr.iterator)).toEqual([])
+    expect(await collect(fan.all.iterator)).toEqual([])
+  })
+
+  test("only stdout closes when only stdout chunks are emitted", async () => {
+    const chunks: LogChunk[] = [
+      { stream: "stdout", data: "hi" },
+      { stream: "stdout", data: " there" },
+    ]
+    const fan = createMailboxFanout(arrayToAsync(chunks), { encode: idEncode })
+    const [outs, errs, alls] = await Promise.all([
+      collect(fan.stdout.iterator),
+      collect(fan.stderr.iterator),
+      collect(fan.all.iterator),
+    ])
+    expect(outs.join("")).toBe("hi there")
+    expect(errs).toEqual([])
+    expect(alls.join("")).toBe("hi there")
+  })
+
+  test("driver errors propagate to every consumer", async () => {
+    const boom = new Error("driver-boom")
+    const driver: AsyncIterable<LogChunk> = {
+      [Symbol.asyncIterator](): AsyncIterator<LogChunk> {
+        let i = 0
+        return {
+          async next() {
+            if (i++ === 0) {
+              return { value: { stream: "stdout", data: "a" }, done: false }
+            }
+            throw boom
+          },
+        }
+      },
+    }
+    const fan = createMailboxFanout(driver, { encode: idEncode })
+
+    const tryCollect = async (
+      it: AsyncIterableIterator<Uint8Array>,
+    ): Promise<{ ok: string[]; err: unknown | null }> => {
+      const ok: string[] = []
+      try {
+        for await (const chunk of it) ok.push(dec.decode(chunk))
+        return { ok, err: null }
+      } catch (e) {
+        return { ok, err: e }
+      }
+    }
+
+    const [a, b, c] = await Promise.all([
+      tryCollect(fan.stdout.iterator),
+      tryCollect(fan.stderr.iterator),
+      tryCollect(fan.all.iterator),
+    ])
+    // stdout received the first chunk before the throw
+    expect(a.ok).toEqual(["a"])
+    expect(a.err).toBe(boom)
+    expect(b.err).toBe(boom)
+    expect(c.err).toBe(boom)
+  })
+
+  test("done promise resolves after the driver completes", async () => {
+    const fan = createMailboxFanout(arrayToAsync<LogChunk>([{ stream: "stdout", data: "x" }]), {
+      encode: idEncode,
+    })
+    // Drain so the driver completes
+    await collect(fan.stdout.iterator)
+    await fan.done
+  })
+
+  test("default encoder converts strings to UTF-8 bytes", async () => {
+    const fan = createMailboxFanout(arrayToAsync<LogChunk>([{ stream: "stdout", data: "héllo" }]))
+    const out = await collect(fan.stdout.iterator)
+    // "héllo" → 6 UTF-8 bytes; if we got 5 we used a wrong encoder
+    const total = out.reduce((acc, s) => acc + new TextEncoder().encode(s).length, 0)
+    expect(total).toBe(6)
+  })
+})

--- a/packages/opencode/test/workspace/helpers/ripgrep.test.ts
+++ b/packages/opencode/test/workspace/helpers/ripgrep.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+import { parseRgJsonLine, rgArgs } from "../../../src/workspace/helpers/ripgrep"
+
+describe("helpers/ripgrep — rgArgs", () => {
+  test("files mode emits --files and the git glob", () => {
+    const args = rgArgs({ mode: "files" })
+    expect(args).toContain("--files")
+    expect(args).toContain("--glob=!.git/*")
+  })
+
+  test("search mode emits --json, --no-messages, and the pattern", () => {
+    const args = rgArgs({ mode: "search", pattern: "foo" })
+    expect(args).toContain("--json")
+    expect(args).toContain("--no-messages")
+    expect(args[args.indexOf("--") + 1]).toBe("foo")
+  })
+
+  test("glob entries each become a --glob argument", () => {
+    const args = rgArgs({ mode: "files", glob: ["*.ts", "*.tsx"] })
+    expect(args).toContain("--glob=*.ts")
+    expect(args).toContain("--glob=*.tsx")
+  })
+
+  test("maxDepth, limit, follow, hidden=false flags pass through", () => {
+    const args = rgArgs({
+      mode: "search",
+      pattern: "x",
+      glob: [],
+      maxDepth: 3,
+      limit: 5,
+      follow: true,
+      hidden: false,
+    })
+    expect(args).toContain("--max-depth=3")
+    expect(args).toContain("--max-count=5")
+    expect(args).toContain("--follow")
+    expect(args).not.toContain("--hidden")
+  })
+
+  test("hidden defaults to true (implicit) — i.e. added unless explicitly false", () => {
+    const args = rgArgs({ mode: "files" })
+    expect(args).toContain("--hidden")
+  })
+
+  test("file list is appended after pattern", () => {
+    const args = rgArgs({ mode: "search", pattern: "foo", file: ["a.txt", "b.txt"] })
+    const dashDash = args.indexOf("--")
+    expect(args[dashDash + 1]).toBe("foo")
+    expect(args.slice(dashDash + 2)).toEqual(["a.txt", "b.txt"])
+  })
+
+  test("search without explicit files defaults positional to '.'", () => {
+    // This guards against rg blocking on stdin when the spawn leaves
+    // stdin as an open pipe and no path is given.
+    const args = rgArgs({ mode: "search", pattern: "foo" })
+    const dashDash = args.indexOf("--")
+    expect(args.slice(dashDash + 1)).toEqual(["foo", "."])
+  })
+})
+
+describe("helpers/ripgrep — parseRgJsonLine", () => {
+  test("returns null for non-match rows", () => {
+    expect(parseRgJsonLine("")).toBeNull()
+    expect(parseRgJsonLine('{"type":"begin","data":{}}')).toBeNull()
+    expect(parseRgJsonLine('{"type":"end","data":{}}')).toBeNull()
+  })
+
+  test("returns null for invalid JSON", () => {
+    expect(parseRgJsonLine("{not json")).toBeNull()
+  })
+
+  test("returns typed hit for match rows", () => {
+    const line = JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "src/foo.ts" },
+        lines: { text: "const x = 1\n" },
+        line_number: 10,
+        absolute_offset: 123,
+        submatches: [{ match: { text: "x" }, start: 6, end: 7 }],
+      },
+    })
+    const hit = parseRgJsonLine(line)
+    expect(hit).not.toBeNull()
+    expect(hit!.path.text).toBe("src/foo.ts")
+    expect(hit!.line_number).toBe(10)
+    expect(hit!.submatches[0].match.text).toBe("x")
+  })
+})

--- a/packages/opencode/test/workspace/primitives.test.ts
+++ b/packages/opencode/test/workspace/primitives.test.ts
@@ -1,0 +1,95 @@
+// Workspace.Primitives error-surface contract: every BackendError from
+// the underlying Backend is mapped to a WorkspaceError with the primitive
+// name preserved in `method` and the original error available via `cause`.
+
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime, Stream } from "effect"
+import { Workspace } from "../../src/workspace"
+import { Workspace as WorkspaceErrors } from "../../src/workspace/errors"
+import { WorkspaceRouter } from "../../src/workspace/router"
+import type { Workspace as WorkspaceTypes } from "../../src/workspace/types"
+import { WorkspaceError } from "../../src/workspace/workspace-error"
+
+const err = (method: string, p?: string) =>
+  new WorkspaceErrors.BackendError({
+    backend: "stub",
+    method,
+    path: p,
+    cause: new Error(`stub-backend: ${method}`),
+  })
+
+const stubBackend: WorkspaceTypes.Backend = {
+  id: "stub",
+  rootPath: "/stub",
+  shell: "/bin/sh",
+  close: Effect.void,
+  stat: (p) => Effect.fail(err("stat", p)),
+  exists: (p) => Effect.fail(err("exists", p)),
+  readFile: (p) => Effect.fail(err("readFile", p)),
+  writeFile: (p) => Effect.fail(err("writeFile", p)),
+  mkDir: (p) => Effect.fail(err("mkDir", p)),
+  readDir: (p) => Effect.fail(err("readDir", p)),
+  remove: (p) => Effect.fail(err("remove", p)),
+  rename: (from) => Effect.fail(err("rename", from)),
+  exec: () => Effect.fail(err("exec")),
+  execStream: () => Effect.fail(err("execStream")),
+  watch: (p) => Stream.fail(err("watch", p)),
+}
+
+const fixedRouter: Layer.Layer<WorkspaceRouter.Service> = Layer.succeed(
+  WorkspaceRouter.Service,
+  WorkspaceRouter.Service.of({
+    backend: Effect.succeed(stubBackend) as Effect.Effect<WorkspaceTypes.Backend, WorkspaceError>,
+  }),
+)
+
+const runtime = ManagedRuntime.make(Workspace.Primitives.layer.pipe(Layer.provide(fixedRouter)))
+
+const expectWrapped = async (
+  method: string,
+  build: (ws: Workspace.Primitives.Interface) => Effect.Effect<unknown, WorkspaceError>,
+) => {
+  const exit = await runtime.runPromiseExit(
+    Effect.gen(function* () {
+      const ws = yield* Workspace.Primitives.Service
+      return yield* build(ws)
+    }),
+  )
+  if (exit._tag === "Success") {
+    throw new Error(`expected WorkspaceError on ${method}, got success`)
+  }
+  const repr = JSON.stringify(exit.cause)
+  expect(repr).toContain("WorkspaceError")
+  expect(repr).toContain(method)
+  // Backend error preserved in the cause chain.
+  expect(repr).toContain("WorkspaceBackendError")
+}
+
+describe("Workspace.Primitives — BackendError → WorkspaceError mapping", () => {
+  test("stat preserves method", () => expectWrapped("stat", (ws) => ws.stat("/x")))
+  test("exists preserves method", () => expectWrapped("exists", (ws) => ws.exists("/x")))
+  test("readFile preserves method", () => expectWrapped("readFile", (ws) => ws.readFile("/x")))
+  test("writeFile preserves method", () => expectWrapped("writeFile", (ws) => ws.writeFile("/x", "data")))
+  test("mkDir preserves method", () => expectWrapped("mkDir", (ws) => ws.mkDir("/x")))
+  test("readDir preserves method", () => expectWrapped("readDir", (ws) => ws.readDir("/x")))
+  test("remove preserves method", () => expectWrapped("remove", (ws) => ws.remove("/x")))
+  test("rename preserves method", () => expectWrapped("rename", (ws) => ws.rename("/a", "/b")))
+  test("exec preserves method", () => expectWrapped("exec", (ws) => ws.exec("true", [])))
+  test("search preserves method", () =>
+    expectWrapped("search", (ws) => ws.search({ pattern: "anything" })))
+
+  test("watch surfaces WorkspaceError on the stream", async () => {
+    const exit = await runtime.runPromiseExit(
+      Effect.gen(function* () {
+        const ws = yield* Workspace.Primitives.Service
+        return yield* Stream.runCollect(ws.watch("/x"))
+      }),
+    )
+    if (exit._tag === "Success") {
+      throw new Error(`expected watch to fail, got success`)
+    }
+    const repr = JSON.stringify(exit.cause)
+    expect(repr).toContain("WorkspaceError")
+    expect(repr).toContain("watch")
+  })
+})

--- a/packages/opencode/test/workspace/router.test.ts
+++ b/packages/opencode/test/workspace/router.test.ts
@@ -1,0 +1,188 @@
+// WorkspaceRouter selection: Flag > Config > "local" default, per-Instance
+// caching, credentials-missing handling on vercel.
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer, ManagedRuntime } from "effect"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { WorkspaceRouter } from "../../src/workspace/router"
+
+const cfgWith = (workspace?: { backend: "local" | "vercel"; vercel?: Record<string, unknown> }) =>
+  Layer.succeed(
+    Config.Service,
+    Config.Service.of({
+      get: () => Effect.succeed({ workspace } as unknown as Config.Info),
+    } as unknown as Config.Interface),
+  )
+
+const setFlag = (value: string | undefined) => {
+  if (value === undefined) delete process.env["OPENCODE_WORKSPACE_BACKEND"]
+  else process.env["OPENCODE_WORKSPACE_BACKEND"] = value
+}
+
+afterEach(async () => {
+  setFlag(undefined)
+  await Instance.disposeAll()
+})
+
+describe("WorkspaceRouter", () => {
+  test("defaults to LocalBackend when no flag and no config", async () => {
+    await Instance.provide({
+      directory: "/tmp/opencode-router-test",
+      fn: async () => {
+        const rt = ManagedRuntime.make(WorkspaceRouter.layer.pipe(Layer.provide(cfgWith())))
+        try {
+          const backend = await rt.runPromise(
+            Effect.gen(function* () {
+              return yield* (yield* WorkspaceRouter.Service).backend
+            }),
+          )
+          expect(backend.id).toBe("local")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("config.workspace.backend=vercel selects vercel", async () => {
+    await Instance.provide({
+      directory: "/tmp/opencode-router-test",
+      fn: async () => {
+        const rt = ManagedRuntime.make(
+          WorkspaceRouter.layer.pipe(
+            Layer.provide(
+              cfgWith({
+                backend: "vercel",
+                vercel: { token: "t", teamId: "tm", projectId: "p" },
+              }),
+            ),
+          ),
+        )
+        try {
+          const backend = await rt.runPromise(
+            Effect.gen(function* () {
+              return yield* (yield* WorkspaceRouter.Service).backend
+            }),
+          )
+          expect(backend.id).toMatch(/^vercel:/)
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("Flag overrides config (flag=local beats config=vercel)", async () => {
+    setFlag("local")
+    await Instance.provide({
+      directory: "/tmp/opencode-router-test",
+      fn: async () => {
+        const rt = ManagedRuntime.make(
+          WorkspaceRouter.layer.pipe(
+            Layer.provide(
+              cfgWith({
+                backend: "vercel",
+                vercel: { token: "t", teamId: "tm", projectId: "p" },
+              }),
+            ),
+          ),
+        )
+        try {
+          const backend = await rt.runPromise(
+            Effect.gen(function* () {
+              return yield* (yield* WorkspaceRouter.Service).backend
+            }),
+          )
+          expect(backend.id).toBe("local")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("unknown flag value falls through to config", async () => {
+    setFlag("garbage")
+    await Instance.provide({
+      directory: "/tmp/opencode-router-test",
+      fn: async () => {
+        const rt = ManagedRuntime.make(
+          WorkspaceRouter.layer.pipe(Layer.provide(cfgWith({ backend: "local" }))),
+        )
+        try {
+          const backend = await rt.runPromise(
+            Effect.gen(function* () {
+              return yield* (yield* WorkspaceRouter.Service).backend
+            }),
+          )
+          expect(backend.id).toBe("local")
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+
+  test("vercel without credentials fails with WorkspaceError", async () => {
+    const saved = {
+      token: process.env["VERCEL_TOKEN"],
+      teamId: process.env["VERCEL_TEAM_ID"],
+      projectId: process.env["VERCEL_PROJECT_ID"],
+    }
+    delete process.env["VERCEL_TOKEN"]
+    delete process.env["VERCEL_TEAM_ID"]
+    delete process.env["VERCEL_PROJECT_ID"]
+    try {
+      await Instance.provide({
+        directory: "/tmp/opencode-router-test",
+        fn: async () => {
+          const rt = ManagedRuntime.make(
+            WorkspaceRouter.layer.pipe(Layer.provide(cfgWith({ backend: "vercel" }))),
+          )
+          try {
+            const exit = await rt.runPromiseExit(
+              Effect.gen(function* () {
+                return yield* (yield* WorkspaceRouter.Service).backend
+              }),
+            )
+            if (exit._tag === "Success") {
+              throw new Error(`expected WorkspaceError, got success: ${JSON.stringify(exit.value)}`)
+            }
+            const repr = JSON.stringify(exit.cause)
+            expect(repr).toContain("WorkspaceError")
+            expect(repr).toContain("credentials")
+          } finally {
+            await rt.dispose()
+          }
+        },
+      })
+    } finally {
+      if (saved.token !== undefined) process.env["VERCEL_TOKEN"] = saved.token
+      if (saved.teamId !== undefined) process.env["VERCEL_TEAM_ID"] = saved.teamId
+      if (saved.projectId !== undefined) process.env["VERCEL_PROJECT_ID"] = saved.projectId
+    }
+  })
+
+  test("per-Instance cache: two reads resolve the same backend", async () => {
+    await Instance.provide({
+      directory: "/tmp/opencode-router-test",
+      fn: async () => {
+        const rt = ManagedRuntime.make(WorkspaceRouter.layer.pipe(Layer.provide(cfgWith())))
+        try {
+          const pair = await rt.runPromise(
+            Effect.gen(function* () {
+              const router = yield* WorkspaceRouter.Service
+              const a = yield* router.backend
+              const b = yield* router.backend
+              return [a, b] as const
+            }),
+          )
+          expect(pair[0]).toBe(pair[1])
+        } finally {
+          await rt.dispose()
+        }
+      },
+    })
+  })
+})

--- a/scripts/count-upper-layer.sh
+++ b/scripts/count-upper-layer.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Measures how much this PR disturbed opencode's upper layer (consumers
+# of substrate primitives) vs the lower layer (substrate implementation
+# + new substrate-scoped code).
+#
+# Upper layer = tools, L4 services, LSP, config schemas the PR shouldn't
+# need to edit beyond swapping a deps set. Ideally near zero modified
+# lines; any non-zero here is something to justify.
+#
+# Lower layer = new substrate code (workspace/, backends/, sandbox
+# image scripts) + the two opencode substrate services
+# (AppFileSystem, ChildProcessSpawner) + package.json/bun.lock for the
+# @vercel/sandbox dependency.
+#
+# Usage:
+#   scripts/count-upper-layer.sh                    # BASE=43b37346b HEAD=HEAD
+#   BASE=<sha> HEAD=<sha> scripts/count-upper-layer.sh
+
+set -euo pipefail
+
+BASE="${BASE:-43b37346b}"
+HEAD="${HEAD:-HEAD}"
+
+# Returns 0 (true) if the path belongs to the lower layer — i.e. code
+# that the Vercel substrate migration is expected to add or replace.
+is_lower() {
+  case "$1" in
+    # New substrate abstraction + backends + tests
+    packages/opencode/src/workspace/*) return 0 ;;
+    packages/opencode/test/workspace/*) return 0 ;;
+    packages/opencode/test/lib/workspace.ts) return 0 ;;
+
+    # Sandbox image build/verify scripts + in-sandbox gateway source
+    packages/opencode/script/sandbox-image/*) return 0 ;;
+    packages/opencode/script/verify-sandbox-image.ts) return 0 ;;
+
+    # Lower-layer substrate services opencode already has
+    packages/opencode/src/filesystem/*) return 0 ;;
+    packages/opencode/src/effect/cross-spawn-spawner.ts) return 0 ;;
+    packages/opencode/src/util/process.ts) return 0 ;;
+
+    # Ephemeral artifacts from earlier migration experiments that should
+    # never land in the final diff. Listed here so they don't inflate
+    # the "upper" count when present.
+    packages/opencode/src/util/path.ts) return 0 ;;
+    packages/opencode/src/workspace/backends/local-factory.ts) return 0 ;;
+    packages/opencode/.substrate-allowlist.json) return 0 ;;
+    packages/opencode/script/check-substrate.ts) return 0 ;;
+
+    # Package manifest + lockfile for the @vercel/sandbox dep
+    packages/opencode/package.json) return 0 ;;
+    bun.lock) return 0 ;;
+
+    # The measurement script itself
+    scripts/count-upper-layer.sh) return 0 ;;
+
+    *) return 1 ;;
+  esac
+}
+
+upper_files=()
+lower_files=()
+upper_add=0
+upper_del=0
+lower_add=0
+lower_del=0
+
+while IFS=$'\t' read -r add del file; do
+  # numstat uses "-" for binary files; skip them.
+  [[ "$add" == "-" ]] && continue
+  if is_lower "$file"; then
+    lower_add=$((lower_add + add))
+    lower_del=$((lower_del + del))
+    lower_files+=("$(printf '  %5d  %5d  %s' "$add" "$del" "$file")")
+  else
+    upper_add=$((upper_add + add))
+    upper_del=$((upper_del + del))
+    upper_files+=("$(printf '  %5d  %5d  %s' "$add" "$del" "$file")")
+  fi
+done < <(git diff --numstat "$BASE" "$HEAD")
+
+upper_total=$((upper_add + upper_del))
+lower_total=$((lower_add + lower_del))
+
+echo "=============================================================="
+echo "  UPPER LAYER (should ideally be zero — every line is a cost)"
+echo "=============================================================="
+if [[ ${#upper_files[@]} -eq 0 ]]; then
+  echo "  (clean)"
+else
+  printf '   +add  -del  path\n'
+  printf '%s\n' "${upper_files[@]}" | sort -k3
+fi
+echo ""
+echo "  upper total: +${upper_add} / -${upper_del}  =  ${upper_total} lines touched across ${#upper_files[@]} files"
+echo ""
+echo "=============================================================="
+echo "  LOWER LAYER (substrate implementation — expected to grow)"
+echo "=============================================================="
+if [[ ${#lower_files[@]} -eq 0 ]]; then
+  echo "  (none)"
+else
+  printf '   +add  -del  path\n'
+  printf '%s\n' "${lower_files[@]}" | sort -k3
+fi
+echo ""
+echo "  lower total: +${lower_add} / -${lower_del}  =  ${lower_total} lines across ${#lower_files[@]} files"
+echo ""
+echo "=============================================================="
+echo "  RATIO"
+echo "=============================================================="
+if [[ $lower_total -gt 0 ]]; then
+  pct=$(awk -v u="$upper_total" -v l="$lower_total" 'BEGIN { printf "%.1f", 100 * u / (u + l) }')
+  echo "  upper / (upper + lower) = ${pct}%"
+fi
+echo ""
+echo "BASE=${BASE}  HEAD=${HEAD}"


### PR DESCRIPTION
Opt-in substrate that runs every tool's fs + subprocess calls inside a per-tenant Vercel sandbox instead of on the host. Use case: a multi-tenant agent server where each user gets their own isolated fs + exec environment (one user = one sandbox, one opencode process handles N tenants).

### Issue for this PR

No existing issue — opening this as a discussion PR. Happy to file one if that's preferred.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Context.** opencode is a CLI AI coding agent. The LLM calls tools (`bash`, `read`, `write`, `edit`, `grep`, `glob`, `lsp`, ...) and opencode executes them against a workspace. Today that workspace is the host: `read` does `fs.readFile`, `bash` shells out via `cross-spawn`, `grep` forks `rg`, `lsp` launches `typescript-language-server`, fs events come from `@parcel/watcher`. Fine for one user = one machine. Breaks for a multi-tenant server where one opencode process serves N users and each user's tool calls must be isolated.

**What this adds.** Set `OPENCODE_WORKSPACE_BACKEND=vercel` and every tool call runs inside that tenant's per-user Vercel sandbox. One tenant = one persistent sandbox, keyed by the opencode `Instance`. Default (`local`) is unchanged.

**Interface.** Everything a tool needs from a substrate, in one interface:

```ts
// src/workspace/types.ts
export interface Backend {
  readonly id: string
  readonly rootPath: string           // substrate-native absolute workspace root
  readonly shell: string              // "/bin/bash" on sandbox, $SHELL on host

  readonly stat:     (p: string) => Effect<FileInfo, BackendError>
  readonly exists:   (p: string) => Effect<boolean, BackendError>
  readonly readFile: (p: string) => Effect<Uint8Array, BackendError>
  readonly writeFile:(p: string, data: Uint8Array) => Effect<void, BackendError>
  readonly mkDir:    (p: string, opts: {recursive: boolean}) => Effect<void, BackendError>
  readonly readDir:  (p: string) => Effect<DirEntry[], BackendError>
  readonly remove:   (p: string, opts: {recursive: boolean}) => Effect<void, BackendError>
  readonly rename:   (from: string, to: string) => Effect<void, BackendError>
  readonly exec:       (cmd, args, opts?) => Effect<ExecResult, BackendError>
  readonly execStream: (cmd, args, opts?) => Effect<ExecStreamHandle, BackendError, Scope>
  readonly watch: (p: string, opts?) => Stream<FsEvent, BackendError>
  readonly close: Effect<void>
}
```

Two implementations ship: `LocalBackend` (wraps `node:fs` + cross-spawn + `@parcel/watcher`) and `VercelBackend` (wraps `@vercel/sandbox`).

**Shape.** Consumers upstream don't change — they still yield the same service tags. Two independent mechanisms route calls down to a `Backend`: funnel dispatch picks the implementation at Layer build, the router picks the tenant's `Backend` instance at Service resolution.

```
                                  CONSUMER CALLS
┌────────────────────────────────────────────────────────────────────────────────┐
│  ─── spawn consumers ───             ─── non-spawn consumers ───               │
│                                                                                │
│  bash, Git, Format,                  File, FileTime, Format (reads),           │
│  Snapshot, Ripgrep, LSP              Snapshot, Ripgrep                         │
└────────────────┬─────────────────────────────────────┬─────────────────────────┘
                 │ yield* ChildProcessSpawner          │
                 │ or import Process.spawn             │ yield* Workspace
                 ▼                                     │ .Primitives
  ┌──────────────────────────────────────┐             │
  │  FUNNEL DISPATCH                     │             │
  │                                      │             │
  │  src/effect/cross-spawn-spawner.ts   │             │
  │  src/util/process.ts                 │             │
  │  src/file/watcher.ts                 │             │
  │                                      │             │
  │  → reads flag at Layer build         │             │
  │  → picks local or vercel impl        │             │
  │  → dynamic import dodges @/global TLA│             │
  └──────────────────┬───────────────────┘             │
                     │                                 │
           ┌─────────┴─────────┐                       │
           ▼                   ▼                       │
  ┌──────────────────┐  ┌─────────────────────────┐    │
  │  "local"         │  │  "vercel"               │    │
  │                  │  │                         │    │
  │  cross-spawn     │  │  VercelChildProcess-    │    │
  │  node:fs         │  │   Spawner               │    │
  │  @parcel/watcher │  │   vercel-spawner.ts     │    │
  │                  │  │                         │    │
  │  (terminal)      │  │  spawnViaVercel         │    │
  │                  │  │   vercel-process.ts     │    │
  │                  │  │                         │    │
  │                  │  │  FileWatcher no-op      │    │
  │                  │  │   vercel-filewatcher.ts │    │
  │                  │  │                         │    │
  │                  │  │  → adapt Backend to     │    │
  │                  │  │    opencode's expected  │    │
  │                  │  │    service shapes       │    │
  └──────────────────┘  └────────────┬────────────┘    │
                                     │                 │
                                     └────────┬────────┘
                                              ▼
                         ┌──────────────────────────────────┐
                         │  Workspace.Primitives.Service    │
                         │  src/workspace/index.ts          │
                         │                                  │
                         │  → tool-facing surface           │
                         │  → BackendError → WorkspaceError │
                         │  → delegates to router's Backend │
                         └────────────────┬─────────────────┘
                                          │ yield* WorkspaceRouter
                                          ▼
                         ┌──────────────────────────────────┐
                         │  WorkspaceRouter.Service         │
                         │  src/workspace/router.ts         │
                         │                                  │
                         │  → picks Backend per tenant      │
                         │  → flag > config > "local"       │
                         │  → validates creds per-call      │
                         │  → lazy construction             │
                         │  → cached per Instance           │
                         └────────────────┬─────────────────┘
                                          │
                       ┌──────────────────┴──────────────────┐
                       ▼                                     ▼
         ┌───────────────────────────┐    ┌──────────────────────────────────┐
         │  LocalBackend             │    │  VercelBackend                   │
         │  backends/local.ts        │    │  backends/vercel.ts              │
         │                           │    │                                  │
         │  → node:fs                │    │  → @vercel/sandbox SDK           │
         │  → cross-spawn            │    │  → owns sandbox lifecycle        │
         │  → @parcel/watcher        │    │  → host↔sandbox path aliasing    │
         │  → $SHELL detection       │    │  → fs via sb.runCommand          │
         │                           │    │  → exec via sb.runCommand        │
         │                           │    │  → execStream via WS gateway     │
         │                           │    │  → watch via find-diff polling   │
         └───────────────────────────┘    └────────────────┬─────────────────┘
                                                           │
                                                           ▼
                                          ┌──────────────────────────────────┐
                                          │  vercel-exec-channel             │
                                          │  backends/vercel-exec-channel.ts │
                                          │                                  │
                                          │  → WS transport for execStream   │
                                          │  → lazy gateway bootstrap        │
                                          │  → auth + frame protocol         │
                                          │  → Node-stream adapters for LSP  │
                                          └────────────────┬─────────────────┘
                                                           │
                                                           ▼
                                          ┌──────────────────────────────────┐
                                          │  opencode-gateway daemon         │
                                          │  script/sandbox-image/gateway/   │
                                          │    gateway.js                    │
                                          │                                  │
                                          │  → runs inside sandbox VM        │
                                          │  → binds :3000 (health + WS)     │
                                          │  → token-authed                  │
                                          │  → spawns child, pipes stdio     │
                                          └──────────────────────────────────┘
```

Two spawn funnels exist because opencode has two spawn shapes: Effect-style returning `Effect<Handle, _, Scope>`, and sync Node-style returning `ChildProcess`. LSP uses `vscode-jsonrpc/node` and needs the latter. One-shot `exec` goes direct to `sb.runCommand` while `execStream` routes through the gateway because the ~13 git commands per agent step would cost ~6s of WS handshake overhead otherwise; LSP needs the live stdio that only the gateway provides.

### How did you verify your code works?

`bun test` in the opencode package is green — 2002 pass, 0 fail, 22 skip, 1 todo across 179 files. A conformance suite under `test/workspace/conformance/` runs the same assertions against all three backends via `OPENCODE_CONFORMANCE_BACKEND={local,throwing,vercel}`; the throwing backend fails every primitive and is the guard against any consumer silently bypassing the Backend seam. The e2e proof described below passes 8/8 against a real Vercel sandbox.

**Running the e2e proof yourself.** Build from this branch:

```bash
cd packages/opencode
bun run build --single
# dist/opencode-<platform>-<arch>/bin/opencode
```

Put the built binary on PATH, set vercel creds, run the proof:

```bash
export PATH=$PWD/dist/opencode-darwin-arm64/bin:$PATH
export VERCEL_TOKEN=... VERCEL_TEAM_ID=... VERCEL_PROJECT_ID=...
export VERCEL_SANDBOX_IMAGE_ID=snap_...

OPENCODE_WORKSPACE_BACKEND=vercel bun test script/vercel-proof.test.ts
```

Takes ~40–90 seconds end-to-end. Skips cleanly when `VERCEL_*` is missing. The harness spawns `opencode serve` as a subprocess, drives it through `@opencode-ai/sdk`, and asserts: a fresh session has zero messages, the bash tool returns `Linux` + `/vercel/sandbox` (proving the command ran in the sandbox, not the host), and filesystem writes persist across prompts in the same tenant.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

### Known limitations

First `execStream` call per sandbox is 1–3s (cold start + gateway bootstrap); subsequent calls reuse the persistent sandbox. Snapshot service fires about 13 git commands per agent step — on vercel each is an SDK round-trip, so snapshotting is ~3s slower than local; a sandbox-local gitdir would fix it but isn't in this PR. FileWatcher is a no-op under vercel by design.

### Review scaffolding (not intended to land)

`script/vercel-proof.test.ts` and `scripts/count-upper-layer.sh` are reviewer-facing verification tooling, not part of the substrate itself. The proof script is here so anyone can reproduce the e2e result end-to-end; the footprint script is how I kept the consumer-side blast radius small while iterating. Both would be dropped (or moved to a separate test/dev-tools PR) before this lands.

### Rebase

Left it at `43b37346b` to keep the diff readable; dev has moved ~80 commits since. If there's any interest or this gets any traction, happy to rebase onto current dev.
