### PR TITLE
refactor: extract Diagnostic namespace into lsp/diagnostic.ts + self-reexport

### DIFF
--- a/packages/opencode/src/lsp/diagnostic.ts
+++ b/packages/opencode/src/lsp/diagnostic.ts
@@ -1,0 +1,29 @@
+import * as LSPClient from "./client"
+
+const MAX_PER_FILE = 20
+
+export function pretty(diagnostic: LSPClient.Diagnostic) {
+  const severityMap = {
+    1: "ERROR",
+    2: "WARN",
+    3: "INFO",
+    4: "HINT",
+  }
+
+  const severity = severityMap[diagnostic.severity || 1]
+  const line = diagnostic.range.start.line + 1
+  const col = diagnostic.range.start.character + 1
+
+  return `${severity} [${line}:${col}] ${diagnostic.message}`
+}
+
+export function report(file: string, issues: LSPClient.Diagnostic[]) {
+  const errors = issues.filter((item) => item.severity === 1)
+  if (errors.length === 0) return ""
+  const limited = errors.slice(0, MAX_PER_FILE)
+  const more = errors.length - MAX_PER_FILE
+  const suffix = more > 0 ? `\n... and ${more} more` : ""
+  return `<diagnostics file="${file}">\n${limited.map(pretty).join("\n")}${suffix}\n</diagnostics>`
+}
+
+export * as Diagnostic from "./diagnostic"

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -505,30 +505,4 @@ export const layer = Layer.effect(
 
 export const defaultLayer = layer.pipe(Layer.provide(Config.defaultLayer))
 
-export namespace Diagnostic {
-  const MAX_PER_FILE = 20
-
-  export function pretty(diagnostic: LSPClient.Diagnostic) {
-    const severityMap = {
-      1: "ERROR",
-      2: "WARN",
-      3: "INFO",
-      4: "HINT",
-    }
-
-    const severity = severityMap[diagnostic.severity || 1]
-    const line = diagnostic.range.start.line + 1
-    const col = diagnostic.range.start.character + 1
-
-    return `${severity} [${line}:${col}] ${diagnostic.message}`
-  }
-
-  export function report(file: string, issues: LSPClient.Diagnostic[]) {
-    const errors = issues.filter((item) => item.severity === 1)
-    if (errors.length === 0) return ""
-    const limited = errors.slice(0, MAX_PER_FILE)
-    const more = errors.length - MAX_PER_FILE
-    const suffix = more > 0 ? `\n... and ${more} more` : ""
-    return `<diagnostics file="${file}">\n${limited.map(pretty).join("\n")}${suffix}\n</diagnostics>`
-  }
-}
+export * as Diagnostic from "./diagnostic"


### PR DESCRIPTION
## Summary

The `Diagnostic` namespace was the only `export namespace` in `lsp/lsp.ts` but lived alongside flat top-level exports (`Event`, `Range`, `Symbol`, etc.) for the main LSP service. A mechanical unwrap would have projected the whole file as `Diagnostic` (so `LSP.Diagnostic.Range`, `LSP.Diagnostic.defaultLayer`, etc. would exist) which is cosmetically wrong.

Instead, extract `Diagnostic` to its own file `lsp/diagnostic.ts` with a self-reexport (`export * as Diagnostic from "./diagnostic"`), and re-export it from `lsp.ts` to preserve the `LSP.Diagnostic.pretty` / `LSP.Diagnostic.report` consumer ergonomics.

Public API unchanged. Consumer imports unchanged.

## Pattern

Before: `lsp/lsp.ts` had 1-507 lines of flat LSP service exports plus a 27-line `export namespace Diagnostic { pretty, report }` tacked on the end.

After:
- `lsp/diagnostic.ts` — new file containing `pretty`, `report`, and `export * as Diagnostic from "./diagnostic"`
- `lsp/lsp.ts` — namespace block removed, replaced with `export * as Diagnostic from "./diagnostic"` at the bottom

Consumers still write `LSP.Diagnostic.pretty(...)` / `LSP.Diagnostic.report(...)`. The resolution chain is:
`lsp/index.ts`'s `export * as LSP from "./lsp"` → `lsp.ts`'s `export * as Diagnostic from "./diagnostic"` → `diagnostic.ts`'s `pretty`/`report`.

## Verification

- `bunx --bun tsgo --noEmit` from `packages/opencode/` — 0 errors
- `bun run --conditions=browser ./src/index.ts generate` — no SDK drift
- `test/lsp/` — 18/18 pass
- `test/tool/{write,edit,apply_patch}.test.ts` (uses `LSP.Diagnostic.report`) — 66/66 pass