### PR TITLE
refactor: unwrap BusEvent namespace + self-reexport

### DIFF
--- a/packages/opencode/src/bus/bus-event.ts
+++ b/packages/opencode/src/bus/bus-event.ts
@@ -1,33 +1,33 @@
 import z from "zod"
 import type { ZodType } from "zod"
 
-export namespace BusEvent {
-  export type Definition = ReturnType<typeof define>
+export type Definition = ReturnType<typeof define>
 
-  const registry = new Map<string, Definition>()
+const registry = new Map<string, Definition>()
 
-  export function define<Type extends string, Properties extends ZodType>(type: Type, properties: Properties) {
-    const result = {
-      type,
-      properties,
-    }
-    registry.set(type, result)
-    return result
+export function define<Type extends string, Properties extends ZodType>(type: Type, properties: Properties) {
+  const result = {
+    type,
+    properties,
   }
-
-  export function payloads() {
-    return registry
-      .entries()
-      .map(([type, def]) => {
-        return z
-          .object({
-            type: z.literal(type),
-            properties: def.properties,
-          })
-          .meta({
-            ref: `Event.${def.type}`,
-          })
-      })
-      .toArray()
-  }
+  registry.set(type, result)
+  return result
 }
+
+export function payloads() {
+  return registry
+    .entries()
+    .map(([type, def]) => {
+      return z
+        .object({
+          type: z.literal(type),
+          properties: def.properties,
+        })
+        .meta({
+          ref: `Event.${def.type}`,
+        })
+    })
+    .toArray()
+}
+
+export * as BusEvent from "./bus-event"


### PR DESCRIPTION
## Summary
- Unwrap the `BusEvent` namespace in `packages/opencode/src/bus/bus-event.ts` to flat top-level exports.
- Append `export * as BusEvent from "./bus-event"` so consumers keep the same `BusEvent.x` import ergonomics.

## Verification (local)
- `bunx --bun tsgo --noEmit` — no new errors vs baseline.
- `bun run --conditions=browser ./src/index.ts generate` — clean.
- `bun run test test/bus` — all pass (if applicable).