### PR TITLE
tui: stabilize session dialog ordering

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -113,7 +113,11 @@ export function DialogSessionList() {
     const today = new Date().toDateString()
     return sessions()
       .filter((x) => x.parentID === undefined)
-      .toSorted((a, b) => b.time.updated - a.time.updated)
+      .toSorted((a, b) => {
+        const updatedDay = new Date(b.time.updated).setHours(0, 0, 0, 0) - new Date(a.time.updated).setHours(0, 0, 0, 0)
+        if (updatedDay !== 0) return updatedDay
+        return b.time.created - a.time.created
+      })
       .map((x) => {
         const workspace = x.workspaceID ? project.workspace.get(x.workspaceID) : undefined
 


### PR DESCRIPTION
## Summary
- sort root sessions in the TUI session dialog by updated day instead of exact update timestamp
- use creation time to order sessions within the same updated day so active sessions stop jumping around constantly
- keep the existing day-based category labels unchanged

## Testing
- bun typecheck